### PR TITLE
Align account command names with the style guide

### DIFF
--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -1,9 +1,11 @@
 import { Command } from '@oclif/command';
 
-import { showLoginPromptAsync } from '../user/actions';
+import { showLoginPromptAsync } from '../../user/actions';
 
-export default class Login extends Command {
+export default class AccountLogin extends Command {
   static description = 'log in with your EAS account';
+
+  static aliases = ['login'];
 
   async run() {
     this.log('Log in to EAS');

--- a/packages/eas-cli/src/commands/account/logout.ts
+++ b/packages/eas-cli/src/commands/account/logout.ts
@@ -1,9 +1,11 @@
 import { Command } from '@oclif/command';
 
-import { logoutAsync } from '../user/User';
+import { logoutAsync } from '../../user/User';
 
-export default class Logout extends Command {
+export default class AccountLogout extends Command {
   static description = 'log out';
+
+  static aliases = ['logout'];
 
   async run() {
     await logoutAsync();

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -1,11 +1,13 @@
 import { Command } from '@oclif/command';
 import chalk from 'chalk';
 
-import log from '../log';
-import { getUserAsync } from '../user/User';
+import log from '../../log';
+import { getUserAsync } from '../../user/User';
 
-export default class Whoami extends Command {
+export default class AccountView extends Command {
   static description = 'show the username you are logged in as';
+
+  static aliases = ['whoami'];
 
   async run() {
     const user = await getUserAsync();


### PR DESCRIPTION
```
% ./bin/run account --help
Log in with your EAS account

USAGE
  $ eas account:COMMAND

COMMANDS
  account:login   Log in with your EAS account
  account:logout  Log out
  account:view    Show the username you are logged in as

```