### PR TITLE
[eas-cli] improve internal distribution on android

### DIFF
--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -1,10 +1,12 @@
 import { Workflow } from '@expo/eas-build-job';
 import { EasConfig } from '@expo/eas-json';
+import chalk from 'chalk';
 
 import AndroidCredentialsProvider, {
   AndroidCredentials,
 } from '../../credentials/android/AndroidCredentialsProvider';
 import { createCredentialsContextAsync } from '../../credentials/context';
+import log from '../../log';
 import { ensureAppIdentifierIsDefinedAsync } from '../../project/projectUtils';
 import { CredentialsResult, startBuildForPlatformAsync } from '../build';
 import { BuildContext, CommandContext, createBuildContext } from '../context';
@@ -22,6 +24,23 @@ export async function startAndroidBuildAsync(
     platform: Platform.Android,
     easConfig,
   });
+
+  const { buildProfile } = buildCtx;
+  if (
+    buildProfile.workflow === Workflow.Generic &&
+    buildProfile.distribution === 'internal' &&
+    buildProfile.gradleCommand &&
+    !buildProfile.gradleCommand.match(/assembleRelease/)
+  ) {
+    log.addNewLineIfNone();
+    log.warn(
+      `You're building your Android app for internal distribution. However, we've detected that the Gradle command you defined (${chalk.underline(
+        buildProfile.gradleCommand
+      )}) does not include string 'assembleRelease'.
+If the Gradle command does not produce an APK, you will not be able to install it on your Android devices straight from the Expo website.`
+    );
+    log.newLine();
+  }
 
   return await startBuildForPlatformAsync({
     ctx: buildCtx,

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -8,6 +8,7 @@ import AndroidCredentialsProvider, {
 import { createCredentialsContextAsync } from '../../credentials/context';
 import log from '../../log';
 import { ensureAppIdentifierIsDefinedAsync } from '../../project/projectUtils';
+import { toggleConfirmAsync } from '../../prompts';
 import { CredentialsResult, startBuildForPlatformAsync } from '../build';
 import { BuildContext, CommandContext, createBuildContext } from '../context';
 import { ensureCredentialsAsync } from '../credentials';
@@ -39,6 +40,11 @@ export async function startAndroidBuildAsync(
 This means that it will most likely produce an AAB and you will not be able to install it on your Android devices straight from the Expo website.`
     );
     log.newLine();
+    const confirmed = await toggleConfirmAsync({ message: 'Would you like to proceed?' });
+    if (!confirmed) {
+      log.error('Please update eas.json and come back again.');
+      process.exit(1);
+    }
   }
 
   return await startBuildForPlatformAsync({

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -29,8 +29,7 @@ export async function startAndroidBuildAsync(
   if (
     buildProfile.workflow === Workflow.Generic &&
     buildProfile.distribution === 'internal' &&
-    buildProfile.gradleCommand &&
-    buildProfile.gradleCommand.match(/bundle/)
+    buildProfile.gradleCommand?.match(/bundle/)
   ) {
     log.addNewLineIfNone();
     log.warn(

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -30,14 +30,14 @@ export async function startAndroidBuildAsync(
     buildProfile.workflow === Workflow.Generic &&
     buildProfile.distribution === 'internal' &&
     buildProfile.gradleCommand &&
-    !buildProfile.gradleCommand.match(/assembleRelease/)
+    buildProfile.gradleCommand.match(/bundle/)
   ) {
     log.addNewLineIfNone();
     log.warn(
       `You're building your Android app for internal distribution. However, we've detected that the Gradle command you defined (${chalk.underline(
         buildProfile.gradleCommand
-      )}) does not include string 'assembleRelease'.
-If the Gradle command does not produce an APK, you will not be able to install it on your Android devices straight from the Expo website.`
+      )}) includes string 'bundle'.
+This means that it will most likely produce an AAB and you will not be able to install it on your Android devices straight from the Expo website.`
     );
     log.newLine();
   }

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -79,6 +79,7 @@ async function prepareGenericJobAsync(
     type: Workflow.Generic,
     gradleCommand: buildProfile.gradleCommand,
     artifactPath: buildProfile.artifactPath,
+    releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,
   };
 }
@@ -92,6 +93,8 @@ async function prepareManagedJobAsync(
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
     type: Workflow.Managed,
+    buildType: buildProfile.buildType,
+    releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,
   };
 }

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -8,21 +8,6 @@ import { gitRootDirectoryAsync } from '../../utils/git';
 import { BuildContext } from '../context';
 import { Platform } from '../types';
 
