### PR TITLE
[submit] Simplify table logs

### DIFF
--- a/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
@@ -8,7 +8,7 @@ import {
   ArchiveType,
   SubmissionPlatform,
 } from '../types';
-import { breakWord, printSummary } from '../utils/summary';
+import { printSummary } from '../utils/summary';
 import { AndroidPackageSource, getAndroidPackageAsync } from './AndroidPackageSource';
 import { AndroidSubmissionConfig, ReleaseStatus, ReleaseTrack } from './AndroidSubmissionConfig';
 import { ServiceAccountSource, getServiceAccountAsync } from './ServiceAccountSource';
@@ -68,17 +68,32 @@ class AndroidSubmitter extends BaseSubmitter<AndroidSubmissionContext, AndroidSu
       projectId,
     };
 
-    printSummary(
-      {
-        ...submissionConfig,
-        serviceAccountPath,
-      },
-      'Android Submission Summary',
-      SummaryHumanReadableKeys,
-      SummaryHumanReadableValues
-    );
+    printSummaryAndroid({
+      ...submissionConfig,
+      serviceAccountPath,
+    });
     return { ...submissionConfig, serviceAccount };
   }
+}
+
+/**
+ * Log the summary as a table. Exported for testing locally.
+ *
+ * @example
+ * printSummaryAndroid({
+ *   androidPackage: 'com.expo.demoapp',
+ *   archivePath: '/Users/example/Documents/863f9337-65d2-40c6-acb3-c1054c5c09f8.apk',
+ *   archiveUrl: 'https://turtle-v2-artifacts.s3.amazonaws.com/ios/6420592d-5b5d-439b-aed4-ccd278647138-ca4145d8468947df9ded737248a1a238.aab',
+ *   archiveType: 'apk' as any,
+ *   serviceAccountPath: '/Users/example/Documents/gsa.json',
+ *   track: ReleaseTrack.production,
+ *   releaseStatus: ReleaseStatus.completed,
+ *   projectId: '863f9337-65d2-40c6-acb3-c1054c5c09f8',
+ * });
+ * @param submissionConfig
+ */
+export function printSummaryAndroid(submissionConfig: Summary) {
+  printSummary(submissionConfig, SummaryHumanReadableKeys, SummaryHumanReadableValues);
 }
 
 interface Summary {
@@ -95,7 +110,7 @@ interface Summary {
 const SummaryHumanReadableKeys: Record<keyof Summary, string> = {
   androidPackage: 'Android package',
   archivePath: 'Archive path',
-  archiveUrl: 'Archive URL',
+  archiveUrl: 'Download URL',
   archiveType: 'Archive type',
   serviceAccountPath: 'Google Service Account',
   track: 'Release track',
@@ -103,9 +118,6 @@ const SummaryHumanReadableKeys: Record<keyof Summary, string> = {
   projectId: 'Project ID',
 };
 
-const SummaryHumanReadableValues: Partial<Record<keyof Summary, Function>> = {
-  archivePath: (path: string) => breakWord(path, 50),
-  archiveUrl: (url: string) => breakWord(url, 50),
-};
+const SummaryHumanReadableValues: Partial<Record<keyof Summary, Function>> = {};
 
 export default AndroidSubmitter;

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import BaseSubmitter from '../BaseSubmitter';
 import { Archive, ArchiveSource, getArchiveAsync } from '../archiveSource';
 import { IosSubmissionContext, SubmissionPlatform } from '../types';
-import { breakWord, printSummary } from '../utils/summary';
+import { printSummary } from '../utils/summary';
 import {
   AppSpecificPasswordSource,
   getAppSpecificPasswordAsync,
@@ -35,12 +35,8 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
       resolvedSourceOptions
     );
 
-    printSummary(
-      submissionConfig,
-      'iOS Submission Summary',
-      SummaryHumanReadableKeys,
-      SummaryHumanReadableValues
-    );
+    printSummaryIOS(submissionConfig);
+
     await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
   }
 
@@ -72,16 +68,37 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
   }
 }
 
