### PR TITLE
[eas-cli] fix apple auth on linux

### DIFF
--- a/packages/eas-cli/src/credentials/ios/appstore/keychain.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/keychain.ts
@@ -42,6 +42,10 @@ export async function getPasswordAsync({
   username,
   serviceName,
 }: Pick<Credentials, 'serviceName' | 'username'>): Promise<string | null> {
+  if (!IS_MAC) {
+    return null;
+  }
+
   return await new Promise((resolve, reject) => {
     keychain.getPassword(
       { account: username, service: serviceName, type: KEYCHAIN_TYPE },


### PR DESCRIPTION
# Why

Fails with `Error: Expected darwin platform, got: linux` on Linux

# How

Add check for platform

# Test Plan

Auth to apple
