### PR TITLE
cleaner logging + typos

### DIFF
--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -8,14 +8,16 @@ EAS command line tool
 [![License](https://img.shields.io/npm/l/eas-cli.svg)](https://github.com/expo/eas-cli/blob/main/package.json)
 
 <!-- toc -->
-* [eas-cli](#eas-cli)
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [eas-cli](#eas-cli)
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
 
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g eas-cli
 $ eas COMMAND
@@ -27,28 +29,30 @@ USAGE
   $ eas COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`eas account:login`](#eas-accountlogin)
-* [`eas account:logout`](#eas-accountlogout)
-* [`eas account:view`](#eas-accountview)
-* [`eas build`](#eas-build)
-* [`eas build:configure`](#eas-buildconfigure)
-* [`eas build:create`](#eas-buildcreate)
-* [`eas build:status`](#eas-buildstatus)
-* [`eas credentials`](#eas-credentials)
-* [`eas device:create`](#eas-devicecreate)
-* [`eas help [COMMAND]`](#eas-help-command)
-* [`eas release:create [RELEASENAME]`](#eas-releasecreate-releasename)
-* [`eas submit --platform=(android|ios)`](#eas-submit---platformandroidios)
-* [`eas update:show`](#eas-updateshow)
+
+- [`eas account:login`](#eas-accountlogin)
+- [`eas account:logout`](#eas-accountlogout)
+- [`eas account:view`](#eas-accountview)
+- [`eas build`](#eas-build)
+- [`eas build:configure`](#eas-buildconfigure)
+- [`eas build:create`](#eas-buildcreate)
+- [`eas build:status`](#eas-buildstatus)
+- [`eas credentials`](#eas-credentials)
+- [`eas device:create`](#eas-devicecreate)
+- [`eas help [COMMAND]`](#eas-help-command)
+- [`eas release:create [RELEASENAME]`](#eas-releasecreate-releasename)
+- [`eas submit --platform=(android|ios)`](#eas-submit---platformandroidios)
+- [`eas update:show`](#eas-updateshow)
 
 ## `eas account:login`
 
-log in with your EAS account
+log in with your Expo account
 
 ```
 USAGE
@@ -271,7 +275,7 @@ EXAMPLES
   $ eas submit --platform=ios
        - Fully interactive iOS submission
 
-  $ eas submit --platform=android 
+  $ eas submit --platform=android
        - Fully interactive Android submission
 
   $ eas submit -p android --latest --key=/path/to/google-services.json
@@ -294,4 +298,5 @@ USAGE
 ```
 
 _See code: [build/commands/update/show.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.10/build/commands/update/show.ts)_
+
 <!-- commandsstop -->

--- a/packages/eas-cli/src/build/android/applicationId.ts
+++ b/packages/eas-cli/src/build/android/applicationId.ts
@@ -103,7 +103,7 @@ However, if you choose the one defined in the Android project you'll have to upd
   } else if (!applicationIdFromAndroidProject && applicationIdFromConfig) {
     // This should never happen, adding warning just in case
     log.warn(
-      'applicationId is not specified in your ./android/app/build.gradle file. Make sure your project is confgured correctly before building.'
+      'applicationId is not specified in your ./android/app/build.gradle file. Make sure your project is configured correctly before building.'
     );
     return;
   }

--- a/packages/eas-cli/src/build/ios/bundleIdentifer.ts
+++ b/packages/eas-cli/src/build/ios/bundleIdentifer.ts
@@ -12,7 +12,7 @@ import {
 import { promptAsync } from '../../prompts';
 import { Platform } from '../types';
 
-enum BundleIdenitiferSource {
+enum BundleIdentiferSource {
   XcodeProject,
   AppJson,
 }
@@ -64,23 +64,23 @@ However, if you choose the one defined in the Xcode project you'll have to updat
         choices: [
           {
             title: `${chalk.bold(bundleIdentifierFromPbxproj)} - In Xcode project`,
-            value: BundleIdenitiferSource.XcodeProject,
+            value: BundleIdentiferSource.XcodeProject,
           },
           {
             title: `${chalk.bold(bundleIdentifierFromConfig)} - In your ${configDescription}`,
-            value: BundleIdenitiferSource.AppJson,
+            value: BundleIdentiferSource.AppJson,
           },
         ],
       });
       switch (bundleIdentifierSource) {
-        case BundleIdenitiferSource.AppJson: {
+        case BundleIdentiferSource.AppJson: {
           IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(
             projectDir,
             bundleIdentifierFromConfig
           );
           break;
         }
-        case BundleIdenitiferSource.XcodeProject: {
+        case BundleIdentiferSource.XcodeProject: {
           if (hasBundleIdentifierInStaticConfig) {
             await updateAppJsonConfigAsync(projectDir, exp, bundleIdentifierFromPbxproj);
           } else {

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -34,16 +34,14 @@ export function printLogsUrls(
 
 export function printBuildResults(builds: (Build | null)[]): void {
   if (builds.length === 1) {
-    log(`Artifact url: ${builds[0]?.artifacts?.buildUrl ?? ''}`);
+    const url = builds[0]?.artifacts?.buildUrl ?? '';
+    log(`App: ${chalk.underline(url)}`);
   } else {
     (builds.filter(i => i) as Build[])
       .filter(build => build.status === 'finished')
       .forEach(build => {
-        log(
-          `Platform: ${platformDisplayNames[build.platform]}, Artifact url: ${
-            build.artifacts?.buildUrl ?? ''
-          }`
-        );
+        const url = build.artifacts?.buildUrl ?? '';
+        log(`Platform: ${platformDisplayNames[build.platform]}, App: ${chalk.underline(url)}`);
       });
   }
 }

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -52,12 +52,12 @@ export function printDeprecationWarnings(deprecationInfo?: DeprecationInfo): voi
   }
   if (deprecationInfo.type === 'internal') {
     log.warn('This command is using API that soon will be deprecated, please update expo-cli.');
-    log.warn("Changes won't affect your project confiuration.");
+    log.warn("Changes won't affect your project config.");
     log.warn(deprecationInfo.message);
   } else if (deprecationInfo.type === 'user-facing') {
     log.warn('This command is using API that soon will be deprecated, please update expo-cli.');
     log.warn(
-      'There might be some changes necessary to your project configuration, latest expo-cli will provide more specific error messages.'
+      'There might be some changes necessary to your project config, latest expo-cli will provide more specific error messages.'
     );
     log.warn(deprecationInfo.message);
   } else {

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -4,7 +4,7 @@ import log from '../../log';
 import { showLoginPromptAsync } from '../../user/actions';
 
 export default class AccountLogin extends Command {
-  static description = 'log in with your EAS account';
+  static description = 'log in with your Expo account';
 
   static aliases = ['login'];
 

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -11,6 +11,6 @@ export default class AccountLogin extends Command {
   async run() {
     log('Log in to EAS');
     await showLoginPromptAsync();
-    log('Logged in.');
+    log('Logged in');
   }
 }

--- a/packages/eas-cli/src/commands/account/logout.ts
+++ b/packages/eas-cli/src/commands/account/logout.ts
@@ -10,6 +10,6 @@ export default class AccountLogout extends Command {
 
   async run() {
     await logoutAsync();
-    log('Logged out.');
+    log('Logged out');
   }
 }

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -14,7 +14,7 @@ export default class AccountView extends Command {
     if (user?.username) {
       log(chalk.green(user.username));
     } else {
-      log.warn('Not logged in.');
+      log.warn('Not logged in');
       process.exit(1);
     }
   }

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/UpdateKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/UpdateKeystore-test.ts
@@ -73,7 +73,7 @@ describe('run UpdateKeystore when keystore exist on www', () => {
   });
 });
 
-describe('run UpdateKeystore when keystore deos not exist on www', () => {
+describe('run UpdateKeystore when keystore does not exist on www', () => {
   it('should fail to fetch credentials and generate new ones', async () => {
     const ctx = createCtxMock({
       android: {

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -119,7 +119,7 @@ class CredentialsContext implements Context {
     );
     log(
       chalk.green(
-        'This is optional, but without Apple account access you will need to provide all the values manually and we can only run minimal validatation on them.'
+        'This is optional, but without Apple account access you will need to provide all the values manually and we can only run minimal validation on them.'
       )
     );
     const confirm = await confirmAsync({

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -103,7 +103,7 @@ export async function updateIosCredentialsAsync(
     projectName: ctx.exp.slug,
     bundleIdentifier,
   };
-  const pprofilePath =
+  const profilePath =
     rawCredentialsJsonObject?.ios?.provisioningProfilePath ?? 'ios/certs/profile.mobileprovision';
   const distCertPath =
     rawCredentialsJsonObject?.ios?.distributionCertificate?.path ?? 'ios/certs/dist-cert.p12';
@@ -129,13 +129,13 @@ export async function updateIosCredentialsAsync(
     }
   }
 
-  log(`Writing Provisioning Profile to ${pprofilePath}`);
+  log(`Writing Provisioning Profile to ${profilePath}`);
   await updateFileAsync(
     ctx.projectDir,
-    pprofilePath,
+    profilePath,
     appCredentials?.credentials?.provisioningProfile
   );
-  const shouldWarnPProfile = await isFileUntrackedAsync(pprofilePath);
+  const shouldWarnPProfile = await isFileUntrackedAsync(profilePath);
 
   log(`Writing Distribution Certificate to ${distCertPath}`);
   await updateFileAsync(ctx.projectDir, distCertPath, distCredentials?.certP12);
@@ -143,7 +143,7 @@ export async function updateIosCredentialsAsync(
 
   const iosCredentials: Partial<CredentialsJson['ios']> = {
     ...(appCredentials?.credentials?.provisioningProfile
-      ? { provisioningProfilePath: pprofilePath }
+      ? { provisioningProfilePath: profilePath }
       : {}),
     ...(distCredentials?.certP12 && distCredentials?.certPassword
       ? {
@@ -162,7 +162,7 @@ export async function updateIosCredentialsAsync(
 
   const newFilePaths = [];
   if (shouldWarnPProfile) {
-    newFilePaths.push(pprofilePath);
+    newFilePaths.push(profilePath);
   }
   if (shouldWarnDistCert) {
     newFilePaths.push(distCertPath);

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -151,7 +151,7 @@ export async function selectDistributionCertificateAsync(
     options.filterInvalid && validDistCredentials ? validDistCredentials : distCredentials;
 
   if (distCredentials.length === 0) {
-    log.warn('There are no Distribution Certificates available in your EAS account.');
+    log.warn('There are no Distribution Certificates available in your Expo account.');
     return null;
   }
 

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log from '../../../log';
+import log, { learnMore } from '../../../log';
 import { promptAsync } from '../../../prompts';
 import { CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
@@ -102,7 +102,7 @@ async function generateDistributionCertificateAsync(
           `✅  Distribution Certificates can be revoked with no side effects for App Store builds.`
         )
       );
-      log(chalk.grey(`ℹ️  Learn more here https://docs.expo.io/distribution/app-signing/#summary`));
+      log(learnMore('https://docs.expo.io/distribution/app-signing/#summary'));
       log.newLine();
 
       const { distCertsToRevoke } = await promptAsync({

--- a/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
@@ -53,7 +53,7 @@ export async function selectProvisioningProfileFromExpoAsync(
     ({ credentials }) => !!credentials.provisioningProfile && !!credentials.provisioningProfileId
   );
   if (profiles.length === 0) {
-    log.warn('There are no Provisioning Profiles available in your EAS account.');
+    log.warn('There are no Provisioning Profiles available in your Expo account.');
     return null;
   }
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
@@ -29,7 +29,7 @@ export class SetupDistributionCertificateForApp implements Action {
       return;
     }
 
-    // autoselect creds if we find valid certs
+    // autoselect credentials if we find valid certs
     const autoselectedCertificate = existingCertificates[0];
 
     if (!ctx.nonInteractive) {

--- a/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
@@ -46,7 +46,7 @@ export class SetupProvisioningProfile implements Action {
     assert(distCert, 'missing Distribution Certificate');
 
     const autoselectedProfile = this.choosePreferred(existingProfiles, distCert);
-    // autoselect creds if we find valid certs
+    // autoselect credentials if we find valid certs
 
     if (!ctx.nonInteractive) {
       const confirm = await confirmAsync({

--- a/packages/eas-cli/src/credentials/ios/api/Client.ts
+++ b/packages/eas-cli/src/credentials/ios/api/Client.ts
@@ -24,14 +24,14 @@ type CredentialFields = {
 // appCredentials are identified by `${projectFullName} ${bundleIdentifier}` (see getAppCredentialsCacheIndex method)
 // userCredentials are identified by id (string or numeric depending on API)
 //
-// Expected behaviour of cache (internals)
+// Expected behavior of cache (internals)
 //
 // - when isPrefetched[accountName] true assume everything is synced for that account
 // - when credentials[accountName].appCredentials[experienceNameBundleIdentifier] is truthy assume that user and app credentials for that app are synced
 // - when accessing user or app credentials identified by AppLookupParams fetch all credentials for that app (user and app credentials)
 // - when updating userCredentials refetch only userCredentials
 // - when deleting userCredentials modify prefetched appCredentials without calling api
-// - when updating provisioningProfile refetch all credentials for that app (user and app crednetials)
+// - when updating provisioningProfile refetch all credentials for that app (user and app credentials)
 // - when deleting provisioningProfile modify appCredentials in cache
 // - when deleting pushCert refetch all credentials for app (app + user)
 //
@@ -278,7 +278,7 @@ export default class iOSApi {
     await this.client.deleteProvisioningProfileApi(appLookupParams);
     const appCredentials = this.credentials?.[accountName]?.appCredentials?.[appCredentialsIndex];
     if (appCredentials?.credentials) {
-      // teamId should still be there becaus it might be part of push cert definition
+      // teamId should still be there because it might be part of push cert definition
       appCredentials.credentials = omit(appCredentials.credentials, [
         'provisioningProfile',
         'provisioningProfileId',

--- a/packages/eas-cli/src/credentials/ios/utils/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/provisioningProfile.ts
@@ -10,7 +10,7 @@ function readAppleTeam(dataBase64: string): AppleTeam {
   const teamId = (profilePlist['TeamIdentifier'] as PlistArray)?.[0] as string;
   const teamName = profilePlist['TeamName'] as string;
   if (!teamId) {
-    throw new Error('Team identifier is missing from provisoning profile');
+    throw new Error('Team identifier is missing from provisioning profile');
   }
   return { teamId, teamName };
 }

--- a/packages/eas-cli/src/credentials/manager/HelperActions.ts
+++ b/packages/eas-cli/src/credentials/manager/HelperActions.ts
@@ -4,7 +4,7 @@ import { Action, CredentialsManager } from '../CredentialsManager';
 import { Context } from '../context';
 
 export class PressAnyKeyToContinue implements Action {
-  public async runAsync(manmager: CredentialsManager, context: Context): Promise<void> {
+  public async runAsync(manager: CredentialsManager, context: Context): Promise<void> {
     log('Press any key to continue...');
     await pressAnyKeyToContinueAsync();
     log.newLine();

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -41,7 +41,7 @@ export class ManageIos implements Action {
     const projectSpecificActions: { value: ActionType; title: string }[] = ctx.hasProjectContext
       ? [
           {
-            // This command will be triggered durring build to ensure all credentials are ready
+            // This command will be triggered during build to ensure all credentials are ready
             // I'm leaving it here for now to simplify testing
             value: ActionType.SetupBuildCredentials,
             title: 'Ensure all credentials for project are valid',

--- a/packages/eas-cli/src/project/ensureProjectExists.ts
+++ b/packages/eas-cli/src/project/ensureProjectExists.ts
@@ -27,11 +27,7 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
     return id;
   } catch (err) {
     if (err.graphQLErrors?.some((it: any) => it.extensions?.errorCode !== 'EXPERIENCE_NOT_FOUND')) {
-      spinner.fail(
-        `Something went wrong when looking for project ${chalk.bold(
-          projectFullName
-        )} on Expo servers`
-      );
+      spinner.fail(`Something went wrong while looking for ${chalk.bold(projectFullName)} on Expo`);
       throw err;
     }
   }

--- a/packages/eas-cli/src/project/ensureProjectExists.ts
+++ b/packages/eas-cli/src/project/ensureProjectExists.ts
@@ -19,9 +19,7 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
   const { accountName, projectName } = projectInfo;
   const projectFullName = `@${accountName}/${projectName}`;
 
-  const spinner = ora(
-    `Ensuring project ${chalk.bold(projectFullName)} is registered on Expo servers`
-  ).start();
+  const spinner = ora(`Ensuring ${chalk.bold(projectFullName)} is created on Expo`).start();
 
   try {
     const id = await findProjectIdByAccountNameAndSlugAsync(accountName, projectName);
@@ -39,7 +37,7 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
   }
 
   try {
-    spinner.text = `Registering project ${chalk.bold(projectFullName)} on Expo servers`;
+    spinner.text = `Creating ${chalk.bold(projectFullName)} on Expo`;
     const id = await registerNewProjectAsync(projectInfo);
     spinner.succeed();
     return id;

--- a/packages/eas-cli/src/project/ensureProjectExists.ts
+++ b/packages/eas-cli/src/project/ensureProjectExists.ts
@@ -26,7 +26,7 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
     spinner.succeed();
     return id;
   } catch (err) {
-    if (err.grapgQLErrors?.some((it: any) => it.extensions?.errorCode !== 'EXPERIENCE_NOT_FOUND')) {
+    if (err.graphQLErrors?.some((it: any) => it.extensions?.errorCode !== 'EXPERIENCE_NOT_FOUND')) {
       spinner.fail(
         `Something went wrong when looking for project ${chalk.bold(
           projectFullName

--- a/packages/eas-cli/src/project/ensureProjectExists.ts
+++ b/packages/eas-cli/src/project/ensureProjectExists.ts
@@ -35,7 +35,7 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
   try {
     spinner.text = `Creating ${chalk.bold(projectFullName)} on Expo`;
     const id = await registerNewProjectAsync(projectInfo);
-    spinner.succeed();
+    spinner.succeed(`Created ${chalk.bold(projectFullName)} on Expo`);
     return id;
   } catch (err) {
     spinner.fail();

--- a/packages/eas-cli/src/submissions/archiveSource/ArchiveTypeSource.ts
+++ b/packages/eas-cli/src/submissions/archiveSource/ArchiveTypeSource.ts
@@ -59,7 +59,7 @@ async function handleInferSourceAsync(
   if (inferredArchiveType) {
     return inferredArchiveType;
   } else {
-    log.warn("We couldn't autodetect the archive type");
+    log.warn("We couldn't auto detect the archive type");
     return getArchiveTypeAsync(platform, { sourceType: ArchiveTypeSourceType.prompt }, location);
   }
 }


### PR DESCRIPTION
# Why

- noticed some typos while recording, did a small audit to get others
- changed "Artifact url: <URL>" to "App: <URL>"
- "Ensuring project ${chalk.bold(projectFullName)} is registered on Expo servers" -> "Ensuring ${chalk.bold(projectFullName)} is created on Expo"
