### PR TITLE
[eas-cli] add release:publish 4/4

### DIFF
--- a/packages/eas-cli/src/commands/release/publish.ts
+++ b/packages/eas-cli/src/commands/release/publish.ts
@@ -10,7 +10,7 @@ import {
   getProjectAccountNameAsync,
   getReleaseByNameAsync,
 } from '../../project/projectUtils';
-import { buildUpdateInfoGroup, collectAssets, uploadAssetsAsync } from '../../project/publish';
+import { buildUpdateInfoGroupAsync, collectAssets, uploadAssetsAsync } from '../../project/publish';
 import { promptAsync } from '../../prompts';
 import { getLastCommitMessageAsync } from '../../utils/git';
 
@@ -127,7 +127,7 @@ export default class ReleasePublish extends Command {
 
     log.withTick('Uploading assets...');
     await uploadAssetsAsync(assets);
-    const updateInfoGroup = buildUpdateInfoGroup(assets);
+    const updateInfoGroup = await buildUpdateInfoGroupAsync(assets);
 
     log.withTick('Publishing...');
     const newUpdateGroup = await PublishMutation.publishUpdateGroupAsync({

--- a/packages/eas-cli/src/commands/release/publish.ts
+++ b/packages/eas-cli/src/commands/release/publish.ts
@@ -26,10 +26,6 @@ export default class ReleasePublish extends Command {
     release: flags.string({
       description: 'current name of the release.',
     }),
-    'runtime-version': flags.string({
-      description: 'runtime version of the updates',
-      required: false,
-    }),
     message: flags.string({
       description: 'Short message describing the updates.',
       required: false,
@@ -45,7 +41,6 @@ export default class ReleasePublish extends Command {
       flags: {
         json: jsonFlag,
         release: releaseName,
-        'runtime-version': runtimeVersion,
         message: publishMessage,
         'input-dir': inputDir,
       },
@@ -55,10 +50,16 @@ export default class ReleasePublish extends Command {
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');
     }
+
     const accountName = await getProjectAccountNameAsync(projectDir);
     const {
-      exp: { slug },
+      exp: { slug, runtimeVersion },
     } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    if (!runtimeVersion) {
+      throw new Error(
+        "Couldn't find either 'runtimeVersion'. Please specify it under the 'expo' key in 'app.json'"
+      );
+    }
     const projectId = await ensureProjectExistsAsync({
       accountName,
       projectName: slug,
@@ -73,19 +74,6 @@ export default class ReleasePublish extends Command {
         type: 'text',
         name: 'releaseName',
         message: 'Please enter the name of the release to publish on:',
-        validate: value => (value ? true : validationMessage),
-      }));
-    }
-
-    if (!runtimeVersion) {
-      const validationMessage = 'runtimeVersion name may not be empty.';
-      if (jsonFlag) {
-        throw new Error(validationMessage);
-      }
-      ({ runtimeVersion } = await promptAsync({
-        type: 'text',
-        name: 'runtimeVersion',
-        message: 'Please enter the runtime version of the updates',
         validate: value => (value ? true : validationMessage),
       }));
     }

--- a/packages/eas-cli/src/commands/release/publish.ts
+++ b/packages/eas-cli/src/commands/release/publish.ts
@@ -41,7 +41,7 @@ export default class ReleasePublish extends Command {
       flags: {
         json: jsonFlag,
         release: releaseName,
-        message: publishMessage,
+        message: updateMessage,
         'input-dir': inputDir,
       },
     } = this.parse(ReleasePublish);
@@ -78,12 +78,12 @@ export default class ReleasePublish extends Command {
       }));
     }
 
-    if (!publishMessage) {
+    if (!updateMessage) {
       const validationMessage = 'publish message may not be empty.';
       if (jsonFlag) {
         throw new Error(validationMessage);
       }
-      ({ publishMessage } = await promptAsync({
+      ({ publishMessage: updateMessage } = await promptAsync({
         type: 'text',
         name: 'publishMessage',
         message: `Please enter a publication message.`,
@@ -98,7 +98,7 @@ export default class ReleasePublish extends Command {
     });
 
     log.withTick(
-      `️Publishing "${publishMessage}" to ${releaseName}@${runtimeVersion} to on project ${chalk.bold(
+      `️Publishing "${updateMessage}" to ${releaseName}@${runtimeVersion} to on project ${chalk.bold(
         `@${accountName}/${slug}`
       )}.`
     );
@@ -114,8 +114,8 @@ export default class ReleasePublish extends Command {
     const newUpdateGroup = await PublishMutation.publishUpdateGroupAsync({
       releaseId,
       updateInfoGroup,
-      runtimeVersion: runtimeVersion!,
-      updateMessage: publishMessage,
+      runtimeVersion,
+      updateMessage,
     });
 
     if (jsonFlag) {

--- a/packages/eas-cli/src/commands/release/publish.ts
+++ b/packages/eas-cli/src/commands/release/publish.ts
@@ -18,18 +18,19 @@ export default class ReleasePublish extends Command {
   static description = 'Publish an update group to a release.';
 
   static flags = {
-    inputDir: flags.string({
+    'input-dir': flags.string({
       description: 'location of the bundle',
+      default: 'dist',
       required: false,
     }),
-    releaseName: flags.string({
+    release: flags.string({
       description: 'current name of the release.',
     }),
-    runtimeVersion: flags.string({
+    'runtime-version': flags.string({
       description: 'runtime version of the updates',
       required: false,
     }),
-    publishMessage: flags.string({
+    message: flags.string({
       description: 'Short message describing the updates.',
       required: false,
     }),
@@ -41,7 +42,13 @@ export default class ReleasePublish extends Command {
 
   async run() {
     let {
-      flags: { json: jsonFlag, releaseName, runtimeVersion, publishMessage, inputDir },
+      flags: {
+        json: jsonFlag,
+        release: releaseName,
+        'runtime-version': runtimeVersion,
+        message: publishMessage,
+        'input-dir': inputDir,
+      },
     } = this.parse(ReleasePublish);
 
     const projectDir = await findProjectRootAsync(process.cwd());
@@ -56,20 +63,6 @@ export default class ReleasePublish extends Command {
       accountName,
       projectName: slug,
     });
-
-    if (!inputDir) {
-      const validationMessage = 'input directory must be specified.';
-      if (jsonFlag) {
-        throw new Error(validationMessage);
-      }
-      ({ inputDir } = await promptAsync({
-        type: 'text',
-        name: 'inputDir',
-        message: 'Please enter the name of the directory created by the bundler:',
-        initial: 'dist',
-        validate: value => (value ? true : validationMessage),
-      }));
-    }
 
     if (!releaseName) {
       const validationMessage = 'release name may not be empty.';

--- a/packages/eas-cli/src/commands/release/publish.ts
+++ b/packages/eas-cli/src/commands/release/publish.ts
@@ -1,0 +1,152 @@
+import { getConfig } from '@expo/config';
+import { Command, flags } from '@oclif/command';
+import chalk from 'chalk';
+
+import { PublishMutation } from '../../graphql/mutations/PublishMutation';
+import log from '../../log';
+import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
+import {
+  findProjectRootAsync,
+  getProjectAccountNameAsync,
+  getReleaseByNameAsync,
+} from '../../project/projectUtils';
+import { buildUpdateInfoGroup, collectAssets, uploadAssetsAsync } from '../../project/publish';
+import { promptAsync } from '../../prompts';
+import { getLastCommitMessageAsync } from '../../utils/git';
+
+export default class ReleasePublish extends Command {
+  static description = 'Publish an update group to a release.';
+
+  static flags = {
+    inputDir: flags.string({
+      description: 'location of the bundle',
+      required: false,
+    }),
+    releaseName: flags.string({
+      description: 'current name of the release.',
+    }),
+    runtimeVersion: flags.string({
+      description: 'runtime version of the updates',
+      required: false,
+    }),
+    publishMessage: flags.string({
+      description: 'Short message describing the updates.',
+      required: false,
+    }),
+    json: flags.boolean({
+      description: `return a json with the edited release's ID and name.`,
+      default: false,
+    }),
+  };
+
+  async run() {
+    let {
+      flags: { json: jsonFlag, releaseName, runtimeVersion, publishMessage, inputDir },
+    } = this.parse(ReleasePublish);
+
+    const projectDir = await findProjectRootAsync(process.cwd());
+    if (!projectDir) {
+      throw new Error('Please run this command inside a project directory.');
+    }
+    const accountName = await getProjectAccountNameAsync(projectDir);
+    const {
+      exp: { slug },
+    } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await ensureProjectExistsAsync({
+      accountName,
+      projectName: slug,
+    });
+
+    if (!inputDir) {
+      const validationMessage = 'input directory must be specified.';
+      if (jsonFlag) {
+        throw new Error(validationMessage);
+      }
+      ({ inputDir } = await promptAsync({
+        type: 'text',
+        name: 'inputDir',
+        message: 'Please enter the name of the directory created by the bundler:',
+        initial: 'dist',
+        validate: value => (value ? true : validationMessage),
+      }));
+    }
+
+    if (!releaseName) {
+      const validationMessage = 'release name may not be empty.';
+      if (jsonFlag) {
+        throw new Error(validationMessage);
+      }
+      ({ releaseName } = await promptAsync({
+        type: 'text',
+        name: 'releaseName',
+        message: 'Please enter the name of the release to publish on:',
+        validate: value => (value ? true : validationMessage),
+      }));
+    }
+
+    if (!runtimeVersion) {
+      const validationMessage = 'runtimeVersion name may not be empty.';
+      if (jsonFlag) {
+        throw new Error(validationMessage);
+      }
+      ({ runtimeVersion } = await promptAsync({
+        type: 'text',
+        name: 'runtimeVersion',
+        message: 'Please enter the runtime version of the updates',
+        validate: value => (value ? true : validationMessage),
+      }));
+    }
+
+    if (!publishMessage) {
+      const validationMessage = 'publish message may not be empty.';
+      if (jsonFlag) {
+        throw new Error(validationMessage);
+      }
+      ({ publishMessage } = await promptAsync({
+        type: 'text',
+        name: 'publishMessage',
+        message: `Please enter a publication message.`,
+        initial: (await getLastCommitMessageAsync())?.trim(),
+        validate: value => (value ? true : validationMessage),
+      }));
+    }
+
+    const { id: releaseId } = await getReleaseByNameAsync({
+      appId: projectId,
+      releaseName: releaseName!,
+    });
+
+    log.withTick(
+      `️Publishing "${publishMessage}" to ${releaseName}@${runtimeVersion} to on project ${chalk.bold(
+        `@${accountName}/${slug}`
+      )}.`
+    );
+
+    log.withTick('Collecting assets...');
+    const assets = collectAssets(inputDir!);
+
+    log.withTick('Uploading assets...');
+    await uploadAssetsAsync(assets);
+    const updateInfoGroup = buildUpdateInfoGroup(assets);
+
+    log.withTick('Publishing...');
+    const newUpdateGroup = await PublishMutation.publishUpdateGroupAsync({
+      releaseId,
+      updateInfoGroup,
+      runtimeVersion: runtimeVersion!,
+      updateMessage: publishMessage,
+    });
+
+    if (jsonFlag) {
+      log(newUpdateGroup);
+      return;
+    }
+    log.withTick(
+      `Published update group ${
+        newUpdateGroup.updateGroup
+      } to release ${releaseName}@${runtimeVersion} on app ${chalk.bold(
+        `@${accountName}/${slug}`
+      )}!`
+    );
+  }
+}

--- a/packages/eas-cli/src/commands/release/publish.ts
+++ b/packages/eas-cli/src/commands/release/publish.ts
@@ -59,7 +59,7 @@ export default class ReleasePublish extends Command {
     } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     if (!runtimeVersion) {
       throw new Error(
-        "Couldn't find either 'runtimeVersion'. Please specify it under the 'expo' key in 'app.json'"
+        "Couldn't find 'runtimeVersion'. Please specify it under the 'expo' key in 'app.json'"
       );
     }
     const projectId = await ensureProjectExistsAsync({

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -151,7 +151,9 @@ describe(resolveInputDirectory, () => {
     const nonExistentPath = path.resolve(uuidv4());
     expect(() => {
       resolveInputDirectory(nonExistentPath);
-    }).toThrow(`${nonExistentPath} does not exist. Please create it with your desired bundler.`);
+    }).toThrow(`The input directory "${nonExistentPath}" does not exist.
+    You'll need to run a command to build the JS bundle first (e.g. 'expo export').
+    You can use '--input-dir' to specify a different input directory.`);
   });
 });
 

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -120,7 +120,9 @@ export async function buildUpdateInfoGroupAsync(assets: CollectedAssets): Promis
 export function resolveInputDirectory(customInputDirectory: string): string {
   const distRoot = path.resolve(customInputDirectory);
   if (!fs.existsSync(distRoot)) {
-    throw new Error(`${distRoot} does not exist. Please create it with your desired bundler.`);
+    throw new Error(`The input directory "${customInputDirectory}" does not exist.
+    You'll need to run a command to build the JS bundle first (e.g. 'expo export').
+    You can use '--input-dir' to specify a different input directory.`);
   }
   return distRoot;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,10 +1574,19 @@
     qqjs "^0.3.10"
     tslib "^1.9.3"
 
-"@expo/plist@0.0.10", "@expo/plist@^0.0.10":
+"@expo/plist@0.0.10":
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.10.tgz#e126a15543c6c67fd159947ca9e35969657a97f4"
   integrity sha512-uKbi7ANPCNJqeAvxLa+ZcS/Qf0fTPOySMqw5T2L4TrycSAdiAxV1VUZ69IzIbUsWb7GdriUVR2i38M/xa6+BvA==
+  dependencies:
+    base64-js "^1.2.3"
+    xmlbuilder "^14.0.0"
+    xmldom "~0.1.31"
+
+"@expo/plist@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.11.tgz#5d7900dc31df57d45a3524c061dde34aacc8dabf"
+  integrity sha512-yza93QHDkbdkdwu/PXef0eJSCMkMNdrHujK5G1viZLaZt0Rxw2s+geTyjgJsYpwqQEAoOYVpKlVymOenK+bFQg==
   dependencies:
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"


### PR DESCRIPTION
# Why

This is the final of 4 PR's to add `eas release:publish`. 

It adds the command.

# How

Ask for: `inputDir`, `releaseName`, `runtimeVersion`, and `updateMessage`.

# Test Plan

yarn test

Also ran this in the alpha.

<img width="1561" alt="Screen Shot 2020-12-13 at 3 51 37 PM" src="https://user-images.githubusercontent.com/1220444/102027742-1810bb00-3d5b-11eb-866e-4ed0be422301.png">
