### PR TITLE
[eas-cli] add foundation for device:create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 /package-lock.json
 tmp
 node_modules
+.history

--- a/packages/eas-cli/__mocks__/@expo/config.ts
+++ b/packages/eas-cli/__mocks__/@expo/config.ts
@@ -1,0 +1,3 @@
+const getConfig = jest.fn();
+
+export { getConfig };

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
     "@eas/config": "0.0.1",
-    "@expo/config": "^3.3.8",
+    "@expo/config": "^3.3.9",
     "@expo/json-file": "^8.2.24",
     "@expo/spawn-async": "^1.5.0",
     "@oclif/command": "^1",
@@ -27,6 +27,7 @@
     "node-fetch": "^2.6.1",
     "node-forge": "^0.10.0",
     "ora": "^5.1.0",
+    "pkg-dir": "^4.2.0",
     "prompts": "^2.3.2",
     "terminal-link": "^2.1.1",
     "tslib": "^1",

--- a/packages/eas-cli/src/__tests__/utils.ts
+++ b/packages/eas-cli/src/__tests__/utils.ts
@@ -1,0 +1,3 @@
+export function asMock(fn: any): jest.Mock {
+  return fn as jest.Mock;
+}

--- a/packages/eas-cli/src/commands/device/create.ts
+++ b/packages/eas-cli/src/commands/device/create.ts
@@ -1,0 +1,18 @@
+import { Command } from '@oclif/command';
+
+import AppStoreApi from '../../credentials/ios/appstore/AppStoreApi';
+import { createContext } from '../../devices/context';
+import DeviceManager from '../../devices/manager';
+import { ensureLoggedInAsync } from '../../user/actions';
+
+export default class DeviceCreate extends Command {
+  static description = 'register new Apple Devices to use for internal distribution';
+
+  async run() {
+    const user = await ensureLoggedInAsync();
+
+    const ctx = await createContext({ appStore: new AppStoreApi(), user });
+    const manager = new DeviceManager(ctx);
+    await manager.createAsync();
+  }
+}

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-constants.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-constants.ts
@@ -3,11 +3,13 @@ import { User } from '../../user/User';
 export const jester: User = {
   username: 'jester',
   userId: 'jester-id',
+  accounts: [{ id: 'jester-account-id', name: 'jester' }],
 };
 
 export const jester2: User = {
   username: 'jester2',
   userId: 'jester2-id',
+  accounts: [{ id: 'jester2-account-id', name: 'jester2' }],
 };
 
 export const testUsername = jester.username;

