### PR TITLE
[eas-cli] move apple api to eas cli

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -14,13 +14,20 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
     "@urql/core": "^1.13.0",
+    "chalk": "^4.1.0",
+    "dateformat": "^3.0.3",
     "env-paths": "^2.2.0",
     "fs-extra": "^9.0.1",
     "got": "^11.5.2",
     "graphql-tag": "^2.11.0",
+    "keychain": "^1.3.0",
     "node-fetch": "^2.6.1",
+    "node-forge": "^0.10.0",
+    "ora": "^5.1.0",
     "prompts": "^2.3.2",
-    "tslib": "^1"
+    "terminal-link": "^2.1.1",
+    "tslib": "^1",
+    "wordwrap": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
@@ -28,10 +35,13 @@
     "@babel/preset-typescript": "^7.10.4",
     "@expo/babel-preset-cli": "^0.2.17",
     "@expo/oclif-dev-cli": "1.23.0-expo",
+    "@types/dateformat": "^3.0.1",
     "@types/fs-extra": "^9.0.1",
     "@types/node": "^12",
     "@types/node-fetch": "^2.5.7",
+    "@types/node-forge": "^0.9.5",
     "@types/prompts": "^2.0.8",
+    "@types/wordwrap": "^1.0.0",
     "@vercel/ncc": "^0.23.0",
     "babel-jest": "^26.3.0",
     "graphql": "^15.3.0",
@@ -40,6 +50,10 @@
     "ts-node": "^8",
     "typescript": "^3.9.7",
     "wonka": "^4.0.14"
+  },
+  "optionalDependencies": {
+    "@expo/traveling-fastlane-darwin": "1.15.1",
+    "@expo/traveling-fastlane-linux": "1.15.1"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/eas-cli/src/commands/login.ts
+++ b/packages/eas-cli/src/commands/login.ts
@@ -1,7 +1,7 @@
 import { Command } from '@oclif/command';
-import { prompt } from 'prompts';
 
 import { loginAsync } from '../accounts';
+import { prompt } from '../prompts';
 
 export default class Login extends Command {
   static description = 'log in with your EAS account';

--- a/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
@@ -1,0 +1,132 @@
+import {
+  DistributionCertificate,
+  DistributionCertificateStoreInfo,
+  ProvisioningProfile,
+  ProvisioningProfileStoreInfo,
+  PushKey,
+  PushKeyStoreInfo,
+} from './Credentials.types';
+import { AuthCtx, authenticateAsync } from './authenticate';
+import { checkWSLAsync } from './checkWSL';
+import {
+  createDistributionCertificateAsync,
+  listDistributionCertificatesAsync,
+  revokeDistributionCertificateAsync,
+} from './distributionCertificate';
+import { AppLookupParams, EnsureAppExistsOptions, ensureAppExistsAsync } from './ensureAppExists';
+import {
+  createProvisioningProfileAsync,
+  listProvisioningProfilesAsync,
+  revokeProvisioningProfileAsync,
+  useExistingProvisioningProfileAsync,
+} from './provisioningProfile';
+import { createOrReuseAdhocProvisioningProfileAsync } from './provisioningProfileAdhoc';
+import { createPushKeyAsync, listPushKeysAsync, revokePushKeyAsync } from './pushKey';
+
+interface Options {
+  appleIdPassword?: string;
+  appleId?: string;
+  teamId?: string;
+}
+
+class AppStoreApi {
+  private authCtx?: AuthCtx;
+
+  constructor(public readonly options?: Options) {}
+
+  public async ensureAuthenticatedAsync(): Promise<AuthCtx> {
+    if (!this.authCtx) {
+      await checkWSLAsync();
+      this.authCtx = await authenticateAsync(this.options);
+    }
+    return this.authCtx;
+  }
+
+  public async ensureAppExistsAsync(
+    app: AppLookupParams,
+    options?: EnsureAppExistsOptions
+  ): Promise<void> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await ensureAppExistsAsync(ctx, app, options);
+  }
+
+  public async listDistributionCertificatesAsync(): Promise<DistributionCertificateStoreInfo[]> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await listDistributionCertificatesAsync(ctx);
+  }
+
+  public async createDistributionCertificateAsync(): Promise<DistributionCertificate> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await createDistributionCertificateAsync(ctx);
+  }
+
+  public async deleteDistributionCertificateAsync(ids: string[]): Promise<void> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await revokeDistributionCertificateAsync(ctx, ids);
+  }
+
+  public async listPushKeysAsync(): Promise<PushKeyStoreInfo[]> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await listPushKeysAsync(ctx);
+  }
+
+  public async createPushKeyAsync(name?: string): Promise<PushKey> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await createPushKeyAsync(ctx, name);
+  }
+
+  public async revokePushKeyAsync(ids: string[]): Promise<void> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await revokePushKeyAsync(ctx, ids);
+  }
+
+  public async useExistingProvisioningProfileAsync(
+    bundleIdentifier: string,
+    provisioningProfile: ProvisioningProfile,
+    distCert: DistributionCertificate
+  ): Promise<ProvisioningProfile> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await useExistingProvisioningProfileAsync(
+      ctx,
+      bundleIdentifier,
+      provisioningProfile,
+      distCert
+    );
+  }
+
+  public async listProvisioningProfilesAsync(
+    bundleIdentifier: string
+  ): Promise<ProvisioningProfileStoreInfo[]> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await listProvisioningProfilesAsync(ctx, bundleIdentifier);
+  }
+
+  public async createProvisioningProfileAsync(
+    bundleIdentifier: string,
+    distCert: DistributionCertificate,
+    profileName: string
+  ): Promise<ProvisioningProfile> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await createProvisioningProfileAsync(ctx, bundleIdentifier, distCert, profileName);
+  }
+
+  public async revokeProvisioningProfileAsync(bundleIdentifier: string): Promise<void> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await revokeProvisioningProfileAsync(ctx, bundleIdentifier);
+  }
+
+  public async createOrReuseAdhocProvisioningProfileAsync(
+    udids: string[],
+    bundleIdentifier: string,
+    distCertSerialNumber: string
+  ): Promise<ProvisioningProfile> {
+    const ctx = await this.ensureAuthenticatedAsync();
+    return await createOrReuseAdhocProvisioningProfileAsync(
+      ctx,
+      udids,
+      bundleIdentifier,
+      distCertSerialNumber
+    );
+  }
+}
+export default AppStoreApi;

