### PR TITLE
[eas-cli] gql nits

### DIFF
--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2703,13 +2703,13 @@ export type PendingBuildsForAccountAndPlatformQuery = (
   ) }
 );
 
-export type Unnamed_1_QueryVariables = Exact<{
+export type ProjectByUsernameAndSlugQueryQueryVariables = Exact<{
   username: Scalars['String'];
   slug: Scalars['String'];
 }>;
 
 
-export type Unnamed_1_Query = (
+export type ProjectByUsernameAndSlugQueryQuery = (
   { __typename?: 'RootQuery' }
   & { project: (
     { __typename?: 'ProjectQuery' }

--- a/packages/eas-cli/src/graphql/queries/ProjectQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ProjectQuery.ts
@@ -11,7 +11,7 @@ const ProjectQuery = {
       graphqlClient
         .query<{ project: { byUsernameAndSlug: ProjectQueryResult } }>(
           gql`
-            query($username: String!, $slug: String!) {
+            query ProjectByUsernameAndSlugQuery($username: String!, $slug: String!) {
               project {
                 byUsernameAndSlug(username: $username, slug: $slug) {
                   id


### PR DESCRIPTION
# Why

this pr makes sure that everything covered by the codegen tool is named

https://the-guild.dev/blog/graphql-codegen-best-practices
```
It's highly important to name your GraphQL operations, because otherwise it will be difficult for your GraphQL client to cache and manage it. It will also make it difficult for the codegen to create easy-to-use types, and it will fallback to Unnamed_Operation_.
```

# Test Plan

- [ ] current tests still pass
