### PR TITLE
Extract common code for submission commands

### DIFF
--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -7,7 +7,7 @@ import { SubmissionPlatform } from './types';
 import { displayLogs } from './utils/logs';
 
 abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
-  protected readonly appStoreName: string = 'app store';
+  protected abstract readonly appStoreName: string;
 
   protected constructor(
     private platform: SubmissionPlatform,
@@ -15,9 +15,7 @@ abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
     protected options: SubmissionOptions
   ) {}
 
-  async submitAsync(): Promise<void> {
-    throw new Error('Not implemented!');
-  }
+  public abstract submitAsync(): Promise<void>;
 
   protected async startSubmissionAsync(
     submissionConfig: SubmissionConfig,

--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -1,0 +1,85 @@
+import ora from 'ora';
+
+import { sleep } from '../utils/promise';
+import SubmissionService, { DEFAULT_CHECK_INTERVAL_MS } from './SubmissionService';
+import { Submission, SubmissionConfig, SubmissionStatus } from './SubmissionService.types';
+import { SubmissionPlatform } from './types';
+import { displayLogs } from './utils/logs';
+
+abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
+  protected readonly appStoreName: string = 'app store';
+
+  protected constructor(
+    private platform: SubmissionPlatform,
+    protected ctx: SubmissionContext,
+    protected options: SubmissionOptions
+  ) {}
+
+  async submitAsync(): Promise<void> {
+    throw new Error('Not implemented!');
+  }
+
+  protected async startSubmissionAsync(
+    submissionConfig: SubmissionConfig,
+    verbose: boolean = false
+  ) {
+    const scheduleSpinner = ora('Scheduling submission').start();
+    let submissionId: string;
+    try {
+      submissionId = await SubmissionService.startSubmissionAsync(
+        this.platform,
+        submissionConfig.projectId,
+        submissionConfig
+      );
+      scheduleSpinner.succeed();
+    } catch (err) {
+      scheduleSpinner.fail('Failed to schedule submission');
+      throw err;
+    }
+
+    let submissionCompleted = false;
+    let submissionStatus: SubmissionStatus | null = null;
+    let submission: Submission | null = null;
+    const submissionSpinner = ora(`Submitting your app to ${this.appStoreName}`).start();
+    try {
+      while (!submissionCompleted) {
+        await sleep(DEFAULT_CHECK_INTERVAL_MS);
+        submission = await SubmissionService.getSubmissionAsync(
+          submissionConfig.projectId,
+          submissionId
+        );
+        submissionSpinner.text = this.getStatusText(submission.status);
+        submissionStatus = submission.status;
+        if (submissionStatus === SubmissionStatus.ERRORED) {
+          submissionCompleted = true;
+          process.exitCode = 1;
+          submissionSpinner.fail();
+        } else if (submissionStatus === SubmissionStatus.FINISHED) {
+          submissionCompleted = true;
+          submissionSpinner.succeed();
+        }
+      }
+    } catch (err) {
+      submissionSpinner.fail(this.getStatusText(SubmissionStatus.ERRORED));
+      throw err;
+    }
+
+    await displayLogs(submission, submissionStatus, verbose);
+  }
+
+  private getStatusText(status: SubmissionStatus): string {
+    if (status === SubmissionStatus.IN_QUEUE) {
+      return `Submitting your app to ${this.appStoreName}: waiting for an available submitter`;
+    } else if (status === SubmissionStatus.IN_PROGRESS) {
+      return `Submitting your app to ${this.appStoreName}: submission in progress`;
+    } else if (status === SubmissionStatus.FINISHED) {
+      return `Successfully submitted your app to ${this.appStoreName}!`;
+    } else if (status === SubmissionStatus.ERRORED) {
+      return `Something went wrong when submitting your app to ${this.appStoreName}.`;
+    } else {
+      throw new Error('This should never happen');
+    }
+  }
+}
+
+export default BaseSubmitter;

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
@@ -1,9 +1,5 @@
-import chalk from 'chalk';
-import Table from 'cli-table3';
 import fs from 'fs-extra';
-import chunk from 'lodash/chunk';
 
