### PR TITLE
[eas-cli] Support for App Store API in iOS submissions

### DIFF
--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -128,7 +128,7 @@ export default class BuildSubmit extends Command {
     }),
     language: flags.string({
       description: 'Primary language (e.g. English, German, ...)',
-      default: 'English',
+      default: 'en-US',
       helpLabel: IOS_FLAGS,
     }),
     'company-name': flags.string({

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -73,6 +73,7 @@ Learn more here: https://expo.fyi/bundle-identifier`
 
 async function isProvisioningAvailableAsync(requestCtx: RequestContext): Promise<boolean> {
   const session = await Session.getAnySessionInfo();
+  // TODO: Investigate if username and email can be different
   const username = session?.user.emailAddress;
   const [user] = await User.getAsync(requestCtx, { query: { filter: { username } } });
   return user.attributes.provisioningAllowed;
@@ -122,15 +123,16 @@ async function runProduceExperimentalAsync(options: ProduceOptions): Promise<App
       });
     } catch (error) {
       if (error.message.match(/An App ID with Identifier '(.*)' is not available/)) {
+        const providerName = authCtx.authState?.session.provider.name;
         throw new Error(
-          `\nThe bundle identifier "${bundleId}" is not available, please change it in your app config and try again.\n`
+          `\nThe bundle identifier "${bundleId}" is not available to provider "${providerName}". Please change it in your app config and try again.\n`
         );
       }
       log.error('Failed to create the app in App Store Connect:');
       throw error;
     }
   } else {
-    // TODO: Maybe update app name
+    // TODO: Update app name when API gives us that possibility
   }
 
   // TODO: Maybe sync capabilities now as well

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -90,8 +90,8 @@ async function runProduceExperimentalAsync(options: ProduceOptions): Promise<App
 
   const authCtx = await authenticateAsync({
     appleId,
-    team: { id: appleTeamId },
-  } as any);
+    teamId: appleTeamId,
+  });
   const requestCtx = getRequestContext(authCtx);
 
   log.addNewLineIfNone();
@@ -123,10 +123,9 @@ async function runProduceExperimentalAsync(options: ProduceOptions): Promise<App
       });
     } catch (error) {
       if (error.message.match(/An App ID with Identifier '(.*)' is not available/)) {
-        log.warn(
+        throw new Error(
           `\nThe bundle identifier "${bundleId}" is not available, please change it in your app config and try again.\n`
         );
-        process.exit(0);
       }
       log.error('Failed to create the app in App Store Connect:');
       throw error;

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -61,7 +61,7 @@ Learn more here: https://expo.fyi/bundle-identifier`
     ...ctx.commandFlags,
     bundleIdentifier: resolvedBundleId,
     appName: appName ?? exp.name ?? (await promptForAppNameAsync()),
-    language: sanitizeLanguage(language) ?? 'English',
+    language: sanitizeLanguage(language),
   };
 
   if (USE_APPLE_UTILS) {
@@ -117,7 +117,6 @@ async function runProduceExperimentalAsync(options: ProduceOptions): Promise<App
       app = await App.createAsync(requestCtx, {
         bundleId,
         name: appName,
-        // TODO: Convert values like "English" to "en-US"
         primaryLocale: language,
         companyName,
       });

--- a/packages/eas-cli/src/submissions/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitCommand.ts
@@ -111,6 +111,7 @@ class IosSubmitCommand {
         )
       )
     );
+    log.addNewLineIfNone();
     return await ensureAppStoreConnectAppExistsAsync(this.ctx);
   }
 

