### PR TITLE
[eas-cli] configure app identifier for iOS and Android

### DIFF
--- a/packages/eas-cli/src/build/android/applicationId.ts
+++ b/packages/eas-cli/src/build/android/applicationId.ts
@@ -1,0 +1,158 @@
+import { ExpoConfig, getConfigFilePaths } from '@expo/config';
+import { AndroidConfig } from '@expo/config-plugins';
+import assert from 'assert';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+
+import log from '../../log';
+import {
+  getAndroidApplicationIdAsync,
+  getProjectConfigDescription,
+} from '../../project/projectUtils';
+import { promptAsync } from '../../prompts';
+import { gitAddAsync } from '../../utils/git';
+
+enum ApplicationIdSource {
+  AndroidProject,
+  AppJson,
+}
+
+export async function configureApplicationIdAsync(
+  projectDir: string,
+  exp: ExpoConfig,
+  allowExperimental: boolean
+): Promise<void> {
+  const configDescription = getProjectConfigDescription(projectDir);
+  const applicationIdFromConfig = AndroidConfig.Package.getPackage(exp);
+  const applicationIdFromAndroidProject = await getAndroidApplicationIdAsync(projectDir);
+
+  if (applicationIdFromAndroidProject && applicationIdFromConfig) {
+    if (applicationIdFromConfig !== applicationIdFromAndroidProject) {
+      log.newLine();
+      log.warn(
+        `We detected that your Android project is configured with a different application id than the one defined in ${configDescription}.`
+      );
+      if (!(await hasApplicationIdInStaticConfigAsync(projectDir, exp))) {
+        log(`If you choose the one defined in ${configDescription} we'll automatically configure your Android project with it.
+However, if you choose the one defined in the Android project you'll have to update ${configDescription} on your own.
+Otherwise, you'll see this prompt again in the future.`);
+      }
+      log.newLine();
+      const { applicationIdSource } = await promptAsync({
+        type: 'select',
+        name: 'applicationIdSource',
+        message: 'Which application id should we use?',
+        choices: [
+          {
+            title: `${chalk.bold(
+              applicationIdFromAndroidProject
+            )} - In build.gradle in Android project`,
+            value: ApplicationIdSource.AndroidProject,
+          },
+          {
+            title: `${chalk.bold(applicationIdFromConfig)} - In your ${configDescription}`,
+            value: ApplicationIdSource.AppJson,
+          },
+        ],
+      });
+      switch (applicationIdSource) {
+        case ApplicationIdSource.AppJson: {
+          await updateApplicationIdInBuildGradleAsync(projectDir, exp);
+          break;
+        }
+        case ApplicationIdSource.AndroidProject: {
+          await updateAppJsonConfigAsync(projectDir, exp, applicationIdFromAndroidProject);
+          break;
+        }
+      }
+    }
+  } else if (!applicationIdFromAndroidProject && !applicationIdFromConfig) {
+    throw new Error(
+      `Please define "android.package" in ${configDescription} and run "eas build:configure" again.`
+    );
+  } else if (applicationIdFromAndroidProject && !applicationIdFromConfig) {
+    if (getConfigFilePaths(projectDir).staticConfigPath) {
+      await updateAppJsonConfigAsync(projectDir, exp, applicationIdFromAndroidProject);
+    } else {
+      throw new Error(
+        `Please define "android.package" in ${configDescription} and run "eas build:configure" again.`
+      );
+    }
+  } else if (!applicationIdFromAndroidProject && applicationIdFromConfig) {
+    // This should never happen, adding warning just in case
+    log.warn(
+      'applicationId is not specified in your ./android/app/build.gradle file. Make sure your project is confgured correctly before building.'
+    );
+    return;
+  }
+  if (allowExperimental) {
+    // package name does not need to be updated
+    await updatePackageNameAsync(projectDir, exp);
+    await gitAddAsync(path.join(projectDir, 'android'), { intentToAdd: true });
+  }
+}
+
+async function updateAppJsonConfigAsync(
+  projectDir: string,
+  exp: ExpoConfig,
+  newApplicationId: string
+): Promise<void> {
+  const paths = getConfigFilePaths(projectDir);
+  assert(paths.staticConfigPath, "can't update dynamic configs");
+
+  const rawStaticConfig = await fs.readJSON(paths.staticConfigPath);
+  rawStaticConfig.expo = {
+    ...rawStaticConfig.expo,
+    android: { ...rawStaticConfig.expo.android, package: newApplicationId },
+  };
+  await fs.writeJson(paths.staticConfigPath, rawStaticConfig, { spaces: 2 });
+
+  exp.android = { ...exp.android, package: newApplicationId };
+}
+
+/**
+ * Check if static config exists and if expo.android.package is defined there.
+ * It will return false if value in static confgi is different than exp.android.package
+ */
+async function hasApplicationIdInStaticConfigAsync(
+  projectDir: string,
+  exp: ExpoConfig
+): Promise<boolean> {
+  if (!exp.android?.package) {
+    return false;
+  }
+  const paths = getConfigFilePaths(projectDir);
+  if (!paths.staticConfigPath) {
+    return false;
+  }
+  const rawStaticConfig = await fs.readJson(paths.staticConfigPath);
+  return rawStaticConfig?.expo?.android?.package === exp.android.package;
+}
+
+async function updateApplicationIdInBuildGradleAsync(projectDir: string, exp: ExpoConfig) {
+  const buildGradlePath = AndroidConfig.Paths.getAppBuildGradle(projectDir);
+  let buildGradleContent = await fs.readFile(buildGradlePath, 'utf8');
+  buildGradleContent = AndroidConfig.Package.setPackageInBuildGradle(exp, buildGradleContent);
+  await fs.writeFile(buildGradlePath, buildGradleContent);
+}
+
+async function updatePackageNameAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
+  const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
+  if (!androidManifestPath) {
+    throw new Error(`Could not find AndroidManifest.xml in project directory: "${projectDir}"`);
+  }
+  const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(
+    androidManifestPath
+  );
+  const updatedAndroidManifest = AndroidConfig.Package.setPackageInAndroidManifest(
+    exp,
+    androidManifest
+  );
+  await AndroidConfig.Manifest.writeAndroidManifestAsync(
+    androidManifestPath,
+    updatedAndroidManifest
+  );
+
+  await AndroidConfig.Package.renamePackageOnDisk(exp, projectDir);
+}

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -5,6 +5,7 @@ import AndroidCredentialsProvider, {
   AndroidCredentials,
 } from '../../credentials/android/AndroidCredentialsProvider';
 import { createCredentialsContextAsync } from '../../credentials/context';
