### PR TITLE
[eas-cli] 5/n apply caps name rule

### DIFF
--- a/packages/eas-cli/.eslintrc.js
+++ b/packages/eas-cli/.eslintrc.js
@@ -26,6 +26,12 @@ module.exports = {
         requiredFields: ['id'],
       },
     ],
+    'graphql/capitalized-type-name': [
+      'error',
+      {
+        schemaJson: require('./graphql.schema.json'),
+      },
+    ],
   },
   plugins: ['graphql'],
 };


### PR DESCRIPTION
# Why

Enforce our naming conventions. There aren't really any `.ts` changes here because I applied them all from the previous rules.  More info here: https://github.com/apollographql/eslint-plugin-graphql .

# Test Plan

- [ ] current tests still pass
