### PR TITLE
[eas submit] Add missing iOS error messages

### DIFF
--- a/packages/eas-cli/src/submissions/utils/errors.ts
+++ b/packages/eas-cli/src/submissions/utils/errors.ts
@@ -35,11 +35,12 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
   [SubmissionErrorCode.IOS_OLD_VERSION_CODE_ERROR]:
     "You've already submitted this version of the app.\n" +
     'Versions are identified by Build Numbers (expo.ios.buildNumber in app.json).\n' +
-    "If you're submitting an Expo project built with EAS Builds, increment the build number in app.json and build the project again.",
+    "If you're submitting an Expo project built with EAS Build, increment the build number in app.json and build the project again." +
+    `${learnMore('https://expo.fyi/bumping-ios-build-number')}.`,
   [SubmissionErrorCode.IOS_UNKNOWN_ERROR]:
     "We couldn't figure out what went wrong. Please see logs to learn more.",
   [SubmissionErrorCode.IOS_MISSING_APP_ICON]:
-    'Your iOS App Icon is missing or has invalid format. The icon must be a 1024x1024 PNG image.\n' +
+    'Your iOS app icon is missing or is an invalid format. The icon must be a 1024x1024 PNG image with no transparency.\n' +
     'Please check your icon image and icon configuration in app.json.\n' +
     `${learnMore('https://docs.expo.io/guides/app-icons/')}`,
   [SubmissionErrorCode.IOS_INVALID_SIGNATURE]:

--- a/packages/eas-cli/src/submissions/utils/errors.ts
+++ b/packages/eas-cli/src/submissions/utils/errors.ts
@@ -8,6 +8,8 @@ enum SubmissionErrorCode {
   ANDROID_FIRST_UPLOAD_ERROR = 'SUBMISSION_SERVICE_ANDROID_FIRST_UPLOAD_ERROR',
   ANDROID_OLD_VERSION_CODE_ERROR = 'SUBMISSION_SERVICE_ANDROID_OLD_VERSION_CODE_ERROR',
   ANDROID_MISSING_PRIVACY_POLICY = 'SUBMISSION_SERVICE_ANDROID_MISSING_PRIVACY_POLICY',
+  IOS_OLD_VERSION_CODE_ERROR = 'SUBMISSION_SERVICE_IOS_OLD_VERSION_CODE_ERROR',
+  IOS_UNKNOWN_ERROR = 'SUBMISSION_SERVICE_IOS_UNKNOWN_ERROR',
 }
 
 const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
@@ -28,6 +30,12 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
   [SubmissionErrorCode.ANDROID_MISSING_PRIVACY_POLICY]:
     'The app has permissions that require a privacy policy set for the app.\n' +
     `${learnMore('https://expo.fyi/missing-privacy-policy')}.`,
+  [SubmissionErrorCode.IOS_OLD_VERSION_CODE_ERROR]:
+    "You've already submitted this version of the app.\n" +
+    'Versions are identified by Build Numbers (expo.ios.buildNumber in app.json).\n' +
+    "If you're submitting an Expo project built with EAS Builds, increment the build number in app.json and build the project again.",
+  [SubmissionErrorCode.IOS_UNKNOWN_ERROR]:
+    "We couldn't figure out what went wrong. Please see logs to learn more.",
 };
 
 export function printSubmissionError(error: SubmissionError): boolean {
@@ -35,7 +43,9 @@ export function printSubmissionError(error: SubmissionError): boolean {
     const errorCode = error.errorCode as SubmissionErrorCode;
     log.addNewLineIfNone();
     log.error(SubmissionErrorMessages[errorCode]);
-    return errorCode === SubmissionErrorCode.ANDROID_UNKNOWN_ERROR;
+    return [SubmissionErrorCode.ANDROID_UNKNOWN_ERROR, SubmissionErrorCode.IOS_UNKNOWN_ERROR].some(
+      code => code === errorCode
+    );
   } else {
     log(error.message);
     return true;

--- a/packages/eas-cli/src/submissions/utils/errors.ts
+++ b/packages/eas-cli/src/submissions/utils/errors.ts
@@ -11,6 +11,7 @@ enum SubmissionErrorCode {
   IOS_OLD_VERSION_CODE_ERROR = 'SUBMISSION_SERVICE_IOS_OLD_VERSION_CODE_ERROR',
   IOS_UNKNOWN_ERROR = 'SUBMISSION_SERVICE_IOS_UNKNOWN_ERROR',
   IOS_MISSING_APP_ICON = 'SUBMISSION_SERVICE_IOS_MISSING_APP_ICON',
+  IOS_INVALID_SIGNATURE = 'SUBMISSION_SERVICE_IOS_INVALID_SIGNATURE',
 }
 
 const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
@@ -41,6 +42,10 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
     'Your iOS App Icon is missing or has invalid format. The icon must be a 1024x1024 PNG image.\n' +
     'Please check your icon image and icon configuration in app.json.\n' +
     `${learnMore('https://docs.expo.io/guides/app-icons/')}`,
+  [SubmissionErrorCode.IOS_INVALID_SIGNATURE]:
+    'Your app signature seems to be invalid.\n' +
+    "Please check your iOS Distribution Certificate and your app's Provisioning Profile.\n" +
+    `${learnMore('https://docs.expo.io/distribution/app-signing')}`,
 };
 
 export function printSubmissionError(error: SubmissionError): boolean {

--- a/packages/eas-cli/src/submissions/utils/errors.ts
+++ b/packages/eas-cli/src/submissions/utils/errors.ts
@@ -10,6 +10,7 @@ enum SubmissionErrorCode {
   ANDROID_MISSING_PRIVACY_POLICY = 'SUBMISSION_SERVICE_ANDROID_MISSING_PRIVACY_POLICY',
   IOS_OLD_VERSION_CODE_ERROR = 'SUBMISSION_SERVICE_IOS_OLD_VERSION_CODE_ERROR',
   IOS_UNKNOWN_ERROR = 'SUBMISSION_SERVICE_IOS_UNKNOWN_ERROR',
+  IOS_MISSING_APP_ICON = 'SUBMISSION_SERVICE_IOS_MISSING_APP_ICON',
 }
 
 const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
@@ -36,6 +37,10 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
     "If you're submitting an Expo project built with EAS Builds, increment the build number in app.json and build the project again.",
   [SubmissionErrorCode.IOS_UNKNOWN_ERROR]:
     "We couldn't figure out what went wrong. Please see logs to learn more.",
+  [SubmissionErrorCode.IOS_MISSING_APP_ICON]:
+    'Your iOS App Icon is missing or has invalid format. The icon must be a 1024x1024 PNG image.\n' +
+    'Please check your icon image and icon configuration in app.json.\n' +
+    `${learnMore('https://docs.expo.io/guides/app-icons/')}`,
 };
 
 export function printSubmissionError(error: SubmissionError): boolean {


### PR DESCRIPTION
# Why

Fixes #115 

# How

- Fixed the _"Redundant Binary Upload"_  error handling was missing in CLI

- Added error handling for (https://github.com/expo/turtle-v2/pull/341):
   - Missing App Icon (`TMS-90022`, `ITMS-90704`)
   - Invalid App Signature (`ITMS-90034`) - seems to happen when Distribution Cert, tied to app Provisioning Provile, is revoked

# Test Plan

Tested manually:
![Screenshot 2020-12-10 at 13 06 51](https://user-images.githubusercontent.com/278340/101770335-9c0f3c80-3ae8-11eb-8379-bec06dcc6b2b.png)