+import { ensureAppIdentifierIsDefinedAsync } from '../../project/projectUtils';
 import { CredentialsResult, startBuildForPlatformAsync } from '../build';
 import { BuildContext, CommandContext, createBuildContext } from '../context';
 import { ensureCredentialsAsync } from '../credentials';
@@ -32,6 +33,7 @@ export async function startAndroidBuildAsync(
       if (buildCtx.buildProfile.workflow === Workflow.Generic) {
         await validateAndSyncProjectConfigurationAsync(commandCtx.projectDir, commandCtx.exp);
       }
+      await ensureAppIdentifierIsDefinedAsync(commandCtx.projectDir, Platform.Android);
     },
     prepareJobAsync,
   });

--- a/packages/eas-cli/src/build/android/configure.ts
+++ b/packages/eas-cli/src/build/android/configure.ts
@@ -39,7 +39,7 @@ export async function validateAndSyncProjectConfigurationAsync(
   );
   if (!isEasBuildGradleConfigured || !isApplicationIdConfigured) {
     throw new Error(
-      'Project is not configured. Please run "eas build:configure" first to configure the project'
+      'Project is not configured. Please run "eas build:configure" to configure the project.'
     );
   }
 

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@expo/config';
 import { EasJsonReader } from '@expo/eas-json';
