### PR TITLE
[eas-cli] Fix support for non-interactive and skip-credentials-check

### DIFF
--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -80,8 +80,11 @@ async function ensureAndroidCredentialsAsync(
       nonInteractive: ctx.commandCtx.nonInteractive,
     }),
     {
-      projectName: ctx.commandCtx.projectName,
-      accountName: ctx.commandCtx.accountName,
+      app: {
+        projectName: ctx.commandCtx.projectName,
+        accountName: ctx.commandCtx.accountName,
+      },
+      skipCredentialsCheck: ctx.commandCtx.skipCredentialsCheck,
     }
   );
   const credentialsSource = await ensureCredentialsAsync(

--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -14,7 +14,7 @@ import { ensureGitRepoExistsAsync, ensureGitStatusIsCleanAsync } from './utils/r
 
 export async function buildAsync(commandCtx: CommandContext): Promise<void> {
   await ensureGitRepoExistsAsync();
-  await ensureGitStatusIsCleanAsync();
+  await ensureGitStatusIsCleanAsync(commandCtx.nonInteractive);
 
   const scheduledBuilds = await startBuildsAsync(commandCtx);
   log.newLine();

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -29,6 +29,7 @@ export async function ensureIosCredentialsAsync(
     credentialsSource: ctx.buildProfile.credentialsSource,
     distribution: ctx.buildProfile.distribution ?? DistributionType.STORE,
     nonInteractive: ctx.commandCtx.nonInteractive,
+    skipCredentialsCheck: ctx.commandCtx.skipCredentialsCheck,
   });
 }
 
