### PR TITLE
[eas submit] UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Display App Store link after successful submission. ([#144](https://github.com/expo/eas-cli/pull/144) by [@barthap](https://github.com/barthap))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -21,7 +21,7 @@ abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
   protected async startSubmissionAsync(
     submissionConfig: SubmissionConfig,
     verbose: boolean = false
-  ) {
+  ): Promise<SubmissionStatus> {
     Log.addNewLineIfNone();
     const scheduleSpinner = ora('Scheduling submission').start();
     let submissionId: string;
@@ -65,6 +65,7 @@ abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
     }
 
     await displayLogs(submission, submissionStatus, verbose);
+    return submissionStatus ?? SubmissionStatus.ERRORED;
   }
 
   private getStatusText(status: SubmissionStatus): string {

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
@@ -10,7 +10,6 @@ import {
 } from '../types';
 import {
   ArchiveSourceSummaryFields,
-  breakWord,
   formatArchiveSourceSummary,
   printSummary,
 } from '../utils/summary';
@@ -115,12 +114,14 @@ const SummaryHumanReadableKeys: Record<keyof Summary, string> = {
   archiveUrl: 'Download URL',
   archiveType: 'Archive type',
   buildId: 'Build ID',
-  serviceAccountPath: 'Google Service Account',
+  serviceAccountPath: 'Google Service Key',
   track: 'Release track',
   releaseStatus: 'Release status',
   projectId: 'Project ID',
 };
 
-const SummaryHumanReadableValues: Partial<Record<keyof Summary, Function>> = {};
+const SummaryHumanReadableValues: Partial<Record<keyof Summary, Function>> = {
+  archiveType: (type: string) => type.toUpperCase(),
+};
 
 export default AndroidSubmitter;

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
@@ -43,7 +43,6 @@ class AndroidSubmitter extends BaseSubmitter<AndroidSubmissionContext, AndroidSu
 
     printSummary(
       this.prepareSummaryData(this.options, resolvedSourceOptions),
-      'Android Submission Summary',
       SummaryHumanReadableKeys,
       SummaryHumanReadableValues
     );

--- a/packages/eas-cli/src/submissions/archiveSource/index.ts
+++ b/packages/eas-cli/src/submissions/archiveSource/index.ts
@@ -14,17 +14,19 @@ export interface ArchiveSource {
 export interface Archive {
   location: string;
   type: ArchiveType;
+  realFileSource: ArchiveFileSource;
 }
 
 export async function getArchiveAsync(
   platform: SubmissionPlatform,
   source: ArchiveSource
 ): Promise<Archive> {
-  const location = await getArchiveFileLocationAsync(source.archiveFile);
+  const { location, realSource } = await getArchiveFileLocationAsync(source.archiveFile);
   const type = await getArchiveTypeAsync(platform, source.archiveType, location);
   return {
     location,
     type,
+    realFileSource: realSource,
   };
 }
 

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -35,9 +35,25 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
       resolvedSourceOptions
     );
 
-    printSummaryIOS(submissionConfig);
+    printSummary(
+      submissionConfig,
+      'iOS Submission Summary',
+      SummaryHumanReadableKeys,
+      SummaryHumanReadableValues
+    );
+    const result = await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
 
-    await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
+    if (result === SubmissionStatus.FINISHED) {
+      log(
+        'Your binary has been successfully uploaded to App Store Connect!\n' +
+          'It is now being processed by Apple - you will receive an e-mail when the processing finishes.\n' +
+          'It usually takes about 5-10 minutes depending on how busy Apple servers are.\n' +
+          'When it’s done, you can see your build here: ' +
+          chalk.dim.underline(
+            `https://appstoreconnect.apple.com/apps/${this.options.ascAppId}/appstore/ios`
+          )
+      );
+    }
   }
 
   private async resolveSourceOptions(): Promise<ResolvedSourceOptions> {

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -7,7 +7,6 @@ import { Archive, ArchiveSource, getArchiveAsync } from '../archiveSource';
 import { IosSubmissionContext, SubmissionPlatform } from '../types';
 import {
   ArchiveSourceSummaryFields,
-  breakWord,
   formatArchiveSourceSummary,
   printSummary,
 } from '../utils/summary';
@@ -118,9 +117,6 @@ const SummaryHumanReadableKeys: Record<keyof SummaryData, string> = {
   buildId: 'Build ID',
 };
 
-const SummaryHumanReadableValues: Partial<Record<keyof SummaryData, Function>> = {
-  archiveUrl: (url: string) => breakWord(url, 50),
-  archivePath: (path: string) => breakWord(path, 50),
-};
+const SummaryHumanReadableValues: Partial<Record<keyof SummaryData, Function>> = {};
 
 export default IosSubmitter;

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -52,11 +52,12 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
     const result = await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
 
     if (result === SubmissionStatus.FINISHED) {
+      Log.addNewLineIfNone();
       Log.log(
         chalk.bold('Your binary has been successfully uploaded to App Store Connect!\n') +
           '- It is now being processed by Apple - you will receive an e-mail when the processing finishes.\n' +
           '- It usually takes about 5-10 minutes depending on how busy Apple servers are.\n' +
-          '- When it’s done, you can see your build here: ' +
+          '- When it’s done, you can see your build here' +
           learnMore(
             `https://appstoreconnect.apple.com/apps/${this.options.ascAppId}/appstore/ios`,
             ''

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log from '../../log';
+import Log, { learnMore } from '../../log';
 import BaseSubmitter from '../BaseSubmitter';
 import { SubmissionStatus } from '../SubmissionService.types';
 import { Archive, ArchiveSource, getArchiveAsync } from '../archiveSource';
@@ -46,20 +46,20 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
 
     printSummary(
       this.prepareSummaryData(this.options, resolvedSourceOptions),
-      'iOS Submission Summary',
       SummaryHumanReadableKeys,
       SummaryHumanReadableValues
     );
     const result = await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
 
     if (result === SubmissionStatus.FINISHED) {
-      log(
-        'Your binary has been successfully uploaded to App Store Connect!\n' +
-          'It is now being processed by Apple - you will receive an e-mail when the processing finishes.\n' +
-          'It usually takes about 5-10 minutes depending on how busy Apple servers are.\n' +
-          'When it’s done, you can see your build here: ' +
-          chalk.dim.underline(
-            `https://appstoreconnect.apple.com/apps/${this.options.ascAppId}/appstore/ios`
+      Log.log(
+        chalk.bold('Your binary has been successfully uploaded to App Store Connect!\n') +
+          '- It is now being processed by Apple - you will receive an e-mail when the processing finishes.\n' +
+          '- It usually takes about 5-10 minutes depending on how busy Apple servers are.\n' +
+          '- When it’s done, you can see your build here: ' +
+          learnMore(
+            `https://appstoreconnect.apple.com/apps/${this.options.ascAppId}/appstore/ios`,
+            ''
           )
       );
     }

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -46,7 +46,8 @@ export function printSummary<T>(
     fields.push({ label, value });
   }
 
-  log.addNewLineIfNone();
+  log.newLine();
   log(chalk.bold(title));
   log(formatFields(fields, { labelFormat: chalk.bold.cyan }));
+  log.addNewLineIfNone();
 }

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 
 import Log from '../../log';
+import formatFields from '../../utils/formatFields';
 import { Archive, ArchiveFileSourceType } from '../archiveSource';
 
 export interface ArchiveSourceSummaryFields {
@@ -34,28 +35,18 @@ export function formatArchiveSourceSummary({
 
 export function printSummary<T>(
   summary: T,
+  title: string,
   keyMap: Record<keyof T, string>,
   valueRemap: Partial<Record<keyof T, Function>>
 ): void {
-  const padWidth = longestStringLength(Object.keys(summary).map(key => keyMap[key as keyof T]));
-
-  const tableFormat = (name: string, msg: string) =>
-    `${chalk.bold.cyan(pad(`${name}:`, padWidth + 1))} ${msg}`;
-
-  Log.newLine();
-  for (const [key, value] of Object.entries(summary)) {
-    const displayKey = chalk.cyan(keyMap[key as keyof T]);
-    const displayValue = valueRemap[key as keyof T]?.(value) ?? value;
-    Log.log(tableFormat(displayKey, displayValue));
+  const fields = [];
+  for (const [key, entryValue] of Object.entries(summary)) {
+    const label = `${keyMap[key as keyof T]}:`;
+    const value = valueRemap[key as keyof T]?.(entryValue) ?? entryValue;
+    fields.push({ label, value });
   }
-  Log.addNewLineIfNone();
-}
 
-function pad(str: string, width: number): string {
-  const len = Math.max(0, width - str.length);
-  return str + Array(len + 1).join(' ');
-}
-
-function longestStringLength(values: string[]): number {
-  return values.reduce((max, option) => Math.max(max, option.length), 0);
+  log.addNewLineIfNone();
+  log(chalk.bold(title));
+  log(formatFields(fields, { labelFormat: chalk.bold.cyan }));
 }

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -14,7 +14,7 @@ export function printSummary<T>(
 
   Log.newLine();
   for (const [key, value] of Object.entries(summary)) {
-    const displayKey = keyMap[key as keyof T];
+    const displayKey = chalk.cyan(keyMap[key as keyof T]);
     const displayValue = valueRemap[key as keyof T]?.(value) ?? value;
     Log.log(tableFormat(displayKey, displayValue));
   }

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -35,7 +35,6 @@ export function formatArchiveSourceSummary({
 
 export function printSummary<T>(
   summary: T,
-  title: string,
   keyMap: Record<keyof T, string>,
   valueRemap: Partial<Record<keyof T, Function>>
 ): void {
@@ -46,8 +45,7 @@ export function printSummary<T>(
     fields.push({ label, value });
   }
 
-  log.newLine();
-  log(chalk.bold(title));
-  log(formatFields(fields, { labelFormat: chalk.bold.cyan }));
-  log.addNewLineIfNone();
+  Log.newLine();
+  Log.log(formatFields(fields, { labelFormat: chalk.bold.cyan }));
+  Log.addNewLineIfNone();
 }

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -1,6 +1,36 @@
 import chalk from 'chalk';
 
 import Log from '../../log';
+import { Archive, ArchiveFileSourceType } from '../archiveSource';
+
+export interface ArchiveSourceSummaryFields {
+  archiveUrl?: string;
+  archivePath?: string;
+  buildId?: string;
+}
+
+export function formatArchiveSourceSummary({
+  realFileSource,
+}: Archive): ArchiveSourceSummaryFields {
+  const summarySlice: ArchiveSourceSummaryFields = {};
+
+  switch (realFileSource.sourceType) {
+    case ArchiveFileSourceType.path:
+      summarySlice.archivePath = realFileSource.path;
+      break;
+    case ArchiveFileSourceType.url:
+      summarySlice.archiveUrl = realFileSource.url;
+      break;
+    case ArchiveFileSourceType.buildId:
+      summarySlice.buildId = realFileSource.id;
+      break;
+    case ArchiveFileSourceType.latest:
+      // TODO: Resolve real build ID here
+      summarySlice.buildId = '[latest]';
+      break;
+  }
+  return summarySlice;
+}
 
 export function printSummary<T>(
   summary: T,

--- a/packages/eas-cli/src/utils/formatFields.ts
+++ b/packages/eas-cli/src/utils/formatFields.ts
@@ -1,21 +1,24 @@
 import chalk from 'chalk';
 
-export default function formatFields(fields: { label: string; value: string }[]) {
+type FormatFieldsOptions = {
+  labelFormat: (raw: string) => string;
+};
+
+export default function formatFields(
+  fields: { label: string; value: string }[],
+  options: FormatFieldsOptions = { labelFormat: chalk.dim }
+) {
   const columnWidth = fields.reduce((a, b) => (a.label.length > b.label.length ? a : b)).label
     .length;
 
   return fields
     .map(({ label, value }) => {
-      let line = '';
-
-      line += chalk.dim(
+      // make all labels fixed-width
+      const formattedLabel = options.labelFormat(
         label.length < columnWidth ? `${label}${' '.repeat(columnWidth - label.length)}` : label
       );
 
-      line += '  ';
-      line += value;
-
-      return line;
+      return `${formattedLabel}  ${value}`;
     })
     .join('\n');
 }


### PR DESCRIPTION
# Why

Addresses internal feedback, a little improves user experience.

# How

- After successful iOS submission, a message with app store link is displayed along with information about processing by Apple. For Android, unfortunately, there's no easy way to achieve link to Google Play Console.
- Changed Submission Summary table - this was done before #157 (had to rebase due to duplication of my changes)
- Removed `App Specific Password` row - it was useless (always displayed `[hidden]`)
- Reordered table values for  both platforms (see below)
- Instead of displaying `Archive URL`, the real user choice is now displayed (path / build id). This needed modification of `ArchiveFileSource.ts` to return also real user choice.
   > Maybe, in case of uploading local file, an archive URL should also be displayed - sometimes it may be useful

## Further Steps

- Ability for user to choose build from the list (extend current choice: id / latest)
- Improve iOS App Store Connect app creation - Ask for confirmation about App Name, optional ask for sku etc.
- Maybe ask for confirmation before starting submission.
- Find a way to check if specific binary has already been submitted.

# Test Plan

Tested manually, changes visible on screens below (mocked some values).

---

![ff](https://user-images.githubusercontent.com/278340/102202694-f2ed8b00-3ec7-11eb-8730-c01214036c4e.png)


![Screenshot 2020-12-15 at 10 42 27](https://user-images.githubusercontent.com/278340/102202673-ec5f1380-3ec7-11eb-8218-ddf7f2dd3a16.png)