+import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -20,6 +21,7 @@ import {
 export async function configureAsync(options: {
   platform: BuildCommandPlatform;
   projectDir: string;
+  allowExperimental: boolean;
 }): Promise<void> {
   await ensureGitRepoExistsAsync();
   await maybeBailOnGitStatusAsync();
@@ -30,6 +32,7 @@ export async function configureAsync(options: {
     user: await ensureLoggedInAsync(),
     projectDir: options.projectDir,
     exp,
+    allowExperimental: options.allowExperimental,
     requestedPlatform: options.platform,
     shouldConfigureAndroid: [BuildCommandPlatform.ALL, BuildCommandPlatform.ANDROID].includes(
       options.platform
@@ -60,6 +63,11 @@ export async function configureAsync(options: {
         "Aborting, run the command again once you're ready. Make sure to commit any changes you've made."
       );
     }
+    log.newLine();
+    log(chalk.green('Successfully configured the project'));
+  } else {
+    log.newLine();
+    log(chalk.green('No changes were necessary, the project is already configured correctly.'));
   }
 }
 

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -65,6 +65,7 @@ export interface ConfigureContext {
   user: User;
   projectDir: string;
   exp: ExpoConfig;
+  allowExperimental: boolean;
   requestedPlatform: BuildCommandPlatform;
   shouldConfigureAndroid: boolean;
   shouldConfigureIos: boolean;

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import sortBy from 'lodash/sortBy';
 
 import log from '../../log';
+import { ensureAppIdentifierIsDefinedAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { startBuildForPlatformAsync } from '../build';
 import { BuildContext, CommandContext, createBuildContext } from '../context';
@@ -39,6 +40,7 @@ export async function startIosBuildAsync(
       if (buildCtx.buildProfile.workflow === Workflow.Generic) {
         await validateAndSyncProjectConfigurationAsync(commandCtx.projectDir, commandCtx.exp);
       }
+      await ensureAppIdentifierIsDefinedAsync(commandCtx.projectDir, Platform.iOS);
     },
     prepareJobAsync,
   });

--- a/packages/eas-cli/src/build/ios/bundleIdentifer.ts
+++ b/packages/eas-cli/src/build/ios/bundleIdentifer.ts
@@ -1,76 +1,121 @@
-import { ExpoConfig } from '@expo/config';
+import { ExpoConfig, getConfigFilePaths } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
+import assert from 'assert';
 import chalk from 'chalk';
-import once from 'lodash/once';
+import fs from 'fs-extra';
 
 import log from '../../log';
+import { getProjectConfigDescription } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 
-export const getBundleIdentifier = once(_getBundleIdentifier);
+enum BundleIdenitiferSource {
+  XcodeProject,
+  AppJson,
+}
 
-async function _getBundleIdentifier(
+export async function configureBundleIdentifierAsync(
   projectDir: string,
-  manifest: ExpoConfig,
-  options?: { displayAutoconfigMessage?: boolean; configDescription?: string }
-): Promise<string> {
-  const configDescription = options?.configDescription ?? 'app.config.js/app.json';
-  const displayAutoconfigMessage = options?.displayAutoconfigMessage ?? true;
+  exp: ExpoConfig
+): Promise<void> {
+  const configDescription = getProjectConfigDescription(projectDir);
   const bundleIdentifierFromPbxproj = IOSConfig.BundleIdenitifer.getBundleIdentifierFromPbxproj(
     projectDir
   );
-  const bundleIdentifierFromConfig = IOSConfig.BundleIdenitifer.getBundleIdentifier(manifest);
-  if (bundleIdentifierFromPbxproj !== null && bundleIdentifierFromConfig !== null) {
-    if (bundleIdentifierFromPbxproj === bundleIdentifierFromConfig) {
-      return bundleIdentifierFromPbxproj;
-    } else {
+  const bundleIdentifierFromConfig = IOSConfig.BundleIdenitifer.getBundleIdentifier(exp);
+  if (bundleIdentifierFromPbxproj && bundleIdentifierFromConfig) {
+    if (bundleIdentifierFromPbxproj !== bundleIdentifierFromConfig) {
       log.addNewLineIfNone();
       log.warn(
         `We detected that your Xcode project is configured with a different bundle identifier than the one defined in ${configDescription}.`
       );
-      if (displayAutoconfigMessage) {
+      if (!(await hasApplicationIdInStaticConfigAsync(projectDir, exp))) {
         log(`If you choose the one defined in ${configDescription} we'll automatically configure your Xcode project with it.
 However, if you choose the one defined in the Xcode project you'll have to update ${configDescription} on your own.
 Otherwise, you'll see this prompt again in the future.`);
       }
       log.newLine();
-      const { bundleIdentifier } = await promptAsync({
+      const { bundleIdentifierSource } = await promptAsync({
         type: 'select',
-        name: 'bundleIdentifier',
+        name: 'bundleIdentifierSource',
         message: 'Which bundle identifier should we use?',
         choices: [
           {
             title: `${chalk.bold(bundleIdentifierFromPbxproj)} - In Xcode project`,
-            value: bundleIdentifierFromPbxproj,
+            value: BundleIdenitiferSource.XcodeProject,
           },
           {
             title: `${chalk.bold(bundleIdentifierFromConfig)} - In your ${configDescription}`,
-            value: bundleIdentifierFromConfig,
+            value: BundleIdenitiferSource.AppJson,
           },
         ],
       });
-      return bundleIdentifier;
+      switch (bundleIdentifierSource) {
+        case BundleIdenitiferSource.AppJson: {
+          IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(
+            projectDir,
+            bundleIdentifierFromConfig
+          );
+          break;
+        }
+        case BundleIdenitiferSource.XcodeProject: {
+          await updateAppJsonConfigAsync(projectDir, exp, bundleIdentifierFromPbxproj);
+          break;
+        }
+      }
     }
-  } else if (bundleIdentifierFromPbxproj === null && bundleIdentifierFromConfig === null) {
-    throw new Error(`Please define "ios.bundleIdentifier" in your ${configDescription}`);
-  } else {
-    if (bundleIdentifierFromPbxproj !== null) {
-      log(
-        `Using ${chalk.bold(
-          bundleIdentifierFromPbxproj
-        )} as the bundle identifier (read from the Xcode project).`
-      );
-      return bundleIdentifierFromPbxproj;
+  } else if (!bundleIdentifierFromPbxproj && !bundleIdentifierFromConfig) {
+    throw new Error(
+      `Please define "ios.bundleIdentifier" in your ${configDescription} and run "eas build:configure" again.`
+    );
+  } else if (bundleIdentifierFromPbxproj && !bundleIdentifierFromConfig) {
+    if (getConfigFilePaths(projectDir).staticConfigPath) {
+      await updateAppJsonConfigAsync(projectDir, exp, bundleIdentifierFromPbxproj);
     } else {
-      // bundleIdentifierFromConfig is never null in this case
-      // the following line is to satisfy TS
-      const bundleIdentifier = bundleIdentifierFromConfig ?? '';
-      log(
-        `Using ${chalk.bold(
-          bundleIdentifier
-        )} as the bundle identifier (read from ${configDescription}).
-We'll automatically configure your Xcode project using this value.`
+      throw new Error(
+        `Please define "ios.bundleIdentifier" in ${configDescription} and run "eas build:configure" again.`
       );
-      return bundleIdentifier;
     }
+  } else if (!bundleIdentifierFromPbxproj && bundleIdentifierFromConfig) {
+    IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(
+      projectDir,
+      bundleIdentifierFromConfig
+    );
   }
+}
+
+async function updateAppJsonConfigAsync(
+  projectDir: string,
+  exp: ExpoConfig,
+  newBundleIdentifier: string
+): Promise<void> {
+  const paths = getConfigFilePaths(projectDir);
+  assert(paths.staticConfigPath, "can't update dynamic configs");
+
+  const rawStaticConfig = await fs.readJSON(paths.staticConfigPath);
+  rawStaticConfig.expo = {
+    ...rawStaticConfig.expo,
+    ios: { ...rawStaticConfig.expo.ios, bundleIdentifier: newBundleIdentifier },
+  };
+  await fs.writeJson(paths.staticConfigPath, rawStaticConfig, { spaces: 2 });
+
+  exp.ios = { ...exp.ios, bundleIdentifier: newBundleIdentifier };
+}
+
+/**
+ * Check if static config exists and if ios.bundleIdentifier is defined there.
+ * It will return false if value in static config is different than exp.ios.bundleIdentifier
+ */
+async function hasApplicationIdInStaticConfigAsync(
+  projectDir: string,
+  exp: ExpoConfig
+): Promise<boolean> {
+  if (!exp.ios?.bundleIdentifier) {
+    return false;
+  }
+  const paths = getConfigFilePaths(projectDir);
+  if (!paths.staticConfigPath) {
+    return false;
+  }
+  const rawStaticConfig = await fs.readJson(paths.staticConfigPath);
+  return rawStaticConfig?.expo?.ios?.bundleIdentifier === exp.ios.bundleIdentifier;
 }

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -28,7 +28,7 @@ export async function validateAndSyncProjectConfigurationAsync(
   );
   if (!bundleIdentifierFromPbxproj || bundleIdentifierFromPbxproj !== exp.ios?.bundleIdentifier) {
     throw new Error(
-      'Bundle identifier is not configured correctly in your Xcode project. Please run "eas build:configure" first to configure it.'
+      'Bundle identifier is not configured correctly in your Xcode project. Please run "eas build:configure" to configure it.'
     );
   }
   if (isExpoUpdatesInstalled(projectDir)) {

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -5,14 +5,13 @@ import log from '../../log';
 import { ConfigureContext } from '../context';
 import { isExpoUpdatesInstalled } from '../utils/updates';
 import { configureUpdatesAsync, syncUpdatesConfigurationAsync } from './UpdatesModule';
-import { getBundleIdentifier } from './bundleIdentifer';
+import { configureBundleIdentifierAsync } from './bundleIdentifer';
 
 export async function configureIosAsync(ctx: ConfigureContext): Promise<void> {
   if (!ctx.hasIosNativeProject) {
     return;
   }
-  const bundleIdentifier = await getBundleIdentifier(ctx.projectDir, ctx.exp);
-  IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(ctx.projectDir, bundleIdentifier, false);
+  await configureBundleIdentifierAsync(ctx.projectDir, ctx.exp);
 
   if (isExpoUpdatesInstalled(ctx.projectDir)) {
     await configureUpdatesAsync(ctx.projectDir, ctx.exp);
@@ -24,7 +23,14 @@ export async function validateAndSyncProjectConfigurationAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<void> {
-  // TODO: check bundle identifier
+  const bundleIdentifierFromPbxproj = IOSConfig.BundleIdenitifer.getBundleIdentifierFromPbxproj(
+    projectDir
+  );
+  if (!bundleIdentifierFromPbxproj || bundleIdentifierFromPbxproj !== exp.ios?.bundleIdentifier) {
+    throw new Error(
+      'Bundle identifier is not configured correctly in your Xcode project. Please run "eas build:configure" first to configure it.'
+    );
+  }
   if (isExpoUpdatesInstalled(projectDir)) {
     await syncUpdatesConfigurationAsync(projectDir, exp);
   }

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -6,10 +6,11 @@ import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
 import log from '../../log';
-import { confirmAsync, promptAsync } from '../../prompts';
+import { confirmAsync, pressAnyKeyToContinueAsync, promptAsync } from '../../prompts';
 import {
   doesGitRepoExistAsync,
   gitDiffAsync,
+  gitDiffOutputAsync,
   gitRootDirectoryAsync,
   gitStatusAsync,
   isGitInstalledAsync,
@@ -113,9 +114,15 @@ async function reviewAndCommitChangesAsync(
     );
   }
 
+  const outputTooLarge = (await gitDiffOutputAsync()).split(/\r\n|\r|\n/).length > 100;
   log('Please review the following changes and pass the message to make the commit.');
-  log.newLine();
-  await gitDiffAsync();
+  if (outputTooLarge) {
+    log('Press any key to see the changes...');
+    await pressAnyKeyToContinueAsync();
+  } else {
+    log.newLine();
+  }
+  await gitDiffAsync({ withPager: outputTooLarge });
   log.newLine();
 
   const confirm = await confirmAsync({

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -9,8 +9,8 @@ import log from '../../log';
 import { confirmAsync, pressAnyKeyToContinueAsync, promptAsync } from '../../prompts';
 import {
   doesGitRepoExistAsync,
+  getGitDiffOutputAsync,
   gitDiffAsync,
-  gitDiffOutputAsync,
   gitRootDirectoryAsync,
   gitStatusAsync,
   isGitInstalledAsync,
@@ -114,7 +114,7 @@ async function reviewAndCommitChangesAsync(
     );
   }
 
-  const outputTooLarge = (await gitDiffOutputAsync()).split(/\r\n|\r|\n/).length > 100;
+  const outputTooLarge = (await getGitDiffOutputAsync()).split(/\r\n|\r|\n/).length > 100;
   log('Please review the following changes and pass the message to make the commit.');
   if (outputTooLarge) {
     log('Press any key to see the changes...');

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -2,6 +2,7 @@ import { Command, flags } from '@oclif/command';
 
 import { configureAsync } from '../../build/configure';
 import { BuildCommandPlatform } from '../../build/types';
+import log from '../../log';
 import { findProjectRootAsync } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
 
@@ -15,15 +16,26 @@ export default class BuildConfigure extends Command {
       options: ['android', 'ios', 'all'],
       default: 'all',
     }),
+    'allow-experimental': flags.boolean({
+      description: 'Enable experimental configuration steps.',
+      default: false,
+    }),
   };
 
   async run() {
     const { flags } = this.parse(BuildConfigure);
     const platform = flags.platform as BuildCommandPlatform;
+    const allowExperimental = flags['allow-experimental'];
+    if (allowExperimental) {
+      log.warn(
+        'Project configuration will execute some additional steps that might fail if structure of your native project is significantly different from "expo eject" or "expo init"'
+      );
+    }
 
     await ensureLoggedInAsync();
     await configureAsync({
       platform,
+      allowExperimental,
       projectDir: (await findProjectRootAsync()) ?? process.cwd(),
     });
   }

--- a/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
@@ -1,7 +1,8 @@
+import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
-import { getBundleIdentifier } from '../../../build/ios/bundleIdentifer';
 import log from '../../../log';
+import { ensureAppIdentifierIsDefinedAsync } from '../../../project/projectUtils';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { updateIosCredentialsAsync } from '../../credentialsJson/update';
@@ -11,7 +12,7 @@ export class UpdateCredentialsJson implements Action {
   constructor(private app: AppLookupParams) {}
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
-    const bundleIdentifer = await getBundleIdentifier(ctx.projectDir, ctx.exp);
+    const bundleIdentifer = await ensureAppIdentifierIsDefinedAsync(ctx.projectDir, Platform.iOS);
     log('Updating iOS credentials in credentials.json');
     await updateIosCredentialsAsync(ctx, bundleIdentifer);
     log(

--- a/packages/eas-cli/src/credentials/manager/HelperActions.ts
+++ b/packages/eas-cli/src/credentials/manager/HelperActions.ts
@@ -1,24 +1,12 @@
-import { constants } from 'os';
-
 import log from '../../log';
+import { pressAnyKeyToContinueAsync } from '../../prompts';
 import { Action, CredentialsManager } from '../CredentialsManager';
 import { Context } from '../context';
 
 export class PressAnyKeyToContinue implements Action {
   public async runAsync(manmager: CredentialsManager, context: Context): Promise<void> {
     log('Press any key to continue...');
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
-    process.stdin.setEncoding('utf8');
-
-    await new Promise(res => {
-      process.stdin.on('data', key => {
-        if (String(key) === '\u0003') {
-          process.exit(constants.signals.SIGINT + 128); // ctrl-c
-        }
-        res();
-      });
-    });
+    await pressAnyKeyToContinueAsync();
     log.newLine();
     log.newLine();
   }

--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -55,3 +55,18 @@ export async function toggleConfirmAsync(
   );
   return value ?? null;
 }
+
+export async function pressAnyKeyToContinueAsync() {
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.setEncoding('utf8');
+
+  await new Promise(res => {
+    process.stdin.on('data', key => {
+      if (String(key) === '\u0003') {
+        process.exit(constants.signals.SIGINT + 128); // ctrl-c
+      }
+      res();
+    });
+  });
+}

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -1,10 +1,10 @@
 import { App, RequestContext, Session, User } from '@expo/apple-utils/build';
-import { ProjectConfig, getConfig } from '@expo/config';
-import * as path from 'path';
+import { getConfig } from '@expo/config';
+import { Platform } from '@expo/eas-build-job';
 
-import { getBundleIdentifier } from '../../build/ios/bundleIdentifer';
 import { authenticateAsync, getRequestContext } from '../../credentials/ios/appstore/authenticate';
 import log from '../../log';
+import { getAppIdentifierAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { IosSubmissionContext } from '../types';
 import { sanitizeLanguage } from './utils/language';
@@ -33,16 +33,9 @@ export async function ensureAppStoreConnectAppExistsAsync(
 
   const { bundleIdentifier, appName, language } = ctx.commandFlags;
 
-  let resolvedBundleId: string;
-  try {
-    const description = getProjectConfigDescription(ctx.projectDir, projectConfig);
-    resolvedBundleId =
-      bundleIdentifier ??
-      (await getBundleIdentifier(ctx.projectDir, exp, {
-        displayAutoconfigMessage: false,
-        configDescription: description,
-      }));
-  } catch (e) {
+  const resolvedBundleId =
+    bundleIdentifier ?? (await getAppIdentifierAsync(ctx.projectDir, Platform.iOS));
+  if (!resolvedBundleId) {
     throw new Error(
       `Please define "expo.ios.bundleIdentifier" in your app config or provide it using --bundle-identifier param.
 Learn more here: https://expo.fyi/bundle-identifier`
@@ -140,30 +133,4 @@ async function promptForAppNameAsync(): Promise<string> {
     validate: (val: string) => val !== '' || 'App name cannot be empty!',
   });
   return appName;
-}
-
-/**
- * Return a useful name describing the project config.
- * - dynamic: app.config.js
- * - static: app.json
- * - custom path app config relative to root folder
- * - both: app.config.js or app.json
- */
-function getProjectConfigDescription(
-  projectRoot: string,
-  projectConfig: Partial<ProjectConfig>
-): string {
-  if (projectConfig.dynamicConfigPath) {
-    const relativeDynamicConfigPath = path.relative(projectRoot, projectConfig.dynamicConfigPath);
-    if (projectConfig.staticConfigPath) {
-      return `${relativeDynamicConfigPath} or ${path.relative(
-        projectRoot,
-        projectConfig.staticConfigPath
-      )}`;
-    }
-    return relativeDynamicConfigPath;
-  } else if (projectConfig.staticConfigPath) {
-    return path.relative(projectRoot, projectConfig.staticConfigPath);
-  }
-  return 'app.config.js/app.json';
 }

--- a/packages/eas-cli/src/utils/git.ts
+++ b/packages/eas-cli/src/utils/git.ts
@@ -13,7 +13,7 @@ async function gitDiffAsync({ withPager = false }: { withPager?: boolean } = {})
   await spawnAsync('git', [...options, 'diff'], { stdio: ['ignore', 'inherit', 'inherit'] });
 }
 
-async function gitDiffOutputAsync(): Promise<string> {
+async function getGitDiffOutputAsync(): Promise<string> {
   return (await spawnAsync('git', ['--no-pager', 'diff'])).stdout;
 }
 
@@ -59,7 +59,7 @@ async function getBranchNameAsync(): Promise<string | undefined> {
 export {
   gitStatusAsync,
   gitDiffAsync,
-  gitDiffOutputAsync,
+  getGitDiffOutputAsync,
   gitAddAsync,
   doesGitRepoExistAsync,
   gitRootDirectoryAsync,

--- a/packages/eas-cli/src/utils/git.ts
+++ b/packages/eas-cli/src/utils/git.ts
@@ -8,8 +8,13 @@ async function gitStatusAsync({ showUntracked }: GitStatusOptions = {}): Promise
   return (await spawnAsync('git', ['status', '-s', showUntracked ? '-uall' : '-uno'])).stdout;
 }
 
-async function gitDiffAsync(): Promise<void> {
-  await spawnAsync('git', ['--no-pager', 'diff'], { stdio: ['ignore', 'inherit', 'inherit'] });
+async function gitDiffAsync({ withPager = false }: { withPager?: boolean } = {}): Promise<void> {
+  const options = withPager ? [] : ['--no-pager'];
+  await spawnAsync('git', [...options, 'diff'], { stdio: ['ignore', 'inherit', 'inherit'] });
+}
+
+async function gitDiffOutputAsync(): Promise<string> {
+  return (await spawnAsync('git', ['--no-pager', 'diff'])).stdout;
 }
 
 async function gitAddAsync(file: string, options?: { intentToAdd?: boolean }): Promise<void> {
@@ -54,6 +59,7 @@ async function getBranchNameAsync(): Promise<string | undefined> {
 export {
   gitStatusAsync,
   gitDiffAsync,
+  gitDiffOutputAsync,
   gitAddAsync,
   doesGitRepoExistAsync,
   gitRootDirectoryAsync,


### PR DESCRIPTION
# Why

- getBundleIdentifier was inconsistent with the rest of configuration and validation steps when building
- We need to configure applicationId for android to support new credentials API

# How

- when reading appIdentifier(bundle identifier or application id) read from app.json and fallback to native project if possible (The same approach as (`exp.owner ?? user.username`)
- when running `build` and app identifiers in a native project do not match thro exception
- when running `configure` ask which value is correct and update either native project or app.json
  - if static config exists it will be updated, if only dynamic config is available throw an exception and ask user to update it
- for android only applicationId is updated by default
  - package name will be updated with flag `--alow-experimental` (I'm not sure about that, I'm still working on getting `AndroidConfig.Package.renamePackageOnDisk` to work)

# Teste Plan 

Run build and configure for a few different cases with matching and mismatched values for different configs.