### PR TITLE
[eas-cli] Add device:list and device:view commands

### DIFF
--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 
+import formatFields from '../../utils/formatFields';
 import { platformDisplayNames } from '../constants';
 import { Build, BuildStatus } from '../types';
 import { getBuildLogsUrl } from './url';
@@ -9,15 +10,15 @@ interface Options {
 }
 
 export default function formatBuild(build: Build, { accountName }: Options) {
-  const fields: { label: string; get: (build: Build) => string }[] = [
-    { label: 'ID', get: build => build.id },
+  const fields: { label: string; value: string }[] = [
+    { label: 'ID', value: build.id },
     {
       label: 'Platform',
-      get: build => platformDisplayNames[build.platform],
+      value: platformDisplayNames[build.platform],
     },
     {
       label: 'Status',
-      get: build => {
+      get value() {
         switch (build.status) {
           case BuildStatus.IN_PROGRESS:
             return chalk.blue('in progress');
@@ -32,11 +33,11 @@ export default function formatBuild(build: Build, { accountName }: Options) {
     },
     {
       label: 'Logs',
-      get: build => getBuildLogsUrl({ buildId: build.id, account: accountName }),
+      value: getBuildLogsUrl({ buildId: build.id, account: accountName }),
     },
     {
       label: 'Artifact',
-      get: build => {
+      get value() {
         if (build.status === BuildStatus.IN_PROGRESS) {
           return '<in progress>';
         }
@@ -50,10 +51,10 @@ export default function formatBuild(build: Build, { accountName }: Options) {
         return url;
       },
     },
-    { label: 'Started at', get: build => new Date(build.createdAt).toLocaleString() },
+    { label: 'Started at', value: new Date(build.createdAt).toLocaleString() },
     {
       label: 'Finished at',
-      get: build =>
+      value:
         build.status === BuildStatus.IN_PROGRESS
           ? '<in progress>'
           : new Date(build.updatedAt).toLocaleString(),
@@ -62,21 +63,5 @@ export default function formatBuild(build: Build, { accountName }: Options) {
     // { label: 'Started by', get: build => 'TODO' },
   ];
 
-  const columnWidth = fields.reduce((a, b) => (a.label.length > b.label.length ? a : b)).label
-    .length;
-
-  return fields
-    .map(({ label, get }) => {
-      let line = '';
-
-      line += chalk.dim(
-        label.length < columnWidth ? `${label}${' '.repeat(columnWidth - label.length)}` : label
-      );
-
-      line += '  ';
-      line += get(build);
-
-      return line;
-    })
-    .join('\n');
+  return formatFields(fields);
 }

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -1,0 +1,91 @@
+import { Command, flags } from '@oclif/command';
+import assert from 'assert';
+import chalk from 'chalk';
+import ora from 'ora';
+
+import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
+import { AppleTeamQuery } from '../../credentials/ios/api/graphql/queries/AppleTeamQuery';
+import formatDevice from '../../devices/utils/formatDevice';
+import log from '../../log';
+import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+import { promptAsync } from '../../prompts';
+
+export default class BuildList extends Command {
+  static description = 'list all registered devices for your account';
+
+  static flags = {
+    'apple-team-id': flags.string(),
+  };
+
+  async run() {
+    let appleTeamIdentifier = this.parse(BuildList).flags['apple-team-id'];
+
+    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const accountName = await getProjectAccountNameAsync(projectDir);
+
+    let spinner: ora.Ora;
+
+    if (!appleTeamIdentifier) {
+      spinner = ora().start('Fetching the list of teams for the project…');
+
+      try {
+        const teams = await AppleTeamQuery.getAllForAccountAsync(accountName);
+
+        if (teams.length) {
+          spinner.succeed();
+
+          if (teams.length === 1) {
+            appleTeamIdentifier = teams[0].appleTeamIdentifier;
+          } else {
+            const result = await promptAsync({
+              type: 'select',
+              name: 'appleTeamIdentifier',
+              message: 'What Apple Team would you like to list devices for?',
+              choices: teams.map(team => ({
+                title: `${team.appleTeamName} (ID: ${team.appleTeamIdentifier})`,
+                value: team.appleTeamIdentifier,
+              })),
+            });
+
+            appleTeamIdentifier = result.appleTeamIdentifier;
+          }
+        } else {
+          spinner.fail(`Couldn't find any teams for the account ${accountName}`);
+        }
+      } catch (e) {
+        spinner.fail(`Something went wrong and we couldn't fetch the list of teams`);
+        throw e;
+      }
+    }
+
+    assert(appleTeamIdentifier, 'No team identifier is specified');
+
+    spinner = ora().start('Fetching the list of devices for the team…');
+
+    try {
+      const result = await AppleDeviceQuery.getAllForAppleTeamAsync(
+        accountName,
+        appleTeamIdentifier
+      );
+
+      if (result?.appleDevices.length) {
+        const { appleTeamName, appleDevices } = result;
+
+        spinner.succeed(`Found ${appleDevices.length} devices for team ${appleTeamName}`);
+
+        const list = appleDevices
+          .map(device =>
+            formatDevice(device, { appleTeamName, appleTeamIdentifier: appleTeamIdentifier! })
+          )
+          .join(`\n\n${chalk.dim('———')}\n\n`);
+
+        log(`\n${list}`);
+      } else {
+        spinner.fail(`Couldn't find any devices for the team ${appleTeamIdentifier}`);
+      }
+    } catch (e) {
+      spinner.fail(`Something went wrong and we couldn't fetch the device list`);
+      throw e;
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -1,0 +1,51 @@
+import { Command } from '@oclif/command';
+import ora from 'ora';
+
+import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
+import formatDevice from '../../devices/utils/formatDevice';
+import log from '../../log';
+import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+
+export default class DeviceView extends Command {
+  static description = 'view a device for your project';
+
+  static args = [{ name: 'UDID' }];
+
+  async run() {
+    const { UDID } = this.parse(DeviceView).args;
+
+    if (!UDID) {
+      log(
+        `The device UDID is required to view a specific device. For example:
+
+   eas device:view 00005787-000872430189501D
+
+If you are not sure what is the UDID of the device you are looking for, run:
+
+   eas device:list
+`
+      );
+      throw new Error('Device UDID is missing');
+    }
+
+    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const accountName = await getProjectAccountNameAsync(projectDir);
+
+    const spinner = ora().start(`Fetching device details for ${UDID}…`);
+
+    try {
+      const device = await AppleDeviceQuery.getByDeviceIdentifier(accountName, UDID);
+
+      if (device) {
+        spinner.succeed('Successfully fetched device details');
+        log(`\n${formatDevice(device, device.appleTeam)}`);
+      } else {
+        spinner.fail(`Couldn't find a device with the UDID ${UDID}`);
+      }
+    } catch (e) {
+      console.log(e);
+      spinner.fail(`Something went wrong and we couldn't fetch the device with UDID ${UDID}`);
+      throw e;
+    }
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -127,7 +127,7 @@ export async function createOrGetExistingAppleTeamAsync(
   { account }: AppLookupParams,
   { appleTeamIdentifier, appleTeamName }: { appleTeamIdentifier: string; appleTeamName?: string }
 ): Promise<AppleTeam> {
-  const appleTeam = await AppleTeamQuery.byAppleTeamIdentifierAsync(
+  const appleTeam = await AppleTeamQuery.getByAppleTeamIdentifierAsync(
     account.id,
     appleTeamIdentifier
   );

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -6,6 +6,21 @@ import { AppleDevice, AppleTeam } from '../../../../../graphql/generated';
 import { AppleDeviceFragment } from '../../../../../graphql/types/credentials/AppleDevice';
 import { AppleTeamFragment } from '../../../../../graphql/types/credentials/AppleTeam';
 
+export type AppleTeamQueryResult = Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>;
+
+export type AppleDeviceQueryResult = Pick<
+  AppleDevice,
+  'id' | 'identifier' | 'name' | 'deviceClass' | 'enabled'
+>;
+
+export type AppleDevicesByTeamIdentifierQueryResult = AppleTeamQueryResult & {
+  appleDevices: AppleDeviceQueryResult[];
+};
+
+export type AppleDevicesByIdentifierQueryResult = AppleDeviceQueryResult & {
+  appleTeam: AppleTeamQueryResult;
+};
+
 const AppleDeviceQuery = {
   async getAllByAppleTeamIdentifierAsync(
     accountId: string,
@@ -42,6 +57,80 @@ const AppleDeviceQuery = {
     const { appleDevices } = data.appleTeam.byAppleTeamIdentifier;
     assert(appleDevices, 'Apple Devices should be defined in this context - enforced by GraphQL');
     return appleDevices.filter(device => device) as AppleDevice[];
+  },
+
+  async getAllForAppleTeamAsync(
+    accountName: string,
+    appleTeamIdentifier: string
+  ): Promise<AppleDevicesByTeamIdentifierQueryResult | null> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<{ account: { byName: { appleTeams: AppleDevicesByTeamIdentifierQueryResult[] } } }>(
+          gql`
+            query AppleDevicesByTeamIdentifier(
+              $accountName: String!
+              $appleTeamIdentifier: String!
+            ) {
+              account {
+                byName(accountName: $accountName) {
+                  appleTeams(appleTeamIdentifier: $appleTeamIdentifier) {
+                    id
+                    appleTeamIdentifier
+                    appleTeamName
+                    appleDevices {
+                      id
+                      identifier
+                      name
+                      deviceClass
+                      enabled
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          { accountName, appleTeamIdentifier }
+        )
+        .toPromise()
+    );
+
+    return data.account.byName.appleTeams[0];
+  },
+
+  async getByDeviceIdentifier(
+    accountName: string,
+    identifier: string
+  ): Promise<AppleDevicesByIdentifierQueryResult | null> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<{ account: { byName: { appleDevices: AppleDevicesByIdentifierQueryResult[] } } }>(
+          gql`
+            query AppleDevicesByIdentifier($accountName: String!, $identifier: String!) {
+              account {
+                byName(accountName: $accountName) {
+                  id
+                  appleDevices(identifier: $identifier) {
+                    id
+                    identifier
+                    name
+                    deviceClass
+                    enabled
+                    appleTeam {
+                      id
+                      appleTeamIdentifier
+                      appleTeamName
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          { accountName, identifier }
+        )
+        .toPromise()
+    );
+
+    return data.account.byName.appleDevices[0] ?? null;
   },
 };
 

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
@@ -4,8 +4,35 @@ import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/cl
 import { AppleTeam } from '../../../../../graphql/generated';
 import { AppleTeamFragment } from '../../../../../graphql/types/credentials/AppleTeam';
 
+type AppleTeamQueryResult = Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>;
+
 const AppleTeamQuery = {
-  async byAppleTeamIdentifierAsync(
+  async getAllForAccountAsync(accountName: string): Promise<AppleTeamQueryResult[]> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<{ account: { byName: { appleTeams: AppleTeamQueryResult[] } } }>(
+          gql`
+            query AppleTeamsByAccountName($accountName: String!) {
+              account {
+                byName(accountName: $accountName) {
+                  appleTeams {
+                    id
+                    appleTeamName
+                    appleTeamIdentifier
+                  }
+                }
+              }
+            }
+          `,
+          { accountName }
+        )
+        .toPromise()
+    );
+
+    return data.account.byName.appleTeams;
+  },
+
+  async getByAppleTeamIdentifierAsync(
     accountId: string,
     appleTeamIdentifier: string
   ): Promise<AppleTeam | null> {

--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -100,7 +100,10 @@ async function ensureAppleTeamExistsAsync(
   accountId: string,
   { appleTeamIdentifier, appleTeamName }: { appleTeamIdentifier: string; appleTeamName: string }
 ): Promise<AppleTeam> {
-  const appleTeam = await AppleTeamQuery.byAppleTeamIdentifierAsync(accountId, appleTeamIdentifier);
+  const appleTeam = await AppleTeamQuery.getByAppleTeamIdentifierAsync(
+    accountId,
+    appleTeamIdentifier
+  );
   if (appleTeam) {
     return appleTeam;
   } else {

--- a/packages/eas-cli/src/devices/utils/formatDevice.ts
+++ b/packages/eas-cli/src/devices/utils/formatDevice.ts
@@ -1,0 +1,26 @@
+import { AppleDevice, AppleTeam } from '../../graphql/generated';
+import formatFields from '../../utils/formatFields';
+
+type Device = Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'deviceClass' | 'enabled'>;
+
+type Team = Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName'>;
+
+export default function formatDevice(device: Device, team?: Team) {
+  const fields = [
+    { label: 'ID', value: device.id },
+    { label: 'Name', value: device.name ?? 'Unknown' },
+    { label: 'Class', value: device.deviceClass ?? 'Unknown' },
+    { label: 'UDID', value: device.identifier },
+  ];
+
+  if (team) {
+    fields.push(
+      ...[
+        { label: 'Apple Team ID', value: team.appleTeamIdentifier },
+        { label: 'Apple Team Name', value: team.appleTeamName ?? 'Unknown' },
+      ]
+    );
+  }
+
+  return formatFields(fields);
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -51,6 +51,8 @@ export type RootQuery = {
    */
   allPublicApps?: Maybe<Array<Maybe<App>>>;
   asset: AssetQuery;
+  /** Top-level query object for querying BuildPublicData publicly. */
+  buildPublicData: BuildPublicDataQuery;
   buildJobs: BuildJobQuery;
   builds: BuildQuery;
   clientBuilds: ClientBuildQuery;
@@ -261,6 +263,15 @@ export type AccountAppleAppIdentifiersArgs = {
  */
 export type AccountAppleProvisioningProfilesArgs = {
   appleAppIdentifierId?: Maybe<Scalars['ID']>;
+};
+
+
+/**
+ * An account is a container owning projects, credentials, billing and other organization
+ * data and settings. Actors may own and be members of accounts.
+ */
+export type AccountAppleDevicesArgs = {
+  identifier?: Maybe<Scalars['String']>;
 };
 
 
@@ -517,6 +528,11 @@ export type User = Actor & {
   hasPendingUserInvitations: Scalars['Boolean'];
   /** Pending UserInvitations for this user. Only resolves for the viewer. */
   pendingUserInvitations: Array<Maybe<UserInvitation>>;
+  /**
+   * Server feature gate values for this actor, optionally filtering by desired gates.
+   * Only resolves for the viewer.
+   */
+  featureGates: Scalars['JSONObject'];
 };
 
 
@@ -540,6 +556,12 @@ export type UserLikesArgs = {
   limit: Scalars['Int'];
 };
 
+
+/** Represents a human (not robot) actor. */
+export type UserFeatureGatesArgs = {
+  filter?: Maybe<Array<Scalars['String']>>;
+};
+
 /** A user or robot that can authenticate with Expo services and be a member of accounts. */
 export type Actor = {
   id: Scalars['ID'];
@@ -550,6 +572,17 @@ export type Actor = {
   accounts?: Maybe<Array<Maybe<Account>>>;
   /** Access Tokens belonging to this actor */
   accessTokens?: Maybe<Array<Maybe<AccessToken>>>;
+  /**
+   * Server feature gate values for this actor, optionally filtering by desired gates.
+   * Only resolves for the viewer.
+   */
+  featureGates: Scalars['JSONObject'];
+};
+
+
+/** A user or robot that can authenticate with Expo services and be a member of accounts. */
+export type ActorFeatureGatesArgs = {
+  filter?: Maybe<Array<Scalars['String']>>;
 };
 
 /** A method of authentication for an Actor */
@@ -564,6 +597,7 @@ export type AccessToken = {
   owner: Actor;
   note?: Maybe<Scalars['String']>;
 };
+
 
 /** A second factor device belonging to a User */
 export type UserSecondFactorDevice = {
@@ -656,12 +690,13 @@ export type Build = ActivityTimelineProjectActivity & {
   logFiles?: Maybe<Array<Maybe<Scalars['String']>>>;
   updatedAt?: Maybe<Scalars['DateTime']>;
   createdAt?: Maybe<Scalars['DateTime']>;
-  status?: Maybe<BuildStatus>;
+  status: BuildStatus;
   expirationDate?: Maybe<Scalars['DateTime']>;
-  platform?: Maybe<AppPlatform>;
+  platform: AppPlatform;
   appVersion?: Maybe<Scalars['String']>;
   sdkVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
+  distribution?: Maybe<DistributionType>;
 };
 
 export type ActivityTimelineProjectActivity = {
@@ -675,6 +710,11 @@ export type BuildArtifacts = {
   buildUrl?: Maybe<Scalars['String']>;
   xcodeBuildLogsUrl?: Maybe<Scalars['String']>;
 };
+
+export enum DistributionType {
+  Store = 'STORE',
+  Internal = 'INTERNAL'
+}
 
 export type IosAppCredentialsFilter = {
   appleAppIdentifierId?: Maybe<Scalars['String']>;
@@ -964,7 +1004,7 @@ export type BuildJob = ActivityTimelineProjectActivity & {
   fullExperienceName?: Maybe<Scalars['String']>;
   status?: Maybe<BuildJobStatus>;
   expirationDate?: Maybe<Scalars['DateTime']>;
-  platform?: Maybe<AppPlatform>;
+  platform: AppPlatform;
   sdkVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
 };
@@ -1153,6 +1193,39 @@ export enum AssetMetadataStatus {
   Exists = 'EXISTS',
   DoesNotExist = 'DOES_NOT_EXIST'
 }
+
+export type BuildPublicDataQuery = {
+  __typename?: 'BuildPublicDataQuery';
+  /** Get BuildPublicData by ID */
+  byId?: Maybe<BuildPublicData>;
+};
+
+
+export type BuildPublicDataQueryByIdArgs = {
+  id: Scalars['ID'];
+};
+
+/** Publicly visible data for a Build. */
+export type BuildPublicData = {
+  __typename?: 'BuildPublicData';
+  id: Scalars['ID'];
+  status: BuildStatus;
+  artifacts: PublicArtifacts;
+  project: ProjectPublicData;
+  platform: AppPlatform;
+  distribution?: Maybe<DistributionType>;
+};
+
+export type PublicArtifacts = {
+  __typename?: 'PublicArtifacts';
+  buildUrl?: Maybe<Scalars['String']>;
+};
+
+export type ProjectPublicData = {
+  __typename?: 'ProjectPublicData';
+  id: Scalars['ID'];
+  fullName: Scalars['String'];
+};
 
 export type BuildJobQuery = {
   __typename?: 'BuildJobQuery';
@@ -1365,6 +1438,8 @@ export type RootMutation = {
   userInvitation: UserInvitationMutation;
   /** Mutations that modify the currently authenticated User */
   me?: Maybe<MeMutation>;
+  /** Mutations that modify an EmailSubscription */
+  emailSubscription: EmailSubscriptionMutation;
 };
 
 
@@ -2031,6 +2106,17 @@ export type Robot = Actor & {
   accounts?: Maybe<Array<Maybe<Account>>>;
   /** Access Tokens belonging to this actor */
   accessTokens?: Maybe<Array<Maybe<AccessToken>>>;
+  /**
+   * Server feature gate values for this actor, optionally filtering by desired gates.
+   * Only resolves for the viewer.
+   */
+  featureGates: Scalars['JSONObject'];
+};
+
+
+/** Represents a robot (not human) actor. */
+export type RobotFeatureGatesArgs = {
+  filter?: Maybe<Array<Scalars['String']>>;
 };
 
 export type DeleteRobotResult = {
@@ -2412,6 +2498,45 @@ export type SecondFactorRegenerateBackupCodesResult = {
   plaintextBackupCodes: Array<Maybe<Scalars['String']>>;
 };
 
+export type EmailSubscriptionMutation = {
+  __typename?: 'EmailSubscriptionMutation';
+  addUser?: Maybe<AddUserPayload>;
+};
+
+
+export type EmailSubscriptionMutationAddUserArgs = {
+  addUserInput: AddUserInput;
+};
+
+export type AddUserInput = {
+  email: Scalars['String'];
+  tags?: Maybe<Array<MailchimpTag>>;
+  audience?: Maybe<MailchimpAudience>;
+};
+
+export enum MailchimpTag {
+  EasMasterList = 'EAS_MASTER_LIST'
+}
+
+export enum MailchimpAudience {
+  ExpoDevelopers = 'EXPO_DEVELOPERS'
+}
+
+export type AddUserPayload = {
+  __typename?: 'AddUserPayload';
+  id?: Maybe<Scalars['String']>;
+  email_address?: Maybe<Scalars['String']>;
+  status?: Maybe<Scalars['String']>;
+  timestamp_signup?: Maybe<Scalars['String']>;
+  tags?: Maybe<Array<MailchimpTagPayload>>;
+  list_id?: Maybe<Scalars['String']>;
+};
+
+export type MailchimpTagPayload = {
+  __typename?: 'MailchimpTagPayload';
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
+};
 
 export type BaseSearchResult = SearchResult & {
   __typename?: 'BaseSearchResult';
@@ -2453,6 +2578,87 @@ export enum CacheControlScope {
   Private = 'PRIVATE'
 }
 
+
+export type AccountByNameQueryVariables = Exact<{
+  accountName: Scalars['String'];
+}>;
+
+
+export type AccountByNameQuery = (
+  { __typename?: 'RootQuery' }
+  & { account: (
+    { __typename?: 'AccountQuery' }
+    & { byName: (
+      { __typename?: 'Account' }
+      & Pick<Account, 'id'>
+    ) }
+  ) }
+);
+
+export type AppleDevicesByAccountNameQueryVariables = Exact<{
+  accountId: Scalars['ID'];
+  identifier: Scalars['String'];
+}>;
+
+
+export type AppleDevicesByAccountNameQuery = (
+  { __typename?: 'RootQuery' }
+  & { appleTeam: (
+    { __typename?: 'AppleTeamQuery' }
+    & { byAppleTeamIdentifier?: Maybe<(
+      { __typename?: 'AppleTeam' }
+      & Pick<AppleTeam, 'id' | 'appleTeamName'>
+      & { appleDevices?: Maybe<Array<Maybe<(
+        { __typename?: 'AppleDevice' }
+        & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'deviceClass' | 'enabled'>
+      )>>> }
+    )> }
+  ) }
+);
+
+export type AppleDevicesByIdentifierQueryVariables = Exact<{
+  accountName: Scalars['String'];
+  identifier: Scalars['String'];
+}>;
+
+
+export type AppleDevicesByIdentifierQuery = (
+  { __typename?: 'RootQuery' }
+  & { account: (
+    { __typename?: 'AccountQuery' }
+    & { byName: (
+      { __typename?: 'Account' }
+      & Pick<Account, 'id'>
+      & { appleDevices?: Maybe<Array<Maybe<(
+        { __typename?: 'AppleDevice' }
+        & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'deviceClass' | 'enabled'>
+        & { appleTeam: (
+          { __typename?: 'AppleTeam' }
+          & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
+        ) }
+      )>>> }
+    ) }
+  ) }
+);
+
+export type AppleTeamsByAccountNameQueryVariables = Exact<{
+  accountName: Scalars['String'];
+}>;
+
+
+export type AppleTeamsByAccountNameQuery = (
+  { __typename?: 'RootQuery' }
+  & { account: (
+    { __typename?: 'AccountQuery' }
+    & { byName: (
+      { __typename?: 'Account' }
+      & { appleTeams: Array<Maybe<(
+        { __typename?: 'AppleTeam' }
+        & Pick<AppleTeam, 'id' | 'appleTeamName' | 'appleTeamIdentifier'>
+      )>> }
+    ) }
+  ) }
+);
 
 export type BuildsByIdQueryQueryVariables = Exact<{
   buildId: Scalars['ID'];

--- a/packages/eas-cli/src/utils/formatFields.ts
+++ b/packages/eas-cli/src/utils/formatFields.ts
@@ -1,0 +1,21 @@
+import chalk from 'chalk';
+
+export default function formatFields(fields: { label: string; value: string }[]) {
+  const columnWidth = fields.reduce((a, b) => (a.label.length > b.label.length ? a : b)).label
+    .length;
+
+  return fields
+    .map(({ label, value }) => {
+      let line = '';
+
+      line += chalk.dim(
+        label.length < columnWidth ? `${label}${' '.repeat(columnWidth - label.length)}` : label
+      );
+
+      line += '  ';
+      line += value;
+
+      return line;
+    })
+    .join('\n');
+}


### PR DESCRIPTION
This adds commands to view registered devices for an account.

<img width="682" alt="Screen Shot 2020-12-10 at 16 28 59" src="https://user-images.githubusercontent.com/1174278/101792964-9b38d380-3b05-11eb-853e-7011c908cf79.png">

<img width="682" alt="Screen Shot 2020-12-10 at 16 38 29" src="https://user-images.githubusercontent.com/1174278/101793496-2914be80-3b06-11eb-9a52-131a18c92a74.png">

Depends on https://github.com/expo/universe/pull/6614