### PR TITLE
[eas-cli] add release:edit

### DIFF
--- a/packages/eas-cli/src/commands/release/edit.ts
+++ b/packages/eas-cli/src/commands/release/edit.ts
@@ -1,0 +1,145 @@
+import { getConfig } from '@expo/config';
+import { Command, flags } from '@oclif/command';
+import chalk from 'chalk';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
+import log from '../../log';
+import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
+import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+import { promptAsync } from '../../prompts';
+
+type UpdateRelease = {
+  id: string;
+  releaseName: string;
+};
+
+async function editUpdateReleaseOnAppAsync({
+  appId,
+  releaseName,
+  newReleaseName,
+}: {
+  appId: string;
+  releaseName: string;
+  newReleaseName: string;
+}): Promise<UpdateRelease> {
+  const data = await withErrorHandlingAsync(
+    graphqlClient
+      .mutation<
+        { updateRelease: { editUpdateRelease: UpdateRelease } },
+        {
+          input: {
+            appId: string;
+            releaseName: string;
+            newReleaseName: string;
+          };
+        }
+      >(
+        gql`
+          mutation EditUpdateRelease($input: EditUpdateReleaseInput!) {
+            updateRelease {
+              editUpdateRelease(input: $input) {
+                id
+                releaseName
+              }
+            }
+          }
+        `,
+        {
+          input: {
+            appId,
+            releaseName,
+            newReleaseName,
+          },
+        }
+      )
+      .toPromise()
+  );
+  return data.updateRelease.editUpdateRelease;
+}
+
+export default class ReleaseEdit extends Command {
+  static description = 'Edit a release.';
+
+  static args = [
+    {
+      name: 'releaseName',
+      required: false,
+      description: 'Name of the release to edit',
+    },
+  ];
+
+  static flags = {
+    rename: flags.string({
+      description: 'what to rename the release.',
+      required: false,
+    }),
+    json: flags.boolean({
+      description: `return a json with the edited release's ID and name.`,
+      default: false,
+    }),
+  };
+
+  async run() {
+    let {
+      args: { releaseName },
+      flags: { json: jsonFlag, rename: renameFlag },
+    } = this.parse(ReleaseEdit);
+
+    const projectDir = await findProjectRootAsync(process.cwd());
+    if (!projectDir) {
+      throw new Error('Please run this command inside a project directory.');
+    }
+    const accountName = await getProjectAccountNameAsync(projectDir);
+    const {
+      exp: { slug },
+    } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await ensureProjectExistsAsync({
+      accountName,
+      projectName: slug,
+    });
+
+    if (!releaseName) {
+      const validationMessage = 'Release name may not be empty.';
+      if (jsonFlag) {
+        throw new Error(validationMessage);
+      }
+      ({ releaseName } = await promptAsync({
+        type: 'text',
+        name: 'releaseName',
+        message: 'Please enter the name of the release to edit:',
+        validate: value => (value ? true : validationMessage),
+      }));
+    }
+
+    if (!renameFlag) {
+      const validationMessage = '--rename may not be empty.';
+      if (jsonFlag) {
+        throw new Error(validationMessage);
+      }
+      ({ renameFlag } = await promptAsync({
+        type: 'text',
+        name: 'renameFlag',
+        message: `Please rename ${releaseName}`,
+        validate: value => (value ? true : validationMessage),
+      }));
+    }
+
+    const editedRelease = await editUpdateReleaseOnAppAsync({
+      appId: projectId,
+      releaseName,
+      newReleaseName: renameFlag!,
+    });
+
+    if (jsonFlag) {
+      log(editedRelease);
+      return;
+    }
+
+    log.withTick(
+      `️Edited a release: ${chalk.bold(editedRelease.releaseName)} on project ${chalk.bold(
+        `@${accountName}/${slug}`
+      )}.`
+    );
+  }
+}

--- a/packages/eas-cli/src/commands/release/rename.ts
+++ b/packages/eas-cli/src/commands/release/rename.ts
@@ -50,7 +50,7 @@ async function renameUpdateReleaseOnAppAsync({
   return data.updateRelease.editUpdateRelease;
 }
 
-export default class ReleaseEdit extends Command {
+export default class ReleaseRename extends Command {
   static description = 'Edit a release.';
 
   static flags = {

--- a/packages/eas-cli/src/commands/release/rename.ts
+++ b/packages/eas-cli/src/commands/release/rename.ts
@@ -8,11 +8,7 @@ import log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-
-type UpdateRelease = {
-  id: string;
-  releaseName: string;
-};
+import { EditUpdateReleaseInput, UpdateRelease } from '../../graphql/generated';
 
 async function renameUpdateReleaseOnAppAsync({
   appId,
@@ -28,11 +24,7 @@ async function renameUpdateReleaseOnAppAsync({
       .mutation<
         { updateRelease: { editUpdateRelease: UpdateRelease } },
         {
-          input: {
-            appId: string;
-            releaseName: string;
-            newReleaseName: string;
-          };
+          input: EditUpdateReleaseInput;
         }
       >(
         gql`

--- a/packages/eas-cli/src/commands/release/rename.ts
+++ b/packages/eas-cli/src/commands/release/rename.ts
@@ -71,7 +71,7 @@ export default class ReleaseRename extends Command {
   async run() {
     let {
       flags: { json: jsonFlag, from: currentName, to: newName },
-    } = this.parse(ReleaseEdit);
+    } = this.parse(ReleaseRename);
 
     const projectDir = await findProjectRootAsync(process.cwd());
     if (!projectDir) {

--- a/packages/eas-cli/src/commands/release/rename.ts
+++ b/packages/eas-cli/src/commands/release/rename.ts
@@ -51,7 +51,7 @@ async function renameUpdateReleaseOnAppAsync({
 }
 
 export default class ReleaseRename extends Command {
-  static description = 'Edit a release.';
+  static description = 'Rename a release.';
 
   static flags = {
     from: flags.string({

--- a/packages/eas-cli/src/commands/release/rename.ts
+++ b/packages/eas-cli/src/commands/release/rename.ts
@@ -4,11 +4,11 @@ import chalk from 'chalk';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
+import { EditUpdateReleaseInput, UpdateRelease } from '../../graphql/generated';
 import log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import { EditUpdateReleaseInput, UpdateRelease } from '../../graphql/generated';
 
 async function renameUpdateReleaseOnAppAsync({
   appId,


### PR DESCRIPTION
While the graphql allows us to edit a release's name by either its `ID`, or the combination of `projectID` + `releaseName`, this command only implements the latter: `projectId` + `releaseName`. Adding both options seemed to add more clutter than utility.

Even though there is only one `edit` option: `rename` chose to require a special flag `--rename`.  This allows extensibility in the future and will also match other edit commands with more options, like the `channel:edit` command (which will have 2 possibilities).