### PR TITLE
[eas-json] Switch from @hapi/joi to joi, types now included in package

### DIFF
--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -8,6 +8,7 @@
     "@expo/eas-build-job": "0.1.3",
     "@hapi/joi": "^17.1.1",
     "fs-extra": "^9.0.1",
+    "joi": "17.2.0",
     "tslib": "^1"
   },
   "devDependencies": {
@@ -16,7 +17,6 @@
     "@babel/preset-typescript": "^7.10.4",
     "@expo/babel-preset-cli": "^0.2.17",
     "@types/fs-extra": "^9.0.1",
-    "@types/hapi__joi": "^17.1.4",
     "@types/node": "^12",
     "babel-jest": "^26.3.0",
     "memfs": "^3.2.0",

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 
 const AndroidGenericSchema = Joi.object({
   workflow: Joi.string().valid('generic').required(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,7 +1917,7 @@
     is-promise "4.0.0"
     tslib "~2.0.1"
 
-"@hapi/address@^4.0.1":
+"@hapi/address@^4.0.1", "@hapi/address@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.1.0.tgz#d60c5c0d930e77456fdcde2598e77302e2955e1d"
   integrity sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==
@@ -3600,11 +3600,6 @@
   integrity sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==
   dependencies:
     "@types/node" "*"
-
-"@types/hapi__joi@^17.1.4":
-  version "17.1.4"
-  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-17.1.4.tgz#e46cd1bd81d25cd45247d652dadb3666514d807c"
-  integrity sha512-gqY3TeTyZvnyNhM02HgyCIoGIWsTFMnuzMfnD8evTsr1KIfueGJaz+QC77j+dFvhZ5cJArUNjDRHUjPxNohzGA==
 
 "@types/http-cache-semantics@*":
   version "4.0.0"
@@ -8451,6 +8446,17 @@ jimp@^0.9.6:
     "@jimp/types" "^0.9.8"
     core-js "^3.4.1"
     regenerator-runtime "^0.13.3"
+
+joi@17.2.0:
+  version "17.2.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.2.0.tgz#81cba6c1145130482d57b6d50129c7ab0e7d8b0a"
+  integrity sha512-9ZC8pMSitNlenuwKARENBGVvvGYHNlwWe5rexo2WxyogaxCB5dNHAgFA1BJQ6nsJrt/jz1p5vSqDT6W6kciDDw==
+  dependencies:
+    "@hapi/address" "^4.1.0"
+    "@hapi/formula" "^2.0.0"
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/pinpoint" "^2.0.0"
+    "@hapi/topo" "^5.0.0"
 
 jpeg-js@^0.3.4:
   version "0.3.7"


### PR DESCRIPTION
# Why

Fixes a few warnings on installing eas-cli:

```
╰─$ npm install eas-cli
npm WARN deprecated @hapi/joi@17.1.1: Switch to 'npm install joi'
npm WARN deprecated @hapi/formula@2.0.0: Moved to 'npm install @sideway/formula'
npm WARN deprecated @hapi/address@4.1.0: Moved to 'npm install @sideway/address'
npm WARN deprecated @hapi/pinpoint@2.0.0: Moved to 'npm install @sideway/pinpoint'
```

# How

- Install the joi package
- Notice that the @types/joi package is out of date
- See that bumping from joi@17.1.1 to joi@17.2.0 would include types, so do that
- Run tests 

# Test Plan

Run tests