### PR TITLE
[eas-cli] commit changes when updating runtime version

### DIFF
--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -86,8 +86,6 @@ async function ensureGitStatusIsCleanAsync(): Promise<void> {
   }
 }
 
-class DirtyGitTreeError extends Error {}
-
 async function makeProjectTarballAsync(): Promise<{ path: string; size: number }> {
   const spinner = ora('Making project tarball').start();
 
@@ -144,38 +142,11 @@ async function commitPromptAsync(initialCommitMessage?: string): Promise<void> {
   await spawnAsync('git', ['commit', '-m', message]);
 }
 
-async function modifyAndCommitAsync(
-  callback: () => Promise<void>,
-  {
-    commitMessage,
-    nonInteractive,
-  }: {
-    commitMessage: string;
-    nonInteractive: boolean;
-  }
-) {
-  await callback();
-
-  if (!(await isGitStatusCleanAsync())) {
-    log.newLine();
-    try {
-      await reviewAndCommitChangesAsync(commitMessage, {
-        nonInteractive,
-      });
-    } catch (e) {
-      throw new Error(
-        "Aborting, run the command again once you're ready. Make sure to commit any changes you've made."
-      );
-    }
-  }
-}
-
 export {
-  DirtyGitTreeError,
+  isGitStatusCleanAsync,
   ensureGitRepoExistsAsync,
   ensureGitStatusIsCleanAsync,
   maybeBailOnGitStatusAsync,
   makeProjectTarballAsync,
   reviewAndCommitChangesAsync,
-  modifyAndCommitAsync,
 };


### PR DESCRIPTION
# Why

If a build is updating some parts of the project, those changes won't be applied in the build process because changes are not committed

# How

- commit changes before upload
- remove `modifyAndCommitAsync`
- configure project before credentials generation (bundle identifier might change during that process)

# Test plan

run configure and build with changed runtimeVersion