### PR TITLE
[expo-cli] configure EAS Build

### DIFF
--- a/packages/config/src/EasJsonReader.ts
+++ b/packages/config/src/EasJsonReader.ts
@@ -13,8 +13,8 @@ import { EasJsonSchema, schemaBuildProfileMap } from './EasJsonSchema';
 
 interface EasJson {
   builds: {
-    android?: { [key: string]: AndroidBuildProfile };
-    ios?: { [key: string]: iOSBuildProfile };
+    android?: { [key: string]: BuildProfilePreValidation };
+    ios?: { [key: string]: BuildProfilePreValidation };
   };
 }
 
@@ -26,7 +26,7 @@ export class EasJsonReader {
   constructor(private projectDir: string, private platform: 'android' | 'ios' | 'all') {}
 
   public async readAsync(buildProfileName: string): Promise<EasConfig> {
-    const easJson = await this.readFile();
+    const easJson = await this.readRawAsync();
 
     let androidConfig;
     if (['android', 'all'].includes(this.platform)) {
@@ -52,6 +52,20 @@ export class EasJsonReader {
     };
   }
 
+  public async readRawAsync(): Promise<EasJson> {
+    const rawFile = await fs.readFile(path.join(this.projectDir, 'eas.json'), 'utf-8');
+    const json = JSON.parse(rawFile);
+
+    const { value, error } = EasJsonSchema.validate(json, {
+      abortEarly: false,
+    });
+
+    if (error) {
+      throw new Error(`eas.json is not valid [${error.toString()}]`);
+    }
+    return value;
+  }
+
   private validateBuildProfile<T extends BuildProfile>(
     platform: 'android' | 'ios' | 'all',
     buildProfileName: string,
@@ -74,20 +88,6 @@ export class EasJsonReader {
       throw new Error(
         `Object "${platform}.${buildProfileName}" in eas.json is not valid [${error.toString()}]`
       );
-    }
-    return value;
-  }
-
-  private async readFile(): Promise<EasJson> {
-    const rawFile = await fs.readFile(path.join(this.projectDir, 'eas.json'), 'utf-8');
-    const json = JSON.parse(rawFile);
-
-    const { value, error } = EasJsonSchema.validate(json, {
-      abortEarly: false,
-    });
-
-    if (error) {
-      throw new Error(`eas.json is not valid [${error.toString()}]`);
     }
     return value;
   }

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
     "@eas/config": "0.0.1",
-    "@expo/config": "^3.3.9",
+    "@expo/config": "^3.3.12",
     "@expo/eas-build-job": "0.1.1",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.10",

--- a/packages/eas-cli/src/build/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/android/UpdatesModule.ts
@@ -1,0 +1,91 @@
+import { AndroidConfig, ExpoConfig } from '@expo/config';
+import fs from 'fs-extra';
+
+import log from '../../log';
+import { ensureLoggedInAsync } from '../../user/actions';
+import { ensureValidVersions } from '../utils/updates';
+
+export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
+  ensureValidVersions(exp);
+  const { username } = await ensureLoggedInAsync();
+  const buildGradlePath = AndroidConfig.Paths.getAppBuildGradle(projectDir);
+  const buildGradleContent = await fs.readFile(buildGradlePath, 'utf8');
+
+  if (!AndroidConfig.Updates.isBuildGradleConfigured(buildGradleContent, projectDir, exp)) {
+    const gradleScriptApply = AndroidConfig.Updates.formatApplyLineForBuildGradle(projectDir, exp);
+
+    await fs.writeFile(
+      buildGradlePath,
+      `${buildGradleContent}\n// Integration with Expo updates\n${gradleScriptApply}\n`
+    );
+  }
+
+  const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
+  if (!androidManifestPath) {
+    throw new Error(`Could not find AndroidManifest.xml in project directory: "${projectDir}"`);
+  }
+  const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(
+    androidManifestPath
+  );
+
+  if (!AndroidConfig.Updates.isMainApplicationMetaDataSynced(exp, androidManifest, username)) {
+    const result = await AndroidConfig.Updates.setUpdatesConfig(exp, androidManifest, username);
+
+    await AndroidConfig.Manifest.writeAndroidManifestAsync(androidManifestPath, result);
+  }
+}
+
+export async function syncUpdatesConfigurationAsync(
+  projectDir: string,
+  exp: ExpoConfig
+): Promise<void> {
+  ensureValidVersions(exp);
+  const { username } = await ensureLoggedInAsync();
+  try {
+    await ensureUpdatesConfiguredAsync(projectDir, exp);
+  } catch (error) {
+    log.error(
+      'expo-updates module is not configured. Please run "eas build:configure" first to configure the project'
+    );
+    throw error;
+  }
+
+  const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
+  if (!androidManifestPath) {
+    throw new Error(`Could not find AndroidManifest.xml in project directory: "${projectDir}"`);
+  }
+  let androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(androidManifestPath);
+
+  if (!AndroidConfig.Updates.areVersionsSynced(exp, androidManifest)) {
+    androidManifest = AndroidConfig.Updates.setVersionsConfig(exp, androidManifest);
+    await AndroidConfig.Manifest.writeAndroidManifestAsync(androidManifestPath, androidManifest);
+  }
+
+  if (!AndroidConfig.Updates.isMainApplicationMetaDataSynced(exp, androidManifest, username)) {
+    log.warn(
+      'Native project configuration is not synced with values present in your app.json, run "eas build:configure" to make sure all values are applied in the native project'
+    );
+  }
+}
+
+async function ensureUpdatesConfiguredAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
+  const buildGradlePath = AndroidConfig.Paths.getAppBuildGradle(projectDir);
+  const buildGradleContent = await fs.readFile(buildGradlePath, 'utf8');
+
+  if (!AndroidConfig.Updates.isBuildGradleConfigured(buildGradleContent, projectDir, exp)) {
+    const gradleScriptApply = AndroidConfig.Updates.formatApplyLineForBuildGradle(projectDir, exp);
+    throw new Error(`Missing ${gradleScriptApply} in ${buildGradlePath}`);
+  }
+
+  const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
+  if (!androidManifestPath) {
+    throw new Error(`Could not find AndroidManifest.xml in project directory: "${projectDir}"`);
+  }
+  const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(
+    androidManifestPath
+  );
+
+  if (!AndroidConfig.Updates.isMainApplicationMetaDataSet(androidManifest)) {
+    throw new Error('Missing values in AndroidManifest.xml');
+  }
+}

