### PR TITLE
Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           node-version: '14'
       - run: yarn install --frozen-lockfile --check-files
+      - run: apt-get install nsis
       - run: yarn oclif-dev pack:win
         working-directory: ${{ github.workspace }}/packages/eas-cli
       - id: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,3 +73,39 @@ jobs:
           asset_path: packages/eas-cli/dist/eas-darwin-x64.tar.gz
           asset_name: eas-darwin-x64.tar.gz
           asset_content_type: application/gzip
+  build-windows:
+    name: Build for Windows
+    runs-on: windows-2019
+    needs: release
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: yarn install --frozen-lockfile --check-files
+      - run: yarn oclif-dev pack:win
+        working-directory: ${{ github.workspace }}/packages/eas-cli
+      - id: x64
+        run: echo "::set-output name=filename::$(ls eas-*-x64.exe)"
+        working-directory: ${{ github.workspace }}/packages/eas-cli/dist/win
+      - id: x86
+        run: echo "::set-output name=filename::$(ls eas-*-x86.exe)"
+        working-directory: ${{ github.workspace }}/packages/eas-cli/dist/win
+      - name: Upload x64 installer
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: packages/eas-cli/dist/win/${{ steps.x64.outputs.filename }}
+          asset_name: ${{ steps.x64.outputs.filename }}
+          asset_content_type: application/gzip
+      - name: Upload x86 installer
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: packages/eas-cli/dist/win/${{ steps.x86.outputs.filename }}
+          asset_name: ${{ steps.x86.outputs.filename }}
+          asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,6 @@ on:
   push:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-  # FIXME: remove this
-  pull_request:
-    types: [opened, synchronize]
 
 name: Release workflow
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           asset_content_type: application/gzip
   build-windows:
     name: Build for Windows
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     needs: release
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           node-version: '14'
       - run: yarn install --frozen-lockfile --check-files
-      - run: apt-get install nsis
+      - run: sudo apt-get install nsis
       - run: yarn oclif-dev pack:win
         working-directory: ${{ github.workspace }}/packages/eas-cli
       - id: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ on:
   push:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  # FIXME: remove this
+  pull_request:
+    types: [opened, synchronize]
 
 name: Release workflow
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.1.0-alpha.1"
+  "version": "0.1.0-alpha.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.1.0-alpha.2"
+  "version": "0.1.0-alpha.3"
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eas/config",
   "description": "A library for interacting with the eas.json",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g eas-cli
 $ eas COMMAND
 running command...
 $ eas (-v|--version|version)
-eas-cli/0.1.0-alpha.2 darwin-x64 node-v12.13.0
+eas-cli/0.1.0-alpha.3 darwin-x64 node-v12.13.0
 $ eas --help [COMMAND]
 USAGE
   $ eas COMMAND
@@ -58,7 +58,7 @@ ALIASES
   $ eas login
 ```
 
-_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/account/login.ts)_
+_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/account/login.ts)_
 
 ## `eas account:logout`
 
@@ -72,7 +72,7 @@ ALIASES
   $ eas logout
 ```
 
-_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/account/logout.ts)_
+_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/account/logout.ts)_
 
 ## `eas account:view`
 
@@ -86,7 +86,7 @@ ALIASES
   $ eas whoami
 ```
 
-_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/account/view.ts)_
+_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/account/view.ts)_
 
 ## `eas build`
 
@@ -97,7 +97,7 @@ USAGE
   $ eas build
 ```
 
-_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/build/index.ts)_
+_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/build/index.ts)_
 
 ## `eas build:configure`
 
@@ -111,7 +111,7 @@ OPTIONS
   -p, --platform=(android|ios|all)  [default: all] Platform to configure
 ```
 
-_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/build/configure.ts)_
+_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/build/configure.ts)_
 
 ## `eas build:create`
 
@@ -130,7 +130,7 @@ OPTIONS
   --wait                            Wait for build(s) to complete
 ```
 
-_See code: [build/commands/build/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/build/create.ts)_
+_See code: [build/commands/build/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/build/create.ts)_
 
 ## `eas build:status`
 
@@ -145,7 +145,7 @@ OPTIONS
   --status=(in-queue|in-progress|errored|finished)
 ```
 
-_See code: [build/commands/build/status.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/build/status.ts)_
+_See code: [build/commands/build/status.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/build/status.ts)_
 
 ## `eas build:submit`
 
@@ -191,7 +191,7 @@ OPTIONS
   --verbose                                                  Always print logs from Submission Service
 ```
 
-_See code: [build/commands/build/submit.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/build/submit.ts)_
+_See code: [build/commands/build/submit.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/build/submit.ts)_
 
 ## `eas credentials`
 
@@ -202,7 +202,7 @@ USAGE
   $ eas credentials
 ```
 
-_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/credentials.ts)_
+_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/credentials.ts)_
 
 ## `eas device:create`
 
@@ -213,7 +213,7 @@ USAGE
   $ eas device:create
 ```
 