--- a/packages/eas-cli/src/submissions/ios/utils/__tests__/language-test.ts
+++ b/packages/eas-cli/src/submissions/ios/utils/__tests__/language-test.ts
@@ -1,0 +1,26 @@
+import { sanitizeLanguage } from '../language';
+
+jest.mock('../../../../credentials/ios/appstore/experimental', () => ({
+  get USE_APPLE_UTILS() {
+    return true;
+  },
+}));
+
+describe(sanitizeLanguage, () => {
+  it('throws when language not found', () => {
+    expect(() => sanitizeLanguage('Ponglish')).toThrowError();
+  });
+
+  it('throws when default language is invalid', () => {
+    expect(() => sanitizeLanguage(undefined, { defaultLang: 'Ponglish' })).toThrowError();
+  });
+
+  it('returns default if no lang is provided', () => {
+    expect(sanitizeLanguage(undefined, { defaultLang: 'en-US' })).toBe('en-US');
+  });
+
+  it('returns language iTunes code when USE_APPLE_UTILS is true', () => {
+    expect(sanitizeLanguage('English')).toBe('en-US');
+    expect(sanitizeLanguage('pl-PL')).toBe('pl');
+  });
+});

--- a/packages/eas-cli/src/submissions/ios/utils/language.ts
+++ b/packages/eas-cli/src/submissions/ios/utils/language.ts
@@ -18,7 +18,6 @@ export function sanitizeLanguage(
   lang?: string,
   { defaultLang = 'en-US' }: { defaultLang?: string } = {}
 ): string {
-  console.log(USE_APPLE_UTILS);
   if (!lang) {
     const found = findLanguage(defaultLang);
     if (!found) {

--- a/packages/eas-cli/src/submissions/ios/utils/language.ts
+++ b/packages/eas-cli/src/submissions/ios/utils/language.ts
@@ -19,7 +19,11 @@ export function sanitizeLanguage(
   { defaultLang = 'en-US' }: { defaultLang?: string } = {}
 ): string {
   if (!lang) {
-    return defaultLang;
+    const found = findLanguage(defaultLang);
+    if (!found) {
+      throw new Error('Invalid default language provided: ' + found);
+    }
+    return USE_APPLE_UTILS ? found.itcLocale ?? found.locale : found.name;
   }
 
   const foundLang = findLanguage(lang);

--- a/packages/eas-cli/src/submissions/ios/utils/language.ts
+++ b/packages/eas-cli/src/submissions/ios/utils/language.ts
@@ -18,10 +18,11 @@ export function sanitizeLanguage(
   lang?: string,
   { defaultLang = 'en-US' }: { defaultLang?: string } = {}
 ): string {
+  console.log(USE_APPLE_UTILS);
   if (!lang) {
     const found = findLanguage(defaultLang);
     if (!found) {
-      throw new Error('Invalid default language provided: ' + found);
+      throw new Error('Invalid default language provided: ' + defaultLang);
     }
     return USE_APPLE_UTILS ? found.itcLocale ?? found.locale : found.name;
   }
@@ -75,6 +76,10 @@ function findLanguage(query: string): Language | null {
   return foundLang ?? null;
 }
 
+/**
+ * This is slightly modified list taken from fastlane: https://github.com/fastlane/fastlane/blob/master/spaceship/lib/assets/languageMapping.json
+ * Currently supported languages can be found here: https://www.ibabbleon.com/iOS-Language-Codes-ISO-639.html
+ */
 const LANGUAGES: Language[] = [
   {
     locale: 'ar-SA',

--- a/packages/eas-cli/src/submissions/ios/utils/language.ts
+++ b/packages/eas-cli/src/submissions/ios/utils/language.ts
@@ -1,49 +1,263 @@
+import { USE_APPLE_UTILS } from '../../../credentials/ios/appstore/experimental';
 import log from '../../../log';
 
-export const LANGUAGES = [
-  'Brazilian Portuguese',
-  'Danish',
-  'Dutch',
-  'English',
-  'English_Australian',
-  'English_CA',
-  'English_UK',
-  'Finnish',
-  'French',
-  'French_CA',
-  'German',
-  'Greek',
-  'Indonesian',
-  'Italian',
-  'Japanese',
-  'Korean',
-  'Malay',
-  'Norwegian',
-  'Portuguese',
-  'Russian',
-  'Simplified Chinese',
-  'Spanish',
-  'Spanish_MX',
-  'Swedish',
-  'Thai',
-  'Traditional Chinese',
-  'Turkish',
-  'Vietnamese',
-];
+type Language = {
+  locale: string;
+  name: string;
+  itcLocale?: string;
+  displayName?: string;
+};
 
 /**
- * Sanitizes language for `travelingFastlane app_produce` command.
+ * Sanitizes language for App Store Connect.
  * @param lang Language to sanitize
  * @returns Provided language if valid
  * @throws Error if language is invalid.s
  */
-export function sanitizeLanguage(lang?: string): string | undefined {
-  if (lang && !LANGUAGES.includes(lang)) {
-    const langList = LANGUAGES.map(lang => `- ${lang}`).join('\n');
-
-    log.addNewLineIfNone();
-    throw new Error(`You must specify a supported language. Supported languages are:\n${langList}`);
+export function sanitizeLanguage(
+  lang?: string,
+  { defaultLang = 'en-US' }: { defaultLang?: string } = {}
+): string {
+  if (!lang) {
+    return defaultLang;
   }
 
-  return lang;
+  const foundLang = findLanguage(lang);
+  if (!foundLang) {
+    log.addNewLineIfNone();
+    throw new Error(
+      `You must specify a supported language. Supported language codes are:\n${languageListToString()}`
+    );
+  }
+
+  if (!USE_APPLE_UTILS) {
+    return foundLang.name;
+  }
+
+  return foundLang.itcLocale ?? foundLang.locale;
 }
+
+/**
+ * Displays language list. When using apple utils, the format is:
+ * - en-US  (English)
+ *
+ * otherwise it's just:
+ * - English
+ */
+function languageListToString(): string {
+  if (!USE_APPLE_UTILS) {
+    return LANGUAGES.map(lang => `- ${lang.name}`).join('\n');
+  }
+
+  return LANGUAGES.map(lang => {
+    const code = lang.itcLocale || lang.locale;
+    const name = lang.displayName || lang.name;
+    return `- ${code}\t(${name})`;
+  }).join('\n');
+}
+
+/**
+ * Finds language by any param.
+ */
+function findLanguage(query: string): Language | null {
+  const foundLang = LANGUAGES.find(
+    lang =>
+      lang.displayName === query ||
+      lang.name === query ||
+      lang.locale === query ||
+      lang.itcLocale === query
+  );
+
+  return foundLang ?? null;
+}
+
+const LANGUAGES: Language[] = [
+  {
+    locale: 'ar-SA',
+    name: 'Arabic',
+    itcLocale: 'ar-SA',
+  },
+  {
+    locale: 'ca-ES',
+    name: 'Catalan',
+    itcLocale: 'ca',
+  },
+  {
+    locale: 'cmn-Hans',
+    name: 'Simplified Chinese',
+    itcLocale: 'zh-Hans',
+  },
+  {
+    locale: 'cmn-Hant',
+    name: 'Traditional Chinese',
+    itcLocale: 'zh-Hant',
+  },
+  {
+    locale: 'cs-CZ',
+    name: 'Czech',
+    itcLocale: 'cs',
+  },
+  {
+    locale: 'da-DK',
+    name: 'Danish',
+    itcLocale: 'da',
+  },
+  {
+    locale: 'nl-NL',
+    name: 'Dutch',
+  },
+  {
+    locale: 'en-AU',
+    name: 'English_Australian',
+    displayName: 'Australian English',
+  },
+  {
+    locale: 'en-CA',
+    name: 'English_CA',
+    displayName: 'Canadian English',
+  },
+  {
+    locale: 'en-GB',
+    name: 'English_UK',
+    displayName: 'UK English',
+  },
+  {
+    locale: 'en-US',
+    name: 'English',
+  },
+  {
+    locale: 'fi-FI',
+    name: 'Finnish',
+    itcLocale: 'fin',
+  },
+  {
+    locale: 'fr-CA',
+    name: 'French_CA',
+    displayName: 'Canadian French',
+  },
+  {
+    locale: 'fr-FR',
+    name: 'French',
+  },
+  {
+    locale: 'de-DE',
+    name: 'German',
+  },
+  {
+    locale: 'el-GR',
+    name: 'Greek',
+    itcLocale: 'el',
+  },
+  {
+    locale: 'he',
+    name: 'Hebrew',
+    itcLocale: 'he',
+  },
+  {
+    locale: 'hi-IN',
+    name: 'Hindi',
+    itcLocale: 'hi',
+  },
+  {
+    locale: 'hr-HR',
+    name: 'Croatian',
+    itcLocale: 'hr',
+  },
+  {
+    locale: 'hu-HU',
+    name: 'Hungarian',
+    itcLocale: 'hu',
+  },
+  {
+    locale: 'id-ID',
+    name: 'Indonesian',
+    itcLocale: 'id',
+  },
+  {
+    locale: 'it-IT',
+    name: 'Italian',
+    itcLocale: 'it',
+  },
+  {
+    locale: 'ja-JP',
+    name: 'Japanese',
+    itcLocale: 'ja',
+  },
+  {
+    locale: 'ko-KR',
+    name: 'Korean',
+    itcLocale: 'ko',
+  },
+  {
+    locale: 'ms-MY',
+    name: 'Malay',
+    itcLocale: 'ms',
+  },
+  {
+    locale: 'no-NO',
+    name: 'Norwegian',
+    itcLocale: 'no',
+  },
+  {
+    locale: 'pl-PL',
+    name: 'Polish',
+    itcLocale: 'pl',
+  },
+  {
+    locale: 'pt-BR',
+    name: 'Brazilian Portuguese',
+  },
+  {
+    locale: 'pt-PT',
+    name: 'Portuguese',
+  },
+  {
+    locale: 'ro-RO',
+    name: 'Romanian',
+    itcLocale: 'ro',
+  },
+  {
+    locale: 'ru-RU',
+    name: 'Russian',
+    itcLocale: 'ru',
+  },
+  {
+    locale: 'es-MX',
+    name: 'Spanish_MX',
+    displayName: 'Mexican Spanish',
+  },
+  {
+    locale: 'es-ES',
+    name: 'Spanish',
+  },
+  {
+    locale: 'sk-SK',
+    name: 'Slovak',
+    itcLocale: 'sk',
+  },
+  {
+    locale: 'sv-SE',
+    name: 'Swedish',
+    itcLocale: 'sv',
+  },
+  {
+    locale: 'th-TH',
+    name: 'Thai',
+    itcLocale: 'th',
+  },
+  {
+    locale: 'tr-TR',
+    name: 'Turkish',
+    itcLocale: 'tr',
+  },
+  {
+    locale: 'uk-UA',
+    name: 'Ukrainian',
+    itcLocale: 'uk',
+  },
+  {
+    locale: 'vi-VI',
+    name: 'Vietnamese',
+    itcLocale: 'vi',
+  },
+];


### PR DESCRIPTION
A step towards removing `traveling-fastlane`

- The whole process now uses the new API when `USE_APPLE_UTILS=1` env var is set
- Updated `--language` parameter to support both fastlane and new API, it is now smarter and supports both `English` and `en-US` formats interchangeably. 
- ~~Fixed `authenticateAsync()` not to prompt for team again when it's already selected.~~ Fix moved to https://github.com/expo/eas-cli/pull/85

TODO in the future:
- Add possibility to update app name on ASC (currently API doesn't allow us to do it)
- [Optional] Update bundle ID capabilities (the same way as `ensureAppExists()` does it for push notifications) based on app config