@@ -38,17 +39,23 @@ interface ResolveCredentialsParams {
   credentialsSource: CredentialsSource;
   distribution: DistributionType;
   nonInteractive: boolean;
+  skipCredentialsCheck: boolean;
 }
 
 export async function resolveIosCredentialsAsync(
   projectDir: string,
   params: ResolveCredentialsParams
 ): Promise<CredentialsResult<IosCredentials>> {
-  const provider = new IosCredentialsProvider(await createCredentialsContextAsync(projectDir, {}), {
-    app: params.app,
-    nonInteractive: params.nonInteractive,
-    distribution: params.distribution,
-  });
+  const provider = new IosCredentialsProvider(
+    await createCredentialsContextAsync(projectDir, {
+      nonInteractive: params.nonInteractive,
+    }),
+    {
+      app: params.app,
+      distribution: params.distribution,
+      skipCredentialsCheck: params.skipCredentialsCheck,
+    }
+  );
   const credentialsSource = await ensureCredentialsAsync(
     provider,
     params.workflow,

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -51,41 +51,46 @@ async function isGitStatusCleanAsync(): Promise<boolean> {
 }
 
 async function maybeBailOnGitStatusAsync(): Promise<void> {
-  if (!(await isGitStatusCleanAsync())) {
-    log.addNewLineIfNone();
-    log.warn(`${chalk.bold('Warning!')} Your git working tree is dirty.`);
-    log(
-      `It's recommended to ${chalk.bold(
-        'commit all your changes before proceeding'
-      )}, so you can revert the changes made by this command if necessary.`
-    );
-    const answer = await confirmAsync({
-      message: `Would you like to proceed?`,
-    });
+  if (await isGitStatusCleanAsync()) {
+    return;
+  }
+  log.addNewLineIfNone();
+  log.warn(`${chalk.bold('Warning!')} Your git working tree is dirty.`);
+  log(
+    `It's recommended to ${chalk.bold(
+      'commit all your changes before proceeding'
+    )}, so you can revert the changes made by this command if necessary.`
+  );
+  const answer = await confirmAsync({
+    message: `Would you like to proceed?`,
+  });
 
-    if (!answer) {
-      throw new Error('Please commit all changes. Aborting...');
-    }
+  if (!answer) {
+    throw new Error('Please commit all changes. Aborting...');
   }
 }
 
-async function ensureGitStatusIsCleanAsync(): Promise<void> {
-  if (!(await isGitStatusCleanAsync())) {
-    log.addNewLineIfNone();
-    log.warn(`${chalk.bold('Warning!')} Your git working tree is dirty.`);
-    log(
-      `This operation needs to be run on a clean working tree, please ${chalk.bold(
-        'commit all your changes before proceeding'
-      )}.`
-    );
-    const answer = await confirmAsync({
-      message: `Commit changes to git?`,
-    });
-    if (answer) {
-      await commitPromptAsync();
-    } else {
-      throw new Error('Please commit all changes. Aborting...');
-    }
+async function ensureGitStatusIsCleanAsync(nonInteractive: boolean): Promise<void> {
+  if (await isGitStatusCleanAsync()) {
+    return;
+  }
+  log.addNewLineIfNone();
+  log.warn(`${chalk.bold('Warning!')} Your git working tree is dirty.`);
+  log(
+    `This operation needs to be run on a clean working tree, please ${chalk.bold(
+      'commit all your changes before proceeding'
+    )}.`
+  );
+  if (nonInteractive) {
+    throw new Error('Please commit all changes. Aborting...');
+  }
+  const answer = await confirmAsync({
+    message: `Commit changes to git?`,
+  });
+  if (answer) {
+    await commitPromptAsync();
+  } else {
+    throw new Error('Please commit all changes. Aborting...');
   }
 }
 

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -70,7 +70,7 @@ async function maybeBailOnGitStatusAsync(): Promise<void> {
   }
 }
 
-async function ensureGitStatusIsCleanAsync(nonInteractive: boolean): Promise<void> {
+async function ensureGitStatusIsCleanAsync(nonInteractive = false): Promise<void> {
   if (await isGitStatusCleanAsync()) {
     return;
   }

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -50,6 +50,13 @@ export default class Build extends Command {
     const { flags } = this.parse(Build);
     await ensureLoggedInAsync();
 
+    const nonInteractive = flags['non-interactive'];
+    if (!flags.platform && nonInteractive) {
+      throw new Error('--platform param is required when building in non-interactive mode');
+    }
+    const platform =
+      (flags.platform as RequestedPlatform | undefined) ?? (await promptForPlatformAsync());
+
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
     const projectId = await getProjectIdAsync(projectDir);
 
@@ -60,9 +67,6 @@ export default class Build extends Command {
     }
 
     await ensureProjectConfiguredAsync(projectDir);
-
-    const platform =
-      (flags.platform as RequestedPlatform | undefined) ?? (await promptForPlatformAsync());
 
     const trackingCtx = {
       tracking_id: uuidv4(),
@@ -76,7 +80,7 @@ export default class Build extends Command {
       projectDir,
       projectId,
       trackingCtx,
-      nonInteractive: flags['non-interactive'],
+      nonInteractive,
       skipCredentialsCheck: flags['skip-credentials-check'],
       skipProjectConfiguration: flags['skip-project-configuration'],
       waitForBuildEnd: flags.wait,

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -52,7 +52,7 @@ export default class Build extends Command {
 
     const nonInteractive = flags['non-interactive'];
     if (!flags.platform && nonInteractive) {
-      throw new Error('--platform param is required when building in non-interactive mode');
+      throw new Error('--platform is required when building in non-interactive mode');
     }
     const platform =
       (flags.platform as RequestedPlatform | undefined) ?? (await promptForPlatformAsync());

--- a/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
@@ -18,13 +18,18 @@ interface AppLookupParams {
   accountName: string;
 }
 
+interface Options {
+  app: AppLookupParams;
+  skipCredentialsCheck?: boolean;
+}
+
 export default class AndroidCredentialsProvider implements CredentialsProvider {
   public readonly platform = Platform.Android;
 
-  constructor(private ctx: Context, private app: AppLookupParams) {}
+  constructor(private ctx: Context, private options: Options) {}
 
   private get projectFullName(): string {
-    const { projectName, accountName } = this.app;
+    const { projectName, accountName } = this.options.app;
     return `@${accountName}/${projectName}`;
   }
 

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -29,7 +29,6 @@ interface PartialIosCredentials {
 interface Options {
   app: AppLookupParams;
   distribution: DistributionType;
-  nonInteractive: boolean;
   skipCredentialsCheck?: boolean;
 }
 

--- a/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
@@ -33,13 +33,11 @@ export class CreateProvisioningProfile implements Action {
   }
 
   private async provideOrGenerateAsync(ctx: Context): Promise<ProvisioningProfile> {
-    if (!ctx.nonInteractive) {
-      const userProvided = await askForUserProvidedAsync(provisioningProfileSchema);
-      if (userProvided) {
-        // userProvided profiles don't come with ProvisioningProfileId's (only accessible from Apple Portal API)
-        log.warn('Provisioning profile: Unable to validate specified profile.');
-        return userProvided;
-      }
+    const userProvided = await askForUserProvidedAsync(provisioningProfileSchema);
+    if (userProvided) {
+      // userProvided profiles don't come with ProvisioningProfileId's (only accessible from Apple Portal API)
+      log.warn('Provisioning profile: Unable to validate specified profile.');
+      return userProvided;
     }
     const distCert = await ctx.ios.getDistributionCertificateAsync(this.app);
     assert(distCert, 'missing distribution certificate');

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -50,7 +50,7 @@ export class SetupBuildCredentials implements Action {
         await manager.runActionAsync(new SetupProvisioningProfile(this.app));
       }
     } catch (error) {
-      log.error('Failed to setup the Provisioning Profile.');
+      log.error('Failed to setup credentials.');
       throw error;
     }
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -37,6 +37,9 @@ export class SetupBuildCredentials implements Action {
         if (!account) {
           throw new Error(`You do not have access to the ${this.app.accountName} account`);
         }
+        if (ctx.nonInteractive) {
+          throw new Error('Internal distribution builds are not supported in non-interactive mode');
+        }
         // for now, let's require the user to authenticate with Apple
         await ctx.appStore.ensureAuthenticatedAsync();
         const action = new SetupAdhocProvisioningProfile({

--- a/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
@@ -24,7 +24,7 @@ export class SetupDistributionCertificateForApp implements Action {
 
     if (ctx.nonInteractive) {
       throw new Error(
-        'Distribution Certificate is not configured correctly. Please run this command againg in interactive mode.'
+        'Distribution Certificate is not configured correctly. Please run this command again in interactive mode.'
       );
     }
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
@@ -22,6 +22,12 @@ export class SetupDistributionCertificateForApp implements Action {
       return;
     }
 
+    if (ctx.nonInteractive) {
+      throw new Error(
+        'Distribution Certificate is not configured correctly. Please run this command againg in interactive mode.'
+      );
+    }
+
     const existingCertificates = await getValidDistCertsAsync(ctx, this.app.accountName);
 
     if (existingCertificates.length === 0) {
@@ -32,22 +38,20 @@ export class SetupDistributionCertificateForApp implements Action {
     // autoselect credentials if we find valid certs
     const autoselectedCertificate = existingCertificates[0];
 
-    if (!ctx.nonInteractive) {
-      const credentials = await ctx.ios.getAllCredentialsAsync(this.app.accountName);
-      const usedByApps = credentials.appCredentials.filter(
-        cred => cred.distCredentialsId === autoselectedCertificate.id
-      );
-      const confirm = await confirmAsync({
-        message: `${formatDistributionCertificate(
-          autoselectedCertificate,
-          usedByApps,
-          ctx.appStore.authCtx ? 'VALID' : 'UNKNOWN'
-        )} \n Would you like to use this certificate?`,
-      });
-      if (!confirm) {
-        await this.createOrReuseAsync(manager, ctx);
-        return;
-      }
+    const credentials = await ctx.ios.getAllCredentialsAsync(this.app.accountName);
+    const usedByApps = credentials.appCredentials.filter(
+      cred => cred.distCredentialsId === autoselectedCertificate.id
+    );
+    const confirm = await confirmAsync({
+      message: `${formatDistributionCertificate(
+        autoselectedCertificate,
+        usedByApps,
+        ctx.appStore.authCtx ? 'VALID' : 'UNKNOWN'
+      )} \n Would you like to use this certificate?`,
+    });
+    if (!confirm) {
+      await this.createOrReuseAsync(manager, ctx);
+      return;
     }
 
     log(`Using Distribution Certificate: ${autoselectedCertificate.certId || '-----'}`);

--- a/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
@@ -28,6 +28,12 @@ export class SetupProvisioningProfile implements Action {
       return;
     }
 
+    if (ctx.nonInteractive) {
+      throw new Error(
+        'Provisioning Profile is not configured correctly. Please run this command againg in interactive mode.'
+      );
+    }
+
     if (!ctx.appStore.authCtx) {
       manager.pushNextAction(new CreateProvisioningProfile(this.app));
       return;

--- a/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
@@ -30,7 +30,7 @@ export class SetupProvisioningProfile implements Action {
 
     if (ctx.nonInteractive) {
       throw new Error(
-        'Provisioning Profile is not configured correctly. Please run this command againg in interactive mode.'
+        'Provisioning Profile is not configured correctly. Please run this command again in interactive mode.'
       );
     }
 

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -76,11 +76,11 @@ export class ManageIos implements Action {
           title: 'Add new Distribution Certificate',
         },
         {
-          value: ActionType.UpdateDistributionCertificate,
+          value: ActionType.RemoveDistributionCertificate,
           title: 'Remove Distribution Certificate',
         },
         {
-          value: ActionType.RemoveDistributionCertificate,
+          value: ActionType.UpdateDistributionCertificate,
           title: 'Update Distribution Certificate',
         },
       ],


### PR DESCRIPTION
# Why

#120

# How

- pass flag in the credentials provider
- verify nonInteractive param before some of the prompts

# Test Plan

Run build for different credentials setups
