### PR TITLE
[eas-cli] Improve wording around archiving and uploading project

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -117,7 +117,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         const projectTarball = await makeProjectTarballAsync();
         projectTarballPath = projectTarball.path;
 
-        log('Uploading project to EAS');
+        log('Uploading project to build servers');
         return await uploadAsync(
           UploadType.TURTLE_PROJECT_SOURCES,
           projectTarball.path,

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -117,7 +117,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         const projectTarball = await makeProjectTarballAsync();
         projectTarballPath = projectTarball.path;
 
-        log('Uploading project to AWS S3');
+        log('Uploading project to EAS');
         return await uploadAsync(
           UploadType.TURTLE_PROJECT_SOURCES,
           projectTarball.path,

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -88,7 +88,7 @@ async function ensureGitStatusIsCleanAsync(): Promise<void> {
 }
 
 async function makeProjectTarballAsync(): Promise<{ path: string; size: number }> {
-  const spinner = ora('Making project tarball').start();
+  const spinner = ora('Preparing project to be uploaded').start();
 
   await fs.mkdirp(getTmpDirectory());
   const tarPath = path.join(getTmpDirectory(), `${uuidv4()}.tar.gz`);
@@ -98,7 +98,7 @@ async function makeProjectTarballAsync(): Promise<{ path: string; size: number }
     ['archive', '--format=tar.gz', '--prefix', 'project/', '-o', tarPath, 'HEAD'],
     { cwd: await gitRootDirectoryAsync() }
   );
-  spinner.succeed('Project tarball created.');
+  spinner.succeed('Project ready to be uploaded');
 
   const { size } = await fs.stat(tarPath);
   return { size, path: tarPath };


### PR DESCRIPTION
This leaves some implementation details out of the messages because they aren't relevant to users. This PR is stacked on top of #103.

## Before

```
╰─$ easd build -p android
✔ Ensuring project @notbrent/tabsy is registered on Expo servers
Resolving credentials source (auto mode)
Using credentials stored on the Expo servers
✔ Project tarball created.
Uploading project to AWS S3
[====================================                            ] 56% 2.4s
```

## After

```
╰─$ easd build -p android
✔ Ensuring project @notbrent/tabsy is registered on Expo servers
Resolving credentials source (auto mode)
Using credentials stored on the Expo servers
✔ Project ready to be uploaded
Uploading project to build servers
[====================================                            ] 56% 2.4s
```