-interface CommonJobProperties {
-  platform: Platform.iOS;
-  projectUrl: string;
-  secrets: {
-    buildCredentials?: {
-      provisioningProfileBase64: string;
-      distributionCertificate: {
-        dataBase64: string;
-        password: string;
-      };
-    };
-    secretEnvs?: Record<string, string>;
-  };
-}
-
 interface JobData {
   archiveUrl: string;
   credentials?: IosCredentials;
@@ -44,6 +29,22 @@ export async function prepareJobAsync(
   } else {
     throw new Error("Unknown workflow. Shouldn't happen");
   }
+}
+
+interface CommonJobProperties {
+  platform: Platform.iOS;
+  projectUrl: string;
+  releaseChannel: string;
+  secrets: {
+    buildCredentials?: {
+      provisioningProfileBase64: string;
+      distributionCertificate: {
+        dataBase64: string;
+        password: string;
+      };
+    };
+    secretEnvs?: Record<string, string>;
+  };
 }
 
 async function prepareJobCommonAsync(
@@ -84,6 +85,7 @@ async function prepareGenericJobAsync(
     type: Workflow.Generic,
     scheme: jobData.projectConfiguration.iosNativeProjectScheme,
     artifactPath: buildProfile.artifactPath,
+    releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,
   };
 }
@@ -91,12 +93,13 @@ async function prepareGenericJobAsync(
 async function prepareManagedJobAsync(
   ctx: BuildContext<Platform.iOS>,
   jobData: JobData,
-  _buildProfile: iOSManagedBuildProfile
+  buildProfile: iOSManagedBuildProfile
 ): Promise<Partial<iOS.ManagedJob>> {
   const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
     type: Workflow.Managed,
+    releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,
   };
 }

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -3,7 +3,11 @@ import Joi from '@hapi/joi';
 const AndroidGenericSchema = Joi.object({
   workflow: Joi.string().valid('generic').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
-  gradleCommand: Joi.string(),
+  gradleCommand: Joi.alternatives().conditional('distribution', {
+    is: 'internal',
+    then: Joi.string().default(':app:assembleRelease'),
+    otherwise: Joi.string(),
+  }),
   releaseChannel: Joi.string(),
   artifactPath: Joi.string(),
   withoutCredentials: Joi.boolean(),
@@ -14,7 +18,11 @@ const AndroidManagedSchema = Joi.object({
   workflow: Joi.string().valid('managed').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
   releaseChannel: Joi.string(),
-  buildType: Joi.string().valid('apk', 'app-bundle', 'development-client').default('app-bundle'),
+  buildType: Joi.alternatives().conditional('distribution', {
+    is: 'internal',
+    then: Joi.string().valid('apk').default('apk'),
+    otherwise: Joi.string().valid('apk', 'app-bundle', 'development-client').default('app-bundle'),
+  }),
   distribution: Joi.string().valid('store', 'internal').default('store'),
 });
 


### PR DESCRIPTION
# Why 

I put up a PR to update the "Configuration with eas.json" page in docs (https://github.com/expo/expo/pull/11192). I mentioned there the `distribution` config option for Android. 
I've realized that we should have more strict validation of internal distribution build profiles on Android.

# How

There are two cases:
- generic projects:
   - `gradleCommand` should produce an APK - I added a warning if it includes string `bundle` (`bundle*` produces AAB)
   - @brentvatne do we want to prompt the user if they want to proceed? or the warning is fine?
- managed projects:
   - validation of eas.json fails if `distribution = internal` and `buildType != apk`

I also fixed passing `releaseChannel` to turtle workers.

# Test plan

- Added unit tests for EasJsonReader.
- Tested manually by building Android for internal distribution.