### PR TITLE
[eas-cli] build - implement internal distribution

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -18,6 +18,7 @@ export interface AndroidManagedBuildProfile {
   credentialsSource: CredentialsSource;
   buildType?: 'apk' | 'app-bundle';
   releaseChannel?: undefined;
+  internal?: boolean;
 }
 
 export interface AndroidGenericBuildProfile {
@@ -27,6 +28,7 @@ export interface AndroidGenericBuildProfile {
   releaseChannel?: string;
   artifactPath?: string;
   withoutCredentials?: boolean;
+  internal?: boolean;
 }
 
 export interface iOSManagedBuildProfile {
@@ -34,6 +36,7 @@ export interface iOSManagedBuildProfile {
   credentialsSource: CredentialsSource;
   buildType?: 'archive' | 'simulator';
   releaseChannel?: undefined;
+  internal?: boolean;
 }
 
 export interface iOSGenericBuildProfile {
@@ -42,6 +45,7 @@ export interface iOSGenericBuildProfile {
   scheme?: string;
   releaseChannel?: string;
   artifactPath?: string;
+  internal?: boolean;
 }
 
 export type AndroidBuildProfile = AndroidManagedBuildProfile | AndroidGenericBuildProfile;

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -13,12 +13,17 @@ export enum CredentialsSource {
   AUTO = 'auto',
 }
 
+export enum DistributionType {
+  STORE = 'store',
+  INTERNAL = 'internal',
+}
+
 export interface AndroidManagedBuildProfile {
   workflow: Workflow.Managed;
   credentialsSource: CredentialsSource;
   buildType?: 'apk' | 'app-bundle';
   releaseChannel?: undefined;
-  internal?: boolean;
+  distribution?: DistributionType;
 }
 
 export interface AndroidGenericBuildProfile {
@@ -28,7 +33,7 @@ export interface AndroidGenericBuildProfile {
   releaseChannel?: string;
   artifactPath?: string;
   withoutCredentials?: boolean;
-  internal?: boolean;
+  distribution?: DistributionType;
 }
 
 export interface iOSManagedBuildProfile {
@@ -36,7 +41,7 @@ export interface iOSManagedBuildProfile {
   credentialsSource: CredentialsSource;
   buildType?: 'archive' | 'simulator';
   releaseChannel?: undefined;
-  internal?: boolean;
+  distribution?: DistributionType;
 }
 
 export interface iOSGenericBuildProfile {
@@ -45,7 +50,7 @@ export interface iOSGenericBuildProfile {
   scheme?: string;
   releaseChannel?: string;
   artifactPath?: string;
-  internal?: boolean;
+  distribution?: DistributionType;
 }
 
 export type AndroidBuildProfile = AndroidManagedBuildProfile | AndroidGenericBuildProfile;

--- a/packages/config/src/EasJsonSchema.ts
+++ b/packages/config/src/EasJsonSchema.ts
@@ -7,12 +7,14 @@ const AndroidGenericSchema = Joi.object({
   releaseChannel: Joi.string(),
   artifactPath: Joi.string(),
   withoutCredentials: Joi.boolean(),
+  internal: Joi.boolean().default(false),
 });
 
 const AndroidManagedSchema = Joi.object({
   workflow: Joi.string().valid('managed').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
   buildType: Joi.string().valid('apk', 'app-bundle').default('app-bundle'),
+  internal: Joi.boolean().default(false),
 });
 
 const iOSGenericSchema = Joi.object({
@@ -21,12 +23,14 @@ const iOSGenericSchema = Joi.object({
   scheme: Joi.string(),
   releaseChannel: Joi.string(),
   artifactPath: Joi.string(),
+  internal: Joi.boolean().default(false),
 });
 
 const iOSManagedSchema = Joi.object({
   workflow: Joi.string().valid('managed').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
   buildType: Joi.string().valid('archive', 'simulator'),
+  internal: Joi.boolean().default(false),
 });
 
 const schemaBuildProfileMap: Record<string, Record<string, Joi.Schema>> = {

--- a/packages/config/src/EasJsonSchema.ts
+++ b/packages/config/src/EasJsonSchema.ts
@@ -7,14 +7,14 @@ const AndroidGenericSchema = Joi.object({
   releaseChannel: Joi.string(),
   artifactPath: Joi.string(),
   withoutCredentials: Joi.boolean(),
-  internal: Joi.boolean().default(false),
+  distribution: Joi.string().valid('store', 'internal').default('store'),
 });
 
 const AndroidManagedSchema = Joi.object({
   workflow: Joi.string().valid('managed').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
   buildType: Joi.string().valid('apk', 'app-bundle').default('app-bundle'),
-  internal: Joi.boolean().default(false),
+  distribution: Joi.string().valid('store', 'internal').default('store'),
 });
 
 const iOSGenericSchema = Joi.object({
@@ -23,14 +23,14 @@ const iOSGenericSchema = Joi.object({
   scheme: Joi.string(),
   releaseChannel: Joi.string(),
   artifactPath: Joi.string(),
-  internal: Joi.boolean().default(false),
+  distribution: Joi.string().valid('store', 'internal').default('store'),
 });
 
 const iOSManagedSchema = Joi.object({
   workflow: Joi.string().valid('managed').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
   buildType: Joi.string().valid('archive', 'simulator'),
-  internal: Joi.boolean().default(false),
+  distribution: Joi.string().valid('store', 'internal').default('store'),
 });
 
 const schemaBuildProfileMap: Record<string, Record<string, Joi.Schema>> = {

--- a/packages/config/src/__tests__/EasJsonReader-test.ts
+++ b/packages/config/src/__tests__/EasJsonReader-test.ts
@@ -25,6 +25,7 @@ test('minimal valid android eas.json', async () => {
     builds: {
       android: {
         workflow: 'generic',
+        internal: false,
         credentialsSource: 'auto',
       },
     },
@@ -46,6 +47,7 @@ test('minimal valid ios eas.json', async () => {
     builds: {
       ios: {
         credentialsSource: 'auto',
+        internal: false,
         workflow: 'generic',
       },
     },
@@ -68,8 +70,8 @@ test('minimal valid eas.json for both platforms', async () => {
   const easJson = await reader.readAsync('release');
   expect({
     builds: {
-      android: { workflow: 'generic', credentialsSource: 'auto' },
-      ios: { workflow: 'generic', credentialsSource: 'auto' },
+      android: { workflow: 'generic', internal: false, credentialsSource: 'auto' },
+      ios: { workflow: 'generic', internal: false, credentialsSource: 'auto' },
     },
   }).toEqual(easJson);
 });
@@ -90,7 +92,7 @@ test('valid eas.json with both platform, but reading only android', async () => 
   const easJson = await reader.readAsync('release');
   expect({
     builds: {
-      android: { workflow: 'generic', credentialsSource: 'auto' },
+      android: { workflow: 'generic', internal: false, credentialsSource: 'auto' },
     },
   }).toEqual(easJson);
 });
@@ -122,11 +124,13 @@ test('valid eas.json for debug builds', async () => {
         workflow: 'generic',
         gradleCommand: ':app:assembleDebug',
         withoutCredentials: true,
+        internal: false,
       },
       ios: {
         credentialsSource: 'auto',
         workflow: 'managed',
         buildType: 'simulator',
+        internal: false,
       },
     },
   }).toEqual(easJson);

--- a/packages/config/src/__tests__/EasJsonReader-test.ts
+++ b/packages/config/src/__tests__/EasJsonReader-test.ts
@@ -25,7 +25,7 @@ test('minimal valid android eas.json', async () => {
     builds: {
       android: {
         workflow: 'generic',
-        internal: false,
+        distribution: 'store',
         credentialsSource: 'auto',
       },
     },
@@ -47,7 +47,7 @@ test('minimal valid ios eas.json', async () => {
     builds: {
       ios: {
         credentialsSource: 'auto',
-        internal: false,
+        distribution: 'store',
         workflow: 'generic',
       },
     },
@@ -70,8 +70,8 @@ test('minimal valid eas.json for both platforms', async () => {
   const easJson = await reader.readAsync('release');
   expect({
     builds: {
-      android: { workflow: 'generic', internal: false, credentialsSource: 'auto' },
-      ios: { workflow: 'generic', internal: false, credentialsSource: 'auto' },
+      android: { workflow: 'generic', distribution: 'store', credentialsSource: 'auto' },
+      ios: { workflow: 'generic', distribution: 'store', credentialsSource: 'auto' },
     },
   }).toEqual(easJson);
 });
@@ -92,7 +92,7 @@ test('valid eas.json with both platform, but reading only android', async () => 
   const easJson = await reader.readAsync('release');
   expect({
     builds: {
-      android: { workflow: 'generic', internal: false, credentialsSource: 'auto' },
+      android: { workflow: 'generic', distribution: 'store', credentialsSource: 'auto' },
     },
   }).toEqual(easJson);
 });
@@ -124,13 +124,13 @@ test('valid eas.json for debug builds', async () => {
         workflow: 'generic',
         gradleCommand: ':app:assembleDebug',
         withoutCredentials: true,
-        internal: false,
+        distribution: 'store',
       },
       ios: {
         credentialsSource: 'auto',
         workflow: 'managed',
         buildType: 'simulator',
-        internal: false,
+        distribution: 'store',
       },
     },
   }).toEqual(easJson);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,7 @@
 export {
   Workflow,
   CredentialsSource,
+  DistributionType,
   AndroidManagedBuildProfile,
   AndroidGenericBuildProfile,
   AndroidBuildProfile,

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -68,7 +68,7 @@
     "@types/node-fetch": "^2.5.7",
     "@types/node-forge": "^0.9.5",
     "@types/progress": "^2.0.3",
-    "@types/prompts": "^2.0.8",
+    "@types/prompts": "^2.0.9",
     "@types/tar": "^4.0.3",
     "@types/tough-cookie": "^4.0.0",
     "@types/uuid": "^8.3.0",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -84,8 +84,8 @@
     "wonka": "^4.0.14"
   },
   "optionalDependencies": {
-    "@expo/traveling-fastlane-darwin": "1.15.1",
-    "@expo/traveling-fastlane-linux": "1.15.1"
+    "@expo/traveling-fastlane-darwin": "1.15.3",
+    "@expo/traveling-fastlane-linux": "1.15.3"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -60,7 +60,7 @@ export async function startBuildForPlatformAsync<
 
   const archiveUrl = await uploadProjectAsync(builder.ctx);
 
-  const metadata = await collectMetadata(builder.ctx, {
+  const metadata = collectMetadata(builder.ctx, {
     credentialsSource: credentialsResult?.source,
   });
   const job = await builder.prepareJobAsync(builder.ctx, {

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -1,4 +1,4 @@
-import { CredentialsSource, Workflow } from '@eas/config';
+import { CredentialsSource, DistributionType, Workflow } from '@eas/config';
 import { ExpoConfig, IOSConfig } from '@expo/config';
 
 import * as ProvisioningProfileUtils from '../../credentials/ios/utils/provisioningProfile';
@@ -53,7 +53,7 @@ async function resolveCredentialsAndConfigureXcodeProjectAsync(
     },
     workflow: Workflow.Generic,
     credentialsSource: CredentialsSource.AUTO,
-    internalDistribution: false,
+    distribution: DistributionType.STORE,
     nonInteractive: false,
   });
 

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -45,21 +45,17 @@ async function resolveCredentialsAndConfigureXcodeProjectAsync(
   ctx: ConfigureContext,
   bundleIdentifier: string
 ): Promise<void> {
-  const { credentials } = await resolveIosCredentialsAsync(
-    ctx.projectDir,
-    {
-      app: {
-        accountName: await getProjectAccountNameAsync(ctx.projectDir),
-        projectName: ctx.exp.slug,
-        bundleIdentifier,
-      },
-      workflow: Workflow.Generic,
-      credentialsSource: CredentialsSource.AUTO,
+  const { credentials } = await resolveIosCredentialsAsync(ctx.projectDir, {
+    app: {
+      accountName: await getProjectAccountNameAsync(ctx.projectDir),
+      projectName: ctx.exp.slug,
+      bundleIdentifier,
     },
-    {
-      nonInteractive: false,
-    }
-  );
+    workflow: Workflow.Generic,
+    credentialsSource: CredentialsSource.AUTO,
+    internalDistribution: false,
+    nonInteractive: false,
+  });
 
   const profileName = ProvisioningProfileUtils.readProfileName(credentials.provisioningProfile);
   const appleTeam = ProvisioningProfileUtils.readAppleTeam(credentials.provisioningProfile);

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -18,44 +18,41 @@ export async function ensureIosCredentialsAsync(
     return;
   }
   assert(ctx.commandCtx.exp?.ios?.bundleIdentifier, 'ios.bundleIdentifier is required');
-  return await resolveIosCredentialsAsync(
-    ctx.commandCtx.projectDir,
-    {
-      app: {
-        accountName: ctx.commandCtx.accountName,
-        projectName: ctx.commandCtx.projectName,
-        bundleIdentifier: ctx.commandCtx.exp.ios.bundleIdentifier,
-      },
-      workflow: ctx.buildProfile.workflow,
-      credentialsSource: ctx.buildProfile.credentialsSource,
+  return await resolveIosCredentialsAsync(ctx.commandCtx.projectDir, {
+    app: {
+      accountName: ctx.commandCtx.accountName,
+      projectName: ctx.commandCtx.projectName,
+      bundleIdentifier: ctx.commandCtx.exp.ios.bundleIdentifier,
     },
-    {
-      nonInteractive: ctx.commandCtx.nonInteractive,
-    }
-  );
+    workflow: ctx.buildProfile.workflow,
+    credentialsSource: ctx.buildProfile.credentialsSource,
+    internalDistribution: ctx.buildProfile.internal ?? false,
+    nonInteractive: ctx.commandCtx.nonInteractive,
+  });
 }
 
 interface ResolveCredentialsParams {
   app: AppLookupParams;
   workflow: Workflow;
   credentialsSource: CredentialsSource;
+  internalDistribution: boolean;
+  nonInteractive: boolean;
 }
 
 export async function resolveIosCredentialsAsync(
   projectDir: string,
-  params: ResolveCredentialsParams,
-  options: { nonInteractive: boolean }
+  params: ResolveCredentialsParams
 ): Promise<CredentialsResult<IosCredentials>> {
-  const provider = new IosCredentialsProvider(
-    await createCredentialsContextAsync(projectDir, { nonInteractive: options.nonInteractive }),
-    params.app,
-    {}
-  );
+  const provider = new IosCredentialsProvider(await createCredentialsContextAsync(projectDir, {}), {
+    app: params.app,
+    nonInteractive: params.nonInteractive,
+    internalDistribution: params.internalDistribution,
+  });
   const credentialsSource = await ensureCredentialsAsync(
     provider,
     params.workflow,
     params.credentialsSource,
-    options.nonInteractive
+    params.nonInteractive
   );
   return {
     credentials: await provider.getCredentialsAsync(credentialsSource),

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -1,4 +1,4 @@
-import { CredentialsSource, Workflow } from '@eas/config';
+import { CredentialsSource, DistributionType, Workflow } from '@eas/config';
 import assert from 'assert';
 
 import { createCredentialsContextAsync } from '../../credentials/context';
@@ -26,7 +26,7 @@ export async function ensureIosCredentialsAsync(
     },
     workflow: ctx.buildProfile.workflow,
     credentialsSource: ctx.buildProfile.credentialsSource,
-    internalDistribution: ctx.buildProfile.internal ?? false,
+    distribution: ctx.buildProfile.distribution ?? DistributionType.STORE,
     nonInteractive: ctx.commandCtx.nonInteractive,
   });
 }
@@ -35,7 +35,7 @@ interface ResolveCredentialsParams {
   app: AppLookupParams;
   workflow: Workflow;
   credentialsSource: CredentialsSource;
-  internalDistribution: boolean;
+  distribution: DistributionType;
   nonInteractive: boolean;
 }
 
@@ -46,7 +46,7 @@ export async function resolveIosCredentialsAsync(
   const provider = new IosCredentialsProvider(await createCredentialsContextAsync(projectDir, {}), {
     app: params.app,
     nonInteractive: params.nonInteractive,
-    internalDistribution: params.internalDistribution,
+    distribution: params.distribution,
   });
   const credentialsSource = await ensureCredentialsAsync(
     provider,

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,4 +1,4 @@
-import { CredentialsSource, Workflow } from '@eas/config';
+import { CredentialsSource, DistributionType, Workflow } from '@eas/config';
 
 import { BuildContext } from './context';
 import { Platform, TrackingContext } from './types';
@@ -53,9 +53,10 @@ export type BuildMetadata = {
   trackingContext: TrackingContext;
 
   /**
-   * Flag indicating whether the build is for internal distribution.
+   * Distribution type
+   * Indicates whether this is a build for store or internal distribution.
    */
-  internalDistribution: boolean;
+  distribution: DistributionType;
 };
 
 export function collectMetadata<T extends Platform>(
@@ -73,6 +74,6 @@ export function collectMetadata<T extends Platform>(
     credentialsSource,
     sdkVersion: ctx.commandCtx.exp.sdkVersion,
     trackingContext: ctx.trackingCtx,
-    internalDistribution: ctx.buildProfile.internal ?? false,
+    distribution: ctx.buildProfile.distribution ?? DistributionType.STORE,
   };
 }

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -51,6 +51,11 @@ export type BuildMetadata = {
    * It's used to track build process across different Expo services and tools.
    */
   trackingContext: TrackingContext;
+
+  /**
+   * Flag indicating whether the build is for internal distribution.
+   */
+  internalDistribution: boolean;
 };
 
 export function collectMetadata<T extends Platform>(
@@ -68,5 +73,6 @@ export function collectMetadata<T extends Platform>(
     credentialsSource,
     sdkVersion: ctx.commandCtx.exp.sdkVersion,
     trackingContext: ctx.trackingCtx,
+    internalDistribution: ctx.buildProfile.internal ?? false,
   };
 }

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -1,6 +1,5 @@
-import { CredentialsSource } from '@eas/config';
+import { CredentialsSource, DistributionType } from '@eas/config';
 import { Platform } from '@expo/eas-build-job';
-import assert from 'assert';
 
 import { IosDistributionType } from '../../graphql/types/credentials/IosAppBuildCredentials';
 import log from '../../log';
@@ -29,7 +28,7 @@ interface PartialIosCredentials {
 
 interface Options {
   app: AppLookupParams;
-  internalDistribution: boolean;
+  distribution: DistributionType;
   nonInteractive: boolean;
   skipCredentialsCheck?: boolean;
 }
@@ -55,7 +54,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   }
 
   public async hasLocalAsync(): Promise<boolean> {
-    if (this.options.internalDistribution) {
+    if (this.options.distribution === DistributionType.INTERNAL) {
       // TODO: add support for using credentials.json for internal distribution
       return false;
     }
@@ -100,7 +99,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   }
 
   private async getLocalAsync(): Promise<IosCredentials> {
-    if (this.options.internalDistribution) {
+    if (this.options.distribution === DistributionType.INTERNAL) {
       // TODO: add support for using credentials.json for internal distribution
       throw new Error('Using credentials.json for internal distribution is not supported yet.');
     }
@@ -113,7 +112,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
     } else {
       await runCredentialsManagerAsync(
         this.ctx,
-        new SetupBuildCredentials(this.options.app, this.options.internalDistribution)
+        new SetupBuildCredentials(this.options.app, this.options.distribution)
       );
     }
 
@@ -146,7 +145,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   }
 
   private async fetchRemoteAsync(): Promise<PartialIosCredentials> {
-    if (this.options.internalDistribution) {
+    if (this.options.distribution === DistributionType.INTERNAL) {
       const { app } = this.options;
       const account = findAccountByName(this.ctx.user.accounts, app.accountName);
       if (!account) {

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -1,3 +1,4 @@
+import { DistributionType } from '@eas/config';
 import assert from 'assert';
 import chalk from 'chalk';
 
@@ -20,7 +21,7 @@ type AppCredentialsAndDistCert = {
 };
 
 export class SetupBuildCredentials implements Action {
-  constructor(private app: AppLookupParams, private internalDistribution: boolean) {}
+  constructor(private app: AppLookupParams, private distribution: DistributionType) {}
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     await ctx.bestEffortAppStoreAuthenticateAsync();
@@ -31,7 +32,7 @@ export class SetupBuildCredentials implements Action {
 
     let iosAppBuildCredentials: IosAppBuildCredentials | null = null;
     try {
-      if (this.internalDistribution) {
+      if (this.distribution === DistributionType.INTERNAL) {
         const account = findAccountByName(ctx.user.accounts, this.app.accountName);
         if (!account) {
           throw new Error(`You do not have access to the ${this.app.accountName} account`);

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -33,7 +33,9 @@ export class SetupBuildCredentials implements Action {
     try {
       if (this.internalDistribution) {
         const account = findAccountByName(ctx.user.accounts, this.app.accountName);
-        assert(account, `You do not have access to the ${this.app.accountName} account`);
+        if (!account) {
+          throw new Error(`You do not have access to the ${this.app.accountName} account`);
+        }
         // for now, let's require the user to authenticate with Apple
         await ctx.appStore.ensureAuthenticatedAsync();
         const action = new SetupAdhocProvisioningProfile({
@@ -92,7 +94,7 @@ export class SetupBuildCredentials implements Action {
         },
         distCert: {
           // the id doesn't really matter, it's only for displaying credentials
-          id: -1,
+          id: null as any,
           type: 'dist-cert',
           certId: distributionCertificate.developerPortalIdentifier,
           certP12: distributionCertificate.certificateP12,

--- a/packages/eas-cli/src/credentials/ios/actions/new/CreateDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/CreateDistributionCertificate.ts
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import chalk from 'chalk';
+
+import { AppleDistributionCertificate } from '../../../../graphql/types/credentials/AppleDistributionCertificate';
+import log from '../../../../log';
+import { Action, CredentialsManager } from '../../../CredentialsManager';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { provideOrGenerateDistributionCertificateAsync } from '../DistributionCertificateUtils';
+
+export class CreateDistributionCertificate implements Action {
+  private _distributionCertificate?: AppleDistributionCertificate;
+
+  constructor(private app: AppLookupParams) {}
+
+  public get distributionCertificate(): AppleDistributionCertificate {
+    assert(
+      this._distributionCertificate,
+      'distributionCertificate can be accessed only after calling .runAsync()'
+    );
+    return this._distributionCertificate;
+  }
+
+  public async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+    const distCert = await provideOrGenerateDistributionCertificateAsync(
+      manager,
+      ctx,
+      this.app.account.name
+    );
+    this._distributionCertificate = await ctx.newIos.createDistributionCertificateAsync(
+      this.app,
+      distCert
+    );
+    log(chalk.green('Successfully created Distribution Certificate.'));
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/DeviceUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/DeviceUtils.ts
@@ -1,0 +1,45 @@
+import {
+  APPLE_DEVICE_CLASS_LABELS,
+  AppleDevice,
+} from '../../../../graphql/types/credentials/AppleDevice';
+import { promptAsync } from '../../.././../prompts';
+
+export async function chooseDevices(
+  allDevices: AppleDevice[],
+  preselectedDeviceIdentifiers: string[] = []
+): Promise<AppleDevice[]> {
+  const preselectedDeviceIdentifierSet = new Set(preselectedDeviceIdentifiers);
+  const isSelected = (device: AppleDevice) =>
+    preselectedDeviceIdentifierSet.size === 0 ||
+    preselectedDeviceIdentifierSet.has(device.identifier);
+  const { devices } = await promptAsync({
+    type: 'multiselect',
+    name: 'devices',
+    message: 'Select devices for the adhoc build:',
+    hint: '- Space to select. Return to submit',
+    choices: allDevices.map(device => ({
+      value: device,
+      title: formatDeviceLabel(device),
+      selected: isSelected(device),
+    })),
+    instructions: false,
+    min: 1,
+  });
+  return devices;
+}
+
+function formatDeviceLabel(device: AppleDevice): string {
+  const deviceDetails = formatDeviceDetails(device);
+  return `${device.name ?? device.identifier}${deviceDetails !== '' ? ` ${deviceDetails}` : ''}`;
+}
+
+function formatDeviceDetails(device: AppleDevice): string {
+  let details = '';
+  if (device.deviceClass) {
+    details += APPLE_DEVICE_CLASS_LABELS[device.deviceClass];
+  }
+  if (device.model) {
+    details += details === '' ? device.model : ` ${device.model}`;
+  }
+  return details === '' ? details : `(${details})`;
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
@@ -1,0 +1,23 @@
+import { AppleDistributionCertificate } from '../../../../graphql/types/credentials/AppleDistributionCertificate';
+import { AppleTeam } from '../../../../graphql/types/credentials/AppleTeam';
+
+export function formatDistributionCertificate({
+  developerPortalIdentifier,
+  serialNumber,
+  appleTeam,
+  validityNotBefore,
+  validityNotAfter,
+}: AppleDistributionCertificate): string {
+  let line: string = '';
+  if (developerPortalIdentifier) {
+    line += `Cert ID: ${developerPortalIdentifier}`;
+  }
+  line += `${line === '' ? '' : ', '}Serial number: ${serialNumber}${
+    appleTeam ? `, ${formatAppleTeam(appleTeam)}` : ''
+  }, Created: ${validityNotBefore}, Expires: ${validityNotAfter}`;
+  return line;
+}
+
+function formatAppleTeam({ appleTeamIdentifier, appleTeamName }: AppleTeam): string {
+  return `Team ID: ${appleTeamIdentifier}${appleTeamName ? `, Team name: ${appleTeamName}` : ''}`;
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/ProvisioningProfileUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/ProvisioningProfileUtils.ts
@@ -1,0 +1,45 @@
+import isEqual from 'lodash/isEqual';
+
+import { AppleDevice } from '../../../../graphql/types/credentials/AppleDevice';
+import { AppleDistributionCertificate } from '../../../../graphql/types/credentials/AppleDistributionCertificate';
+import log from '../../../../log';
+import { ProvisioningProfileStoreInfo } from '../../appstore/Credentials.types';
+
+export function isDevPortalAdhocProfileValid(
+  profileFromDevPortal: ProvisioningProfileStoreInfo | null,
+  distCert: AppleDistributionCertificate,
+  expectedDevices: AppleDevice[]
+): boolean {
+  if (!profileFromDevPortal) {
+    return false;
+  }
+
+  if (profileFromDevPortal.status === 'Invalid' || profileFromDevPortal.certificates.length === 0) {
+    log('Provisioning Profile is invalid');
+    return false;
+  }
+
+  const currentDistCertId = profileFromDevPortal.certificates[0].id;
+  if (
+    distCert.developerPortalIdentifier &&
+    distCert.developerPortalIdentifier !== currentDistCertId
+  ) {
+    log(
+      `Provisioning Profile was generated for Distribution Certificate with ID "${currentDistCertId}", expected ID "${distCert.developerPortalIdentifier}"`
+    );
+    return false;
+  }
+
+  const profileDeviceUdids = (profileFromDevPortal.devices ?? []).map(({ udid }) => udid);
+  const expectedDeviceUdids = expectedDevices.map(({ identifier }) => identifier);
+  if (!doUDIDsMatch(profileDeviceUdids, expectedDeviceUdids)) {
+    log('Provisioning Profile was generated for another set of devices');
+    return false;
+  }
+
+  return true;
+}
+
+export function doUDIDsMatch(udidsA: string[], udidsB: string[]): boolean {
+  return isEqual(new Set(udidsA), new Set(udidsB));
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
@@ -1,0 +1,157 @@
+import assert from 'assert';
+import nullthrows from 'nullthrows';
+
+import { AppleDevice } from '../../../../graphql/types/credentials/AppleDevice';
+import {
+  IosAppBuildCredentials,
+  IosDistributionType,
+} from '../../../../graphql/types/credentials/IosAppBuildCredentials';
+import { confirmAsync } from '../../../../prompts';
+import { Action, CredentialsManager } from '../../../CredentialsManager';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { ProvisioningProfileStoreInfo } from '../../appstore/Credentials.types';
+import { ProfileClass } from '../../appstore/provisioningProfile';
+import { chooseDevices } from './DeviceUtils';
+import { doUDIDsMatch, isDevPortalAdhocProfileValid } from './ProvisioningProfileUtils';
+import { SetupDistributionCertificate } from './SetupDistributionCertificate';
+
+export class SetupAdhocProvisioningProfile implements Action {
+  private _iosAppBuildCredentials?: IosAppBuildCredentials;
+
+  constructor(private app: AppLookupParams) {}
+
+  public get iosAppBuildCredentials(): IosAppBuildCredentials {
+    assert(
+      this._iosAppBuildCredentials,
+      'iosAppBuildCredentials can be accessed only after calling .runAsync()'
+    );
+    return this._iosAppBuildCredentials;
+  }
+
+  async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+    assert(
+      ctx.appStore.authCtx,
+      'authCtx is defined in this context - enforced by ensureAuthenticatedAsync call in SetupBuildCredentials'
+    );
+
+    // 0. Fetch apple team object
+    const appleTeam = await ctx.newIos.createOrGetExistingAppleTeamAsync(this.app, {
+      appleTeamIdentifier: ctx.appStore.authCtx.team.id,
+      appleTeamName: ctx.appStore.authCtx.team.name,
+    });
+
+    // 1. Fetch devices registered on Expo servers.
+    const registeredAppleDevices = await ctx.newIos.getDevicesForAppleTeamAsync(
+      this.app,
+      appleTeam
+    );
+    const registeredAppleDeviceIdentifiers = registeredAppleDevices.map(
+      ({ identifier }) => identifier
+    );
+    if (registeredAppleDeviceIdentifiers.length === 0) {
+      throw new Error(`Run 'eas device:create' to register your devices first`);
+    }
+
+    // 2. Setup Distribution Certificate
+    const distCertAction = new SetupDistributionCertificate(this.app);
+    await manager.runActionAsync(distCertAction);
+    const distCert = distCertAction.distributionCertificate;
+
+    // 3. Fetch profile from Expo servers
+    let currentProfileFromExpoServers = await ctx.newIos.getProvisioningProfileAsync(
+      this.app,
+      appleTeam,
+      IosDistributionType.AD_HOC
+    );
+
+    // 4. Choose devices for internal distribution
+    let chosenDevices: AppleDevice[];
+    if (currentProfileFromExpoServers) {
+      const appleDeviceIdentifiersFromProfile = (
+        currentProfileFromExpoServers.appleDevices ?? []
+      ).map(({ identifier }) => identifier);
+
+      let shouldAskToChooseDevices = true;
+      if (doUDIDsMatch(appleDeviceIdentifiersFromProfile, registeredAppleDeviceIdentifiers)) {
+        shouldAskToChooseDevices = await confirmAsync({
+          message: `All your registered devices are present in the Provisioning Profile. Would you like to exclude some devices?`,
+          initial: false,
+        });
+      }
+
+      chosenDevices = shouldAskToChooseDevices
+        ? await chooseDevices(registeredAppleDevices, appleDeviceIdentifiersFromProfile)
+        : registeredAppleDevices;
+    } else {
+      chosenDevices = await chooseDevices(registeredAppleDevices);
+    }
+
+    // 5. Try to find the profile on Apple Developer Portal
+    const currentProfileFromDevPortal = await this.getProfileFromDevPortalAsync(ctx);
+
+    // 6. Validate the profile and possibly recreate it
+    let profileToUse: ProvisioningProfileStoreInfo;
+    let profileWasRecreated = false;
+    if (isDevPortalAdhocProfileValid(currentProfileFromDevPortal, distCert, chosenDevices)) {
+      profileToUse = nullthrows(currentProfileFromDevPortal);
+    } else {
+      const chosenDeviceUDIDs = chosenDevices.map(({ identifier }) => identifier);
+      await ctx.appStore.createOrReuseAdhocProvisioningProfileAsync(
+        chosenDeviceUDIDs,
+        this.app.bundleIdentifier,
+        distCert.serialNumber
+      );
+      profileToUse = nullthrows(await this.getProfileFromDevPortalAsync(ctx));
+      profileWasRecreated = true;
+    }
+
+    // 7. Send profile to www if new has been created
+    const appleAppIdentifier = await ctx.newIos.createOrGetExistingAppleAppIdentifierAsync(
+      this.app,
+      appleTeam
+    );
+    if (currentProfileFromExpoServers) {
+      if (profileWasRecreated) {
+        currentProfileFromExpoServers = await ctx.newIos.updateProvisioningProfileAsync(
+          currentProfileFromExpoServers.id,
+          {
+            appleProvisioningProfile: profileToUse.provisioningProfile,
+            developerPortalIdentifier: profileToUse.provisioningProfileId,
+          }
+        );
+      }
+    } else {
+      currentProfileFromExpoServers = await ctx.newIos.createProvisioningProfileAsync(
+        this.app,
+        appleAppIdentifier,
+        {
+          appleProvisioningProfile: profileToUse.provisioningProfile,
+          developerPortalIdentifier: profileToUse.provisioningProfileId,
+        }
+      );
+    }
+
+    // 8. Create (or update) app build credentials
+    this._iosAppBuildCredentials = await ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync(
+      this.app,
+      {
+        appleTeam,
+        appleAppIdentifierId: appleAppIdentifier.id,
+        appleDistributionCertificateId: distCert.id,
+        appleProvisioningProfileId: currentProfileFromExpoServers.id,
+        iosDistributionType: IosDistributionType.AD_HOC,
+      }
+    );
+  }
+
+  private async getProfileFromDevPortalAsync(
+    ctx: Context
+  ): Promise<ProvisioningProfileStoreInfo | null> {
+    const profilesFromDevPortal = await ctx.appStore.listProvisioningProfilesAsync(
+      this.app.bundleIdentifier,
+      ProfileClass.Adhoc
+    );
+    return profilesFromDevPortal.length >= 1 ? profilesFromDevPortal[0] : null;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
@@ -30,15 +30,12 @@ export class SetupAdhocProvisioningProfile implements Action {
   }
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
-    assert(
-      ctx.appStore.authCtx,
-      'authCtx is defined in this context - enforced by ensureAuthenticatedAsync call in SetupBuildCredentials'
-    );
+    const authCtx = await ctx.appStore.ensureAuthenticatedAsync();
 
     // 0. Fetch apple team object
     const appleTeam = await ctx.newIos.createOrGetExistingAppleTeamAsync(this.app, {
-      appleTeamIdentifier: ctx.appStore.authCtx.team.id,
-      appleTeamName: ctx.appStore.authCtx.team.name,
+      appleTeamIdentifier: authCtx.team.id,
+      appleTeamName: authCtx.team.name,
     });
 
     // 1. Fetch devices registered on Expo servers.

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
@@ -1,0 +1,161 @@
+import assert from 'assert';
+import sortBy from 'lodash/sortBy';
+
+import { AppleDistributionCertificate } from '../../../../graphql/types/credentials/AppleDistributionCertificate';
+import { IosDistributionType } from '../../../../graphql/types/credentials/IosAppBuildCredentials';
+import log from '../../../../log';
+import { confirmAsync, promptAsync } from '../../../../prompts';
+import { Action, CredentialsManager } from '../../../CredentialsManager';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { getValidCertSerialNumbers } from '../../appstore/CredentialsUtils';
+import { CreateDistributionCertificate } from './CreateDistributionCertificate';
+import { formatDistributionCertificate } from './DistributionCertificateUtils';
+
+export class SetupDistributionCertificate implements Action {
+  private validDistCerts?: AppleDistributionCertificate[];
+  private _distributionCertificate?: AppleDistributionCertificate;
+
+  constructor(private app: AppLookupParams) {}
+
+  public get distributionCertificate(): AppleDistributionCertificate {
+    assert(
+      this._distributionCertificate,
+      'distributionCertificate can be accessed only after calling .runAsync()'
+    );
+    return this._distributionCertificate;
+  }
+
+  public async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+    assert(
+      ctx.appStore.authCtx,
+      'authCtx is defined in this context - enforced by ensureAuthenticatedAsync call in SetupBuildCredentials'
+    );
+    const appleTeam = await ctx.newIos.createOrGetExistingAppleTeamAsync(this.app, {
+      appleTeamIdentifier: ctx.appStore.authCtx.team.id,
+      appleTeamName: ctx.appStore.authCtx.team.name,
+    });
+
+    const currentCertificate = await ctx.newIos.getDistributionCertificateForAppAsync(
+      this.app,
+      appleTeam,
+      IosDistributionType.AD_HOC
+    );
+
+    if (await this.isCurrentCertificateValidAsync(ctx, currentCertificate)) {
+      assert(currentCertificate, 'currentCertificate is defined here');
+      this._distributionCertificate = currentCertificate;
+      return;
+    }
+
+    const validDistCertsOnFile = await this.getValidDistCertsAsync(ctx);
+    this._distributionCertificate =
+      validDistCertsOnFile.length === 0
+        ? await this.createNewDistCertAsync(manager)
+        : await this.createOrReuseDistCert(manager, ctx);
+  }
+
+  private async isCurrentCertificateValidAsync(
+    ctx: Context,
+    currentCertificate: AppleDistributionCertificate | null
+  ): Promise<boolean> {
+    if (!currentCertificate) {
+      return false;
+    }
+    const validCertSerialNumbers = (await this.getValidDistCertsAsync(ctx)).map(
+      i => i.serialNumber
+    );
+    const isValid = validCertSerialNumbers.includes(currentCertificate.serialNumber);
+    if (!isValid) {
+      log.warn("Current Distribution Certificate is no longer valid on Apple's server");
+    }
+    return isValid;
+  }
+
+  private async createOrReuseDistCert(
+    manager: CredentialsManager,
+    ctx: Context
+  ): Promise<AppleDistributionCertificate> {
+    const validDistCerts = await this.getValidDistCertsAsync(ctx);
+    const autoselectedDistCert = validDistCerts[0];
+
+    const useAutoselected = await confirmAsync({
+      message: `Would you to reuse this distribution certificate?\n${formatDistributionCertificate(
+        autoselectedDistCert
+      )}`,
+    });
+
+    if (useAutoselected) {
+      log(`Using Distribution Certificate with serial number ${autoselectedDistCert.serialNumber}`);
+      return autoselectedDistCert;
+    }
+
+    const { action } = await promptAsync({
+      type: 'select',
+      name: 'action',
+      message: 'Select the iOS Distribution Certificate to use for code signing:',
+      choices: [
+        {
+          title: '[Choose another existing certificate] (Recommended)',
+          value: 'CHOOSE_EXISTING',
+        },
+        { title: '[Add a new certificate]', value: 'GENERATE' },
+      ],
+    });
+
+    if (action === 'GENERATE') {
+      return await this.createNewDistCertAsync(manager);
+    } else {
+      return await this.reuseDistCertAsync(ctx);
+    }
+  }
+
+  private async createNewDistCertAsync(
+    manager: CredentialsManager
+  ): Promise<AppleDistributionCertificate> {
+    const action = new CreateDistributionCertificate(this.app);
+    await manager.runActionAsync(action);
+    return action.distributionCertificate;
+  }
+
+  private async reuseDistCertAsync(ctx: Context): Promise<AppleDistributionCertificate> {
+    const validDistCerts = await this.getValidDistCertsAsync(ctx);
+    const { distCert } = await promptAsync({
+      type: 'select',
+      name: 'distCert',
+      message: 'Select the iOS Distribution Certificate from the list:',
+      choices: validDistCerts.map(distCert => ({
+        title: formatDistributionCertificate(distCert),
+        value: distCert,
+      })),
+    });
+    return distCert;
+  }
+
+  private async getValidDistCertsAsync(ctx: Context): Promise<AppleDistributionCertificate[]> {
+    if (this.validDistCerts) {
+      return this.validDistCerts;
+    }
+
+    const validDistCertSerialNumbers = getValidCertSerialNumbers(
+      await ctx.appStore.listDistributionCertificatesAsync()
+    );
+    const validDistCertSerialNumberSet = new Set(validDistCertSerialNumbers);
+
+    const distCertsForAccount = await ctx.newIos.getDistributionCertificatesForAccountAsync(
+      this.app
+    );
+    const distCertsForAppleTeam = distCertsForAccount.filter(distCert => {
+      return (
+        !distCert.appleTeam ||
+        distCert.appleTeam.appleTeamIdentifier === ctx.appStore.authCtx?.team.id
+      );
+    });
+
+    const validDistCerts = distCertsForAppleTeam.filter(distCert => {
+      return validDistCertSerialNumberSet.has(distCert.serialNumber);
+    });
+    this.validDistCerts = sortBy(validDistCerts, 'validityNotAfter', 'desc');
+    return this.validDistCerts;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/api/Client.ts
+++ b/packages/eas-cli/src/credentials/ios/api/Client.ts
@@ -309,8 +309,8 @@ export default class iOSApi {
     }
   }
 
-  // ensures that credentials are fetched from the server if they exists
-  // if there is no credentials on server for specific app this function should still succeed.
+  // ensures that credentials are fetched from the server if they exist
+  // if there are no credentials on server for specific app this function should still succeed
   private async ensureAppCredentialsAsync(appLookupParams: AppLookupParams): Promise<void> {
     const appCredentialsIndex = this.getAppCredentialsCacheIndex(appLookupParams);
     const { accountName } = appLookupParams;

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -105,12 +105,14 @@ export async function createOrGetExistingIosAppCredentialsWithBuildCredentialsAs
   if (maybeIosAppCredentials) {
     return maybeIosAppCredentials;
   } else {
-    const { account } = appLookupParams;
-    const app = await getAppAsync(appLookupParams);
+    const [app, appleAppIdentifier] = await Promise.all([
+      getAppAsync(appLookupParams),
+      createOrGetExistingAppleAppIdentifierAsync(appLookupParams, appleTeam),
+    ]);
     await IosAppCredentialsMutation.createIosAppCredentialsAsync(
       { appleTeamId: appleTeam.id },
       app.id,
-      account.id
+      appleAppIdentifier.id
     );
     return nullthrows(
       await IosAppCredentialsQuery.withBuildCredentialsByAppIdentifierIdAsync(projectFullName, {
@@ -244,6 +246,7 @@ export async function createDistributionCertificateAsync(
       certP12: distCert.certP12,
       certPassword: distCert.certPassword,
       certPrivateSigningKey: distCert.certPrivateSigningKey,
+      developerPortalIdentifier: distCert.certId,
       appleTeamId: appleTeam.id,
     },
     account.id

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
@@ -80,7 +80,7 @@ const IosAppBuildCredentialsMutation = {
           gql`
             mutation IosAppBuildCredentialsMutation($iosAppBuildCredentialsId: ID!, $provisioningProfileId: ID!) {
               iosAppBuildCredentials {
-                setProvisioningProfile(iosAppBuildCredentialsId: $iosAppBuildCredentialsId, distributionCertificateId: $distributionCertificateId) {
+                setProvisioningProfile(id: $iosAppBuildCredentialsId, provisioningProfileId: $provisioningProfileId) {
                   ...${IosAppBuildCredentialsFragment.name}
                 }
               }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
@@ -13,7 +13,7 @@ const IosAppCredentialsMutation = {
       pushKeyId?: string;
     },
     appId: string,
-    accountId: string
+    appleAppIdentifierId: string
   ): Promise<IosAppCredentials> {
     const data = await withErrorHandlingAsync(
       graphqlClient
@@ -31,7 +31,7 @@ const IosAppCredentialsMutation = {
           {
             iosAppCredentialsInput,
             appId,
-            accountId,
+            appleAppIdentifierId,
           }
         )
         .toPromise()

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
@@ -16,7 +16,7 @@ const AppQuery = {
                 }
               }
             }
-            ...${AppFragment.definition}
+            ${AppFragment.definition}
           `,
           { fullName }
         )

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
@@ -29,6 +29,9 @@ const AppleAppIdentifierQuery = {
           {
             accountName,
             bundleIdentifier,
+          },
+          {
+            additionalTypenames: ['AppleAppIdentifier'],
           }
         )
         .toPromise()

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -36,7 +36,8 @@ const AppleDeviceQuery = {
           {
             accountId,
             appleTeamIdentifier,
-          }
+          },
+          { additionalTypenames: ['AppleDevice'] }
         )
         .toPromise()
     );

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
@@ -59,6 +59,9 @@ const AppleDistributionCertificateQuery = {
             projectFullName,
             appleAppIdentifierId,
             iosDistributionType,
+          },
+          {
+            additionalTypenames: ['IosAppCredentials', 'IosAppBuildCredentials'],
           }
         )
         .toPromise()

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
@@ -69,6 +69,9 @@ const AppleProvisioningProfileQuery = {
             projectFullName,
             appleAppIdentifierId,
             iosDistributionType,
+          },
+          {
+            additionalTypenames: ['IosAppCredentials', 'IosAppBuildCredentials'],
           }
         )
         .toPromise()

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
@@ -50,6 +50,9 @@ const IosAppBuildCredentialsQuery = {
             projectFullName,
             appleAppIdentifierId,
             iosDistributionType,
+          },
+          {
+            additionalTypenames: ['IosAppCredentials', 'IosAppBuildCredentials'],
           }
         )
         .toPromise()

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
@@ -33,6 +33,9 @@ const IosAppCredentialsQuery = {
           {
             projectFullName,
             appleAppIdentifierId,
+          },
+          {
+            additionalTypenames: ['IosAppCredentials'],
           }
         )
         .toPromise()
@@ -74,6 +77,9 @@ const IosAppCredentialsQuery = {
             projectFullName,
             appleAppIdentifierId,
             iosDistributionType,
+          },
+          {
+            additionalTypenames: ['IosAppCredentials', 'IosAppBuildCredentials'],
           }
         )
         .toPromise()

--- a/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
@@ -17,6 +17,7 @@ import {
 import { AppLookupParams, EnsureAppExistsOptions, ensureAppExistsAsync } from './ensureAppExists';
 import { USE_APPLE_UTILS } from './experimental';
 import {
+  ProfileClass,
   createProvisioningProfileAsync,
   listProvisioningProfilesAsync,
   revokeProvisioningProfileAsync,
@@ -94,36 +95,49 @@ class AppStoreApi {
   public async useExistingProvisioningProfileAsync(
     bundleIdentifier: string,
     provisioningProfile: ProvisioningProfile,
-    distCert: DistributionCertificate
+    distCert: DistributionCertificate,
+    profileClass?: ProfileClass
   ): Promise<ProvisioningProfile> {
     const ctx = await this.ensureAuthenticatedAsync();
     return await useExistingProvisioningProfileAsync(
       ctx,
       bundleIdentifier,
       provisioningProfile,
-      distCert
+      distCert,
+      profileClass
     );
   }
 
   public async listProvisioningProfilesAsync(
-    bundleIdentifier: string
+    bundleIdentifier: string,
+    profileClass?: ProfileClass
   ): Promise<ProvisioningProfileStoreInfo[]> {
     const ctx = await this.ensureAuthenticatedAsync();
-    return await listProvisioningProfilesAsync(ctx, bundleIdentifier);
+    return await listProvisioningProfilesAsync(ctx, bundleIdentifier, profileClass);
   }
 
   public async createProvisioningProfileAsync(
     bundleIdentifier: string,
     distCert: DistributionCertificate,
-    profileName: string
+    profileName: string,
+    profileClass?: ProfileClass
   ): Promise<ProvisioningProfile> {
     const ctx = await this.ensureAuthenticatedAsync();
-    return await createProvisioningProfileAsync(ctx, bundleIdentifier, distCert, profileName);
+    return await createProvisioningProfileAsync(
+      ctx,
+      bundleIdentifier,
+      distCert,
+      profileName,
+      profileClass
+    );
   }
 
-  public async revokeProvisioningProfileAsync(bundleIdentifier: string): Promise<void> {
+  public async revokeProvisioningProfileAsync(
+    bundleIdentifier: string,
+    profileClass?: ProfileClass
+  ): Promise<void> {
     const ctx = await this.ensureAuthenticatedAsync();
-    return await revokeProvisioningProfileAsync(ctx, bundleIdentifier);
+    return await revokeProvisioningProfileAsync(ctx, bundleIdentifier, profileClass);
   }
 
   public async createOrReuseAdhocProvisioningProfileAsync(

--- a/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
@@ -48,6 +48,11 @@ export interface ProvisioningProfileStoreInfo extends ProvisioningProfile {
   expires: number;
   distributionMethod: string;
   certificates: DistributionCertificateStoreInfo[];
+  devices?: {
+    id: string;
+    udid: string;
+    name?: string;
+  }[];
 }
 
 export interface PushKeyStoreInfo {

--- a/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtils.ts
@@ -36,3 +36,14 @@ export function sortCertificatesByExpiryDesc<T extends DistributionCertificate>(
     return certBExpiry - certAExpiry;
   });
 }
+
+export function getValidCertSerialNumbers(
+  certInfoFromApple: DistributionCertificateStoreInfo[]
+): string[] {
+  return certInfoFromApple
+    .filter(
+      // remove expired certs
+      cert => cert.expires > Math.floor(Date.now() / 1000)
+    )
+    .map(cert => cert.serialNumber);
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -1,5 +1,4 @@
 import { Device, Profile, ProfileState, ProfileType } from '@expo/apple-utils';
-import omit from 'lodash/omit';
 import ora from 'ora';
 
 import { ProvisioningProfile } from './Credentials.types';

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -1,4 +1,5 @@
 import { Device, Profile, ProfileState, ProfileType } from '@expo/apple-utils';
+import omit from 'lodash/omit';
 import ora from 'ora';
 
 import { ProvisioningProfile } from './Credentials.types';
@@ -232,10 +233,17 @@ export async function createOrReuseAdhocProvisioningProfileAsync(
         bundleIdentifier,
         distCertSerialNumber,
       ];
-      adhocProvisioningProfile = await runActionAsync(
+      const travelingFastlaneProfile = await runActionAsync(
         travelingFastlane.manageAdHocProvisioningProfile,
         args
       );
+      adhocProvisioningProfile = {
+        provisioningProfile: travelingFastlane.provisioningProfile,
+        provisioningProfileId: travelingFastlane.provisioningProfileId,
+        profileName: travelingFastlaneProfile.provisioningProfileName,
+        didUpdate: !!travelingFastlaneProfile.provisioningProfileUpdateTimestamp,
+        didCreate: !!travelingFastlaneProfile.provisioningProfileCreateTimestamp,
+      };
     }
 
     const { didUpdate, didCreate, profileName } = adhocProvisioningProfile;

--- a/packages/eas-cli/src/credentials/ios/credentials.ts
+++ b/packages/eas-cli/src/credentials/ios/credentials.ts
@@ -1,3 +1,4 @@
+import { AppleDevice } from '../../graphql/types/credentials/AppleDevice';
 import log from '../../log';
 import { CredentialSchema } from '../utils/promptForCredentials';
 import {
@@ -40,6 +41,9 @@ export interface IosAppCredentials {
   credentials: {
     provisioningProfileId?: string;
     provisioningProfile?: string;
+
+    // for adhoc provisioning profiles
+    devices?: AppleDevice[];
 
     teamId?: string;
     teamName?: string;

--- a/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
@@ -1,5 +1,9 @@
 import chalk from 'chalk';
 
+import {
+  APPLE_DEVICE_CLASS_LABELS,
+  AppleDevice,
+} from '../../../graphql/types/credentials/AppleDevice';
 import log from '../../../log';
 import {
   AppLookupParams,
@@ -74,6 +78,12 @@ export function displayIosAppCredentials(appCredentials: IosAppCredentials) {
   } else {
     log('    Provisioning profile is missing. It will be generated during the next build');
   }
+  if (appCredentials.credentials.devices && appCredentials.credentials.devices.length > 0) {
+    log(`    Provisioned devices:`);
+    for (const device of appCredentials.credentials.devices) {
+      log(`    - ${formatDevice(device)}`);
+    }
+  }
   if (appCredentials.credentials.teamId || appCredentials.credentials.teamName) {
     log(
       `    Apple Team ID: ${chalk.green(
@@ -88,6 +98,33 @@ export function displayIosAppCredentials(appCredentials: IosAppCredentials) {
       )})`
     );
   }
+}
+
+function formatDevice(device: AppleDevice): string {
+  let deviceString = '';
+  if (device.name) {
+    deviceString += device.name;
+  }
+  if (device.deviceClass || device.model) {
+    const deviceDetails = [
+      device.deviceClass && APPLE_DEVICE_CLASS_LABELS[device.deviceClass],
+      device.model,
+    ]
+      .filter(i => i)
+      .join(' ');
+    if (deviceString === '') {
+      deviceString += deviceDetails;
+    } else {
+      deviceString += ` - ${deviceDetails}`;
+    }
+  }
+
+  if (deviceString === '') {
+    deviceString += device.identifier;
+  } else {
+    deviceString += ` (UDID: ${device.identifier})`;
+  }
+  return deviceString;
 }
 
 export function displayIosUserCredentials(

--- a/packages/eas-cli/src/credentials/ios/validators/validateDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validateDistributionCertificate.ts
@@ -7,7 +7,7 @@ export async function validateDistributionCertificateAsync(
   distributionCertificate: DistributionCertificate
 ): Promise<boolean> {
   const certInfoFromApple = await ctx.appStore.listDistributionCertificatesAsync();
-  const validDistributionCerts = await filterRevokedDistributionCerts(
+  const validDistributionCerts = filterRevokedDistributionCerts(
     [distributionCertificate],
     certInfoFromApple
   );

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -14,6 +14,7 @@ import { UseExistingDistributionCertificate } from '../ios/actions/UseDistributi
 import { AppLookupParams } from '../ios/credentials';
 import { displayAllIosCredentials } from '../ios/utils/printCredentials';
 import { PressAnyKeyToContinue } from './HelperActions';
+import { DistributionType } from '@eas/config';
 
 enum ActionType {
   SetupBuildCredentials,
@@ -118,7 +119,7 @@ export class ManageIos implements Action {
       }
       case ActionType.SetupBuildCredentials: {
         const app = this.getAppLookupParamsFromContext(ctx);
-        return new SetupBuildCredentials(app, false);
+        return new SetupBuildCredentials(app, DistributionType.STORE);
       }
       case ActionType.RemoveSpecificProvisioningProfile: {
         const app = this.getAppLookupParamsFromContext(ctx);

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -118,7 +118,7 @@ export class ManageIos implements Action {
       }
       case ActionType.SetupBuildCredentials: {
         const app = this.getAppLookupParamsFromContext(ctx);
-        return new SetupBuildCredentials(app);
+        return new SetupBuildCredentials(app, /* TODO: figure out if this is fine */ false);
       }
       case ActionType.RemoveSpecificProvisioningProfile: {
         const app = this.getAppLookupParamsFromContext(ctx);

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -118,7 +118,7 @@ export class ManageIos implements Action {
       }
       case ActionType.SetupBuildCredentials: {
         const app = this.getAppLookupParamsFromContext(ctx);
-        return new SetupBuildCredentials(app, /* TODO: figure out if this is fine */ false);
+        return new SetupBuildCredentials(app, false);
       }
       case ActionType.RemoveSpecificProvisioningProfile: {
         const app = this.getAppLookupParamsFromContext(ctx);

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -1,3 +1,5 @@
+import { DistributionType } from '@eas/config';
+
 import { promptAsync } from '../../prompts';
 import { Action, CredentialsManager } from '../CredentialsManager';
 import { Context } from '../context';
@@ -14,7 +16,6 @@ import { UseExistingDistributionCertificate } from '../ios/actions/UseDistributi
 import { AppLookupParams } from '../ios/credentials';
 import { displayAllIosCredentials } from '../ios/utils/printCredentials';
 import { PressAnyKeyToContinue } from './HelperActions';
-import { DistributionType } from '@eas/config';
 
 enum ActionType {
   SetupBuildCredentials,

--- a/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
@@ -26,6 +26,13 @@ export const AppleProvisioningProfileFragment: Fragment = {
         appleTeamIdentifier
         appleTeamName
       }
+      appleDevices {
+        id
+        identifier
+        name
+        model
+        deviceClass
+      }
     }
   `,
 };

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
@@ -24,6 +24,50 @@ export const IosAppBuildCredentialsFragment: Fragment = {
     fragment iosAppBuildCredentials on IosAppBuildCredentials {
       id
       iosDistributionType
+      distributionCertificate {
+        id
+        certificateP12
+        certificatePassword
+        serialNumber
+        developerPortalIdentifier
+        validityNotBefore
+        validityNotAfter
+        appleTeam {
+          id
+          appleTeamIdentifier
+          appleTeamName
+        }
+      }
+      provisioningProfile {
+        id
+        expiration
+        developerPortalIdentifier
+        provisioningProfile
+        appleDevices {
+          id
+          identifier
+          name
+          model
+          deviceClass
+        }
+        appleTeam {
+          id
+          appleTeamIdentifier
+          appleTeamName
+        }
+      }
+      appleDevices {
+        id
+        identifier
+        name
+        model
+        deviceClass
+        appleTeam {
+          id
+          appleTeamIdentifier
+          appleTeamName
+        }
+      }
     }
   `,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,15 +1571,15 @@
   dependencies:
     cross-spawn "^6.0.5"
 
-"@expo/traveling-fastlane-darwin@1.15.1":
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.15.1.tgz#87b34e39a91377044070a55f3b03c575d00be39e"
-  integrity sha512-7sjG83+o9BT4MVPNq2UVqy1Oyg3n47FpEIDxc0M9CQvbC1WgYsAKloOJ85g5GRXZAjqzPOPUZF+lBhGbOwmQvg==
+"@expo/traveling-fastlane-darwin@1.15.3":
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.15.3.tgz#9019b1691ab356c6a97384dd63794156c83751f4"
+  integrity sha512-B8x45xV2HpyG6mVN1pUL7s1y2LGWYuK4ls3SU9DHsBJIvQpTbLOTv5jmr5fcNN8v9iLNvxQef3AMUdFEGE9hpg==
 
-"@expo/traveling-fastlane-linux@1.15.1":
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.15.1.tgz#3b77e3a3d490cbe59fbcffd155068e267c2e95c8"
-  integrity sha512-YaFAYYOOxImYNx9s6X3tY6fC1y6rka0KXstrs2zrS+vHyyBD8IOhNtIUvybHScM3jUL+qukgKElAb+7gzlF6Eg==
+"@expo/traveling-fastlane-linux@1.15.3":
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.15.3.tgz#13a3031b1732234574da0246074d5fae41faf382"
+  integrity sha512-vDw4TT0i3W2AjFUsqyFddcPNyHH1kDPZzcnGbBjSc82Oo33r/YE/KT4yjg248oBokfmzAEIhlPQTL7lfCn51pg==
 
 "@graphql-codegen/cli@^1.19.2":
   version "1.19.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,10 +3756,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/prompts@^2.0.8":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.0.8.tgz#350fc8341426b2b68a56f874ea3bae399f771800"
-  integrity sha512-lXXAa8c8ASoA61Tj9H5E5V2mRUTvNZ/dpJ5KxghI+O5geWMHt73NLZ9kEBBDK7zUUfMsMY3ZH4Sqeqh3SjSyfg==
+"@types/prompts@^2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.0.9.tgz#19f419310eaa224a520476b19d4183f6a2b3bd8f"
+  integrity sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
This PR implements internal distribution with EAS Build. Internal distribution means that a developer can distribution their iOS app without submitting it to App Store/Testflight. That's thanks to ad-hoc provisioning profiles. If an app is signed with an ad-hoc provisioning profile it can be installed on all devices included in the profile, simply by opening a plist file with the URL to the .ipa file. 

In this PR, I implemented generating credentials for ad-hoc builds. In order to do so, I had to use the new credentials API because the old one was assuming that all credentials are for App Store distribution.

This is how to build an app for internal distribution from the developer's perspective:
- register all devices using command `eas device:create`
- add a new build profile with `"distribution": "internal",` (e.g. named `internal`)
- run build with `eas build:create -p ios --profile internal` and follow all interactive steps

Another thing worth mentioning is that I used a slightly modified traveling-fastlane for managing ad-hoc provisioning profiles. The changes are in https://github.com/expo/expo-cli/pull/2928 (that PR should be merged before this one).

I tested these changes by manually executing `eas build:create -p ios --profile internal` multiple times. I hadn't had time to write any unit/integration tests as the deadline is pretty tight. I'll add them when I have more time.

Still to do (but I'd prefer to do that in separate PRs):
- [x] ~I've started working on this before https://github.com/expo/eas-cli/pull/64 was merged. I need to make sure this feature works fine when `USE_APPLE_UTILS=true` is set.~ It seems to be working fine, I just made a few tweaks.
- [ ] This only supports App Store teams for now. No support for enterprise teams for yet (it's also possible it works fine but I haven't tested it).

As long as this command is complete and it allows for building binaries signed with the ad-hoc provisioning profiles, one of the missing parts is a custom page on our website. For now, I only tested installing the binary on my iPhone by manually creating the plist file and hosting it from my computer. However, @satya164 is working on the new page already and it should be ready soon.