### PR TITLE
[eas-cli] Use unified website route for all builds (no more /v2)

### DIFF
--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -7,7 +7,7 @@ export function getBuildLogsUrl({
   buildId: string;
   account: string;
 }): string {
-  return `${getExpoWebsiteBaseUrl()}/accounts/${account}/builds/v2/${buildId}`;
+  return `${getExpoWebsiteBaseUrl()}/accounts/${account}/builds/${buildId}`;
 }
 
 export function getArtifactUrl(artifactId: string): string {


### PR DESCRIPTION
# Why

As a follow-up to https://github.com/expo/universe/pull/6547, which unifies the URL structure of builds pages for Turtle v2, we should stop serving those URLs in our CLIs.

# How

- removed `/v2` from build link template
