### PR TITLE
Add tsc to CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: yarn install --frozen-lockfile --check-files
+      - run: yarn lerna run build
       - run: yarn test
         if: ${{ !matrix.coverage }}
       - run: yarn test --coverage
         if: ${{ matrix.coverage }}
-      - run: yarn lerna run build
       - run: yarn lint
       - run: shellcheck bin/*.sh
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         if: ${{ !matrix.coverage }}
       - run: yarn test --coverage
         if: ${{ matrix.coverage }}
+      - run: yarn lerna run build
       - run: yarn lint
       - run: shellcheck bin/*.sh
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
Turns out `tsc` was not running in the CI for all PRs at the moment.

Run `tsc` after the tests to ensure that there are no type errors.