### PR TITLE
[eas-cli] print better message when internal distribution build completes

### DIFF
--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -26,7 +26,7 @@ export async function buildAsync(commandCtx: CommandContext): Promise<void> {
       commandCtx,
       scheduledBuilds.map(i => i.buildId)
     );
-    printBuildResults(builds);
+    printBuildResults(commandCtx.accountName, builds);
   }
 }
 

--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -26,6 +26,7 @@ export async function buildAsync(commandCtx: CommandContext): Promise<void> {
       commandCtx,
       scheduledBuilds.map(i => i.buildId)
     );
+    log.newLine();
     printBuildResults(commandCtx.accountName, builds);
   }
 }

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,8 +1,7 @@
-import { Workflow } from '@expo/eas-build-job';
 import { CredentialsSource, DistributionType } from '@expo/eas-json';
 
 import { BuildContext } from './context';
-import { Platform, TrackingContext } from './types';
+import { BuildMetadata, Platform } from './types';
 
 /**
  * We use require() to exclude package.json from TypeScript's analysis since it lives outside
@@ -10,55 +9,6 @@ import { Platform, TrackingContext } from './types';
  * under the build directory
  */
 const packageJSON = require('../../package.json');
-
-export type BuildMetadata = {
-  /**
-   * Application version (the expo.version key in app.json/app.config.js)
-   */
-  appVersion: string;
-
-  /**
-   * EAS CLI version
-   */
-  cliVersion: string;
-
-  /**
-   * Build workflow
-   * It's either 'generic' or 'managed'
-   */
-  workflow: Workflow;
-
-  /**
-   * Credentials source
-   * Credentials could be obtained either from credential.json or Expo servers.
-   */
-  credentialsSource?: CredentialsSource.LOCAL | CredentialsSource.REMOTE;
-
-  /**
-   * Expo SDK version
-   * It's determined by the expo package version in package.json.
-   * It's undefined if the expo package is not installed for the project.
-   */
-  sdkVersion?: string;
-
-  /**
-   * Release channel (for expo-updates)
-   * It's undefined if the expo-updates package is not installed for the project.
-   */
-  releaseChannel?: string;
-
-  /**
-   * Tracking context
-   * It's used to track build process across different Expo services and tools.
-   */
-  trackingContext: TrackingContext;
-
-  /**
-   * Distribution type
-   * Indicates whether this is a build for store or internal distribution.
-   */
-  distribution: DistributionType;
-};
 
 export function collectMetadata<T extends Platform>(
   ctx: BuildContext<T>,

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -1,5 +1,10 @@
-import { Platform } from '@expo/eas-build-job';
-import { AndroidBuildProfile, iOSBuildProfile } from '@expo/eas-json';
+import { Platform, Workflow } from '@expo/eas-build-job';
+import {
+  AndroidBuildProfile,
+  CredentialsSource,
+  DistributionType,
+  iOSBuildProfile,
+} from '@expo/eas-json';
 
 export enum RequestedPlatform {
   Android = 'android',
@@ -24,12 +29,62 @@ export interface Build {
   platform: Platform;
   createdAt: string;
   artifacts?: BuildArtifacts;
+  metadata?: Partial<BuildMetadata>;
 }
 
 interface BuildArtifacts {
   buildUrl?: string;
   logsUrl: string;
 }
+
+export type BuildMetadata = {
+  /**
+   * Application version (the expo.version key in app.json/app.config.js)
+   */
+  appVersion: string;
+
+  /**
+   * EAS CLI version
+   */
+  cliVersion: string;
+
+  /**
+   * Build workflow
+   * It's either 'generic' or 'managed'
+   */
+  workflow: Workflow;
+
+  /**
+   * Credentials source
+   * Credentials could be obtained either from credential.json or Expo servers.
+   */
+  credentialsSource?: CredentialsSource.LOCAL | CredentialsSource.REMOTE;
+
+  /**
+   * Expo SDK version
+   * It's determined by the expo package version in package.json.
+   * It's undefined if the expo package is not installed for the project.
+   */
+  sdkVersion?: string;
+
+  /**
+   * Release channel (for expo-updates)
+   * It's undefined if the expo-updates package is not installed for the project.
+   */
+  releaseChannel?: string;
+
+  /**
+   * Tracking context
+   * It's used to track build process across different Expo services and tools.
+   */
+  trackingContext: TrackingContext;
+
+  /**
+   * Distribution type
+   * Indicates whether this is a build for store or internal distribution.
+   */
+  distribution: DistributionType;
+};
 
 export type PlatformBuildProfile<T extends Platform> = T extends Platform.Android
   ? AndroidBuildProfile

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -57,13 +57,9 @@ function printBuildResult(accountName: string, build: Build): void {
       account: accountName,
     });
     log(
-      `Open this link on your ${
-        platformDisplayNames[build.platform]
-      } devices (or scan the QR code) to install the app:`
+      `Open this link on your ${platformDisplayNames[build.platform]} devices to install the app:`
     );
     log(`${chalk.underline(logsUrl)}`);
-    log.newLine();
-    qrcodeTerminal.generate(logsUrl, code => console.log(`${indentString(code, 2)}\n`));
   } else {
     const url = build.artifacts?.buildUrl ?? '';
     log(`Platform: ${platformDisplayNames[build.platform]}, App: ${chalk.underline(url)}`);

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -1,8 +1,6 @@
 import { DistributionType } from '@expo/eas-json';
 import assert from 'assert';
 import chalk from 'chalk';
-import indentString from 'indent-string';
-import qrcodeTerminal from 'qrcode-terminal';
 
 import log from '../../log';
 import { platformDisplayNames } from '../constants';

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -1,4 +1,8 @@
+import { DistributionType } from '@expo/eas-json';
+import assert from 'assert';
 import chalk from 'chalk';
+import indentString from 'indent-string';
+import qrcodeTerminal from 'qrcode-terminal';
 
 import log from '../../log';
 import { platformDisplayNames } from '../constants';
@@ -34,17 +38,35 @@ export function printLogsUrls(
   }
 }
 