--- a/packages/eas-cli/src/build/android/configure.ts
+++ b/packages/eas-cli/src/build/android/configure.ts
@@ -1,0 +1,22 @@
+import { AndroidConfig } from '@expo/config';
+
+import log from '../../log';
+import { gitAddAsync } from '../../utils/git';
+import { ConfigureContext } from '../context';
+import { isExpoUpdatesInstalled } from '../utils/updates';
+import { configureUpdatesAsync } from './UpdatesModule';
+
+export async function configureAndroidAsync(ctx: ConfigureContext): Promise<void> {
+  if (!ctx.hasAndroidNativeProject) {
+    return;
+  }
+  await AndroidConfig.EasBuild.configureEasBuildAsync(ctx.projectDir);
+
+  const easGradlePath = AndroidConfig.EasBuild.getEasBuildGradlePath(ctx.projectDir);
+  await gitAddAsync(easGradlePath, { intentToAdd: true });
+
+  if (isExpoUpdatesInstalled(ctx.projectDir)) {
+    await configureUpdatesAsync(ctx.projectDir, ctx.exp);
+  }
+  log.withTick('Configured the Android project');
+}

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -61,6 +61,16 @@ export async function createCommandContextAsync({
   };
 }
 
+export interface ConfigureContext {
+  user: User;
+  projectDir: string;
+  exp: ExpoConfig;
+  shouldConfigureAndroid: boolean;
+  shouldConfigureIos: boolean;
+  hasAndroidNativeProject: boolean;
+  hasIosNativeProject: boolean;
+}
+
 type PlatformBuildProfile<T extends Platform> = T extends Platform.Android
   ? AndroidBuildProfile
   : iOSBuildProfile;

