### PR TITLE
[eas-cli] Slightly easier to read output when build is completed

### DIFF
--- a/packages/eas-cli/src/build/constants.ts
+++ b/packages/eas-cli/src/build/constants.ts
@@ -1,7 +1,12 @@
-import { RequestedPlatform } from './types';
+import { Platform, RequestedPlatform } from './types';
 
 export const platformDisplayNames = {
   [RequestedPlatform.iOS]: 'iOS',
   [RequestedPlatform.Android]: 'Android',
   [RequestedPlatform.All]: 'Android and iOS',
+};
+
+export const platformEmojis = {
+  [Platform.iOS]: '🍎',
+  [Platform.Android]: '🤖',
 };

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -3,7 +3,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 
 import log from '../../log';
-import { platformDisplayNames } from '../constants';
+import { platformDisplayNames, platformEmojis } from '../constants';
 import { Build } from '../types';
 import { getBuildLogsUrl } from './url';
 
@@ -29,9 +29,7 @@ export function printLogsUrls(
         buildId,
         account: accountName,
       });
-      log(
-        `Platform: ${platformDisplayNames[platform]}, Build details: ${chalk.underline(logsUrl)}`
-      );
+      log(`${platformDisplayNames[platform]} build details: ${chalk.underline(logsUrl)}`);
     });
   }
 }
@@ -55,12 +53,19 @@ function printBuildResult(accountName: string, build: Build): void {
       account: accountName,
     });
     log(
-      `Open this link on your ${platformDisplayNames[build.platform]} devices to install the app:`
+      `${platformEmojis[build.platform]} Open this link on your ${
+        platformDisplayNames[build.platform]
+      } devices to install the app:`
     );
     log(`${chalk.underline(logsUrl)}`);
+    log.newLine();
   } else {
+    // TODO: it looks like buildUrl could possibly be undefined, based on the code below.
+    // we should account for this case better if it is possible
     const url = build.artifacts?.buildUrl ?? '';
-    log(`Platform: ${platformDisplayNames[build.platform]}, App: ${chalk.underline(url)}`);
+    log(`${platformEmojis[build.platform]} ${platformDisplayNames[build.platform]} app:`);
+    log(`${chalk.underline(url)}`);
+    log.newLine();
   }
 }
 


### PR DESCRIPTION
# Why

A more pleasant ending to a successful build.

### Before

```
Platform: Android, Build details: https://expo.io/accounts/notbrent/builds/0bc60508-6e5d-4084-88fc-3a5db55dc241
Platform: iOS, Build details: https://expo.io/accounts/notbrent/builds/dc4c2578-3893-43b8-9804-adc8fba54e7a

Waiting for build to complete. You can press Ctrl+C to exit.
✔ All builds have finished

Open this link on your Android devices to install the app:
https://expo.io/accounts/notbrent/builds/0bc60508-6e5d-4084-88fc-3a5db55dc241
Open this link on your iOS devices to install the app:
https://expo.io/accounts/notbrent/builds/dc4c2578-3893-43b8-9804-adc8fba54e7a
```

### After

```
Android build details: https://expo.io/accounts/notbrent/builds/0bc60508-6e5d-4084-88fc-3a5db55dc241
iOS build details: https://expo.io/accounts/notbrent/builds/dc4c2578-3893-43b8-9804-adc8fba54e7a

Waiting for build to complete. You can press Ctrl+C to exit.
✔ All builds have finished

🤖 Open this link on your Android devices to install the app:
https://expo.io/accounts/notbrent/builds/0bc60508-6e5d-4084-88fc-3a5db55dc241

🍎 Open this link on your iOS devices to install the app:
https://expo.io/accounts/notbrent/builds/dc4c2578-3893-43b8-9804-adc8fba54e7a
```

Similar for builds that are not intended for internal distribution, but with the appropriate messaging.

# How

Update the logs accordingly.

# Test Plan

Run a build, wait a while, see the above logs.