-export function printBuildResults(builds: (Build | null)[]): void {
+export function printBuildResults(accountName: string, builds: (Build | null)[]): void {
   if (builds.length === 1) {
-    const url = builds[0]?.artifacts?.buildUrl ?? '';
-    log(`App: ${chalk.underline(url)}`);
+    const [build] = builds;
+    assert(build, 'Build should be defined');
+    printBuildResult(accountName, build);
   } else {
     (builds.filter(i => i) as Build[])
       .filter(build => build.status === 'finished')
-      .forEach(build => {
-        const url = build.artifacts?.buildUrl ?? '';
-        log(`Platform: ${platformDisplayNames[build.platform]}, App: ${chalk.underline(url)}`);
-      });
+      .forEach(build => printBuildResult(accountName, build));
+  }
+}
+
+function printBuildResult(accountName: string, build: Build): void {
+  if (build.metadata?.distribution === DistributionType.INTERNAL) {
+    const logsUrl = getBuildLogsUrl({
+      buildId: build.id,
+      account: accountName,
+    });
+    log(
+      `Open this link on your ${
+        platformDisplayNames[build.platform]
+      } devices (or scan the QR code) to install the app:`
+    );
+    log(`${chalk.underline(logsUrl)}`);
+    log.newLine();
+    qrcodeTerminal.generate(logsUrl, code => console.log(`${indentString(code, 2)}\n`));
+  } else {
+    const url = build.artifacts?.buildUrl ?? '';
+    log(`Platform: ${platformDisplayNames[build.platform]}, App: ${chalk.underline(url)}`);
   }
 }
 


### PR DESCRIPTION
# Why

From Slack conversation with @brentvatne: 
> we should be more clear when the build is complete where users can go to install the app on their phone. currently we just show: “App: https://turtle-v2-artifacts.s3.amazonaws.com/etc-etc-etc”

# How

In the case of internal distribution builds, I changed the message after the build completes. EAS CLI is now printing the URL to the build details page as well as a QR code.

# Test Plan

<img width="795" alt="aa" src="https://user-images.githubusercontent.com/5256730/101494141-40697580-3967-11eb-9c4c-4558c8cbd298.png">

