### PR TITLE
Fix the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: '14'
       - run: yarn install --frozen-lockfile --check-files
+      - run: yarn build
       - name: Build tarballs
         working-directory: ${{ github.workspace }}/packages/eas-cli
         run: yarn oclif-dev pack --targets linux-x64,linux-arm
@@ -61,6 +62,7 @@ jobs:
         with:
           node-version: '14'
       - run: yarn install --frozen-lockfile --check-files
+      - run: yarn build
       - name: Build tarballs
         working-directory: ${{ github.workspace }}/packages/eas-cli
         run: yarn oclif-dev pack --targets darwin-x64
@@ -84,6 +86,7 @@ jobs:
           node-version: '14'
       - run: yarn install --frozen-lockfile --check-files
       - run: sudo apt-get install nsis
+      - run: yarn build
       - run: yarn oclif-dev pack:win
         working-directory: ${{ github.workspace }}/packages/eas-cli
       - id: x64

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.1.0-alpha.18"
+  "version": "0.1.0-alpha.19"
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "packages/*"
   ],
   "scripts": {
+    "build": "lerna run build",
     "eas": "packages/eas-cli/bin/run",
     "lint": "eslint . --ext .ts",
     "release": "lerna version",

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g eas-cli
 $ eas COMMAND
 running command...
 $ eas (-v|--version|version)
-eas-cli/0.1.0-alpha.18 darwin-x64 node-v14.15.0
+eas-cli/0.1.0-alpha.19 darwin-x64 node-v12.13.0
 $ eas --help [COMMAND]
 USAGE
   $ eas COMMAND
@@ -35,10 +35,7 @@ USAGE
 * [`eas account:login`](#eas-accountlogin)
 * [`eas account:logout`](#eas-accountlogout)
 * [`eas account:view`](#eas-accountview)
-* [`eas build`](#eas-build)
-* [`eas build:configure`](#eas-buildconfigure)
 * [`eas build:status`](#eas-buildstatus)
-* [`eas credentials`](#eas-credentials)
 * [`eas device:create`](#eas-devicecreate)
 * [`eas help [COMMAND]`](#eas-help-command)
 * [`eas submit --platform=(android|ios)`](#eas-submit---platformandroidios)
@@ -55,7 +52,7 @@ ALIASES
   $ eas login
 ```
 
-_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.18/build/commands/account/login.ts)_
+_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.19/build/commands/account/login.ts)_
 
 ## `eas account:logout`
 
@@ -69,7 +66,7 @@ ALIASES
   $ eas logout
 ```
 
-_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.18/build/commands/account/logout.ts)_
+_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.19/build/commands/account/logout.ts)_
 
 ## `eas account:view`
 
@@ -83,41 +80,7 @@ ALIASES
   $ eas whoami
 ```
 
-_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.18/build/commands/account/view.ts)_
-
-## `eas build`
-
-Start a build
-
-```
-USAGE
-  $ eas build
-
-OPTIONS
-  -p, --platform=(android|ios|all)
-  --non-interactive                 Run command in --non-interactive mode
-  --profile=profile                 [default: release] Name of the build profile from eas.json
-  --skip-credentials-check          Skip validation of build credentials
-  --skip-project-configuration      Skip project configuration
-  --wait                            Wait for build(s) to complete
-```
-
-_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.18/build/commands/build/index.ts)_
-
-## `eas build:configure`
-
-Configure the project to support EAS Build.
-
-```
-USAGE
-  $ eas build:configure
-
-OPTIONS
-  -p, --platform=(android|ios|all)  Platform to configure
-  --allow-experimental              Enable experimental configuration steps.
-```
-
-_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.18/build/commands/build/configure.ts)_
+_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.19/build/commands/account/view.ts)_
 
 ## `eas build:status`
 
@@ -132,18 +95,7 @@ OPTIONS
   --status=(in-queue|in-progress|errored|finished)
 ```
 
-_See code: [build/commands/build/status.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.18/build/commands/build/status.ts)_
-
-## `eas credentials`
-
-Manage your credentials
-
-```
-USAGE
-  $ eas credentials
-```
-
-_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.18/build/commands/credentials.ts)_
+_See code: [build/commands/build/status.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.19/build/commands/build/status.ts)_
 
 ## `eas device:create`
 
@@ -154,7 +106,7 @@ USAGE
   $ eas device:create
 ```
 
-_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.18/build/commands/device/create.ts)_
+_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.19/build/commands/device/create.ts)_
 
 ## `eas help [COMMAND]`
 
@@ -251,5 +203,5 @@ EXAMPLES
          and provide its App ID
 ```
 
-_See code: [build/commands/submit.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.18/build/commands/submit.ts)_
+_See code: [build/commands/submit.ts](https://github.com/expo/eas-cli/blob/v0.1.0-alpha.19/build/commands/submit.ts)_
 <!-- commandsstop -->

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eas-cli",
   "description": "EAS command line tool",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "author": "Expo <support@expo.io>",
   "bin": {
     "eas": "./bin/run"
@@ -12,7 +12,7 @@
     "@expo/config": "~3.3.19",
     "@expo/config-plugins": "~1.0.9",
     "@expo/eas-build-job": "0.1.3",
-    "@expo/eas-json": "^0.1.0-alpha.13",
+    "@expo/eas-json": "^0.1.0-alpha.19",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.10",
     "@expo/results": "^1.0.0",

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@expo/eas-json",
   "description": "A library for interacting with the eas.json",
-  "version": "0.1.0-alpha.13",
+  "version": "0.1.0-alpha.19",
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -32,6 +32,7 @@
   "repository": "expo/eas-cli",
   "scripts": {
     "build": "tsc",
+    "prepack": "rm -rf build && yarn build",
     "test": "jest"
   },
   "publishConfig": {


### PR DESCRIPTION
# Why

The build was failing, e.g. https://github.com/expo/eas-cli/runs/1518995963

# How

Need to make sure all packages are built with `tsc` before running `oclif-dev pack`.

# Test Plan
 
Push a version tag and check the results.