### PR TITLE
[eas-cli] Use project account name in prepare managed job

### DIFF
--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -11,7 +11,7 @@ import path from 'path';
 
 import { AndroidCredentials } from '../../credentials/android/AndroidCredentialsProvider';
 import { readSecretEnvsAsync } from '../../credentials/credentialsJson/read';
-import { ensureLoggedInAsync } from '../../user/actions';
+import { getProjectAccountNameAsync } from '../../project/projectUtils';
 import { gitRootDirectoryAsync } from '../../utils/git';
 import { BuildContext } from '../context';
 import { Platform } from '../types';
@@ -101,11 +101,11 @@ async function prepareManagedJobAsync(
   buildProfile: AndroidManagedBuildProfile
 ): Promise<Partial<Android.ManagedJob>> {
   const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
-  const { username } = await ensureLoggedInAsync();
+  const accountName = await getProjectAccountNameAsync(ctx.commandCtx.projectDir);
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
     type: Workflow.Managed,
-    username,
+    username: accountName,
     buildType: buildProfile.buildType,
     releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -11,7 +11,7 @@ import path from 'path';
 
 import { readSecretEnvsAsync } from '../../credentials/credentialsJson/read';
 import { IosCredentials } from '../../credentials/ios/IosCredentialsProvider';
-import { ensureLoggedInAsync } from '../../user/actions';
+import { getProjectAccountNameAsync } from '../../project/projectUtils';
 import { gitRootDirectoryAsync } from '../../utils/git';
 import { BuildContext } from '../context';
 import { Platform } from '../types';
@@ -107,11 +107,11 @@ async function prepareManagedJobAsync(
   buildProfile: iOSManagedBuildProfile
 ): Promise<Partial<iOS.ManagedJob>> {
   const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
-  const { username } = await ensureLoggedInAsync();
+  const accountName = await getProjectAccountNameAsync(ctx.commandCtx.projectDir);
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
     type: Workflow.Managed,
-    username,
+    username: accountName,
     releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,
   };


### PR DESCRIPTION
# Why

With the robot integration we can't use `username` from the user, robots don't have one. Always use the "project owner" or "username of a normal user" instead, through `getProjectAccountName(Async)`

# How

Replaced username with `getProjectAccountNameAsync` method.

# Test Plan

Run a managed job with EAS.
