### PR TITLE
[eas-cli] standalone credentials manager error handling

### DIFF
--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -1,6 +1,6 @@
 import { Command } from '@oclif/command';
 
-import { runCredentialsManagerAsync } from '../credentials/CredentialsManager';
+import { runStandaloneCredentialsManagerAsync } from '../credentials/CredentialsManager';
 import { createCredentialsContextAsync } from '../credentials/context';
 import { SelectPlatform } from '../credentials/manager/SelectPlatform';
 
@@ -9,6 +9,6 @@ export default class Credentials extends Command {
 
   async run() {
     const ctx = await createCredentialsContextAsync(process.cwd(), {});
-    await runCredentialsManagerAsync(ctx, new SelectPlatform());
+    await runStandaloneCredentialsManagerAsync(ctx, new SelectPlatform());
   }
 }

--- a/packages/eas-cli/src/credentials/CredentialsManager.ts
+++ b/packages/eas-cli/src/credentials/CredentialsManager.ts
@@ -25,7 +25,7 @@ export async function runStandaloneCredentialsManagerAsync(
 
 export async function runCredentialsManagerAsync(ctx: Context, startAction: Action): Promise<void> {
   const manager = new CredentialsManagerImpl(ctx, startAction);
-  await manager.runManagerAsync(false);
+  await manager.runManagerAsync();
 }
 
 class CredentialsManagerImpl implements CredentialsManager {
@@ -44,10 +44,10 @@ class CredentialsManagerImpl implements CredentialsManager {
   }
 
   public async runActionAsync(action: Action) {
-    await new CredentialsManagerImpl(this.ctx, action).doRunManagerAsync(false);
+    await new CredentialsManagerImpl(this.ctx, action).doRunManagerAsync();
   }
 
-  public async runManagerAsync(isStandaloneManager: boolean): Promise<void> {
+  public async runManagerAsync(isStandaloneManager: boolean = false): Promise<void> {
     try {
       await this.doRunManagerAsync(isStandaloneManager);
     } catch (error) {
@@ -58,7 +58,7 @@ class CredentialsManagerImpl implements CredentialsManager {
     }
   }
 
-  private async doRunManagerAsync(isStandaloneManager: boolean): Promise<void> {
+  private async doRunManagerAsync(isStandaloneManager: boolean = false): Promise<void> {
     while (true) {
       try {
         const currentAction = this.popAction();


### PR DESCRIPTION
# Why

credentials manager started from `eas credentials` should ignore errors triggered by failing actions, but if run it from build command error should be propagated.

# How

Add flag to `runManagerAsync`

