### PR TITLE
[eas-cli] disable eas build & submit for non-paying users

### DIFF
--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -14,14 +14,12 @@ import { prepareJobAsync } from './prepareJob';
 
 export async function startAndroidBuildAsync(
   commandCtx: CommandContext,
-  easConfig: EasConfig,
-  projectId: string
+  easConfig: EasConfig
 ): Promise<string> {
   const buildCtx = createBuildContext<Platform.Android>({
     commandCtx,
     platform: Platform.Android,
     easConfig,
-    projectId,
   });
 
   return await startBuildForPlatformAsync({

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -83,7 +83,7 @@ export async function startBuildForPlatformAsync<
         const {
           data: { buildId, deprecationInfo },
         } = await apiClient
-          .post(`projects/${builder.ctx.projectId}/builds`, {
+          .post(`projects/${builder.ctx.commandCtx.projectId}/builds`, {
             json: {
               job,
               metadata,

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -10,6 +10,7 @@ export interface CommandContext {
   requestedPlatform: BuildCommandPlatform;
   profile: string;
   projectDir: string;
+  projectId: string;
   user: User;
   accountName: string;
   projectName: string;
@@ -25,6 +26,7 @@ export async function createCommandContextAsync({
   requestedPlatform,
   profile,
   projectDir,
+  projectId,
   trackingCtx,
   nonInteractive = false,
   skipCredentialsCheck = false,
@@ -33,6 +35,7 @@ export async function createCommandContextAsync({
 }: {
   requestedPlatform: BuildCommandPlatform;
   profile: string;
+  projectId: string;
   projectDir: string;
   trackingCtx: TrackingContext;
   nonInteractive: boolean;
@@ -49,6 +52,7 @@ export async function createCommandContextAsync({
     requestedPlatform,
     profile,
     projectDir,
+    projectId,
     user,
     accountName,
     projectName,
@@ -80,7 +84,6 @@ export interface BuildContext<T extends Platform> {
   commandCtx: CommandContext;
   trackingCtx: TrackingContext;
   platform: T;
-  projectId: string;
   buildProfile: PlatformBuildProfile<T>;
 }
 
@@ -88,12 +91,10 @@ export function createBuildContext<T extends Platform>({
   platform,
   easConfig,
   commandCtx,
-  projectId,
 }: {
   platform: T;
   easConfig: EasConfig;
   commandCtx: CommandContext;
-  projectId: string;
 }): BuildContext<T> {
   const buildProfile = easConfig.builds[platform] as PlatformBuildProfile<T> | undefined;
   if (!buildProfile) {
@@ -108,6 +109,5 @@ export function createBuildContext<T extends Platform>({
     trackingCtx: builderTrackingCtx,
     platform,
     buildProfile,
-    projectId,
   };
 }

--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -4,7 +4,6 @@ import ora from 'ora';
 
 import { apiClient } from '../api';
 import log from '../log';
-import { getProjectIdAsync } from '../project/projectUtils';
 import { sleep } from '../utils/promise';
 import { startAndroidBuildAsync } from './android/build';
 import { CommandContext } from './context';
@@ -17,9 +16,7 @@ export async function buildAsync(commandCtx: CommandContext): Promise<void> {
   await ensureGitRepoExistsAsync();
   await ensureGitStatusIsCleanAsync();
 
-  const projectId = await getProjectIdAsync(commandCtx.projectDir);
-
-  const scheduledBuilds = await startBuildsAsync(commandCtx, projectId);
+  const scheduledBuilds = await startBuildsAsync(commandCtx);
   log.newLine();
   printLogsUrls(commandCtx.accountName, scheduledBuilds);
   log.newLine();
@@ -27,7 +24,6 @@ export async function buildAsync(commandCtx: CommandContext): Promise<void> {
   if (commandCtx.waitForBuildEnd) {
     const builds = await waitForBuildEndAsync(
       commandCtx,
-      projectId,
       scheduledBuilds.map(i => i.buildId)
     );
     printBuildResults(builds);
@@ -35,8 +31,7 @@ export async function buildAsync(commandCtx: CommandContext): Promise<void> {
 }
 
 async function startBuildsAsync(
-  commandCtx: CommandContext,
-  projectId: string
+  commandCtx: CommandContext
 ): Promise<
   { platform: BuildCommandPlatform.ANDROID | BuildCommandPlatform.IOS; buildId: string }[]
 > {
@@ -56,11 +51,11 @@ async function startBuildsAsync(
     buildId: string;
   }[] = [];
   if (shouldBuildAndroid) {
-    const buildId = await startAndroidBuildAsync(commandCtx, easConfig, projectId);
+    const buildId = await startAndroidBuildAsync(commandCtx, easConfig);
     scheduledBuilds.push({ platform: BuildCommandPlatform.ANDROID, buildId });
   }
   if (shouldBuildiOS) {
-    const buildId = await startIosBuildAsync(commandCtx, easConfig, projectId);
+    const buildId = await startIosBuildAsync(commandCtx, easConfig);
     scheduledBuilds.push({ platform: BuildCommandPlatform.IOS, buildId });
   }
   return scheduledBuilds;
@@ -68,7 +63,6 @@ async function startBuildsAsync(
 
 async function waitForBuildEndAsync(
   commandCtx: CommandContext,
-  projectId: string,
   buildIds: string[],
   { timeoutSec = 1800, intervalSec = 30 } = {}
 ): Promise<(Build | null)[]> {
@@ -80,7 +74,9 @@ async function waitForBuildEndAsync(
     const builds: (Build | null)[] = await Promise.all(
       buildIds.map(async buildId => {
         try {
-          const { data } = await apiClient.get(`projects/${projectId}/builds/${buildId}`).json();
+          const { data } = await apiClient
+            .get(`projects/${commandCtx.projectId}/builds/${buildId}`)
+            .json();
           return data;
         } catch (err) {
           return null;

--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -4,7 +4,7 @@ import ora from 'ora';
 
 import { apiClient } from '../api';
 import log from '../log';
-import { ensureProjectExistsAsync } from '../project/ensureProjectExists';
+import { getProjectIdAsync } from '../project/projectUtils';
 import { sleep } from '../utils/promise';
 import { startAndroidBuildAsync } from './android/build';
 import { CommandContext } from './context';
@@ -17,15 +17,11 @@ export async function buildAsync(commandCtx: CommandContext): Promise<void> {
   await ensureGitRepoExistsAsync();
   await ensureGitStatusIsCleanAsync();
 
-  const projectId = await ensureProjectExistsAsync({
-    accountName: commandCtx.accountName,
-    projectName: commandCtx.projectName,
-    privacy: commandCtx.exp.privacy,
-  });
+  const projectId = await getProjectIdAsync(commandCtx.projectDir);
 
   const scheduledBuilds = await startBuildsAsync(commandCtx, projectId);
   log.newLine();
-  await printLogsUrls(commandCtx.accountName, scheduledBuilds);
+  printLogsUrls(commandCtx.accountName, scheduledBuilds);
   log.newLine();
 
   if (commandCtx.waitForBuildEnd) {

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -15,14 +15,12 @@ import { prepareJobAsync } from './prepareJob';
 
 export async function startIosBuildAsync(
   commandCtx: CommandContext,
-  easConfig: EasConfig,
-  projectId: string
+  easConfig: EasConfig
 ): Promise<string> {
   const buildCtx = createBuildContext<Platform.iOS>({
     commandCtx,
     platform: Platform.iOS,
     easConfig,
-    projectId,
   });
 
   let iosNativeProjectScheme: string | undefined;

--- a/packages/eas-cli/src/commands/build/create.ts
+++ b/packages/eas-cli/src/commands/build/create.ts
@@ -65,6 +65,7 @@ export default class BuildCreate extends Command {
       requestedPlatform: flags.platform as BuildCommandPlatform,
       profile: flags.profile,
       projectDir,
+      projectId,
       trackingCtx,
       nonInteractive: flags['non-interactive'],
       skipCredentialsCheck: flags['skip-credentials-check'],

--- a/packages/eas-cli/src/commands/build/create.ts
+++ b/packages/eas-cli/src/commands/build/create.ts
@@ -1,4 +1,5 @@
 import { Command, flags } from '@oclif/command';
+import chalk from 'chalk';
 import { v4 as uuidv4 } from 'uuid';
 
 import { createCommandContextAsync } from '../../build/context';
@@ -46,7 +47,9 @@ export default class BuildCreate extends Command {
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
       log.error(
-        'Your account does not have access to Expo Application Services (EAS) features. Please enroll in EAS to give it a try.'
+        `Your account does not have access to Expo Application Services (EAS) features. Please enroll in EAS to give it a try. ${chalk.dim(
+          'Learn more: https://expo.io/eas'
+        )}`
       );
       process.exitCode = 1;
       return;

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -1,4 +1,5 @@
 import { Command, flags } from '@oclif/command';
+import chalk from 'chalk';
 
 import log from '../log';
 import { isEasEnabledForProjectAsync } from '../project/isEasEnabledForProject';
@@ -168,7 +169,9 @@ export default class BuildSubmit extends Command {
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
       log.error(
-        'Your account does not have access to Expo Application Services (EAS) features. Please enroll in EAS to give it a try.'
+        `Your account does not have access to Expo Application Services (EAS) features. Please enroll in EAS to give it a try. ${chalk.dim(
+          'Learn more: https://expo.io/eas'
+        )}`
       );
       process.exitCode = 1;
       return;

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -1,6 +1,8 @@
 import { Command, flags } from '@oclif/command';
 
-import { findProjectRootAsync } from '../project/projectUtils';
+import log from '../log';
+import { isEasEnabledForProjectAsync } from '../project/isEasEnabledForProject';
+import { findProjectRootAsync, getProjectIdAsync } from '../project/projectUtils';
 import AndroidSubmitCommand from '../submissions/android/AndroidSubmitCommand';
 import IosSubmitCommand from '../submissions/ios/IosSubmitCommand';
 import {
@@ -22,7 +24,7 @@ export default class BuildSubmit extends Command {
   static examples = [
     `$ eas submit --platform=ios
     - Fully interactive iOS submission\n`,
-    `$ eas submit --platform=android 
+    `$ eas submit --platform=android
     - Fully interactive Android submission\n`,
     `$ eas submit -p android --latest --key=/path/to/google-services.json
     - Minimal non-interactive Android submission, however it can ask you for other params if not specified\n`,
@@ -138,7 +140,7 @@ export default class BuildSubmit extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     const {
       flags: {
         // android
@@ -160,7 +162,17 @@ export default class BuildSubmit extends Command {
     } = this.parse(BuildSubmit);
 
     await ensureLoggedInAsync();
-    const projectDir = await findProjectRootAsync(process.cwd());
+
+    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectId = await getProjectIdAsync(projectDir);
+
+    if (!(await isEasEnabledForProjectAsync(projectId))) {
+      log.error(
+        'Your account does not have access to Expo Application Services (EAS) features. Please enroll in EAS to give it a try.'
+      );
+      process.exitCode = 1;
+      return;
+    }
 
     // TODO: Make this work outside project dir
     if (!projectDir) {

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -189,7 +189,7 @@ export default class BuildSubmit extends Command {
         ...flags,
       };
 
-      const ctx = AndroidSubmitCommand.createContext(projectDir, options);
+      const ctx = AndroidSubmitCommand.createContext(projectDir, projectId, options);
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
     } else if (platform === SubmissionPlatform.iOS) {
@@ -203,7 +203,7 @@ export default class BuildSubmit extends Command {
         ...flags,
       };
 
-      const ctx = IosSubmitCommand.createContext(projectDir, options);
+      const ctx = IosSubmitCommand.createContext(projectDir, projectId, options);
       const command = new IosSubmitCommand(ctx);
       await command.runAsync();
     } else {

--- a/packages/eas-cli/src/project/isEasEnabledForProject.ts
+++ b/packages/eas-cli/src/project/isEasEnabledForProject.ts
@@ -11,11 +11,11 @@ export async function isEasEnabledForProjectAsync(projectId: string): Promise<bo
       data: { enabled },
     } = await apiClient.get(`projects/${projectId}/eas-enabled`).json();
     return enabled;
-  } catch (err) {
-    if (err.response.statusCode === 404) {
+  } catch (error) {
+    if (error.response?.statusCode === 404) {
       return true;
     } else {
-      throw err;
+      throw error;
     }
   }
 }

--- a/packages/eas-cli/src/project/isEasEnabledForProject.ts
+++ b/packages/eas-cli/src/project/isEasEnabledForProject.ts
@@ -1,0 +1,21 @@
+import { apiClient } from '../api';
+
+/**
+ * Checks if the project is allowed for using EAS services.
+ * THIS IS A TEMPORARY STEP NEEDED FOR OPEN PREVIEW
+ * @returns boolean
+ */
+export async function isEasEnabledForProjectAsync(projectId: string): Promise<boolean> {
+  try {
+    const {
+      data: { enabled },
+    } = await apiClient.get(`projects/${projectId}/eas-enabled`).json();
+    return enabled;
+  } catch (err) {
+    if (err.message.match(/Response code 404/)) {
+      return true;
+    } else {
+      throw err;
+    }
+  }
+}

--- a/packages/eas-cli/src/project/isEasEnabledForProject.ts
+++ b/packages/eas-cli/src/project/isEasEnabledForProject.ts
@@ -12,7 +12,7 @@ export async function isEasEnabledForProjectAsync(projectId: string): Promise<bo
     } = await apiClient.get(`projects/${projectId}/eas-enabled`).json();
     return enabled;
   } catch (err) {
-    if (err.message.match(/Response code 404/)) {
+    if (err.response.statusCode === 404) {
       return true;
     } else {
       throw err;

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -1,5 +1,4 @@
 import { getConfig } from '@expo/config';
-import once from 'lodash/once';
 import pkgDir from 'pkg-dir';
 
 import { ensureLoggedInAsync } from '../user/actions';
@@ -16,9 +15,7 @@ export async function findProjectRootAsync(cwd?: string): Promise<string | null>
   return projectRootDir ?? null;
 }
 
-export const getProjectIdAsync = once(_getProjectIdAsync);
-
-async function _getProjectIdAsync(projectDir: string): Promise<string> {
+export async function getProjectIdAsync(projectDir: string): Promise<string> {
   const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
   return await ensureProjectExistsAsync({
     accountName: await getProjectAccountNameAsync(projectDir),

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '@expo/config';
+import once from 'lodash/once';
 import pkgDir from 'pkg-dir';
 
 import { ensureLoggedInAsync } from '../user/actions';
@@ -15,10 +16,13 @@ export async function findProjectRootAsync(cwd?: string): Promise<string | null>
   return projectRootDir ?? null;
 }
 
-export async function getProjectIdAsync(projectDir: string): Promise<string> {
+export const getProjectIdAsync = once(_getProjectIdAsync);
+
+async function _getProjectIdAsync(projectDir: string): Promise<string> {
   const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
   return await ensureProjectExistsAsync({
     accountName: await getProjectAccountNameAsync(projectDir),
     projectName: exp.slug,
+    privacy: exp.privacy,
   });
 }

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -5,7 +5,6 @@ import { asMock } from '../../../__tests__/utils';
 import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { ensureProjectExistsAsync } from '../../../project/ensureProjectExists';
-import { getProjectIdAsync } from '../../../project/projectUtils';
 import SubmissionService from '../../SubmissionService';
 import { Submission, SubmissionStatus } from '../../SubmissionService.types';
 import { AndroidArchiveType, AndroidSubmitCommandFlags, SubmissionPlatform } from '../../types';
@@ -90,7 +89,6 @@ describe(AndroidSubmitCommand, () => {
         }
       );
       asMock(ensureProjectExistsAsync).mockImplementationOnce(() => projectId);
-      asMock(getProjectIdAsync).mockImplementationOnce(() => projectId);
 
       const options: AndroidSubmitCommandFlags = {
         latest: false,
@@ -101,7 +99,7 @@ describe(AndroidSubmitCommand, () => {
         releaseStatus: 'draft',
         verbose: false,
       };
-      const ctx = AndroidSubmitCommand.createContext(testProject.projectRoot, options);
+      const ctx = AndroidSubmitCommand.createContext(testProject.projectRoot, projectId, options);
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
 

--- a/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
@@ -5,7 +5,6 @@ import { asMock } from '../../../__tests__/utils';
 import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { ensureProjectExistsAsync } from '../../../project/ensureProjectExists';
-import { getProjectIdAsync } from '../../../project/projectUtils';
 import SubmissionService from '../../SubmissionService';
 import { Submission, SubmissionStatus } from '../../SubmissionService.types';
 import { IosSubmitCommandFlags, SubmissionPlatform } from '../../types';
@@ -85,7 +84,6 @@ describe(IosSubmitCommand, () => {
         }
       );
       asMock(ensureProjectExistsAsync).mockImplementationOnce(() => projectId);
-      asMock(getProjectIdAsync).mockImplementationOnce(() => projectId);
 
       process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD = 'supersecret';
 
@@ -96,7 +94,7 @@ describe(IosSubmitCommand, () => {
         ascAppId: '12345678',
         verbose: false,
       };
-      const ctx = IosSubmitCommand.createContext(testProject.projectRoot, options);
+      const ctx = IosSubmitCommand.createContext(testProject.projectRoot, projectId, options);
       const command = new IosSubmitCommand(ctx);
       await command.runAsync();
 

--- a/packages/eas-cli/src/submissions/types.ts
+++ b/packages/eas-cli/src/submissions/types.ts
@@ -1,5 +1,6 @@
 export interface SubmissionContext<T extends SubmitCommandFlags> {
   projectDir: string;
+  projectId: string;
   commandFlags: T;
 }
 


### PR DESCRIPTION
For Open Preview, we want to allow using EAS services (Build and Submit) only for paid (_paying?_) users.

- https://www.notion.so/expo/Allowlist-Free-Priority-Plan-for-existing-external-testers-for-EAS-Build-5b69631944134d8bb71a0112ef316dfc
- https://www.notion.so/expo/Gate-Open-Preview-behind-Dev-Services-558c8aefb4f348d9b8ab3739a867810c

API changes are in https://github.com/expo/universe/pull/6477