--- a/packages/eas-cli/src/build/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/ios/UpdatesModule.ts
@@ -1,0 +1,97 @@
+import { ExpoConfig, IOSConfig } from '@expo/config';
+import plist from '@expo/plist';
+import fs from 'fs-extra';
+import path from 'path';
+
+import log from '../../log';
+import { ensureLoggedInAsync } from '../../user/actions';
+import { gitAddAsync } from '../../utils/git';
+import { ensureValidVersions } from '../utils/updates';
+
+export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
+  ensureValidVersions(exp);
+  const { username } = await ensureLoggedInAsync();
+  let xcodeProject = IOSConfig.XcodeUtils.getPbxproj(projectDir);
+
+  if (!IOSConfig.Updates.isShellScriptBuildPhaseConfigured(projectDir, exp, xcodeProject)) {
+    xcodeProject = IOSConfig.Updates.ensureBundleReactNativePhaseContainsConfigurationScript(
+      projectDir,
+      exp,
+      xcodeProject
+    );
+    await fs.writeFile(IOSConfig.Paths.getPBXProjectPath(projectDir), xcodeProject.writeSync());
+  }
+
+  let expoPlist = await readExpoPlistAsync(projectDir);
+  if (!IOSConfig.Updates.isPlistConfigurationSynced(exp, expoPlist, username)) {
+    expoPlist = IOSConfig.Updates.setUpdatesConfig(exp, expoPlist, username);
+    await writeExpoPlistAsync(projectDir, expoPlist);
+  }
+  // TODO: ensure ExpoPlist in pbxproj
+}
+
+export async function syncUpdatesConfigurationAsync(
+  projectDir: string,
+  exp: ExpoConfig
+): Promise<void> {
+  ensureValidVersions(exp);
+  const { username } = await ensureLoggedInAsync();
+  try {
+    await ensureUpdatesConfiguredAsync(projectDir, exp);
+  } catch (error) {
+    log.error(
+      'expo-updates module is not configured. Please run "eas build:configure" first to configure the project'
+    );
+    throw error;
+  }
+
+  let expoPlist = await readExpoPlistAsync(projectDir);
+  if (!IOSConfig.Updates.isPlistVersionConfigurationSynced(exp, expoPlist)) {
+    expoPlist = IOSConfig.Updates.setVersionsConfig(exp, expoPlist);
+    await writeExpoPlistAsync(projectDir, expoPlist);
+  }
+
+  if (!IOSConfig.Updates.isPlistConfigurationSynced(exp, expoPlist, username)) {
+    log.warn(
+      'Native project configuration is not synced with values present in you app.json, run "eas build:configure" to make sure all values are applied in the native project'
+    );
+  }
+}
+
+async function ensureUpdatesConfiguredAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
+  const xcodeProject = IOSConfig.XcodeUtils.getPbxproj(projectDir);
+
+  if (!IOSConfig.Updates.isShellScriptBuildPhaseConfigured(projectDir, exp, xcodeProject)) {
+    const script = 'expo-updates/scripts/create-manifest-ios.sh';
+    const buildPhase = '"Bundle React Native code and images"';
+    throw new Error(`Path to ${script} is missing in a ${buildPhase} build phase.`);
+  }
+
+  const expoPlist = await readExpoPlistAsync(projectDir);
+  if (!IOSConfig.Updates.isPlistConfigurationSet(expoPlist)) {
+    throw new Error('Missing values in Expo.plist');
+  }
+}
+
+async function readExpoPlistAsync(projectDir: string): Promise<IOSConfig.ExpoPlist> {
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(projectDir);
+
+  let expoPlist = {};
+  if (await fs.pathExists(expoPlistPath)) {
+    const expoPlistContent = await fs.readFile(expoPlistPath, 'utf8');
+    expoPlist = plist.parse(expoPlistContent);
+  }
+  return expoPlist;
+}
+
+async function writeExpoPlistAsync(
+  projectDir: string,
+  expoPlist: IOSConfig.ExpoPlist
+): Promise<void> {
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(projectDir);
+  const expoPlistContent = plist.build(expoPlist);
+
+  await fs.mkdirp(path.dirname(expoPlistPath));
+  await fs.writeFile(expoPlistPath, expoPlistContent);
+  await gitAddAsync(expoPlistPath, { intentToAdd: true });
+}

