### PR TITLE
[eas-cli] generate fragment types

### DIFF
--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -23,7 +24,7 @@ const AppleAppIdentifierMutation = {
                 }
               }
             }
-            ${AppleAppIdentifierFragment.definition}
+            ${print(AppleAppIdentifierFragment.definition)}
           `,
           {
             appleAppIdentifierInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -25,7 +26,7 @@ const AppleDeviceMutation = {
                 }
               }
             }
-            ${AppleDeviceFragment.definition}
+            ${print(AppleDeviceFragment.definition)}
           `,
           {
             appleDeviceInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -27,7 +28,7 @@ const AppleDeviceRegistrationRequestMutation = {
                 }
               }
             }
-            ${AppleDeviceRegistrationRequestFragment.definition}
+            ${print(AppleDeviceRegistrationRequestFragment.definition)}
           `,
           {
             appleTeamId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -40,8 +41,8 @@ const AppleDistributionCertificateMutation = {
                 }
               }
             }
-            ${AppleDistributionCertificateFragment.definition}
-            ${AppleTeamFragment.definition}
+            ${print(AppleDistributionCertificateFragment.definition)}
+            ${print(AppleTeamFragment.definition)}
           `,
           {
             appleDistributionCertificateInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -38,8 +39,8 @@ const AppleProvisioningProfileMutation = {
                 }
               }
             }
-            ${AppleProvisioningProfileFragment.definition}
-            ${AppleTeamFragment.definition}
+            ${print(AppleProvisioningProfileFragment.definition)}
+            ${print(AppleTeamFragment.definition)}
           `,
           {
             appleProvisioningProfileInput,
@@ -80,8 +81,8 @@ const AppleProvisioningProfileMutation = {
                 }
               }
             }
-            ${AppleProvisioningProfileFragment.definition}
-            ${AppleTeamFragment.definition}
+            ${print(AppleProvisioningProfileFragment.definition)}
+            ${print(AppleTeamFragment.definition)}
           `,
           {
             appleProvisioningProfileId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -27,7 +28,7 @@ const AppleTeamMutation = {
                 }
               }
             }
-            ${AppleTeamFragment.definition}
+            ${print(AppleTeamFragment.definition)}
           `,
           {
             appleTeamInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -26,7 +27,7 @@ const IosAppBuildCredentialsMutation = {
                 }
               }
             }
-            ${IosAppBuildCredentialsFragment.definition}
+            ${print(IosAppBuildCredentialsFragment.definition)}
           `,
           {
             iosAppBuildCredentialsInput,
@@ -54,7 +55,7 @@ const IosAppBuildCredentialsMutation = {
                 }
               }
             }
-            ${IosAppBuildCredentialsFragment.definition}
+            ${print(IosAppBuildCredentialsFragment.definition)}
           `,
           {
             iosAppBuildCredentialsId,
@@ -82,7 +83,7 @@ const IosAppBuildCredentialsMutation = {
                 }
               }
             }
-            ${IosAppBuildCredentialsFragment.definition}
+            ${print(IosAppBuildCredentialsFragment.definition)}
           `,
           {
             iosAppBuildCredentialsId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -24,7 +25,7 @@ const IosAppCredentialsMutation = {
                 }
               }
             }
-            ${IosAppCredentialsFragment.definition}
+            ${print(IosAppCredentialsFragment.definition)}
           `,
           {
             iosAppCredentialsInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -17,7 +18,7 @@ const AppQuery = {
                 }
               }
             }
-            ${AppFragment.definition}
+            ${print(AppFragment.definition)}
           `,
           { fullName }
         )

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -22,7 +23,7 @@ const AppleAppIdentifierQuery = {
                 }
               }
             }
-            ${AppleAppIdentifierFragment.definition}
+            ${print(AppleAppIdentifierFragment.definition)}
           `,
           {
             accountName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -43,8 +44,8 @@ const AppleDeviceQuery = {
                 }
               }
             }
-            ${AppleTeamFragment.definition}
-            ${AppleDeviceFragment.definition}
+            ${print(AppleTeamFragment.definition)}
+            ${print(AppleDeviceFragment.definition)}
           `,
           {
             accountId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -52,8 +53,8 @@ const AppleDistributionCertificateQuery = {
                 }
               }
             }