-import log from '../../log';
 import BaseSubmitter from '../BaseSubmitter';
 import { Archive, ArchiveSource, getArchiveAsync } from '../archive-source';
 import {
@@ -12,6 +8,7 @@ import {
   ArchiveType,
   SubmissionPlatform,
 } from '../types';
+import { breakWord, printSummary } from '../utils/summary';
 import { AndroidPackageSource, getAndroidPackageAsync } from './AndroidPackageSource';
 import { AndroidSubmissionConfig, ReleaseStatus, ReleaseTrack } from './AndroidSubmissionConfig';
 import { ServiceAccountSource, getServiceAccountAsync } from './ServiceAccountSource';
@@ -70,10 +67,16 @@ class AndroidSubmitter extends BaseSubmitter<AndroidSubmissionContext, AndroidSu
       releaseStatus,
       projectId,
     };
-    printSummary({
-      ...submissionConfig,
-      serviceAccountPath,
-    });
+
+    printSummary(
+      {
+        ...submissionConfig,
+        serviceAccountPath,
+      },
+      'Android Submission Summary',
+      SummaryHumanReadableKeys,
+      SummaryHumanReadableValues
+    );
     return { ...submissionConfig, serviceAccount };
   }
 }
@@ -104,31 +107,5 @@ const SummaryHumanReadableValues: Partial<Record<keyof Summary, Function>> = {
   archivePath: (path: string) => breakWord(path, 50),
   archiveUrl: (url: string) => breakWord(url, 50),
 };
-
-function breakWord(word: string, chars: number): string {
-  return chunk(word, chars)
-    .map((arr: string[]) => arr.join(''))
-    .join('\n');
-}
-
-function printSummary(summary: Summary): void {
-  const table = new Table({
-    colWidths: [25, 55],
-    wordWrap: true,
-  });
-  table.push([
-    {
-      colSpan: 2,
-      content: chalk.bold('Android Submission Summary'),
-      hAlign: 'center',
-    },
-  ]);
-  for (const [key, value] of Object.entries(summary)) {
-    const displayKey = SummaryHumanReadableKeys[key as keyof Summary];
-    const displayValue = SummaryHumanReadableValues[key as keyof Summary]?.(value) ?? value;
-    table.push([displayKey, displayValue]);
-  }
-  log(table.toString());
-}
 
 export default AndroidSubmitter;

--- a/packages/eas-cli/src/submissions/commons.ts
+++ b/packages/eas-cli/src/submissions/commons.ts
@@ -1,0 +1,69 @@
+import { getConfig } from '@expo/config';
+import * as uuid from 'uuid';
+
+import { ensureProjectExistsAsync } from '../project/ensureProjectExists';
+import { getProjectAccountNameAsync } from '../project/projectUtils';
+import { ArchiveFileSource, ArchiveFileSourceType } from './archive-source';
+import { AndroidSubmissionContext, IosSubmissionContext, SubmissionPlatform } from './types';
+
+export async function getProjectIdAsync(projectDir: string): Promise<string> {
+  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+  return await ensureProjectExistsAsync({
+    accountName: await getProjectAccountNameAsync(projectDir),
+    projectName: exp.slug,
+  });
+}
+
+export function resolveArchiveFileSource(
+  ctx: AndroidSubmissionContext | IosSubmissionContext,
+  projectId: string
+): ArchiveFileSource {
+  const { url, path, id, latest } = ctx.commandFlags;
+  const chosenOptions = [url, path, id, latest];
+  if (chosenOptions.filter(opt => opt).length > 1) {
+    throw new Error(`Pass only one of: --url, --path, --id, --latest`);
+  }
+
+  if (url) {
+    return {
+      sourceType: ArchiveFileSourceType.url,
+      url,
+      projectId,
+      platform: SubmissionPlatform.iOS,
+      projectDir: ctx.projectDir,
+    };
+  } else if (path) {
+    return {
+      sourceType: ArchiveFileSourceType.path,
+      path,
+      projectId,
+      platform: SubmissionPlatform.iOS,
+      projectDir: ctx.projectDir,
+    };
+  } else if (id) {
+    if (!uuid.validate(id)) {
+      throw new Error(`${id} is not an ID`);
+    }
+    return {
+      sourceType: ArchiveFileSourceType.buildId,
+      id,
+      projectId,
+      platform: SubmissionPlatform.iOS,
+      projectDir: ctx.projectDir,
+    };
+  } else if (latest) {
+    return {
+      sourceType: ArchiveFileSourceType.latest,
+      platform: SubmissionPlatform.iOS,
+      projectDir: ctx.projectDir,
+      projectId,
+    };
+  } else {
+    return {
+      sourceType: ArchiveFileSourceType.prompt,
+      platform: SubmissionPlatform.iOS,
+      projectDir: ctx.projectDir,
+      projectId,
+    };
+  }
+}

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -1,6 +1,9 @@
+import chalk from 'chalk';
+
 import BaseSubmitter from '../BaseSubmitter';
 import { Archive, ArchiveSource, getArchiveAsync } from '../archive-source';
 import { IosSubmissionContext, SubmissionPlatform } from '../types';
