### PR TITLE
credentials.json support + fixes for managed

### DIFF
--- a/packages/config/src/EasJsonReader.ts
+++ b/packages/config/src/EasJsonReader.ts
@@ -52,6 +52,27 @@ export class EasJsonReader {
     };
   }
 
+  public async validateAsync(): Promise<void> {
+    const easJson = await this.readRawAsync();
+
+    for (const [name, profile] of Object.entries(easJson.builds?.android ?? {})) {
+      try {
+        await this.validateBuildProfile(Platform.Android, name, profile);
+      } catch (err) {
+        err.msg = `Failed to validate Android build profile "${name}"\n${err.msg}`;
+        throw err;
+      }
+    }
+    for (const [name, profile] of Object.entries(easJson.builds?.ios ?? {})) {
+      try {
+        await this.validateBuildProfile(Platform.iOS, name, profile);
+      } catch (err) {
+        err.msg = `Failed to validate iOS build profile "${name}"\n${err.msg}`;
+        throw err;
+      }
+    }
+  }
+
   public async readRawAsync(): Promise<EasJson> {
     const rawFile = await fs.readFile(path.join(this.projectDir, 'eas.json'), 'utf-8');
     const json = JSON.parse(rawFile);
@@ -67,7 +88,7 @@ export class EasJsonReader {
   }
 
   private validateBuildProfile<T extends BuildProfile>(
-    platform: 'android' | 'ios' | 'all',
+    platform: Platform,
     buildProfileName: string,
     buildProfile?: BuildProfilePreValidation
   ): T {

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@eas/config": "0.0.1",
     "@expo/config": "^3.3.12",
-    "@expo/eas-build-job": "0.1.1",
+    "@expo/eas-build-job": "0.1.2",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.10",
     "@expo/results": "^1.0.0",

--- a/packages/eas-cli/src/build/android/configure.ts
+++ b/packages/eas-cli/src/build/android/configure.ts
@@ -1,10 +1,10 @@
-import { AndroidConfig } from '@expo/config';
+import { AndroidConfig, ExpoConfig } from '@expo/config';
 
 import log from '../../log';
 import { gitAddAsync } from '../../utils/git';
 import { ConfigureContext } from '../context';
 import { isExpoUpdatesInstalled } from '../utils/updates';
-import { configureUpdatesAsync } from './UpdatesModule';
+import { configureUpdatesAsync, syncUpdatesConfigurationAsync } from './UpdatesModule';
 
 export async function configureAndroidAsync(ctx: ConfigureContext): Promise<void> {
   if (!ctx.hasAndroidNativeProject) {
@@ -19,4 +19,22 @@ export async function configureAndroidAsync(ctx: ConfigureContext): Promise<void
     await configureUpdatesAsync(ctx.projectDir, ctx.exp);
   }
   log.withTick('Configured the Android project');
+}
+
+export async function validateAndSyncProjectConfigurationAsync(
+  projectDir: string,
+  exp: ExpoConfig
+): Promise<void> {
+  const isProjectConfigured = await AndroidConfig.EasBuild.isEasBuildGradleConfiguredAsync(
+    projectDir
+  );
+  if (!isProjectConfigured) {
+    throw new Error(
+      'Project is not configured. Please run "eas build:configure" first to configure the project'
+    );
+  }
+
+  if (isExpoUpdatesInstalled(projectDir)) {
+    await syncUpdatesConfigurationAsync(projectDir, exp);
+  }
 }

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -1,5 +1,5 @@
-import { AndroidGenericBuildProfile, AndroidManagedBuildProfile, Workflow } from '@eas/config';
-import { Android, BuildType, Job, sanitizeJob } from '@expo/eas-build-job';
+import { AndroidGenericBuildProfile, AndroidManagedBuildProfile } from '@eas/config';
+import { Android, Job, Workflow, sanitizeJob } from '@expo/eas-build-job';
 import path from 'path';
 
 import { AndroidCredentials } from '../../credentials/android/AndroidCredentialsProvider';
@@ -76,7 +76,7 @@ async function prepareGenericJobAsync(
   const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
-    type: BuildType.Generic,
+    type: Workflow.Generic,
     gradleCommand: buildProfile.gradleCommand,
     artifactPath: buildProfile.artifactPath,
     projectRootDirectory,
@@ -88,10 +88,10 @@ async function prepareManagedJobAsync(
   jobData: JobData,
   buildProfile: AndroidManagedBuildProfile
 ): Promise<Partial<Android.ManagedJob>> {
+  const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
-    type: BuildType.Managed,
-    packageJson: { example: 'packageJson' },
-    manifest: { example: 'manifest' },
+    type: Workflow.Managed,
+    projectRootDirectory,
   };
 }

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -1,3 +1,4 @@
+import { EasJsonReader } from '@eas/config';
 import { getConfig } from '@expo/config';
 import fs from 'fs-extra';
 import path from 'path';
@@ -28,6 +29,7 @@ export async function configureAsync(options: {
     user: await ensureLoggedInAsync(),
     projectDir: options.projectDir,
     exp,
+    requestedPlatform: options.platform,
     shouldConfigureAndroid: [BuildCommandPlatform.ALL, BuildCommandPlatform.ANDROID].includes(
       options.platform
     ),
@@ -58,6 +60,8 @@ export async function configureAsync(options: {
 export async function ensureEasJsonExistsAsync(ctx: ConfigureContext): Promise<void> {
   const easJsonPath = path.join(ctx.projectDir, 'eas.json');
   if (await fs.pathExists(easJsonPath)) {
+    await new EasJsonReader(ctx.projectDir, ctx.requestedPlatform).validateAsync();
+    log.withTick('eas.json validated successfully');
     return;
   }
 

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -65,6 +65,7 @@ export interface ConfigureContext {
   user: User;
   projectDir: string;
   exp: ExpoConfig;
+  requestedPlatform: BuildCommandPlatform;
   shouldConfigureAndroid: boolean;
   shouldConfigureIos: boolean;
   hasAndroidNativeProject: boolean;

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -8,7 +8,7 @@ import { promptAsync } from '../../prompts';
 import { startBuildForPlatformAsync } from '../build';
 import { BuildContext, CommandContext, createBuildContext } from '../context';
 import { Platform } from '../types';
-import { syncProjectConfigurationAsync } from './configure';
+import { validateAndSyncProjectConfigurationAsync } from './configure';
 import { ensureIosCredentialsAsync } from './credentials';
 import { prepareJobAsync } from './prepareJob';
 
@@ -28,16 +28,17 @@ export async function startIosBuildAsync(
   if (buildCtx.buildProfile.workflow === Workflow.Generic) {
     iosNativeProjectScheme = buildCtx.buildProfile.scheme ?? (await resolveSchemeAsync(buildCtx));
   }
-  if (buildCtx.buildProfile.workflow === Workflow.Generic) {
-    await syncProjectConfigurationAsync(commandCtx.projectDir, commandCtx.exp);
-  }
   return await startBuildForPlatformAsync({
     ctx: buildCtx,
     projectConfiguration: {
       iosNativeProjectScheme,
     },
     ensureCredentialsAsync: ensureIosCredentialsAsync,
-    ensureProjectConfiguredAsync: async () => {},
+    ensureProjectConfiguredAsync: async () => {
+      if (buildCtx.buildProfile.workflow === Workflow.Generic) {
+        await validateAndSyncProjectConfigurationAsync(commandCtx.projectDir, commandCtx.exp);
+      }
+    },
     prepareJobAsync,
   });
 }

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -31,7 +31,7 @@ export async function configureIosAsync(ctx: ConfigureContext): Promise<void> {
   log.withTick('Configured the Xcode project.');
 }
 
-export async function syncProjectConfigurationAsync(
+export async function validateAndSyncProjectConfigurationAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<void> {

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -47,9 +47,9 @@ export async function resolveIosCredentialsAsync(
   options: { nonInteractive: boolean }
 ): Promise<CredentialsResult<IosCredentials>> {
   const provider = new IosCredentialsProvider(
-    await createCredentialsContextAsync(projectDir, {}),
+    await createCredentialsContextAsync(projectDir, { nonInteractive: options.nonInteractive }),
     params.app,
-    { nonInteractive: options.nonInteractive }
+    {}
   );
   const credentialsSource = await ensureCredentialsAsync(
     provider,

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -1,5 +1,5 @@
-import { Workflow, iOSGenericBuildProfile, iOSManagedBuildProfile } from '@eas/config';
-import { BuildType, Job, iOS, sanitizeJob } from '@expo/eas-build-job';
+import { iOSGenericBuildProfile, iOSManagedBuildProfile } from '@eas/config';
+import { Job, Workflow, iOS, sanitizeJob } from '@expo/eas-build-job';
 import path from 'path';
 
 import { readSecretEnvsAsync } from '../../credentials/credentialsJson/read';
@@ -81,7 +81,7 @@ async function prepareGenericJobAsync(
   const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
-    type: BuildType.Generic,
+    type: Workflow.Generic,
     scheme: jobData.projectConfiguration.iosNativeProjectScheme,
     artifactPath: buildProfile.artifactPath,
     projectRootDirectory,
@@ -93,10 +93,10 @@ async function prepareManagedJobAsync(
   jobData: JobData,
   _buildProfile: iOSManagedBuildProfile
 ): Promise<Partial<iOS.ManagedJob>> {
+  const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
-    type: BuildType.Managed,
-    packageJson: { example: 'packageJson' },
-    manifest: { example: 'manifest' },
+    type: Workflow.Managed,
+    projectRootDirectory,
   };
 }

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
@@ -4,10 +4,11 @@ import { CredentialsManager } from '../CredentialsManager';
 import { Context } from '../context';
 import { getAndroidApiMockWithoutCredentials } from './fixtures-android';
 import { testAppJson, testUsername } from './fixtures-constants';
+import { getIosApiMockWithoutCredentials } from './fixtures-ios';
 
 export function createCtxMock(mockOverride: Record<string, any> = {}): Context {
   const defaultMock = {
-    ios: jest.fn(),
+    ios: getIosApiMockWithoutCredentials(),
     android: getAndroidApiMockWithoutCredentials(),
     appStore: jest.fn(),
     ensureAppleCtx: jest.fn(),
@@ -16,7 +17,7 @@ export function createCtxMock(mockOverride: Record<string, any> = {}): Context {
     },
     hasAppleCtx: jest.fn(() => true),
     hasProjectContext: true,
-    manifest: testAppJson,
+    exp: testAppJson,
     projectDir: '.',
   };
   return merge(defaultMock, mockOverride) as any;

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -1,0 +1,156 @@
+import {
+  DistributionCertificate,
+  DistributionCertificateStoreInfo,
+  ProvisioningProfile,
+  ProvisioningProfileStoreInfo,
+  PushKey,
+  PushKeyStoreInfo,
+} from '../ios/appstore/Credentials.types';
+import { IosDistCredentials, IosPushCredentials } from '../ios/credentials';
+import { testProvisioningProfileBase64 } from './fixtures-base64-data';
+import { testBundleIdentifier, testExperienceName } from './fixtures-constants';
+
+const today = new Date();
+const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
+
+export const testAppleTeam = {
+  id: 'test-team-id',
+};
+export const testProvisioningProfile: ProvisioningProfile = {
+  provisioningProfileId: 'test-id',
+  provisioningProfile: testProvisioningProfileBase64,
+  teamId: 'id',
+};
+export const testProvisioningProfiles = [testProvisioningProfile];
+export const testProvisioningProfileFromApple: ProvisioningProfileStoreInfo = {
+  name: 'test-name',
+  status: 'Active',
+  expires: tomorrow.getTime(),
+  distributionMethod: 'test',
+  certificates: [],
+  provisioningProfileId: testProvisioningProfile.provisioningProfileId,
+  provisioningProfile: testProvisioningProfile.provisioningProfile,
+  teamId: 'id',
+};
+export const testProvisioningProfilesFromApple = [testProvisioningProfileFromApple];
+
+export const testDistCert: DistributionCertificate = {
+  certP12: 'Y2VydHAxMg==',
+  certPassword: 'test-password',
+  distCertSerialNumber: 'test-serial',
+  teamId: 'test-team-id',
+};
+export const testIosDistCredential: IosDistCredentials = {
+  id: 1,
+  type: 'dist-cert',
+  ...testDistCert,
+};
+export const testIosDistCredentials = [testIosDistCredential];
+export const testDistCertFromApple: DistributionCertificateStoreInfo = {
+  id: 'test-id',
+  name: 'test-name',
+  status: 'Active',
+  created: today.getTime(),
+  expires: tomorrow.getTime(),
+  ownerType: 'test-owner-type',
+  ownerName: 'test-owner',
+  ownerId: 'test-id',
+  serialNumber: testIosDistCredential.distCertSerialNumber as string,
+};
+export const testDistCertsFromApple = [testDistCertFromApple];
+
+export const testPushKey: PushKey = {
+  apnsKeyP8: 'test-p8',
+  apnsKeyId: 'test-key-id',
+  teamId: 'test-team-id',
+};
+
+export const testIosPushCredential: IosPushCredentials = {
+  id: 2,
+  type: 'push-key',
+  ...testPushKey,
+};
+export const testIosPushCredentials = [testIosPushCredential];
+export const testPushKeyFromApple: PushKeyStoreInfo = {
+  id: testIosPushCredential.apnsKeyId,
+  name: 'test-name',
+};
+export const testPushKeysFromApple = [testPushKeyFromApple];
+export const testLegacyPushCert = {
+  pushId: 'test-push-id',
+  pushP12: 'test-push-p12',
+  pushPassword: 'test-push-password',
+};
+export const testAppCredential = {
+  experienceName: testExperienceName,
+  bundleIdentifier: testBundleIdentifier,
+  distCredentialsId: testIosDistCredential.id,
+  pushCredentialsId: testIosPushCredential.id,
+  credentials: {
+    ...testProvisioningProfile,
+  },
+};
+export const testAllCredentialsForApp = {
+  ...testAppCredential,
+  pushCredentials: testPushKey,
+  distCredentials: testDistCert,
+};
+export const testAppCredentials = [testAppCredential];
+export const testAllCredentials = {
+  userCredentials: [...testIosDistCredentials, ...testIosPushCredentials],
+  appCredentials: testAppCredentials,
+};
+
+export function getIosApiMock() {
+  return {
+    getAllCredentials: jest.fn(() => testAllCredentials),
+    getDistributionCertificateAsync: jest.fn(() => testIosDistCredential),
+    getDistributionCertificateByIdAsync: jest.fn(id =>
+      id === testIosDistCredential.id ? testIosDistCredential : null
+    ),
+    createDistributionCertificateAsync: jest.fn((owner, cert) => ({
+      id: 123,
+      type: 'dist-cert',
+      ...cert,
+    })),
+    updateDistributionCertificateAsync: jest.fn(),
+    deleteDistributionCertificateAsync: jest.fn(),
+    useDistributionCertificateAsync: jest.fn(),
+    getPushKey: jest.fn(() => testIosPushCredential),
+    createPushKeyAsync: jest.fn((owner, key) => ({ id: 124, type: 'push-key', ...key })),
+    updatePushKeyAsync: jest.fn(),
+    deletePushKeyAsync: jest.fn(),
+    usePushKeyAsync: jest.fn(),
+
+    getAppCredentialsAsync: jest.fn(() => testAppCredentials),
+    getProvisioningProfileAsync: jest.fn(() => testProvisioningProfile),
+    updateProvisioningProfileAsync: jest.fn(),
+    deleteProvisioningProfileAsync: jest.fn(),
+  };
+}
+
+export function getIosApiMockWithoutCredentials() {
+  return {
+    getAllCredentials: jest.fn(() => ({ appCredentials: [], userCredentials: [] })),
+    getDistributionCertificateAsync: jest.fn(() => null),
+    getDistributionCertificateByIdAsync: jest.fn(() => {
+      throw new Error('not found');
+    }),
+    createDistributionCertificateAsync: jest.fn(),
+    updateDistributionCertificateAsync: jest.fn(),
+    deleteDistributionCertificateAsync: jest.fn(),
+    useDistributionCertificateAsync: jest.fn(),
+    getPushKeyAsync: jest.fn(() => null),
+    createPushKeyAsync: jest.fn(),
+    updatePushKeyAsync: jest.fn(),
+    deletePushKeyAsync: jest.fn(),
+    usePushKeyAsync: jest.fn(),
+    getAppCredentialsAsync: jest.fn(app => ({
+      experienceName: `${app.accountName}/${app.projectName}`,
+      bundleIdentifier: app.bundleIdentifier,
+    })),
+    getProvisioningProfileAsync: jest.fn(() => null),
+    updateProvisioningProfileAsync: jest.fn(),
+    deleteProvisioningProfileAsync: jest.fn(),
+  };
+}

--- a/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts
@@ -1,0 +1,20 @@
+import chalk from 'chalk';
+
+import log from '../../../log';
+import { Action, CredentialsManager } from '../../CredentialsManager';
+import { Context } from '../../context';
+import { updateAndroidCredentialsAsync } from '../../credentialsJson/update';
+
+export class UpdateCredentialsJson implements Action {
+  constructor(private projectFullName: string) {}
+
+  async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+    log('Updating content of credentials.json');
+    await updateAndroidCredentialsAsync(ctx);
+    log(
+      chalk.green(
+        'Android part of your local credentials.json is synced with values store on Expo servers.'
+      )
+    );
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts
@@ -9,11 +9,11 @@ export class UpdateCredentialsJson implements Action {
   constructor(private projectFullName: string) {}
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
-    log('Updating content of credentials.json');
+    log('Updating Android credentials in credentials.json');
     await updateAndroidCredentialsAsync(ctx);
     log(
       chalk.green(
-        'Android part of your local credentials.json is synced with values store on Expo servers.'
+        'Android part of your local credentials.json is synced with values stored on Expo servers.'
       )
     );
   }

--- a/packages/eas-cli/src/credentials/credentialsJson/__tests__/update-test.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/__tests__/update-test.ts
@@ -1,0 +1,335 @@
+import fs from 'fs-extra';
+import { vol } from 'memfs';
+import prompts from 'prompts';
+
+import { asMock } from '../../../__tests__/utils';
+import { testKeystore } from '../../__tests__/fixtures-android';
+import { createCtxMock } from '../../__tests__/fixtures-context';
+import {
+  testAllCredentialsForApp,
+  testIosDistCredential,
+  testProvisioningProfile,
+} from '../../__tests__/fixtures-ios';
+import { updateAndroidCredentialsAsync, updateIosCredentialsAsync } from '../update';
+
+jest.mock('fs');
+jest.mock('prompts');
+
+const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+
+beforeAll(() => {
+  console.log = jest.fn();
+  console.warn = jest.fn();
+});
+
+afterAll(() => {
+  console.log = originalConsoleLog;
+  console.warn = originalConsoleWarn;
+});
+
+beforeEach(() => {
+  vol.reset();
+  asMock(prompts).mockReset();
+  asMock(prompts).mockImplementation(() => {
+    throw new Error(`unhandled prompts call - this shouldn't happen - fix tests!`);
+  });
+});
+
+describe('update credentials.json', () => {
+  describe(updateAndroidCredentialsAsync, () => {
+    it('should update keystore in credentials.json if www returns valid credentials', async () => {
+      const ctx = createCtxMock({
+        android: {
+          fetchKeystoreAsync: jest.fn(() => testKeystore),
+        },
+      });
+      vol.fromJSON({
+        './credentials.json': JSON.stringify({
+          android: {
+            keystore: {
+              keystorePath: 'keystore.jks',
+              keystorePassword: 'keystorePassword',
+              keyAlias: 'keyAlias',
+              keyPassword: 'keyPassword',
+            },
+          },
+        }),
+        'keystore.jks': 'somebinarydata',
+      });
+      await updateAndroidCredentialsAsync(ctx);
+      const keystore = await fs.readFile('./keystore.jks', 'base64');
+      const credJson = await fs.readJson('./credentials.json');
+      expect(keystore).toEqual(testKeystore.keystore);
+      expect(credJson).toEqual({
+        android: {
+          keystore: {
+            keystorePath: 'keystore.jks',
+            keystorePassword: testKeystore.keystorePassword,
+            keyAlias: testKeystore.keyAlias,
+            keyPassword: testKeystore.keyPassword,
+          },
+        },
+      });
+    });
+    it('should create credentials.json and keystore if credentials.json does not exist', async () => {
+      const ctx = createCtxMock({
+        android: {
+          fetchKeystoreAsync: jest.fn(() => testKeystore),
+        },
+      });
+      await updateAndroidCredentialsAsync(ctx);
+      const keystore = await fs.readFile('./android/keystores/keystore.jks', 'base64');
+      const credJson = await fs.readJson('./credentials.json');
+      expect(keystore).toEqual(testKeystore.keystore);
+      expect(credJson).toEqual({
+        android: {
+          keystore: {
+            keystorePath: 'android/keystores/keystore.jks',
+            keystorePassword: testKeystore.keystorePassword,
+            keyAlias: testKeystore.keyAlias,
+            keyPassword: testKeystore.keyPassword,
+          },
+        },
+      });
+    });
+    it('should not do anything if keystore in www is missing', async () => {
+      const ctx = createCtxMock();
+      const credJson = {
+        android: {
+          keystore: {
+            keystorePath: 'keystore.jks',
+            keystorePassword: 'keystorePassword',
+            keyAlias: 'keyAlias',
+            keyPassword: 'keyPassword',
+          },
+        },
+      };
+      vol.fromJSON({
+        './credentials.json': JSON.stringify(credJson),
+        'keystore.jks': 'somebinarydata',
+      });
+      try {
+        await updateAndroidCredentialsAsync(ctx);
+        throw new Error('updateAndroidCredentialsAsync should throw an error');
+      } catch (e) {
+        expect(e.message).toMatch(
+          'There are no credentials configured for this project on Expo servers'
+        );
+      }
+      const keystore = await fs.readFile('./keystore.jks', 'base64');
+      const newCredJson = await fs.readJson('./credentials.json');
+      expect(keystore).toEqual('c29tZWJpbmFyeWRhdGE='); // base64 "somebinarydata"
+      expect(newCredJson).toEqual(credJson);
+    });
+    it('should update keystore and credentials.json if android part of credentials.json is not valid', async () => {
+      const ctx = createCtxMock({
+        android: {
+          fetchKeystoreAsync: jest.fn(() => testKeystore),
+        },
+      });
+      vol.fromJSON({
+        './credentials.json': JSON.stringify({ android: { test: '123' } }),
+      });
+      await updateAndroidCredentialsAsync(ctx);
+      const keystore = await fs.readFile('./android/keystores/keystore.jks', 'base64');
+      const credJson = await fs.readJson('./credentials.json');
+      expect(keystore).toEqual(testKeystore.keystore);
+      expect(credJson).toEqual({
+        android: {
+          keystore: {
+            keystorePath: 'android/keystores/keystore.jks',
+            keystorePassword: testKeystore.keystorePassword,
+            keyAlias: testKeystore.keyAlias,
+            keyPassword: testKeystore.keyPassword,
+          },
+        },
+      });
+    });
+    it('should update keystore and credentials.json if ios part of credentials.json is not valid', async () => {
+      const ctx = createCtxMock({
+        android: {
+          fetchKeystoreAsync: jest.fn(() => testKeystore),
+        },
+      });
+      const credJson = {
+        android: {
+          keystore: {
+            keystorePath: 'keystore.jks',
+            keystorePassword: 'keystorePassword',
+            keyAlias: 'keyAlias',
+            keyPassword: 'keyPassword',
+          },
+        },
+        ios: {
+          test: '123',
+        },
+      };
+      vol.fromJSON({
+        './credentials.json': JSON.stringify(credJson),
+        'keystore.jks': 'somebinarydata',
+      });
+      await updateAndroidCredentialsAsync(ctx);
+      const keystore = await fs.readFile('./keystore.jks', 'base64');
+      const newCredJson = await fs.readJson('./credentials.json');
+      expect(keystore).toEqual(testKeystore.keystore);
+      expect(newCredJson).toEqual({
+        android: {
+          keystore: {
+            keystorePath: 'keystore.jks',
+            keystorePassword: testKeystore.keystorePassword,
+            keyAlias: testKeystore.keyAlias,
+            keyPassword: testKeystore.keyPassword,
+          },
+        },
+        ios: {
+          test: '123',
+        },
+      });
+    });
+  });
+  describe(updateIosCredentialsAsync, () => {
+    it('should update ios credentials in credentials.json if www returns valid credentials', async () => {
+      const ctx = createCtxMock({
+        ios: {
+          getAppCredentialsAsync: jest.fn(() => testAllCredentialsForApp),
+          getDistributionCertificateAsync: jest.fn(() => testIosDistCredential),
+          getProvisioningProfileAsync: jest.fn(() => testProvisioningProfile),
+        },
+      });
+      vol.fromJSON({
+        './credentials.json': JSON.stringify({
+          ios: {
+            provisioningProfilePath: 'pprofile',
+            distributionCertificate: {
+              path: 'cert.p12',
+              password: 'certPass',
+            },
+          },
+        }),
+        './pprofile': 'somebinarycontent',
+        './cert.p12': 'somebinarycontent2',
+      });
+      await updateIosCredentialsAsync(ctx, 'bundleIdentifier');
+      const certP12 = await fs.readFile('./cert.p12', 'base64');
+      const pprofile = await fs.readFile('./pprofile', 'base64');
+      const credJson = await fs.readJson('./credentials.json');
+      expect(certP12).toEqual(testAllCredentialsForApp.distCredentials.certP12);
+      expect(pprofile).toEqual(testAllCredentialsForApp.credentials.provisioningProfile);
+      expect(credJson).toEqual({
+        ios: {
+          provisioningProfilePath: 'pprofile',
+          distributionCertificate: {
+            path: 'cert.p12',
+            password: testAllCredentialsForApp.distCredentials.certPassword,
+          },
+        },
+      });
+    });
+    it('should create credentials.json provisioning profile and distribution certificate if credentials.json does not exist', async () => {
+      const ctx = createCtxMock({
+        ios: {
+          getAppCredentialsAsync: jest.fn(() => testAllCredentialsForApp),
+          getDistributionCertificateAsync: jest.fn(() => testIosDistCredential),
+          getProvisioningProfileAsync: jest.fn(() => testProvisioningProfile),
+        },
+      });
+      await updateIosCredentialsAsync(ctx, 'bundleIdentifier');
+      const certP12 = await fs.readFile('./ios/certs/dist-cert.p12', 'base64');
+      const pprofile = await fs.readFile('./ios/certs/profile.mobileprovision', 'base64');
+      const credJson = await fs.readJson('./credentials.json');
+      expect(certP12).toEqual(testAllCredentialsForApp.distCredentials.certP12);
+      expect(pprofile).toEqual(testAllCredentialsForApp.credentials.provisioningProfile);
+      expect(credJson).toEqual({
+        ios: {
+          provisioningProfilePath: 'ios/certs/profile.mobileprovision',
+          distributionCertificate: {
+            path: 'ios/certs/dist-cert.p12',
+            password: testAllCredentialsForApp.distCredentials.certPassword,
+          },
+        },
+      });
+    });
+    it('should not do anything if no credentials are returned from www', async () => {
+      const ctx = createCtxMock({
+        ios: {
+          getAppCredentialsAsync: jest.fn(() => null),
+          getDistributionCertificateAsync: jest.fn(() => null),
+          getProvisioningProfileAsync: jest.fn(() => null),
+        },
+      });
+      const credJson = {
+        ios: {
+          provisioningProfilePath: 'pprofile',
+          distributionCertificate: {
+            path: 'cert.p12',
+            password: 'certPass',
+          },
+        },
+      };
+      vol.fromJSON({
+        './credentials.json': JSON.stringify(credJson),
+        './pprofile': 'somebinarycontent',
+        './cert.p12': 'somebinarycontent2',
+      });
+      try {
+        await updateIosCredentialsAsync(ctx, 'bundleIdentifier');
+        throw new Error('updateIosCredentialsAsync should throw na error');
+      } catch (e) {
+        expect(e.message).toMatch(
+          'There are no credentials configured for this project on Expo servers'
+        );
+      }
+      const certP12 = await fs.readFile('./cert.p12', 'base64');
+      const pprofile = await fs.readFile('./pprofile', 'base64');
+      const newCredJson = await fs.readJson('./credentials.json');
+      expect(certP12).toEqual('c29tZWJpbmFyeWNvbnRlbnQy'); // base64 "somebinarycontent2"
+      expect(pprofile).toEqual('c29tZWJpbmFyeWNvbnRlbnQ='); // base64 "somebinarycontent"
+      expect(newCredJson).toEqual(credJson);
+    });
+    it('should display confirm prompt if some credentials are missing in www (confirm: true)', async () => {
+      const ctx = createCtxMock({
+        ios: {
+          getAppCredentialsAsync: jest.fn(() => ({
+            ...testAllCredentialsForApp,
+            distCredentialsId: undefined,
+            distCredentials: undefined,
+          })),
+          getDistributionCertificateAsync: jest.fn(() => null),
+          getProvisioningProfileAsync: jest.fn(() => testProvisioningProfile),
+        },
+      });
+
+      (prompts as any)
+        .mockImplementationOnce(() => ({ value: true })) // Continue with partial credentials
+        .mockImplementation(() => {
+          throw new Error("shouldn't happen");
+        });
+
+      vol.fromJSON({
+        './credentials.json': JSON.stringify({
+          ios: {
+            provisioningProfilePath: 'pprofile',
+            distributionCertificate: {
+              path: 'cert.p12',
+              password: 'certPass',
+            },
+          },
+        }),
+        './pprofile': 'somebinarycontent',
+        './cert.p12': 'somebinarycontent2',
+      });
+      await updateIosCredentialsAsync(ctx, 'bundleIdentifier');
+      const certP12Exists = await fs.pathExists('./cert.p12');
+      const pprofile = await fs.readFile('./pprofile', 'base64');
+      const credJson = await fs.readJson('./credentials.json');
+      expect(certP12Exists).toEqual(false);
+      expect(pprofile).toEqual(testAllCredentialsForApp.credentials.provisioningProfile);
+      expect(credJson).toEqual({
+        ios: {
+          provisioningProfilePath: 'pprofile',
+        },
+      });
+    });
+  });
+});

--- a/packages/eas-cli/src/credentials/credentialsJson/read.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/read.ts
@@ -32,7 +32,7 @@ const CredentialsJsonSchema = Joi.object({
       keystorePassword: Joi.string().required(),
       keyAlias: Joi.string().required(),
       keyPassword: Joi.string().required(),
-    }),
+    }).required(),
   }),
   ios: Joi.object({
     provisioningProfilePath: Joi.string().required(),

--- a/packages/eas-cli/src/credentials/credentialsJson/read.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/read.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 import { Keystore } from '../android/credentials';
 
-interface CredentialsJson {
+export interface CredentialsJson {
   android?: {
     keystore: {
       keystorePath: string;

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -6,7 +6,7 @@ import { confirmAsync } from '../../prompts';
 import { gitStatusAsync } from '../../utils/git';
 import { Context } from '../context';
 
-export async function updateAndroidCredentialsAsync(ctx: Context) {
+export async function updateAndroidCredentialsAsync(ctx: Context): Promise<void> {
   const credentialsJsonFilePath = path.join(ctx.projectDir, 'credentials.json');
   let rawCredentialsJsonObject: any = {};
   if (await fs.pathExists(credentialsJsonFilePath)) {
@@ -68,7 +68,10 @@ export async function updateAndroidCredentialsAsync(ctx: Context) {
   displayUntrackedFilesWarning(newFilePaths);
 }
 
-export async function updateIosCredentialsAsync(ctx: Context, bundleIdentifier: string) {
+export async function updateIosCredentialsAsync(
+  ctx: Context,
+  bundleIdentifier: string
+): Promise<void> {
   const credentialsJsonFilePath = path.join(ctx.projectDir, 'credentials.json');
   let rawCredentialsJsonObject: any = {};
   if (await fs.pathExists(credentialsJsonFilePath)) {

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -1,0 +1,192 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import log from '../../log';
+import { confirmAsync } from '../../prompts';
+import { gitStatusAsync } from '../../utils/git';
+import { Context } from '../context';
+
+export async function updateAndroidCredentialsAsync(ctx: Context) {
+  const credentialsJsonFilePath = path.join(ctx.projectDir, 'credentials.json');
+  let rawCredentialsJsonObject: any = {};
+  if (await fs.pathExists(credentialsJsonFilePath)) {
+    try {
+      const rawFile = await fs.readFile(credentialsJsonFilePath, 'utf-8');
+      rawCredentialsJsonObject = JSON.parse(rawFile);
+    } catch (error) {
+      log.error(`There was an error while reading credentials.json [${error}]`);
+      log.error('Make sure that file is correct (or remove it) and rerun this command.');
+      throw error;
+    }
+  }
+  const experienceName = `@${ctx.exp.owner || ctx.user.username}/${ctx.exp.slug}`;
+  const keystore = await ctx.android.fetchKeystoreAsync(experienceName);
+  if (!keystore) {
+    throw new Error('There are no credentials configured for this project on Expo servers');
+  }
+
+  const isKeystoreComplete =
+    keystore.keystore && keystore.keystorePassword && keystore.keyPassword && keystore.keyAlias;
+
+  if (!isKeystoreComplete) {
+    const confirm = await confirmAsync({
+      message:
+        'Credentials on Expo servers might be invalid or incomplete. Are you sure you want to continue?',
+    });
+    if (!confirm) {
+      log.warn('Aborting...');
+      return;
+    }
+  }
+
+  const keystorePath =
+    rawCredentialsJsonObject?.android?.keystore?.keystorePath ?? 'android/keystores/keystore.jks';
+  log(`Writing Keystore to ${keystorePath}`);
+  await updateFileAsync(ctx.projectDir, keystorePath, keystore.keystore);
+  const shouldWarnKeystore = await isFileUntrackedAsync(keystorePath);
+
+  rawCredentialsJsonObject.android = {
+    keystore: {
+      keystorePath,
+      keystorePassword: keystore.keystorePassword,
+      keyAlias: keystore.keyAlias,
+      keyPassword: keystore.keyPassword,
+    },
+  };
+  await fs.writeJson(credentialsJsonFilePath, rawCredentialsJsonObject, {
+    spaces: 2,
+  });
+  const shouldWarnCredentialsJson = await isFileUntrackedAsync('credentials.json');
+
+  const newFilePaths = [];
+  if (shouldWarnKeystore) {
+    newFilePaths.push(keystorePath);
+  }
+  if (shouldWarnCredentialsJson) {
+    newFilePaths.push('credentials.json');
+  }
+  displayUntrackedFilesWarning(newFilePaths);
+}
+
+export async function updateIosCredentialsAsync(ctx: Context, bundleIdentifier: string) {
+  const credentialsJsonFilePath = path.join(ctx.projectDir, 'credentials.json');
+  let rawCredentialsJsonObject: any = {};
+  if (await fs.pathExists(credentialsJsonFilePath)) {
+    try {
+      const rawFile = await fs.readFile(credentialsJsonFilePath, 'utf-8');
+      rawCredentialsJsonObject = JSON.parse(rawFile);
+    } catch (error) {
+      log.error(`There was an error while reading credentials.json [${error}]`);
+      log.error('Make sure that file is correct (or remove it) and rerun this command.');
+      throw error;
+    }
+  }
+
+  const appLookupParams = {
+    accountName: ctx.exp.owner ?? ctx.user.username,
+    projectName: ctx.exp.slug,
+    bundleIdentifier,
+  };
+  const pprofilePath =
+    rawCredentialsJsonObject?.ios?.provisioningProfilePath ?? 'ios/certs/profile.mobileprovision';
+  const distCertPath =
+    rawCredentialsJsonObject?.ios?.distributionCertificate?.path ?? 'ios/certs/dist-cert.p12';
+  const appCredentials = await ctx.ios.getAppCredentialsAsync(appLookupParams);
+  const distCredentials = await ctx.ios.getDistributionCertificateAsync(appLookupParams);
+  if (!appCredentials?.credentials?.provisioningProfile && !distCredentials) {
+    throw new Error('There are no credentials configured for this project on Expo servers');
+  }
+
+  const areCredentialsComplete =
+    appCredentials?.credentials?.provisioningProfile &&
+    distCredentials?.certP12 &&
+    distCredentials?.certPassword;
+
+  if (!areCredentialsComplete) {
+    const confirm = await confirmAsync({
+      message:
+        'Credentials on Expo servers might be invalid or incomplete. Are you sure you want to continue?',
+    });
+    if (!confirm) {
+      log.warn('Aborting...');
+      return;
+    }
+  }
+
+  log(`Writing Provisioning Profile to ${pprofilePath}`);
+  await updateFileAsync(
+    ctx.projectDir,
+    pprofilePath,
+    appCredentials?.credentials?.provisioningProfile
+  );
+  const shouldWarnPProfile = await isFileUntrackedAsync(pprofilePath);
+
+  log(`Writing Distribution Certificate to ${distCertPath}`);
+  await updateFileAsync(ctx.projectDir, distCertPath, distCredentials?.certP12);
+  const shouldWarnDistCert = await isFileUntrackedAsync(distCertPath);
+
+  rawCredentialsJsonObject.ios = {
+    ...(appCredentials?.credentials?.provisioningProfile
+      ? { provisioningProfilePath: pprofilePath }
+      : {}),
+    ...(distCredentials?.certP12 && distCredentials?.certPassword
+      ? {
+          distributionCertificate: {
+            path: distCertPath,
+            password: distCredentials?.certPassword,
+          },
+        }
+      : {}),
+  };
+  await fs.writeJson(credentialsJsonFilePath, rawCredentialsJsonObject, {
+    spaces: 2,
+  });
+  const shouldWarnCredentialsJson = await isFileUntrackedAsync('credentials.json');
+
+  const newFilePaths = [];
+  if (shouldWarnPProfile) {
+    newFilePaths.push(pprofilePath);
+  }
+  if (shouldWarnDistCert) {
+    newFilePaths.push(distCertPath);
+  }
+  if (shouldWarnCredentialsJson) {
+    newFilePaths.push('credentials.json');
+  }
+  displayUntrackedFilesWarning(newFilePaths);
+}
+
+async function updateFileAsync(projectDir: string, filePath: string, base64Data?: string) {
+  const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(projectDir, filePath);
+  if (await fs.pathExists(absolutePath)) {
+    await fs.remove(absolutePath);
+  }
+  if (base64Data) {
+    await fs.mkdirp(path.dirname(filePath));
+    await fs.writeFile(filePath, Buffer.from(base64Data, 'base64'));
+  }
+}
+
+async function isFileUntrackedAsync(path: string): Promise<boolean> {
+  const withUntrackedFiles = await gitStatusAsync({ showUntracked: true });
+  const trackedFiles = await gitStatusAsync({ showUntracked: false });
+  const pathWithoutLeadingDot = path.replace(/^\.\//, ''); // remove leading './' from path
+  return (
+    withUntrackedFiles.includes(pathWithoutLeadingDot) &&
+    !trackedFiles.includes(pathWithoutLeadingDot)
+  );
+}
+
+function displayUntrackedFilesWarning(newFilePaths: string[]) {
+  if (newFilePaths.length === 1) {
+    log.warn(
+      `File ${newFilePaths[0]} is currently untracked, remember to add it to .gitignore or to encrypt it. (e.g. with git-crypt)`
+    );
+  } else if (newFilePaths.length > 1) {
+    log.warn(
+      `Files ${newFilePaths.join(
+        ', '
+      )} are currently untracked, remember to add them to .gitignore or to encrypt them. (e.g. with git-crypt)`
+    );
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
 
 import log from '../../../log';
+import { promptAsync } from '../../../prompts';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
-import { AppLookupParams } from '../credentials';
+import { readIosCredentialsAsync } from '../../credentialsJson/read';
+import { AppLookupParams, IosAppCredentials } from '../credentials';
 import { displayProjectCredentials } from '../utils/printCredentials';
+import { readAppleTeam } from '../utils/provisioningProfile';
 import { SetupProvisioningProfile } from './SetupProvisioningProfile';
 
 export class SetupBuildCredentials implements Action {
@@ -25,6 +28,90 @@ export class SetupBuildCredentials implements Action {
     }
 
     const appInfo = `@${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`;
+    displayProjectCredentials(
+      this.app,
+      await ctx.ios.getAppCredentialsAsync(this.app),
+      undefined,
+      await ctx.ios.getDistributionCertificateAsync(this.app)
+    );
+    log.newLine();
+    log(chalk.green(`All credentials are ready to build ${appInfo}`));
+    log.newLine();
+  }
+}
+
+export class SetupBuildCredentialsFromCredentialsJson implements Action {
+  constructor(private app: AppLookupParams) {}
+
+  async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+    let localCredentials;
+    try {
+      localCredentials = await readIosCredentialsAsync(ctx.projectDir);
+    } catch (error) {
+      log.error(
+        'Reading credentials from credentials.json failed. Make sure this file is correct and all credentials are present there.'
+      );
+      throw error;
+    }
+
+    const team = readAppleTeam(localCredentials.provisioningProfile);
+    await ctx.ios.updateProvisioningProfileAsync(this.app, {
+      ...team,
+      provisioningProfile: localCredentials.provisioningProfile,
+    });
+    const credentials = await ctx.ios.getAllCredentialsAsync(this.app.accountName);
+    const distCert = await ctx.ios.getDistributionCertificateAsync(this.app);
+    const appsUsingCert = distCert?.id
+      ? (credentials.appCredentials || []).filter(
+          (cred: IosAppCredentials) => cred.distCredentialsId === distCert.id
+        )
+      : [];
+
+    const appInfo = `@${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`;
+    const newDistCert = {
+      ...team,
+      certP12: localCredentials.distributionCertificate.certP12,
+      certPassword: localCredentials.distributionCertificate.certPassword,
+    };
+
+    if (appsUsingCert.length > 1 && distCert?.id) {
+      const { update } = await promptAsync({
+        type: 'select',
+        name: 'update',
+        message:
+          'Current distribution certificate is used by multiple apps. Do you want to update all of them?',
+        choices: [
+          { title: 'Update all apps', value: 'all' },
+          { title: `Update only ${appInfo}`, value: 'app' },
+        ],
+      });
+      if (update === 'all') {
+        await ctx.ios.updateDistributionCertificateAsync(
+          distCert.id,
+          this.app.accountName,
+          newDistCert
+        );
+      } else {
+        const createdDistCert = await ctx.ios.createDistributionCertificateAsync(
+          this.app.accountName,
+          newDistCert
+        );
+        await ctx.ios.useDistributionCertificateAsync(this.app, createdDistCert.id);
+      }
+    } else if (distCert?.id) {
+      await ctx.ios.updateDistributionCertificateAsync(
+        distCert.id,
+        this.app.accountName,
+        newDistCert
+      );
+    } else {
+      const createdDistCert = await ctx.ios.createDistributionCertificateAsync(
+        this.app.accountName,
+        newDistCert
+      );
+      await ctx.ios.useDistributionCertificateAsync(this.app, createdDistCert.id);
+    }
+
     displayProjectCredentials(
       this.app,
       await ctx.ios.getAppCredentialsAsync(this.app),

--- a/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
@@ -12,11 +12,11 @@ export class UpdateCredentialsJson implements Action {
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     const bundleIdentifer = await getBundleIdentifier(ctx.projectDir, ctx.exp);
-    log('Updating content of credentials.json');
+    log('Updating iOS credentials in credentials.json');
     await updateIosCredentialsAsync(ctx, bundleIdentifer);
     log(
       chalk.green(
-        'iOS part of your local credentials.json is synced with values store on Expo servers.'
+        'iOS part of your local credentials.json is synced with values stored on Expo servers.'
       )
     );
   }

--- a/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
@@ -1,0 +1,23 @@
+import chalk from 'chalk';
+
+import { getBundleIdentifier } from '../../../build/ios/bundleIdentifer';
+import log from '../../../log';
+import { Action, CredentialsManager } from '../../CredentialsManager';
+import { Context } from '../../context';
+import { updateIosCredentialsAsync } from '../../credentialsJson/update';
+import { AppLookupParams } from '../credentials';
+
+export class UpdateCredentialsJson implements Action {
+  constructor(private app: AppLookupParams) {}
+
+  async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+    const bundleIdentifer = await getBundleIdentifier(ctx.projectDir, ctx.exp);
+    log('Updating content of credentials.json');
+    await updateIosCredentialsAsync(ctx, bundleIdentifer);
+    log(
+      chalk.green(
+        'iOS part of your local credentials.json is synced with values store on Expo servers.'
+      )
+    );
+  }
+}

--- a/packages/eas-cli/src/credentials/manager/ManageAndroidApp.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroidApp.ts
@@ -6,10 +6,22 @@ import { Action, CredentialsManager } from '../CredentialsManager';
 import { DownloadKeystore } from '../android/actions/DownloadKeystore';
 import { UpdateFcmKey } from '../android/actions/FcmKey';
 import { RemoveKeystore } from '../android/actions/RemoveKeystore';
+import { SetupBuildCredentialsFromCredentialsJson } from '../android/actions/SetupBuildCredentials';
+import { UpdateCredentialsJson } from '../android/actions/UpdateCredentialsJson';
 import { UpdateKeystore } from '../android/actions/UpdateKeystore';
 import { printAndroidAppCredentials } from '../android/utils/printCredentials';
 import { Context } from '../context';
 import { PressAnyKeyToContinue } from './HelperActions';
+
+enum ActionType {
+  UpdateCredentialsJson,
+  SetupBuildCredentialsFromCredentialsJson,
+  UpdateKeystore,
+  RemoveKeystore,
+  DownloadKeystore,
+  UpdateFcmKey,
+  GoBack,
+}
 
 export class ManageAndroidApp implements Action {
   constructor(private projectFullName: string) {}
@@ -31,16 +43,24 @@ export class ManageAndroidApp implements Action {
         name: 'action',
         message: 'What do you want to do?',
         choices: [
-          { value: 'update-keystore', title: 'Update Keystore' },
-          { value: 'remove-keystore', title: 'Remove Keystore' },
-          { value: 'fetch-keystore', title: 'Download Keystore from the Expo servers' },
-          { value: 'update-fcm-key', title: 'Update FCM API Key' },
-          { value: 'go-back', title: 'Go back to project list' },
+          {
+            value: ActionType.UpdateCredentialsJson,
+            title: 'Update credentials.json with values from Expo servers',
+          },
+          {
+            value: ActionType.SetupBuildCredentialsFromCredentialsJson,
+            title: 'Update credentials on Expo servers with values from credentials.json',
+          },
+          { value: ActionType.UpdateKeystore, title: 'Update Keystore' },
+          { value: ActionType.RemoveKeystore, title: 'Remove Keystore' },
+          { value: ActionType.DownloadKeystore, title: 'Download Keystore from the Expo servers' },
+          { value: ActionType.UpdateFcmKey, title: 'Update FCM API Key' },
+          { value: ActionType.GoBack, title: 'Go back to project list' },
         ],
       },
     ]);
 
-    if (action === 'go-back') {
+    if (action === ActionType.GoBack) {
       manager.popAction();
       return;
     }
@@ -49,16 +69,24 @@ export class ManageAndroidApp implements Action {
     manager.pushNextAction(this.getAction(ctx, action));
   }
 
-  private getAction(context: Context, selected: string): Action {
+  private getAction(context: Context, selected: ActionType): Action {
     switch (selected) {
-      case 'update-keystore':
+      case ActionType.UpdateKeystore:
         return new UpdateKeystore(this.projectFullName);
-      case 'remove-keystore':
+      case ActionType.RemoveKeystore:
         return new RemoveKeystore(this.projectFullName);
-      case 'update-fcm-key':
+      case ActionType.UpdateFcmKey:
         return new UpdateFcmKey(this.projectFullName);
-      case 'fetch-keystore':
+      case ActionType.DownloadKeystore:
         return new DownloadKeystore(this.projectFullName);
+      case ActionType.UpdateCredentialsJson: {
+        return new UpdateCredentialsJson(this.projectFullName);
+      }
+      case ActionType.SetupBuildCredentialsFromCredentialsJson: {
+        return new SetupBuildCredentialsFromCredentialsJson(this.projectFullName, {
+          skipKeystoreValidation: false,
+        });
+      }
       default:
         throw new Error('unknown action');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1090,6 +1090,13 @@
   dependencies:
     "@hapi/joi" "^17.1.1"
 
+"@expo/eas-build-job@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.2.tgz#104b9bcb1602a23aabf893506e8e55d0dc61cd79"
+  integrity sha512-hBYVWlEWi8Iu+jWmbzKy2bMsYoWvRwY7MZ+SdKpNvAl+sMpp8rwvxRyRs7cRTa6DuiQ2sdOxqemnw9MJ6S5cRA==
+  dependencies:
+    "@hapi/joi" "^17.1.1"
+
 "@expo/image-utils@0.3.7":
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.7.tgz#48436a5f509818dc43a30f73dbfd4baed88a5f23"


### PR DESCRIPTION
Reaching feature parity with expo-cli (for builds) + full support for managed workflow
- actions for syncing credentials.json with www under `eas credentials` command
- `credentials.json` support when building
- support for managed builds
- test fixtures for ios credentials api
- fixes to the project configuration when running `eas build:create`