+/**
+ * Log the summary as a table. Exported for testing locally.
+ * @example
+ * printSummaryIOS({
+ *   appleId: 'examplename@expo.io',
+ *   appSpecificPassword: 'Apple Pie^',
+ *   appAppleId: '1234567890',
+ *   projectId: '863f9337-65d2-40c6-acb3-c1054c5c09f8',
+ *   archiveUrl: 'https://turtle-v2-artifacts.s3.amazonaws.com/ios/6420592d-5b5d-439b-aed4-ccd278647138-ca4145d8468947df9ded737248a1a238.ipa',
+ * });
+ * @param submissionConfig
+ */
+export function printSummaryIOS(submissionConfig: IosSubmissionConfig) {
+  const { appSpecificPassword, projectId, archiveUrl, ...logConfig } = submissionConfig;
+
+  printSummary(
+    { ...logConfig, projectId, archiveUrl },
+    SummaryHumanReadableKeys,
+    SummaryHumanReadableValues
+  );
+}
+
 const SummaryHumanReadableKeys: Record<keyof IosSubmissionConfig, string> = {
   appleId: 'Apple ID',
-  archiveUrl: 'Archive URL',
+  archiveUrl: 'Download URL',
   appSpecificPassword: 'Apple app-specific password',
-  appAppleId: 'App Store Connect App ID',
+  appAppleId: 'ASC App ID',
   projectId: 'Project ID',
 };
 
 const SummaryHumanReadableValues: Partial<Record<keyof IosSubmissionConfig, Function>> = {
-  archiveUrl: (url: string) => breakWord(url, 50),
   appSpecificPassword: () => chalk.italic('[hidden]'),
 };
 

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -1,36 +1,31 @@
 import chalk from 'chalk';
-import Table from 'cli-table3';
-import chunk from 'lodash/chunk';
 
 import log from '../../log';
 
-export function breakWord(word: string, chars: number): string {
-  return chunk(word, chars)
-    .map((arr: string[]) => arr.join(''))
-    .join('\n');
-}
-
 export function printSummary<T>(
   summary: T,
-  title: string,
   keyMap: Record<keyof T, string>,
   valueRemap: Partial<Record<keyof T, Function>>
 ): void {
-  const table = new Table({
-    colWidths: [25, 55],
-    wordWrap: true,
-  });
-  table.push([
-    {
-      colSpan: 2,
-      content: chalk.bold(title),
-      hAlign: 'center',
-    },
-  ]);
+  const padWidth = longestStringLength(Object.keys(summary).map(key => keyMap[key as keyof T]));
+
+  const tableFormat = (name: string, msg: string) =>
+    `${chalk.bold.cyan(pad(`${name}:`, padWidth + 1))} ${msg}`;
+
+  log.newLine();
   for (const [key, value] of Object.entries(summary)) {
     const displayKey = keyMap[key as keyof T];
     const displayValue = valueRemap[key as keyof T]?.(value) ?? value;
-    table.push([displayKey, displayValue]);
+    log(tableFormat(displayKey, displayValue));
   }
-  log(table.toString());
+  log.addNewLineIfNone();
+}
+
+function pad(str: string, width: number): string {
+  const len = Math.max(0, width - str.length);
+  return str + Array(len + 1).join(' ');
+}
+
+function longestStringLength(values: string[]): number {
+  return values.reduce((max, option) => Math.max(max, option.length), 0);
 }


### PR DESCRIPTION
# Why

- Match the simpler UI used in the promo video. 
- make links usable
- remove unused app specific password

<img width="488" alt="Screen Shot 2020-12-14 at 1 44 14 PM" src="https://user-images.githubusercontent.com/9664363/102139313-89f80b80-3e12-11eb-82f0-83e86045df75.png">
