### PR TITLE
unify learn more url's format and clean up logs

### DIFF
--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -1,3 +1,5 @@
+import chalk from 'chalk';
+
 import log from '../../log';
 import { platformDisplayNames } from '../constants';
 import { Build } from '../types';
@@ -18,14 +20,14 @@ export function printLogsUrls(
       buildId,
       account: accountName,
     });
-    log(`Logs url: ${logsUrl}`);
+    log(`Logs url: ${chalk.underline(logsUrl)}`);
   } else {
     builds.forEach(({ buildId, platform }) => {
       const logsUrl = getBuildLogsUrl({
         buildId,
         account: accountName,
       });
-      log(`Platform: ${platformDisplayNames[platform]}, Logs url: ${logsUrl}`);
+      log(`Platform: ${platformDisplayNames[platform]}, Logs url: ${chalk.underline(logsUrl)}`);
     });
   }
 }

--- a/packages/eas-cli/src/commands/build/create.ts
+++ b/packages/eas-cli/src/commands/build/create.ts
@@ -46,9 +46,9 @@ export default class BuildCreate extends Command {
     const projectId = await getProjectIdAsync(projectDir);
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
-      log.error(
-        `Your account does not have access to Expo Application Services (EAS) features. Please enroll in EAS to give it a try. ${chalk.dim(
-          'Learn more: https://expo.io/eas'
+      log.warn(
+        `Your account doesn't have access to Expo Application Services (EAS) features. Enroll in EAS to give it a try: ${chalk.underline(
+          'https://expo.io/eas'
         )}`
       );
       process.exitCode = 1;

--- a/packages/eas-cli/src/commands/build/create.ts
+++ b/packages/eas-cli/src/commands/build/create.ts
@@ -1,13 +1,14 @@
 import { Command, flags } from '@oclif/command';
-import chalk from 'chalk';
 import { v4 as uuidv4 } from 'uuid';
 
 import { createCommandContextAsync } from '../../build/context';
 import { buildAsync } from '../../build/create';
 import { AnalyticsEvent, BuildCommandPlatform } from '../../build/types';
 import Analytics from '../../build/utils/analytics';
-import log from '../../log';
-import { isEasEnabledForProjectAsync } from '../../project/isEasEnabledForProject';
+import {
+  isEasEnabledForProjectAsync,
+  warnEasUnavailable,
+} from '../../project/isEasEnabledForProject';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
 
@@ -46,11 +47,7 @@ export default class BuildCreate extends Command {
     const projectId = await getProjectIdAsync(projectDir);
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
-      log.warn(
-        `Your account doesn't have access to Expo Application Services (EAS) features. Enroll in EAS to give it a try: ${chalk.underline(
-          'https://expo.io/eas'
-        )}`
-      );
+      warnEasUnavailable();
       process.exitCode = 1;
       return;
     }

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -1,8 +1,7 @@
 import { Command, flags } from '@oclif/command';
-import chalk from 'chalk';
 
-import log, { learnMore } from '../log';
-import { isEasEnabledForProjectAsync } from '../project/isEasEnabledForProject';
+import { learnMore } from '../log';
+import { isEasEnabledForProjectAsync, warnEasUnavailable } from '../project/isEasEnabledForProject';
 import { findProjectRootAsync, getProjectIdAsync } from '../project/projectUtils';
 import AndroidSubmitCommand from '../submissions/android/AndroidSubmitCommand';
 import IosSubmitCommand from '../submissions/ios/IosSubmitCommand';
@@ -170,11 +169,7 @@ export default class BuildSubmit extends Command {
     const projectId = await getProjectIdAsync(projectDir);
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
-      log.warn(
-        `Your account doesn't have access to Expo Application Services (EAS) features. Enroll in EAS to give it a try: ${chalk.underline(
-          'https://expo.io/eas'
-        )}`
-      );
+      warnEasUnavailable();
       process.exitCode = 1;
       return;
     }

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -1,4 +1,5 @@
 import { Command, flags } from '@oclif/command';
+import chalk from 'chalk';
 
 import log, { learnMore } from '../log';
 import { isEasEnabledForProjectAsync } from '../project/isEasEnabledForProject';
@@ -169,8 +170,8 @@ export default class BuildSubmit extends Command {
     const projectId = await getProjectIdAsync(projectDir);
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
-      log.error(
-        `Your account does not have access to Expo Application Services (EAS) features. Please enroll in EAS to give it a try. ${learnMore(
+      log.warn(
+        `Your account doesn't have access to Expo Application Services (EAS) features. Enroll in EAS to give it a try: ${chalk.underline(
           'https://expo.io/eas'
         )}`
       );

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -1,7 +1,6 @@
 import { Command, flags } from '@oclif/command';
-import chalk from 'chalk';
 
-import log from '../log';
+import log, { learnMore } from '../log';
 import { isEasEnabledForProjectAsync } from '../project/isEasEnabledForProject';
 import { findProjectRootAsync, getProjectIdAsync } from '../project/projectUtils';
 import AndroidSubmitCommand from '../submissions/android/AndroidSubmitCommand';
@@ -107,7 +106,9 @@ export default class BuildSubmit extends Command {
       helpLabel: IOS_FLAGS,
     }),
     'asc-app-id': flags.string({
-      description: `App Store Connect unique application Apple ID number. Providing this param results in skipping app creation step. Learn more here: https://expo.fyi/asc-app-id`,
+      description: `App Store Connect unique application Apple ID number. Providing this param results in skipping app creation step. ${learnMore(
+        'https://expo.fyi/asc-app-id'
+      )}`,
       helpLabel: IOS_FLAGS,
     }),
     'apple-team-id': flags.string({
@@ -169,8 +170,8 @@ export default class BuildSubmit extends Command {
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
       log.error(
-        `Your account does not have access to Expo Application Services (EAS) features. Please enroll in EAS to give it a try. ${chalk.dim(
-          'Learn more: https://expo.io/eas'
+        `Your account does not have access to Expo Application Services (EAS) features. Please enroll in EAS to give it a try. ${learnMore(
+          'https://expo.io/eas'
         )}`
       );
       process.exitCode = 1;

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -69,4 +69,14 @@ log.withTick = function (...args: any[]) {
   consoleLog(chalk.green(figures.tick), ...args);
 };
 
+/**
+ * Format links as dim with an underline.
+ *
+ * @example Learn more: https://expo.io
+ * @param url
+ */
+export function learnMore(url: string): string {
+  return chalk.dim(`Learn more: ${chalk.underline(url)}`);
+}
+
 export default log;

--- a/packages/eas-cli/src/project/isEasEnabledForProject.ts
+++ b/packages/eas-cli/src/project/isEasEnabledForProject.ts
@@ -1,4 +1,7 @@
+import chalk from 'chalk';
+
 import { apiClient } from '../api';
+import log from '../log';
 
 /**
  * Checks if the project is allowed for using EAS services.
@@ -18,4 +21,12 @@ export async function isEasEnabledForProjectAsync(projectId: string): Promise<bo
       throw error;
     }
   }
+}
+
+export function warnEasUnavailable() {
+  log.warn(
+    `Your account doesn't have access to Expo Application Services (EAS) features. Enroll in EAS to give it a try: ${chalk.underline(
+      'https://expo.io/eas'
+    )}`
+  );
 }

--- a/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
-import log from '../../log';
+import log, { learnMore } from '../../log';
 import { promptAsync } from '../../prompts';
 import { isExistingFile } from '../utils/files';
 
@@ -57,8 +57,8 @@ async function askForServiceAccountPathAsync(): Promise<string> {
     `${chalk.bold(
       'A Google Service Account JSON key is required to upload your app to Google Play Store'
     )}.\n` +
-      `If you're not sure what this is or how to create one, ${chalk.dim(
-        'Learn more: https://expo.fyi/creating-google-service-account'
+      `If you're not sure what this is or how to create one, ${learnMore(
+        'https://expo.fyi/creating-google-service-account'
       )}.`
   );
   const { filePath } = await promptAsync({

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -38,7 +38,7 @@ export async function ensureAppStoreConnectAppExistsAsync(
   if (!resolvedBundleId) {
     throw new Error(
       `Please define "expo.ios.bundleIdentifier" in your app config or provide it using --bundle-identifier param.
-Learn more here: https://expo.fyi/bundle-identifier`
+Learn more: https://expo.fyi/bundle-identifier`
     );
   }
 

--- a/packages/eas-cli/src/submissions/ios/AppSpecificPasswordSource.ts
+++ b/packages/eas-cli/src/submissions/ios/AppSpecificPasswordSource.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import wordwrap from 'wordwrap';
 
-import log from '../../log';
+import log, { learnMore } from '../../log';
 import { promptAsync } from '../../prompts';
 
 export enum AppSpecificPasswordSourceType {
@@ -39,7 +39,7 @@ export async function getAppSpecificPasswordAsync(source: AppSpecificPasswordSou
         )} env variable.`
       )
     );
-    log('Learn more about app-specific password: https://expo.fyi/apple-app-specific-password');
+    log(learnMore('https://expo.fyi/apple-app-specific-password'));
 
     const { appSpecificPassword } = await promptAsync({
       name: 'appSpecificPassword',
@@ -49,6 +49,7 @@ export async function getAppSpecificPasswordAsync(source: AppSpecificPasswordSou
     });
     return appSpecificPassword;
   } else {
-    throw new Error('This should never happen');
+    // exhaustive -- should never happen
+    throw new Error(`Unknown app specific password source type "${(source as any)?.sourceType}"`);
   }
 }

--- a/packages/eas-cli/src/submissions/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitCommand.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import getenv from 'getenv';
 import wordwrap from 'wordwrap';
 
-import log from '../../log';
+import log, { learnMore } from '../../log';
 import { promptAsync } from '../../prompts';
 import UserSettings from '../../user/UserSettings';
 import { ArchiveSource, ArchiveTypeSourceType } from '../archiveSource';
@@ -106,7 +106,9 @@ class IosSubmitCommand {
       wrap(
         chalk.italic(
           'Ensuring your app exists on App Store Connect. ' +
-            'This step can be skipped by providing the --asc-app-id param. Learn more here: https://expo.fyi/asc-app-id'
+            `This step can be skipped by providing the --asc-app-id param. ${learnMore(
+              'https://expo.fyi/asc-app-id'
+            )}`
         )
       )
     );

--- a/packages/eas-cli/src/submissions/utils/errors.ts
+++ b/packages/eas-cli/src/submissions/utils/errors.ts
@@ -1,6 +1,4 @@
-import chalk from 'chalk';
-
-import log from '../../log';
+import log, { learnMore } from '../../log';
 import { SubmissionError } from '../SubmissionService.types';
 
 enum SubmissionErrorCode {
@@ -21,15 +19,15 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
     "We couldn't figure out what went wrong. Please see logs to learn more.",
   [SubmissionErrorCode.ANDROID_FIRST_UPLOAD_ERROR]:
     "You haven't submitted this app to Google Play Store yet. The first submission of the app needs to be performed manually.\n" +
-    `${chalk.dim('Learn more: https://expo.fyi/first-android-submission')}.`,
+    `${learnMore('https://expo.fyi/first-android-submission')}.`,
   [SubmissionErrorCode.ANDROID_OLD_VERSION_CODE_ERROR]:
     "You've already submitted this version of the app.\n" +
     'Versions are identified by Android version code (expo.android.versionCode in app.json).\n' +
     "If you're submitting a managed Expo project, increment the version code in app.json and build the project with expo build:android.\n" +
-    `${chalk.dim('Learn more: https://expo.fyi/bumping-android-version-code')}.`,
+    `${learnMore('https://expo.fyi/bumping-android-version-code')}.`,
   [SubmissionErrorCode.ANDROID_MISSING_PRIVACY_POLICY]:
     'The app has permissions that require a privacy policy set for the app.\n' +
-    `${chalk.dim('Learn more: https://expo.fyi/missing-privacy-policy')}.`,
+    `${learnMore('https://expo.fyi/missing-privacy-policy')}.`,
 };
 
 export function printSubmissionError(error: SubmissionError): boolean {


### PR DESCRIPTION
# Why

- In prep for marketing, follow the style of our other tools a little closer (still doesn't implement linked text support).
- dim the `Learn more: <URL>`
- underline the URL
- downgrade user error message to warning
<img width="1046" alt="Screen Shot 2020-12-03 at 10 44 48 AM" src="https://user-images.githubusercontent.com/9664363/101073818-d7dc5c00-3554-11eb-8187-2a666b2914ff.png">

