### PR TITLE
[eas-cli][tests] Remove console logs from submission tests

### DIFF
--- a/packages/eas-cli/__mocks__/ora.ts
+++ b/packages/eas-cli/__mocks__/ora.ts
@@ -1,0 +1,6 @@
+export default jest.fn().mockReturnValue({
+  start: jest.fn().mockReturnValue({
+    fail: jest.fn(),
+    succeed: jest.fn(),
+  }),
+});

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -17,6 +17,14 @@ import {
 import AndroidSubmitCommand from '../AndroidSubmitCommand';
 
 jest.mock('fs');
+jest.mock('ora', () =>
+  jest.fn().mockReturnValue({
+    start: jest.fn().mockReturnValue({
+      fail: jest.fn(),
+      succeed: jest.fn(),
+    }),
+  })
+);
 jest.mock('../../SubmissionService');
 jest.mock('../../../project/ensureProjectExists');
 jest.mock('../../../user/User', () => ({
@@ -39,7 +47,10 @@ describe(AndroidSubmitCommand, () => {
     '/google-service-account.json': JSON.stringify({ service: 'account' }),
   };
 
+  const originalConsoleLog = console.log;
   beforeAll(() => {
+    console.log = jest.fn();
+
     vol.fromJSON({
       ...testProject.projectTree,
       ...fakeFiles,
@@ -54,6 +65,8 @@ describe(AndroidSubmitCommand, () => {
     vol.reset();
 
     jest.unmock('@expo/config');
+
+    console.log = originalConsoleLog;
   });
 
   afterEach(() => {

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -17,14 +17,7 @@ import {
 import AndroidSubmitCommand from '../AndroidSubmitCommand';
 
 jest.mock('fs');
-jest.mock('ora', () =>
-  jest.fn().mockReturnValue({
-    start: jest.fn().mockReturnValue({
-      fail: jest.fn(),
-      succeed: jest.fn(),
-    }),
-  })
-);
+jest.mock('ora');
 jest.mock('../../SubmissionService');
 jest.mock('../../../project/ensureProjectExists');
 jest.mock('../../../user/User', () => ({

--- a/packages/eas-cli/src/submissions/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/ServiceAccountSource-test.ts
@@ -12,13 +12,22 @@ jest.mock('fs');
 jest.mock('../../../prompts');
 
 describe(getServiceAccountAsync, () => {
+  const originalConsoleLog = console.log;
+  const originalConsoleWarn = console.warn;
+
   beforeAll(() => {
+    console.log = jest.fn();
+    console.warn = jest.fn();
+
     vol.fromJSON({
       '/google-service-account.json': JSON.stringify({ service: 'account' }),
     });
   });
   afterAll(() => {
     vol.reset();
+
+    console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
   });
 
   afterEach(() => {


### PR DESCRIPTION
Replaced `ora`, `console.log` and `console.warn` with mocks in submission tests to improve readability of `yarn test`.