-            ${AppleDistributionCertificateFragment.definition}
-            ${AppleTeamFragment.definition}
+            ${print(AppleDistributionCertificateFragment.definition)}
+            ${print(AppleTeamFragment.definition)}
           `,
           {
             projectFullName,
@@ -94,8 +95,8 @@ const AppleDistributionCertificateQuery = {
                 }
               }
             }
-            ${AppleDistributionCertificateFragment.definition}
-            ${AppleTeamFragment.definition}
+            ${print(AppleDistributionCertificateFragment.definition)}
+            ${print(AppleTeamFragment.definition)}
           `,
           {
             accountName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -57,10 +58,10 @@ const AppleProvisioningProfileQuery = {
                 }
               }
             }
-            ${AppleProvisioningProfileFragment.definition}
-            ${AppleTeamFragment.definition}
-            ${AppleDeviceFragment.definition}
-            ${AppleAppIdentifierFragment.definition}
+            ${print(AppleProvisioningProfileFragment.definition)}
+            ${print(AppleTeamFragment.definition)}
+            ${print(AppleDeviceFragment.definition)}
+            ${print(AppleAppIdentifierFragment.definition)}
           `,
           {
             projectFullName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -47,7 +48,7 @@ const AppleTeamQuery = {
                 }
               }
             }
-            ${AppleTeamFragment.definition}
+            ${print(AppleTeamFragment.definition)}
           `,
           {
             accountId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -41,7 +42,7 @@ const IosAppBuildCredentialsQuery = {
                 }
               }
             }
-            ${IosAppBuildCredentialsFragment.definition}
+            ${print(IosAppBuildCredentialsFragment.definition)}
           `,
           {
             projectFullName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
@@ -1,3 +1,4 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
@@ -23,7 +24,7 @@ const IosAppCredentialsQuery = {
                 }
               }
             }
-            ${IosAppCredentialsFragment.definition}
+            ${print(IosAppCredentialsFragment.definition)}
           `,
           {
             projectFullName,
@@ -65,8 +66,8 @@ const IosAppCredentialsQuery = {
                   }
                 }
               }
