### PR TITLE
upgraded apple utils to support request contexts

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
     "@eas/config": "^0.1.0-alpha.4",
-    "@expo/apple-utils": "0.0.0-alpha.8",
+    "@expo/apple-utils": "0.0.0-alpha.9",
     "@expo/config": "^3.3.12",
     "@expo/eas-build-job": "0.1.2",
     "@expo/json-file": "^8.2.24",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
     "@eas/config": "^0.1.0-alpha.4",
-    "@expo/apple-utils": "0.0.0-alpha.9",
+    "@expo/apple-utils": "0.0.0-alpha.10",
     "@expo/config": "^3.3.12",
     "@expo/eas-build-job": "0.1.2",
     "@expo/json-file": "^8.2.24",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
     "@eas/config": "^0.1.0-alpha.4",
-    "@expo/apple-utils": "0.0.0-alpha.5",
+    "@expo/apple-utils": "0.0.0-alpha.8",
     "@expo/config": "^3.3.12",
     "@expo/eas-build-job": "0.1.2",
     "@expo/json-file": "^8.2.24",

--- a/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
@@ -60,9 +60,9 @@ export type AuthCtx = {
   authState?: Session.AuthState;
 };
 
-export function getRequestContext(ctx: AuthCtx): RequestContext {
-  assert(ctx.authState?.context, 'Apple request context must be defined');
-  return ctx.authState.context;
+export function getRequestContext(authCtx: AuthCtx): RequestContext {
+  assert(authCtx.authState?.context, 'Apple request context must be defined');
+  return authCtx.authState.context;
 }
 
 async function authenticateWithExperimentalAsync(options: Options = {}): Promise<AuthCtx> {

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleId.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleId.ts
@@ -1,15 +1,21 @@
-import { BundleId, Profile } from '@expo/apple-utils';
+import { BundleId, Profile, RequestContext } from '@expo/apple-utils';
 
-export async function getProfilesForBundleIdAsync(bundleIdentifier: string): Promise<Profile[]> {
-  const bundleId = await BundleId.findAsync({ identifier: bundleIdentifier });
+export async function getProfilesForBundleIdAsync(
+  context: RequestContext,
+  bundleIdentifier: string
+): Promise<Profile[]> {
+  const bundleId = await BundleId.findAsync(context, { identifier: bundleIdentifier });
   if (bundleId) {
     return bundleId.getProfilesAsync();
   }
   return [];
 }
 
-export async function getBundleIdForIdentifierAsync(bundleIdentifier: string): Promise<BundleId> {
-  const bundleId = await BundleId.findAsync({ identifier: bundleIdentifier });
+export async function getBundleIdForIdentifierAsync(
+  context: RequestContext,
+  bundleIdentifier: string
+): Promise<BundleId> {
+  const bundleId = await BundleId.findAsync(context, { identifier: bundleIdentifier });
   if (!bundleId) {
     throw new Error(`Failed to find Bundle ID item with identifier "${bundleIdentifier}"`);
   }

--- a/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
@@ -78,12 +78,12 @@ export function transformCertificate(cert: Certificate): DistributionCertificate
 }
 
 export async function listDistributionCertificatesAsync(
-  ctx: AuthCtx
+  authCtx: AuthCtx
 ): Promise<DistributionCertificateStoreInfo[]> {
   const spinner = ora(`Getting Distribution Certificates from Apple...`).start();
   try {
     if (USE_APPLE_UTILS) {
-      const context = getRequestContext(ctx);
+      const context = getRequestContext(authCtx);
       const certs = (
         await Certificate.getAsync(context, {
           query: {
@@ -101,7 +101,13 @@ export async function listDistributionCertificatesAsync(
       return certs;
     }
 
-    const args = ['list', ctx.appleId, ctx.appleIdPassword, ctx.team.id, String(ctx.team.inHouse)];
+    const args = [
+      'list',
+      authCtx.appleId,
+      authCtx.appleIdPassword,
+      authCtx.team.id,
+      String(authCtx.team.inHouse),
+    ];
     const { certs } = await runActionAsync(travelingFastlane.manageDistCerts, args);
     spinner.succeed();
     return certs;
@@ -115,12 +121,12 @@ export async function listDistributionCertificatesAsync(
  * Run from `eas credentials` -> iOS -> Add new Distribution Certificate
  */
 export async function createDistributionCertificateAsync(
-  ctx: AuthCtx
+  authCtx: AuthCtx
 ): Promise<DistributionCertificate> {
   const spinner = ora(`Creating Distribution Certificate on Apple Servers...`).start();
   if (USE_APPLE_UTILS) {
     try {
-      const context = getRequestContext(ctx);
+      const context = getRequestContext(authCtx);
       const results = await createCertificateAndP12Async(context, {
         certificateType: CertificateType.IOS_DISTRIBUTION,
       });
@@ -131,8 +137,8 @@ export async function createDistributionCertificateAsync(
         certPassword: results.password,
         certPrivateSigningKey: results.privateSigningKey,
         distCertSerialNumber: results.certificate.attributes.serialNumber,
-        teamId: ctx.team.id,
-        teamName: ctx.team.name,
+        teamId: authCtx.team.id,
+        teamName: authCtx.team.name,
       };
     } catch (error) {
       spinner.fail('Failed to create Distribution Certificate on Apple Servers');
@@ -152,15 +158,15 @@ export async function createDistributionCertificateAsync(
   try {
     const args = [
       'create',
-      ctx.appleId,
-      ctx.appleIdPassword,
-      ctx.team.id,
-      String(ctx.team.inHouse),
+      authCtx.appleId,
+      authCtx.appleIdPassword,
+      authCtx.team.id,
+      String(authCtx.team.inHouse),
     ];
     const result = {
       ...(await runActionAsync(travelingFastlane.manageDistCerts, args)),
-      teamId: ctx.team.id,
-      teamName: ctx.team.name,
+      teamId: authCtx.team.id,
+      teamName: authCtx.team.name,
     };
     spinner.succeed();
     return result;
@@ -175,21 +181,21 @@ export async function createDistributionCertificateAsync(
 }
 
 export async function revokeDistributionCertificateAsync(
-  ctx: AuthCtx,
+  authCtx: AuthCtx,
   ids: string[]
 ): Promise<void> {
   const spinner = ora(`Revoking Distribution Certificate on Apple Servers...`).start();
   try {
     if (USE_APPLE_UTILS) {
-      const context = getRequestContext(ctx);
+      const context = getRequestContext(authCtx);
       await Promise.all(ids.map(id => Certificate.deleteAsync(context, { id })));
     } else {
       const args = [
         'revoke',
-        ctx.appleId,
-        ctx.appleIdPassword,
-        ctx.team.id,
-        String(ctx.team.inHouse),
+        authCtx.appleId,
+        authCtx.appleIdPassword,
+        authCtx.team.id,
+        String(authCtx.team.inHouse),
         ids.join(','),
       ];
       await runActionAsync(travelingFastlane.manageDistCerts, args);

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -16,11 +16,11 @@ export interface AppLookupParams {
 }
 
 async function ensureBundleIdExistsAsync(
-  ctx: AuthCtx,
+  authCtx: AuthCtx,
   { accountName, projectName, bundleIdentifier }: AppLookupParams,
   options: EnsureAppExistsOptions = {}
 ) {
-  const context = getRequestContext(ctx);
+  const context = getRequestContext(authCtx);
   let spinner = ora(`Registering Bundle ID "${bundleIdentifier}"`).start();
 
   try {
@@ -62,21 +62,21 @@ async function ensureBundleIdExistsAsync(
 }
 
 export async function ensureAppExistsAsync(
-  ctx: AuthCtx,
+  authCtx: AuthCtx,
   app: AppLookupParams,
   options: EnsureAppExistsOptions = {}
 ) {
   if (USE_APPLE_UTILS) {
-    return await ensureBundleIdExistsAsync(ctx, app, options);
+    return await ensureBundleIdExistsAsync(authCtx, app, options);
   }
 
   const spinner = ora(`Ensuring App ID exists on Apple Developer Portal...`).start();
   try {
     const { created } = await runActionAsync(travelingFastlane.ensureAppExists, [
       ...(options.enablePushNotifications ? ['--push-notifications'] : []),
-      ctx.appleId,
-      ctx.appleIdPassword,
-      ctx.team.id,
+      authCtx.appleId,
+      authCtx.appleIdPassword,
+      authCtx.team.id,
       app.bundleIdentifier,
       `@${app.accountName}/${app.projectName}`,
     ]);

--- a/packages/eas-cli/src/credentials/ios/appstore/experimental.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/experimental.ts
@@ -1,10 +1,13 @@
-import { BundleId, Profile } from '@expo/apple-utils';
+import { BundleId, Profile, RequestContext } from '@expo/apple-utils';
 import { boolish } from 'getenv';
 
 export const USE_APPLE_UTILS = boolish('USE_APPLE_UTILS', false);
 
-export async function getProfilesForBundleIdAsync(bundleIdentifier: string): Promise<Profile[]> {
-  const [bundleId] = await BundleId.getAsync({
+export async function getProfilesForBundleIdAsync(
+  context: RequestContext,
+  bundleIdentifier: string
+): Promise<Profile[]> {
+  const [bundleId] = await BundleId.getAsync(context, {
     query: {
       filter: {
         identifier: bundleIdentifier,
@@ -17,8 +20,11 @@ export async function getProfilesForBundleIdAsync(bundleIdentifier: string): Pro
   return [];
 }
 
-export async function getBundleIdForIdentifierAsync(bundleIdentifier: string): Promise<BundleId> {
-  const bundleId = await BundleId.findAsync({ identifier: bundleIdentifier });
+export async function getBundleIdForIdentifierAsync(
+  context: RequestContext,
+  bundleIdentifier: string
+): Promise<BundleId> {
+  const bundleId = await BundleId.findAsync(context, { identifier: bundleIdentifier });
   if (!bundleId) {
     throw new Error(`Failed to find Bundle ID item with identifier "${bundleIdentifier}"`);
   }

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -1,8 +1,8 @@
-import { Device, Profile, ProfileState, ProfileType } from '@expo/apple-utils';
+import { Device, Profile, ProfileState, ProfileType, RequestContext } from '@expo/apple-utils';
 import ora from 'ora';
 
 import { ProvisioningProfile } from './Credentials.types';
-import { AuthCtx } from './authenticate';
+import { AuthCtx, getRequestContext } from './authenticate';
 import { getBundleIdForIdentifierAsync, getProfilesForBundleIdAsync } from './bundleId';
 import { getDistributionCertificateAync } from './distributionCertificate';
 import { USE_APPLE_UTILS } from './experimental';
@@ -21,8 +21,11 @@ function uniqueItems<T = any>(items: T[]): T[] {
   return [...set];
 }
 
-async function registerMissingDevicesAsync(udids: string[]): Promise<Device[]> {
-  const allIosProfileDevices = await Device.getAllIOSProfileDevicesAsync();
+async function registerMissingDevicesAsync(
+  context: RequestContext,
+  udids: string[]
+): Promise<Device[]> {
+  const allIosProfileDevices = await Device.getAllIOSProfileDevicesAsync(context);
   const alreadyAdded = allIosProfileDevices.filter(device =>
     udids.includes(device.attributes.udid)
   );
@@ -31,7 +34,10 @@ async function registerMissingDevicesAsync(udids: string[]): Promise<Device[]> {
   await Promise.all(
     udids.map(async udid => {
       if (!alreadyAddedUdids.includes(udid)) {
-        const device = await Device.createAsync({ name: 'iOS Device (added by Expo)', udid });
+        const device = await Device.createAsync(context, {
+          name: 'iOS Device (added by Expo)',
+          udid,
+        });
         alreadyAdded.push(device);
       }
     })
@@ -41,13 +47,14 @@ async function registerMissingDevicesAsync(udids: string[]): Promise<Device[]> {
 }
 
 async function findProfileByBundleIdAsync(
+  context: RequestContext,
   bundleId: string,
   certSerialNumber: string
 ): Promise<{
   profile: Profile | null;
   didUpdate: boolean;
 }> {
-  const expoProfiles = (await getProfilesForBundleIdAsync(bundleId)).filter(profile => {
+  const expoProfiles = (await getProfilesForBundleIdAsync(context, bundleId)).filter(profile => {
     return (
       profile.attributes.profileType === ProfileType.IOS_APP_ADHOC &&
       profile.attributes.name.startsWith('*[expo]') &&
@@ -76,7 +83,7 @@ async function findProfileByBundleIdAsync(
   } else if (expoProfiles) {
     // there is an expo managed profile, but it doesn't have our desired certificate
     // append the certificate and update the profile
-    const distributionCertificate = await getDistributionCertificateAync(certSerialNumber);
+    const distributionCertificate = await getDistributionCertificateAync(context, certSerialNumber);
     if (!distributionCertificate) {
       throw new Error(`Certificate for serial number "${certSerialNumber}" does not exist`);
     }
@@ -96,33 +103,40 @@ function sortByExpiration(a: Profile, b: Profile): number {
   );
 }
 
-async function findProfileByIdAsync(profileId: string, bundleId: string): Promise<Profile | null> {
-  let profiles = await getProfilesForBundleIdAsync(bundleId);
+async function findProfileByIdAsync(
+  context: RequestContext,
+  profileId: string,
+  bundleId: string
+): Promise<Profile | null> {
+  let profiles = await getProfilesForBundleIdAsync(context, bundleId);
   profiles = profiles.filter(
     profile => profile.attributes.profileType === ProfileType.IOS_APP_ADHOC
   );
   return profiles.find(profile => profile.id === profileId) ?? null;
 }
 
-async function manageAdHocProfilesAsync({
-  udids,
-  bundleId,
-  certSerialNumber,
-  profileId,
-}: {
-  udids: string[];
-  bundleId: string;
-  certSerialNumber: string;
-  profileId?: string;
-}): Promise<ProfileResults> {
+async function manageAdHocProfilesAsync(
+  context: RequestContext,
+  {
+    udids,
+    bundleId,
+    certSerialNumber,
+    profileId,
+  }: {
+    udids: string[];
+    bundleId: string;
+    certSerialNumber: string;
+    profileId?: string;
+  }
+): Promise<ProfileResults> {
   // We register all missing devices on the Apple Developer Portal. They are identified by UDIDs.
-  const devices = await registerMissingDevicesAsync(udids);
+  const devices = await registerMissingDevicesAsync(context, udids);
 
   let existingProfile: Profile | null;
   let didUpdate = false;
 
   if (profileId) {
-    existingProfile = await findProfileByIdAsync(profileId, bundleId);
+    existingProfile = await findProfileByIdAsync(context, profileId, bundleId);
     // Fail if we cannot find the profile that was specifically requested
     if (!existingProfile)
       throw new Error(
@@ -130,7 +144,7 @@ async function manageAdHocProfilesAsync({
       );
   } else {
     // If no profile id is passed, try to find a suitable provisioning profile for the App ID.
-    const results = await findProfileByBundleIdAsync(bundleId, certSerialNumber);
+    const results = await findProfileByBundleIdAsync(context, bundleId, certSerialNumber);
     existingProfile = results.profile;
     didUpdate = results.didUpdate;
   }
@@ -160,7 +174,8 @@ async function manageAdHocProfilesAsync({
     existingProfile.attributes.devices = devices;
     await existingProfile.regenerateAsync();
 
-    const updatedProfile = (await findProfileByBundleIdAsync(bundleId, certSerialNumber)).profile;
+    const updatedProfile = (await findProfileByBundleIdAsync(context, bundleId, certSerialNumber))
+      .profile;
     if (!updatedProfile) {
       throw new Error(
         `Failed to locate updated profile for bundle identifier "${bundleId}" and serial number "${certSerialNumber}"`
@@ -177,7 +192,7 @@ async function manageAdHocProfilesAsync({
   // No existing profile...
 
   // We need to find user's distribution certificate to make a provisioning profile for it.
-  const distributionCertificate = await getDistributionCertificateAync(certSerialNumber);
+  const distributionCertificate = await getDistributionCertificateAync(context, certSerialNumber);
 
   if (!distributionCertificate) {
     // If the distribution certificate doesn't exist, the user must have deleted it, we can't do anything here :(
@@ -185,9 +200,9 @@ async function manageAdHocProfilesAsync({
       `No distribution certificate for serial number "${certSerialNumber}" is available to make a provisioning profile against`
     );
   }
-  const bundleIdItem = await getBundleIdForIdentifierAsync(bundleId);
+  const bundleIdItem = await getBundleIdForIdentifierAsync(context, bundleId);
   // If the provisioning profile for the App ID doesn't exist, we just need to create a new one!
-  const newProfile = await Profile.createAsync({
+  const newProfile = await Profile.createAsync(context, {
     bundleId: bundleIdItem.id,
     // apple drops [ if its the first char (!!),
     name: `*[expo] ${bundleId} AdHoc ${Date.now()}`,
@@ -216,7 +231,8 @@ export async function createOrReuseAdhocProvisioningProfileAsync(
     let adhocProvisioningProfile: ProfileResults;
 
     if (USE_APPLE_UTILS) {
-      adhocProvisioningProfile = await manageAdHocProfilesAsync({
+      const context = getRequestContext(ctx);
+      adhocProvisioningProfile = await manageAdHocProfilesAsync(context, {
         udids,
         bundleId: bundleIdentifier,
         certSerialNumber: distCertSerialNumber,

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -221,7 +221,7 @@ async function manageAdHocProfilesAsync(
 }
 
 export async function createOrReuseAdhocProvisioningProfileAsync(
-  ctx: AuthCtx,
+  authCtx: AuthCtx,
   udids: string[],
   bundleIdentifier: string,
   distCertSerialNumber: string
@@ -231,7 +231,7 @@ export async function createOrReuseAdhocProvisioningProfileAsync(
     let adhocProvisioningProfile: ProfileResults;
 
     if (USE_APPLE_UTILS) {
-      const context = getRequestContext(ctx);
+      const context = getRequestContext(authCtx);
       adhocProvisioningProfile = await manageAdHocProfilesAsync(context, {
         udids,
         bundleId: bundleIdentifier,
@@ -240,10 +240,10 @@ export async function createOrReuseAdhocProvisioningProfileAsync(
     } else {
       const args = [
         '--apple-id',
-        ctx.appleId,
+        authCtx.appleId,
         '--apple-password',
-        ctx.appleIdPassword,
-        ctx.team.id,
+        authCtx.appleIdPassword,
+        authCtx.team.id,
         udids.join(','),
         bundleIdentifier,
         distCertSerialNumber,
@@ -276,8 +276,8 @@ export async function createOrReuseAdhocProvisioningProfileAsync(
 
     return {
       ...adhocProvisioningProfile,
-      teamId: ctx.team.id,
-      teamName: ctx.team.name,
+      teamId: authCtx.team.id,
+      teamName: authCtx.team.name,
     };
   } catch (error) {
     spinner.fail();

--- a/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
@@ -17,16 +17,16 @@ Please revoke the old ones or reuse existing from your other apps.
 Please remember that Apple Keys are not application specific!
 `;
 
-export async function listPushKeysAsync(ctx: AuthCtx): Promise<PushKeyStoreInfo[]> {
+export async function listPushKeysAsync(authCtx: AuthCtx): Promise<PushKeyStoreInfo[]> {
   const spinner = ora(`Getting Push Keys from Apple...`).start();
   try {
     if (USE_APPLE_UTILS) {
-      const context = getRequestContext(ctx);
+      const context = getRequestContext(authCtx);
       const keys = await Keys.getKeysAsync(context);
       spinner.succeed();
       return keys;
     } else {
-      const args = ['list', ctx.appleId, ctx.appleIdPassword, ctx.team.id];
+      const args = ['list', authCtx.appleId, authCtx.appleIdPassword, authCtx.team.id];
       const { keys } = await runActionAsync(travelingFastlane.managePushKeys, args);
       spinner.succeed();
       return keys;
@@ -38,31 +38,31 @@ export async function listPushKeysAsync(ctx: AuthCtx): Promise<PushKeyStoreInfo[
 }
 
 export async function createPushKeyAsync(
-  ctx: AuthCtx,
+  authCtx: AuthCtx,
   name: string = `Expo Push Notifications Key ${dateformat('yyyymmddHHMMss')}`
 ): Promise<PushKey> {
   const spinner = ora(`Creating Push Key on Apple Servers...`).start();
   try {
     if (USE_APPLE_UTILS) {
-      const context = getRequestContext(ctx);
+      const context = getRequestContext(authCtx);
       const key = await Keys.createKeyAsync(context, { name, isApns: true });
       const apnsKeyP8 = await Keys.downloadKeyAsync(context, { id: key.id });
       spinner.succeed();
       return {
         apnsKeyId: key.id,
         apnsKeyP8,
-        teamId: ctx.team.id,
-        teamName: ctx.team.name,
+        teamId: authCtx.team.id,
+        teamName: authCtx.team.name,
       };
     } else {
-      const args = ['create', ctx.appleId, ctx.appleIdPassword, ctx.team.id, name];
+      const args = ['create', authCtx.appleId, authCtx.appleIdPassword, authCtx.team.id, name];
       const { apnsKeyId, apnsKeyP8 } = await runActionAsync(travelingFastlane.managePushKeys, args);
       spinner.succeed();
       return {
         apnsKeyId,
         apnsKeyP8,
-        teamId: ctx.team.id,
-        teamName: ctx.team.name,
+        teamId: authCtx.team.id,
+        teamName: authCtx.team.name,
       };
     }
   } catch (err) {
@@ -78,14 +78,20 @@ export async function createPushKeyAsync(
   }
 }
 
-export async function revokePushKeyAsync(ctx: AuthCtx, ids: string[]): Promise<void> {
+export async function revokePushKeyAsync(authCtx: AuthCtx, ids: string[]): Promise<void> {
   const spinner = ora(`Revoking Push Key on Apple Servers...`).start();
   try {
     if (USE_APPLE_UTILS) {
-      const context = getRequestContext(ctx);
+      const context = getRequestContext(authCtx);
       await Promise.all(ids.map(id => Keys.revokeKeyAsync(context, { id })));
     } else {
-      const args = ['revoke', ctx.appleId, ctx.appleIdPassword, ctx.team.id, ids.join(',')];
+      const args = [
+        'revoke',
+        authCtx.appleId,
+        authCtx.appleIdPassword,
+        authCtx.team.id,
+        ids.join(','),
+      ];
       await runActionAsync(travelingFastlane.managePushKeys, args);
     }
     spinner.succeed();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,10 +1413,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/apple-utils@0.0.0-alpha.8":
-  version "0.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.8.tgz#1397c5f1dc7b6dd6f7813cca4ce82b49b1c91645"
-  integrity sha512-GmgAjnAw+EWR6vflxHhbnzD0ABvY8+gO0K+Q477Dc9hex+PaJf7pvxkuy2ORoEH0DLYdSTztc0u6ah3eM5P7tA==
+"@expo/apple-utils@0.0.0-alpha.9":
+  version "0.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.9.tgz#ebc8be95eeccb4c6fe96b636a60cdfc771ec8a23"
+  integrity sha512-f5t7wFajXyazGiqtMAmrwUEgIhr/TNtil7F+NUIcNuW4V0qq4i8BKHsPk2ebYiy/rJ7bBaJJwAcBO/D2FpC4/w==
 
 "@expo/babel-preset-cli@0.2.18":
   version "0.2.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,10 +1413,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/apple-utils@0.0.0-alpha.5":
-  version "0.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.5.tgz#993fa73c9ef9e9a7ab7efd1ba7c5071794adf2d7"
-  integrity sha512-GzMK1qUr5oIust57PXBwijEdXvCjqguBFsL4tCTkob90JEmewYmtH5tqBM6zaKXRE4TEGZghDlBiFrm4PTmj8Q==
+"@expo/apple-utils@0.0.0-alpha.8":
+  version "0.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.8.tgz#1397c5f1dc7b6dd6f7813cca4ce82b49b1c91645"
+  integrity sha512-GmgAjnAw+EWR6vflxHhbnzD0ABvY8+gO0K+Q477Dc9hex+PaJf7pvxkuy2ORoEH0DLYdSTztc0u6ah3eM5P7tA==
 
 "@expo/babel-preset-cli@0.2.18":
   version "0.2.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,10 +1413,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/apple-utils@0.0.0-alpha.9":
-  version "0.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.9.tgz#ebc8be95eeccb4c6fe96b636a60cdfc771ec8a23"
-  integrity sha512-f5t7wFajXyazGiqtMAmrwUEgIhr/TNtil7F+NUIcNuW4V0qq4i8BKHsPk2ebYiy/rJ7bBaJJwAcBO/D2FpC4/w==
+"@expo/apple-utils@0.0.0-alpha.10":
+  version "0.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.10.tgz#084cb6acdd6a41342589fd3ab03018a590c4ca2d"
+  integrity sha512-BVLDXfwhpxtpiWRsOITW5TiEbkiHKeXOkL5Ub8Fehd0RQNjmZflUzOI3O0V5+00WxgBZFg2MxXCnQSPKX9n1ag==
 
 "@expo/babel-preset-cli@0.2.18":
   version "0.2.18"


### PR DESCRIPTION
- upgraded apple-utils which now requires request context (`{ teamId, providerId }`) be passed to every request.

# Test Plan

- In an Expo project -> `eas credentials` -> iOS -> sign in -> Ensure all credentials are valid