### PR TITLE
Simplify the prompts for auto generation

### DIFF
--- a/packages/eas-cli/src/credentials/android/actions/__tests__/UpdateKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/UpdateKeystore-test.ts
@@ -38,7 +38,7 @@ describe('run UpdateKeystore when keystore exist on www', () => {
     });
     const manager = createManagerMock();
 
-    (prompts as any).mockImplementationOnce(() => ({ answer: false })); // promptForCredentials: let expo handle
+    (prompts as any).mockImplementationOnce(() => ({ value: true })); // promptForCredentials: let expo handle
 
     await new UpdateKeystore(testExperienceName).runAsync(manager, ctx);
 
@@ -58,7 +58,7 @@ describe('run UpdateKeystore when keystore exist on www', () => {
 
     await fs.writeFile('/keystore.jks', testKeystore.keystore, 'base64');
     (prompts as any)
-      .mockImplementationOnce(() => ({ answer: true })) // promptForCredentials: user specified
+      .mockImplementationOnce(() => ({ value: false })) // promptForCredentials: user specified
       .mockImplementationOnce(() => ({ input: '/keystore.jks' })) // keystore
       .mockImplementationOnce(() => ({ input: 'test' })) // keystore password
       .mockImplementationOnce(() => ({ input: 'test' })) // key alias
@@ -82,7 +82,7 @@ describe('run UpdateKeystore when keystore does not exist on www', () => {
     });
     const manager = createManagerMock();
 
-    (prompts as any).mockImplementationOnce(() => ({ answer: false })); // Let expo handle
+    (prompts as any).mockImplementationOnce(() => ({ value: true })); // Let expo handle
 
     await new UpdateKeystore(testExperienceName).runAsync(manager, ctx);
 
@@ -102,7 +102,7 @@ describe('run UpdateKeystore when keystore does not exist on www', () => {
 
     await fs.writeFile('/keystore.jks', testKeystore.keystore, 'base64');
     (prompts as any)
-      .mockImplementationOnce(() => ({ answer: true })) // promptForCredentials: user specified
+      .mockImplementationOnce(() => ({ value: false })) // promptForCredentials: user specified
       .mockImplementationOnce(() => ({ input: '/keystore.jks' })) // keystore
       .mockImplementationOnce(() => ({ input: 'test' })) // keystore password
       .mockImplementationOnce(() => ({ input: 'test' })) // key alias

--- a/packages/eas-cli/src/credentials/android/credentials.ts
+++ b/packages/eas-cli/src/credentials/android/credentials.ts
@@ -20,9 +20,7 @@ export type AndroidCredentials = {
 export const keystoreSchema: CredentialSchema<Keystore> = {
   name: 'Android Keystore',
   provideMethodQuestion: {
-    question: `Would you like to upload a Keystore or have us generate one for you?\nIf you don't know what this means, let us generate it! :)`,
-    expoGenerated: 'Generate new keystore',
-    userProvided: 'I want to upload my own file',
+    question: `Generate a new Android Keystore?`,
   },
   questions: [
     {

--- a/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
+++ b/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import untildify from 'untildify';
 
 import log from '../../log';
-import { Question as PromptQuestion, promptAsync } from '../../prompts';
+import { confirmAsync, promptAsync, Question as PromptQuestion } from '../../prompts';
 
 export type Question = {
   field: string;
@@ -18,8 +18,6 @@ export type CredentialSchema<T> = {
   questions: Question[];
   provideMethodQuestion?: {
     question?: string;
-    expoGenerated?: string;
-    userProvided?: string;
   };
   transformResultAsync?: (answers: Partial<T>) => Promise<T>;
 };
@@ -28,7 +26,6 @@ const EXPERT_PROMPT = once(() =>
   log.warn(`
 In this mode, we won't be able to make sure that your credentials are valid.
 Please double check that you're uploading valid files for your app otherwise you may encounter strange errors!
-
 When building for IOS make sure you've created your App ID on the Apple Developer Portal, that your App ID
 is in app.json as \`bundleIdentifier\`, and that the provisioning profile you
 upload matches that Team ID and App ID.
@@ -39,11 +36,11 @@ export async function askForUserProvidedAsync<T>(
   schema: CredentialSchema<T>,
   initialValues: Partial<T> = {}
 ): Promise<T | null> {
-  if (await willUserProvideCredentialsAsync<T>(schema)) {
-    EXPERT_PROMPT();
-    return await getCredentialsFromUserAsync<T>(schema, initialValues);
+  if (await shouldAutoGenerateCredentialsAsync<T>(schema)) {
+    return null;
   }
-  return null;
+  EXPERT_PROMPT();
+  return await getCredentialsFromUserAsync<T>(schema, initialValues);
 }
 
 export async function getCredentialsFromUserAsync<T>(
@@ -62,21 +59,10 @@ export async function getCredentialsFromUserAsync<T>(
     : (results as T);
 }
 
-async function willUserProvideCredentialsAsync<T>(schema: CredentialSchema<T>) {
-  const { answer } = await promptAsync({
-    type: 'select',
-    name: 'answer',
-    message: schema?.provideMethodQuestion?.question ?? `Will you provide your own ${schema.name}?`,
-    choices: [
-      {
-        title: schema?.provideMethodQuestion?.expoGenerated ?? 'Let EAS handle the process',
-        value: false,
-      },
-      {
-        title: schema?.provideMethodQuestion?.userProvided ?? 'I want to upload my own file',
-        value: true,
-      },
-    ],
+async function shouldAutoGenerateCredentialsAsync<T>(schema: CredentialSchema<T>) {
+  const answer = await confirmAsync({
+    message: schema?.provideMethodQuestion?.question ?? `Generate a new ${schema.name}?`,
+    initial: true,
   });
   return answer;
 }

--- a/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
+++ b/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import untildify from 'untildify';
 
 import log from '../../log';
-import { confirmAsync, promptAsync, Question as PromptQuestion } from '../../prompts';
+import { Question as PromptQuestion, confirmAsync, promptAsync } from '../../prompts';
 
 export type Question = {
   field: string;


### PR DESCRIPTION
# Why

Prompts for auto generation are too complex:

```
Would you like to upload a Keystore or have us generate one for you?\nIf you don't know what this means, let us generate it! :) [Use arrow keys ...]

- Generate new keystore
- I want to upload my own file
```

Is now a confirm prompt

```
? Generate a new Android Keystore? (Y/n)
```


# Test Plan

```
✔ Do you want to generate new credentials? … yes
✔ Generate a new Android Keystore? … no

In this mode, we won't be able to make sure that your credentials are valid.
Please double check that you're uploading valid files for your app otherwise you may encounter strange errors!
When building for IOS make sure you've created your App ID on the Apple Developer Portal, that your App ID
is in app.json as `bundleIdentifier`, and that the provisioning profile you
upload matches that Team ID and App ID.

✖ Path to the Keystore file. … 
demo 𝝠 eas build -p android
✔ Ensuring @bacon/demo2 is created on Expo
✔ Do you want to generate new credentials? … yes
✔ Generate a new Android Keystore? … yes
```