### PR TITLE
Add support for grouping flags in --help

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -42,6 +42,7 @@
     "progress": "^2.0.3",
     "prompts": "^2.3.2",
     "qrcode-terminal": "^0.12.0",
+    "strip-ansi": "^6.0.0",
     "tar": "^6.0.5",
     "tslib": "^1",
     "untildify": "^4.0.0",
@@ -107,6 +108,7 @@
     "plugins": [
       "@oclif/plugin-help"
     ],
+    "helpClass": "./build/help",
     "topics": {
       "build": {
         "description": "build app binaries"

--- a/packages/eas-cli/src/commands/build/submit.ts
+++ b/packages/eas-cli/src/commands/build/submit.ts
@@ -28,7 +28,7 @@ export default class BuildSubmit extends Command {
 
     /* Common flags for both platforms */
     latest: flags.boolean({
-      description: '23Submit the latest build',
+      description: 'Submit the latest build',
       exclusive: ['id', 'path', 'url'],
       default: false,
       helpLabel: COMMON_FLAGS,

--- a/packages/eas-cli/src/commands/build/submit.ts
+++ b/packages/eas-cli/src/commands/build/submit.ts
@@ -10,6 +10,10 @@ import {
 } from '../../submissions/types';
 import { ensureLoggedInAsync } from '../../user/actions';
 
+const COMMON_FLAGS = '';
+const ANDROID_FLAGS = 'Android specific options';
+const IOS_FLAGS = 'iOS specific options';
+
 export default class BuildSubmit extends Command {
   static description = 'Submits build artifact to app store';
 
@@ -19,43 +23,52 @@ export default class BuildSubmit extends Command {
       description: 'For which platform you want to submit a build',
       options: ['android', 'ios'],
       required: true,
+      helpLabel: COMMON_FLAGS,
     }),
 
     /* Common flags for both platforms */
     latest: flags.boolean({
-      description: 'Submit the latest build',
+      description: '23Submit the latest build',
       exclusive: ['id', 'path', 'url'],
       default: false,
+      helpLabel: COMMON_FLAGS,
     }),
     id: flags.string({
       description: 'ID of the build to submit',
       exclusive: ['latest, path, url'],
+      helpLabel: COMMON_FLAGS,
     }),
     path: flags.string({
       description: 'Path to the .apk/.aab file',
       exclusive: ['latest', 'id', 'url'],
+      helpLabel: COMMON_FLAGS,
     }),
     url: flags.string({
       description: 'App archive url',
       exclusive: ['latest', 'id', 'path'],
+      helpLabel: COMMON_FLAGS,
     }),
 
     verbose: flags.boolean({
       description: 'Always print logs from Submission Service',
       default: false,
+      helpLabel: COMMON_FLAGS,
     }),
 
     /* Android specific flags */
     type: flags.enum<'apk' | 'aab'>({
       description: 'Android archive type',
       options: ['apk', 'aab'],
+      helpLabel: ANDROID_FLAGS,
     }),
 
     key: flags.string({
       description: 'Path to the JSON key used to authenticate with Google Play',
+      helpLabel: ANDROID_FLAGS,
     }),
     'android-package': flags.string({
       description: 'Android package name (using expo.android.package from app.json by default)',
+      helpLabel: ANDROID_FLAGS,
     }),
 
     track: flags.enum({
@@ -63,24 +76,29 @@ export default class BuildSubmit extends Command {
         'The track of the application to use, choose from: production, beta, alpha, internal, rollout',
       default: 'internal',
       options: ['production', 'beta', 'alpha', 'internal', 'rollout'],
+      helpLabel: ANDROID_FLAGS,
     }),
     'release-status': flags.enum({
       description:
         'Release status (used when uploading new apks/aabs), choose from: completed, draft, halted, inProgress',
       default: 'completed',
       options: ['completed', 'draft', 'halted', 'inProgress'],
+      helpLabel: ANDROID_FLAGS,
     }),
 
     /* iOS specific flags */
     'apple-id': flags.string({
       description: 'Your Apple ID username (you can also set EXPO_APPLE_ID env variable)',
+      helpLabel: IOS_FLAGS,
     }),
     'apple-app-specific-password': flags.string({
       description:
         'Your Apple ID app-specific password. You can also set EXPO_APPLE_APP_SPECIFIC_PASSWORD env variable.',
+      helpLabel: IOS_FLAGS,
     }),
     'app-apple-id': flags.string({
       description: 'App Store Connect unique application Apple ID number.',
+      helpLabel: IOS_FLAGS,
     }),
   };
 

--- a/packages/eas-cli/src/help.ts
+++ b/packages/eas-cli/src/help.ts
@@ -2,11 +2,9 @@ import * as Config from '@oclif/config';
 import Help from '@oclif/plugin-help';
 import CommandHelp from '@oclif/plugin-help/lib/command';
 import { compact, sortBy } from '@oclif/plugin-help/lib/util';
+import chalk from 'chalk';
 import groupBy from 'lodash/groupBy';
-import chalk, { underline } from 'chalk';
 import stripAnsi from 'strip-ansi';
-import Command from './command';
-import { Dictionary } from 'lodash';
 
 export default class CustomHelp extends Help {
   protected formatCommand(command: Config.Command): string {

--- a/packages/eas-cli/src/help.ts
+++ b/packages/eas-cli/src/help.ts
@@ -1,0 +1,62 @@
+import * as Config from '@oclif/config';
+import Help from '@oclif/plugin-help';
+import CommandHelp from '@oclif/plugin-help/lib/command';
+import { compact, sortBy } from '@oclif/plugin-help/lib/util';
+import groupBy from 'lodash/groupBy';
+import chalk, { underline } from 'chalk';
+import stripAnsi from 'strip-ansi';
+import Command from './command';
+import { Dictionary } from 'lodash';
+
+export default class CustomHelp extends Help {
+  protected formatCommand(command: Config.Command): string {
+    const help = new CustomCommandHelp(command, this.config, this.opts);
+    return help.generate();
+  }
+}
+
+class CustomCommandHelp extends CommandHelp {
+  generate(): string {
+    const cmd = this.command;
+    const flags = sortBy(
+      Object.entries(cmd.flags || {})
+        .filter(([, v]) => !v.hidden)
+        .map(([k, v]) => {
+          v.name = k;
+          return v;
+        }),
+      f => [f.helpLabel, f.name]
+    );
+    const args = (cmd.args || []).filter(a => !a.hidden);
+    let output = compact([
+      this.usage(flags),
+      this.args(args),
+      this.flags(flags),
+      this.description(),
+      this.aliases(cmd.aliases),
+      this.examples(cmd.examples || (cmd as any).example),
+    ]).join('\n\n');
+    if (this.opts.stripAnsi) output = stripAnsi(output);
+    return output;
+  }
+
+  protected flags(flags: Config.Command.Flag[]): string | undefined {
+    if (flags.length === 0) return;
+    const groupableFlags = flags.map(originalFlag => {
+      const { helpLabel, ...flag } = originalFlag;
+      // We re-purpose `helpLabel` to mean a "header to group the flag under".
+      return { ...flag, group: helpLabel };
+    });
+
+    const groups = groupBy(groupableFlags, flag => flag.group || '');
+    let output = chalk.bold('OPTIONS') + '\n';
+    for (const [label, flags] of Object.entries(groups)) {
+      if (label) {
+        output += '  ' + chalk.underline(label) + '\n';
+      }
+      output += super.flags(flags)?.split('\n').slice(1).join('\n') ?? '';
+      output += '\n\n';
+    }
+    return output.trimEnd();
+  }
+}


### PR DESCRIPTION
This re-purposes the `helpLabel` property of flags (previously used to override the left column in `--help`) to be used as a group, so that flags can be grouped in the help output.

This is currently used in `eas build:submit --help`.
<img width="1170" alt="Screen Shot 2020-11-20 at 18 10 58" src="https://user-images.githubusercontent.com/497214/99822570-0a04bb80-2b5c-11eb-9ed7-b778e9987b0d.png">