--- a/packages/eas-cli/src/credentials/ios/appstore/Credentials.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/Credentials.ts
@@ -1,0 +1,53 @@
+import dateformat from 'dateformat';
+
+import {
+  DistributionCertificate,
+  DistributionCertificateStoreInfo,
+  PushKey,
+  PushKeyStoreInfo,
+} from './Credentials.types';
+
+export function formatDistributionCertificate({
+  name,
+  id,
+  status,
+  expires,
+  created,
+  ownerName,
+}: DistributionCertificateStoreInfo): string {
+  const expiresDate = _formatTimestamp(expires);
+  const createdDate = _formatTimestamp(created);
+  return `${name} (${status}) - ID: ${id} - expires: ${expiresDate} (created: ${createdDate}) - owner: ${ownerName}`;
+}
+
+export function isDistributionCertificate(val: {
+  [key: string]: any;
+}): val is DistributionCertificate {
+  return (
+    val.certP12 &&
+    typeof val.certP12 === 'string' &&
+    val.certPassword &&
+    typeof val.certPassword === 'string' &&
+    val.teamId &&
+    typeof val.teamId === 'string'
+  );
+}
+
+export function formatPushKey({ id, name }: PushKeyStoreInfo): string {
+  return `${name} - ID: ${id}`;
+}
+
+export function isPushKey(obj: { [key: string]: any }): obj is PushKey {
+  return (
+    obj.apnsKeyP8 &&
+    typeof obj.apnsKeyP8 === 'string' &&
+    obj.apnsKeyId &&
+    typeof obj.apnsKeyId === 'string' &&
+    obj.teamId &&
+    typeof obj.teamId === 'string'
+  );
+}
+
+function _formatTimestamp(timestamp: number): string {
+  return dateformat(new Date(timestamp * 1000));
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
@@ -1,0 +1,48 @@
+export interface DistributionCertificateStoreInfo {
+  id: string;
+  name: string;
+  status: string;
+  created: number;
+  expires: number;
+  ownerType: string;
+  ownerName: string;
+  ownerId: string;
+  serialNumber: string;
+}
+
+export interface DistributionCertificate {
+  certId?: string;
+  certP12: string;
+  certPassword: string;
+  certPrivateSigningKey?: string;
+  distCertSerialNumber?: string;
+  teamId: string;
+  teamName?: string;
+}
+
+export interface ProvisioningProfile {
+  provisioningProfileId?: string;
+  provisioningProfile: string;
+  teamId: string;
+  teamName?: string;
+}
+
+export interface ProvisioningProfileStoreInfo extends ProvisioningProfile {
+  name: string;
+  status: string;
+  expires: number;
+  distributionMethod: string;
+  certificates: DistributionCertificateStoreInfo[];
+}
+
+export interface PushKeyStoreInfo {
+  id: string;
+  name: string;
+}
+
+export interface PushKey {
+  apnsKeyP8: string;
+  apnsKeyId: string;
+  teamId: string;
+  teamName?: string;
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
@@ -1,0 +1,276 @@
+import chalk from 'chalk';
+import terminalLink from 'terminal-link';
+import wordwrap from 'wordwrap';
+
+import log from '../../../log';
+import { prompt } from '../../../prompts';
+import UserSettings from '../../../utils/UserSettings';
+import { runActionAsync, travelingFastlane } from './fastlane';
+import * as Keychain from './keychain';
+
+const APPLE_IN_HOUSE_TEAM_TYPE = 'in-house';
+const IS_MAC = process.platform === 'darwin';
+
+export type Options = {
+  appleId?: string;
+  teamId?: string;
+};
+
+type AppleCredentials = {
+  appleIdPassword: string;
+  appleId: string;
+};
+
+export type Team = {
+  id: string;
+  name?: string;
+  inHouse?: boolean;
+};
+
+type FastlaneTeam = {
+  name: string;
+  teamId: string;
+  status: string;
+  type: string;
+};
+
+export type AuthCtx = {
+  appleId: string;
+  appleIdPassword: string;
+  team: Team;
+  fastlaneSession: string;
+};
+
+export async function authenticateAsync(options: Options = {}): Promise<AuthCtx> {
+  const { appleId, appleIdPassword } = await requestAppleCredentialsAsync(options);
+  log(`Authenticating to Apple Developer Portal...`); // use log instead of spinner in case we need to prompt user for 2fa
+  try {
+    const { teams, fastlaneSession } = await runActionAsync(
+      travelingFastlane.authenticate,
+      [appleId, appleIdPassword],
+      {
+        pipeStdout: true,
+      }
+    );
+    log(chalk.green('Authenticated with Apple Developer Portal successfully!'));
+    const team = await chooseTeamAsync(teams, options.teamId);
+    return { appleId, appleIdPassword, team, fastlaneSession };
+  } catch (err) {
+    if (err.rawDump?.match(/Invalid username and password combination/)) {
+      log(chalk.red('Invalid username and password combination, try again.'));
+      const anotherPromptResult = await promptForAppleCredentialsAsync({
+        firstAttempt: false,
+      });
+      return authenticateAsync({ ...options, ...anotherPromptResult });
+    }
+    log(chalk.red('Authentication with Apple Developer Portal failed!'));
+    throw err;
+  }
+}
+
+export async function requestAppleCredentialsAsync(options: Options): Promise<AppleCredentials> {
+  return getAppleCredentialsFromParams(options) ?? (await promptForAppleCredentialsAsync());
+}
+
+function getAppleCredentialsFromParams({ appleId }: Options): AppleCredentials | null {
+  if (!appleId) {
+    return null;
+  }
+  const appleIdPassword = process.env.EXPO_APPLE_PASSWORD;
+
+  // partial apple id params were set, assume user has intention of passing it in
+  if (!appleIdPassword) {
+    throw new Error(
+      'In order to provide your Apple ID credentials, you must set the --apple-id flag and set the EXPO_APPLE_PASSWORD environment variable.'
+    );
+  }
+
+  return {
+    appleId,
+    appleIdPassword,
+  };
+}
+
+async function promptForAppleCredentialsAsync({
+  firstAttempt = true,
+}: { firstAttempt?: boolean } = {}): Promise<AppleCredentials> {
+  if (firstAttempt) {
+    const wrap = wordwrap(process.stdout.columns || 80);
+    log(
+      wrap(
+        'Please enter your Apple Developer Program account credentials. ' +
+          'These credentials are needed to manage certificates, keys and provisioning profiles ' +
+          `in your Apple Developer account.`
+      )
+    );
+
+    // https://docs.expo.io/distribution/security/#apple-developer-account-credentials
+    const here = terminalLink('here', 'https://bit.ly/2VtGWhU');
+    log(
+      wrap(
+        chalk.bold(
+          `The password is only used to authenticate with Apple and never stored on Expo servers`
+        )
+      )
+    );
+    log(wrap(chalk.grey(`Learn more ${here}`)));
+  }
+
+  // Get the email address that was last used and set it as
+  // the default value for quicker authentication.
+  const lastAppleId = await getLastUsedAppleIdAsync();
+
+  const { appleId: promptAppleId } = await prompt({
+    type: 'text',
+    name: 'appleId',
+    message: `Apple ID:`,
+    validate: (val: string) => !!val,
+    initial: lastAppleId ?? undefined,
+  });
+
+  // If a new email was used then store it as a suggestion for next time.
+  if (lastAppleId !== promptAppleId) {
+    await UserSettings.setAsync('appleId', promptAppleId);
+  }
+
+  // Only check on the first attempt in case the user changed their password.
+  if (firstAttempt) {
+    const password = await getPasswordAsync({ appleId: promptAppleId });
+
+    if (password) {
+      log(
+        `Using password from your local Keychain. ${chalk.dim(
+          `Learn more ${chalk.underline('https://docs.expo.io/distribution/security#keychain')}`
+        )}`
+      );
+      return { appleId: promptAppleId, appleIdPassword: password };
+    }
+  }
+  const { appleIdPassword } = await prompt({
+    type: 'password',
+    name: 'appleIdPassword',
+    message: `Password (for ${promptAppleId}):`,
+    validate: (val: string) => !!val,
+  });
+
+  await setPasswordAsync({ appleId: promptAppleId, appleIdPassword });
+
+  return { appleId: promptAppleId, appleIdPassword };
+}
+
+async function chooseTeamAsync(teams: FastlaneTeam[], userProvidedTeamId?: string): Promise<Team> {
+  if (teams.length === 0) {
+    throw new Error(`You have no team associated with your Apple account, cannot proceed.
+(Do you have a paid Apple Developer account?)`);
+  }
+
+  if (userProvidedTeamId) {
+    const foundTeam = teams.find(({ teamId }) => teamId === userProvidedTeamId);
+    if (foundTeam) {
+      log(`Using Apple Team with ID: ${userProvidedTeamId}`);
+      return formatTeam(foundTeam);
+    } else {
+      log.warn(`Your account is not associated with Apple Team with ID: ${userProvidedTeamId}`);
+    }
+  }
+
+  if (teams.length === 1) {
+    const [team] = teams;
+    log(`Only 1 team associated with your account, using Apple Team with ID: ${team.teamId}`);
+    return formatTeam(team);
+  } else {
+    log(`You have ${teams.length} teams associated with your account`);
+    const choices = teams.map((team, i) => ({
+      title: `${i + 1}) ${team.teamId} "${team.name}" (${team.type})`,
+      value: team,
+    }));
+    const { team } = await prompt({
+      type: 'select',
+      name: 'team',
+      message: 'Which team would you like to use?',
+      choices,
+    });
+    return formatTeam(team);
+  }
+}
+
+function formatTeam({ teamId, name, type }: FastlaneTeam): Team {
+  return {
+    id: teamId,
+    name: `${name} (${type})`,
+    inHouse: type.toLowerCase() === APPLE_IN_HOUSE_TEAM_TYPE,
+  };
+}
+
+async function getLastUsedAppleIdAsync(): Promise<string | null> {
+  const lastAppleId = await UserSettings.getAsync('appleId', null);
+  if (lastAppleId && typeof lastAppleId === 'string') {
+    return lastAppleId;
+  }
+  return null;
+}
+
+/**
+ * Returns the same prefix used by Fastlane in order to potentially share access between services.
+ * [Cite. Fastlane](https://github.com/fastlane/fastlane/blob/f831062fa6f4b216b8ee38949adfe28fc11a0a8e/credentials_manager/lib/credentials_manager/account_manager.rb#L8).
+ *
+ * @param appleId email address
+ */
+function getKeychainServiceName(appleId: string): string {
+  return `deliver.${appleId}`;
+}
+
+async function deletePasswordAsync({ appleId }: Pick<AppleCredentials, 'appleId'>): Promise<void> {
+  if (!IS_MAC) {
+    return;
+  }
+  try {
+    const serviceName = getKeychainServiceName(appleId);
+    await Keychain.deletePasswordAsync({ username: appleId, serviceName });
+    log('Removed Apple ID password from the native Keychain.');
+  } catch (error) {
+    log.warn('Failed to remove Apple ID password from the native Keychain');
+  }
+}
+
+async function getPasswordAsync({
+  appleId,
+}: Pick<AppleCredentials, 'appleId'>): Promise<string | null> {
+  if (!IS_MAC) {
+    return null;
+  }
+  try {
+    // If the user opts out, delete the password.
+    if (Keychain.EXPO_NO_KEYCHAIN) {
+      await deletePasswordAsync({ appleId });
+      return null;
+    }
+
+    const serviceName = getKeychainServiceName(appleId);
+    return Keychain.getPasswordAsync({ username: appleId, serviceName });
+  } catch (error) {
+    return null;
+  }
+}
+
+async function setPasswordAsync({ appleId, appleIdPassword }: AppleCredentials): Promise<void> {
+  if (!IS_MAC) {
+    return;
+  }
+  if (Keychain.EXPO_NO_KEYCHAIN) {
+    log('Skip storing Apple ID password in the local Keychain.');
+    return;
+  }
+
+  log(
+    `Saving Apple ID password to the local Keychain. ${chalk.dim(
+      `Learn more ${chalk.underline('https://docs.expo.io/distribution/security#keychain')}`
+    )}`
+  );
+  try {
+    const serviceName = getKeychainServiceName(appleId);
+    return Keychain.setPasswordAsync({ username: appleId, password: appleIdPassword, serviceName });
+  } catch (error) {
+    log.warn('Saving Apple ID password failed', error);
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/checkWSL.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/checkWSL.ts
@@ -1,0 +1,35 @@
+import fs from 'fs-extra';
+import { release } from 'os';
+
+import { WSL_BASH_PATH } from './fastlane';
+
+const ENABLE_WSL = `
+Does not seem like WSL is enabled on this machine. Download from
+the Windows app store a distribution of Linux, then in an admin powershell run:
+
+Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
+
+and run the new Linux installation at least once
+`;
+
+let checkCompleted = false;
+export async function checkWSLAsync() {
+  if (checkCompleted) {
+    return;
+  }
+
+  if (process.platform === 'win32') {
+    const [version] = release().match(/\d./) || [null];
+    if (version !== '10') {
+      throw new Error('Must be on at least Windows version 10 for WSL support to work');
+    }
+
+    try {
+      await fs.access(WSL_BASH_PATH, fs.constants.F_OK);
+    } catch (e) {
+      throw new Error(ENABLE_WSL);
+    }
+  }
+
+  checkCompleted = true;
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
@@ -1,0 +1,80 @@
+import chalk from 'chalk';
+import ora from 'ora';
+
+import { DistributionCertificate, DistributionCertificateStoreInfo } from './Credentials.types';
+import { AuthCtx } from './authenticate';
+import { runActionAsync, travelingFastlane } from './fastlane';
+
+const APPLE_DIST_CERTS_TOO_MANY_GENERATED_ERROR = `
+You can have only ${chalk.underline(
+  'three'
+)} Apple Distribution Certificates generated on your Apple Developer account.
+Please revoke the old ones or reuse existing from your other apps.
+Please remember that Apple Distribution Certificates are not application specific!
+`;
+
+export async function listDistributionCertificatesAsync(
+  ctx: AuthCtx
+): Promise<DistributionCertificateStoreInfo[]> {
+  const spinner = ora(`Getting Distribution Certificates from Apple...`).start();
+  try {
+    const args = ['list', ctx.appleId, ctx.appleIdPassword, ctx.team.id, String(ctx.team.inHouse)];
+    const { certs } = await runActionAsync(travelingFastlane.manageDistCerts, args);
+    spinner.succeed();
+    return certs;
+  } catch (error) {
+    spinner.fail();
+    throw error;
+  }
+}
+
+export async function createDistributionCertificateAsync(
+  ctx: AuthCtx
+): Promise<DistributionCertificate> {
+  const spinner = ora(`Creating Distribution Certificate on Apple Servers...`).start();
+  try {
+    const args = [
+      'create',
+      ctx.appleId,
+      ctx.appleIdPassword,
+      ctx.team.id,
+      String(ctx.team.inHouse),
+    ];
+    const result = {
+      ...(await runActionAsync(travelingFastlane.manageDistCerts, args)),
+      teamId: ctx.team.id,
+      teamName: ctx.team.name,
+    };
+    spinner.succeed();
+    return result;
+  } catch (err) {
+    spinner.fail('Failed to create Distribution Certificate on Apple Servers');
+    const resultString = err.rawDump?.resultString;
+    if (resultString && resultString.match(/Maximum number of certificates generated/)) {
+      throw new Error(APPLE_DIST_CERTS_TOO_MANY_GENERATED_ERROR);
+    }
+    throw err;
+  }
+}
+
+export async function revokeDistributionCertificateAsync(
+  ctx: AuthCtx,
+  ids: string[]
+): Promise<void> {
+  const spinner = ora(`Revoking Distribution Certificate on Apple Servers...`).start();
+  try {
+    const args = [
+      'revoke',
+      ctx.appleId,
+      ctx.appleIdPassword,
+      ctx.team.id,
+      String(ctx.team.inHouse),
+      ids.join(','),
+    ];
+    await runActionAsync(travelingFastlane.manageDistCerts, args);
+    spinner.succeed();
+  } catch (error) {
+    spinner.fail('Failed to revoke Distribution Certificate on Apple Servers');
+    throw error;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -1,0 +1,43 @@
+import ora from 'ora';
+
+import { AuthCtx } from './authenticate';
+import { runActionAsync, travelingFastlane } from './fastlane';
+
+export interface AppLookupParams {
+  accountName: string;
+  projectName: string;
+  bundleIdentifier: string;
+}
+
+export interface EnsureAppExistsOptions {
+  enablePushNotifications?: boolean;
+}
+
+export async function ensureAppExistsAsync(
+  authCtx: AuthCtx,
+  app: AppLookupParams,
+  options: EnsureAppExistsOptions = {}
+): Promise<void> {
+  const { appleId, appleIdPassword, team } = authCtx;
+  const spinner = ora(`Ensuring App ID exists on Apple Developer Portal...`).start();
+  try {
+    const { created } = await runActionAsync(travelingFastlane.ensureAppExists, [
+      ...(options.enablePushNotifications ? ['--push-notifications'] : []),
+      appleId,
+      appleIdPassword,
+      team.id,
+      app.bundleIdentifier,
+      `@${app.accountName}/${app.projectName}`,
+    ]);
+    if (created) {
+      spinner.succeed(`App ID created with bundle identifier ${app.bundleIdentifier}.`);
+    } else {
+      spinner.succeed('App ID found on Apple Developer Portal.');
+    }
+  } catch (err) {
+    spinner.fail(
+      'Something went wrong when trying to ensure App ID exists on Apple Developer Portal!'
+    );
+    throw err;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/fastlane.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/fastlane.ts
@@ -1,0 +1,58 @@
+import spawnAsync from '@expo/spawn-async';
+import slash from 'slash';
+
+const travelingFastlane =
+  process.platform === 'darwin'
+    ? require('@expo/traveling-fastlane-darwin')()
+    : require('@expo/traveling-fastlane-linux')();
+
+const WSL_BASH_PATH = 'C:\\Windows\\system32\\bash.exe';
+const WSL_BASH = 'bash';
+const WSL_ONLY_PATH = 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+
+type Options = {
+  pipeStdout?: boolean;
+};
+
+async function runActionAsync(fastlaneAction: string, args: string[], options: Options = {}) {
+  const { pipeStdout = false } = options;
+  const { command, commandArgs } = getCommandAndArgsForPlatform(fastlaneAction, args);
+  const { stderr } = await spawnAsync(command, commandArgs, {
+    stdio: ['inherit', pipeStdout ? 'inherit' : 'pipe', 'pipe'],
+  });
+  const { result, ...rest } = JSON.parse(stderr.trim());
+  if (result === 'success') {
+    return rest;
+  } else {
+    const { reason, rawDump } = rest;
+    const err = new Error(`Reason: ${reason}, raw: ${JSON.stringify(rawDump)}`);
+    // @ts-ignore
+    err.rawDump = rawDump;
+    throw err;
+  }
+}
+
+function getCommandAndArgsForPlatform(fastlaneAction: string, args: string[]) {
+  if (process.platform === 'win32') {
+    const command = WSL_BASH;
+    const argsJoined = args.map(i => `"${i}"`).join(' ');
+    const commandArgs = [
+      '-c',
+      `${WSL_ONLY_PATH} ${windowsToWSLPath(fastlaneAction)} ${argsJoined}`,
+    ];
+    return { command, commandArgs };
+  } else {
+    const command = fastlaneAction;
+    const commandArgs = [...args];
+    return { command, commandArgs };
+  }
+}
+
+function windowsToWSLPath(_path: string) {
+  const slashPath = slash(_path);
+  const diskLetter = _path[0].toLowerCase();
+  const pathOnDisk = slashPath.slice(2);
+  return `/mnt/${diskLetter}${pathOnDisk}`;
+}
+
+export { travelingFastlane, runActionAsync, WSL_BASH_PATH };

--- a/packages/eas-cli/src/credentials/ios/appstore/keychain.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/keychain.ts
@@ -1,0 +1,72 @@
+import keychain from 'keychain';
+
+const KEYCHAIN_TYPE = 'internet';
+const NO_PASSWORD_REGEX = /Could not find password/;
+
+// When enabled, the password will not only be skipped but also deleted.
+// This makes it easier to completely opt-out of Keychain functionality.
+export const EXPO_NO_KEYCHAIN = process.env['EXPO_NO_KEYCHAIN'];
+
+interface Credentials {
+  serviceName: string;
+  username: string;
+  password: string;
+}
+
+export async function deletePasswordAsync({
+  username,
+  serviceName,
+}: Pick<Credentials, 'username' | 'serviceName'>): Promise<void> {
+  return await new Promise((resolve, reject) => {
+    keychain.deletePassword(
+      { account: username, service: serviceName, type: KEYCHAIN_TYPE },
+      (error: Error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      }
+    );
+  });
+}
+
+export async function getPasswordAsync({
+  username,
+  serviceName,
+}: Pick<Credentials, 'serviceName' | 'username'>): Promise<string | null> {
+  return await new Promise((resolve, reject) => {
+    keychain.getPassword(
+      { account: username, service: serviceName, type: KEYCHAIN_TYPE },
+      (error: Error, password: string) => {
+        if (error) {
+          if (error.message.match(NO_PASSWORD_REGEX)) {
+            return resolve(null);
+          }
+          reject(error);
+        } else {
+          resolve(password);
+        }
+      }
+    );
+  });
+}
+
+export async function setPasswordAsync({
+  serviceName,
+  username,
+  password,
+}: Credentials): Promise<void> {
+  return await new Promise((resolve, reject) => {
+    keychain.setPassword(
+      { account: username, service: serviceName, password, type: KEYCHAIN_TYPE },
+      (error: Error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      }
+    );
+  });
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
@@ -1,0 +1,139 @@
+import ora from 'ora';
+
+import { findP12CertSerialNumber } from '../utils/p12Certificate';
+import {
+  DistributionCertificate,
+  ProvisioningProfile,
+  ProvisioningProfileStoreInfo,
+} from './Credentials.types';
+import { AuthCtx } from './authenticate';
+import { runActionAsync, travelingFastlane } from './fastlane';
+
+export async function useExistingProvisioningProfileAsync(
+  ctx: AuthCtx,
+  bundleIdentifier: string,
+  provisioningProfile: ProvisioningProfile,
+  distCert: DistributionCertificate
+): Promise<ProvisioningProfile> {
+  const spinner = ora(`Configuring existing Provisioning Profiles from Apple...`).start();
+  try {
+    if (!provisioningProfile.provisioningProfileId) {
+      throw new Error('Provisioning profile: cannot use existing profile, insufficient id');
+    }
+
+    if (!distCert.distCertSerialNumber) {
+      distCert.distCertSerialNumber = findP12CertSerialNumber(
+        distCert.certP12,
+        distCert.certPassword
+      );
+    }
+
+    const args = [
+      'use-existing',
+      ctx.appleId,
+      ctx.appleIdPassword,
+      ctx.team.id,
+      String(ctx.team.inHouse),
+      bundleIdentifier,
+      provisioningProfile.provisioningProfileId,
+      distCert.distCertSerialNumber,
+    ];
+    const result = await runActionAsync(travelingFastlane.manageProvisioningProfiles, args);
+    spinner.succeed();
+    return {
+      ...result,
+      teamId: ctx.team.id,
+      teamName: ctx.team.name,
+    };
+  } catch (error) {
+    spinner.fail();
+    throw error;
+  }
+}
+
+export async function listProvisioningProfilesAsync(
+  ctx: AuthCtx,
+  bundleIdentifier: string
+): Promise<ProvisioningProfileStoreInfo[]> {
+  const spinner = ora(`Getting Provisioning Profiles from Apple...`).start();
+  try {
+    const args = [
+      'list',
+      ctx.appleId,
+      ctx.appleIdPassword,
+      ctx.team.id,
+      String(ctx.team.inHouse),
+      bundleIdentifier,
+    ];
+    const { profiles } = await runActionAsync(travelingFastlane.manageProvisioningProfiles, args);
+    spinner.succeed();
+    return profiles.map((profile: Omit<ProvisioningProfileStoreInfo, 'teamId' | 'teamName'>) => ({
+      ...profile,
+      teamId: ctx.team.id,
+      teamName: ctx.team.name,
+    }));
+  } catch (error) {
+    spinner.fail();
+    throw error;
+  }
+}
+
+export async function createProvisioningProfileAsync(
+  ctx: AuthCtx,
+  bundleIdentifier: string,
+  distCert: DistributionCertificate,
+  profileName: string
+): Promise<ProvisioningProfile> {
+  const spinner = ora(`Creating Provisioning Profile on Apple Servers...`).start();
+  try {
+    if (!distCert.distCertSerialNumber) {
+      distCert.distCertSerialNumber = findP12CertSerialNumber(
+        distCert.certP12,
+        distCert.certPassword
+      );
+    }
+
+    const args = [
+      'create',
+      ctx.appleId,
+      ctx.appleIdPassword,
+      ctx.team.id,
+      String(ctx.team.inHouse),
+      bundleIdentifier,
+      distCert.distCertSerialNumber,
+      profileName,
+    ];
+    const result = await runActionAsync(travelingFastlane.manageProvisioningProfiles, args);
+    spinner.succeed();
+    return {
+      ...result,
+      teamId: ctx.team.id,
+      teamName: ctx.team.name,
+    };
+  } catch (error) {
+    spinner.fail('Failed to create Provisioning Profile on Apple Servers');
+    throw error;
+  }
+}
+
+export async function revokeProvisioningProfileAsync(
+  ctx: AuthCtx,
+  bundleIdentifier: string
+): Promise<void> {
+  const spinner = ora(`Revoking Provisioning Profile on Apple Servers...`).start();
+  try {
+    const args = [
+      'revoke',
+      ctx.appleId,
+      ctx.appleIdPassword,
+      ctx.team.id,
+      String(ctx.team.inHouse),
+      bundleIdentifier,
+    ];
+    await runActionAsync(travelingFastlane.manageProvisioningProfiles, args);
+    spinner.succeed();
+  } catch (error) {
+    spinner.fail('Failed to revoke Provisioning Profile on Apple Servers');
+    throw error;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -1,0 +1,56 @@
+import ora from 'ora';
+
+import { ProvisioningProfile } from './Credentials.types';
+import { AuthCtx } from './authenticate';
+import { runActionAsync, travelingFastlane } from './fastlane';
+
+export async function createOrReuseAdhocProvisioningProfileAsync(
+  ctx: AuthCtx,
+  udids: string[],
+  bundleIdentifier: string,
+  distCertSerialNumber: string
+): Promise<ProvisioningProfile> {
+  const spinner = ora(`Handling Adhoc provisioning profiles on Apple Developer Portal...`).start();
+  try {
+    const args = [
+      '--apple-id',
+      ctx.appleId,
+      '--apple-password',
+      ctx.appleIdPassword,
+      ctx.team.id,
+      udids.join(','),
+      bundleIdentifier,
+      distCertSerialNumber,
+    ];
+    const adhocProvisioningProfile = await runActionAsync(
+      travelingFastlane.manageAdHocProvisioningProfile,
+      args
+    );
+
+    const {
+      provisioningProfileUpdateTimestamp,
+      provisioningProfileCreateTimestamp,
+      provisioningProfileName,
+    } = adhocProvisioningProfile;
+    if (provisioningProfileCreateTimestamp) {
+      spinner.succeed(`Created new profile: ${provisioningProfileName}`);
+    } else if (provisioningProfileUpdateTimestamp) {
+      spinner.succeed(`Updated existing profile: ${provisioningProfileName}`);
+    } else {
+      spinner.succeed(`Used existing profile: ${provisioningProfileName}`);
+    }
+
+    delete adhocProvisioningProfile.provisioningProfileUpdateTimestamp;
+    delete adhocProvisioningProfile.provisioningProfileCreateTimestamp;
+    delete adhocProvisioningProfile.provisioningProfileName;
+
+    return {
+      ...adhocProvisioningProfile,
+      teamId: ctx.team.id,
+      teamName: ctx.team.name,
+    };
+  } catch (error) {
+    spinner.fail();
+    throw error;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
@@ -1,0 +1,65 @@
+import chalk from 'chalk';
+import dateformat from 'dateformat';
+import ora from 'ora';
+
+import log from '../../../log';
+import { PushKey, PushKeyStoreInfo } from './Credentials.types';
+import { AuthCtx } from './authenticate';
+import { runActionAsync, travelingFastlane } from './fastlane';
+
+const APPLE_KEYS_TOO_MANY_GENERATED_ERROR = `
+You can have only ${chalk.underline('two')} Apple Keys generated on your Apple Developer account.
+Please revoke the old ones or reuse existing from your other apps.
+Please remember that Apple Keys are not application specific!
+`;
+
+export async function listPushKeysAsync(ctx: AuthCtx): Promise<PushKeyStoreInfo[]> {
+  const spinner = ora(`Getting Push Keys from Apple...`).start();
+  try {
+    const args = ['list', ctx.appleId, ctx.appleIdPassword, ctx.team.id];
+    const { keys } = await runActionAsync(travelingFastlane.managePushKeys, args);
+    spinner.succeed();
+    return keys;
+  } catch (error) {
+    spinner.fail();
+    throw error;
+  }
+}
+
+export async function createPushKeyAsync(
+  ctx: AuthCtx,
+  name: string = `Expo Push Notifications Key ${dateformat('yyyymmddHHMMss')}`
+): Promise<PushKey> {
+  const spinner = ora(`Creating Push Key on Apple Servers...`).start();
+  try {
+    const args = ['create', ctx.appleId, ctx.appleIdPassword, ctx.team.id, name];
+    const { apnsKeyId, apnsKeyP8 } = await runActionAsync(travelingFastlane.managePushKeys, args);
+    spinner.succeed();
+    return {
+      apnsKeyId,
+      apnsKeyP8,
+      teamId: ctx.team.id,
+      teamName: ctx.team.name,
+    };
+  } catch (err) {
+    spinner.fail('Failed to create Push Notifications Key');
+    const resultString = err.rawDump?.resultString;
+    if (resultString && resultString.match(/maximum allowed number of Keys/)) {
+      throw new Error(APPLE_KEYS_TOO_MANY_GENERATED_ERROR);
+    }
+    throw err;
+  }
+}
+
+export async function revokePushKeyAsync(ctx: AuthCtx, ids: string[]): Promise<void> {
+  const spinner = ora(`Revoking Push Key on Apple Servers...`).start();
+  try {
+    const args = ['revoke', ctx.appleId, ctx.appleIdPassword, ctx.team.id, ids.join(',')];
+    await runActionAsync(travelingFastlane.managePushKeys, args);
+    spinner.succeed();
+  } catch (error) {
+    log.error(error);
+    spinner.fail('Failed to revoke Push Key on Apple Servers');
+    throw error;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/utils/p12Certificate.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/p12Certificate.ts
@@ -1,0 +1,49 @@
+import forge, { pki } from 'node-forge';
+
+export function getP12CertFingerprint(
+  p12Buffer: Buffer | string,
+  passwordRaw: string | null
+): string {
+  const certData = _getCertData(p12Buffer, passwordRaw);
+  const certAsn1 = forge.pki.certificateToAsn1(certData);
+  const certDer = forge.asn1.toDer(certAsn1).getBytes();
+  return forge.md.sha1.create().update(certDer).digest().toHex().toUpperCase();
+}
+
+export function findP12CertSerialNumber(
+  p12Buffer: Buffer | string,
+  passwordRaw: string | null
+): string {
+  const { serialNumber } = getCertData(p12Buffer, passwordRaw);
+  return serialNumber;
+}
+
+export function getCertData(
+  p12Buffer: Buffer | string,
+  passwordRaw: string | null
+): pki.Certificate {
+  const certData = _getCertData(p12Buffer, passwordRaw);
+  return {
+    ...certData,
+    serialNumber: certData.serialNumber.replace(/^0+/, '').toUpperCase(),
+  };
+}
+
+function _getCertData(p12Buffer: Buffer | string, passwordRaw: string | null): pki.Certificate {
+  if (Buffer.isBuffer(p12Buffer)) {
+    p12Buffer = p12Buffer.toString('base64');
+  } else if (typeof p12Buffer !== 'string') {
+    throw new Error('_getCertData only takes strings and buffers.');
+  }
+
+  const password = String(passwordRaw || '');
+  const p12Der = forge.util.decode64(p12Buffer);
+  const p12Asn1 = forge.asn1.fromDer(p12Der);
+  const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, password);
+  const certBagType = forge.pki.oids.certBag;
+  const certData = p12.getBags({ bagType: certBagType })?.[certBagType]?.[0]?.cert;
+  if (!certData) {
+    throw new Error("_getCertData: couldn't find cert bag");
+  }
+  return certData;
+}

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -1,0 +1,67 @@
+import chalk from 'chalk';
+
+type Color = (...text: string[]) => string;
+
+let _isLastLineNewLine = false;
+function _updateIsLastLineNewLine(args: any[]) {
+  if (args.length === 0) {
+    _isLastLineNewLine = true;
+  } else {
+    const lastArg = args[args.length - 1];
+    if (typeof lastArg === 'string' && (lastArg === '' || lastArg.match(/[\r\n]$/))) {
+      _isLastLineNewLine = true;
+    } else {
+      _isLastLineNewLine = false;
+    }
+  }
+}
+
+function consoleLog(...args: any[]) {
+  _updateIsLastLineNewLine(args);
+
+  console.log(...args);
+}
+
+function consoleWarn(...args: any[]) {
+  _updateIsLastLineNewLine(args);
+
+  console.warn(...args);
+}
+
+function consoleError(...args: any[]) {
+  _updateIsLastLineNewLine(args);
+
+  console.error(...args);
+}
+
+function withTextColor(args: any[], chalkColor: Color) {
+  return args.map(arg => chalkColor(arg));
+}
+
+function log(...args: any[]) {
+  consoleLog(...args);
+}
+
+log.newLine = function newLine() {
+  consoleLog();
+};
+
+log.addNewLineIfNone = function addNewLineIfNone() {
+  if (!_isLastLineNewLine) {
+    log.newLine();
+  }
+};
+
+log.error = function error(...args: any[]) {
+  consoleError(...withTextColor(args, chalk.red));
+};
+
+log.warn = function warn(...args: any[]) {
+  consoleWarn(...withTextColor(args, chalk.yellow));
+};
+
+log.gray = function (...args: any[]) {
+  consoleLog(...withTextColor(args, chalk.gray));
+};
+
+export default log;

--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -1,0 +1,16 @@
+import { exit } from '@oclif/errors';
+import { constants } from 'os';
+import prompts, { Options, PromptType, PromptObject as Question } from 'prompts';
+
+export { PromptType, Question };
+
+type PromptOptions = { nonInteractiveHelp?: string } & Options;
+
+export function prompt(questions: Question | Question[], options: PromptOptions = {}) {
+  return prompts(questions, {
+    onCancel() {
+      exit(constants.signals.SIGINT + 128); // Exit code 130 used when process is interrupted with ctrl+c.
+    },
+    ...options,
+  });
+}

--- a/packages/eas-cli/tsconfig.json
+++ b/packages/eas-cli/tsconfig.json
@@ -7,7 +7,12 @@
     "outDir": "build",
     "rootDir": "src",
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "typeRoots": [
+      "../../ts-declarations",
+      "./node_modules/@types",
+      "../../node_modules/@types"
+    ]
   },
   "include": ["src/**/*"]
 }

--- a/ts-declarations/keychain/index.d.ts
+++ b/ts-declarations/keychain/index.d.ts
@@ -1,0 +1,15 @@
+declare module 'keychain' {
+  interface Options {
+    account: string;
+    service: string;
+    type: string;
+  }
+
+  interface OptionsWitPassword extends Options {
+    password: string;
+  }
+
+  function getPassword(opts: Options, cb: (err: Error, password: string) => void): void;
+  function setPassword(opts: OptionsWitPassword, cb: (err: Error) => void): void;
+  function deletePassword(opts: Options, cb: (err: Error) => void): void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,6 +1100,16 @@
     fs-extra "^9.0.0"
     lodash.template "^4.5.0"
 
+"@expo/traveling-fastlane-darwin@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.15.1.tgz#87b34e39a91377044070a55f3b03c575d00be39e"
+  integrity sha512-7sjG83+o9BT4MVPNq2UVqy1Oyg3n47FpEIDxc0M9CQvbC1WgYsAKloOJ85g5GRXZAjqzPOPUZF+lBhGbOwmQvg==
+
+"@expo/traveling-fastlane-linux@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.15.1.tgz#3b77e3a3d490cbe59fbcffd155068e267c2e95c8"
+  integrity sha512-YaFAYYOOxImYNx9s6X3tY6fC1y6rka0KXstrs2zrS+vHyyBD8IOhNtIUvybHScM3jUL+qukgKElAb+7gzlF6Eg==
+
 "@expo/turtle-spawn@0.0.13":
   version "0.0.13"
   resolved "https://registry.yarnpkg.com/@expo/turtle-spawn/-/turtle-spawn-0.0.13.tgz#207604e3eab99a4e6bf17aa26d39e6572df84dcd"
@@ -2331,6 +2341,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/dateformat@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/dateformat/-/dateformat-3.0.1.tgz#98d747a2e5e9a56070c6bf14e27bff56204e34cc"
+  integrity sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -2438,6 +2453,13 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
+"@types/node-forge@^0.9.5":
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-0.9.5.tgz#648231d79da197216290429020698d4e767365a0"
+  integrity sha512-rrN3xfA/oZIzwOnO3d2wRQz7UdeVkmMMPjWUCfpPTPuKFVb3D6G10LuiVHYYmvrivBBLMx4m0P/FICoDbNZUMA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@>= 8":
   version "14.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
@@ -2476,6 +2498,11 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/wordwrap@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/wordwrap/-/wordwrap-1.0.0.tgz#959ffdd318eb8b6915de78c8fc4978681ad2aa4d"
+  integrity sha512-XknqsI3sxtVduA/zP475wjMPH/qaZB6teY+AGvZkNUPhwxAac/QuKt6fpJCY9iO6ZpDhBmu9iOHgLXK78hoEDA==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -3355,6 +3382,11 @@ cli-progress@^3.4.0:
     colors "^1.1.2"
     string-width "^4.2.0"
 
+cli-spinners@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.4.0.tgz#c6256db216b878cfba4720e719cec7cf72685d7f"
+  integrity sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==
+
 cli-ux@^5.2.1:
   version "5.4.9"
   resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-5.4.9.tgz#2e6dc990d977efea2592daa14f78ace092666e1a"
@@ -3771,7 +3803,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dateformat@^3.0.0:
+dateformat@^3.0.0, dateformat@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
@@ -5638,6 +5670,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -6376,6 +6413,11 @@ jsx-ast-utils@^2.4.1:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
 
+keychain@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/keychain/-/keychain-1.3.0.tgz#ccb8ddc64a62f34d541ac25e612186442a432410"
+  integrity sha1-zLjdxkpi801UGsJeYSGGRCpDJBA=
+
 keyv@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.1.tgz#9fe703cb4a94d6d11729d320af033307efd02ee6"
@@ -6590,6 +6632,13 @@ lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+log-symbols@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
+  integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
+  dependencies:
+    chalk "^4.0.0"
 
 loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -7055,6 +7104,11 @@ node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-forge@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+
 node-forge@^0.9.1:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.2.tgz#b35a44c28889b2ea55cabf8c79e3563f9676190a"
@@ -7364,6 +7418,20 @@ optionator@^0.8.1, optionator@^0.8.3:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
+
+ora@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.1.0.tgz#b188cf8cd2d4d9b13fd25383bc3e5cba352c94f8"
+  integrity sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==
+  dependencies:
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.4.0"
+    is-interactive "^1.0.0"
+    log-symbols "^4.0.0"
+    mute-stream "0.0.8"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -9032,7 +9100,7 @@ tempy@^0.7.0:
     type-fest "^0.16.0"
     unique-string "^2.0.0"
 
-terminal-link@^2.0.0:
+terminal-link@^2.0.0, terminal-link@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
   integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
@@ -9517,7 +9585,7 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-wcwidth@^1.0.0:
+wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=


### PR DESCRIPTION
# Why
Part of #20 

# How

Moved from expo-cli.

Changes from expo-cli implementation:
- rename to `appstore`
- move P12Utils from xdl
- ensure all ora spinners are always stopped
- modify keychain password storage (mostly around non macos systems)
- add prompt and log utils (`log.ts` is copied from expo-cli)
- add `Async` suffix

# Test plan

tested only authentication
