### PR TITLE
[eas-cli] Force update plist library to fix missing invariant

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -14,7 +14,7 @@
     "@expo/eas-build-job": "0.1.4",
     "@expo/eas-json": "^0.1.0-alpha.20",
     "@expo/json-file": "^8.2.24",
-    "@expo/plist": "^0.0.10",
+    "@expo/plist": "^0.0.11",
     "@expo/plugin-warn-if-update-available": "^1.7.0",
     "@expo/results": "^1.0.0",
     "@expo/spawn-async": "^1.5.0",


### PR DESCRIPTION
# Why

We are receiving reports about `MODULE_NOT_FOUND` errors related to `invariant`. Somehow `@expo/plist@0.0.10` doesn't have this as listed dependencies, but the code still requires it. In `0.0.11`, `invariant` is fully removed and should work as expected.

Not sure why NPM would pick `0.0.10` over `0.0.11` when using the `^0.0.10` version. It could be related to the version being an early alpha version. I know that `0.1.0` -> `0.2.0` would be [considered a breaking change because there is no stable version yet](https://semver.org/#spec-item-4) and thus not updated to `0.2.0` when using `^0.1.0`. Could be similar to `0.0.1`.

> Edit, this also seems to be happening for Yarn.

# How

Force-bumping this to `0.0.11` should fix the issue, see below how to repro, check and fix this manually.

# Test Plan

**Repro the issue**
- `$ npm i -g eas-cli`
- `$ eas build:configure` in any Expo project
- Fails with `MODULE_NOT_FOUND - Cannot find module 'invariant'`

**Double-check the issue**
- `$ npm list eas-cli`, go to the listed folder
- `$ npm list @expo/plist`, should list something like this:
```
eas-cli@0.1.1
├─┬ @expo/config-plugins@1.0.13
│ └── @expo/plist@0.0.11
└── @expo/plist@0.0.10
```

**Manually fix the issue**
- `$ npm list eas-cli`, go to the listed folder
- `$ npm install @expo/plist@0.0.11`