### PR TITLE
[eas-cli] 4/n apply required id field rule

### DIFF
--- a/packages/eas-cli/.eslintrc.js
+++ b/packages/eas-cli/.eslintrc.js
@@ -18,6 +18,14 @@ module.exports = {
         schemaJson: require('./graphql.schema.json'),
       },
     ],
+    'graphql/required-fields': [
+      'error',
+      {
+        env: 'apollo',
+        schemaJson: require('./graphql.schema.json'),
+        requiredFields: ['id'],
+      },
+    ],
   },
   plugins: ['graphql'],
 };

--- a/packages/eas-cli/src/commands/release/list.ts
+++ b/packages/eas-cli/src/commands/release/list.ts
@@ -63,8 +63,10 @@ export default class ReleaseList extends Command {
                   id
                   releaseName
                   updates(offset: 0, limit: 1) {
+                    id
                     actor {
                       __typename
+                      id
                       ... on User {
                         username
                       }

--- a/packages/eas-cli/src/commands/release/view.ts
+++ b/packages/eas-cli/src/commands/release/view.ts
@@ -51,14 +51,17 @@ async function viewUpdateReleaseAsync({
           query ViewRelease($appId: String!, $releaseName: String!, $limit: Int!) {
             app {
               byId(appId: $appId) {
+                id
                 updateReleaseByReleaseName(releaseName: $releaseName) {
                   id
                   releaseName
                   updates(offset: 0, limit: $limit) {
+                    id
                     updateGroup
                     updateMessage
                     createdAt
                     actor {
+                      id
                       ... on User {
                         firstName
                       }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
@@ -26,6 +26,7 @@ const AppleAppIdentifierMutation = {
                   appleAppIdentifierInput: $appleAppIdentifierInput
                   accountId: $accountId
                 ) {
+                  id
                   ...AppleAppIdentifierFragment
                 }
               }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
@@ -22,6 +22,7 @@ const AppleDeviceMutation = {
             mutation AppleDeviceMutation($appleDeviceInput: AppleDeviceInput!, $accountId: ID!) {
               appleDevice {
                 createAppleDevice(appleDeviceInput: $appleDeviceInput, accountId: $accountId) {
+                  id
                   ...AppleDeviceFragment
                 }
               }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
@@ -24,6 +24,7 @@ const AppleDeviceRegistrationRequestMutation = {
                   appleTeamId: $appleTeamId
                   accountId: $accountId
                 ) {
+                  id
                   ...AppleDeviceRegistrationRequestFragment
                 }
               }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
@@ -34,8 +34,10 @@ const AppleDistributionCertificateMutation = {
                   appleDistributionCertificateInput: $appleDistributionCertificateInput
                   accountId: $accountId
                 ) {
+                  id
                   ...AppleDistributionCertificateFragment
                   appleTeam {
+                    id
                     ...AppleTeamFragment
                   }
                 }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
@@ -32,8 +32,10 @@ const AppleProvisioningProfileMutation = {
                   accountId: $accountId
                   appleAppIdentifierId: $appleAppIdentifierId
                 ) {
+                  id
                   ...AppleProvisioningProfileFragment
                   appleTeam {
+                    id
                     ...AppleTeamFragment
                   }
                 }
@@ -74,8 +76,10 @@ const AppleProvisioningProfileMutation = {
                   id: $appleProvisioningProfileId
                   appleProvisioningProfileInput: $appleProvisioningProfileInput
                 ) {
+                  id
                   ...AppleProvisioningProfileFragment
                   appleTeam {
+                    id
                     ...AppleTeamFragment
                   }
                 }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
@@ -20,6 +20,7 @@ const AppleTeamMutation = {
             mutation AppleTeamMutation($appleTeamInput: AppleTeamInput!, $accountId: ID!) {
               appleTeam {
                 createAppleTeam(appleTeamInput: $appleTeamInput, accountId: $accountId) {
+                  id
                   ...AppleTeamFragment
                   account {
                     id

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
@@ -29,6 +29,7 @@ const IosAppBuildCredentialsMutation = {
                   iosAppBuildCredentialsInput: $iosAppBuildCredentialsInput
                   iosAppCredentialsId: $iosAppCredentialsId
                 ) {
+                  id
                   ...IosAppBuildCredentialsFragment
                 }
               }
@@ -63,6 +64,7 @@ const IosAppBuildCredentialsMutation = {
                   id: $iosAppBuildCredentialsId
                   distributionCertificateId: $distributionCertificateId
                 ) {
+                  id
                   ...IosAppBuildCredentialsFragment
                 }
               }
@@ -97,6 +99,7 @@ const IosAppBuildCredentialsMutation = {
                   id: $iosAppBuildCredentialsId
                   provisioningProfileId: $provisioningProfileId
                 ) {
+                  id
                   ...IosAppBuildCredentialsFragment
                 }
               }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
@@ -29,6 +29,7 @@ const IosAppCredentialsMutation = {
                   appId: $appId
                   appleAppIdentifierId: $appleAppIdentifierId
                 ) {
+                  id
                   ...IosAppCredentialsFragment
                 }
               }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
@@ -14,6 +14,7 @@ const AppQuery = {
             query AppByFullNameQuery($fullName: String!) {
               app {
                 byFullName(fullName: $fullName) {
+                  id
                   ...AppFragment
                 }
               }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
@@ -20,7 +20,9 @@ const AppleAppIdentifierQuery = {
             ) {
               account {
                 byName(accountName: $accountName) {
+                  id
                   appleAppIdentifiers(bundleIdentifier: $bundleIdentifier) {
+                    id
                     ...AppleAppIdentifierFragment
                   }
                 }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -34,10 +34,13 @@ const AppleDeviceQuery = {
             query AppleDevicesByAppleTeamQuery($accountId: ID!, $appleTeamIdentifier: String!) {
               appleTeam {
                 byAppleTeamIdentifier(accountId: $accountId, identifier: $appleTeamIdentifier) {
+                  id
                   ...AppleTeamFragment
                   appleDevices {
+                    id
                     ...AppleDeviceFragment
                     appleTeam {
+                      id
                       ...AppleTeamFragment
                     }
                   }
@@ -74,6 +77,7 @@ const AppleDeviceQuery = {
             ) {
               account {
                 byName(accountName: $accountName) {
+                  id
                   appleTeams(appleTeamIdentifier: $appleTeamIdentifier) {
                     id
                     appleTeamIdentifier

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
@@ -38,13 +38,18 @@ const AppleDistributionCertificateQuery = {
             ) {
               app {
                 byFullName(fullName: $projectFullName) {
+                  id
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
+                    id
                     iosAppBuildCredentialsArray(
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
+                      id
                       distributionCertificate {
+                        id
                         ...AppleDistributionCertificateFragment
                         appleTeam {
+                          id
                           ...AppleTeamFragment
                         }
                       }
@@ -86,9 +91,12 @@ const AppleDistributionCertificateQuery = {
             query AppleDistributionCertificateByAccountQuery($accountName: String!) {
               account {
                 byName(accountName: $accountName) {
+                  id
                   appleDistributionCertificates {
+                    id
                     ...AppleDistributionCertificateFragment
                     appleTeam {
+                      id
                       ...AppleTeamFragment
                     }
                   }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
@@ -37,19 +37,26 @@ const AppleProvisioningProfileQuery = {
             ) {
               app {
                 byFullName(fullName: $projectFullName) {
+                  id
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
+                    id
                     iosAppBuildCredentialsArray(
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
+                      id
                       provisioningProfile {
+                        id
                         ...AppleProvisioningProfileFragment
                         appleTeam {
+                          id
                           ...AppleTeamFragment
                         }
                         appleDevices {
+                          id
                           ...AppleDeviceFragment
                         }
                         appleAppIdentifier {
+                          id
                           ...AppleAppIdentifierFragment
                         }
                       }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
@@ -16,6 +16,7 @@ const AppleTeamQuery = {
             query AppleTeamsByAccountName($accountName: String!) {
               account {
                 byName(accountName: $accountName) {
+                  id
                   appleTeams {
                     id
                     appleTeamName
@@ -44,6 +45,7 @@ const AppleTeamQuery = {
             query AppleTeamByIdentifierQuery($accountId: ID!, $appleTeamIdentifier: String!) {
               appleTeam {
                 byAppleTeamIdentifier(accountId: $accountId, identifier: $appleTeamIdentifier) {
+                  id
                   ...AppleTeamFragment
                 }
               }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
@@ -32,10 +32,13 @@ const IosAppBuildCredentialsQuery = {
             ) {
               app {
                 byFullName(fullName: $projectFullName) {
+                  id
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
+                    id
                     iosAppBuildCredentialsArray(
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
+                      id
                       ...IosAppBuildCredentialsFragment
                     }
                   }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
@@ -21,7 +21,9 @@ const IosAppCredentialsQuery = {
             ) {
               app {
                 byFullName(fullName: $projectFullName) {
+                  id
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
+                    id
                     ...IosAppCredentialsFragment
                   }
                 }
@@ -62,11 +64,14 @@ const IosAppCredentialsQuery = {
             ) {
               app {
                 byFullName(fullName: $projectFullName) {
+                  id
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
+                    id
                     ...IosAppCredentialsFragment
                     iosAppBuildCredentialsArray(
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
+                      id
                       ...IosAppBuildCredentialsFragment
                     }
                   }

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -42,6 +42,7 @@ const PublishMutation = {
             mutation PublishMutation($publishUpdateGroupInput: PublishUpdateGroupInput) {
               updateRelease {
                 publishUpdateGroup(publishUpdateGroupInput: $publishUpdateGroupInput) {
+                  id
                   updateGroup
                 }
               }

--- a/packages/eas-cli/src/graphql/queries/BuildQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BuildQuery.ts
@@ -20,6 +20,7 @@ const BuildQuery = {
             query BuildsByIdQuery($buildId: ID!) {
               builds {
                 byId(buildId: $buildId) {
+                  id
                   platform
                   artifacts {
                     buildUrl
@@ -56,6 +57,7 @@ const BuildQuery = {
                   platform: $platform
                   status: $status
                 ) {
+                  id
                   platform
                   artifacts {
                     buildUrl
@@ -93,6 +95,7 @@ const BuildQuery = {
             ) {
               account {
                 byName(accountName: $accountName) {
+                  id
                   inQueueBuilds: builds(
                     offset: 0
                     limit: 1

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -149,6 +149,7 @@ export async function getReleaseByNameAsync({
           query ViewRelease($appId: String!, $releaseName: String!) {
             app {
               byId(appId: $appId) {
+                id
                 updateReleaseByReleaseName(releaseName: $releaseName) {
                   id
                   releaseName


### PR DESCRIPTION
# Why

Require that we get the `id` field whenever possible in our graphql queries and mutations. I have mixed feelings about this rule because:
- it has a huge upside. Most graphql cachers will rely on the presence of `id` to figure whether to invalidate or add to the cache. I have personally experienced many painful bugs because of this 😭 
- downside: this rule doesn't look for `id` in referenced fragments, leading to a lot of redundancy. This is currently an unresolved bug: https://github.com/apollographql/eslint-plugin-graphql/issues/248

# Test Plan

- [ ] current tests still pass
