### PR TITLE
[eas-cli] add getReleaseByNameAsync

### DIFF
--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -117,7 +117,7 @@ export async function getReleaseByNameAsync({
 }): Promise<UpdateRelease> {
   const data = await withErrorHandlingAsync(
     graphqlClient
-      .mutation<
+      .query<
         {
           app: {
             byId: {


### PR DESCRIPTION
# Why

For several of the eas-cli commands under development, it will be useful to translate the user supplied releaseName to a releaseId.

# How

Add a method to translate a releaseName into a releaseId.

# Test Plan

Tested in graphql playground