--- a/packages/eas-cli/src/credentials/ios/adhoc/devices.ts
+++ b/packages/eas-cli/src/credentials/ios/adhoc/devices.ts
@@ -1,0 +1,11 @@
+import chalk from 'chalk';
+
+import log from '../../../log';
+import { Account } from '../../../user/Account';
+
+export async function generateDeviceRegistrationURL(account: Account, appleTeamId: string) {
+  log.error(
+    `this will generate a URL for registering devices under account ${account.name} and apple team id ${appleTeamId}`
+  );
+  log.error(`but it's ${chalk.bold('not implemented yet')}`);
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
@@ -1,3 +1,19 @@
+export interface Device {
+  id: string;
+  teamId: string;
+  identifier: string;
+  name?: string;
+  model?: string;
+  deviceClass?: DeviceClass;
+  softwareVersion?: string;
+  enabled: boolean;
+}
+
+export enum DeviceClass {
+  IPHONE = 'iphone',
+  IPAD = 'ipad',
+}
+
 export interface DistributionCertificateStoreInfo {
   id: string;
   name: string;

--- a/packages/eas-cli/src/devices/__tests__/manager-test.ts
+++ b/packages/eas-cli/src/devices/__tests__/manager-test.ts
@@ -1,0 +1,93 @@
+import prompts from 'prompts';
+
+import { asMock } from '../../__tests__/utils';
+import { User } from '../../user/User';
+import { AccountResolver } from '../manager';
+
+jest.mock('prompts');
+
+jest.mock('../../utils/project', () => {
+  return {
+    getProjectAccountNameAsync: () => 'foo',
+  };
+});
+
+beforeEach(() => {
+  asMock(prompts).mockReset();
+  asMock(prompts).mockImplementation(() => {
+    throw new Error(`unhandled prompts call - this shouldn't happen - fix tests!`);
+  });
+});
+
+describe(AccountResolver, () => {
+  describe('#resolveAccountAsync', () => {
+    const user: User = {
+      userId: 'user_id_666',
+      username: 'dominik',
+      accounts: [
+        { id: 'account_id_777', name: 'dominik' },
+        { id: 'account_id_888', name: 'foo' },
+      ],
+    };
+
+    describe('when inside project dir', () => {
+      const projectDir = '/app';
+
+      it('returns the account defined in app.json/app.config.js if user confirms', async () => {
+        asMock(prompts).mockImplementationOnce(() => ({
+          value: true,
+        }));
+
+        const resolver = new AccountResolver(projectDir, user);
+        const account = await resolver.resolveAccountAsync();
+        expect(account).toEqual(user.accounts[1]);
+      });
+
+      it('asks the user to choose the account from his account list if he rejects to use the one defined in app.json / app.config.js', async () => {
+        asMock(prompts).mockImplementationOnce(() => ({
+          useProjectAccount: false,
+        }));
+        asMock(prompts).mockImplementationOnce(() => ({
+          account: user.accounts[0],
+        }));
+
+        const resolver = new AccountResolver(projectDir, user);
+        const account = await resolver.resolveAccountAsync();
+        expect(account).toEqual(user.accounts[0]);
+      });
+
+      it(`asks the user to choose the account from his account list if he doesn't have access to the account defined in app.json / app.config.js`, async () => {
+        asMock(prompts).mockImplementationOnce(() => ({
+          account: user.accounts[0],
+        }));
+
+        const userWithAccessToProjectAccount: User = {
+          ...user,
+          accounts: [user.accounts[0]],
+        };
+
+        const originalConsoleWarn = console.warn;
+        console.warn = jest.fn();
+
+        const resolver = new AccountResolver(projectDir, userWithAccessToProjectAccount);
+        const account = await resolver.resolveAccountAsync();
+        expect(account).toEqual(user.accounts[0]);
+        expect(console.warn).toBeCalledWith(expect.stringMatching(/doesn't have access to the/));
+
+        console.warn = originalConsoleWarn;
+      });
+    });
+
+    describe('when outside project dir', () => {
+      it('asks the user to choose the account from his account list', async () => {
+        asMock(prompts).mockImplementationOnce(() => ({
+          account: user.accounts[0],
+        }));
+
+        const resolver = new AccountResolver(null, user);
+        const account = await resolver.resolveAccountAsync();
+        expect(account).toEqual(user.accounts[0]);
+      });
+    });
+  });
+});

--- a/packages/eas-cli/src/devices/actions/__tests__/create-test.ts
+++ b/packages/eas-cli/src/devices/actions/__tests__/create-test.ts
@@ -1,0 +1,37 @@
+import prompts from 'prompts';
+
+import { asMock } from '../../../__tests__/utils';
+import { generateDeviceRegistrationURL } from '../../../credentials/ios/adhoc/devices';
+import { Account } from '../../../user/Account';
+import DeviceCreateAction, { RegistrationMethod } from '../create';
+
+jest.mock('prompts');
+jest.mock('../../../credentials/ios/adhoc/devices');
+
+beforeEach(() => {
+  const promptsMock = asMock(prompts);
+  promptsMock.mockReset();
+  promptsMock.mockImplementation(() => {
+    throw new Error(`unhandled prompts call - this shouldn't happen - fix tests!`);
+  });
+});
+
+describe(DeviceCreateAction, () => {
+  describe('#runAsync', () => {
+    it('calls generateDeviceRegistrationURL if user chooses the website option', async () => {
+      asMock(prompts).mockImplementationOnce(() => ({
+        method: RegistrationMethod.WEBSITE,
+      }));
+
+      const account: Account = {
+        id: 'account_id',
+        name: 'foobar',
+      };
+      const appleTeamId = 'ABC123Y';
+      const action = new DeviceCreateAction(account, appleTeamId);
+      await action.runAsync();
+
+      expect(generateDeviceRegistrationURL).toBeCalled();
+    });
+  });
+});

--- a/packages/eas-cli/src/devices/actions/create.ts
+++ b/packages/eas-cli/src/devices/actions/create.ts
@@ -1,0 +1,53 @@
+import chalk from 'chalk';
+
+import { generateDeviceRegistrationURL } from '../../credentials/ios/adhoc/devices';
+import log from '../../log';
+import { promptAsync } from '../../prompts';
+import { Account } from '../../user/Account';
+
+export enum RegistrationMethod {
+  WEBSITE,
+  INPUT,
+  EXIT,
+}
+
+export default class DeviceCreateAction {
+  constructor(private account: Account, private appleTeamId: string) {}
+
+  public async runAsync(): Promise<void> {
+    const method = await this.askForRegistrationMethodAsync();
+
+    if (method === RegistrationMethod.WEBSITE) {
+      await generateDeviceRegistrationURL(this.account, this.appleTeamId);
+    } else if (method === RegistrationMethod.INPUT) {
+      throw new Error('not implemented yet');
+    } else if (method === RegistrationMethod.EXIT) {
+      log('Bye!');
+      process.exit(0);
+    }
+  }
+
+  private async askForRegistrationMethodAsync(): Promise<RegistrationMethod> {
+    const { method } = await promptAsync({
+      type: 'select',
+      name: 'method',
+      message: `How would you like to register your devices?`,
+      choices: [
+        {
+          title: `${chalk.bold(
+            'Website'
+          )} - generates a registration URL to be opened on your devices`,
+          value: RegistrationMethod.WEBSITE,
+        },
+        {
+          title: `${chalk.bold('Input')} - allows you to type in UDIDs (advanced option)`,
+          value: RegistrationMethod.INPUT,
+        },
+        { title: chalk.bold('Exit'), value: RegistrationMethod.EXIT },
+      ],
+      validate: (val: RegistrationMethod) => Object.values(RegistrationMethod).includes(val),
+      initial: RegistrationMethod.WEBSITE,
+    });
+    return method;
+  }
+}

--- a/packages/eas-cli/src/devices/context.ts
+++ b/packages/eas-cli/src/devices/context.ts
@@ -1,0 +1,25 @@
+import AppStoreApi from '../credentials/ios/appstore/AppStoreApi';
+import { User } from '../user/User';
+import { findProjectRootAsync } from '../utils/project';
+
+export interface DeviceManagerContext {
+  appStore: AppStoreApi;
+  projectDir: string | null;
+  user: User;
+}
+
+export async function createContext({
+  appStore,
+  cwd,
+  user,
+}: {
+  appStore: AppStoreApi;
+  cwd?: string;
+  user: User;
+}): Promise<DeviceManagerContext> {
+  return {
+    appStore,
+    projectDir: await findProjectRootAsync(cwd),
+    user,
+  };
+}

--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -1,0 +1,91 @@
+import assert from 'assert';
+import chalk from 'chalk';
+
+import log from '../log';
+import { Choice, confirmAsync, promptAsync } from '../prompts';
+import { Account, findAccountByName } from '../user/Account';
+import { User } from '../user/User';
+import { getProjectAccountNameAsync } from '../utils/project';
+import DeviceCreateAction from './actions/create';
+import { DeviceManagerContext } from './context';
+
+const CREATE_COMMAND_DESCRIPTION = `This command lets you register your Apple devices (iPhones and iPads) for internal distribution of your app.
+Internal distribution means that you won't need upload your app archive to App Store / Testflight.
+Your app archive (.ipa) will be installable on your equipment as long as you sign your application with an adhoc provisiong profile.
+The provisioning profile needs to contain the UDIDs (unique identifiers) of your iPhones and iPads.
+
+First of all, please choose the Expo account under which you want to register your devices.
+Later, authenticate with Apple and choose your desired Apple Team (if you're Apple ID has access to multiple teams).`;
+
+export default class DeviceManager {
+  constructor(private ctx: DeviceManagerContext) {}
+
+  public async createAsync(): Promise<void> {
+    log(chalk.green(CREATE_COMMAND_DESCRIPTION));
+    log.addNewLineIfNone();
+
+    const account = await this.resolveAccountAsync();
+    const { team: appleTeam } = await this.ctx.appStore.ensureAuthenticatedAsync();
+
+    const action = new DeviceCreateAction(account, appleTeam.id);
+    await action.runAsync();
+  }
+
+  private async resolveAccountAsync(): Promise<Account> {
+    const resolver = new AccountResolver(this.ctx.projectDir, this.ctx.user);
+    return await resolver.resolveAccountAsync();
+  }
+}
+
+export class AccountResolver {
+  constructor(private projectDir: string | null, private user: User) {}
+
+  public async resolveAccountAsync(): Promise<Account> {
+    if (this.projectDir) {
+      const account = await this.resolveProjectAccountAsync();
+      if (account) {
+        return account;
+      }
+    }
+    return await this.promptForAccountAsync();
+  }
+
+  private async resolveProjectAccountAsync(): Promise<Account | undefined> {
+    assert(this.projectDir, 'project directory is not set ');
+
+    const projectAccountName = await getProjectAccountNameAsync(this.projectDir);
+    const projectAccount = findAccountByName(this.user.accounts, projectAccountName);
+    if (!projectAccount) {
+      log.warn(
+        `Your user (${this.user.username}) doesn't have access to the ${chalk.bold(
+          projectAccountName
+        )} account`
+      );
+      return;
+    }
+
+    const useProjectAccount = await confirmAsync({
+      message: `You're inside the project directory. Would you like to use ${chalk.underline(
+        projectAccountName
+      )} account?`,
+    });
+
+    if (useProjectAccount) {
+      return projectAccount;
+    }
+  }
+
+  private async promptForAccountAsync(): Promise<Account> {
+    const choices: Choice[] = this.user.accounts.map(account => ({
+      title: account.name,
+      value: account,
+    }));
+    const { account } = await promptAsync({
+      type: 'select',
+      name: 'account',
+      message: 'Which account to use?',
+      choices,
+    });
+    return account;
+  }
+}

--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -1,15 +1,15 @@
 import { constants } from 'os';
-import prompts, { Answers, Options, PromptType, PromptObject as Question } from 'prompts';
+import prompts, { Answers, Choice, Options, PromptType, PromptObject as Question } from 'prompts';
 
-export { PromptType, Question };
+export { PromptType, Question, Choice };
 
 type NamelessQuestion = Omit<Question<'value'>, 'name' | 'type'>;
 
 export async function promptAsync<T extends string = string>(
   questions: Question<T> | Question<T>[],
   options: Options = {}
-): Promise<prompts.Answers<T>> {
-  return await prompts(questions, {
+): Promise<Answers<T>> {
+  return await prompts<T>(questions, {
     onCancel() {
       process.exit(constants.signals.SIGINT + 128); // Exit code 130 used when process is interrupted with ctrl+c.
     },
@@ -30,5 +30,5 @@ export async function confirmAsync(
     },
     options
   );
-  return value ?? null;
+  return value;
 }

--- a/packages/eas-cli/src/user/Account.ts
+++ b/packages/eas-cli/src/user/Account.ts
@@ -1,0 +1,8 @@
+export interface Account {
+  id: string;
+  name: string;
+}
+
+export function findAccountByName(accounts: Account[], needle: string): Account | undefined {
+  return accounts.find(({ name }) => name === needle);
+}

--- a/packages/eas-cli/src/user/User.ts
+++ b/packages/eas-cli/src/user/User.ts
@@ -1,11 +1,13 @@
 import gql from 'graphql-tag';
 
 import { apiClient, graphqlClient } from '../api';
+import { Account } from './Account';
 import { getSession, setSessionAsync } from './sessionStorage';
 
 export interface User {
   userId: string;
   username: string;
+  accounts: Account[];
 }
 
 let currentUser: User | undefined;
@@ -27,6 +29,10 @@ export async function getUserAsync(): Promise<User | undefined> {
             viewer {
               id
               username
+              accounts {
+                id
+                name
+              }
             }
           }
         `
@@ -36,6 +42,7 @@ export async function getUserAsync(): Promise<User | undefined> {
     currentUser = {
       userId: data.viewer.id,
       username: data.viewer.username,
+      accounts: data.viewer.accounts,
     };
   }
   return currentUser;

--- a/packages/eas-cli/src/utils/__tests__/project-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/project-test.ts
@@ -1,0 +1,95 @@
+import { getConfig } from '@expo/config';
+import { vol } from 'memfs';
+
+import { asMock } from '../../__tests__/utils';
+import { User, getUserAsync } from '../../user/User';
+import { findProjectRootAsync, getProjectAccountNameAsync } from '../project';
+
+jest.mock('@expo/config');
+jest.mock('fs');
+
+jest.mock('../../user/User');
+
+describe(findProjectRootAsync, () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it('returns null if not inside the project directory', async () => {
+    vol.fromJSON(
+      {
+        './README.md': '1',
+      },
+      '/app'
+    );
+    const projectRoot = await findProjectRootAsync('/app');
+    expect(projectRoot).toBeNull();
+  });
+
+  it('returns the root directory of the project', async () => {
+    vol.fromJSON(
+      {
+        './README.md': '1',
+        './package.json': '2',
+        './src/index.ts': '3',
+      },
+      '/app'
+    );
+    const projectRoot = await findProjectRootAsync('/app/src');
+    expect(projectRoot).toBe('/app');
+  });
+});
+
+describe(getProjectAccountNameAsync, () => {
+  beforeEach(() => {
+    asMock(getConfig).mockReset();
+    asMock(getUserAsync).mockReset();
+  });
+
+  it(`returns the owner field's value from app.json / app.config.js`, async () => {
+    asMock(getConfig).mockImplementation(() => ({
+      exp: {
+        owner: 'dominik',
+      },
+    }));
+    asMock(getUserAsync).mockImplementation((): User | undefined => ({
+      userId: 'user_id',
+      username: 'notnotbrent',
+      accounts: [
+        { id: 'account_id_1', name: 'notnotbrent' },
+        { id: 'account_id_2', name: 'dominik' },
+      ],
+    }));
+
+    const projectAccountName = await getProjectAccountNameAsync('/app');
+    expect(projectAccountName).toBe('dominik');
+  });
+
+  it(`returns the username if owner field is not set in app.json / app.config.js`, async () => {
+    asMock(getConfig).mockImplementation(() => ({
+      exp: {},
+    }));
+    asMock(getUserAsync).mockImplementation((): User | undefined => ({
+      userId: 'user_id',
+      username: 'notnotbrent',
+      accounts: [
+        { id: 'account_id_1', name: 'notnotbrent' },
+        { id: 'account_id_2', name: 'dominik' },
+      ],
+    }));
+
+    const projectAccountName = await getProjectAccountNameAsync('/app');
+    expect(projectAccountName).toBe('notnotbrent');
+  });
+
+  it(`throws an error if the user is not logged in`, async () => {
+    asMock(getConfig).mockImplementation(() => ({
+      exp: {
+        owner: 'dominik',
+      },
+    }));
+    asMock(getUserAsync).mockImplementation((): User | undefined => undefined);
+
+    expect(getProjectAccountNameAsync('/app')).rejects.toThrow(/logged in/);
+  });
+});

--- a/packages/eas-cli/src/utils/project.ts
+++ b/packages/eas-cli/src/utils/project.ts
@@ -1,0 +1,17 @@
+import { getConfig } from '@expo/config';
+import assert from 'assert';
+import pkgDir from 'pkg-dir';
+
+import { getUserAsync } from '../user/User';
+
+export async function getProjectAccountNameAsync(projectDir: string): Promise<string> {
+  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+  const user = await getUserAsync();
+  assert(user, 'You need to be logged in');
+  return exp.owner || user.username;
+}
+
+export async function findProjectRootAsync(cwd?: string): Promise<string | null> {
+  const projectRootDir = await pkgDir(cwd);
+  return projectRootDir ?? null;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,16 +1072,16 @@
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-40.0.0-beta.1.tgz#4192b120edc9ec235147329a50bd0a7da16ae89c"
   integrity sha512-hTp+6ZIKK57O8qhVoO+GBCkx0UCdOhwcWxaXfjpsELIR8LfXDGz8OmCxTzGvb7nnadcrGCccHBX5dO1NmPBbmg==
 
-"@expo/config@^3.3.8":
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.3.8.tgz#3e792809bc16d997138efb1c8cb9c8000187213e"
-  integrity sha512-TxopzvIFLJTt8GjN7k0BUhZp2NqWDMvw5+bMNhpNR6aFZMNU5JAO8eORNy0GdMV5KM0liu5fpT0yQAzAsniSMA==
+"@expo/config@^3.3.9":
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.3.9.tgz#d116be31654555031f450daaabbc9a6f929c90d2"
+  integrity sha512-AeM7CNUsvG0tN4vKwdcqQjl0x8nyYS2Xcao+9HWQf30+V2Kt2qAy5RjZUElR/H7sWapluudRjiyLQ7/ThgXTuQ==
   dependencies:
     "@babel/core" "7.9.0"
     "@expo/babel-preset-cli" "0.2.18"
     "@expo/config-types" "^40.0.0-beta.1"
     "@expo/configure-splash-screen" "0.2.1"
-    "@expo/image-utils" "0.3.6"
+    "@expo/image-utils" "0.3.7"
     "@expo/json-file" "8.2.24"
     "@expo/plist" "0.0.10"
     fs-extra "9.0.0"
@@ -1127,10 +1127,10 @@
     "@expo/logger" "0.0.13"
     "@expo/turtle-spawn" "0.0.13"
 
-"@expo/image-utils@0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.6.tgz#b51d8c51b6fc467696fdad0ee86b3663af482df5"
-  integrity sha512-jHbyqw3s/EG4XkVMI3EVt79sJJ6HiBajU5RwAscUVcNX9CpyJIhyvm05kNx0Dk+yANuDLkbyjvXJcZVLIYWZxg==
+"@expo/image-utils@0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.7.tgz#48436a5f509818dc43a30f73dbfd4baed88a5f23"
+  integrity sha512-Vo1p5uv1JlRacgVIiVa+83oRoHfC7grSU8cypAtgvOYpbmdCWR8+3F4v+vaabHe6ktvIKRE78jh6vHMGwv2aOA==
   dependencies:
     "@expo/spawn-async" "1.5.0"
     chalk "^4.0.0"
@@ -4455,21 +4455,21 @@ dedent@^0.7.0:
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-equal@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.0.3.tgz#cad1c15277ad78a5c01c49c2dee0f54de8a6a7b0"
-  integrity sha512-Spqdl4H+ky45I9ByyJtXteOm9CaIrPmnIPmOhrkKGNYWeDgCvJ8jNYVCTjChxW4FqGuZnLHADc8EKRMX6+CgvA==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.0.4.tgz#6b0b407a074666033169df3acaf128e1c6f3eab6"
+  integrity sha512-BUfaXrVoCfgkOQY/b09QdO9L3XNoF2XH0A3aY9IQwQL/ZjLOe8FQgCNVl1wiolhsFo8kFdO9zdPViCPbmaJA5w==
   dependencies:
-    es-abstract "^1.17.5"
+    es-abstract "^1.18.0-next.1"
     es-get-iterator "^1.1.0"
     is-arguments "^1.0.4"
     is-date-object "^1.0.2"
-    is-regex "^1.0.5"
+    is-regex "^1.1.1"
     isarray "^2.0.5"
-    object-is "^1.1.2"
+    object-is "^1.1.3"
     object-keys "^1.1.1"
-    object.assign "^4.1.0"
+    object.assign "^4.1.1"
     regexp.prototype.flags "^1.3.0"
-    side-channel "^1.0.2"
+    side-channel "^1.0.3"
     which-boxed-primitive "^1.0.1"
     which-collection "^1.0.1"
     which-typed-array "^1.1.2"
@@ -4738,7 +4738,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.4, es-abstract@^1.17.5:
+es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
   version "1.17.6"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
   integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
@@ -4752,6 +4752,41 @@ es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.4, es-abstrac
     object-inspect "^1.7.0"
     object-keys "^1.1.1"
     object.assign "^4.1.0"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-abstract@^1.17.4:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.7.tgz#a4de61b2f66989fc7421676c1cb9787573ace54c"
+  integrity sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.2"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.1"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-abstract@^1.18.0-next.0, es-abstract@^1.18.0-next.1:
+  version "1.18.0-next.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.1.tgz#6e3a0a4bda717e5023ab3b8e90bec36108d22c68"
+  integrity sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.2"
+    is-negative-zero "^2.0.0"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.1"
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
@@ -6222,6 +6257,11 @@ is-callable@^1.1.4, is-callable@^1.2.0:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
   integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
 
+is-callable@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
+  integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -6349,6 +6389,11 @@ is-map@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.1.tgz#520dafc4307bb8ebc33b813de5ce7c9400d644a1"
   integrity sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==
 
+is-negative-zero@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
+  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+
 is-number-object@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197"
@@ -6413,7 +6458,7 @@ is-potential-custom-element-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
 
-is-regex@^1.0.5, is-regex@^1.1.0:
+is-regex@^1.1.0, is-regex@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
@@ -8091,18 +8136,18 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.7.0:
+object-inspect@^1.7.0, object-inspect@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
-object-is@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.2.tgz#c5d2e87ff9e119f78b7a088441519e2eec1573b6"
-  integrity sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==
+object-is@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.3.tgz#2e3b9e65560137455ee3bd62aec4d90a2ea1cc81"
+  integrity sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==
   dependencies:
     define-properties "^1.1.3"
-    es-abstract "^1.17.5"
+    es-abstract "^1.18.0-next.1"
 
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -8130,6 +8175,16 @@ object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
+
+object.assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
+  integrity sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.0"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 object.entries@^1.1.2:
   version "1.1.2"
@@ -9456,15 +9511,23 @@ side-channel@^1.0.2:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
 
+side-channel@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.3.tgz#cdc46b057550bbab63706210838df5d4c19519c3"
+  integrity sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==
+  dependencies:
+    es-abstract "^1.18.0-next.0"
+    object-inspect "^1.8.0"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
 simple-plist@^1.0.0, simple-plist@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-1.1.0.tgz#8354ab63eb3922a054c78ce96c209c532e907a23"
-  integrity sha512-2i5Tc0BYAqppM7jVzmNrI+aEUntPolIq4fDgji6WuNNn1D/qYdn2KwoLhZdzQkE04lu9L5tUoeJsjuJAvd+lFg==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-1.1.1.tgz#54367ca28bc5996a982c325c1c4a4c1a05f4047c"
+  integrity sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==
   dependencies:
     bplist-creator "0.0.8"
     bplist-parser "0.2.0"


### PR DESCRIPTION
This PR adds foundation for the `eas device:create` command.

- This command doesn't work yet but the user experience is more or less ready.
  - **One of the missing parts is the graphql / rest endpoint for generating a registration URL.**
- I added some utils that could be used for other commands, like:
  - `AccountResolver` class  - for resolving a target Expo account (depending on the place where `eas` has been run - inside or outside the project directory)
  - `src/utils/project.ts` with `getProjectAccountNameAsync ` function for getting the account name when in context of a project
  - ... and a few others 

I'll finish the implementation of this command when the missing www endpoints are in place. I think it's worth merging before this happens as some parts of this PR could be used elsewhere.