### PR TITLE
[eas-cli] validate bundleIdentifer and applicationId

### DIFF
--- a/packages/eas-cli/src/build/android/applicationId.ts
+++ b/packages/eas-cli/src/build/android/applicationId.ts
@@ -7,15 +7,33 @@ import path from 'path';
 
 import log from '../../log';
 import {
+  ensureAppIdentifierIsDefinedAsync,
   getAndroidApplicationIdAsync,
   getProjectConfigDescription,
 } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { gitAddAsync } from '../../utils/git';
+import { Platform } from '../types';
 
 enum ApplicationIdSource {
   AndroidProject,
   AppJson,
+}
+
+function isApplicationIdValid(applicationId: string): boolean {
+  return /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/.test(applicationId);
+}
+
+export async function ensureApplicationIdIsValidAsync(projectDir: string) {
+  const applicationId = await ensureAppIdentifierIsDefinedAsync(projectDir, Platform.Android);
+  if (!isApplicationIdValid(applicationId)) {
+    const configDescription = getProjectConfigDescription(projectDir);
+    log.error(
+      `Invalid format of Android applicationId. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter.`
+    );
+    log.error(`Update "android.package" in ${configDescription} and run this command again.`);
+    throw new Error('Invalid applicationId');
+  }
 }
 
 export async function configureApplicationIdAsync(

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -7,12 +7,12 @@ import AndroidCredentialsProvider, {
 } from '../../credentials/android/AndroidCredentialsProvider';
 import { createCredentialsContextAsync } from '../../credentials/context';
 import log from '../../log';
-import { ensureAppIdentifierIsDefinedAsync } from '../../project/projectUtils';
 import { toggleConfirmAsync } from '../../prompts';
 import { CredentialsResult, startBuildForPlatformAsync } from '../build';
 import { BuildContext, CommandContext, createBuildContext } from '../context';
 import { ensureCredentialsAsync } from '../credentials';
 import { Platform } from '../types';
+import { ensureApplicationIdIsValidAsync } from './applicationId';
 import { validateAndSyncProjectConfigurationAsync } from './configure';
 import { prepareJobAsync } from './prepareJob';
 
@@ -47,6 +47,8 @@ This means that it will most likely produce an AAB and you will not be able to i
     }
   }
 
+  await ensureApplicationIdIsValidAsync(commandCtx.projectDir);
+
   return await startBuildForPlatformAsync({
     ctx: buildCtx,
     projectConfiguration: {},
@@ -55,7 +57,6 @@ This means that it will most likely produce an AAB and you will not be able to i
       if (buildCtx.buildProfile.workflow === Workflow.Generic) {
         await validateAndSyncProjectConfigurationAsync(commandCtx.projectDir, commandCtx.exp);
       }
-      await ensureAppIdentifierIsDefinedAsync(commandCtx.projectDir, Platform.Android);
     },
     prepareJobAsync,
   });

--- a/packages/eas-cli/src/build/android/configure.ts
+++ b/packages/eas-cli/src/build/android/configure.ts
@@ -7,7 +7,7 @@ import { gitAddAsync } from '../../utils/git';
 import { ConfigureContext } from '../context';
 import { isExpoUpdatesInstalled } from '../utils/updates';
 import { configureUpdatesAsync, syncUpdatesConfigurationAsync } from './UpdatesModule';
