### PR TITLE
[eas-cli] private bucket support for project archive

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -11,7 +11,7 @@
     "@expo/apple-utils": "0.0.0-alpha.16",
     "@expo/config": "~3.3.19",
     "@expo/config-plugins": "~1.0.9",
-    "@expo/eas-build-job": "0.1.3",
+    "@expo/eas-build-job": "0.1.4",
     "@expo/eas-json": "^0.1.0-alpha.20",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.10",

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -36,7 +36,7 @@ interface Builder<TPlatform extends Platform, Credentials, ProjectConfiguration>
   prepareJobAsync(
     ctx: BuildContext<TPlatform>,
     jobData: {
-      archiveUrl: string;
+      archiveBucketKey: string;
       credentials?: Credentials;
       projectConfiguration?: ProjectConfiguration;
     }
@@ -74,13 +74,13 @@ export async function prepareBuildRequestForPlatformAsync<
     });
   }
 
-  const archiveUrl = await uploadProjectAsync(builder.ctx);
+  const archiveBucketKey = await uploadProjectAsync(builder.ctx);
 
   const metadata = await collectMetadata(builder.ctx, {
     credentialsSource: credentialsResult?.source,
   });
   const job = await builder.prepareJobAsync(builder.ctx, {
-    archiveUrl,
+    archiveBucketKey,
     credentials: credentialsResult?.credentials,
     projectConfiguration: builder.projectConfiguration,
   });
@@ -129,11 +129,12 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         projectTarballPath = projectTarball.path;
 
         log('Uploading project to build servers');
-        return await uploadAsync(
+        const { bucketKey } = await uploadAsync(
           UploadType.TURTLE_PROJECT_SOURCES,
           projectTarball.path,
           createProgressTracker(projectTarball.size)
         );
+        return bucketKey;
       },
       {
         successEvent: AnalyticsEvent.PROJECT_UPLOAD_SUCCESS,

--- a/packages/eas-cli/src/submissions/utils/files.ts
+++ b/packages/eas-cli/src/submissions/utils/files.ts
@@ -82,11 +82,12 @@ export async function downloadAppArchiveAsync(url: string): Promise<string> {
 
 export async function uploadAppArchiveAsync(path: string): Promise<string> {
   const fileSize = (await fs.stat(path)).size;
-  return await uploadAsync(
+  const { url } = await uploadAsync(
     UploadType.SUBMISSION_APP_ARCHIVE,
     path,
     createProgressTracker(fileSize)
   );
+  return url;
 }
 
 async function createTemporaryDirectoryForExtractionAsync(): Promise<string> {

--- a/packages/eas-cli/src/uploads.ts
+++ b/packages/eas-cli/src/uploads.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import FormData from 'form-data';
 import fs from 'fs';
 import got, { Progress } from 'got';
@@ -17,13 +18,15 @@ export async function uploadAsync(
   uploadType: UploadType,
   path: string,
   handleProgressEvent?: ProgressHandler
-): Promise<string> {
+): Promise<{ url: string; bucketKey: string }> {
   const presignedPost = await obtainS3PresignedPostAsync(uploadType, path);
-  return await uploadWithPresignedPostAsync(
+  const url = await uploadWithPresignedPostAsync(
     fs.createReadStream(path),
     presignedPost,
     handleProgressEvent
   );
+  assert(presignedPost.fields.key, 'key is not specified in in presigned post');
+  return { url, bucketKey: presignedPost.fields.key };
 }
 
 export interface PresignedPost {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,6 +1508,13 @@
   dependencies:
     "@hapi/joi" "^17.1.1"
 
+"@expo/eas-build-job@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.4.tgz#71188a68e62ad1ecf1c6d20e4ebcfefa4143a9a2"
+  integrity sha512-wibByQQBu7kREeMmOWXBZXVjLuORUTzxKJSxhSk6aQ8iGC5FhcjSUzpCyi+949iOzhumryu4198ZCjGuQD8+4A==
+  dependencies:
+    "@hapi/joi" "^17.1.1"
+
 "@expo/image-utils@0.3.9":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.9.tgz#10dc8044943c1bd34fe9658f2835a079e4041a0b"


### PR DESCRIPTION
Requires https://github.com/expo/turtle-v2/pull/343/files and the new version of `@expo/eas-build-job` to be published

# Why

Support for private bucket uploads/downloads

# How

Update code to new job schema
Pass s3 bucket key to the job instead of url

# Test Plan

run build locally
