### PR TITLE
Build macOS tarballs on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,3 +73,40 @@ jobs:
           asset_path: packages/eas-cli/dist/eas-darwin-x64.tar.gz
           asset_name: eas-darwin-x64.tar.gz
           asset_content_type: application/gzip
+  build-windows:
+    name: Build for Windows
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: yarn install --frozen-lockfile --check-files
+      - run: sudo apt-get install nsis
+      - run: yarn oclif-dev pack:win
+        working-directory: ${{ github.workspace }}/packages/eas-cli
+      - id: x64
+        run: echo "::set-output name=filename::$(ls eas-*-x64.exe)"
+        working-directory: ${{ github.workspace }}/packages/eas-cli/dist/win
+      - id: x86
+        run: echo "::set-output name=filename::$(ls eas-*-x86.exe)"
+        working-directory: ${{ github.workspace }}/packages/eas-cli/dist/win
+      - name: Upload x64 installer
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: packages/eas-cli/dist/win/${{ steps.x64.outputs.filename }}
+          asset_name: ${{ steps.x64.outputs.filename }}
+          asset_content_type: application/gzip
+      - name: Upload x86 installer
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: packages/eas-cli/dist/win/${{ steps.x86.outputs.filename }}
+          asset_name: ${{ steps.x86.outputs.filename }}
+          asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,26 @@ on:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
-name: Create Release
+name: Release workflow
 
 jobs:
-  build:
-    name: Create Release
+  release:
+    name: Create a release
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          draft: true
+  build-linux:
+    name: Build for Linux
+    runs-on: ubuntu-latest
+    needs: release
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -17,30 +31,13 @@ jobs:
       - run: yarn install --frozen-lockfile --check-files
       - name: Build tarballs
         working-directory: ${{ github.workspace }}/packages/eas-cli
-        run: yarn oclif-dev pack --targets linux-x64,linux-arm,darwin-x64
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ github.ref }}
-          draft: true
-      - name: Upload darwin-x64 tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: packages/eas-cli/dist/eas-darwin-x64.tar.gz
-          asset_name: eas-darwin-x64.tar.gz
-          asset_content_type: application/gzip
+        run: yarn oclif-dev pack --targets linux-x64,linux-arm
       - name: Upload linux-x64 tarball
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: packages/eas-cli/dist/eas-linux-x64.tar.gz
           asset_name: eas-linux-x64.tar.gz
           asset_content_type: application/gzip
@@ -49,7 +46,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: packages/eas-cli/dist/eas-linux-arm.tar.gz
           asset_name: eas-linux-arm.tar.gz
+          asset_content_type: application/gzip
+  build-mac:
+    name: Build for macOS
+    # Use macOS to get the platform specific dependencies like traveling-fastlane-darwin
+    runs-on: macos-latest
+    needs: release
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: yarn install --frozen-lockfile --check-files
+      - name: Build tarballs
+        working-directory: ${{ github.workspace }}/packages/eas-cli
+        run: yarn oclif-dev pack --targets darwin-x64
+      - name: Upload darwin-x64 tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: packages/eas-cli/dist/eas-darwin-x64.tar.gz
+          asset_name: eas-darwin-x64.tar.gz
           asset_content_type: application/gzip

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.1.0-alpha.0"
+  "version": "0.1.0-alpha.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.1.0-alpha.1"
+  "version": "0.1.0-alpha.3"
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eas/config",
   "description": "A library for interacting with the eas.json",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eas/config",
   "description": "A library for interacting with the eas.json",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g eas-cli
 $ eas COMMAND
 running command...
 $ eas (-v|--version|version)
-eas-cli/0.1.0-alpha.0 darwin-x64 node-v12.13.0
+eas-cli/0.1.0-alpha.1 darwin-x64 node-v12.13.0
 $ eas --help [COMMAND]
 USAGE
   $ eas COMMAND
@@ -32,6 +32,9 @@ USAGE
 # Commands
 
 <!-- commands -->
