### PR TITLE
Remove CI envvar which is set by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,3 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn test
-        env:
-          CI: true


### PR DESCRIPTION
This is [already set by default](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables) and we shouldn't have to define it 😄  (Sorry I missed this in the previous PR!)