+import { breakWord, printSummary } from '../utils/summary';
 import {
   AppSpecificPasswordSource,
   getAppSpecificPasswordAsync,
@@ -31,7 +34,14 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
       this.options,
       resolvedSourceOptions
     );
-    await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
+
+    printSummary(
+      submissionConfig,
+      'iOS Submission Summary',
+      SummaryHumanReadableKeys,
+      SummaryHumanReadableValues
+    );
+    // await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
   }
 
   private async resolveSourceOptions(): Promise<ResolvedSourceOptions> {
@@ -53,13 +63,26 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
     const { projectId, appleId, appAppleId } = options;
     const submissionConfig = {
       archiveUrl: archive.location,
-      projectId,
+      appleId,
       appSpecificPassword,
       appAppleId,
-      appleId,
+      projectId,
     };
     return submissionConfig;
   }
 }
+
+const SummaryHumanReadableKeys: Record<keyof IosSubmissionConfig, string> = {
+  appleId: 'Apple ID',
+  archiveUrl: 'Archive URL',
+  appSpecificPassword: 'Apple app-specific password',
+  appAppleId: ' App Store Connect Apple ID number',
+  projectId: 'Project ID',
+};
+
+const SummaryHumanReadableValues: Partial<Record<keyof IosSubmissionConfig, Function>> = {
+  archiveUrl: (url: string) => breakWord(url, 50),
+  appSpecificPassword: () => chalk.italic('[hidden]'),
+};
 
 export default IosSubmitter;

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -1,11 +1,6 @@
-import ora from 'ora';
-
-import { sleep } from '../../utils/promise';
-import SubmissionService, { DEFAULT_CHECK_INTERVAL_MS } from '../SubmissionService';
-import { Submission, SubmissionStatus } from '../SubmissionService.types';
+import BaseSubmitter from '../BaseSubmitter';
 import { Archive, ArchiveSource, getArchiveAsync } from '../archive-source';
 import { IosSubmissionContext, SubmissionPlatform } from '../types';
