### PR TITLE
format links

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -53,6 +53,7 @@
     "strip-ansi": "^6.0.0",
     "tar": "^6.0.5",
     "tempy": "^0.7.0",
+    "terminal-link": "^2.1.1",
     "timeago.js": "^4.0.2",
     "tslib": "^1",
     "untildify": "^4.0.0",

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import figures from 'figures';
 import { boolish } from 'getenv';
 import ora from 'ora';
+import terminalLink from 'terminal-link';
 
 type Color = (...text: string[]) => string;
 
@@ -86,6 +87,10 @@ log.isDebug = IS_DEBUG;
  * @param url
  */
 export function learnMore(url: string, learnMoreMessage?: string): string {
+  // Links can be disabled via env variables https://github.com/jamestalmage/supports-hyperlinks/blob/master/index.js
+  if (terminalLink.isSupported) {
+    return chalk.dim(terminalLink(learnMoreMessage ?? 'Learn more.', url));
+  }
   return chalk.dim(`${learnMoreMessage ?? 'Learn more'}: ${chalk.underline(url)}`);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,10 +1574,19 @@
     qqjs "^0.3.10"
     tslib "^1.9.3"
 
-"@expo/plist@0.0.10", "@expo/plist@^0.0.10":
+"@expo/plist@0.0.10":
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.10.tgz#e126a15543c6c67fd159947ca9e35969657a97f4"
   integrity sha512-uKbi7ANPCNJqeAvxLa+ZcS/Qf0fTPOySMqw5T2L4TrycSAdiAxV1VUZ69IzIbUsWb7GdriUVR2i38M/xa6+BvA==
+  dependencies:
+    base64-js "^1.2.3"
+    xmlbuilder "^14.0.0"
+    xmldom "~0.1.31"
+
+"@expo/plist@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.11.tgz#5d7900dc31df57d45a3524c061dde34aacc8dabf"
+  integrity sha512-yza93QHDkbdkdwu/PXef0eJSCMkMNdrHujK5G1viZLaZt0Rxw2s+geTyjgJsYpwqQEAoOYVpKlVymOenK+bFQg==
   dependencies:
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
@@ -11941,7 +11950,7 @@ tempy@^0.7.0:
     type-fest "^0.16.0"
     unique-string "^2.0.0"
 
-terminal-link@^2.0.0:
+terminal-link@^2.0.0, terminal-link@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
   integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==


### PR DESCRIPTION
# Why

- format links optimally for iTerm and other CLIs that support complex links.
- Links can be disabled by toggling a couple different env variables https://github.com/jamestalmage/supports-hyperlinks/blob/master/index.js