-import { configureApplicationIdAsync } from './applicationId';
+import { configureApplicationIdAsync, ensureApplicationIdIsValidAsync } from './applicationId';
 
 export async function configureAndroidAsync(ctx: ConfigureContext): Promise<void> {
   if (!ctx.hasAndroidNativeProject) {
@@ -15,6 +15,7 @@ export async function configureAndroidAsync(ctx: ConfigureContext): Promise<void
   }
   await AndroidConfig.EasBuild.configureEasBuildAsync(ctx.projectDir);
   await configureApplicationIdAsync(ctx.projectDir, ctx.exp, ctx.allowExperimental);
+  await ensureApplicationIdIsValidAsync(ctx.projectDir);
 
   const easGradlePath = AndroidConfig.EasBuild.getEasBuildGradlePath(ctx.projectDir);
   await gitAddAsync(easGradlePath, { intentToAdd: true });

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -5,11 +5,11 @@ import chalk from 'chalk';
 import sortBy from 'lodash/sortBy';
 
 import log from '../../log';
-import { ensureAppIdentifierIsDefinedAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { startBuildForPlatformAsync } from '../build';
 import { BuildContext, CommandContext, createBuildContext } from '../context';
 import { Platform } from '../types';
+import { ensureBundleIdentifierIsValidAsync } from './bundleIdentifer';
 import { validateAndSyncProjectConfigurationAsync } from './configure';
 import { ensureIosCredentialsAsync } from './credentials';
 import { prepareJobAsync } from './prepareJob';
@@ -28,6 +28,8 @@ export async function startIosBuildAsync(
   if (buildCtx.buildProfile.workflow === Workflow.Generic) {
     iosNativeProjectScheme = buildCtx.buildProfile.scheme ?? (await resolveSchemeAsync(buildCtx));
   }
+  await ensureBundleIdentifierIsValidAsync(commandCtx.projectDir);
+
   return await startBuildForPlatformAsync({
     ctx: buildCtx,
     projectConfiguration: {
@@ -38,7 +40,6 @@ export async function startIosBuildAsync(
       if (buildCtx.buildProfile.workflow === Workflow.Generic) {
         await validateAndSyncProjectConfigurationAsync(commandCtx.projectDir, commandCtx.exp);
       }
-      await ensureAppIdentifierIsDefinedAsync(commandCtx.projectDir, Platform.iOS);
     },
     prepareJobAsync,
   });

--- a/packages/eas-cli/src/build/ios/bundleIdentifer.ts
+++ b/packages/eas-cli/src/build/ios/bundleIdentifer.ts
@@ -26,7 +26,7 @@ export async function ensureBundleIdentifierIsValidAsync(projectDir: string) {
   if (!isBundleIdentifierValid(bundleIdentifier)) {
     const configDescription = getProjectConfigDescription(projectDir);
     log.error(
-      `Invalid format of iOS bundleId. Only alphanumeric characters, '.', '-', and '_' are allowed, and each '.' must be followed by a letter.`
+      `Invalid format of iOS bundleId. Only alphanumeric characters, '.' and '-' are allowed, and each '.' must be followed by a letter.`
     );
     log.error(`Update "ios.bundleIdentifier" in ${configDescription} and run this command again.`);
     throw new Error('Invalid bundleIdentifier');

--- a/packages/eas-cli/src/build/ios/bundleIdentifer.ts
+++ b/packages/eas-cli/src/build/ios/bundleIdentifer.ts
@@ -5,12 +5,32 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 
 import log from '../../log';
-import { getProjectConfigDescription } from '../../project/projectUtils';
+import {
+  ensureAppIdentifierIsDefinedAsync,
+  getProjectConfigDescription,
+} from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
+import { Platform } from '../types';
 
 enum BundleIdenitiferSource {
   XcodeProject,
   AppJson,
+}
+
+function isBundleIdentifierValid(bundleIdentifier: string): boolean {
+  return /^[a-zA-Z][a-zA-Z0-9\-.]+$/.test(bundleIdentifier);
+}
+
+export async function ensureBundleIdentifierIsValidAsync(projectDir: string) {
+  const bundleIdentifier = await ensureAppIdentifierIsDefinedAsync(projectDir, Platform.iOS);
+  if (!isBundleIdentifierValid(bundleIdentifier)) {
+    const configDescription = getProjectConfigDescription(projectDir);
+    log.error(
+      `Invalid format of iOS bundleId. Only alphanumeric characters, '.', '-', and '_' are allowed, and each '.' must be followed by a letter.`
+    );
+    log.error(`Update "ios.bundleIdentifier" in ${configDescription} and run this command again.`);
+    throw new Error('Invalid bundleIdentifier');
+  }
 }
 
 export async function configureBundleIdentifierAsync(

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -5,13 +5,17 @@ import log from '../../log';
 import { ConfigureContext } from '../context';
 import { isExpoUpdatesInstalled } from '../utils/updates';
 import { configureUpdatesAsync, syncUpdatesConfigurationAsync } from './UpdatesModule';
-import { configureBundleIdentifierAsync } from './bundleIdentifer';
+import {
+  configureBundleIdentifierAsync,
+  ensureBundleIdentifierIsValidAsync,
+} from './bundleIdentifer';
 
 export async function configureIosAsync(ctx: ConfigureContext): Promise<void> {
   if (!ctx.hasIosNativeProject) {
     return;
   }
   await configureBundleIdentifierAsync(ctx.projectDir, ctx.exp);
+  await ensureBundleIdentifierIsValidAsync(ctx.projectDir);
 
   if (isExpoUpdatesInstalled(ctx.projectDir)) {
     await configureUpdatesAsync(ctx.projectDir, ctx.exp);


### PR DESCRIPTION
# Why

app identifier is not validated when running build

# How

- regexp and some of the error messages reused from expo-cli
- validate during build and configuration commands

# Test Plan

run build and configure with valid and invalid app identifiers