--- a/packages/eas-cli/src/build/ios/bundleIdentifer.ts
+++ b/packages/eas-cli/src/build/ios/bundleIdentifer.ts
@@ -1,0 +1,67 @@
+import { ExpoConfig, IOSConfig } from '@expo/config';
+import chalk from 'chalk';
+import once from 'lodash/once';
+
+import log from '../../log';
+import { promptAsync } from '../../prompts';
+
+export const getBundleIdentifier = once(_getBundleIdentifier);
+
+async function _getBundleIdentifier(projectDir: string, manifest: ExpoConfig): Promise<string> {
+  const bundleIdentifierFromPbxproj = IOSConfig.BundleIdenitifer.getBundleIdentifierFromPbxproj(
+    projectDir
+  );
+  const bundleIdentifierFromConfig = IOSConfig.BundleIdenitifer.getBundleIdentifier(manifest);
+  if (bundleIdentifierFromPbxproj !== null && bundleIdentifierFromConfig !== null) {
+    if (bundleIdentifierFromPbxproj === bundleIdentifierFromConfig) {
+      return bundleIdentifierFromPbxproj;
+    } else {
+      log.newLine();
+      log.warn(
+        `We detected that your Xcode project is configured with a different bundle identifier than the one defined in app.json/app.config.js.`
+      );
+      log(`If you choose the one defined in app.json/app.config.js we'll automatically configure your Xcode project with it.
+However, if you choose the one defined in the Xcode project you'll have to update app.json/app.config.js on your own.
+Otherwise, you'll see this prompt again in the future.`);
+      log.newLine();
+      const { bundleIdentifier } = await promptAsync({
+        type: 'select',
+        name: 'bundleIdentifier',
+        message: 'Which bundle identifier should we use?',
+        choices: [
+          {
+            title: `Defined in the Xcode project: ${chalk.bold(bundleIdentifierFromPbxproj)}`,
+            value: bundleIdentifierFromPbxproj,
+          },
+          {
+            title: `Defined in app.json/app.config.js: ${chalk.bold(bundleIdentifierFromConfig)}`,
+            value: bundleIdentifierFromConfig,
+          },
+        ],
+      });
+      return bundleIdentifier;
+    }
+  } else if (bundleIdentifierFromPbxproj === null && bundleIdentifierFromConfig === null) {
+    throw new Error('Please define "expo.ios.bundleIdentifier" in app.json/app.config.js');
+  } else {
+    if (bundleIdentifierFromPbxproj !== null) {
+      log(
+        `Using ${chalk.bold(
+          bundleIdentifierFromPbxproj
+        )} as the bundle identifier (read from the Xcode project).`
+      );
+      return bundleIdentifierFromPbxproj;
+    } else {
+      // bundleIdentifierFromConfig is never null in this case
+      // the following line is to satisfy TS
+      const bundleIdentifier = bundleIdentifierFromConfig ?? '';
+      log(
+        `Using ${chalk.bold(
+          bundleIdentifier
+        )} as the bundle identifier (read from app.json/app.config.js).
+We'll automatically configure your Xcode project using this value.`
+      );
+      return bundleIdentifier;
+    }
+  }
+}

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -1,0 +1,71 @@
+import { CredentialsSource, Workflow } from '@eas/config';
+import { ExpoConfig, IOSConfig } from '@expo/config';
+
+import * as ProvisioningProfileUtils from '../../credentials/ios/utils/provisioningProfile';
+import log from '../../log';
+import { getProjectAccountNameAsync } from '../../project/projectUtils';
+import { confirmAsync } from '../../prompts';
+import { ConfigureContext } from '../context';
+import { isExpoUpdatesInstalled } from '../utils/updates';
+import { configureUpdatesAsync, syncUpdatesConfigurationAsync } from './UpdatesModule';
+import { getBundleIdentifier } from './bundleIdentifer';
+import { resolveIosCredentialsAsync } from './credentials';
+
+export async function configureIosAsync(ctx: ConfigureContext): Promise<void> {
+  if (!ctx.hasIosNativeProject) {
+    return;
+  }
+  const bundleIdentifier = await getBundleIdentifier(ctx.projectDir, ctx.exp);
+  IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(ctx.projectDir, bundleIdentifier, false);
+
+  const confirm = await confirmAsync({
+    message: 'Do you want to configure credentials for the Xcode project?',
+  });
+  if (confirm) {
+    await resolveCredentialsAndConfigureXcodeProjectAsync(ctx, bundleIdentifier);
+  }
+
+  if (isExpoUpdatesInstalled(ctx.projectDir)) {
+    await configureUpdatesAsync(ctx.projectDir, ctx.exp);
+  }
+  log.withTick('Configured the Xcode project.');
+}
+
+export async function syncProjectConfigurationAsync(
+  projectDir: string,
+  exp: ExpoConfig
+): Promise<void> {
+  // TODO: check bundle identifier
+  if (isExpoUpdatesInstalled(projectDir)) {
+    await syncUpdatesConfigurationAsync(projectDir, exp);
+  }
+}
+
+async function resolveCredentialsAndConfigureXcodeProjectAsync(
+  ctx: ConfigureContext,
+  bundleIdentifier: string
+): Promise<void> {
+  const { credentials } = await resolveIosCredentialsAsync(
+    ctx.projectDir,
+    {
+      app: {
+        accountName: await getProjectAccountNameAsync(ctx.projectDir),
+        projectName: ctx.exp.slug,
+        bundleIdentifier,
+      },
+      workflow: Workflow.Generic,
+      credentialsSource: CredentialsSource.AUTO,
+    },
+    {
+      nonInteractive: false,
+    }
+  );
+
+  const profileName = ProvisioningProfileUtils.readProfileName(credentials.provisioningProfile);
+  const appleTeam = ProvisioningProfileUtils.readAppleTeam(credentials.provisioningProfile);
+  IOSConfig.ProvisioningProfile.setProvisioningProfileForPbxproj(ctx.projectDir, {
+    profileName,
+    appleTeamId: appleTeam.teamId,
+  });
+  // TODO: copy profile and add dist cert to keychain
+}

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -1,0 +1,72 @@
+import { CredentialsSource, Workflow } from '@eas/config';
+import assert from 'assert';
+
+import { createCredentialsContextAsync } from '../../credentials/context';
+import IosCredentialsProvider, {
+  IosCredentials,
+} from '../../credentials/ios/IosCredentialsProvider';
+import { AppLookupParams } from '../../credentials/ios/credentials';
+import { CredentialsResult } from '../build';
+import { BuildContext } from '../context';
+import { ensureCredentialsAsync } from '../credentials';
+import { Platform } from '../types';
+
+export async function ensureIosCredentialsAsync(
+  ctx: BuildContext<Platform.iOS>
+): Promise<CredentialsResult<IosCredentials> | undefined> {
+  if (!shouldProvideCredentials(ctx)) {
+    return;
+  }
+  assert(ctx.commandCtx.exp?.ios?.bundleIdentifier, 'ios.bundleIdentifier is required');
+  return await resolveIosCredentialsAsync(
+    ctx.commandCtx.projectDir,
+    {
+      app: {
+        accountName: ctx.commandCtx.accountName,
+        projectName: ctx.commandCtx.projectName,
+        bundleIdentifier: ctx.commandCtx.exp.ios.bundleIdentifier,
+      },
+      workflow: ctx.buildProfile.workflow,
+      credentialsSource: ctx.buildProfile.credentialsSource,
+    },
+    {
+      nonInteractive: ctx.commandCtx.nonInteractive,
+    }
+  );
+}
+
+interface ResolveCredentialsParams {
+  app: AppLookupParams;
+  workflow: Workflow;
+  credentialsSource: CredentialsSource;
+}
+
+export async function resolveIosCredentialsAsync(
+  projectDir: string,
+  params: ResolveCredentialsParams,
+  options: { nonInteractive: boolean }
+): Promise<CredentialsResult<IosCredentials>> {
+  const provider = new IosCredentialsProvider(
+    await createCredentialsContextAsync(projectDir, {}),
+    params.app,
+    { nonInteractive: options.nonInteractive }
+  );
+  const credentialsSource = await ensureCredentialsAsync(
+    provider,
+    params.workflow,
+    params.credentialsSource,
+    options.nonInteractive
+  );
+  return {
+    credentials: await provider.getCredentialsAsync(credentialsSource),
+    source: credentialsSource,
+  };
+}
+
+function shouldProvideCredentials(ctx: BuildContext<Platform.iOS>): boolean {
+  return (
+    (ctx.buildProfile.workflow === Workflow.Managed &&
+      ctx.buildProfile.buildType !== 'simulator') ||
+    ctx.buildProfile.workflow === Workflow.Generic
+  );
+}

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -1,6 +1,4 @@
 import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
