### PR TITLE
[eas-cli] use more accurrate graphql types

### DIFF
--- a/packages/eas-cli/graphql-codegen.yml
+++ b/packages/eas-cli/graphql-codegen.yml
@@ -2,11 +2,14 @@ overwrite: true
 schema: 'https://staging.exp.host/--/graphql'
 documents:
   - 'src/graphql/**/!(*.d).{ts,tsx}'
+  - 'src/credentials/ios/api/graphql/queries/AppQuery.ts'
 generates:
   src/graphql/generated.ts:
     plugins:
       - 'typescript'
       - 'typescript-operations'
+    config:
+      dedupeOperationSuffix: true
     hooks:
       afterOneFileWrite:
         - ./annotate-graphql-codegen.sh

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -1,7 +1,7 @@
 import nullthrows from 'nullthrows';
 
 import {
-  App,
+  AppFragment,
   AppleAppIdentifier,
   AppleDevice,
   AppleDistributionCertificate,
@@ -33,7 +33,7 @@ export interface AppLookupParams {
   bundleIdentifier: string;
 }
 
-export async function getAppAsync(appLookupParams: AppLookupParams): Promise<App> {
+export async function getAppAsync(appLookupParams: AppLookupParams): Promise<AppFragment> {
   const projectFullName = formatProjectFullName(appLookupParams);
   return await AppQuery.byFullNameAsync(projectFullName);
 }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
@@ -2,12 +2,12 @@ import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
-import { App } from '../../../../../graphql/generated';
+import { App, AppByFullNameQuery, AppFragment } from '../../../../../graphql/generated';
 import { AppFragmentNode } from '../../../../../graphql/types/App';
 
 const AppQuery = {
-  async byFullNameAsync(fullName: string): Promise<App> {
-    const data = await withErrorHandlingAsync(
+  async byFullNameAsync(fullName: string): Promise<AppFragment> {
+    const data = (await withErrorHandlingAsync(
       graphqlClient
         .query<{ app: { byFullName: App } }>(
           gql`
@@ -24,9 +24,9 @@ const AppQuery = {
           { fullName }
         )
         .toPromise()
-    );
+    )) as AppByFullNameQuery;
 
-    return data.app.byFullName;
+    return data.app!.byFullName;
   },
 };
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2604,12 +2604,12 @@ export enum CacheControlScope {
 }
 
 
-export type GetSignedUploadMutationMutationVariables = Exact<{
+export type GetSignedUploadMutationVariables = Exact<{
   contentTypes: Array<Scalars['String']>;
 }>;
 
 
-export type GetSignedUploadMutationMutation = (
+export type GetSignedUploadMutation = (
   { __typename?: 'RootMutation' }
   & { asset: (
     { __typename?: 'AssetMutation' }
@@ -2620,12 +2620,12 @@ export type GetSignedUploadMutationMutation = (
   ) }
 );
 
-export type PublishMutationMutationVariables = Exact<{
+export type PublishMutationVariables = Exact<{
   publishUpdateGroupInput?: Maybe<PublishUpdateGroupInput>;
 }>;
 
 
-export type PublishMutationMutation = (
+export type PublishMutation = (
   { __typename?: 'RootMutation' }
   & { updateRelease: (
     { __typename?: 'UpdateReleaseMutation' }
@@ -2636,12 +2636,12 @@ export type PublishMutationMutation = (
   ) }
 );
 
-export type BuildsByIdQueryQueryVariables = Exact<{
+export type BuildsByIdQueryVariables = Exact<{
   buildId: Scalars['ID'];
 }>;
 
 
-export type BuildsByIdQueryQuery = (
+export type BuildsByIdQuery = (
   { __typename?: 'RootQuery' }
   & { builds: (
     { __typename?: 'BuildQuery' }
@@ -2656,7 +2656,7 @@ export type BuildsByIdQueryQuery = (
   ) }
 );
 
-export type BuildsForAppQueryQueryVariables = Exact<{
+export type BuildsForAppQueryVariables = Exact<{
   appId: Scalars['String'];
   limit?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
@@ -2665,7 +2665,7 @@ export type BuildsForAppQueryQueryVariables = Exact<{
 }>;
 
 
-export type BuildsForAppQueryQuery = (
+export type BuildsForAppQuery = (
   { __typename?: 'RootQuery' }
   & { builds: (
     { __typename?: 'BuildQuery' }
@@ -2723,12 +2723,12 @@ export type ProjectByUsernameAndSlugQueryQuery = (
   ) }
 );
 
-export type GetAssetMetadataQueryQueryVariables = Exact<{
+export type GetAssetMetadataQueryVariables = Exact<{
   storageKeys: Array<Scalars['String']>;
 }>;
 
 
-export type GetAssetMetadataQueryQuery = (
+export type GetAssetMetadataQuery = (
   { __typename?: 'RootQuery' }
   & { asset: (
     { __typename?: 'AssetQuery' }
@@ -2840,4 +2840,20 @@ export type IosAppBuildCredentialsFragment = (
 export type IosAppCredentialsFragment = (
   { __typename?: 'IosAppCredentials' }
   & Pick<IosAppCredentials, 'id'>
+);
+
+export type AppByFullNameQueryVariables = Exact<{
+  fullName: Scalars['String'];
+}>;
+
+
+export type AppByFullNameQuery = (
+  { __typename?: 'RootQuery' }
+  & { app?: Maybe<(
+    { __typename?: 'AppQuery' }
+    & { byFullName: (
+      { __typename?: 'App' }
+      & AppFragment
+    ) }
+  )> }
 );

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2631,7 +2631,7 @@ export type PublishMutation = (
     { __typename?: 'UpdateReleaseMutation' }
     & { publishUpdateGroup: Array<Maybe<(
       { __typename?: 'Update' }
-      & Pick<Update, 'updateGroup'>
+      & Pick<Update, 'id' | 'updateGroup'>
     )>> }
   ) }
 );
@@ -2647,7 +2647,7 @@ export type BuildsByIdQuery = (
     { __typename?: 'BuildQuery' }
     & { byId: (
       { __typename?: 'Build' }
-      & Pick<Build, 'platform'>
+      & Pick<Build, 'id' | 'platform'>
       & { artifacts?: Maybe<(
         { __typename?: 'BuildArtifacts' }
         & Pick<BuildArtifacts, 'buildUrl'>
@@ -2671,7 +2671,7 @@ export type BuildsForAppQuery = (
     { __typename?: 'BuildQuery' }
     & { allForApp: Array<Maybe<(
       { __typename?: 'Build' }
-      & Pick<Build, 'platform'>
+      & Pick<Build, 'id' | 'platform'>
       & { artifacts?: Maybe<(
         { __typename?: 'BuildArtifacts' }
         & Pick<BuildArtifacts, 'buildUrl'>
@@ -2692,6 +2692,7 @@ export type PendingBuildsForAccountAndPlatformQuery = (
     { __typename?: 'AccountQuery' }
     & { byName: (
       { __typename?: 'Account' }
+      & Pick<Account, 'id'>
       & { inQueueBuilds: Array<(
         { __typename?: 'Build' }
         & Pick<Build, 'id' | 'platform'>
@@ -2703,13 +2704,13 @@ export type PendingBuildsForAccountAndPlatformQuery = (
   ) }
 );
 
-export type ProjectByUsernameAndSlugQueryQueryVariables = Exact<{
+export type ProjectByUsernameAndSlugQueryVariables = Exact<{
   username: Scalars['String'];
   slug: Scalars['String'];
 }>;
 
 
-export type ProjectByUsernameAndSlugQueryQuery = (
+export type ProjectByUsernameAndSlugQuery = (
   { __typename?: 'RootQuery' }
   & { project: (
     { __typename?: 'ProjectQuery' }
@@ -2781,7 +2782,7 @@ export type AppleDeviceRegistrationRequestFragment = (
   & Pick<AppleDeviceRegistrationRequest, 'id'>
 );
 
-export type AppleDistCertFragment = (
+export type AppleDistributionCertificateFragment = (
   { __typename?: 'AppleDistributionCertificate' }
   & Pick<AppleDistributionCertificate, 'id' | 'certificateP12' | 'certificatePassword' | 'serialNumber' | 'developerPortalIdentifier' | 'validityNotBefore' | 'validityNotAfter'>
   & { appleTeam?: Maybe<(
@@ -2853,6 +2854,7 @@ export type AppByFullNameQuery = (
     { __typename?: 'AppQuery' }
     & { byFullName: (
       { __typename?: 'App' }
+      & Pick<App, 'id'>
       & AppFragment
     ) }
   )> }


### PR DESCRIPTION
# Why

This is mostly a proposal on using more accurate Graphql Types in our codebase. I only changed `AppQuery` and `AppFragment` for a concrete example. If everyone is happy with these changes, i'll propagate them everywhere else.

# Problems

1. Graphql codegenerate can't autogenerate queries that use template literals in certain parts of the AST string. For example:
```
            query($fullName: String!) {
              app {
                byFullName(fullName: $fullName) {
                  ...${AppFragment.name} // <-------- Not OK
                }
              }
            }
            ${AppFragment.definition}  // <-------- Seems to be OK
```

There are several workarounds, like using [graphql-tag-pluck ](https://github.com/ardatan/graphql-tools/tree/master/packages/graphql-tag-pluck) to resolve them. However, it just seemed simpler to change the `AppFragment` variable to have the same name as the graphql name.  

```
            query($fullName: String!) {
              app {
                byFullName(fullName: $fullName) {
                  ... AppFragment
                }
              }
            }
            ${AppFragment} 
```

2. Our queries don't return the accurate graphql types. For example, the `AppQuery` return type is the `App` type generated from the server (has all the available fields like `buildJobs`, etc). However, `AppQuery` should actually be returning the `AppFragment` type, which only returns the `id` field.

3. changed autogen code to dedupe variable names (ie) `type FooQueryQuery` -> `type FooQuery`

# Test Plan

- [ ] current tests still pass
