### PR TITLE
[eas-cli] add app name and app identifier to build metadata

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -76,7 +76,7 @@ export async function prepareBuildRequestForPlatformAsync<
 
   const archiveUrl = await uploadProjectAsync(builder.ctx);
 
-  const metadata = collectMetadata(builder.ctx, {
+  const metadata = await collectMetadata(builder.ctx, {
     credentialsSource: credentialsResult?.source,
   });
   const job = await builder.prepareJobAsync(builder.ctx, {

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,5 +1,6 @@
 import { CredentialsSource, DistributionType } from '@expo/eas-json';
 
+import { getAppIdentifierAsync } from '../project/projectUtils';
 import { BuildContext } from './context';
 import { BuildMetadata, Platform } from './types';
 
@@ -10,14 +11,14 @@ import { BuildMetadata, Platform } from './types';
  */
 const packageJSON = require('../../package.json');
 
-export function collectMetadata<T extends Platform>(
+export async function collectMetadata<T extends Platform>(
   ctx: BuildContext<T>,
   {
     credentialsSource,
   }: {
     credentialsSource?: CredentialsSource.LOCAL | CredentialsSource.REMOTE;
   }
-): BuildMetadata {
+): Promise<BuildMetadata> {
   return {
     appVersion: ctx.commandCtx.exp.version!,
     cliVersion: packageJSON.version,
@@ -26,5 +27,8 @@ export function collectMetadata<T extends Platform>(
     sdkVersion: ctx.commandCtx.exp.sdkVersion,
     trackingContext: ctx.trackingCtx,
     distribution: ctx.buildProfile.distribution ?? DistributionType.STORE,
+    appName: ctx.commandCtx.exp.name,
+    appIdentifier:
+      (await getAppIdentifierAsync(ctx.commandCtx.projectDir, ctx.platform)) ?? undefined,
   };
 }

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -84,6 +84,18 @@ export type BuildMetadata = {
    * Indicates whether this is a build for store or internal distribution.
    */
   distribution: DistributionType;
+
+  /**
+   * App name (expo.name in app.json/app.config.js)
+   */
+  appName?: string;
+
+  /**
+   * App identifier:
+   * - iOS builds: the bundle identifier (expo.ios.bundleIdentifier in app.json/app.config.js)
+   * - Android builds: the application id (expo.android.package in app.json/app.config.js)
+   */
+  appIdentifier?: string;
 };
 
 export type PlatformBuildProfile<T extends Platform> = T extends Platform.Android


### PR DESCRIPTION
**Merge only after https://github.com/expo/universe/pull/6597 is merged and pushed to prod.**

# Why

https://www.notion.so/expo/iOS-Internal-Distribution-doesn-t-work-when-the-app-is-not-published-e622b160521c412bafe98a940fd0ebda

https://github.com/expo/universe/pull/6597

To fix internal distribution for unpublished projects.

# How

- I added two new fields to build metadata:
  - `appName` - (`expo.name` in app.json/app.config.js)
  - `appIdentifier`
    - iOS builds: the bundle identifier (expo.ios.bundleIdentifier in app.json/app.config.js)
    - Android builds: the application id (expo.android.package in app.json/app.config.js)
- **See also https://github.com/expo/universe/pull/6597**

# Test Plan

Ran a build and saw that the metadata were stored in the db.