-              ${IosAppCredentialsFragment.definition}
-              ${IosAppBuildCredentialsFragment.definition}
+              ${print(IosAppCredentialsFragment.definition)}
+              ${print(IosAppBuildCredentialsFragment.definition)}
             `,
           {
             projectFullName,

--- a/packages/eas-cli/src/graphql/fragment.ts
+++ b/packages/eas-cli/src/graphql/fragment.ts
@@ -1,4 +1,6 @@
+import { DocumentNode } from 'graphql';
+
 export interface Fragment {
   name: string;
-  definition: string;
+  definition: DocumentNode;
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2760,3 +2760,84 @@ export type CurrentUserQuery = (
     )> }
   )> }
 );
+
+export type AppFragment = (
+  { __typename?: 'App' }
+  & Pick<App, 'id'>
+);
+
+export type AppleAppIdentifierFragment = (
+  { __typename?: 'AppleAppIdentifier' }
+  & Pick<AppleAppIdentifier, 'id' | 'bundleIdentifier'>
+);
+
+export type AppleDeviceFragment = (
+  { __typename?: 'AppleDevice' }
+  & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'model' | 'deviceClass'>
+);
+
+export type AppleDeviceRegistrationRequestFragment = (
+  { __typename?: 'AppleDeviceRegistrationRequest' }
+  & Pick<AppleDeviceRegistrationRequest, 'id'>
+);
+
+export type AppleDistCertFragment = (
+  { __typename?: 'AppleDistributionCertificate' }
+  & Pick<AppleDistributionCertificate, 'id' | 'certificateP12' | 'certificatePassword' | 'serialNumber' | 'developerPortalIdentifier' | 'validityNotBefore' | 'validityNotAfter'>
+  & { appleTeam?: Maybe<(
+    { __typename?: 'AppleTeam' }
+    & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
+  )> }
+);
+
+export type AppleProvisioningProfileFragment = (
+  { __typename?: 'AppleProvisioningProfile' }
+  & Pick<AppleProvisioningProfile, 'id' | 'expiration' | 'developerPortalIdentifier' | 'provisioningProfile'>
+  & { appleTeam?: Maybe<(
+    { __typename?: 'AppleTeam' }
+    & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
+  )>, appleDevices: Array<(
+    { __typename?: 'AppleDevice' }
+    & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'model' | 'deviceClass'>
+  )> }
+);
+
+export type AppleTeamFragment = (
+  { __typename?: 'AppleTeam' }
+  & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
+);
+
+export type IosAppBuildCredentialsFragment = (
+  { __typename?: 'IosAppBuildCredentials' }
+  & Pick<IosAppBuildCredentials, 'id' | 'iosDistributionType'>
+  & { distributionCertificate?: Maybe<(
+    { __typename?: 'AppleDistributionCertificate' }
+    & Pick<AppleDistributionCertificate, 'id' | 'certificateP12' | 'certificatePassword' | 'serialNumber' | 'developerPortalIdentifier' | 'validityNotBefore' | 'validityNotAfter'>
+    & { appleTeam?: Maybe<(
+      { __typename?: 'AppleTeam' }
+      & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
+    )> }
+  )>, provisioningProfile?: Maybe<(
+    { __typename?: 'AppleProvisioningProfile' }
+    & Pick<AppleProvisioningProfile, 'id' | 'expiration' | 'developerPortalIdentifier' | 'provisioningProfile'>
+    & { appleDevices: Array<(
+      { __typename?: 'AppleDevice' }
+      & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'model' | 'deviceClass'>
+    )>, appleTeam?: Maybe<(
+      { __typename?: 'AppleTeam' }
+      & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
+    )> }
+  )>, appleDevices?: Maybe<Array<Maybe<(
+    { __typename?: 'AppleDevice' }
+    & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'model' | 'deviceClass'>
+    & { appleTeam: (
+      { __typename?: 'AppleTeam' }
+      & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
+    ) }
+  )>>> }
+);
+
+export type IosAppCredentialsFragment = (
+  { __typename?: 'IosAppCredentials' }
+  & Pick<IosAppCredentials, 'id'>
+);

--- a/packages/eas-cli/src/graphql/types/App.ts
+++ b/packages/eas-cli/src/graphql/types/App.ts
@@ -1,8 +1,10 @@
+import gql from 'graphql-tag';
+
 import { Fragment } from '../fragment';
 
 export const AppFragment: Fragment = {
   name: 'app',
-  definition: /* GraphQL*/ `
+  definition: gql`
     fragment app on App {
       id
     }

--- a/packages/eas-cli/src/graphql/types/App.ts
+++ b/packages/eas-cli/src/graphql/types/App.ts
@@ -2,7 +2,7 @@ import { Fragment } from '../fragment';
 
 export const AppFragment: Fragment = {
   name: 'app',
-  definition: `
+  definition: /* GraphQL*/ `
     fragment app on App {
       id
     }

--- a/packages/eas-cli/src/graphql/types/credentials/AppleAppIdentifier.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleAppIdentifier.ts
@@ -1,8 +1,10 @@
+import gql from 'graphql-tag';
+
 import { Fragment } from '../../fragment';
 
 export const AppleAppIdentifierFragment: Fragment = {
   name: 'appleAppIdentifier',
-  definition: /* GraphQL*/ `
+  definition: gql`
     fragment appleAppIdentifier on AppleAppIdentifier {
       id
       bundleIdentifier

--- a/packages/eas-cli/src/graphql/types/credentials/AppleAppIdentifier.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleAppIdentifier.ts
@@ -2,7 +2,7 @@ import { Fragment } from '../../fragment';
 
 export const AppleAppIdentifierFragment: Fragment = {
   name: 'appleAppIdentifier',
-  definition: `
+  definition: /* GraphQL*/ `
     fragment appleAppIdentifier on AppleAppIdentifier {
       id
       bundleIdentifier

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDevice.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDevice.ts
@@ -1,3 +1,5 @@
+import gql from 'graphql-tag';
+
 import { Fragment } from '../../fragment';
 import { AppleDeviceClass } from '../../generated';
 
@@ -8,7 +10,7 @@ export const APPLE_DEVICE_CLASS_LABELS: Record<AppleDeviceClass, string> = {
 
 export const AppleDeviceFragment: Fragment = {
   name: 'appleDevice',
-  definition: /* GraphQL*/ `
+  definition: gql`
     fragment appleDevice on AppleDevice {
       id
       identifier

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDevice.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDevice.ts
@@ -8,7 +8,7 @@ export const APPLE_DEVICE_CLASS_LABELS: Record<AppleDeviceClass, string> = {
 
 export const AppleDeviceFragment: Fragment = {
   name: 'appleDevice',
-  definition: `
+  definition: /* GraphQL*/ `
     fragment appleDevice on AppleDevice {
       id
       identifier

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDeviceRegistrationRequest.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDeviceRegistrationRequest.ts
@@ -2,7 +2,7 @@ import { Fragment } from '../../fragment';
 
 export const AppleDeviceRegistrationRequestFragment: Fragment = {
   name: 'appleDeviceRegistrationRequest',
-  definition: `
+  definition: /* GraphQL*/ `
     fragment appleDeviceRegistrationRequest on AppleDeviceRegistrationRequest {
       id
     }

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDeviceRegistrationRequest.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDeviceRegistrationRequest.ts
@@ -1,8 +1,10 @@
+import gql from 'graphql-tag';
+
 import { Fragment } from '../../fragment';
 
 export const AppleDeviceRegistrationRequestFragment: Fragment = {
   name: 'appleDeviceRegistrationRequest',
-  definition: /* GraphQL*/ `
+  definition: gql`
     fragment appleDeviceRegistrationRequest on AppleDeviceRegistrationRequest {
       id
     }

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDistributionCertificate.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDistributionCertificate.ts
@@ -1,8 +1,10 @@
+import gql from 'graphql-tag';
+
 import { Fragment } from '../../fragment';
 
 export const AppleDistributionCertificateFragment: Fragment = {
   name: 'appleDistCert',
-  definition: /* GraphQL*/ `
+  definition: gql`
     fragment appleDistCert on AppleDistributionCertificate {
       id
       certificateP12

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDistributionCertificate.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDistributionCertificate.ts
@@ -2,7 +2,7 @@ import { Fragment } from '../../fragment';
 
 export const AppleDistributionCertificateFragment: Fragment = {
   name: 'appleDistCert',
-  definition: `
+  definition: /* GraphQL*/ `
     fragment appleDistCert on AppleDistributionCertificate {
       id
       certificateP12

--- a/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
@@ -2,7 +2,7 @@ import { Fragment } from '../../fragment';
 
 export const AppleProvisioningProfileFragment: Fragment = {
   name: 'appleProvisioningProfile',
-  definition: `
+  definition: /* GraphQL*/ `
     fragment appleProvisioningProfile on AppleProvisioningProfile {
       id
       expiration

--- a/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
@@ -1,8 +1,10 @@
+import gql from 'graphql-tag';
+
 import { Fragment } from '../../fragment';
 
 export const AppleProvisioningProfileFragment: Fragment = {
   name: 'appleProvisioningProfile',
-  definition: /* GraphQL*/ `
+  definition: gql`
     fragment appleProvisioningProfile on AppleProvisioningProfile {
       id
       expiration

--- a/packages/eas-cli/src/graphql/types/credentials/AppleTeam.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleTeam.ts
@@ -2,7 +2,7 @@ import { Fragment } from '../../fragment';
 
 export const AppleTeamFragment: Fragment = {
   name: 'appleTeam',
-  definition: `
+  definition: /* GraphQL*/ `
     fragment appleTeam on AppleTeam {
       id
       appleTeamIdentifier

--- a/packages/eas-cli/src/graphql/types/credentials/AppleTeam.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleTeam.ts
@@ -1,8 +1,10 @@
+import gql from 'graphql-tag';
+
 import { Fragment } from '../../fragment';
 
 export const AppleTeamFragment: Fragment = {
   name: 'appleTeam',
-  definition: /* GraphQL*/ `
+  definition: gql`
     fragment appleTeam on AppleTeam {
       id
       appleTeamIdentifier

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
@@ -1,8 +1,10 @@
+import gql from 'graphql-tag';
+
 import { Fragment } from '../../fragment';
 
 export const IosAppBuildCredentialsFragment: Fragment = {
   name: 'iosAppBuildCredentials',
-  definition: /* GraphQL*/ `
+  definition: gql`
     fragment iosAppBuildCredentials on IosAppBuildCredentials {
       id
       iosDistributionType

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
@@ -2,7 +2,7 @@ import { Fragment } from '../../fragment';
 
 export const IosAppBuildCredentialsFragment: Fragment = {
   name: 'iosAppBuildCredentials',
-  definition: `
+  definition: /* GraphQL*/ `
     fragment iosAppBuildCredentials on IosAppBuildCredentials {
       id
       iosDistributionType

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
@@ -1,8 +1,10 @@
+import gql from 'graphql-tag';
+
 import { Fragment } from '../../fragment';
 
 export const IosAppCredentialsFragment: Fragment = {
   name: 'iosAppCredentials',
-  definition: /* GraphQL*/ `
+  definition: gql`
     fragment iosAppCredentials on IosAppCredentials {
       id
     }

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
@@ -2,7 +2,7 @@ import { Fragment } from '../../fragment';
 
 export const IosAppCredentialsFragment: Fragment = {
   name: 'iosAppCredentials',
-  definition: `
+  definition: /* GraphQL*/ `
     fragment iosAppCredentials on IosAppCredentials {
       id
     }


### PR DESCRIPTION
# Why

- The graphql code generator won't parse AST strings unless it is in a `gql` tag or preceded by the `/* GraphQL*/ ` comment.
- This PR allows fragments types to be autogenerated so we can use them in the future

# Test Plan

- [ ] current tests still pass
