### PR TITLE
[eas-cli] Implement apple utils

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -9,6 +9,7 @@
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
     "@eas/config": "^0.1.0-alpha.2",
+    "@expo/apple-utils": "^0.0.0-alpha.2",
     "@expo/config": "^3.3.12",
     "@expo/eas-build-job": "0.1.1",
     "@expo/json-file": "^8.2.24",
@@ -25,6 +26,7 @@
     "env-paths": "^2.2.0",
     "form-data": "^3.0.0",
     "fs-extra": "^9.0.1",
+    "getenv": "^1.0.0",
     "got": "^11.5.2",
     "graphql-tag": "^2.11.0",
     "indent-string": "^4.0.0",
@@ -54,6 +56,7 @@
     "@types/dateformat": "^3.0.1",
     "@types/form-data": "^2.5.0",
     "@types/fs-extra": "^9.0.1",
+    "@types/getenv": "^1.0.0",
     "@types/lodash": "^4.14.161",
     "@types/node": "^12",
     "@types/node-fetch": "^2.5.7",

--- a/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
@@ -20,7 +20,6 @@ export interface DistributionCertificateStoreInfo {
   status: string;
   created: number;
   expires: number;
-  ownerType: string;
   ownerName: string;
   ownerId: string;
   serialNumber: string;

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -1,24 +1,82 @@
+import { BundleId, CapabilityType, CapabilityTypeOption, Session, Teams } from '@expo/apple-utils';
 import ora from 'ora';
 
-import { AuthCtx } from './authenticate';
+import { AuthCtx, authenticateAsync } from './authenticate';
+import { USE_APPLE_UTILS } from './experimental';
 import { runActionAsync, travelingFastlane } from './fastlane';
 
-export interface AppLookupParams {
+type Options = {
+  enablePushNotifications?: boolean;
+};
+
+interface BundleIdActionProps {
   accountName: string;
   projectName: string;
   bundleIdentifier: string;
 }
 
-export interface EnsureAppExistsOptions {
-  enablePushNotifications?: boolean;
+export async function ensureAuthenticatedAsync(
+  appleCtx: Omit<AuthCtx, 'fastlaneSession'>
+): Promise<Omit<AuthCtx, 'fastlaneSession'>> {
+  if (!Session.getSessionInfo()) {
+    appleCtx = await authenticateAsync({
+      appleId: appleCtx.appleId,
+      teamId: appleCtx.team.id,
+    });
+  }
+  Teams.setSelectedTeamId(appleCtx.team.id);
+  return appleCtx;
 }
 
-export async function ensureAppExistsAsync(
-  authCtx: AuthCtx,
-  app: AppLookupParams,
-  options: EnsureAppExistsOptions = {}
-): Promise<void> {
-  const { appleId, appleIdPassword, team } = authCtx;
+async function ensureBundleIdExistsAsync(
+  appleCtx: Omit<AuthCtx, 'fastlaneSession'>,
+  { accountName, projectName, bundleIdentifier }: BundleIdActionProps,
+  options: Options = {}
+) {
+  let spinner = ora(`Registering Bundle ID "${bundleIdentifier}"`).start();
+
+  appleCtx = await ensureAuthenticatedAsync(appleCtx);
+
+  // Get the bundle id
+  let bundleId = await BundleId.findAsync({ identifier: bundleIdentifier });
+
+  if (bundleId) {
+    spinner.succeed('Bundle ID already registered');
+  } else {
+    // If it doesn't exist, create it
+    bundleId = await BundleId.createAsync({
+      name: `@${accountName}/${projectName}`,
+      identifier: bundleIdentifier,
+    });
+    spinner.succeed(`Registered Bundle ID "${bundleIdentifier}"`);
+  }
+
+  spinner = ora(`Syncing app capabilities`).start();
+
+  // Update the capabilities
+  await bundleId.updateBundleIdCapabilityAsync({
+    capabilityType: CapabilityType.PUSH_NOTIFICATIONS,
+    option: options.enablePushNotifications ? CapabilityTypeOption.ON : CapabilityTypeOption.OFF,
+    // TODO: Add more capabilities
+  });
+  spinner.succeed(`Sync'd app capabilities`);
+}
+
+export async function ensureAppExists(
+  appleCtx: Omit<AuthCtx, 'fastlaneSession'>,
+  { accountName, projectName, bundleIdentifier }: BundleIdActionProps,
+  options: Options = {}
+) {
+  if (USE_APPLE_UTILS) {
+    return await ensureBundleIdExistsAsync(
+      appleCtx,
+      { accountName, projectName, bundleIdentifier },
+      options
+    );
+  }
+
+  const { appleId, appleIdPassword, team } = appleCtx;
+
   const spinner = ora(`Ensuring App ID exists on Apple Developer Portal...`).start();
   try {
     const { created } = await runActionAsync(travelingFastlane.ensureAppExists, [
@@ -26,11 +84,11 @@ export async function ensureAppExistsAsync(
       appleId,
       appleIdPassword,
       team.id,
-      app.bundleIdentifier,
-      `@${app.accountName}/${app.projectName}`,
+      bundleIdentifier,
+      `@${accountName}/${projectName}`,
     ]);
     if (created) {
-      spinner.succeed(`App ID created with bundle identifier ${app.bundleIdentifier}.`);
+      spinner.succeed(`App ID created with bundle identifier ${bundleIdentifier}.`);
     } else {
       spinner.succeed('App ID found on Apple Developer Portal.');
     }

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -5,11 +5,11 @@ import { AuthCtx, authenticateAsync } from './authenticate';
 import { USE_APPLE_UTILS } from './experimental';
 import { runActionAsync, travelingFastlane } from './fastlane';
 
-type Options = {
+export interface EnsureAppExistsOptions {
   enablePushNotifications?: boolean;
-};
+}
 
-interface BundleIdActionProps {
+export interface AppLookupParams {
   accountName: string;
   projectName: string;
   bundleIdentifier: string;
@@ -30,8 +30,8 @@ export async function ensureAuthenticatedAsync(
 
 async function ensureBundleIdExistsAsync(
   appleCtx: Omit<AuthCtx, 'fastlaneSession'>,
-  { accountName, projectName, bundleIdentifier }: BundleIdActionProps,
-  options: Options = {}
+  { accountName, projectName, bundleIdentifier }: AppLookupParams,
+  options: EnsureAppExistsOptions = {}
 ) {
   let spinner = ora(`Registering Bundle ID "${bundleIdentifier}"`).start();
 
@@ -62,17 +62,13 @@ async function ensureBundleIdExistsAsync(
   spinner.succeed(`Sync'd app capabilities`);
 }
 
-export async function ensureAppExists(
+export async function ensureAppExistsAsync(
   appleCtx: Omit<AuthCtx, 'fastlaneSession'>,
-  { accountName, projectName, bundleIdentifier }: BundleIdActionProps,
-  options: Options = {}
+  app: AppLookupParams,
+  options: EnsureAppExistsOptions = {}
 ) {
   if (USE_APPLE_UTILS) {
-    return await ensureBundleIdExistsAsync(
-      appleCtx,
-      { accountName, projectName, bundleIdentifier },
-      options
-    );
+    return await ensureBundleIdExistsAsync(appleCtx, app, options);
   }
 
   const { appleId, appleIdPassword, team } = appleCtx;
@@ -84,11 +80,11 @@ export async function ensureAppExists(
       appleId,
       appleIdPassword,
       team.id,
-      bundleIdentifier,
-      `@${accountName}/${projectName}`,
+      app.bundleIdentifier,
+      `@${app.accountName}/${app.projectName}`,
     ]);
     if (created) {
-      spinner.succeed(`App ID created with bundle identifier ${bundleIdentifier}.`);
+      spinner.succeed(`App ID created with bundle identifier ${app.bundleIdentifier}.`);
     } else {
       spinner.succeed('App ID found on Apple Developer Portal.');
     }

--- a/packages/eas-cli/src/credentials/ios/appstore/experimental.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/experimental.ts
@@ -1,0 +1,26 @@
+import { BundleId, Profile } from '@expo/apple-utils';
+import { boolish } from 'getenv';
+
+export const USE_APPLE_UTILS = boolish('USE_APPLE_UTILS', false);
+
+export async function getProfilesForBundleId(bundleIdentifier: string): Promise<Profile[]> {
+  const [bundleId] = await BundleId.getAsync({
+    query: {
+      filter: {
+        identifier: bundleIdentifier,
+      },
+    },
+  });
+  if (bundleId) {
+    return bundleId.getProfilesAsync();
+  }
+  return [];
+}
+
+export async function getBundleIdForIdentifier(bundleIdentifier: string): Promise<BundleId> {
+  const bundleId = await BundleId.findAsync({ identifier: bundleIdentifier });
+  if (!bundleId) {
+    throw new Error(`Failed to find Bundle ID item with identifier "${bundleIdentifier}"`);
+  }
+  return bundleId;
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -1,8 +1,218 @@
+import {
+  Certificate,
+  CertificateType,
+  Device,
+  Profile,
+  ProfileState,
+  ProfileType,
+  Teams,
+} from '@expo/apple-utils';
 import ora from 'ora';
 
 import { ProvisioningProfile } from './Credentials.types';
 import { AuthCtx } from './authenticate';
+import { USE_APPLE_UTILS, getBundleIdForIdentifier, getProfilesForBundleId } from './experimental';
 import { runActionAsync, travelingFastlane } from './fastlane';
+
+async function registerMissingDevicesAsync(udids: string[]) {
+  const allIosProfileDevices = await Device.getAllIOSProfileDevicesAsync();
+  const alreadyAdded = allIosProfileDevices.filter(d => udids.includes(d.attributes.udid));
+  const alreadyAddedUdids = alreadyAdded.map(i => i.attributes.udid);
+
+  for (const udid of udids) {
+    if (!alreadyAddedUdids.includes(udid)) {
+      const device = await Device.createAsync({ name: 'iOS Device (added by Expo)', udid });
+      alreadyAdded.push(device);
+    }
+  }
+
+  return alreadyAdded;
+}
+
+async function findDistCert(serial_number: string, isEnterprise: boolean) {
+  const certs = await Certificate.getAsync({
+    query: {
+      filter: {
+        certificateType: CertificateType.IOS_DISTRIBUTION,
+      },
+    },
+  });
+
+  if (serial_number === '__last__') {
+    return certs[certs.length - 1];
+  }
+
+  return certs.find(c => c.attributes.serialNumber === serial_number) ?? null;
+}
+
+async function findProfileByBundleId(bundleId: string, certSerialNumber: string) {
+  let expoProfiles = await getProfilesForBundleId(bundleId);
+  expoProfiles = expoProfiles.filter(
+    profile => profile.attributes.profileType === ProfileType.IOS_APP_INHOUSE
+  );
+
+  expoProfiles = expoProfiles.filter(profile => {
+    return (
+      profile.attributes.name.startsWith('*[expo]') &&
+      profile.attributes.profileState !== ProfileState.EXPIRED
+    );
+  });
+
+  const expoProfilesWithCert: Profile[] = [];
+  // find profiles associated with our development cert
+  for (const profile of expoProfiles) {
+    const certificates = await profile.getCertificatesAsync();
+    if (certificates.some(cert => cert.attributes.serialNumber === certSerialNumber)) {
+      expoProfilesWithCert.push(profile);
+    }
+  }
+
+  if (expoProfilesWithCert) {
+    // there is an expo managed profile with our desired certificate
+    // return the profile that will be valid for the longest duration
+    return {
+      profile: expoProfilesWithCert.sort(sortByExpiration)[expoProfilesWithCert.length - 1],
+      didUpdate: false,
+    };
+  } else if (expoProfiles) {
+    // there is an expo managed profile, but it doesnt have our desired certificate
+    // append the certificate and update the profile
+    const isInHouse = (await Teams.getTeamInfoAsync()).type.toLowerCase() === 'in-house';
+    const distCert = await findDistCert(certSerialNumber, isInHouse);
+    if (!distCert) throw new Error('expected cert not found');
+    const profile = expoProfiles.sort(sortByExpiration)[expoProfiles.length - 1];
+    profile.attributes.certificates = [distCert];
+    return { profile: await profile.regenerateAsync(), didUpdate: true };
+  }
+
+  // there is no valid provisioning profile available
+  return { profile: null, didUpdate: false };
+}
+
+function sortByExpiration(a: Profile, b: Profile): number {
+  return (
+    new Date(a.attributes.expirationDate).getTime() -
+    new Date(b.attributes.expirationDate).getTime()
+  );
+}
+
+async function findProfileById(profileId: string, bundleId: string) {
+  let profiles = await getProfilesForBundleId(bundleId);
+  profiles = profiles.filter(
+    profile => profile.attributes.profileType === ProfileType.IOS_APP_ADHOC
+  );
+  return profiles.find(profile => profile.id === profileId) ?? null;
+}
+
+function uniqueItems<T = any>(items: T[]): T[] {
+  const set = new Set(items);
+  // @ts-ignore: downlevel iteration
+  return [...set];
+}
+
+async function fastlaneActionAsync({
+  udids,
+  bundleId,
+  certSerialNumber,
+  profileId,
+}: {
+  udids: string[];
+  bundleId: string;
+  certSerialNumber: string;
+  profileId?: string;
+}): Promise<ProfileResults> {
+  // We register all missing devices on the Apple Developer Portal. They are identified by UDIDs.
+  const devices = await registerMissingDevicesAsync(udids);
+
+  let existingProfile: Profile | null;
+  let didUpdate = false;
+
+  if (profileId) {
+    existingProfile = await findProfileById(profileId, bundleId);
+    // Fail if we cannot find the profile that was specifically requested
+    if (!existingProfile)
+      throw new Error(
+        `Could not find profile with profile id "${profileId}" for bundle id "${bundleId}"`
+      );
+  } else {
+    // If no profile id is passed, try to find a suitable provisioning profile for the App ID.
+    const results = await findProfileByBundleId(bundleId, certSerialNumber);
+    existingProfile = results.profile;
+    didUpdate = results.didUpdate;
+  }
+
+  if (existingProfile) {
+    // We need to verify whether the existing profile includes all user's devices.
+    let deviceUdidsInProfile =
+      existingProfile?.attributes?.devices?.map?.(i => i.attributes.udid) ?? [];
+    deviceUdidsInProfile = uniqueItems(deviceUdidsInProfile.filter(Boolean));
+    const allDeviceUdids = uniqueItems(udids);
+    const hasEqualUdids =
+      deviceUdidsInProfile.length === allDeviceUdids.length &&
+      deviceUdidsInProfile.every(udid => allDeviceUdids.includes(udid));
+    if (hasEqualUdids && existingProfile.isValid()) {
+      const result: ProfileResults = {
+        provisioningProfileName: existingProfile?.attributes?.name,
+        provisioningProfileId: existingProfile?.id,
+        provisioningProfile: existingProfile?.attributes.profileContent,
+      };
+      if (didUpdate) {
+        result.provisioningProfileUpdateTimestamp = Date.now();
+      }
+
+      return result;
+    }
+    // We need to add new devices to the list and create a new provisioning profile.
+    existingProfile.attributes.devices = devices;
+    await existingProfile.regenerateAsync();
+
+    const updatedProfile = (await findProfileByBundleId(bundleId, certSerialNumber)).profile;
+    if (!updatedProfile) throw new Error('Failed to locate updated profile');
+    return {
+      provisioningProfileUpdateTimestamp: Date.now(),
+      provisioningProfileName: updatedProfile.attributes.name,
+      provisioningProfileId: updatedProfile.id,
+      provisioningProfile: updatedProfile.attributes.profileContent,
+    };
+  }
+
+  // No existing profile
+  const isInHouse = (await Teams.getTeamInfoAsync()).type.toLowerCase() === 'in-house';
+
+  // We need to find user's distribution certificate to make a provisioning profile for it.
+  const distCert = await findDistCert(certSerialNumber, isInHouse);
+
+  if (!distCert) {
+    // If the distribution certificate doesn't exist, the user must have deleted it, we can't do anything here :(
+    throw new Error('No distribution certificate available to make provisioning profile against');
+  }
+  const bundleIdItem = await getBundleIdForIdentifier(bundleId);
+  // If the provisioning profile for the App ID doesn't exist, we just need to create a new one!
+  const newProfile = await Profile.createAsync({
+    bundleId: bundleIdItem.id,
+    // apple drops [ if its the first char (!!),
+    name: `*[expo] ${bundleId} AdHoc ${Date.now()}`,
+    certificates: [distCert.id],
+    devices: devices.map(device => device.id),
+    profileType: ProfileType.IOS_APP_ADHOC,
+  });
+
+  return {
+    provisioningProfileUpdateTimestamp: Date.now(),
+    provisioningProfileCreateTimestamp: Date.now(),
+    provisioningProfileName: newProfile.attributes.name,
+    provisioningProfileId: newProfile.id,
+    provisioningProfile: newProfile.attributes.profileContent,
+  };
+}
+
+interface ProfileResults {
+  provisioningProfileUpdateTimestamp?: number;
+  provisioningProfileCreateTimestamp?: number;
+  provisioningProfileName?: string;
+  provisioningProfileId: string;
+  provisioningProfile: any;
+}
 
 export async function createOrReuseAdhocProvisioningProfileAsync(
   ctx: AuthCtx,
@@ -12,20 +222,30 @@ export async function createOrReuseAdhocProvisioningProfileAsync(
 ): Promise<ProvisioningProfile> {
   const spinner = ora(`Handling Adhoc provisioning profiles on Apple Developer Portal...`).start();
   try {
-    const args = [
-      '--apple-id',
-      ctx.appleId,
-      '--apple-password',
-      ctx.appleIdPassword,
-      ctx.team.id,
-      udids.join(','),
-      bundleIdentifier,
-      distCertSerialNumber,
-    ];
-    const adhocProvisioningProfile = await runActionAsync(
-      travelingFastlane.manageAdHocProvisioningProfile,
-      args
-    );
+    let adhocProvisioningProfile: ProfileResults;
+
+    if (USE_APPLE_UTILS) {
+      adhocProvisioningProfile = await fastlaneActionAsync({
+        udids,
+        bundleId: bundleIdentifier,
+        certSerialNumber: distCertSerialNumber,
+      });
+    } else {
+      const args = [
+        '--apple-id',
+        ctx.appleId,
+        '--apple-password',
+        ctx.appleIdPassword,
+        ctx.team.id,
+        udids.join(','),
+        bundleIdentifier,
+        distCertSerialNumber,
+      ];
+      adhocProvisioningProfile = await runActionAsync(
+        travelingFastlane.manageAdHocProvisioningProfile,
+        args
+      );
+    }
 
     const {
       provisioningProfileUpdateTimestamp,

--- a/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
@@ -1,3 +1,4 @@
+import { Keys } from '@expo/apple-utils';
 import chalk from 'chalk';
 import dateformat from 'dateformat';
 import ora from 'ora';
@@ -5,7 +6,10 @@ import ora from 'ora';
 import log from '../../../log';
 import { PushKey, PushKeyStoreInfo } from './Credentials.types';
 import { AuthCtx } from './authenticate';
+import { USE_APPLE_UTILS } from './experimental';
 import { runActionAsync, travelingFastlane } from './fastlane';
+
+const { MaxKeysCreatedError } = Keys;
 
 const APPLE_KEYS_TOO_MANY_GENERATED_ERROR = `
 You can have only ${chalk.underline('two')} Apple Keys generated on your Apple Developer account.
@@ -16,6 +20,11 @@ Please remember that Apple Keys are not application specific!
 export async function listPushKeysAsync(ctx: AuthCtx): Promise<PushKeyStoreInfo[]> {
   const spinner = ora(`Getting Push Keys from Apple...`).start();
   try {
+    if (USE_APPLE_UTILS) {
+      const keys = await Keys.getKeysAsync();
+      spinner.succeed();
+      return keys;
+    }
     const args = ['list', ctx.appleId, ctx.appleIdPassword, ctx.team.id];
     const { keys } = await runActionAsync(travelingFastlane.managePushKeys, args);
     spinner.succeed();
@@ -32,6 +41,17 @@ export async function createPushKeyAsync(
 ): Promise<PushKey> {
   const spinner = ora(`Creating Push Key on Apple Servers...`).start();
   try {
+    if (USE_APPLE_UTILS) {
+      const key = await Keys.createKeyAsync({ name, isApns: true });
+      const apnsKeyP8 = await Keys.downloadKeyAsync({ id: key.id });
+      spinner.succeed();
+      return {
+        apnsKeyId: key.id,
+        apnsKeyP8,
+        teamId: ctx.team.id,
+        teamName: ctx.team.name,
+      };
+    }
     const args = ['create', ctx.appleId, ctx.appleIdPassword, ctx.team.id, name];
     const { apnsKeyId, apnsKeyP8 } = await runActionAsync(travelingFastlane.managePushKeys, args);
     spinner.succeed();
@@ -44,7 +64,10 @@ export async function createPushKeyAsync(
   } catch (err) {
     spinner.fail('Failed to create Push Notifications Key');
     const resultString = err.rawDump?.resultString;
-    if (resultString && resultString.match(/maximum allowed number of Keys/)) {
+    if (
+      err instanceof MaxKeysCreatedError ||
+      (resultString && resultString.match(/maximum allowed number of Keys/))
+    ) {
       throw new Error(APPLE_KEYS_TOO_MANY_GENERATED_ERROR);
     }
     throw err;
@@ -54,8 +77,14 @@ export async function createPushKeyAsync(
 export async function revokePushKeyAsync(ctx: AuthCtx, ids: string[]): Promise<void> {
   const spinner = ora(`Revoking Push Key on Apple Servers...`).start();
   try {
-    const args = ['revoke', ctx.appleId, ctx.appleIdPassword, ctx.team.id, ids.join(',')];
-    await runActionAsync(travelingFastlane.managePushKeys, args);
+    if (USE_APPLE_UTILS) {
+      for (const id of ids) {
+        await Keys.revokeKeyAsync({ id });
+      }
+    } else {
+      const args = ['revoke', ctx.appleId, ctx.appleIdPassword, ctx.team.id, ids.join(',')];
+      await runActionAsync(travelingFastlane.managePushKeys, args);
+    }
     spinner.succeed();
   } catch (error) {
     log.error(error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,6 +1020,11 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@expo/apple-utils@^0.0.0-alpha.2":
+  version "0.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.2.tgz#00cd2109c85a4a244f950d47ac1d0ce8cdd2c22a"
+  integrity sha512-u3EXp3KO14WGGnEy//b96/WGVRYziaV6TYhRkpDvgL4EDhosUZGBXz50ZEcZ6lf4ByO/yq1a+Pca1CiczdgGwg==
+
 "@expo/babel-preset-cli@0.2.18":
   version "0.2.18"
   resolved "https://registry.yarnpkg.com/@expo/babel-preset-cli/-/babel-preset-cli-0.2.18.tgz#136acf8a0efe259e29ebc614b68552e5acb47d86"
@@ -2806,6 +2811,13 @@
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.1.tgz#91c8fc4c51f6d5dbe44c2ca9ab09310bd00c7918"
   integrity sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/getenv@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/getenv/-/getenv-1.0.0.tgz#fa5e6901e9fb84bfb40205d4952fd06c8afcf006"
+  integrity sha512-w8qs+09o4pfFb/4XkHJzsHEZ2m36s/d9vJhglbOeSiSe9mPu0OmCQbU4iEgGl2DNP9WfOHCVd6fBwIvBd4AZhg==
   dependencies:
     "@types/node" "*"
 
@@ -5639,6 +5651,11 @@ getenv@0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/getenv/-/getenv-0.7.0.tgz#39b91838707e2086fd1cf6ef8777d1c93e14649e"
   integrity sha1-ObkYOHB+IIb9HPbvh3fRyT4UZJ4=
+
+getenv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/getenv/-/getenv-1.0.0.tgz#874f2e7544fbca53c7a4738f37de8605c3fcfc31"
+  integrity sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==
 
 getpass@^0.1.1:
   version "0.1.7"


### PR DESCRIPTION
- Implement `apple-utils` package behind `USE_APPLE_UTILS` env variable
- Reformat session cookies to match custom Fastlane YAML format
- Remove unused `ownerType` property from certificates type
- Largest change is in `packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts`

# Test Plan

- TBD