### PR TITLE
[eas-cli] 2/n apply template literals rule

### DIFF
--- a/packages/eas-cli/.eslintrc.js
+++ b/packages/eas-cli/.eslintrc.js
@@ -5,6 +5,13 @@ module.exports = {
       'error',
       { devDependencies: ['**/__tests__/**/*', '**/__mocks__/**/*'] },
     ],
+    'graphql/template-strings': [
+      'error',
+      {
+        env: 'apollo',
+        schemaJson: require('./graphql.schema.json'),
+      },
+    ],
   },
   plugins: ['graphql'],
 };

--- a/packages/eas-cli/src/commands/release/view.ts
+++ b/packages/eas-cli/src/commands/release/view.ts
@@ -44,16 +44,17 @@ async function viewUpdateReleaseAsync({
         {
           appId: string;
           releaseName: string;
+          limit: number;
         }
       >(
         gql`
-          query ViewRelease($appId: String!, $releaseName: String!) {
+          query ViewRelease($appId: String!, $releaseName: String!, $limit: Int!) {
             app {
               byId(appId: $appId) {
                 updateReleaseByReleaseName(releaseName: $releaseName) {
                   id
                   releaseName
-                  updates(offset: 0, limit: ${PAGE_LIMIT}) {
+                  updates(offset: 0, limit: $limit) {
                     updateGroup
                     updateMessage
                     createdAt
@@ -74,6 +75,7 @@ async function viewUpdateReleaseAsync({
         {
           appId,
           releaseName,
+          limit: PAGE_LIMIT,
         }
       )
       .toPromise()

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleAppIdentifier } from '../../../../../graphql/generated';
-import { AppleAppIdentifierFragment } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
+import { AppleAppIdentifierFragmentDoc } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
 
 const AppleAppIdentifierMutation = {
   async createAppleAppIdentifierAsync(
@@ -17,14 +17,20 @@ const AppleAppIdentifierMutation = {
       graphqlClient
         .mutation<{ appleAppIdentifier: { createAppleAppIdentifier: AppleAppIdentifier } }>(
           gql`
-            mutation AppleAppIdentifierMutation($appleAppIdentifierInput: AppleAppIdentifierInput!, $accountId: ID!) {
+            mutation AppleAppIdentifierMutation(
+              $appleAppIdentifierInput: AppleAppIdentifierInput!
+              $accountId: ID!
+            ) {
               appleAppIdentifier {
-                createAppleAppIdentifier(appleAppIdentifierInput: $appleAppIdentifierInput, accountId: $accountId) {
-                  ...${AppleAppIdentifierFragment.name}
+                createAppleAppIdentifier(
+                  appleAppIdentifierInput: $appleAppIdentifierInput
+                  accountId: $accountId
+                ) {
+                  ...AppleAppIdentifierFragment
                 }
               }
             }
-            ${print(AppleAppIdentifierFragment.definition)}
+            ${print(AppleAppIdentifierFragmentDoc)}
           `,
           {
             appleAppIdentifierInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleAppIdentifier } from '../../../../../graphql/generated';
-import { AppleAppIdentifierFragmentDoc } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
+import { AppleAppIdentifierFragmentNode } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
 
 const AppleAppIdentifierMutation = {
   async createAppleAppIdentifierAsync(
@@ -30,7 +30,7 @@ const AppleAppIdentifierMutation = {
                 }
               }
             }
-            ${print(AppleAppIdentifierFragmentDoc)}
+            ${print(AppleAppIdentifierFragmentNode)}
           `,
           {
             appleAppIdentifierInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleDevice, AppleDeviceClass } from '../../../../../graphql/generated';
-import { AppleDeviceFragment } from '../../../../../graphql/types/credentials/AppleDevice';
+import { AppleDeviceFragmentDoc } from '../../../../../graphql/types/credentials/AppleDevice';
 
 const AppleDeviceMutation = {
   async createAppleDeviceAsync(
@@ -22,11 +22,11 @@ const AppleDeviceMutation = {
             mutation AppleDeviceMutation($appleDeviceInput: AppleDeviceInput!, $accountId: ID!) {
               appleDevice {
                 createAppleDevice(appleDeviceInput: $appleDeviceInput, accountId: $accountId) {
-                  ...${AppleDeviceFragment.name}
+                  ...AppleDeviceFragment
                 }
               }
             }
-            ${print(AppleDeviceFragment.definition)}
+            ${print(AppleDeviceFragmentDoc)}
           `,
           {
             appleDeviceInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleDevice, AppleDeviceClass } from '../../../../../graphql/generated';
-import { AppleDeviceFragmentDoc } from '../../../../../graphql/types/credentials/AppleDevice';
+import { AppleDeviceFragmentNode } from '../../../../../graphql/types/credentials/AppleDevice';
 
 const AppleDeviceMutation = {
   async createAppleDeviceAsync(
@@ -26,7 +26,7 @@ const AppleDeviceMutation = {
                 }
               }
             }
-            ${print(AppleDeviceFragmentDoc)}
+            ${print(AppleDeviceFragmentNode)}
           `,
           {
             appleDeviceInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleDeviceRegistrationRequest } from '../../../../../graphql/generated';
-import { AppleDeviceRegistrationRequestFragment } from '../../../../../graphql/types/credentials/AppleDeviceRegistrationRequest';
+import { AppleDeviceRegistrationRequestFragmentDoc } from '../../../../../graphql/types/credentials/AppleDeviceRegistrationRequest';
 
 const AppleDeviceRegistrationRequestMutation = {
   async createAppleDeviceRegistrationRequestAsync(
@@ -24,11 +24,11 @@ const AppleDeviceRegistrationRequestMutation = {
                   appleTeamId: $appleTeamId
                   accountId: $accountId
                 ) {
-                  ...${AppleDeviceRegistrationRequestFragment.name}
+                  ...AppleDeviceRegistrationRequestFragment
                 }
               }
             }
-            ${print(AppleDeviceRegistrationRequestFragment.definition)}
+            ${print(AppleDeviceRegistrationRequestFragmentDoc)}
           `,
           {
             appleTeamId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleDeviceRegistrationRequest } from '../../../../../graphql/generated';
-import { AppleDeviceRegistrationRequestFragmentDoc } from '../../../../../graphql/types/credentials/AppleDeviceRegistrationRequest';
+import { AppleDeviceRegistrationRequestFragmentNode } from '../../../../../graphql/types/credentials/AppleDeviceRegistrationRequest';
 
 const AppleDeviceRegistrationRequestMutation = {
   async createAppleDeviceRegistrationRequestAsync(
@@ -28,7 +28,7 @@ const AppleDeviceRegistrationRequestMutation = {
                 }
               }
             }
-            ${print(AppleDeviceRegistrationRequestFragmentDoc)}
+            ${print(AppleDeviceRegistrationRequestFragmentNode)}
           `,
           {
             appleTeamId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleDistributionCertificate } from '../../../../../graphql/generated';
-import { AppleDistributionCertificateFragment } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
-import { AppleTeamFragment } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleDistributionCertificateFragmentDoc } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
+import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
 
 const AppleDistributionCertificateMutation = {
   async createAppleDistributionCertificate(
@@ -34,15 +34,15 @@ const AppleDistributionCertificateMutation = {
                   appleDistributionCertificateInput: $appleDistributionCertificateInput
                   accountId: $accountId
                 ) {
-                  ...${AppleDistributionCertificateFragment.name}
+                  ...AppleDistributionCertificateFragment
                   appleTeam {
-                    ...${AppleTeamFragment.name}
+                    ...AppleTeamFragment
                   }
                 }
               }
             }
-            ${print(AppleDistributionCertificateFragment.definition)}
-            ${print(AppleTeamFragment.definition)}
+            ${print(AppleDistributionCertificateFragmentDoc)}
+            ${print(AppleTeamFragmentDoc)}
           `,
           {
             appleDistributionCertificateInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleDistributionCertificate } from '../../../../../graphql/generated';
-import { AppleDistributionCertificateFragmentDoc } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
-import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleDistributionCertificateFragmentNode } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
+import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
 const AppleDistributionCertificateMutation = {
   async createAppleDistributionCertificate(
@@ -41,8 +41,8 @@ const AppleDistributionCertificateMutation = {
                 }
               }
             }
-            ${print(AppleDistributionCertificateFragmentDoc)}
-            ${print(AppleTeamFragmentDoc)}
+            ${print(AppleDistributionCertificateFragmentNode)}
+            ${print(AppleTeamFragmentNode)}
           `,
           {
             appleDistributionCertificateInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleProvisioningProfile } from '../../../../../graphql/generated';
-import { AppleProvisioningProfileFragmentDoc } from '../../../../../graphql/types/credentials/AppleProvisioningProfile';
-import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleProvisioningProfileFragmentNode } from '../../../../../graphql/types/credentials/AppleProvisioningProfile';
+import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
 const AppleProvisioningProfileMutation = {
   async createAppleProvisioningProfileAsync(
@@ -39,8 +39,8 @@ const AppleProvisioningProfileMutation = {
                 }
               }
             }
-            ${print(AppleProvisioningProfileFragmentDoc)}
-            ${print(AppleTeamFragmentDoc)}
+            ${print(AppleProvisioningProfileFragmentNode)}
+            ${print(AppleTeamFragmentNode)}
           `,
           {
             appleProvisioningProfileInput,
@@ -81,8 +81,8 @@ const AppleProvisioningProfileMutation = {
                 }
               }
             }
-            ${print(AppleProvisioningProfileFragmentDoc)}
-            ${print(AppleTeamFragmentDoc)}
+            ${print(AppleProvisioningProfileFragmentNode)}
+            ${print(AppleTeamFragmentNode)}
           `,
           {
             appleProvisioningProfileId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleProvisioningProfile } from '../../../../../graphql/generated';
-import { AppleProvisioningProfileFragment } from '../../../../../graphql/types/credentials/AppleProvisioningProfile';
-import { AppleTeamFragment } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleProvisioningProfileFragmentDoc } from '../../../../../graphql/types/credentials/AppleProvisioningProfile';
+import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
 
 const AppleProvisioningProfileMutation = {
   async createAppleProvisioningProfileAsync(
@@ -32,15 +32,15 @@ const AppleProvisioningProfileMutation = {
                   accountId: $accountId
                   appleAppIdentifierId: $appleAppIdentifierId
                 ) {
-                  ...${AppleProvisioningProfileFragment.name}
+                  ...AppleProvisioningProfileFragment
                   appleTeam {
-                    ...${AppleTeamFragment.name}
+                    ...AppleTeamFragment
                   }
                 }
               }
             }
-            ${print(AppleProvisioningProfileFragment.definition)}
-            ${print(AppleTeamFragment.definition)}
+            ${print(AppleProvisioningProfileFragmentDoc)}
+            ${print(AppleTeamFragmentDoc)}
           `,
           {
             appleProvisioningProfileInput,
@@ -74,15 +74,15 @@ const AppleProvisioningProfileMutation = {
                   id: $appleProvisioningProfileId
                   appleProvisioningProfileInput: $appleProvisioningProfileInput
                 ) {
-                  ...${AppleProvisioningProfileFragment.name}
+                  ...AppleProvisioningProfileFragment
                   appleTeam {
-                    ...${AppleTeamFragment.name}
+                    ...AppleTeamFragment
                   }
                 }
               }
             }
-            ${print(AppleProvisioningProfileFragment.definition)}
-            ${print(AppleTeamFragment.definition)}
+            ${print(AppleProvisioningProfileFragmentDoc)}
+            ${print(AppleTeamFragmentDoc)}
           `,
           {
             appleProvisioningProfileId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleTeam } from '../../../../../graphql/generated';
-import { AppleTeamFragment } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
 
 const AppleTeamMutation = {
   async createAppleTeamAsync(
@@ -20,7 +20,7 @@ const AppleTeamMutation = {
             mutation AppleTeamMutation($appleTeamInput: AppleTeamInput!, $accountId: ID!) {
               appleTeam {
                 createAppleTeam(appleTeamInput: $appleTeamInput, accountId: $accountId) {
-                  ...${AppleTeamFragment.name}
+                  ...AppleTeamFragment
                   account {
                     id
                     name
@@ -28,7 +28,7 @@ const AppleTeamMutation = {
                 }
               }
             }
-            ${print(AppleTeamFragment.definition)}
+            ${print(AppleTeamFragmentDoc)}
           `,
           {
             appleTeamInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleTeam } from '../../../../../graphql/generated';
-import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
 const AppleTeamMutation = {
   async createAppleTeamAsync(
@@ -28,7 +28,7 @@ const AppleTeamMutation = {
                 }
               }
             }
-            ${print(AppleTeamFragmentDoc)}
+            ${print(AppleTeamFragmentNode)}
           `,
           {
             appleTeamInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { IosAppBuildCredentials, IosDistributionType } from '../../../../../graphql/generated';
-import { IosAppBuildCredentialsFragmentDoc } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
+import { IosAppBuildCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
 
 const IosAppBuildCredentialsMutation = {
   async createIosAppBuildCredentialsAsync(
@@ -33,7 +33,7 @@ const IosAppBuildCredentialsMutation = {
                 }
               }
             }
-            ${print(IosAppBuildCredentialsFragmentDoc)}
+            ${print(IosAppBuildCredentialsFragmentNode)}
           `,
           {
             iosAppBuildCredentialsInput,
@@ -67,7 +67,7 @@ const IosAppBuildCredentialsMutation = {
                 }
               }
             }
-            ${print(IosAppBuildCredentialsFragmentDoc)}
+            ${print(IosAppBuildCredentialsFragmentNode)}
           `,
           {
             iosAppBuildCredentialsId,
@@ -101,7 +101,7 @@ const IosAppBuildCredentialsMutation = {
                 }
               }
             }
-            ${print(IosAppBuildCredentialsFragmentDoc)}
+            ${print(IosAppBuildCredentialsFragmentNode)}
           `,
           {
             iosAppBuildCredentialsId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { IosAppBuildCredentials, IosDistributionType } from '../../../../../graphql/generated';
-import { IosAppBuildCredentialsFragment } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
+import { IosAppBuildCredentialsFragmentDoc } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
 
 const IosAppBuildCredentialsMutation = {
   async createIosAppBuildCredentialsAsync(
@@ -20,14 +20,20 @@ const IosAppBuildCredentialsMutation = {
           iosAppBuildCredentials: { createIosAppBuildCredentials: IosAppBuildCredentials };
         }>(
           gql`
-            mutation IosAppBuildCredentialsMutation($iosAppBuildCredentialsInput: IosAppBuildCredentialsInput!, $iosAppCredentialsId: ID!) {
+            mutation IosAppBuildCredentialsMutation(
+              $iosAppBuildCredentialsInput: IosAppBuildCredentialsInput!
+              $iosAppCredentialsId: ID!
+            ) {
               iosAppBuildCredentials {
-                createIosAppBuildCredentials(iosAppBuildCredentialsInput: $iosAppBuildCredentialsInput, iosAppCredentialsId: $iosAppCredentialsId) {
-                  ...${IosAppBuildCredentialsFragment.name}
+                createIosAppBuildCredentials(
+                  iosAppBuildCredentialsInput: $iosAppBuildCredentialsInput
+                  iosAppCredentialsId: $iosAppCredentialsId
+                ) {
+                  ...IosAppBuildCredentialsFragment
                 }
               }
             }
-            ${print(IosAppBuildCredentialsFragment.definition)}
+            ${print(IosAppBuildCredentialsFragmentDoc)}
           `,
           {
             iosAppBuildCredentialsInput,
@@ -48,14 +54,20 @@ const IosAppBuildCredentialsMutation = {
           iosAppBuildCredentials: { setDistributionCertificate: IosAppBuildCredentials };
         }>(
           gql`
-            mutation IosAppBuildCredentialsMutation($iosAppBuildCredentialsId: ID!, $distributionCertificateId: ID!) {
+            mutation IosAppBuildCredentialsMutation(
+              $iosAppBuildCredentialsId: ID!
+              $distributionCertificateId: ID!
+            ) {
               iosAppBuildCredentials {
-                setDistributionCertificate(id: $iosAppBuildCredentialsId, distributionCertificateId: $distributionCertificateId) {
-                  ...${IosAppBuildCredentialsFragment.name}
+                setDistributionCertificate(
+                  id: $iosAppBuildCredentialsId
+                  distributionCertificateId: $distributionCertificateId
+                ) {
+                  ...IosAppBuildCredentialsFragment
                 }
               }
             }
-            ${print(IosAppBuildCredentialsFragment.definition)}
+            ${print(IosAppBuildCredentialsFragmentDoc)}
           `,
           {
             iosAppBuildCredentialsId,
@@ -76,14 +88,20 @@ const IosAppBuildCredentialsMutation = {
           iosAppBuildCredentials: { setProvisioningProfile: IosAppBuildCredentials };
         }>(
           gql`
-            mutation IosAppBuildCredentialsMutation($iosAppBuildCredentialsId: ID!, $provisioningProfileId: ID!) {
+            mutation IosAppBuildCredentialsMutation(
+              $iosAppBuildCredentialsId: ID!
+              $provisioningProfileId: ID!
+            ) {
               iosAppBuildCredentials {
-                setProvisioningProfile(id: $iosAppBuildCredentialsId, provisioningProfileId: $provisioningProfileId) {
-                  ...${IosAppBuildCredentialsFragment.name}
+                setProvisioningProfile(
+                  id: $iosAppBuildCredentialsId
+                  provisioningProfileId: $provisioningProfileId
+                ) {
+                  ...IosAppBuildCredentialsFragment
                 }
               }
             }
-            ${print(IosAppBuildCredentialsFragment.definition)}
+            ${print(IosAppBuildCredentialsFragmentDoc)}
           `,
           {
             iosAppBuildCredentialsId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { IosAppCredentials } from '../../../../../graphql/generated';
-import { IosAppCredentialsFragment } from '../../../../../graphql/types/credentials/IosAppCredentials';
+import { IosAppCredentialsFragmentDoc } from '../../../../../graphql/types/credentials/IosAppCredentials';
 
 const IosAppCredentialsMutation = {
   async createIosAppCredentialsAsync(
@@ -18,14 +18,22 @@ const IosAppCredentialsMutation = {
       graphqlClient
         .mutation<{ iosAppCredentials: { createIosAppCredentials: IosAppCredentials } }>(
           gql`
-            mutation IosAppCredentialsMutation($iosAppCredentialsInput: IosAppCredentialsInput!, $appId: ID!, $appleAppIdentifierId: ID!) {
+            mutation IosAppCredentialsMutation(
+              $iosAppCredentialsInput: IosAppCredentialsInput!
+              $appId: ID!
+              $appleAppIdentifierId: ID!
+            ) {
               iosAppCredentials {
-                createIosAppCredentials(iosAppCredentialsInput: $iosAppCredentialsInput, appId: $appId, appleAppIdentifierId: $appleAppIdentifierId) {
-                  ...${IosAppCredentialsFragment.name}
+                createIosAppCredentials(
+                  iosAppCredentialsInput: $iosAppCredentialsInput
+                  appId: $appId
+                  appleAppIdentifierId: $appleAppIdentifierId
+                ) {
+                  ...IosAppCredentialsFragment
                 }
               }
             }
-            ${print(IosAppCredentialsFragment.definition)}
+            ${print(IosAppCredentialsFragmentDoc)}
           `,
           {
             iosAppCredentialsInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { IosAppCredentials } from '../../../../../graphql/generated';
-import { IosAppCredentialsFragmentDoc } from '../../../../../graphql/types/credentials/IosAppCredentials';
+import { IosAppCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppCredentials';
 
 const IosAppCredentialsMutation = {
   async createIosAppCredentialsAsync(
@@ -33,7 +33,7 @@ const IosAppCredentialsMutation = {
                 }
               }
             }
-            ${print(IosAppCredentialsFragmentDoc)}
+            ${print(IosAppCredentialsFragmentNode)}
           `,
           {
             iosAppCredentialsInput,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { App } from '../../../../../graphql/generated';
-import { AppFragment } from '../../../../../graphql/types/App';
+import { AppFragmentNode } from '../../../../../graphql/types/App';
 
 const AppQuery = {
   async byFullNameAsync(fullName: string): Promise<App> {
@@ -18,7 +18,7 @@ const AppQuery = {
                 }
               }
             }
-            ${print(AppFragment)}
+            ${print(AppFragmentNode)}
           `,
           { fullName }
         )

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
@@ -14,11 +14,11 @@ const AppQuery = {
             query($fullName: String!) {
               app {
                 byFullName(fullName: $fullName) {
-                  ...${AppFragment.name}
+                  ...AppFragment
                 }
               }
             }
-            ${print(AppFragment.definition)}
+            ${print(AppFragment)}
           `,
           { fullName }
         )

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleAppIdentifier } from '../../../../../graphql/generated';
-import { AppleAppIdentifierFragment } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
+import { AppleAppIdentifierFragmentDoc } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
 
 const AppleAppIdentifierQuery = {
   async byBundleIdentifierAsync(
@@ -18,12 +18,12 @@ const AppleAppIdentifierQuery = {
               account {
                 byName(accountName: $accountName) {
                   appleAppIdentifiers(bundleIdentifier: $bundleIdentifier) {
-                    ...${AppleAppIdentifierFragment.name}
+                    ...AppleAppIdentifierFragment
                   }
                 }
               }
             }
-            ${print(AppleAppIdentifierFragment.definition)}
+            ${print(AppleAppIdentifierFragmentDoc)}
           `,
           {
             accountName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleAppIdentifier } from '../../../../../graphql/generated';
-import { AppleAppIdentifierFragmentDoc } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
+import { AppleAppIdentifierFragmentNode } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
 
 const AppleAppIdentifierQuery = {
   async byBundleIdentifierAsync(
@@ -23,7 +23,7 @@ const AppleAppIdentifierQuery = {
                 }
               }
             }
-            ${print(AppleAppIdentifierFragmentDoc)}
+            ${print(AppleAppIdentifierFragmentNode)}
           `,
           {
             accountName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -4,8 +4,8 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleDevice, AppleTeam } from '../../../../../graphql/generated';
-import { AppleDeviceFragment } from '../../../../../graphql/types/credentials/AppleDevice';
-import { AppleTeamFragment } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleDeviceFragmentDoc } from '../../../../../graphql/types/credentials/AppleDevice';
+import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
 
 export type AppleTeamQueryResult = Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>;
 
@@ -34,18 +34,18 @@ const AppleDeviceQuery = {
             query($accountId: ID!, $appleTeamIdentifier: String!) {
               appleTeam {
                 byAppleTeamIdentifier(accountId: $accountId, identifier: $appleTeamIdentifier) {
-                  ...${AppleTeamFragment.name}
+                  ...AppleTeamFragment
                   appleDevices {
-                    ...${AppleDeviceFragment.name}
+                    ...AppleDeviceFragment
                     appleTeam {
-                      ...${AppleTeamFragment.name}
+                      ...AppleTeamFragment
                     }
                   }
                 }
               }
             }
-            ${print(AppleTeamFragment.definition)}
-            ${print(AppleDeviceFragment.definition)}
+            ${print(AppleTeamFragmentDoc)}
+            ${print(AppleDeviceFragmentDoc)}
           `,
           {
             accountId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -4,8 +4,8 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleDevice, AppleTeam } from '../../../../../graphql/generated';
-import { AppleDeviceFragmentDoc } from '../../../../../graphql/types/credentials/AppleDevice';
-import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleDeviceFragmentNode } from '../../../../../graphql/types/credentials/AppleDevice';
+import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
 export type AppleTeamQueryResult = Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>;
 
@@ -44,8 +44,8 @@ const AppleDeviceQuery = {
                 }
               }
             }
-            ${print(AppleTeamFragmentDoc)}
-            ${print(AppleDeviceFragmentDoc)}
+            ${print(AppleTeamFragmentNode)}
+            ${print(AppleDeviceFragmentNode)}
           `,
           {
             accountId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
@@ -6,8 +6,8 @@ import {
   AppleDistributionCertificate,
   IosDistributionType,
 } from '../../../../../graphql/generated';
-import { AppleDistributionCertificateFragment } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
-import { AppleTeamFragment } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleDistributionCertificateFragmentDoc } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
+import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
 
 const AppleDistributionCertificateQuery = {
   async getForAppAsync(
@@ -43,9 +43,9 @@ const AppleDistributionCertificateQuery = {
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
                       distributionCertificate {
-                        ...${AppleDistributionCertificateFragment.name}
+                        ...AppleDistributionCertificateFragment
                         appleTeam {
-                          ...${AppleTeamFragment.name}
+                          ...AppleTeamFragment
                         }
                       }
                     }
@@ -53,8 +53,8 @@ const AppleDistributionCertificateQuery = {
                 }
               }
             }
-            ${print(AppleDistributionCertificateFragment.definition)}
-            ${print(AppleTeamFragment.definition)}
+            ${print(AppleDistributionCertificateFragmentDoc)}
+            ${print(AppleTeamFragmentDoc)}
           `,
           {
             projectFullName,
@@ -87,16 +87,16 @@ const AppleDistributionCertificateQuery = {
               account {
                 byName(accountName: $accountName) {
                   appleDistributionCertificates {
-                    ...${AppleDistributionCertificateFragment.name}
+                    ...AppleDistributionCertificateFragment
                     appleTeam {
-                      ...${AppleTeamFragment.name}
+                      ...AppleTeamFragment
                     }
                   }
                 }
               }
             }
-            ${print(AppleDistributionCertificateFragment.definition)}
-            ${print(AppleTeamFragment.definition)}
+            ${print(AppleDistributionCertificateFragmentDoc)}
+            ${print(AppleTeamFragmentDoc)}
           `,
           {
             accountName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
@@ -6,8 +6,8 @@ import {
   AppleDistributionCertificate,
   IosDistributionType,
 } from '../../../../../graphql/generated';
-import { AppleDistributionCertificateFragmentDoc } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
-import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleDistributionCertificateFragmentNode } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
+import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
 const AppleDistributionCertificateQuery = {
   async getForAppAsync(
@@ -53,8 +53,8 @@ const AppleDistributionCertificateQuery = {
                 }
               }
             }
-            ${print(AppleDistributionCertificateFragmentDoc)}
-            ${print(AppleTeamFragmentDoc)}
+            ${print(AppleDistributionCertificateFragmentNode)}
+            ${print(AppleTeamFragmentNode)}
           `,
           {
             projectFullName,
@@ -95,8 +95,8 @@ const AppleDistributionCertificateQuery = {
                 }
               }
             }
-            ${print(AppleDistributionCertificateFragmentDoc)}
-            ${print(AppleTeamFragmentDoc)}
+            ${print(AppleDistributionCertificateFragmentNode)}
+            ${print(AppleTeamFragmentNode)}
           `,
           {
             accountName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
@@ -3,10 +3,10 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleProvisioningProfile, IosDistributionType } from '../../../../../graphql/generated';
-import { AppleAppIdentifierFragment } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
-import { AppleDeviceFragment } from '../../../../../graphql/types/credentials/AppleDevice';
-import { AppleProvisioningProfileFragment } from '../../../../../graphql/types/credentials/AppleProvisioningProfile';
-import { AppleTeamFragment } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleAppIdentifierFragmentDoc } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
+import { AppleDeviceFragmentDoc } from '../../../../../graphql/types/credentials/AppleDevice';
+import { AppleProvisioningProfileFragmentDoc } from '../../../../../graphql/types/credentials/AppleProvisioningProfile';
+import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
 
 const AppleProvisioningProfileQuery = {
   async getForAppAsync(
@@ -42,15 +42,15 @@ const AppleProvisioningProfileQuery = {
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
                       provisioningProfile {
-                        ...${AppleProvisioningProfileFragment.name}
+                        ...AppleProvisioningProfileFragment
                         appleTeam {
-                          ...${AppleTeamFragment.name}
+                          ...AppleTeamFragment
                         }
                         appleDevices {
-                          ...${AppleDeviceFragment.name}
+                          ...AppleDeviceFragment
                         }
                         appleAppIdentifier {
-                          ...${AppleAppIdentifierFragment.name}
+                          ...AppleAppIdentifierFragment
                         }
                       }
                     }
@@ -58,10 +58,10 @@ const AppleProvisioningProfileQuery = {
                 }
               }
             }
-            ${print(AppleProvisioningProfileFragment.definition)}
-            ${print(AppleTeamFragment.definition)}
-            ${print(AppleDeviceFragment.definition)}
-            ${print(AppleAppIdentifierFragment.definition)}
+            ${print(AppleProvisioningProfileFragmentDoc)}
+            ${print(AppleTeamFragmentDoc)}
+            ${print(AppleDeviceFragmentDoc)}
+            ${print(AppleAppIdentifierFragmentDoc)}
           `,
           {
             projectFullName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
@@ -3,10 +3,10 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleProvisioningProfile, IosDistributionType } from '../../../../../graphql/generated';
-import { AppleAppIdentifierFragmentDoc } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
-import { AppleDeviceFragmentDoc } from '../../../../../graphql/types/credentials/AppleDevice';
-import { AppleProvisioningProfileFragmentDoc } from '../../../../../graphql/types/credentials/AppleProvisioningProfile';
-import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleAppIdentifierFragmentNode } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
+import { AppleDeviceFragmentNode } from '../../../../../graphql/types/credentials/AppleDevice';
+import { AppleProvisioningProfileFragmentNode } from '../../../../../graphql/types/credentials/AppleProvisioningProfile';
+import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
 const AppleProvisioningProfileQuery = {
   async getForAppAsync(
@@ -58,10 +58,10 @@ const AppleProvisioningProfileQuery = {
                 }
               }
             }
-            ${print(AppleProvisioningProfileFragmentDoc)}
-            ${print(AppleTeamFragmentDoc)}
-            ${print(AppleDeviceFragmentDoc)}
-            ${print(AppleAppIdentifierFragmentDoc)}
+            ${print(AppleProvisioningProfileFragmentNode)}
+            ${print(AppleTeamFragmentNode)}
+            ${print(AppleDeviceFragmentNode)}
+            ${print(AppleAppIdentifierFragmentNode)}
           `,
           {
             projectFullName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleTeam } from '../../../../../graphql/generated';
-import { AppleTeamFragment } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
 
 type AppleTeamQueryResult = Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>;
 
@@ -44,11 +44,11 @@ const AppleTeamQuery = {
             query($accountId: ID!, $appleTeamIdentifier: String!) {
               appleTeam {
                 byAppleTeamIdentifier(accountId: $accountId, identifier: $appleTeamIdentifier) {
-                  ...${AppleTeamFragment.name}
+                  ...AppleTeamFragment
                 }
               }
             }
-            ${print(AppleTeamFragment.definition)}
+            ${print(AppleTeamFragmentDoc)}
           `,
           {
             accountId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { AppleTeam } from '../../../../../graphql/generated';
-import { AppleTeamFragmentDoc } from '../../../../../graphql/types/credentials/AppleTeam';
+import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
 type AppleTeamQueryResult = Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>;
 
@@ -48,7 +48,7 @@ const AppleTeamQuery = {
                 }
               }
             }
-            ${print(AppleTeamFragmentDoc)}
+            ${print(AppleTeamFragmentNode)}
           `,
           {
             accountId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { IosAppBuildCredentials, IosDistributionType } from '../../../../../graphql/generated';
-import { IosAppBuildCredentialsFragment } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
+import { IosAppBuildCredentialsFragmentDoc } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
 
 const IosAppBuildCredentialsQuery = {
   async byAppIdentifierIdAndDistributionTypeAsync(
@@ -25,24 +25,24 @@ const IosAppBuildCredentialsQuery = {
           };
         }>(
           gql`
-          query(
-            $projectFullName: String!
-            $appleAppIdentifierId: String!
-            $iosDistributionType: IosDistributionType!
-          ) {
+            query(
+              $projectFullName: String!
+              $appleAppIdentifierId: String!
+              $iosDistributionType: IosDistributionType!
+            ) {
               app {
                 byFullName(fullName: $projectFullName) {
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
                     iosAppBuildCredentialsArray(
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
-                      ...${IosAppBuildCredentialsFragment.name}
+                      ...IosAppBuildCredentialsFragment
                     }
                   }
                 }
               }
             }
-            ${print(IosAppBuildCredentialsFragment.definition)}
+            ${print(IosAppBuildCredentialsFragmentDoc)}
           `,
           {
             projectFullName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { IosAppBuildCredentials, IosDistributionType } from '../../../../../graphql/generated';
-import { IosAppBuildCredentialsFragmentDoc } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
+import { IosAppBuildCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
 
 const IosAppBuildCredentialsQuery = {
   async byAppIdentifierIdAndDistributionTypeAsync(
@@ -42,7 +42,7 @@ const IosAppBuildCredentialsQuery = {
                 }
               }
             }
-            ${print(IosAppBuildCredentialsFragmentDoc)}
+            ${print(IosAppBuildCredentialsFragmentNode)}
           `,
           {
             projectFullName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { IosAppCredentials, IosDistributionType } from '../../../../../graphql/generated';
-import { IosAppBuildCredentialsFragment } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
-import { IosAppCredentialsFragment } from '../../../../../graphql/types/credentials/IosAppCredentials';
+import { IosAppBuildCredentialsFragmentDoc } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
+import { IosAppCredentialsFragmentDoc } from '../../../../../graphql/types/credentials/IosAppCredentials';
 
 const IosAppCredentialsQuery = {
   async byAppIdentifierIdAsync(
@@ -19,12 +19,12 @@ const IosAppCredentialsQuery = {
               app {
                 byFullName(fullName: $projectFullName) {
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
-                    ...${IosAppCredentialsFragment.name}
+                    ...IosAppCredentialsFragment
                   }
                 }
               }
             }
-            ${print(IosAppCredentialsFragment.definition)}
+            ${print(IosAppCredentialsFragmentDoc)}
           `,
           {
             projectFullName,
@@ -52,23 +52,27 @@ const IosAppCredentialsQuery = {
       graphqlClient
         .query<{ app: { byFullName: { iosAppCredentials: IosAppCredentials[] } } }>(
           gql`
-              query($projectFullName: String!, $appleAppIdentifierId: String!, $iosDistributionType: IosDistributionType!) {
-                app {
-                  byFullName(fullName: $projectFullName) {
-                    iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
-                      ...${IosAppCredentialsFragment.name}
-                      iosAppBuildCredentialsArray(
-                        filter: { iosDistributionType: $iosDistributionType }
-                      ) {
-                        ...${IosAppBuildCredentialsFragment.name}
-                      }
+            query(
+              $projectFullName: String!
+              $appleAppIdentifierId: String!
+              $iosDistributionType: IosDistributionType!
+            ) {
+              app {
+                byFullName(fullName: $projectFullName) {
+                  iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
+                    ...IosAppCredentialsFragment
+                    iosAppBuildCredentialsArray(
+                      filter: { iosDistributionType: $iosDistributionType }
+                    ) {
+                      ...IosAppBuildCredentialsFragment
                     }
                   }
                 }
               }
-              ${print(IosAppCredentialsFragment.definition)}
-              ${print(IosAppBuildCredentialsFragment.definition)}
-            `,
+            }
+            ${print(IosAppCredentialsFragmentDoc)}
+            ${print(IosAppBuildCredentialsFragmentDoc)}
+          `,
           {
             projectFullName,
             appleAppIdentifierId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import { IosAppCredentials, IosDistributionType } from '../../../../../graphql/generated';
-import { IosAppBuildCredentialsFragmentDoc } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
-import { IosAppCredentialsFragmentDoc } from '../../../../../graphql/types/credentials/IosAppCredentials';
+import { IosAppBuildCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
+import { IosAppCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppCredentials';
 
 const IosAppCredentialsQuery = {
   async byAppIdentifierIdAsync(
@@ -24,7 +24,7 @@ const IosAppCredentialsQuery = {
                 }
               }
             }
-            ${print(IosAppCredentialsFragmentDoc)}
+            ${print(IosAppCredentialsFragmentNode)}
           `,
           {
             projectFullName,
@@ -70,8 +70,8 @@ const IosAppCredentialsQuery = {
                 }
               }
             }
-            ${print(IosAppCredentialsFragmentDoc)}
-            ${print(IosAppBuildCredentialsFragmentDoc)}
+            ${print(IosAppCredentialsFragmentNode)}
+            ${print(IosAppBuildCredentialsFragmentNode)}
           `,
           {
             projectFullName,

--- a/packages/eas-cli/src/graphql/fragment.ts
+++ b/packages/eas-cli/src/graphql/fragment.ts
@@ -1,6 +1,0 @@
-import { DocumentNode } from 'graphql';
-
-export interface Fragment {
-  name: string;
-  definition: DocumentNode;
-}

--- a/packages/eas-cli/src/graphql/types/App.ts
+++ b/packages/eas-cli/src/graphql/types/App.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-export const AppFragment = gql`
+export const AppFragmentNode = gql`
   fragment AppFragment on App {
     id
   }

--- a/packages/eas-cli/src/graphql/types/App.ts
+++ b/packages/eas-cli/src/graphql/types/App.ts
@@ -1,12 +1,7 @@
 import gql from 'graphql-tag';
 
-import { Fragment } from '../fragment';
-
-export const AppFragment: Fragment = {
-  name: 'app',
-  definition: gql`
-    fragment app on App {
-      id
-    }
-  `,
-};
+export const AppFragment = gql`
+  fragment AppFragment on App {
+    id
+  }
+`;

--- a/packages/eas-cli/src/graphql/types/credentials/AppleAppIdentifier.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleAppIdentifier.ts
@@ -1,13 +1,8 @@
 import gql from 'graphql-tag';
 
-import { Fragment } from '../../fragment';
-
-export const AppleAppIdentifierFragment: Fragment = {
-  name: 'appleAppIdentifier',
-  definition: gql`
-    fragment appleAppIdentifier on AppleAppIdentifier {
-      id
-      bundleIdentifier
-    }
-  `,
-};
+export const AppleAppIdentifierFragmentDoc = gql`
+  fragment AppleAppIdentifierFragment on AppleAppIdentifier {
+    id
+    bundleIdentifier
+  }
+`;

--- a/packages/eas-cli/src/graphql/types/credentials/AppleAppIdentifier.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleAppIdentifier.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-export const AppleAppIdentifierFragmentDoc = gql`
+export const AppleAppIdentifierFragmentNode = gql`
   fragment AppleAppIdentifierFragment on AppleAppIdentifier {
     id
     bundleIdentifier

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDevice.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDevice.ts
@@ -7,7 +7,7 @@ export const APPLE_DEVICE_CLASS_LABELS: Record<AppleDeviceClass, string> = {
   [AppleDeviceClass.Iphone]: 'iPhone',
 };
 
-export const AppleDeviceFragmentDoc = gql`
+export const AppleDeviceFragmentNode = gql`
   fragment AppleDeviceFragment on AppleDevice {
     id
     identifier

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDevice.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDevice.ts
@@ -1,6 +1,5 @@
 import gql from 'graphql-tag';
 
-import { Fragment } from '../../fragment';
 import { AppleDeviceClass } from '../../generated';
 
 export const APPLE_DEVICE_CLASS_LABELS: Record<AppleDeviceClass, string> = {
@@ -8,15 +7,12 @@ export const APPLE_DEVICE_CLASS_LABELS: Record<AppleDeviceClass, string> = {
   [AppleDeviceClass.Iphone]: 'iPhone',
 };
 
-export const AppleDeviceFragment: Fragment = {
-  name: 'appleDevice',
-  definition: gql`
-    fragment appleDevice on AppleDevice {
-      id
-      identifier
-      name
-      model
-      deviceClass
-    }
-  `,
-};
+export const AppleDeviceFragmentDoc = gql`
+  fragment AppleDeviceFragment on AppleDevice {
+    id
+    identifier
+    name
+    model
+    deviceClass
+  }
+`;

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDeviceRegistrationRequest.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDeviceRegistrationRequest.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-export const AppleDeviceRegistrationRequestFragmentDoc = gql`
+export const AppleDeviceRegistrationRequestFragmentNode = gql`
   fragment AppleDeviceRegistrationRequestFragment on AppleDeviceRegistrationRequest {
     id
   }

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDeviceRegistrationRequest.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDeviceRegistrationRequest.ts
@@ -1,12 +1,7 @@
 import gql from 'graphql-tag';
 
-import { Fragment } from '../../fragment';
-
-export const AppleDeviceRegistrationRequestFragment: Fragment = {
-  name: 'appleDeviceRegistrationRequest',
-  definition: gql`
-    fragment appleDeviceRegistrationRequest on AppleDeviceRegistrationRequest {
-      id
-    }
-  `,
-};
+export const AppleDeviceRegistrationRequestFragmentDoc = gql`
+  fragment AppleDeviceRegistrationRequestFragment on AppleDeviceRegistrationRequest {
+    id
+  }
+`;

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDistributionCertificate.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDistributionCertificate.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-export const AppleDistributionCertificateFragmentDoc = gql`
+export const AppleDistributionCertificateFragmentNode = gql`
   fragment AppleDistributionCertificateFragment on AppleDistributionCertificate {
     id
     certificateP12

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDistributionCertificate.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDistributionCertificate.ts
@@ -1,23 +1,18 @@
 import gql from 'graphql-tag';
 
-import { Fragment } from '../../fragment';
-
-export const AppleDistributionCertificateFragment: Fragment = {
-  name: 'appleDistCert',
-  definition: gql`
-    fragment appleDistCert on AppleDistributionCertificate {
+export const AppleDistributionCertificateFragmentDoc = gql`
+  fragment AppleDistributionCertificateFragment on AppleDistributionCertificate {
+    id
+    certificateP12
+    certificatePassword
+    serialNumber
+    developerPortalIdentifier
+    validityNotBefore
+    validityNotAfter
+    appleTeam {
       id
-      certificateP12
-      certificatePassword
-      serialNumber
-      developerPortalIdentifier
-      validityNotBefore
-      validityNotAfter
-      appleTeam {
-        id
-        appleTeamIdentifier
-        appleTeamName
-      }
+      appleTeamIdentifier
+      appleTeamName
     }
-  `,
-};
+  }
+`;

--- a/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
@@ -1,27 +1,22 @@
 import gql from 'graphql-tag';
 
-import { Fragment } from '../../fragment';
-
-export const AppleProvisioningProfileFragment: Fragment = {
-  name: 'appleProvisioningProfile',
-  definition: gql`
-    fragment appleProvisioningProfile on AppleProvisioningProfile {
+export const AppleProvisioningProfileFragmentDoc = gql`
+  fragment AppleProvisioningProfileFragment on AppleProvisioningProfile {
+    id
+    expiration
+    developerPortalIdentifier
+    provisioningProfile
+    appleTeam {
       id
-      expiration
-      developerPortalIdentifier
-      provisioningProfile
-      appleTeam {
-        id
-        appleTeamIdentifier
-        appleTeamName
-      }
-      appleDevices {
-        id
-        identifier
-        name
-        model
-        deviceClass
-      }
+      appleTeamIdentifier
+      appleTeamName
     }
-  `,
-};
+    appleDevices {
+      id
+      identifier
+      name
+      model
+      deviceClass
+    }
+  }
+`;

--- a/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-export const AppleProvisioningProfileFragmentDoc = gql`
+export const AppleProvisioningProfileFragmentNode = gql`
   fragment AppleProvisioningProfileFragment on AppleProvisioningProfile {
     id
     expiration

--- a/packages/eas-cli/src/graphql/types/credentials/AppleTeam.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleTeam.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-export const AppleTeamFragmentDoc = gql`
+export const AppleTeamFragmentNode = gql`
   fragment AppleTeamFragment on AppleTeam {
     id
     appleTeamIdentifier

--- a/packages/eas-cli/src/graphql/types/credentials/AppleTeam.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleTeam.ts
@@ -1,14 +1,9 @@
 import gql from 'graphql-tag';
 
-import { Fragment } from '../../fragment';
-
-export const AppleTeamFragment: Fragment = {
-  name: 'appleTeam',
-  definition: gql`
-    fragment appleTeam on AppleTeam {
-      id
-      appleTeamIdentifier
-      appleTeamName
-    }
-  `,
-};
+export const AppleTeamFragmentDoc = gql`
+  fragment AppleTeamFragment on AppleTeam {
+    id
+    appleTeamIdentifier
+    appleTeamName
+  }
+`;

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
@@ -1,57 +1,52 @@
 import gql from 'graphql-tag';
 
-import { Fragment } from '../../fragment';
-
-export const IosAppBuildCredentialsFragment: Fragment = {
-  name: 'iosAppBuildCredentials',
-  definition: gql`
-    fragment iosAppBuildCredentials on IosAppBuildCredentials {
+export const IosAppBuildCredentialsFragmentDoc = gql`
+  fragment IosAppBuildCredentialsFragment on IosAppBuildCredentials {
+    id
+    iosDistributionType
+    distributionCertificate {
       id
-      iosDistributionType
-      distributionCertificate {
+      certificateP12
+      certificatePassword
+      serialNumber
+      developerPortalIdentifier
+      validityNotBefore
+      validityNotAfter
+      appleTeam {
         id
-        certificateP12
-        certificatePassword
-        serialNumber
-        developerPortalIdentifier
-        validityNotBefore
-        validityNotAfter
-        appleTeam {
-          id
-          appleTeamIdentifier
-          appleTeamName
-        }
+        appleTeamIdentifier
+        appleTeamName
       }
-      provisioningProfile {
-        id
-        expiration
-        developerPortalIdentifier
-        provisioningProfile
-        appleDevices {
-          id
-          identifier
-          name
-          model
-          deviceClass
-        }
-        appleTeam {
-          id
-          appleTeamIdentifier
-          appleTeamName
-        }
-      }
+    }
+    provisioningProfile {
+      id
+      expiration
+      developerPortalIdentifier
+      provisioningProfile
       appleDevices {
         id
         identifier
         name
         model
         deviceClass
-        appleTeam {
-          id
-          appleTeamIdentifier
-          appleTeamName
-        }
+      }
+      appleTeam {
+        id
+        appleTeamIdentifier
+        appleTeamName
       }
     }
-  `,
-};
+    appleDevices {
+      id
+      identifier
+      name
+      model
+      deviceClass
+      appleTeam {
+        id
+        appleTeamIdentifier
+        appleTeamName
+      }
+    }
+  }
+`;

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-export const IosAppBuildCredentialsFragmentDoc = gql`
+export const IosAppBuildCredentialsFragmentNode = gql`
   fragment IosAppBuildCredentialsFragment on IosAppBuildCredentials {
     id
     iosDistributionType

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
@@ -1,12 +1,7 @@
 import gql from 'graphql-tag';
 
-import { Fragment } from '../../fragment';
-
-export const IosAppCredentialsFragment: Fragment = {
-  name: 'iosAppCredentials',
-  definition: gql`
-    fragment iosAppCredentials on IosAppCredentials {
-      id
-    }
-  `,
-};
+export const IosAppCredentialsFragmentDoc = gql`
+  fragment IosAppCredentialsFragment on IosAppCredentials {
+    id
+  }
+`;

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-export const IosAppCredentialsFragmentDoc = gql`
+export const IosAppCredentialsFragmentNode = gql`
   fragment IosAppCredentialsFragment on IosAppCredentials {
     id
   }


### PR DESCRIPTION
# Why

Apply the graphql `template-strings` rule which perform a bunch of validations, most notably disallowing template literals in certain part of the AST string. More info here: https://github.com/apollographql/eslint-plugin-graphql

- I've also refactored the `Fragments` as discussed here: https://github.com/expo/eas-cli/pull/185#issuecomment-756765674

# Test Plan

- [ ] current tests still pass