-import { displayLogs } from '../utils/logs';
 import {
   AppSpecificPasswordSource,
   getAppSpecificPasswordAsync,
@@ -23,8 +18,12 @@ interface ResolvedSourceOptions {
   appSpecificPassword: string;
 }
 
-class IosSubmitter {
-  constructor(private ctx: IosSubmissionContext, private options: IosSubmissionOptions) {}
+class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOptions> {
+  protected readonly appStoreName: string = 'Apple TestFlight';
+
+  constructor(ctx: IosSubmissionContext, options: IosSubmissionOptions) {
+    super(SubmissionPlatform.iOS, ctx, options);
+  }
 
   async submitAsync(): Promise<void> {
     const resolvedSourceOptions = await this.resolveSourceOptions();
@@ -35,54 +34,6 @@ class IosSubmitter {
     await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
   }
 
-  // TODO: Temp - change public to private
-  public async startSubmissionAsync(
-    submissionConfig: IosSubmissionConfig,
-    verbose: boolean = false
-  ): Promise<void> {
-    const scheduleSpinner = ora('Scheduling submission').start();
-    let submissionId: string;
-    try {
-      submissionId = await SubmissionService.startSubmissionAsync(
-        SubmissionPlatform.iOS,
-        submissionConfig.projectId,
-        submissionConfig
-      );
-      scheduleSpinner.succeed();
-    } catch (err) {
-      scheduleSpinner.fail('Failed to schedule submission');
-      throw err;
-    }
-
-    let submissionCompleted = false;
-    let submissionStatus: SubmissionStatus | null = null;
-    let submission: Submission | null = null;
-    const submissionSpinner = ora('Submitting your app to Apple TestFlight').start();
-    try {
-      while (!submissionCompleted) {
-        await sleep(DEFAULT_CHECK_INTERVAL_MS);
-        submission = await SubmissionService.getSubmissionAsync(
-          submissionConfig.projectId,
-          submissionId
-        );
-        submissionSpinner.text = IosSubmitter.getStatusText(submission.status);
-        submissionStatus = submission.status;
-        if (submissionStatus === SubmissionStatus.ERRORED) {
-          submissionCompleted = true;
-          process.exitCode = 1;
-          submissionSpinner.fail();
-        } else if (submissionStatus === SubmissionStatus.FINISHED) {
-          submissionCompleted = true;
-          submissionSpinner.succeed();
-        }
-      }
-    } catch (err) {
-      submissionSpinner.fail(IosSubmitter.getStatusText(SubmissionStatus.ERRORED));
-      throw err;
-    }
-
-    await displayLogs(submission, submissionStatus, verbose);
-  }
   private async resolveSourceOptions(): Promise<ResolvedSourceOptions> {
     const archive = await getArchiveAsync(SubmissionPlatform.iOS, this.options.archiveSource);
     const appSpecificPassword = await getAppSpecificPasswordAsync(
@@ -108,20 +59,6 @@ class IosSubmitter {
       appleId,
     };
     return submissionConfig;
-  }
-
-  private static getStatusText(status: SubmissionStatus): string {
-    if (status === SubmissionStatus.IN_QUEUE) {
-      return 'Submitting your app to Apple TestFlight: waiting for an available submitter';
-    } else if (status === SubmissionStatus.IN_PROGRESS) {
-      return 'Submitting your app to Apple TestFlight: submission in progress';
-    } else if (status === SubmissionStatus.FINISHED) {
-      return 'Successfully submitted your app to Apple TestFlight!';
-    } else if (status === SubmissionStatus.ERRORED) {
-      return 'Something went wrong when submitting your app to Apple TestFlight.';
-    } else {
-      throw new Error('This should never happen');
-    }
   }
 }
 

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -22,7 +22,7 @@ interface ResolvedSourceOptions {
 }
 
 class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOptions> {
-  protected readonly appStoreName: string = 'Apple TestFlight';
+  protected readonly appStoreName: string = 'Apple App Store';
 
   constructor(ctx: IosSubmissionContext, options: IosSubmissionOptions) {
     super(SubmissionPlatform.iOS, ctx, options);
@@ -41,7 +41,7 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
       SummaryHumanReadableKeys,
       SummaryHumanReadableValues
     );
-    // await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
+    await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
   }
 
   private async resolveSourceOptions(): Promise<ResolvedSourceOptions> {

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -1,0 +1,36 @@
+import chalk from 'chalk';
+import Table from 'cli-table3';
+import chunk from 'lodash/chunk';
+
+import log from '../../log';
+
+export function breakWord(word: string, chars: number): string {
+  return chunk(word, chars)
+    .map((arr: string[]) => arr.join(''))
+    .join('\n');
+}
+
+export function printSummary<T>(
+  summary: T,
+  title: string,
+  keyMap: Record<keyof T, string>,
+  valueRemap: Partial<Record<keyof T, Function>>
+): void {
+  const table = new Table({
+    colWidths: [25, 55],
+    wordWrap: true,
+  });
+  table.push([
+    {
+      colSpan: 2,
+      content: chalk.bold(title),
+      hAlign: 'center',
+    },
+  ]);
+  for (const [key, value] of Object.entries(summary)) {
+    const displayKey = keyMap[key as keyof T];
+    const displayValue = valueRemap[key as keyof T]?.(value) ?? value;
+    table.push([displayKey, displayValue]);
+  }
+  log(table.toString());
+}


### PR DESCRIPTION
Chained PR for #56

- Extracted common parts from `IosSubmitter` and `AndroidSubmitter`, created class hierarchy - they now derive from `BaseSubmitter`
- Extracted common methods from `AndroidSubmitCommand` and `IosSubmitCommand` to `commons.ts`
- Implemented "Print Summary" for iOS and extracted common code