### PR TITLE
[expo-cli] set noImplicitReturns to true

### DIFF
--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -80,9 +80,7 @@ export class AccountResolver {
       )} account?`,
     });
 
-    if (useProjectAccount) {
-      return projectAccount;
-    }
+    return useProjectAccount ? projectAccount : undefined;
   }
 
   private async promptForAccountAsync(): Promise<Account> {

--- a/packages/eas-cli/src/utils/git.ts
+++ b/packages/eas-cli/src/utils/git.ts
@@ -50,10 +50,12 @@ async function isGitInstalledAsync(): Promise<boolean> {
   return true;
 }
 
-async function getBranchNameAsync(): Promise<string | undefined> {
+async function getBranchNameAsync(): Promise<string | null> {
   try {
     return (await spawnAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout;
-  } catch (e) {}
+  } catch (e) {
+    return null;
+  }
 }
 
 async function getLastCommitMessageAsync(): Promise<string | null> {

--- a/packages/eas-cli/tsconfig.json
+++ b/packages/eas-cli/tsconfig.json
@@ -4,6 +4,7 @@
     "importHelpers": true,
     "module": "commonjs",
     "esModuleInterop": true,
+    "noImplicitReturns": true,
     "outDir": "build",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
# Why

Enforcing no implicit returns has been useful in catching errors in `www` and we seem to have an explicit is better than implicit philosophy in this repo already.

# How

added tsconfig and fixed two violations.

# Test Plan

yarn tsc