### PR TITLE
flip profile querying logic

### DIFF
--- a/packages/eas-cli/src/credentials/ios/appstore/bundleId.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleId.ts
@@ -1,14 +1,16 @@
-import { BundleId, Profile, RequestContext } from '@expo/apple-utils';
+import { BundleId, Profile, ProfileType, RequestContext } from '@expo/apple-utils';
 
 export async function getProfilesForBundleIdAsync(
   context: RequestContext,
-  bundleIdentifier: string
+  bundleIdentifier: string,
+  profileType?: ProfileType
 ): Promise<Profile[]> {
-  const bundleId = await BundleId.findAsync(context, { identifier: bundleIdentifier });
-  if (bundleId) {
-    return bundleId.getProfilesAsync();
-  }
-  return [];
+  const allProfiles = await Profile.getAsync(context, {
+    query: { filter: { profileType }, includes: ['devices', 'bundleId', 'certificates'] },
+  });
+  return allProfiles.filter(
+    profile => profile.attributes.bundleId?.attributes.identifier === bundleIdentifier
+  );
 }
 
 export async function getBundleIdForIdentifierAsync(


### PR DESCRIPTION
# Why

- https://exponent-internal.slack.com/archives/C017N0N99RA/p1607342838383800
> I wonder if maybe the problem is: we query a `BundleId` then query the `profiles` on that object (URL `bundleIds/ID/profiles`) but maybe those are stale and apple doesn’t update them :thinking_face: we could try querying against all `profiles/` then filtering by bundle id locally. 

# Test Plan

- Unsure how to test this logic against the use-case that failed.