### PR TITLE
[eas-cli] Improve keytool detection

### DIFF
--- a/packages/eas-cli/src/credentials/android/utils/keystore.ts
+++ b/packages/eas-cli/src/credentials/android/utils/keystore.ts
@@ -13,10 +13,7 @@ export async function keytoolCommandExistsAsync(): Promise<boolean> {
   try {
     await spawnAsync('keytool');
   } catch (error) {
-    if (error.code === 'ENOENT') {
-      return false;
-    }
-    throw error;
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1607874915439400
calling `keytool` might fail with even if binary is in PATH

# How

Treat those cases the same as if keytool was not installed.

# Test Plan

Can't reproduce that on my system, but it should work
