### PR TITLE
[eas-cli] Only configure eas.json for the requested platform

### DIFF
--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -50,17 +50,30 @@ export default class BuildConfigure extends Command {
     });
 
     log.newLine();
-    log(`🎉 Your iOS and Android projects are ready to build.
+    logSuccess(platform);
+  }
+}
+
+function logSuccess(platform: RequestedPlatform) {
+  let platformsText = 'iOS and Android projects are';
+  let storesText = 'the Apple App Store or Google Play Store';
+
+  if (platform === 'android') {
+    platformsText = 'Android project is';
+    storesText = 'the Google Play Store';
+  } else if (platform === 'ios') {
+    platformsText = 'iOS project is';
+    storesText = 'the Apple App Store';
+  }
+
+  log(`🎉 Your ${platformsText} ready to build.
 
 - Run ${chalk.bold('eas build')} when you are ready to create your first build.
-- Once the build is completed, run ${chalk.bold(
-      'eas submit'
-    )} to upload the app to the Apple App Store or Google Play Store.
+- Once the build is completed, run ${chalk.bold('eas submit')} to upload the app to ${storesText}
 - ${learnMore(
-      'https://docs.expo.io/build/introduction',
-      'Learn more about other capabilities of EAS Build'
-    )}`);
-  }
+    'https://docs.expo.io/build/introduction',
+    'Learn more about other capabilities of EAS Build'
+  )}`);
 }
 
 async function promptForPlatformAsync(): Promise<RequestedPlatform> {


### PR DESCRIPTION
# Why

It's strange to get eas.json populated with ios and android build configuration when you request only one of the platforms.

# How

Updated related configure code to work as expected for a single platform. Should have included tests but it looks like there wasn't any existing testing around this, so we should follow up on this later.

## iOS only

![Screen Shot 2020-12-10 at 8 25 49 PM](https://user-images.githubusercontent.com/90494/101862049-5b361880-3b26-11eb-8d64-e5ec59d2bc79.png)

## Android only, on top of already-configured iOS

![Screen Shot 2020-12-10 at 8 26 23 PM](https://user-images.githubusercontent.com/90494/101862065-62f5bd00-3b26-11eb-9460-98e962c82692.png)

## All, in an unconfigured project

![Screen Shot 2020-12-10 at 8 31 35 PM](https://user-images.githubusercontent.com/90494/101862214-b831ce80-3b26-11eb-9998-a1055be964b1.png)

## All, on an already configured project

![Screen Shot 2020-12-10 at 8 30 18 PM](https://user-images.githubusercontent.com/90494/101862136-8587d600-3b26-11eb-9cd0-7321f5aa697a.png)

# Test Plan

I tested the scenarios above