### PR TITLE
alias device:create to device

### DIFF
--- a/packages/eas-cli/src/commands/device/create.ts
+++ b/packages/eas-cli/src/commands/device/create.ts
@@ -7,6 +7,7 @@ import { ensureLoggedInAsync } from '../../user/actions';
 
 export default class DeviceCreate extends Command {
   static description = 'register new Apple Devices to use for internal distribution';
+  static aliases = ['device'];
 
   async run() {
     const user = await ensureLoggedInAsync();


### PR DESCRIPTION
# Why

According to the style guide:

> Top-level commands are just verbs. To avoid polluting the top level namespace and to keep the list of commands easy to browse, top level is reserved for a few, frequently used key commands like build, submit or publish.

- There is currently only one sub command for `device`, which is `device:create`, thereby making it the most frequently used subcommand of `device`.
- I'd imagine if we add some other command in the future it would be for removal of devices, but we haven't seen any need to add it in expo-cli with custom client builds, and at that point it's really just something that can be done in Apple dev portal, that we don't add much extra value to.
- Other "device" related functionality would maybe be something relating to simulators, or screen shots, etc. but none of this would make sense as other subcommands to `device:create` which registers internal devices for iOS only.
- In the future we could also possibly make `eas device` prompt which subcommand to run if we ever added any, and regret this choice. But in my opinion, `device` is already too vague and possibly too valuable of a command name to use for the very specific case it's currently being used for.
- Our marketing currently demonstrates the following commands:
  - eas build
  - eas submit
  - eas device:create
  - expo update
- All of these are easy to memorize, accept the outlier one.