### PR TITLE
[eas-cli] relocate getProjectIdAsync

### DIFF
--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -2,6 +2,7 @@ import { getConfig } from '@expo/config';
 import pkgDir from 'pkg-dir';
 
 import { ensureLoggedInAsync } from '../user/actions';
+import { ensureProjectExistsAsync } from './ensureProjectExists';
 
 export async function getProjectAccountNameAsync(projectDir: string): Promise<string> {
   const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
@@ -12,4 +13,12 @@ export async function getProjectAccountNameAsync(projectDir: string): Promise<st
 export async function findProjectRootAsync(cwd?: string): Promise<string | null> {
   const projectRootDir = await pkgDir(cwd);
   return projectRootDir ?? null;
+}
+
+export async function getProjectIdAsync(projectDir: string): Promise<string> {
+  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+  return await ensureProjectExistsAsync({
+    accountName: await getProjectAccountNameAsync(projectDir),
+    projectName: exp.slug,
+  });
 }

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
@@ -2,8 +2,9 @@ import { getConfig } from '@expo/config';
 import { Result, result } from '@expo/results';
 
 import log from '../../log';
+import { getProjectIdAsync } from '../../project/projectUtils';
 import { ArchiveSource, ArchiveTypeSource, ArchiveTypeSourceType } from '../archiveSource';
-import { getProjectIdAsync, resolveArchiveFileSource } from '../commons';
+import { resolveArchiveFileSource } from '../commons';
 import {
   AndroidArchiveType,
   AndroidSubmissionContext,

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -5,6 +5,7 @@ import { asMock } from '../../../__tests__/utils';
 import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { ensureProjectExistsAsync } from '../../../project/ensureProjectExists';
+import { getProjectIdAsync } from '../../../project/projectUtils';
 import SubmissionService from '../../SubmissionService';
 import { Submission, SubmissionStatus } from '../../SubmissionService.types';
 import { AndroidArchiveType, AndroidSubmitCommandFlags, SubmissionPlatform } from '../../types';
@@ -89,6 +90,7 @@ describe(AndroidSubmitCommand, () => {
         }
       );
       asMock(ensureProjectExistsAsync).mockImplementationOnce(() => projectId);
+      asMock(getProjectIdAsync).mockImplementationOnce(() => projectId);
 
       const options: AndroidSubmitCommandFlags = {
         latest: false,

--- a/packages/eas-cli/src/submissions/commons.ts
+++ b/packages/eas-cli/src/submissions/commons.ts
@@ -1,18 +1,7 @@
-import { getConfig } from '@expo/config';
 import * as uuid from 'uuid';
 
-import { ensureProjectExistsAsync } from '../project/ensureProjectExists';
-import { getProjectAccountNameAsync } from '../project/projectUtils';
 import { ArchiveFileSource, ArchiveFileSourceType } from './archiveSource';
 import { AndroidSubmissionContext, IosSubmissionContext, SubmissionPlatform } from './types';
-
-export async function getProjectIdAsync(projectDir: string): Promise<string> {
-  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-  return await ensureProjectExistsAsync({
-    accountName: await getProjectAccountNameAsync(projectDir),
-    projectName: exp.slug,
-  });
-}
 
 export function resolveArchiveFileSource(
   platform: SubmissionPlatform,

--- a/packages/eas-cli/src/submissions/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitCommand.ts
@@ -3,10 +3,11 @@ import chalk from 'chalk';
 import wordwrap from 'wordwrap';
 
 import log from '../../log';
+import { getProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import UserSettings from '../../user/UserSettings';
 import { ArchiveSource, ArchiveTypeSourceType } from '../archiveSource';
-import { getProjectIdAsync, resolveArchiveFileSource } from '../commons';
+import { resolveArchiveFileSource } from '../commons';
 import { IosSubmissionContext, IosSubmitCommandFlags, SubmissionPlatform } from '../types';
 import {
   AppSpecificPasswordSource,

--- a/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
@@ -5,6 +5,7 @@ import { asMock } from '../../../__tests__/utils';
 import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { ensureProjectExistsAsync } from '../../../project/ensureProjectExists';
+import { getProjectIdAsync } from '../../../project/projectUtils';
 import SubmissionService from '../../SubmissionService';
 import { Submission, SubmissionStatus } from '../../SubmissionService.types';
 import { IosSubmitCommandFlags, SubmissionPlatform } from '../../types';
@@ -84,6 +85,7 @@ describe(IosSubmitCommand, () => {
         }
       );
       asMock(ensureProjectExistsAsync).mockImplementationOnce(() => projectId);
+      asMock(getProjectIdAsync).mockImplementationOnce(() => projectId);
 
       const options: IosSubmitCommandFlags = {
         latest: false,


### PR DESCRIPTION
close https://github.com/expo/eas-cli/issues/72

Left name as `getProjectIdAsync` as I am under the impression that we want to move away from `app`.