+* [`eas account:login`](#eas-accountlogin)
+* [`eas account:logout`](#eas-accountlogout)
+* [`eas account:view`](#eas-accountview)
 * [`eas build`](#eas-build)
 * [`eas build:configure`](#eas-buildconfigure)
 * [`eas build:create`](#eas-buildcreate)
@@ -40,11 +43,44 @@ USAGE
 * [`eas credentials`](#eas-credentials)
 * [`eas device:create`](#eas-devicecreate)
 * [`eas help [COMMAND]`](#eas-help-command)
-* [`eas login`](#eas-login)
-* [`eas logout`](#eas-logout)
 * [`eas update`](#eas-update)
 * [`eas update:show`](#eas-updateshow)
-* [`eas whoami`](#eas-whoami)
+
+## `eas account:login`
+
+log in with your EAS account
+
+```
+USAGE
+  $ eas account:login
+
+ALIASES
+  $ eas login
+```
+
+## `eas account:logout`
+
+log out
+
+```
+USAGE
+  $ eas account:logout
+
+ALIASES
+  $ eas logout
+```
+
+## `eas account:view`
+
+show the username you are logged in as
+
+```
+USAGE
+  $ eas account:view
+
+ALIASES
+  $ eas whoami
+```
 
 ## `eas build`
 
@@ -55,7 +91,7 @@ USAGE
   $ eas build
 ```
 
-_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/build/index.ts)_
+_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/index.ts)_
 
 ## `eas build:configure`
 
@@ -69,7 +105,7 @@ OPTIONS
   -p, --platform=(android|ios|all)  [default: all] Platform to configure
 ```
 
-_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/build/configure.ts)_
+_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/configure.ts)_
 
 ## `eas build:create`
 
@@ -88,7 +124,7 @@ OPTIONS
   --wait                            Wait for build(s) to complete
 ```
 
-_See code: [build/commands/build/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/build/create.ts)_
+_See code: [build/commands/build/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/create.ts)_
 
 ## `eas build:status`
 
@@ -103,7 +139,7 @@ OPTIONS
   --status=(in-queue|in-progress|errored|finished)
 ```
 
-_See code: [build/commands/build/status.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/build/status.ts)_
+_See code: [build/commands/build/status.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/status.ts)_
 
 ## `eas build:submit`
 
@@ -149,7 +185,7 @@ OPTIONS
   --verbose                                                  Always print logs from Submission Service
 ```
 
-_See code: [build/commands/build/submit.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/build/submit.ts)_
+_See code: [build/commands/build/submit.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/submit.ts)_
 
 ## `eas credentials`
 
@@ -160,7 +196,7 @@ USAGE
   $ eas credentials
 ```
 
-_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/credentials.ts)_
+_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/credentials.ts)_
 
 ## `eas device:create`
 
@@ -171,7 +207,7 @@ USAGE
   $ eas device:create
 ```
 
-_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/device/create.ts)_
+_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/device/create.ts)_
 
 ## `eas help [COMMAND]`
 
@@ -190,28 +226,6 @@ OPTIONS
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.0/src/commands/help.ts)_
 
-## `eas login`
-
-log in with your EAS account
-
-```
-USAGE
-  $ eas login
-```
-
-_See code: [build/commands/login.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/login.ts)_
-
-## `eas logout`
-
-log out
-
-```
-USAGE
-  $ eas logout
-```
-
-_See code: [build/commands/logout.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/logout.ts)_
-
 ## `eas update`
 
 create a revision for given channel
@@ -224,7 +238,7 @@ ALIASES
   $ eas update:publish
 ```
 
-_See code: [build/commands/update/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/update/index.ts)_
+_See code: [build/commands/update/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/update/index.ts)_
 
 ## `eas update:show`
 
@@ -235,16 +249,5 @@ USAGE
   $ eas update:show
 ```
 
-_See code: [build/commands/update/show.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/update/show.ts)_
-
-## `eas whoami`
-
-show the username you are logged in as
-
-```
-USAGE
-  $ eas whoami
-```
-
-_See code: [build/commands/whoami.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.0/build/commands/whoami.ts)_
+_See code: [build/commands/update/show.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/update/show.ts)_
 <!-- commandsstop -->

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g eas-cli
 $ eas COMMAND
 running command...
 $ eas (-v|--version|version)
-eas-cli/0.1.0-alpha.1 darwin-x64 node-v12.13.0
+eas-cli/0.1.0-alpha.3 darwin-x64 node-v12.13.0
 $ eas --help [COMMAND]
 USAGE
   $ eas COMMAND
@@ -58,6 +58,8 @@ ALIASES
   $ eas login
 ```
 
+_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/account/login.ts)_
+
 ## `eas account:logout`
 
 log out
@@ -69,6 +71,8 @@ USAGE
 ALIASES
   $ eas logout
 ```
+
+_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/account/logout.ts)_
 
 ## `eas account:view`
 
@@ -82,6 +86,8 @@ ALIASES
   $ eas whoami
 ```
 
+_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/account/view.ts)_
+
 ## `eas build`
 
 build an app binary for your project
@@ -91,7 +97,7 @@ USAGE
   $ eas build
 ```
 
-_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/index.ts)_
+_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/build/index.ts)_
 
 ## `eas build:configure`
 
@@ -105,7 +111,7 @@ OPTIONS
   -p, --platform=(android|ios|all)  [default: all] Platform to configure
 ```
 
-_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/configure.ts)_
+_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/build/configure.ts)_
 
 ## `eas build:create`
 
@@ -124,7 +130,7 @@ OPTIONS
   --wait                            Wait for build(s) to complete
 ```
 
-_See code: [build/commands/build/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/create.ts)_
+_See code: [build/commands/build/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/build/create.ts)_
 
 ## `eas build:status`
 
@@ -139,7 +145,7 @@ OPTIONS
   --status=(in-queue|in-progress|errored|finished)
 ```
 
-_See code: [build/commands/build/status.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/status.ts)_
+_See code: [build/commands/build/status.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/build/status.ts)_
 
 ## `eas build:submit`
 
@@ -185,7 +191,7 @@ OPTIONS
   --verbose                                                  Always print logs from Submission Service
 ```
 
-_See code: [build/commands/build/submit.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/submit.ts)_
+_See code: [build/commands/build/submit.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/build/submit.ts)_
 
 ## `eas credentials`
 
@@ -196,7 +202,7 @@ USAGE
   $ eas credentials
 ```
 
-_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/credentials.ts)_
+_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/credentials.ts)_
 
 ## `eas device:create`
 
@@ -207,7 +213,7 @@ USAGE
   $ eas device:create
 ```
 
-_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/device/create.ts)_
+_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/device/create.ts)_
 
 ## `eas help [COMMAND]`
 
@@ -238,7 +244,7 @@ ALIASES
   $ eas update:publish
 ```
 
-_See code: [build/commands/update/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/update/index.ts)_
+_See code: [build/commands/update/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/update/index.ts)_
 
 ## `eas update:show`
 
@@ -249,5 +255,5 @@ USAGE
   $ eas update:show
 ```
 
-_See code: [build/commands/update/show.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/update/show.ts)_
+_See code: [build/commands/update/show.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/update/show.ts)_
 <!-- commandsstop -->

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "eas-cli",
   "description": "EAS command line tool",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "author": "Expo <support@expo.io>",
   "bin": {
     "eas": "./bin/run"
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@eas/config": "^0.1.0-alpha.0",
+    "@eas/config": "^0.1.0-alpha.1",
     "@expo/config": "^3.3.12",
     "@expo/eas-build-job": "0.1.1",
     "@expo/json-file": "^8.2.24",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "eas-cli",
   "description": "EAS command line tool",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.3",
   "author": "Expo <support@expo.io>",
   "bin": {
     "eas": "./bin/run"
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@eas/config": "^0.1.0-alpha.1",
+    "@eas/config": "^0.1.0-alpha.2",
     "@expo/config": "^3.3.12",
     "@expo/eas-build-job": "0.1.1",
     "@expo/json-file": "^8.2.24",
@@ -110,6 +110,9 @@
       }
     },
     "update": {
+      "node": {
+        "version": "12.13.0"
+      },
       "s3": {
         "templates": {
           "target": {


### PR DESCRIPTION
Change the release action to use `macos-latest` to build the macOS release packages, so that they include the correct `optionalDependencies` (for example `@expo/traveling-fastlane-darwin`).