### PR TITLE
[eas-cli] Add support for Robot users

### DIFF
--- a/packages/eas-cli/__mocks__/@expo/config.ts
+++ b/packages/eas-cli/__mocks__/@expo/config.ts
@@ -1,3 +1,4 @@
-const getConfig = jest.fn();
+const exp = {};
+const getConfig = jest.fn(() => ({ exp }));
 
 export { getConfig };

--- a/packages/eas-cli/__mocks__/@expo/config.ts
+++ b/packages/eas-cli/__mocks__/@expo/config.ts
@@ -1,4 +1,3 @@
-const exp = {};
-const getConfig = jest.fn(() => ({ exp }));
+const getConfig = jest.fn(() => ({ exp: {} }));
 
 export { getConfig };

--- a/packages/eas-cli/src/__tests__/project-utils.ts
+++ b/packages/eas-cli/src/__tests__/project-utils.ts
@@ -1,4 +1,4 @@
-import { User } from '../user/User';
+import { Actor } from '../user/User';
 
 interface MockProject {
   projectRoot: string;
@@ -20,13 +20,13 @@ interface AppJSON {
     version: string;
     slug: string;
     sdkVersion: string;
-    owner: string;
+    owner?: string;
     [key: string]: any;
   };
 }
 
 function createTestProject(
-  user: User,
+  user: Actor,
   appJSONExtraData?: Record<string, object | string>
 ): MockProject {
   const projectRoot = '/test-project';
@@ -37,13 +37,14 @@ function createTestProject(
     main: 'index.js',
   };
 
+  const owner = appJSONExtraData?.owner as string | undefined;
   const appJSON: AppJSON = {
     expo: {
       name: 'testing 123',
       version: '0.1.0',
       slug: 'testing-123',
       sdkVersion: '33.0.0',
-      owner: user.username,
+      owner: owner ?? (user.__typename === 'User' ? user.username : undefined),
       ...appJSONExtraData,
     },
   };

--- a/packages/eas-cli/src/build/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/android/UpdatesModule.ts
@@ -3,12 +3,13 @@ import { AndroidConfig } from '@expo/config-plugins';
 import fs from 'fs-extra';
 
 import log from '../../log';
-import { getProjectAccountNameAsync } from '../../project/projectUtils';
+import { getProjectAccountName } from '../../project/projectUtils';
+import { ensureLoggedInAsync } from '../../user/actions';
 import { ensureValidVersions } from '../utils/updates';
 
 export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
   ensureValidVersions(exp);
-  const accountName = await getProjectAccountNameAsync(projectDir);
+  const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
   const buildGradlePath = AndroidConfig.Paths.getAppBuildGradle(projectDir);
   const buildGradleContent = await fs.readFile(buildGradlePath, 'utf8');
 
@@ -41,7 +42,7 @@ export async function syncUpdatesConfigurationAsync(
   exp: ExpoConfig
 ): Promise<void> {
   ensureValidVersions(exp);
-  const accountName = await getProjectAccountNameAsync(projectDir);
+  const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
   try {
     await ensureUpdatesConfiguredAsync(projectDir, exp);
   } catch (error) {

--- a/packages/eas-cli/src/build/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/android/UpdatesModule.ts
@@ -3,12 +3,12 @@ import { AndroidConfig } from '@expo/config-plugins';
 import fs from 'fs-extra';
 
 import log from '../../log';
-import { ensureLoggedInAsync } from '../../user/actions';
+import { getProjectAccountNameAsync } from '../../project/projectUtils';
 import { ensureValidVersions } from '../utils/updates';
 
 export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
   ensureValidVersions(exp);
-  const { username } = await ensureLoggedInAsync();
+  const accountName = await getProjectAccountNameAsync(projectDir);
   const buildGradlePath = AndroidConfig.Paths.getAppBuildGradle(projectDir);
   const buildGradleContent = await fs.readFile(buildGradlePath, 'utf8');
 
@@ -29,8 +29,8 @@ export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig)
     androidManifestPath
   );
 
-  if (!AndroidConfig.Updates.isMainApplicationMetaDataSynced(exp, androidManifest, username)) {
-    const result = await AndroidConfig.Updates.setUpdatesConfig(exp, androidManifest, username);
+  if (!AndroidConfig.Updates.isMainApplicationMetaDataSynced(exp, androidManifest, accountName)) {
+    const result = await AndroidConfig.Updates.setUpdatesConfig(exp, androidManifest, accountName);
 
     await AndroidConfig.Manifest.writeAndroidManifestAsync(androidManifestPath, result);
   }
@@ -41,7 +41,7 @@ export async function syncUpdatesConfigurationAsync(
   exp: ExpoConfig
 ): Promise<void> {
   ensureValidVersions(exp);
-  const { username } = await ensureLoggedInAsync();
+  const accountName = await getProjectAccountNameAsync(projectDir);
   try {
     await ensureUpdatesConfiguredAsync(projectDir, exp);
   } catch (error) {
@@ -62,7 +62,7 @@ export async function syncUpdatesConfigurationAsync(
     await AndroidConfig.Manifest.writeAndroidManifestAsync(androidManifestPath, androidManifest);
   }
 
-  if (!AndroidConfig.Updates.isMainApplicationMetaDataSynced(exp, androidManifest, username)) {
+  if (!AndroidConfig.Updates.isMainApplicationMetaDataSynced(exp, androidManifest, accountName)) {
     log.warn(
       'Native project configuration is not synced with values present in your app.json, run "eas build:configure" to make sure all values are applied in the native project'
     );

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -2,7 +2,7 @@ import { ExpoConfig, getConfig } from '@expo/config';
 import { AndroidBuildProfile, EasConfig, iOSBuildProfile } from '@expo/eas-json';
 
 import { getProjectAccountNameAsync } from '../project/projectUtils';
-import { RobotUser, User } from '../user/User';
+import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import { Platform, RequestedPlatform, TrackingContext } from './types';
 
@@ -11,7 +11,7 @@ export interface CommandContext {
   profile: string;
   projectDir: string;
   projectId: string;
-  user: User | RobotUser;
+  user: Actor;
   accountName: string;
   projectName: string;
   exp: ExpoConfig;
@@ -66,7 +66,7 @@ export async function createCommandContextAsync({
 }
 
 export interface ConfigureContext {
-  user: User | RobotUser;
+  user: Actor;
   projectDir: string;
   exp: ExpoConfig;
   allowExperimental: boolean;

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -2,7 +2,7 @@ import { ExpoConfig, getConfig } from '@expo/config';
 import { AndroidBuildProfile, EasConfig, iOSBuildProfile } from '@expo/eas-json';
 
 import { getProjectAccountNameAsync } from '../project/projectUtils';
-import { User } from '../user/User';
+import { RobotUser, User } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import { Platform, RequestedPlatform, TrackingContext } from './types';
 
@@ -11,7 +11,7 @@ export interface CommandContext {
   profile: string;
   projectDir: string;
   projectId: string;
-  user: User;
+  user: User | RobotUser;
   accountName: string;
   projectName: string;
   exp: ExpoConfig;
@@ -66,7 +66,7 @@ export async function createCommandContextAsync({
 }
 
 export interface ConfigureContext {
-  user: User;
+  user: User | RobotUser;
   projectDir: string;
   exp: ExpoConfig;
   allowExperimental: boolean;

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -1,7 +1,7 @@
 import { ExpoConfig, getConfig } from '@expo/config';
 import { AndroidBuildProfile, EasConfig, iOSBuildProfile } from '@expo/eas-json';
 
-import { getProjectAccountNameAsync } from '../project/projectUtils';
+import { getProjectAccountName } from '../project/projectUtils';
 import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import { Platform, RequestedPlatform, TrackingContext } from './types';
@@ -45,7 +45,7 @@ export async function createCommandContextAsync({
 }): Promise<CommandContext> {
   const user = await ensureLoggedInAsync();
   const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-  const accountName = await getProjectAccountNameAsync(projectDir);
+  const accountName = getProjectAccountName(exp, user);
   const projectName = exp.slug;
 
   return {

--- a/packages/eas-cli/src/build/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/ios/UpdatesModule.ts
@@ -5,13 +5,13 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import log from '../../log';
-import { ensureLoggedInAsync } from '../../user/actions';
+import { getProjectAccountNameAsync } from '../../project/projectUtils';
 import { gitAddAsync } from '../../utils/git';
 import { ensureValidVersions } from '../utils/updates';
 
 export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
   ensureValidVersions(exp);
-  const { username } = await ensureLoggedInAsync();
+  const accountName = await getProjectAccountNameAsync(projectDir);
   let xcodeProject = IOSConfig.XcodeUtils.getPbxproj(projectDir);
 
   if (!IOSConfig.Updates.isShellScriptBuildPhaseConfigured(projectDir, exp, xcodeProject)) {
@@ -24,8 +24,8 @@ export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig)
   }
 
   let expoPlist = await readExpoPlistAsync(projectDir);
-  if (!IOSConfig.Updates.isPlistConfigurationSynced(exp, expoPlist, username)) {
-    expoPlist = IOSConfig.Updates.setUpdatesConfig(exp, expoPlist, username);
+  if (!IOSConfig.Updates.isPlistConfigurationSynced(exp, expoPlist, accountName)) {
+    expoPlist = IOSConfig.Updates.setUpdatesConfig(exp, expoPlist, accountName);
     await writeExpoPlistAsync(projectDir, expoPlist);
   }
   // TODO: ensure ExpoPlist in pbxproj
@@ -36,7 +36,7 @@ export async function syncUpdatesConfigurationAsync(
   exp: ExpoConfig
 ): Promise<void> {
   ensureValidVersions(exp);
-  const { username } = await ensureLoggedInAsync();
+  const accountName = await getProjectAccountNameAsync(projectDir);
   try {
     await ensureUpdatesConfiguredAsync(projectDir, exp);
   } catch (error) {
@@ -52,7 +52,7 @@ export async function syncUpdatesConfigurationAsync(
     await writeExpoPlistAsync(projectDir, expoPlist);
   }
 
-  if (!IOSConfig.Updates.isPlistConfigurationSynced(exp, expoPlist, username)) {
+  if (!IOSConfig.Updates.isPlistConfigurationSynced(exp, expoPlist, accountName)) {
     log.warn(
       'Native project configuration is not synced with values present in you app.json, run "eas build:configure" to make sure all values are applied in the native project'
     );

--- a/packages/eas-cli/src/build/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/ios/UpdatesModule.ts
@@ -5,13 +5,14 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import log from '../../log';
-import { getProjectAccountNameAsync } from '../../project/projectUtils';
+import { getProjectAccountName } from '../../project/projectUtils';
+import { ensureLoggedInAsync } from '../../user/actions';
 import { gitAddAsync } from '../../utils/git';
 import { ensureValidVersions } from '../utils/updates';
 
 export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
   ensureValidVersions(exp);
-  const accountName = await getProjectAccountNameAsync(projectDir);
+  const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
   let xcodeProject = IOSConfig.XcodeUtils.getPbxproj(projectDir);
 
   if (!IOSConfig.Updates.isShellScriptBuildPhaseConfigured(projectDir, exp, xcodeProject)) {
@@ -36,7 +37,7 @@ export async function syncUpdatesConfigurationAsync(
   exp: ExpoConfig
 ): Promise<void> {
   ensureValidVersions(exp);
-  const accountName = await getProjectAccountNameAsync(projectDir);
+  const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
   try {
     await ensureUpdatesConfiguredAsync(projectDir, exp);
   } catch (error) {

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import log from '../../log';
 import { getUserAsync } from '../../user/User';
+import { getActorDisplayName } from '../../user/actions';
 
 export default class AccountView extends Command {
   static description = 'show the username you are logged in as';
@@ -11,8 +12,8 @@ export default class AccountView extends Command {
 
   async run() {
     const user = await getUserAsync();
-    if (user?.username) {
-      log(chalk.green(user.username));
+    if (user) {
+      log(chalk.green(getActorDisplayName(user)));
     } else {
       log.warn('Not logged in');
       process.exit(1);

--- a/packages/eas-cli/src/commands/release/rename.ts
+++ b/packages/eas-cli/src/commands/release/rename.ts
@@ -7,8 +7,9 @@ import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import { EditUpdateReleaseInput, UpdateRelease } from '../../graphql/generated';
 import log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
-import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+import { findProjectRootAsync, getProjectAccountName } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
+import { ensureLoggedInAsync } from '../../user/actions';
 
 async function renameUpdateReleaseOnAppAsync({
   appId,
@@ -78,13 +79,11 @@ export default class ReleaseRename extends Command {
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');
     }
-    const accountName = await getProjectAccountNameAsync(projectDir);
-    const {
-      exp: { slug },
-    } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const { exp } = await getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
     const projectId = await ensureProjectExistsAsync({
       accountName,
-      projectName: slug,
+      projectName: exp.slug,
     });
 
     if (!currentName) {
@@ -127,7 +126,7 @@ export default class ReleaseRename extends Command {
     log.withTick(
       `️Renamed release from ${currentName} to ${chalk.bold(
         editedRelease.releaseName
-      )} on project ${chalk.bold(`@${accountName}/${slug}`)}.`
+      )} on project ${chalk.bold(`@${accountName}/${exp.slug}`)}.`
     );
   }
 }

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-constants.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-constants.ts
@@ -1,12 +1,14 @@
 import { User } from '../../user/User';
 
 export const jester: User = {
+  kind: 'user',
   username: 'jester',
   userId: 'jester-id',
   accounts: [{ id: 'jester-account-id', name: 'jester' }],
 };
 
 export const jester2: User = {
+  kind: 'user',
   username: 'jester2',
   userId: 'jester2-id',
   accounts: [{ id: 'jester2-account-id', name: 'jester2' }],

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-constants.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-constants.ts
@@ -1,16 +1,16 @@
-import { User } from '../../user/User';
+import { Actor } from '../../user/User';
 
-export const jester: User = {
-  kind: 'user',
+export const jester: Actor = {
+  __typename: 'User',
+  id: 'jester-id',
   username: 'jester',
-  userId: 'jester-id',
   accounts: [{ id: 'jester-account-id', name: 'jester' }],
 };
 
-export const jester2: User = {
-  kind: 'user',
+export const jester2: Actor = {
+  __typename: 'User',
+  id: 'jester2-id',
   username: 'jester2',
-  userId: 'jester2-id',
   accounts: [{ id: 'jester2-account-id', name: 'jester2' }],
 };
 

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -4,7 +4,7 @@ import pick from 'lodash/pick';
 
 import log from '../log';
 import { confirmAsync } from '../prompts';
-import { User } from '../user/User';
+import { RobotUser, User } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import AndroidApi from './android/api/Client';
 import iOSApi from './ios/api/Client';
@@ -23,7 +23,7 @@ interface Options extends AppleCtxOptions {
 
 export interface Context {
   readonly projectDir: string;
-  readonly user: User;
+  readonly user: User | RobotUser;
   readonly nonInteractive: boolean;
   readonly android: AndroidApi;
   readonly ios: iOSApi;
@@ -63,7 +63,7 @@ class CredentialsContext implements Context {
 
   constructor(
     public readonly projectDir: string,
-    public readonly user: User,
+    public readonly user: User | RobotUser,
     private _exp: ExpoConfig | undefined,
     options: Options
   ) {

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -93,8 +93,7 @@ class CredentialsContext implements Context {
     if (this.hasProjectContext) {
       const owner = getProjectAccountName(this.exp, this.user);
       // Figure out if User A is configuring credentials as admin for User B's project
-      const isProxyUser =
-        this.user.__typename === 'Robot' || (owner && owner !== this.user.username);
+      const isProxyUser = this.user.__typename === 'Robot' || owner !== this.user.username;
 
       log(
         `Accessing credentials ${isProxyUser ? 'on behalf of' : 'for'} ${owner} in project ${

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -6,7 +6,7 @@ import log from '../log';
 import { getProjectAccountName } from '../project/projectUtils';
 import { confirmAsync } from '../prompts';
 import { Actor } from '../user/User';
-import { ensureLoggedInAsync } from '../user/actions';
+import { ensureLoggedInAsync, getActorDisplayName } from '../user/actions';
 import AndroidApi from './android/api/Client';
 import iOSApi from './ios/api/Client';
 import * as IosGraphqlClient from './ios/api/GraphqlClient';
@@ -90,8 +90,8 @@ class CredentialsContext implements Context {
   }
 
   public logOwnerAndProject() {
-    const owner = getProjectAccountName(this.exp, this.user);
     if (this.hasProjectContext) {
+      const owner = getProjectAccountName(this.exp, this.user);
       // Figure out if User A is configuring credentials as admin for User B's project
       const isProxyUser =
         this.user.__typename === 'Robot' || (owner && owner !== this.user.username);
@@ -102,7 +102,7 @@ class CredentialsContext implements Context {
         }`
       );
     } else {
-      log(`Accessing credentials for ${owner}`);
+      log(`Accessing credentials for ${this.exp.owner ?? getActorDisplayName(this.user)}`);
     }
   }
 

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import log from '../../log';
-import { getProjectAccountNameAsync } from '../../project/projectUtils';
+import { getProjectAccountName } from '../../project/projectUtils';
 import { confirmAsync } from '../../prompts';
 import { gitStatusAsync } from '../../utils/git';
 import { Context } from '../context';
@@ -26,7 +26,7 @@ export async function updateAndroidCredentialsAsync(ctx: Context): Promise<void>
       throw error;
     }
   }
-  const accountName = await getProjectAccountNameAsync(ctx.projectDir);
+  const accountName = await getProjectAccountName(ctx.exp, ctx.user);
   const experienceName = `@${accountName}/${ctx.exp.slug}`;
   const keystore = await ctx.android.fetchKeystoreAsync(experienceName);
   if (!keystore) {
@@ -100,7 +100,7 @@ export async function updateIosCredentialsAsync(
     }
   }
 
-  const accountName = await getProjectAccountNameAsync(ctx.projectDir);
+  const accountName = await getProjectAccountName(ctx.exp, ctx.user);
   const appLookupParams = {
     accountName,
     projectName: ctx.exp.slug,

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import log from '../../log';
+import { getProjectAccountNameAsync } from '../../project/projectUtils';
 import { confirmAsync } from '../../prompts';
 import { gitStatusAsync } from '../../utils/git';
 import { Context } from '../context';
@@ -25,7 +26,8 @@ export async function updateAndroidCredentialsAsync(ctx: Context): Promise<void>
       throw error;
     }
   }
-  const experienceName = `@${ctx.exp.owner || ctx.user.username}/${ctx.exp.slug}`;
+  const accountName = await getProjectAccountNameAsync(ctx.projectDir);
+  const experienceName = `@${accountName}/${ctx.exp.slug}`;
   const keystore = await ctx.android.fetchKeystoreAsync(experienceName);
   if (!keystore) {
     throw new Error('There are no credentials configured for this project on Expo servers');
@@ -98,8 +100,9 @@ export async function updateIosCredentialsAsync(
     }
   }
 
+  const accountName = await getProjectAccountNameAsync(ctx.projectDir);
   const appLookupParams = {
-    accountName: ctx.exp.owner ?? ctx.user.username,
+    accountName,
     projectName: ctx.exp.slug,
     bundleIdentifier,
   };

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -146,7 +146,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   private async fetchRemoteAsync(): Promise<PartialIosCredentials> {
     if (this.options.distribution === DistributionType.INTERNAL) {
       const { app } = this.options;
-      const account = findAccountByName(this.ctx.user.accounts, app.accountName);
+      const account = findAccountByName(this.ctx.user.accounts ?? [], app.accountName);
       if (!account) {
         throw new Error(`You do not have access to the ${app.accountName} account`);
       }

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -3,7 +3,7 @@ import { CredentialsSource, DistributionType } from '@expo/eas-json';
 
 import { IosDistributionType } from '../../graphql/generated';
 import log from '../../log';
-import { findAccountByName } from '../../user/Account';
+import { ensureAccounts, findAccountByName } from '../../user/Account';
 import { runCredentialsManagerAsync } from '../CredentialsManager';
 import { CredentialsProvider } from '../CredentialsProvider';
 import { Context } from '../context';
@@ -146,7 +146,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   private async fetchRemoteAsync(): Promise<PartialIosCredentials> {
     if (this.options.distribution === DistributionType.INTERNAL) {
       const { app } = this.options;
-      const account = findAccountByName(this.ctx.user.accounts ?? [], app.accountName);
+      const account = findAccountByName(ensureAccounts(this.ctx.user.accounts), app.accountName);
       if (!account) {
         throw new Error(`You do not have access to the ${app.accountName} account`);
       }

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -33,7 +33,8 @@ export class SetupBuildCredentials implements Action {
     let iosAppBuildCredentials: IosAppBuildCredentials | null = null;
     try {
       if (this.distribution === DistributionType.INTERNAL) {
-        const account = findAccountByName(ctx.user.accounts, this.app.accountName);
+        // todo(cedric): check if we can make `meActor.accounts` a non-nullable array (or always a non-nullable array)
+        const account = findAccountByName(ctx.user.accounts ?? [], this.app.accountName);
         if (!account) {
           throw new Error(`You do not have access to the ${this.app.accountName} account`);
         }

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { AppleDevice, IosAppBuildCredentials } from '../../../graphql/generated';
 import log from '../../../log';
 import { promptAsync } from '../../../prompts';
-import { findAccountByName } from '../../../user/Account';
+import { ensureAccounts, findAccountByName } from '../../../user/Account';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { readIosCredentialsAsync } from '../../credentialsJson/read';
@@ -33,8 +33,7 @@ export class SetupBuildCredentials implements Action {
     let iosAppBuildCredentials: IosAppBuildCredentials | null = null;
     try {
       if (this.distribution === DistributionType.INTERNAL) {
-        // todo(cedric): check if we can make `meActor.accounts` a non-nullable array (or always a non-nullable array)
-        const account = findAccountByName(ctx.user.accounts ?? [], this.app.accountName);
+        const account = findAccountByName(ensureAccounts(ctx.user.accounts), this.app.accountName);
         if (!account) {
           throw new Error(`You do not have access to the ${this.app.accountName} account`);
         }

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -1,6 +1,8 @@
 import { DistributionType } from '@expo/eas-json';
 
+import { getProjectAccountName } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
+import { ensureActorHasUsername } from '../../user/actions';
 import { Action, CredentialsManager } from '../CredentialsManager';
 import { Context } from '../context';
 import { CreateDistributionCertificateStandaloneManager } from '../ios/actions/CreateDistributionCertificate';
@@ -33,7 +35,9 @@ export class ManageIos implements Action {
     manager.pushNextAction(this);
     await ctx.bestEffortAppStoreAuthenticateAsync();
 
-    const accountName = (ctx.hasProjectContext ? ctx.exp.owner : undefined) ?? ctx.user.username;
+    const accountName = ctx.hasProjectContext
+      ? getProjectAccountName(ctx.exp, ctx.user)
+      : ensureActorHasUsername(ctx.user);
     const iosCredentials = await ctx.ios.getAllCredentialsAsync(accountName);
 
     await displayAllIosCredentials(iosCredentials);
@@ -92,7 +96,7 @@ export class ManageIos implements Action {
 
   private getAppLookupParamsFromContext(ctx: Context): AppLookupParams {
     const projectName = ctx.exp.slug;
-    const accountName = ctx.exp.owner || ctx.user.username;
+    const accountName = getProjectAccountName(ctx.exp, ctx.user);
     const bundleIdentifier = ctx.exp.ios?.bundleIdentifier;
     if (!bundleIdentifier) {
       throw new Error(`ios.bundleIdentifier needs to be defined`);

--- a/packages/eas-cli/src/credentials/manager/SelectAndroidApp.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectAndroidApp.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 
+import { getProjectAccountName } from '../../project/projectUtils';
 import { confirmAsync, promptAsync } from '../../prompts';
 import { Action, CredentialsManager, QuitError } from '../CredentialsManager';
 import { AndroidCredentials } from '../android/credentials';
@@ -17,7 +18,7 @@ export class SelectAndroidApp implements Action {
     this.firstRun = false;
 
     if (ctx.hasProjectContext && this.askAboutProjectMode && firstRun) {
-      const projectFullName = `@${ctx.exp.owner || ctx.user.username}/${ctx.exp.slug}`;
+      const projectFullName = `@${getProjectAccountName(ctx.exp, ctx.user)}/${ctx.exp.slug}`;
       const runProjectContext = await confirmAsync({
         message: `You are currently in a directory with project ${chalk.green(
           projectFullName

--- a/packages/eas-cli/src/devices/__tests__/manager-test.ts
+++ b/packages/eas-cli/src/devices/__tests__/manager-test.ts
@@ -1,7 +1,7 @@
 import prompts from 'prompts';
 
 import { asMock } from '../../__tests__/utils';
-import { User } from '../../user/User';
+import { Actor } from '../../user/User';
 import { AccountResolver } from '../manager';
 
 jest.mock('prompts');
@@ -22,9 +22,9 @@ beforeEach(() => {
 
 describe(AccountResolver, () => {
   describe('#resolveAccountAsync', () => {
-    const user: User = {
-      kind: 'user',
-      userId: 'user_id_666',
+    const user: Actor = {
+      __typename: 'User',
+      id: 'user_id_666',
       username: 'dominik',
       accounts: [
         { id: 'account_id_777', name: 'dominik' },
@@ -42,7 +42,7 @@ describe(AccountResolver, () => {
 
         const resolver = new AccountResolver(projectDir, user);
         const account = await resolver.resolveAccountAsync();
-        expect(account).toEqual(user.accounts[1]);
+        expect(account).toEqual(user.accounts![1]);
       });
 
       it('asks the user to choose the account from his account list if he rejects to use the one defined in app.json / app.config.js', async () => {
@@ -50,22 +50,22 @@ describe(AccountResolver, () => {
           useProjectAccount: false,
         }));
         asMock(prompts).mockImplementationOnce(() => ({
-          account: user.accounts[0],
+          account: user.accounts![0],
         }));
 
         const resolver = new AccountResolver(projectDir, user);
         const account = await resolver.resolveAccountAsync();
-        expect(account).toEqual(user.accounts[0]);
+        expect(account).toEqual(user.accounts![0]);
       });
 
       it(`asks the user to choose the account from his account list if he doesn't have access to the account defined in app.json / app.config.js`, async () => {
         asMock(prompts).mockImplementationOnce(() => ({
-          account: user.accounts[0],
+          account: user.accounts![0],
         }));
 
-        const userWithAccessToProjectAccount: User = {
+        const userWithAccessToProjectAccount: Actor = {
           ...user,
-          accounts: [user.accounts[0]],
+          accounts: [user.accounts![0]],
         };
 
         const originalConsoleWarn = console.warn;
@@ -73,7 +73,7 @@ describe(AccountResolver, () => {
 
         const resolver = new AccountResolver(projectDir, userWithAccessToProjectAccount);
         const account = await resolver.resolveAccountAsync();
-        expect(account).toEqual(user.accounts[0]);
+        expect(account).toEqual(user.accounts![0]);
         expect(console.warn).toBeCalledWith(expect.stringMatching(/doesn't have access to the/));
 
         console.warn = originalConsoleWarn;
@@ -83,12 +83,12 @@ describe(AccountResolver, () => {
     describe('when outside project dir', () => {
       it('asks the user to choose the account from his account list', async () => {
         asMock(prompts).mockImplementationOnce(() => ({
-          account: user.accounts[0],
+          account: user.accounts![0],
         }));
 
         const resolver = new AccountResolver(null, user);
         const account = await resolver.resolveAccountAsync();
-        expect(account).toEqual(user.accounts[0]);
+        expect(account).toEqual(user.accounts![0]);
       });
     });
   });

--- a/packages/eas-cli/src/devices/__tests__/manager-test.ts
+++ b/packages/eas-cli/src/devices/__tests__/manager-test.ts
@@ -42,7 +42,7 @@ describe(AccountResolver, () => {
 
         const resolver = new AccountResolver(projectDir, user);
         const account = await resolver.resolveAccountAsync();
-        expect(account).toEqual(user.accounts![1]);
+        expect(account).toEqual(user.accounts[1]);
       });
 
       it('asks the user to choose the account from his account list if he rejects to use the one defined in app.json / app.config.js', async () => {
@@ -50,22 +50,22 @@ describe(AccountResolver, () => {
           useProjectAccount: false,
         }));
         asMock(prompts).mockImplementationOnce(() => ({
-          account: user.accounts![0],
+          account: user.accounts[0],
         }));
 
         const resolver = new AccountResolver(projectDir, user);
         const account = await resolver.resolveAccountAsync();
-        expect(account).toEqual(user.accounts![0]);
+        expect(account).toEqual(user.accounts[0]);
       });
 
       it(`asks the user to choose the account from his account list if he doesn't have access to the account defined in app.json / app.config.js`, async () => {
         asMock(prompts).mockImplementationOnce(() => ({
-          account: user.accounts![0],
+          account: user.accounts[0],
         }));
 
         const userWithAccessToProjectAccount: Actor = {
           ...user,
-          accounts: [user.accounts![0]],
+          accounts: [user.accounts[0]],
         };
 
         const originalConsoleWarn = console.warn;
@@ -73,7 +73,7 @@ describe(AccountResolver, () => {
 
         const resolver = new AccountResolver(projectDir, userWithAccessToProjectAccount);
         const account = await resolver.resolveAccountAsync();
-        expect(account).toEqual(user.accounts![0]);
+        expect(account).toEqual(user.accounts[0]);
         expect(console.warn).toBeCalledWith(expect.stringMatching(/doesn't have access to the/));
 
         console.warn = originalConsoleWarn;
@@ -83,12 +83,12 @@ describe(AccountResolver, () => {
     describe('when outside project dir', () => {
       it('asks the user to choose the account from his account list', async () => {
         asMock(prompts).mockImplementationOnce(() => ({
-          account: user.accounts![0],
+          account: user.accounts[0],
         }));
 
         const resolver = new AccountResolver(null, user);
         const account = await resolver.resolveAccountAsync();
-        expect(account).toEqual(user.accounts![0]);
+        expect(account).toEqual(user.accounts[0]);
       });
     });
   });

--- a/packages/eas-cli/src/devices/__tests__/manager-test.ts
+++ b/packages/eas-cli/src/devices/__tests__/manager-test.ts
@@ -23,6 +23,7 @@ beforeEach(() => {
 describe(AccountResolver, () => {
   describe('#resolveAccountAsync', () => {
     const user: User = {
+      kind: 'user',
       userId: 'user_id_666',
       username: 'dominik',
       accounts: [

--- a/packages/eas-cli/src/devices/context.ts
+++ b/packages/eas-cli/src/devices/context.ts
@@ -1,11 +1,11 @@
 import AppStoreApi from '../credentials/ios/appstore/AppStoreApi';
 import { findProjectRootAsync } from '../project/projectUtils';
-import { RobotUser, User } from '../user/User';
+import { Actor } from '../user/User';
 
 export interface DeviceManagerContext {
   appStore: AppStoreApi;
   projectDir: string | null;
-  user: User | RobotUser;
+  user: Actor;
 }
 
 export async function createContext({
@@ -15,7 +15,7 @@ export async function createContext({
 }: {
   appStore: AppStoreApi;
   cwd?: string;
-  user: User | RobotUser;
+  user: Actor;
 }): Promise<DeviceManagerContext> {
   return {
     appStore,

--- a/packages/eas-cli/src/devices/context.ts
+++ b/packages/eas-cli/src/devices/context.ts
@@ -1,11 +1,11 @@
 import AppStoreApi from '../credentials/ios/appstore/AppStoreApi';
 import { findProjectRootAsync } from '../project/projectUtils';
-import { User } from '../user/User';
+import { RobotUser, User } from '../user/User';
 
 export interface DeviceManagerContext {
   appStore: AppStoreApi;
   projectDir: string | null;
-  user: User;
+  user: User | RobotUser;
 }
 
 export async function createContext({
@@ -15,7 +15,7 @@ export async function createContext({
 }: {
   appStore: AppStoreApi;
   cwd?: string;
-  user: User;
+  user: User | RobotUser;
 }): Promise<DeviceManagerContext> {
   return {
     appStore,

--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -8,7 +8,7 @@ import log from '../log';
 import { getProjectAccountNameAsync } from '../project/projectUtils';
 import { Choice, confirmAsync, promptAsync } from '../prompts';
 import { Account, findAccountByName } from '../user/Account';
-import { User } from '../user/User';
+import { RobotUser, User } from '../user/User';
 import DeviceCreateAction from './actions/create/action';
 import { DeviceManagerContext } from './context';
 
@@ -44,7 +44,7 @@ export default class DeviceManager {
 }
 
 export class AccountResolver {
-  constructor(private projectDir: string | null, private user: User) {}
+  constructor(private projectDir: string | null, private user: User | RobotUser) {}
 
   public async resolveAccountAsync(): Promise<Account> {
     if (this.projectDir) {

--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -64,7 +64,7 @@ export class AccountResolver {
     const projectAccount = findAccountByName(this.user.accounts ?? [], projectAccountName);
     if (!projectAccount) {
       log.warn(
-        `Your user (${getActorDisplayName(this.user)}) doesn't have access to the ${chalk.bold(
+        `Your account (${getActorDisplayName(this.user)}) doesn't have access to the ${chalk.bold(
           projectAccountName
         )} account`
       );

--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -7,7 +7,7 @@ import { AppleTeam } from '../graphql/generated';
 import log from '../log';
 import { getProjectAccountNameAsync } from '../project/projectUtils';
 import { Choice, confirmAsync, promptAsync } from '../prompts';
-import { Account, findAccountByName } from '../user/Account';
+import { Account, ensureAccounts, findAccountByName } from '../user/Account';
 import { Actor } from '../user/User';
 import { getActorDisplayName } from '../user/actions';
 import DeviceCreateAction from './actions/create/action';
@@ -61,7 +61,10 @@ export class AccountResolver {
     assert(this.projectDir, 'project directory is not set ');
 
     const projectAccountName = await getProjectAccountNameAsync(this.projectDir);
-    const projectAccount = findAccountByName(this.user.accounts ?? [], projectAccountName);
+    const projectAccount = findAccountByName(
+      ensureAccounts(this.user.accounts),
+      projectAccountName
+    );
     if (!projectAccount) {
       log.warn(
         `Your account (${getActorDisplayName(this.user)}) doesn't have access to the ${chalk.bold(
@@ -83,8 +86,8 @@ export class AccountResolver {
   }
 
   private async promptForAccountAsync(): Promise<Account> {
-    const choices: Choice[] = (this.user.accounts ?? []).filter(Boolean).map(account => ({
-      title: account!.name,
+    const choices: Choice[] = ensureAccounts(this.user.accounts).map(account => ({
+      title: account.name,
       value: account,
     }));
     const { account } = await promptAsync({

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1201,9 +1201,15 @@ export type BuildPublicData = {
   __typename?: 'BuildPublicData';
   id: Scalars['ID'];
   status: BuildStatus;
+  artifacts: PublicArtifacts;
   project: ProjectPublicData;
   platform: AppPlatform;
   distribution?: Maybe<DistributionType>;
+};
+
+export type PublicArtifacts = {
+  __typename?: 'PublicArtifacts';
+  buildUrl?: Maybe<Scalars['String']>;
 };
 
 export type ProjectPublicData = {
@@ -1423,6 +1429,8 @@ export type RootMutation = {
   userInvitation: UserInvitationMutation;
   /** Mutations that modify the currently authenticated User */
   me?: Maybe<MeMutation>;
+  /** Mutations that modify an EmailSubscription */
+  emailSubscription: EmailSubscriptionMutation;
 };
 
 
@@ -2479,6 +2487,46 @@ export type SecondFactorBooleanResult = {
 export type SecondFactorRegenerateBackupCodesResult = {
   __typename?: 'SecondFactorRegenerateBackupCodesResult';
   plaintextBackupCodes: Array<Maybe<Scalars['String']>>;
+};
+
+export type EmailSubscriptionMutation = {
+  __typename?: 'EmailSubscriptionMutation';
+  addUser?: Maybe<AddUserPayload>;
+};
+
+
+export type EmailSubscriptionMutationAddUserArgs = {
+  addUserInput: AddUserInput;
+};
+
+export type AddUserInput = {
+  email: Scalars['String'];
+  tags?: Maybe<Array<MailchimpTag>>;
+  audience?: Maybe<MailchimpAudience>;
+};
+
+export enum MailchimpTag {
+  EasMasterList = 'EAS_MASTER_LIST'
+}
+
+export enum MailchimpAudience {
+  ExpoDevelopers = 'EXPO_DEVELOPERS'
+}
+
+export type AddUserPayload = {
+  __typename?: 'AddUserPayload';
+  id?: Maybe<Scalars['String']>;
+  email_address?: Maybe<Scalars['String']>;
+  status?: Maybe<Scalars['String']>;
+  timestamp_signup?: Maybe<Scalars['String']>;
+  tags?: Maybe<Array<MailchimpTagPayload>>;
+  list_id?: Maybe<Scalars['String']>;
+};
+
+export type MailchimpTagPayload = {
+  __typename?: 'MailchimpTagPayload';
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 export type BaseSearchResult = SearchResult & {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2593,14 +2593,14 @@ export type CurrentUserQuery = (
   { __typename?: 'RootQuery' }
   & { meActor?: Maybe<(
     { __typename: 'User' }
-    & Pick<User, 'username' | 'id' | 'isExpoAdmin'>
+    & Pick<User, 'username' | 'id'>
     & { accounts?: Maybe<Array<Maybe<(
       { __typename?: 'Account' }
       & Pick<Account, 'id' | 'name'>
     )>>> }
   ) | (
     { __typename: 'Robot' }
-    & Pick<Robot, 'firstName' | 'id' | 'isExpoAdmin'>
+    & Pick<Robot, 'firstName' | 'id'>
     & { accounts?: Maybe<Array<Maybe<(
       { __typename?: 'Account' }
       & Pick<Account, 'id' | 'name'>

--- a/packages/eas-cli/src/graphql/queries/UserQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UserQuery.ts
@@ -1,23 +1,19 @@
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
-import { Account, Robot, User } from '../generated';
-
-type CurrentUserQueryResult = { accounts: Pick<Account, 'id' | 'name'>[] } & (
-  | Pick<User, '__typename' | 'id' | 'username'>
-  | Pick<Robot, '__typename' | 'id' | 'firstName'>
-);
+import { CurrentUserQuery } from '../generated';
 
 const UserQuery = {
-  async currentUserAsync(): Promise<CurrentUserQueryResult | null> {
+  async currentUserAsync(): Promise<CurrentUserQuery['meActor']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<{ meActor: CurrentUserQueryResult | null }>(
+        .query<CurrentUserQuery>(
           gql`
-            {
+            query CurrentUser {
               meActor {
                 __typename
                 id
+                isExpoAdmin
                 ... on User {
                   username
                 }

--- a/packages/eas-cli/src/graphql/queries/UserQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UserQuery.ts
@@ -13,7 +13,6 @@ const UserQuery = {
               meActor {
                 __typename
                 id
-                isExpoAdmin
                 ... on User {
                   username
                 }

--- a/packages/eas-cli/src/project/__tests__/project-utils.ts
+++ b/packages/eas-cli/src/project/__tests__/project-utils.ts
@@ -1,4 +1,4 @@
-import { User } from '../../user/User';
+import { Actor } from '../../user/User';
 
 interface MockProject {
   projectRoot: string;
@@ -20,13 +20,13 @@ interface AppJSON {
     version: string;
     slug: string;
     sdkVersion: string;
-    owner: string;
+    owner?: string;
     [key: string]: any;
   };
 }
 
 function createTestProject(
-  user: User,
+  user: Actor,
   appJSONExtraData?: Record<string, object | string>
 ): MockProject {
   const projectRoot = '/test-project';
@@ -37,13 +37,14 @@ function createTestProject(
     main: 'index.js',
   };
 
+  const owner = appJSONExtraData?.owner as string | undefined;
   const appJSON: AppJSON = {
     expo: {
       name: 'testing 123',
       version: '0.1.0',
       slug: 'testing-123',
       sdkVersion: '33.0.0',
-      owner: user.username,
+      owner: owner ?? (user.__typename === 'User' ? user.username : undefined),
       ...appJSONExtraData,
     },
   };

--- a/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
@@ -2,7 +2,7 @@ import { getConfig } from '@expo/config';
 import { vol } from 'memfs';
 
 import { asMock } from '../../__tests__/utils';
-import { User, getUserAsync } from '../../user/User';
+import { RobotUser, User, getUserAsync } from '../../user/User';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../projectUtils';
 
 jest.mock('@expo/config');
@@ -52,7 +52,8 @@ describe(getProjectAccountNameAsync, () => {
         owner: 'dominik',
       },
     }));
-    asMock(getUserAsync).mockImplementation((): User | undefined => ({
+    asMock(getUserAsync).mockImplementation((): User | RobotUser | undefined => ({
+      kind: 'user',
       userId: 'user_id',
       username: 'notnotbrent',
       accounts: [
@@ -70,6 +71,7 @@ describe(getProjectAccountNameAsync, () => {
       exp: {},
     }));
     asMock(getUserAsync).mockImplementation((): User | undefined => ({
+      kind: 'user',
       userId: 'user_id',
       username: 'notnotbrent',
       accounts: [

--- a/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
@@ -3,7 +3,11 @@ import { vol } from 'memfs';
 
 import { asMock } from '../../__tests__/utils';
 import { Actor, getUserAsync } from '../../user/User';
-import { findProjectRootAsync, getProjectAccountNameAsync } from '../projectUtils';
+import {
+  findProjectRootAsync,
+  getProjectAccountName,
+  getProjectAccountNameAsync,
+} from '../projectUtils';
 
 jest.mock('@expo/config');
 jest.mock('fs');
@@ -37,6 +41,48 @@ describe(findProjectRootAsync, () => {
     );
     const projectRoot = await findProjectRootAsync('/app/src');
     expect(projectRoot).toBe('/app');
+  });
+});
+
+describe(getProjectAccountName, () => {
+  const expWithOwner: any = { owner: 'dominik' };
+  const expWithoutOwner: any = {};
+
+  it('returns owner for user actor', () => {
+    const projectAccountName = getProjectAccountName(expWithOwner, {
+      __typename: 'User',
+      id: 'userId',
+      username: 'notbrent',
+    });
+    expect(projectAccountName).toBe(expWithOwner.owner);
+  });
+
+  it('returns owner for robot actor', () => {
+    const projectAccountName = getProjectAccountName(expWithOwner, {
+      __typename: 'Robot',
+      id: 'userId',
+      firstName: 'notauser',
+    });
+    expect(projectAccountName).toBe(expWithOwner.owner);
+  });
+
+  it('returns username for user actor when owner is undefined', () => {
+    const projectAccountName = getProjectAccountName(expWithoutOwner, {
+      __typename: 'User',
+      id: 'userId',
+      username: 'dominik',
+    });
+    expect(projectAccountName).toBe('dominik');
+  });
+
+  it('throws for robot actor when owner is undefined', () => {
+    const resolveProjectAccountName = () =>
+      getProjectAccountName(expWithoutOwner, {
+        __typename: 'Robot',
+        id: 'userId',
+        firstName: 'notauser',
+      });
+    expect(resolveProjectAccountName).toThrow('manifest property is required');
   });
 });
 
@@ -93,5 +139,21 @@ describe(getProjectAccountNameAsync, () => {
     asMock(getUserAsync).mockImplementation((): Actor | undefined => undefined);
 
     expect(getProjectAccountNameAsync('/app')).rejects.toThrow(/logged in/);
+  });
+
+  it(`throws when project owner is undefined for robot actors`, async () => {
+    asMock(getConfig).mockImplementation(() => ({
+      exp: {},
+    }));
+    asMock(getUserAsync).mockImplementation((): Actor | undefined => ({
+      __typename: 'Robot',
+      id: 'user_id',
+      firstName: 'GLaDOS',
+      accounts: [
+        { id: 'account_id_1', name: 'notnotbrent' },
+        { id: 'account_id_2', name: 'dominik' },
+      ],
+    }));
+    expect(getProjectAccountNameAsync('/app')).rejects.toThrow('manifest property is required');
   });
 });

--- a/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
@@ -2,7 +2,7 @@ import { getConfig } from '@expo/config';
 import { vol } from 'memfs';
 
 import { asMock } from '../../__tests__/utils';
-import { RobotUser, User, getUserAsync } from '../../user/User';
+import { Actor, getUserAsync } from '../../user/User';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../projectUtils';
 
 jest.mock('@expo/config');
@@ -52,9 +52,9 @@ describe(getProjectAccountNameAsync, () => {
         owner: 'dominik',
       },
     }));
-    asMock(getUserAsync).mockImplementation((): User | RobotUser | undefined => ({
-      kind: 'user',
-      userId: 'user_id',
+    asMock(getUserAsync).mockImplementation((): Actor | undefined => ({
+      __typename: 'User',
+      id: 'user_id',
       username: 'notnotbrent',
       accounts: [
         { id: 'account_id_1', name: 'notnotbrent' },
@@ -70,9 +70,9 @@ describe(getProjectAccountNameAsync, () => {
     asMock(getConfig).mockImplementation(() => ({
       exp: {},
     }));
-    asMock(getUserAsync).mockImplementation((): User | undefined => ({
-      kind: 'user',
-      userId: 'user_id',
+    asMock(getUserAsync).mockImplementation((): Actor | undefined => ({
+      __typename: 'User',
+      id: 'user_id',
       username: 'notnotbrent',
       accounts: [
         { id: 'account_id_1', name: 'notnotbrent' },
@@ -90,7 +90,7 @@ describe(getProjectAccountNameAsync, () => {
         owner: 'dominik',
       },
     }));
-    asMock(getUserAsync).mockImplementation((): User | undefined => undefined);
+    asMock(getUserAsync).mockImplementation((): Actor | undefined => undefined);
 
     expect(getProjectAccountNameAsync('/app')).rejects.toThrow(/logged in/);
   });

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -14,6 +14,11 @@ import { ensureProjectExistsAsync } from './ensureProjectExists';
 export async function getProjectAccountNameAsync(projectDir: string): Promise<string> {
   const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
   const user = await ensureLoggedInAsync();
+  if (user.kind === 'robot' && !exp.owner) {
+    throw new Error(
+      'The "owner" manifest property is required when using robot users. See: https://docs.expo.io/versions/latest/config/app/#owner'
+    );
+  }
   return exp.owner || user.username;
 }
 

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -12,7 +12,7 @@ import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import { ensureProjectExistsAsync } from './ensureProjectExists';
 
-export function getProjectAccountName(exp: ExpoConfig, user: Actor) {
+export function getProjectAccountName(exp: ExpoConfig, user: Actor): string {
   switch (user.__typename) {
     case 'User':
       return exp.owner || user.username;

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -40,7 +40,7 @@ export async function findProjectRootAsync(cwd?: string): Promise<string | null>
 export async function getProjectIdAsync(projectDir: string): Promise<string> {
   const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
   return await ensureProjectExistsAsync({
-    accountName: await getProjectAccountNameAsync(projectDir),
+    accountName: getProjectAccountName(exp, await ensureLoggedInAsync()),
     projectName: exp.slug,
     privacy: exp.privacy,
   });

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -1,4 +1,4 @@
-import { getConfig, getConfigFilePaths } from '@expo/config';
+import { ExpoConfig, getConfig, getConfigFilePaths } from '@expo/config';
 import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
 import { Platform } from '@expo/eas-build-job';
 import fs from 'fs-extra';
@@ -8,18 +8,28 @@ import pkgDir from 'pkg-dir';
 
 import { graphqlClient, withErrorHandlingAsync } from '../graphql/client';
 import { UpdateRelease } from '../graphql/generated';
+import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import { ensureProjectExistsAsync } from './ensureProjectExists';
+
+export function getProjectAccountName(exp: ExpoConfig, user: Actor) {
+  switch (user.__typename) {
+    case 'User':
+      return exp.owner || user.username;
+    case 'Robot':
+      if (!exp.owner) {
+        throw new Error(
+          'The "owner" manifest property is required when using robot users. See: https://docs.expo.io/versions/latest/config/app/#owner'
+        );
+      }
+      return exp.owner;
+  }
+}
 
 export async function getProjectAccountNameAsync(projectDir: string): Promise<string> {
   const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
   const user = await ensureLoggedInAsync();
-  if (user.kind === 'robot' && !exp.owner) {
-    throw new Error(
-      'The "owner" manifest property is required when using robot users. See: https://docs.expo.io/versions/latest/config/app/#owner'
-    );
-  }
-  return exp.owner || user.username;
+  return getProjectAccountName(exp, user);
 }
 
 export async function findProjectRootAsync(cwd?: string): Promise<string | null> {

--- a/packages/eas-cli/src/user/Account.ts
+++ b/packages/eas-cli/src/user/Account.ts
@@ -2,6 +2,9 @@ import { Account as GraphQLAccount } from '../graphql/generated';
 
 export type Account = Pick<GraphQLAccount, 'id' | 'name'>;
 
-export function findAccountByName(accounts: Account[], needle: string): Account | undefined {
-  return accounts.find(({ name }) => name === needle);
+export function findAccountByName(
+  accounts: (Account | null)[],
+  needle: string
+): Account | undefined {
+  return accounts.find(account => account?.name === needle)!;
 }

--- a/packages/eas-cli/src/user/Account.ts
+++ b/packages/eas-cli/src/user/Account.ts
@@ -2,9 +2,13 @@ import { Account as GraphQLAccount } from '../graphql/generated';
 
 export type Account = Pick<GraphQLAccount, 'id' | 'name'>;
 
-export function findAccountByName(
-  accounts: (Account | null)[],
-  needle: string
-): Account | undefined {
-  return accounts.find(account => account?.name === needle)!;
+export function findAccountByName(accounts: Account[], needle: string): Account | undefined {
+  return accounts.find(({ name }) => name === needle);
+}
+
+/**
+ * @todo Remove once the server has strict `[Account!]!` typing
+ */
+export function ensureAccounts(accounts?: (Account | null)[] | null): Account[] {
+  return (accounts || []).filter(account => account) as Account[];
 }

--- a/packages/eas-cli/src/user/__tests__/actions-test.ts
+++ b/packages/eas-cli/src/user/__tests__/actions-test.ts
@@ -1,0 +1,42 @@
+import { Actor } from '../User';
+import { ensureActorHasUsername, getActorDisplayName } from '../actions';
+
+const userStub: Actor = {
+  __typename: 'User',
+  id: 'userId',
+  username: 'username',
+};
+
+const robotStub: Actor = {
+  __typename: 'Robot',
+  id: 'userId',
+  firstName: 'GLaDOS',
+};
+
+describe('getActorDisplayName', () => {
+  it('returns anonymous for unauthenticated users', () => {
+    expect(getActorDisplayName()).toBe('anonymous');
+  });
+
+  it('returns username for user actors', () => {
+    expect(getActorDisplayName(userStub)).toBe(userStub.username);
+  });
+
+  it('returns firstName with robot prefix for robot actors', () => {
+    expect(getActorDisplayName(robotStub)).toBe(`${robotStub.firstName} (robot)`);
+  });
+
+  it('returns robot prefix only for robot actors without firstName', () => {
+    expect(getActorDisplayName({ ...robotStub, firstName: undefined })).toBe('robot');
+  });
+});
+
+describe('ensureActorHasUsername', () => {
+  it('returns username for user actors', () => {
+    expect(ensureActorHasUsername(userStub)).toBe(userStub.username);
+  });
+
+  it('throws for robot actors', () => {
+    expect(() => ensureActorHasUsername(robotStub)).toThrow('not supported for robot');
+  });
+});

--- a/packages/eas-cli/src/user/__tests__/sessionStorage-test.ts
+++ b/packages/eas-cli/src/user/__tests__/sessionStorage-test.ts
@@ -1,0 +1,66 @@
+import fs from 'fs-extra';
+import { vol } from 'memfs';
+import path from 'path';
+
+import { getStateJsonPath } from '../../utils/paths';
+import { getAccessToken, getSession, getSessionSecret, setSessionAsync } from '../sessionStorage';
+
+jest.mock('fs');
+
+const authStub: any = {
+  sessionSecret: 'SESSION_SECRET',
+  userId: 'USER_ID',
+  username: 'USERNAME',
+  currentConnection: 'Username-Password-Authentication',
+};
+
+beforeEach(() => {
+  vol.reset();
+});
+
+describe('getSession', () => {
+  it('returns null when session is not stored', () => {
+    expect(getSession()).toBeNull();
+  });
+
+  it('returns stored session data', async () => {
+    await fs.mkdirp(path.dirname(getStateJsonPath()));
+    await fs.writeJSON(getStateJsonPath(), { auth: authStub });
+    expect(getSession()).toMatchObject(authStub);
+  });
+});
+
+describe('setSessionAsync', () => {
+  it('stores empty session data', async () => {
+    await setSessionAsync();
+    expect(await fs.pathExists(getStateJsonPath())).toBeTruthy();
+  });
+
+  it('stores actual session data', async () => {
+    await setSessionAsync(authStub);
+    expect(await fs.readJSON(getStateJsonPath())).toMatchObject({ auth: authStub });
+  });
+});
+
+describe('getAccessToken', () => {
+  it('returns null when envvar is undefined', () => {
+    expect(getAccessToken()).toBeNull();
+  });
+
+  it('returns token when envar is defined', () => {
+    process.env.EXPO_TOKEN = 'mytesttoken';
+    expect(getAccessToken()).toBe('mytesttoken');
+    process.env.EXPO_TOKEN = undefined;
+  });
+});
+
+describe('getSessionSecret', () => {
+  it('returns null when session is not stored', () => {
+    expect(getSessionSecret()).toBeNull();
+  });
+
+  it('returns secret when session is stored', async () => {
+    await setSessionAsync(authStub);
+    expect(getSessionSecret()).toBe(authStub.sessionSecret);
+  });
+});

--- a/packages/eas-cli/src/user/actions.ts
+++ b/packages/eas-cli/src/user/actions.ts
@@ -1,6 +1,6 @@
 import log from '../log';
 import { promptAsync } from '../prompts';
-import { RobotUser, User, getUserAsync, loginAsync } from './User';
+import { Actor, getUserAsync, loginAsync } from './User';
 
 export async function showLoginPromptAsync(): Promise<void> {
   const { username, password } = await promptAsync([
@@ -21,8 +21,8 @@ export async function showLoginPromptAsync(): Promise<void> {
   });
 }
 
-export async function ensureLoggedInAsync(): Promise<User | RobotUser> {
-  let user: User | RobotUser | undefined;
+export async function ensureLoggedInAsync(): Promise<Actor> {
+  let user: Actor | undefined;
   try {
     user = await getUserAsync();
   } catch (_) {}
@@ -39,4 +39,27 @@ export async function ensureLoggedInAsync(): Promise<User | RobotUser> {
   }
 
   return user;
+}
+
+/**
+ * Resolve the name of the actor, either normal user or robot user.
+ * This should be used whenever the "current user" needs to be displayed.
+ * The display name CANNOT be used as project owner.
+ */
+export function getActorDisplayName(user?: Actor): string {
+  switch (user?.__typename) {
+    case 'User':
+      return user.username;
+    case 'Robot':
+      return user.firstName ? `${user.firstName} (robot)` : 'robot';
+    default:
+      return 'anonymous';
+  }
+}
+
+export function ensureActorHasUsername(user: Actor) {
+  if (user.__typename === 'User') {
+    return user.username;
+  }
+  throw new Error('This action is not supported for robot users.');
 }

--- a/packages/eas-cli/src/user/actions.ts
+++ b/packages/eas-cli/src/user/actions.ts
@@ -1,6 +1,6 @@
 import log from '../log';
 import { promptAsync } from '../prompts';
-import { User, getUserAsync, loginAsync } from './User';
+import { RobotUser, User, getUserAsync, loginAsync } from './User';
 
 export async function showLoginPromptAsync(): Promise<void> {
   const { username, password } = await promptAsync([
@@ -21,8 +21,8 @@ export async function showLoginPromptAsync(): Promise<void> {
   });
 }
 
-export async function ensureLoggedInAsync(): Promise<User> {
-  let user: User | undefined;
+export async function ensureLoggedInAsync(): Promise<User | RobotUser> {
+  let user: User | RobotUser | undefined;
   try {
     user = await getUserAsync();
   } catch (_) {}

--- a/packages/eas-cli/src/user/actions.ts
+++ b/packages/eas-cli/src/user/actions.ts
@@ -57,7 +57,7 @@ export function getActorDisplayName(user?: Actor): string {
   }
 }
 
-export function ensureActorHasUsername(user: Actor) {
+export function ensureActorHasUsername(user: Actor): string {
   if (user.__typename === 'User') {
     return user.username;
   }


### PR DESCRIPTION
# Why

This adds support for robot users, through `EXPO_TOKEN=<robot-user-token> eas ...`. 

# Future stuff

We could wait for the outcome of the `Actor.displayName` discussion. That could replace the `getActorUserName` helper and make our usernames easier to use.

# How

It's similar to [PR #2440](https://github.com/expo/expo-cli/pull/2440), but implemented in such way that it's heavily reliant on the `CurrentUserQuery` result. If we add properties, like `isExpoAdmin` to this query, they are propagated everywhere once you run `$ yarn generate-graphql-code`.

This has a lot of benefits, including easier to maintain and more type-related to the output of the API. But, relating it more the GraphQL API also has its downsides. For example, the `meActor.accounts` is typed in GraphQL as `accounts: [Account]` meaning:
- `meActor.accounts` can be `null`
- `meActor.accounts` can be an `array`
  - this array can contain `null`
  - this array can contain an object with `id` and `name`

This type of arrays are pure suffering in TypeScript, because we have to account for the possible "`null` or `array`" _AND_ "`null` within the `array`". Would be nicer to have this typed as `accounts: [Account!]!` where possible, it still may contain an empty array but it's way easier to not-have-to-account-for all those possible `null` values.

# Test Plan

- Updated all tests, run `yarn test`
- Add additional tests to both `project` and `user`

**To test manually**
- Create a robot user for your account (see GraphQL query below, not yet available on website)
- Create an access token for your robot user ([using this link](https://staging.expo.io/settings/access-tokens))
- Try smoke testing commands with `EXPO_TOKEN=<robot-token> eas ...` (e.g. `eas whoami`)

<details>
<summary>Create a robot with graphql mutation</summary>
<pre>
mutation {
  robot {
    createRobotForAccount(
      accountID: "{id}"
      robotData: { name: "GLaDOS" }
      permissions: PUBLISH
    ) {
      id
      firstName
    }
  }
}
</pre>
</details>
