### PR TITLE
[eas-cli] Move build:create to top-level command

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -117,7 +117,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         const projectTarball = await makeProjectTarballAsync();
         projectTarballPath = projectTarball.path;
 
-        log('Uploading project to AWS S3');
+        log('Uploading project to build servers');
         return await uploadAsync(
           UploadType.TURTLE_PROJECT_SOURCES,
           projectTarball.path,

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -88,7 +88,7 @@ async function ensureGitStatusIsCleanAsync(): Promise<void> {
 }
 
 async function makeProjectTarballAsync(): Promise<{ path: string; size: number }> {
-  const spinner = ora('Making project tarball').start();
+  const spinner = ora('Preparing project to be uploaded').start();
 
   await fs.mkdirp(getTmpDirectory());
   const tarPath = path.join(getTmpDirectory(), `${uuidv4()}.tar.gz`);
@@ -98,7 +98,7 @@ async function makeProjectTarballAsync(): Promise<{ path: string; size: number }
     ['archive', '--format=tar.gz', '--prefix', 'project/', '-o', tarPath, 'HEAD'],
     { cwd: await gitRootDirectoryAsync() }
   );
-  spinner.succeed('Project tarball created.');
+  spinner.succeed('Project ready to be uploaded');
 
   const { size } = await fs.stat(tarPath);
   return { size, path: tarPath };

--- a/packages/eas-cli/src/commands/build.ts
+++ b/packages/eas-cli/src/commands/build.ts
@@ -2,17 +2,18 @@ import { Command, flags } from '@oclif/command';
 import chalk from 'chalk';
 import { v4 as uuidv4 } from 'uuid';
 
-import { createCommandContextAsync } from '../../build/context';
-import { buildAsync } from '../../build/create';
-import { AnalyticsEvent, BuildCommandPlatform } from '../../build/types';
-import Analytics from '../../build/utils/analytics';
-import log from '../../log';
-import { isEasEnabledForProjectAsync } from '../../project/isEasEnabledForProject';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
-import { ensureLoggedInAsync } from '../../user/actions';
+import { createCommandContextAsync } from '../build/context';
+import { buildAsync } from '../build/create';
+import { AnalyticsEvent, BuildCommandPlatform } from '../build/types';
+import Analytics from '../build/utils/analytics';
+import log from '../log';
+import { isEasEnabledForProjectAsync } from '../project/isEasEnabledForProject';
+import { findProjectRootAsync, getProjectIdAsync } from '../project/projectUtils';
+import { ensureLoggedInAsync } from '../user/actions';
 
-export default class BuildCreate extends Command {
+export default class Build extends Command {
   static description = 'Start a build';
+  static aliases = ['build:submit'];
 
   static flags = {
     platform: flags.enum({ char: 'p', options: ['android', 'ios', 'all'], required: true }),
@@ -39,7 +40,7 @@ export default class BuildCreate extends Command {
   };
 
   async run(): Promise<void> {
-    const { flags } = this.parse(BuildCreate);
+    const { flags } = this.parse(Build);
     await ensureLoggedInAsync();
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();


### PR DESCRIPTION
This makes it possible to run `eas build` rather than `eas build:create`