### PR TITLE
improve user interaction for build and configure + cleanup types

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -12,6 +12,8 @@
     "@expo/config": "^3.3.12",
     "@expo/eas-build-job": "0.1.2",
     "@expo/eas-json": "^0.1.0-alpha.8",
+    "@expo/eas-build-job": "0.1.3",
+    "@expo/eas-json": "^0.1.0-alpha.4",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.10",
     "@expo/results": "^1.0.0",

--- a/packages/eas-cli/src/build/__tests__/credentials-test.ts
+++ b/packages/eas-cli/src/build/__tests__/credentials-test.ts
@@ -1,4 +1,5 @@
-import { CredentialsSource, Workflow } from '@expo/eas-json';
+import { Workflow } from '@expo/eas-build-job';
+import { CredentialsSource } from '@expo/eas-json';
 import prompts from 'prompts';
 
 import { asMock } from '../../__tests__/utils';

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -1,4 +1,5 @@
-import { EasConfig, Workflow } from '@expo/eas-json';
+import { Workflow } from '@expo/eas-build-job';
+import { EasConfig } from '@expo/eas-json';
 
 import AndroidCredentialsProvider, {
   AndroidCredentials,

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -12,7 +12,7 @@ import { configureIosAsync } from './ios/configure';
 import { BuildCommandPlatform } from './types';
 import {
   ensureGitRepoExistsAsync,
-  ensureGitStatusIsCleanAsync,
+  maybeBailOnGitStatusAsync,
   modifyAndCommitAsync,
 } from './utils/repository';
 
@@ -21,7 +21,7 @@ export async function configureAsync(options: {
   projectDir: string;
 }): Promise<void> {
   await ensureGitRepoExistsAsync();
-  await ensureGitStatusIsCleanAsync();
+  await maybeBailOnGitStatusAsync();
 
   const { exp } = getConfig(options.projectDir, { skipSDKVersionRequirement: true });
 
@@ -36,7 +36,6 @@ export async function configureAsync(options: {
     shouldConfigureIos: [BuildCommandPlatform.ALL, BuildCommandPlatform.IOS].includes(
       options.platform
     ),
-    // TODO: better detection of native projects
     hasAndroidNativeProject: await fs.pathExists(path.join(options.projectDir, 'android')),
     hasIosNativeProject: await fs.pathExists(path.join(options.projectDir, 'ios')),
   };

--- a/packages/eas-cli/src/build/credentials.ts
+++ b/packages/eas-cli/src/build/credentials.ts
@@ -1,4 +1,5 @@
-import { CredentialsSource, Workflow } from '@expo/eas-json';
+import { Workflow } from '@expo/eas-build-job';
+import { CredentialsSource } from '@expo/eas-json';
 import chalk from 'chalk';
 
 import { CredentialsProvider } from '../credentials/CredentialsProvider';

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -1,5 +1,6 @@
 import { IOSConfig } from '@expo/config';
-import { EasConfig, Workflow } from '@expo/eas-json';
+import { Workflow } from '@expo/eas-build-job';
+import { EasConfig } from '@expo/eas-json';
 import chalk from 'chalk';
 import sortBy from 'lodash/sortBy';
 

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -1,15 +1,10 @@
 import { ExpoConfig, IOSConfig } from '@expo/config';
-import { CredentialsSource, DistributionType, Workflow } from '@expo/eas-json';
 
-import * as ProvisioningProfileUtils from '../../credentials/ios/utils/provisioningProfile';
 import log from '../../log';
-import { getProjectAccountNameAsync } from '../../project/projectUtils';
-import { confirmAsync } from '../../prompts';
 import { ConfigureContext } from '../context';
 import { isExpoUpdatesInstalled } from '../utils/updates';
 import { configureUpdatesAsync, syncUpdatesConfigurationAsync } from './UpdatesModule';
 import { getBundleIdentifier } from './bundleIdentifer';
-import { resolveIosCredentialsAsync } from './credentials';
 
 export async function configureIosAsync(ctx: ConfigureContext): Promise<void> {
   if (!ctx.hasIosNativeProject) {
@@ -17,13 +12,6 @@ export async function configureIosAsync(ctx: ConfigureContext): Promise<void> {
   }
   const bundleIdentifier = await getBundleIdentifier(ctx.projectDir, ctx.exp);
   IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(ctx.projectDir, bundleIdentifier, false);
-
-  const confirm = await confirmAsync({
-    message: 'Do you want to configure credentials for the Xcode project?',
-  });
-  if (confirm) {
-    await resolveCredentialsAndConfigureXcodeProjectAsync(ctx, bundleIdentifier);
-  }
 
   if (isExpoUpdatesInstalled(ctx.projectDir)) {
     await configureUpdatesAsync(ctx.projectDir, ctx.exp);
@@ -39,29 +27,4 @@ export async function validateAndSyncProjectConfigurationAsync(
   if (isExpoUpdatesInstalled(projectDir)) {
     await syncUpdatesConfigurationAsync(projectDir, exp);
   }
-}
-
-async function resolveCredentialsAndConfigureXcodeProjectAsync(
-  ctx: ConfigureContext,
-  bundleIdentifier: string
-): Promise<void> {
-  const { credentials } = await resolveIosCredentialsAsync(ctx.projectDir, {
-    app: {
-      accountName: await getProjectAccountNameAsync(ctx.projectDir),
-      projectName: ctx.exp.slug,
-      bundleIdentifier,
-    },
-    workflow: Workflow.Generic,
-    credentialsSource: CredentialsSource.AUTO,
-    distribution: DistributionType.STORE,
-    nonInteractive: false,
-  });
-
-  const profileName = ProvisioningProfileUtils.readProfileName(credentials.provisioningProfile);
-  const appleTeam = ProvisioningProfileUtils.readAppleTeam(credentials.provisioningProfile);
-  IOSConfig.ProvisioningProfile.setProvisioningProfileForPbxproj(ctx.projectDir, {
-    profileName,
-    appleTeamId: appleTeam.teamId,
-  });
-  // TODO: copy profile and add dist cert to keychain
 }

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -1,4 +1,5 @@
-import { CredentialsSource, DistributionType, Workflow } from '@expo/eas-json';
+import { Workflow } from '@expo/eas-build-job';
+import { CredentialsSource, DistributionType } from '@expo/eas-json';
 import assert from 'assert';
 
 import { createCredentialsContextAsync } from '../../credentials/context';
@@ -61,9 +62,5 @@ export async function resolveIosCredentialsAsync(
 }
 
 function shouldProvideCredentials(ctx: BuildContext<Platform.iOS>): boolean {
-  return (
-    (ctx.buildProfile.workflow === Workflow.Managed &&
-      ctx.buildProfile.buildType !== 'simulator') ||
-    ctx.buildProfile.workflow === Workflow.Generic
-  );
+  return true;
 }

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,4 +1,5 @@
-import { CredentialsSource, DistributionType, Workflow } from '@expo/eas-json';
+import { Workflow } from '@expo/eas-build-job';
+import { CredentialsSource, DistributionType } from '@expo/eas-json';
 
 import { BuildContext } from './context';
 import { Platform, TrackingContext } from './types';

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -44,7 +44,7 @@ export class ManageIos implements Action {
             // This command will be triggered durring build to ensure all credentials are ready
             // I'm leaving it here for now to simplify testing
             value: ActionType.SetupBuildCredentials,
-            title: 'Ensure all credentials are valid',
+            title: 'Ensure all credentials for project are valid',
           },
           {
             value: ActionType.UpdateCredentialsJson,

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.1.1",
+    "@expo/eas-build-job": "0.1.3",
     "@hapi/joi": "^17.1.1",
     "fs-extra": "^9.0.1",
     "tslib": "^1"

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -1,11 +1,4 @@
-// Workflow is representing different value than BuildType from @expo/eas-build-job
-// Each workflow has a set of BuildTypes available
-// - Generic workflow allows to build 'generic' and 'generic-client'
-// - Managed workflow allows to build 'managed' and 'managed-client'
-export enum Workflow {
-  Generic = 'generic',
-  Managed = 'managed',
-}
+import { Android, Workflow } from '@expo/eas-build-job';
 
 export enum CredentialsSource {
   LOCAL = 'local',
@@ -21,8 +14,8 @@ export enum DistributionType {
 export interface AndroidManagedBuildProfile {
   workflow: Workflow.Managed;
   credentialsSource: CredentialsSource;
-  buildType?: 'apk' | 'app-bundle';
-  releaseChannel?: undefined;
+  buildType?: Android.ManagedBuildType;
+  releaseChannel?: string;
   distribution?: DistributionType;
 }
 
@@ -39,8 +32,7 @@ export interface AndroidGenericBuildProfile {
 export interface iOSManagedBuildProfile {
   workflow: Workflow.Managed;
   credentialsSource: CredentialsSource;
-  buildType?: 'archive' | 'simulator';
-  releaseChannel?: undefined;
+  releaseChannel?: string;
   distribution?: DistributionType;
 }
 

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -1,14 +1,8 @@
-import { Platform } from '@expo/eas-build-job';
+import { Platform, Workflow } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 import path from 'path';
 
-import {
-  AndroidBuildProfile,
-  BuildProfile,
-  EasConfig,
-  Workflow,
-  iOSBuildProfile,
-} from './Config.types';
+import { AndroidBuildProfile, BuildProfile, EasConfig, iOSBuildProfile } from './Config.types';
 import { EasJsonSchema, schemaBuildProfileMap } from './EasJsonSchema';
 
 interface EasJson {

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -13,7 +13,8 @@ const AndroidGenericSchema = Joi.object({
 const AndroidManagedSchema = Joi.object({
   workflow: Joi.string().valid('managed').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
-  buildType: Joi.string().valid('apk', 'app-bundle').default('app-bundle'),
+  releaseChannel: Joi.string(),
+  buildType: Joi.string().valid('apk', 'app-bundle', 'development-client').default('app-bundle'),
   distribution: Joi.string().valid('store', 'internal').default('store'),
 });
 
@@ -29,7 +30,7 @@ const iOSGenericSchema = Joi.object({
 const iOSManagedSchema = Joi.object({
   workflow: Joi.string().valid('managed').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
-  buildType: Joi.string().valid('archive', 'simulator'),
+  releaseChannel: Joi.string(),
   distribution: Joi.string().valid('store', 'internal').default('store'),
 });
 

--- a/packages/eas-json/src/__tests__/EasJsonReader-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-test.ts
@@ -129,7 +129,6 @@ test('valid eas.json for debug builds', async () => {
       ios: {
         credentialsSource: 'auto',
         workflow: 'managed',
-        buildType: 'simulator',
         distribution: 'store',
       },
     },
@@ -164,7 +163,7 @@ test('invalid eas.json when using buildType for wrong platform', async () => {
   const reader = new EasJsonReader('/project', 'android');
   const promise = reader.readAsync('release');
   await expect(promise).rejects.toThrowError(
-    'Object "android.release" in eas.json is not valid [ValidationError: "buildType" must be one of [apk, app-bundle]]'
+    'Object "android.release" in eas.json is not valid [ValidationError: "buildType" must be one of [apk, app-bundle, development-client]]'
   );
 });
 

--- a/packages/eas-json/src/index.ts
+++ b/packages/eas-json/src/index.ts
@@ -1,5 +1,4 @@
 export {
-  Workflow,
   CredentialsSource,
   DistributionType,
   AndroidManagedBuildProfile,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,17 +1488,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.1.tgz#7b71f87ac57192ba03613e18fb0fd5f639d21b6d"
-  integrity sha512-V5zrRdz6qa45Aflh84CmsEyNcNHG95O7dyzQqpzEI73phB+Jr7ffM+AP0f3+POjy6mwNXIKHgbzH8VG3excPpA==
-  dependencies:
-    "@hapi/joi" "^17.1.1"
-
-"@expo/eas-build-job@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.2.tgz#104b9bcb1602a23aabf893506e8e55d0dc61cd79"
-  integrity sha512-hBYVWlEWi8Iu+jWmbzKy2bMsYoWvRwY7MZ+SdKpNvAl+sMpp8rwvxRyRs7cRTa6DuiQ2sdOxqemnw9MJ6S5cRA==
+"@expo/eas-build-job@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.3.tgz#a3d3da6da553dfa07a1e8fe9038146a7b84705db"
+  integrity sha512-c4M5wytogfipBo7cuZRHe/pSf0muwEI+gsNkfOj8onNaGhHWH4HD5daUQ76SpH59l1NqYks1sjKDRNNe0C7Z2g==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
# Why
Copied from slack
>   :bulb: we decided to remove generating credentials for ios from build:configure for now (do it while running eas build instead, this is what happens for android already). in the future, we work towards handling credentials generation more ergonomically in the build:configure command but will do this when new credentials work is all ready.

>  change the way we handle a dirty git index when running build:configure and build
     -  :bulb: build:configure: don’t block running on dirty git index, just warn and let the user proceed if they want (https://www.notion.so/expo/Minimal-suggested-new-output-401a03083eb041a8b619edc41b7147be)
    -  :bulb: build: it’s important that we can commit changes during the build command, for example to bump runtime version. so, we will prompt users to commit their changes if the index is dirty when the command is run.
    - we will continue to evaluate whether we want to depend on git in eas build or not. the main benefits we get are being able to easily show diffs when running commands like configure, and, most importantly, git archive does a lot of heavy lifting for us when it comes to producing an archive to upload to eas build.

# How

 - above changes
 - cleanup types (replace duplicated types from #expo/eas-build-job`)
 - remove unsupported `buildType` for ios