-import figures from 'figures';
 import fs from 'fs-extra';
 import ora from 'ora';
 import path from 'path';
@@ -119,45 +117,31 @@ async function reviewAndCommitChangesAsync(
 async function modifyAndCommitAsync(
   callback: () => Promise<void>,
   {
-    startMessage,
-    successMessage,
     commitMessage,
-    commitSuccessMessage,
     nonInteractive,
   }: {
-    startMessage: string;
-    successMessage: string;
     commitMessage: string;
-    commitSuccessMessage: string;
     nonInteractive: boolean;
   }
 ) {
-  const spinner = ora(startMessage);
-
   try {
     await callback();
 
     await ensureGitStatusIsCleanAsync();
-
-    spinner.succeed();
   } catch (err) {
     if (err instanceof DirtyGitTreeError) {
-      spinner.succeed(successMessage);
       log.newLine();
 
       try {
         await reviewAndCommitChangesAsync(commitMessage, {
           nonInteractive,
         });
-
-        log(`${chalk.green(figures.tick)} ${commitSuccessMessage}.`);
       } catch (e) {
         throw new Error(
           "Aborting, run the command again once you're ready. Make sure to commit any changes you've made."
         );
       }
     } else {
-      spinner.fail();
       throw err;
     }
   }

--- a/packages/eas-cli/src/build/utils/updates.ts
+++ b/packages/eas-cli/src/build/utils/updates.ts
@@ -1,0 +1,14 @@
+import { ExpoConfig, getPackageJson } from '@expo/config';
+
+export function isExpoUpdatesInstalled(projectDir: string) {
+  const packageJson = getPackageJson(projectDir);
+  return packageJson.dependencies && 'expo-updates' in packageJson.dependencies;
+}
+
+export function ensureValidVersions(exp: ExpoConfig): void {
+  if (!exp.runtimeVersion && !exp.sdkVersion) {
+    throw new Error(
+      "Couldn't find either 'runtimeVersion' or 'sdkVersion' to configure 'expo-updates'. Please specify at least one of these properties under the 'expo' key in 'app.json'"
+    );
+  }
+}

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -1,12 +1,30 @@
-import { Command } from '@oclif/command';
+import { Command, flags } from '@oclif/command';
+
+import { configureAsync } from '../../build/configure';
+import { BuildCommandPlatform } from '../../build/types';
+import { findProjectRootAsync } from '../../project/projectUtils';
+import { ensureLoggedInAsync } from '../../user/actions';
 
 export default class BuildConfigure extends Command {
-  static description = 'Start a build';
+  static description = 'Configure the project to support EAS Build.';
 
-  static flags = {};
+  static flags = {
+    platform: flags.enum({
+      description: 'Platform to configure',
+      char: 'p',
+      options: ['android', 'ios', 'all'],
+      default: 'all',
+    }),
+  };
 
   async run() {
-    // const { flags } = this.parse(Add);
-    throw new Error('Not implemented');
+    const { flags } = this.parse(BuildConfigure);
+    const platform = flags.platform as BuildCommandPlatform;
+
+    await ensureLoggedInAsync();
+    await configureAsync({
+      platform,
+      projectDir: (await findProjectRootAsync()) ?? process.cwd(),
+    });
   }
 }

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import figures from 'figures';
 
 type Color = (...text: string[]) => string;
 
@@ -62,6 +63,10 @@ log.warn = function warn(...args: any[]) {
 
 log.gray = function (...args: any[]) {
   consoleLog(...withTextColor(args, chalk.gray));
+};
+
+log.withTick = function (...args: any[]) {
+  consoleLog(chalk.green(figures.tick), ...args);
 };
 
 export default log;

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -1,13 +1,11 @@
 import { getConfig } from '@expo/config';
-import assert from 'assert';
 import pkgDir from 'pkg-dir';
 
-import { getUserAsync } from '../user/User';
+import { ensureLoggedInAsync } from '../user/actions';
 
 export async function getProjectAccountNameAsync(projectDir: string): Promise<string> {
   const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-  const user = await getUserAsync();
-  assert(user, 'You need to be logged in');
+  const user = await ensureLoggedInAsync();
   return exp.owner || user.username;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,10 +1044,10 @@
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-40.0.0-beta.1.tgz#4192b120edc9ec235147329a50bd0a7da16ae89c"
   integrity sha512-hTp+6ZIKK57O8qhVoO+GBCkx0UCdOhwcWxaXfjpsELIR8LfXDGz8OmCxTzGvb7nnadcrGCccHBX5dO1NmPBbmg==
 
-"@expo/config@^3.3.9":
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.3.11.tgz#3ad56c82d796c8b5beed7f9b8273a24410a6e110"
-  integrity sha512-+WrAc5pZbgUMGpBMwF/rBw5igngaouWIyFSVlmYbrp0wV2Y/T99uqgylPzNA/Ei14X+34ucZNj2IaLs9Z4Krew==
+"@expo/config@^3.3.12":
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.3.12.tgz#895d503d12ed133f38e6ca79865742d8d839cef8"
+  integrity sha512-SFsWB1hpZHDpUXZDHpVKPrecAxXOKzH840km3iFkBgyMdIv23Nbw9FWh9+5TaqTZKZ0fJOaTFd7axszw6TaeQA==
   dependencies:
     "@babel/core" "7.9.0"
     "@expo/babel-preset-cli" "0.2.18"


### PR DESCRIPTION
add `build:configure` command
- creates eas.json if it doesn't exist
- configure native project (android: create eas-build.gradle, ios: bundle identifier in xcode project)
- configure updates (set values in AndroidManifest.xml, Expo.plist, ios build phase script, android gradle script)

add a step to `build:create` command
- verify if `build:configure` was run before
- update sdk version or runtime version if app.json value changed