-_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/device/create.ts)_
+_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/device/create.ts)_
 
 ## `eas help [COMMAND]`
 
@@ -244,7 +244,7 @@ ALIASES
   $ eas update:publish
 ```
 
-_See code: [build/commands/update/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/update/index.ts)_
+_See code: [build/commands/update/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/update/index.ts)_
 
 ## `eas update:show`
 
@@ -255,5 +255,5 @@ USAGE
   $ eas update:show
 ```
 
-_See code: [build/commands/update/show.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/update/show.ts)_
+_See code: [build/commands/update/show.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.3/build/commands/update/show.ts)_
 <!-- commandsstop -->

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g eas-cli
 $ eas COMMAND
 running command...
 $ eas (-v|--version|version)
-eas-cli/0.1.0-alpha.1 darwin-x64 node-v12.13.0
+eas-cli/0.1.0-alpha.2 darwin-x64 node-v12.13.0
 $ eas --help [COMMAND]
 USAGE
   $ eas COMMAND
@@ -58,6 +58,8 @@ ALIASES
   $ eas login
 ```
 
+_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/account/login.ts)_
+
 ## `eas account:logout`
 
 log out
@@ -69,6 +71,8 @@ USAGE
 ALIASES
   $ eas logout
 ```
+
+_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/account/logout.ts)_
 
 ## `eas account:view`
 
@@ -82,6 +86,8 @@ ALIASES
   $ eas whoami
 ```
 
+_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/account/view.ts)_
+
 ## `eas build`
 
 build an app binary for your project
@@ -91,7 +97,7 @@ USAGE
   $ eas build
 ```
 
-_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/index.ts)_
+_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/build/index.ts)_
 
 ## `eas build:configure`
 
@@ -105,7 +111,7 @@ OPTIONS
   -p, --platform=(android|ios|all)  [default: all] Platform to configure
 ```
 
-_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/configure.ts)_
+_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/build/configure.ts)_
 
 ## `eas build:create`
 
@@ -124,7 +130,7 @@ OPTIONS
   --wait                            Wait for build(s) to complete
 ```
 
-_See code: [build/commands/build/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/create.ts)_
+_See code: [build/commands/build/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/build/create.ts)_
 
 ## `eas build:status`
 
@@ -139,7 +145,7 @@ OPTIONS
   --status=(in-queue|in-progress|errored|finished)
 ```
 
-_See code: [build/commands/build/status.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/status.ts)_
+_See code: [build/commands/build/status.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/build/status.ts)_
 
 ## `eas build:submit`
 
@@ -185,7 +191,7 @@ OPTIONS
   --verbose                                                  Always print logs from Submission Service
 ```
 
-_See code: [build/commands/build/submit.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/build/submit.ts)_
+_See code: [build/commands/build/submit.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/build/submit.ts)_
 
 ## `eas credentials`
 
@@ -196,7 +202,7 @@ USAGE
   $ eas credentials
 ```
 
-_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/credentials.ts)_
+_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/credentials.ts)_
 
 ## `eas device:create`
 
@@ -207,7 +213,7 @@ USAGE
   $ eas device:create
 ```
 
-_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/device/create.ts)_
+_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/device/create.ts)_
 
 ## `eas help [COMMAND]`
 
@@ -238,7 +244,7 @@ ALIASES
   $ eas update:publish
 ```
 
-_See code: [build/commands/update/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/update/index.ts)_
+_See code: [build/commands/update/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/update/index.ts)_
 
 ## `eas update:show`
 
@@ -249,5 +255,5 @@ USAGE
   $ eas update:show
 ```
 
-_See code: [build/commands/update/show.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.1/build/commands/update/show.ts)_
+_See code: [build/commands/update/show.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.2/build/commands/update/show.ts)_
 <!-- commandsstop -->

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "eas-cli",
   "description": "EAS command line tool",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "author": "Expo <support@expo.io>",
   "bin": {
     "eas": "./bin/run"
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@eas/config": "^0.1.0-alpha.1",
+    "@eas/config": "^0.1.0-alpha.2",
     "@expo/config": "^3.3.12",
     "@expo/eas-build-job": "0.1.1",
     "@expo/json-file": "^8.2.24",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -110,6 +110,9 @@
       }
     },
     "update": {
+      "node": {
+        "version": "12.13.0"
+      },
       "s3": {
         "templates": {
           "target": {

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eas-cli",
   "description": "EAS command line tool",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "author": "Expo <support@expo.io>",
   "bin": {
     "eas": "./bin/run"


### PR DESCRIPTION
This PR builds on #62 and adds Windows 32-bit and 64-bit installers, built with `oclif-dev pack:win`. We build these on Ubuntu because that's how the pack commands in `oclif-dev` are supposed to be used (they don't run on Windows).