### PR TITLE
Add GitHub Actions workflow measuring the difference in size of the CLI

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,18 @@
+name: Size
+on:
+  pull_request:
+    types: [synchronize, opened]
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          build-script: 'build:tarballs:linux'
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          pattern: './packages/eas-cli/dist/*.tar.gz'
+          compression: 'none'

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   ],
   "scripts": {
     "build": "lerna run build",
+    "build:tarballs:linux": "yarn build && yarn workspace eas-cli oclif-dev pack --targets linux-x64",
     "eas": "packages/eas-cli/bin/run",
     "lint": "eslint . --ext .ts",
     "release": "lerna version",


### PR DESCRIPTION
# Why

We should be intentional about adding dependencies and be aware of the effect they have on the download size of EAS CLI, because making it too large will make installing the tools too slow. The target time to install our tools is 30 seconds. To be able to achieve this, the full EAS CLI download should probably not be larger than ~40 MB it is at the moment.

# How

Added a GitHub Action inspired by https://github.com/expo/eas-cli/issues/7.

# Test Plan

Make sure the action succeeds.
