### PR TITLE
clean up spinners and logs

### DIFF
--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -86,7 +86,7 @@ async function waitForBuildEndAsync(
     if (builds.length === 1) {
       switch (builds[0]?.status) {
         case BuildStatus.FINISHED:
-          spinner.succeed('Build finished.');
+          spinner.succeed('Build finished');
           return builds;
         case BuildStatus.IN_QUEUE:
           spinner.text = 'Build queued...';
@@ -95,7 +95,7 @@ async function waitForBuildEndAsync(
           spinner.text = 'Build in progress...';
           break;
         case BuildStatus.ERRORED:
-          spinner.fail('Build failed.');
+          spinner.fail('Build failed');
           throw new Error(`Standalone build failed!`);
         default:
           spinner.warn('Unknown status.');
@@ -103,14 +103,14 @@ async function waitForBuildEndAsync(
       }
     } else {
       if (builds.filter(build => build?.status === BuildStatus.FINISHED).length === builds.length) {
-        spinner.succeed('All build have finished.');
+        spinner.succeed('All builds have finished');
         return builds;
       } else if (
         builds.filter(build =>
           build?.status ? [BuildStatus.FINISHED, BuildStatus.ERRORED].includes(build.status) : false
         ).length === builds.length
       ) {
-        spinner.fail('Some of the builds failed.');
+        spinner.fail('Some of the builds failed');
         return builds;
       } else {
         const inQueue = builds.filter(build => build?.status === BuildStatus.IN_QUEUE).length;
@@ -132,7 +132,7 @@ async function waitForBuildEndAsync(
     time = new Date().getTime();
     await sleep(intervalSec * 1000);
   }
-  spinner.warn('Timed out.');
+  spinner.warn('Timed out');
   throw new Error(
     'Timeout reached! It is taking longer than expected to finish the build, aborting...'
   );

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -31,7 +31,7 @@ export class ConfigureProvisioningProfile implements Action {
   public async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     const profile = await ctx.ios.getProvisioningProfileAsync(this.app);
     if (!profile) {
-      throw new Error('No Provisioning Profile to configure.');
+      throw new Error('No provisioning profile to configure');
     }
 
     if (!profile.provisioningProfileId) {
@@ -42,7 +42,7 @@ export class ConfigureProvisioningProfile implements Action {
     if (ctx.appStore.authCtx) {
       const distCert = await ctx.ios.getDistributionCertificateAsync(this.app);
       if (!distCert) {
-        log.warn('There is no Distribution Certificate assigned to this app.');
+        log.warn('There is no distribution certificate for this app.');
         return;
       }
       const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
@@ -58,9 +58,9 @@ export class ConfigureProvisioningProfile implements Action {
       await this.configureAndUpdateAsync(ctx, this.app, distCert, profilesWithMatchingId[0]);
     } else {
       log.warn(
-        "Without access to your Apple account we can't configure Provisioning Profile for you."
+        "Without access to your Apple account we can't configure provisioning profiles for you."
       );
-      log.warn('Make sure to recreate it if you switched to new Distribution Certificate.');
+      log.warn('Make sure to recreate the profile if you selected a new distribution certificate.');
     }
   }
 
@@ -76,11 +76,10 @@ export class ConfigureProvisioningProfile implements Action {
       profileFromApple,
       distCert
     );
+    const certIdTag = distCert.certId ? ` (${distCert.certId})` : '';
     log(
       chalk.green(
-        `Successfully configured Provisioning Profile ${
-          profileFromApple.provisioningProfileId
-        } on Apple Servers with Distribution Certificate ${distCert.certId || ''}`
+        `Updated Apple provisioning profile (${profileFromApple.provisioningProfileId}) with distribution certificate${certIdTag}`
       )
     );
 
@@ -88,7 +87,7 @@ export class ConfigureProvisioningProfile implements Action {
     await ctx.ios.updateProvisioningProfileAsync(app, updatedProfile);
     log(
       chalk.green(
-        `Successfully updated Provisioning Profile for @${app.accountName}/${app.projectName} (${app.bundleIdentifier})`
+        `Updated provisioning profile for @${app.accountName}/${app.projectName} (${app.bundleIdentifier})`
       )
     );
   }

--- a/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
@@ -65,8 +65,6 @@ export function getRequestContext(authCtx: AuthCtx): RequestContext {
 
 export async function authenticateAsync(options: Options = {}): Promise<AuthCtx> {
   const { appleId, appleIdPassword } = await requestAppleCredentialsAsync(options);
-  log(`Authenticating to Apple Developer Portal...`); // use log instead of spinner in case we need to prompt user for 2fa
-
   try {
     // TODO: The password isn't required for apple-utils. Remove the local prompt when we remove traveling Fastlane.
     const authState = await Auth.loginAsync({
@@ -75,7 +73,6 @@ export async function authenticateAsync(options: Options = {}): Promise<AuthCtx>
       cookies: options.cookies,
       teamId: options.teamId,
     });
-    log(chalk.green('Authenticated with Apple Developer Portal successfully!'));
 
     // Currently, this is resolved once, inside the apple-utils package.
     const teamId = authState.context.teamId!;

--- a/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
@@ -78,7 +78,7 @@ export function transformCertificate(cert: Certificate): DistributionCertificate
 export async function listDistributionCertificatesAsync(
   authCtx: AuthCtx
 ): Promise<DistributionCertificateStoreInfo[]> {
-  const spinner = ora(`Getting Distribution Certificates from Apple...`).start();
+  const spinner = ora(`Fetching Apple distribution certificates`).start();
   try {
     const context = getRequestContext(authCtx);
     const certs = (
@@ -94,10 +94,10 @@ export async function listDistributionCertificatesAsync(
         },
       })
     ).map(transformCertificate);
-    spinner.succeed();
+    spinner.succeed(`Fetched Apple distribution certificates`);
     return certs;
   } catch (error) {
-    spinner.fail();
+    spinner.fail(`Failed to fetch Apple distribution certificates`);
     throw error;
   }
 }
@@ -108,13 +108,13 @@ export async function listDistributionCertificatesAsync(
 export async function createDistributionCertificateAsync(
   authCtx: AuthCtx
 ): Promise<DistributionCertificate> {
-  const spinner = ora(`Creating Distribution Certificate on Apple Servers...`).start();
+  const spinner = ora(`Creating Apple distribution certificate`).start();
   try {
     const context = getRequestContext(authCtx);
     const results = await createCertificateAndP12Async(context, {
       certificateType: CertificateType.IOS_DISTRIBUTION,
     });
-    spinner.succeed();
+    spinner.succeed(`Created Apple distribution certificate`);
     return {
       certId: results.certificate.id,
       certP12: results.certificateP12,
@@ -125,7 +125,7 @@ export async function createDistributionCertificateAsync(
       teamName: authCtx.team.name,
     };
   } catch (error) {
-    spinner.fail('Failed to create Distribution Certificate on Apple Servers');
+    spinner.fail('Failed to create Apple distribution certificate');
     // TODO: Move check into apple-utils
     if (
       /You already have a current .* certificate or a pending certificate request/.test(
@@ -142,14 +142,15 @@ export async function revokeDistributionCertificateAsync(
   authCtx: AuthCtx,
   ids: string[]
 ): Promise<void> {
-  const spinner = ora(`Revoking Distribution Certificate on Apple Servers...`).start();
+  const name = `Apple distribution certificate${ids?.length === 1 ? '' : 's'}`;
+  const spinner = ora(`Revoking ${name}`).start();
   try {
     const context = getRequestContext(authCtx);
     await Promise.all(ids.map(id => Certificate.deleteAsync(context, { id })));
 
-    spinner.succeed();
+    spinner.succeed(`Revoked ${name}`);
   } catch (error) {
-    spinner.fail('Failed to revoke Distribution Certificate on Apple Servers');
+    spinner.fail(`Failed to revoke ${name}`);
     throw error;
   }
 }

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -56,9 +56,9 @@ export async function ensureAppExistsAsync(
       option: options.enablePushNotifications ? CapabilityTypeOption.ON : CapabilityTypeOption.OFF,
       // TODO: Add more capabilities
     });
-    spinner.succeed(`Updated app capabilities for "${bundleIdentifier}"`);
+    spinner.succeed(`Updated capabilities for "${bundleIdentifier}"`);
   } catch (err) {
-    spinner.fail(`Failed to update app capabilities for "${bundleIdentifier}"`);
+    spinner.fail(`Failed to update capabilities for "${bundleIdentifier}"`);
 
     throw err;
   }

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -19,23 +19,22 @@ export async function ensureAppExistsAsync(
   options: EnsureAppExistsOptions = {}
 ) {
   const context = getRequestContext(authCtx);
-  let spinner = ora(`Registering bundle identifier "${bundleIdentifier}"`).start();
+  let spinner = ora(`Checking bundle identifier "${bundleIdentifier}"`).start();
 
   let bundleId: BundleId | null;
   try {
     // Get the bundle id
     bundleId = await BundleId.findAsync(context, { identifier: bundleIdentifier });
 
-    if (bundleId) {
-      spinner.succeed(`Already registered bundle identifier "${bundleIdentifier}"`);
-    } else {
+    if (!bundleId) {
+      spinner.text = `Registering bundle identifier "${bundleIdentifier}"`;
       // If it doesn't exist, create it
       bundleId = await BundleId.createAsync(context, {
         name: `@${accountName}/${projectName}`,
         identifier: bundleIdentifier,
       });
-      spinner.succeed(`Registered bundle identifier "${bundleIdentifier}"`);
     }
+    spinner.succeed(`Bundle identifier "${bundleIdentifier}" registered`);
   } catch (err) {
     if (err.message.match(/An App ID with Identifier '(.*)' is not available/)) {
       spinner.fail(

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -224,7 +224,7 @@ export async function createOrReuseAdhocProvisioningProfileAsync(
   bundleIdentifier: string,
   distCertSerialNumber: string
 ): Promise<ProvisioningProfile> {
-  const spinner = ora(`Handling Adhoc provisioning profiles on Apple Developer Portal...`).start();
+  const spinner = ora(`Handling Apple AdHoc provisioning profiles`).start();
   try {
     const context = getRequestContext(authCtx);
     const {
@@ -252,7 +252,7 @@ export async function createOrReuseAdhocProvisioningProfileAsync(
       teamName: authCtx.team.name,
     };
   } catch (error) {
-    spinner.fail();
+    spinner.fail(`Failed to handle Apple profiles`);
     throw error;
   }
 }

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -224,7 +224,7 @@ export async function createOrReuseAdhocProvisioningProfileAsync(
   bundleIdentifier: string,
   distCertSerialNumber: string
 ): Promise<ProvisioningProfile> {
-  const spinner = ora(`Handling Apple AdHoc provisioning profiles`).start();
+  const spinner = ora(`Handling Apple ad hoc provisioning profiles`).start();
   try {
     const context = getRequestContext(authCtx);
     const {

--- a/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
@@ -16,14 +16,14 @@ Please remember that Apple Keys are not application specific!
 `;
 
 export async function listPushKeysAsync(authCtx: AuthCtx): Promise<PushKeyStoreInfo[]> {
-  const spinner = ora(`Getting Push Keys from Apple...`).start();
+  const spinner = ora(`Fetching Push Keys from Apple`).start();
   try {
     const context = getRequestContext(authCtx);
     const keys = await Keys.getKeysAsync(context);
-    spinner.succeed();
+    spinner.succeed(`Fetched Push Keys from Apple`);
     return keys;
   } catch (error) {
-    spinner.fail();
+    spinner.fail(`Failed to fetch Push Keys from Apple`);
     throw error;
   }
 }
@@ -32,12 +32,12 @@ export async function createPushKeyAsync(
   authCtx: AuthCtx,
   name: string = `Expo Push Notifications Key ${dateformat('yyyymmddHHMMss')}`
 ): Promise<PushKey> {
-  const spinner = ora(`Creating Push Key on Apple Servers...`).start();
+  const spinner = ora(`Creating Push Key on Apple`).start();
   try {
     const context = getRequestContext(authCtx);
     const key = await Keys.createKeyAsync(context, { name, isApns: true });
     const apnsKeyP8 = await Keys.downloadKeyAsync(context, { id: key.id });
-    spinner.succeed();
+    spinner.succeed(`Created Push Key on Apple`);
     return {
       apnsKeyId: key.id,
       apnsKeyP8,
@@ -45,7 +45,7 @@ export async function createPushKeyAsync(
       teamName: authCtx.team.name,
     };
   } catch (err) {
-    spinner.fail('Failed to create Push Notifications Key');
+    spinner.fail('Failed to create Push Key on Apple');
     const resultString = err.rawDump?.resultString;
     if (
       err instanceof MaxKeysCreatedError ||
@@ -58,15 +58,15 @@ export async function createPushKeyAsync(
 }
 
 export async function revokePushKeyAsync(authCtx: AuthCtx, ids: string[]): Promise<void> {
-  const spinner = ora(`Revoking Push Key on Apple Servers...`).start();
+  const spinner = ora(`Revoking Push Key on Apple`).start();
   try {
     const context = getRequestContext(authCtx);
     await Promise.all(ids.map(id => Keys.revokeKeyAsync(context, { id })));
 
-    spinner.succeed();
+    spinner.succeed(`Revoked Push Key on Apple`);
   } catch (error) {
     log.error(error);
-    spinner.fail('Failed to revoke Push Key on Apple Servers');
+    spinner.fail('Failed to revoke Push Key on Apple');
     throw error;
   }
 }

--- a/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
@@ -16,14 +16,14 @@ Please remember that Apple Keys are not application specific!
 `;
 
 export async function listPushKeysAsync(authCtx: AuthCtx): Promise<PushKeyStoreInfo[]> {
-  const spinner = ora(`Fetching Push Keys from Apple`).start();
+  const spinner = ora(`Fetching Apple push keys`).start();
   try {
     const context = getRequestContext(authCtx);
     const keys = await Keys.getKeysAsync(context);
-    spinner.succeed(`Fetched Push Keys from Apple`);
+    spinner.succeed(`Fetched Apple push keys`);
     return keys;
   } catch (error) {
-    spinner.fail(`Failed to fetch Push Keys from Apple`);
+    spinner.fail(`Failed to fetch Apple push keys`);
     throw error;
   }
 }
@@ -32,12 +32,12 @@ export async function createPushKeyAsync(
   authCtx: AuthCtx,
   name: string = `Expo Push Notifications Key ${dateformat('yyyymmddHHMMss')}`
 ): Promise<PushKey> {
-  const spinner = ora(`Creating Push Key on Apple`).start();
+  const spinner = ora(`Creating Apple push key`).start();
   try {
     const context = getRequestContext(authCtx);
     const key = await Keys.createKeyAsync(context, { name, isApns: true });
     const apnsKeyP8 = await Keys.downloadKeyAsync(context, { id: key.id });
-    spinner.succeed(`Created Push Key on Apple`);
+    spinner.succeed(`Created Apple push key`);
     return {
       apnsKeyId: key.id,
       apnsKeyP8,
@@ -45,7 +45,7 @@ export async function createPushKeyAsync(
       teamName: authCtx.team.name,
     };
   } catch (err) {
-    spinner.fail('Failed to create Push Key on Apple');
+    spinner.fail('Failed to create Apple push key');
     const resultString = err.rawDump?.resultString;
     if (
       err instanceof MaxKeysCreatedError ||
@@ -58,15 +58,17 @@ export async function createPushKeyAsync(
 }
 
 export async function revokePushKeyAsync(authCtx: AuthCtx, ids: string[]): Promise<void> {
-  const spinner = ora(`Revoking Push Key on Apple`).start();
+  const name = `Apple push key${ids?.length === 1 ? '' : 's'}`;
+
+  const spinner = ora(`Revoking ${name}`).start();
   try {
     const context = getRequestContext(authCtx);
     await Promise.all(ids.map(id => Keys.revokeKeyAsync(context, { id })));
 
-    spinner.succeed(`Revoked Push Key on Apple`);
+    spinner.succeed(`Revoked ${name}`);
   } catch (error) {
     log.error(error);
-    spinner.fail('Failed to revoke Push Key on Apple');
+    spinner.fail(`Failed to revoke ${name}`);
     throw error;
   }
 }

--- a/packages/eas-cli/src/credentials/ios/validators/validateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validateProvisioningProfile.ts
@@ -41,7 +41,7 @@ async function validateProvisioningProfileWithAppleAsync(
   );
   if (!configuredProfileFromApple) {
     return {
-      error: `Provisioning Profile (id: ${profile.provisioningProfileId}) does not exist on Apple servers`,
+      error: `Provisioning profile (id: ${profile.provisioningProfileId}) does not exist in Apple Dev Portal`,
       ok: false,
     };
   }

--- a/packages/eas-cli/src/devices/actions/create/inputMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/inputMethod.ts
@@ -46,7 +46,7 @@ async function collectDataAndRegisterDeviceAsync({
 }): Promise<void> {
   const { udid, deviceClass, name } = await collectDeviceDataAsync(appleTeam);
 
-  const spinner = ora(`Registering Apple Device on the Expo servers`).start();
+  const spinner = ora(`Registering Apple device on Expo`).start();
   try {
     await AppleDeviceMutation.createAppleDeviceAsync(
       {


### PR DESCRIPTION
# Why

- unify spinner behavior and logging format
- make error handling a bit better
