### PR TITLE
Fix a typo in provisioningProfileAdhoc.ts

### DIFF
--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -237,8 +237,8 @@ export async function createOrReuseAdhocProvisioningProfileAsync(
         args
       );
       adhocProvisioningProfile = {
-        provisioningProfile: travelingFastlane.provisioningProfile,
-        provisioningProfileId: travelingFastlane.provisioningProfileId,
+        provisioningProfile: travelingFastlaneProfile.provisioningProfile,
+        provisioningProfileId: travelingFastlaneProfile.provisioningProfileId,
         profileName: travelingFastlaneProfile.provisioningProfileName,
         didUpdate: !!travelingFastlaneProfile.provisioningProfileUpdateTimestamp,
         didCreate: !!travelingFastlaneProfile.provisioningProfileCreateTimestamp,


### PR DESCRIPTION
`travelingFastlane` doesn't have the properties `provisioningProfile` and `provisioningProfileId`.

Looks like this code was added in #59.