### PR TITLE
[eas-cli] initial fetch for credentials manager

### DIFF
--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -4,6 +4,7 @@ import {
   AppFragment,
   AppleAppIdentifierFragment,
   AppleTeamFragment,
+  CommonIosAppCredentialsFragment,
   IosAppBuildCredentialsFragment,
   IosDistributionType,
 } from '../../../graphql/generated';
@@ -96,6 +97,23 @@ export async function createOrUpdateIosAppBuildCredentialsAsync(
       appleProvisioningProfileId
     );
   }
+}
+
+export async function getIosAppCredentialsWithBuildCredentialsAsync(
+  appLookupParams: AppLookupParams
+): Promise<CommonIosAppCredentialsFragment | null> {
+  const { account, bundleIdentifier } = appLookupParams;
+  const appleAppIdentifier = await AppleAppIdentifierQuery.byBundleIdentifierAsync(
+    account.name,
+    bundleIdentifier
+  );
+  if (!appleAppIdentifier) {
+    return null;
+  }
+  const projectFullName = formatProjectFullName(appLookupParams);
+  return await IosAppCredentialsQuery.withCommonFieldsByAppIdentifierIdAsync(projectFullName, {
+    appleAppIdentifierId: appleAppIdentifier.id,
+  });
 }
 
 export async function createOrGetExistingIosAppCredentialsWithBuildCredentialsAsync(

--- a/packages/eas-cli/src/credentials/ios/utils/printCredentialsBeta.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/printCredentialsBeta.ts
@@ -1,0 +1,124 @@
+import chalk from 'chalk';
+import dateformat from 'dateformat';
+
+import {
+  CommonIosAppCredentialsFragment,
+  IosAppBuildCredentialsFragment,
+  IosDistributionType,
+} from '../../../graphql/generated';
+import log from '../../../log';
+import { fromNow } from '../../../utils/date';
+import { AppLookupParams } from '../api/GraphqlClient';
+
+export function prettyIosDistributionType(distributionType: IosDistributionType): string {
+  switch (distributionType) {
+    case IosDistributionType.AppStore:
+      return 'App Store';
+    case IosDistributionType.AdHoc:
+      return 'Ad Hoc';
+    case IosDistributionType.Development:
+      return 'Development';
+    case IosDistributionType.Enterprise:
+      return 'Enterprise';
+    default:
+      return 'Unknown';
+  }
+}
+
+export function displayEmptyIosCredentials(appLookupParams: AppLookupParams): void {
+  const { projectName, bundleIdentifier } = appLookupParams;
+  log(chalk.bold(`iOS Credentials`));
+  log(`  Project: ${projectName}`);
+  log(`  Bundle Identifier: ${bundleIdentifier}`);
+  log(`  No credentials set up yet!`);
+}
+
+/**
+ * sort a build credentials array in descending order of preference
+ */
+function sortBuildCredentialsByDistributionType(
+  iosAppBuildCredentialsArray: IosAppBuildCredentialsFragment[]
+): IosAppBuildCredentialsFragment[] {
+  // The order in which we choose the distribution type from least to most preferred
+  const typePriority = [
+    IosDistributionType.Development,
+    IosDistributionType.AdHoc,
+    IosDistributionType.Enterprise,
+    IosDistributionType.AppStore,
+  ];
+  return iosAppBuildCredentialsArray
+    .sort(
+      (buildCredentialsA, buildCredentialsB) =>
+        typePriority.indexOf(buildCredentialsA.iosDistributionType) -
+        typePriority.indexOf(buildCredentialsB.iosDistributionType)
+    )
+    .reverse();
+}
+
+export function displayIosAppCredentials(credentials: CommonIosAppCredentialsFragment): void {
+  log(chalk.bold(`iOS Credentials`));
+  log(`  Project: ${credentials.app.fullName}`);
+  log(`  Bundle Identifier: ${credentials.appleAppIdentifier.bundleIdentifier}`);
+  const appleTeam = credentials.appleTeam;
+  if (appleTeam) {
+    const { appleTeamIdentifier, appleTeamName } = appleTeam;
+    log(`  Apple Team: ${appleTeamIdentifier} ${appleTeamName ? `(${appleTeamName})` : ''}`);
+  }
+  log.newLine();
+
+  if (credentials.iosAppBuildCredentialsArray.length === 0) {
+    log(`  Configuration: None setup yet`);
+    log.newLine();
+    return;
+  }
+  const sortedIosAppBuildCredentialsArray = sortBuildCredentialsByDistributionType(
+    credentials.iosAppBuildCredentialsArray
+  );
+  for (const iosAppBuildCredentials of sortedIosAppBuildCredentialsArray) {
+    displayIosAppBuildCredentials(iosAppBuildCredentials);
+  }
+}
+
+export function displayIosAppBuildCredentials(
+  buildCredentials: IosAppBuildCredentialsFragment
+): void {
+  log(
+    chalk.bold(
+      `  Configuration: ${prettyIosDistributionType(buildCredentials.iosDistributionType)}`
+    )
+  );
+  const maybeDistCert = buildCredentials.distributionCertificate;
+  log(`  Distribution Certificate:`);
+  if (maybeDistCert) {
+    const { serialNumber, updatedAt, validityNotAfter, appleTeam } = maybeDistCert;
+    log(`    Serial Number: ${serialNumber}`);
+    log(`    Expiration Date: ${dateformat(validityNotAfter, 'expiresHeaderFormat')}`);
+    if (appleTeam) {
+      const { appleTeamIdentifier, appleTeamName } = appleTeam;
+      log(`    Apple Team: ${appleTeamIdentifier} ${appleTeamName ? `(${appleTeamName})` : ''}`);
+    }
+    log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
+  } else {
+    log(`    None assigned yet`);
+  }
+  log.newLine();
+
+  const maybeProvProf = buildCredentials.provisioningProfile;
+  log(`  Provisioning Profile:`);
+  if (maybeProvProf) {
+    const { expiration, updatedAt, status, developerPortalIdentifier, appleTeam } = maybeProvProf;
+    if (developerPortalIdentifier) {
+      log(`    Developer Portal ID: ${developerPortalIdentifier}`);
+    }
+    log(`    Status: ${status}`);
+    log(`    Expiration Date: ${dateformat(expiration, 'expiresHeaderFormat')}`);
+    if (appleTeam) {
+      const { appleTeamIdentifier, appleTeamName } = appleTeam;
+      log(`    Apple Team: ${appleTeamIdentifier} ${appleTeamName ? `(${appleTeamName})` : ''}`);
+    }
+    log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
+  } else {
+    log(`    None assigned yet`);
+  }
+  log.newLine();
+}

--- a/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
@@ -1,0 +1,105 @@
+import { CommonIosAppCredentialsFragment, IosDistributionType } from '../../graphql/generated';
+import { getProjectAccountName, getProjectConfigDescription } from '../../project/projectUtils';
+import { promptAsync } from '../../prompts';
+import { findAccountByName } from '../../user/Account';
+import { ensureActorHasUsername } from '../../user/actions';
+import { Action, CredentialsManager } from '../CredentialsManager';
+import { Context } from '../context';
+//import { RemoveDistributionCertificateBeta } from '../ios/actions/RemoveDistributionCertificateBeta';
+import { AppLookupParams } from '../ios/api/GraphqlClient';
+import {
+  displayAllIosCredentials,
+  displayEmptyIosCredentials,
+  displayIosAppCredentials,
+} from '../ios/utils/printCredentialsBeta';
+import { PressAnyKeyToContinue } from './HelperActions';
+
+enum ActionType {
+  SetupBuildCredentials,
+  SetupBuildCredentialsFromCredentialsJson,
+  UpdateCredentialsJson,
+  UseExistingDistributionCertificate,
+  RemoveSpecificProvisioningProfile,
+  CreateDistributionCertificate,
+  UpdateDistributionCertificate,
+  RemoveDistributionCertificate,
+}
+
+export class ManageIosBeta implements Action {
+  async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+    // TODO uncomment this before committing!
+    //manager.pushNextAction(this);
+    await ctx.bestEffortAppStoreAuthenticateAsync();
+
+    const accountName = ctx.hasProjectContext
+      ? getProjectAccountName(ctx.exp, ctx.user)
+      : ensureActorHasUsername(ctx.user);
+
+    const account = findAccountByName(ctx.user.accounts, accountName);
+    if (!account) {
+      throw new Error(`You do not have access to account: ${accountName}`);
+    }
+    if (ctx.hasProjectContext) {
+      const appLookupParams = this.getAppLookupParamsFromContext(ctx);
+      const iosAppCredentials = await ctx.newIos.getIosAppCredentialsWithBuildCredentialsAsync(
+        appLookupParams
+      );
+      if (!iosAppCredentials) {
+        displayEmptyIosCredentials(appLookupParams);
+      } else {
+        displayIosAppCredentials(iosAppCredentials);
+      }
+    }
+
+    const projectSpecificActions: { value: ActionType; title: string }[] = ctx.hasProjectContext
+      ? []
+      : [];
+
+    const { action } = await promptAsync({
+      type: 'select',
+      name: 'action',
+      message: 'What do you want to do?',
+      choices: [
+        ...projectSpecificActions,
+        {
+          value: ActionType.RemoveDistributionCertificate,
+          title: 'Remove Distribution Certificate',
+        },
+      ],
+    });
+
+    manager.pushNextAction(new PressAnyKeyToContinue());
+    manager.pushNextAction(this.getAction(ctx, accountName, action));
+  }
+
+  private getAppLookupParamsFromContext(ctx: Context): AppLookupParams {
+    ctx.ensureProjectContext();
+    const projectName = ctx.exp.slug;
+    const accountName = getProjectAccountName(ctx.exp, ctx.user);
+
+    const account = findAccountByName(ctx.user.accounts, accountName);
+    if (!account) {
+      throw new Error(`You do not have access to account: ${accountName}`);
+    }
+
+    const bundleIdentifier = ctx.exp.ios?.bundleIdentifier;
+    if (!bundleIdentifier) {
+      throw new Error(
+        `ios.bundleIdentifier needs to be defined in your ${getProjectConfigDescription(
+          ctx.projectDir
+        )} file`
+      );
+    }
+
+    return { account, projectName, bundleIdentifier };
+  }
+
+  private getAction(ctx: Context, accountName: string, action: ActionType): Action {
+    switch (action) {
+      /*       case ActionType.RemoveDistributionCertificate:
+        return new RemoveDistributionCertificateBeta(accountName); */
+      default:
+        throw new Error('Unknown action selected');
+    }
+  }
+}

--- a/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
@@ -1,4 +1,3 @@
-import { CommonIosAppCredentialsFragment, IosDistributionType } from '../../graphql/generated';
 import { getProjectAccountName, getProjectConfigDescription } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { findAccountByName } from '../../user/Account';
@@ -8,7 +7,6 @@ import { Context } from '../context';
 //import { RemoveDistributionCertificateBeta } from '../ios/actions/RemoveDistributionCertificateBeta';
 import { AppLookupParams } from '../ios/api/GraphqlClient';
 import {
-  displayAllIosCredentials,
   displayEmptyIosCredentials,
   displayIosAppCredentials,
 } from '../ios/utils/printCredentialsBeta';

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3161,6 +3161,28 @@ export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = (
   )> }
 );
 
+export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQueryVariables = Exact<{
+  projectFullName: Scalars['String'];
+  appleAppIdentifierId: Scalars['String'];
+}>;
+
+
+export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = (
+  { __typename?: 'RootQuery' }
+  & { app?: Maybe<(
+    { __typename?: 'AppQuery' }
+    & { byFullName: (
+      { __typename?: 'App' }
+      & Pick<App, 'id'>
+      & { iosAppCredentials: Array<(
+        { __typename?: 'IosAppCredentials' }
+        & Pick<IosAppCredentials, 'id'>
+        & CommonIosAppCredentialsFragment
+      )> }
+    ) }
+  )> }
+);
+
 export type GetSignedUploadMutationVariables = Exact<{
   contentTypes: Array<Scalars['String']>;
 }>;
@@ -3321,7 +3343,7 @@ export type CurrentUserQuery = (
 
 export type AppFragment = (
   { __typename?: 'App' }
-  & Pick<App, 'id'>
+  & Pick<App, 'id' | 'fullName'>
 );
 
 export type AppleAppIdentifierFragment = (
@@ -3370,14 +3392,14 @@ export type IosAppBuildCredentialsFragment = (
   & Pick<IosAppBuildCredentials, 'id' | 'iosDistributionType'>
   & { distributionCertificate?: Maybe<(
     { __typename?: 'AppleDistributionCertificate' }
-    & Pick<AppleDistributionCertificate, 'id' | 'certificateP12' | 'certificatePassword' | 'serialNumber' | 'developerPortalIdentifier' | 'validityNotBefore' | 'validityNotAfter'>
+    & Pick<AppleDistributionCertificate, 'id' | 'certificateP12' | 'certificatePassword' | 'serialNumber' | 'developerPortalIdentifier' | 'validityNotBefore' | 'validityNotAfter' | 'updatedAt'>
     & { appleTeam?: Maybe<(
       { __typename?: 'AppleTeam' }
       & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
     )> }
   )>, provisioningProfile?: Maybe<(
     { __typename?: 'AppleProvisioningProfile' }
-    & Pick<AppleProvisioningProfile, 'id' | 'expiration' | 'developerPortalIdentifier' | 'provisioningProfile'>
+    & Pick<AppleProvisioningProfile, 'id' | 'expiration' | 'developerPortalIdentifier' | 'provisioningProfile' | 'updatedAt' | 'status'>
     & { appleDevices: Array<(
       { __typename?: 'AppleDevice' }
       & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'model' | 'deviceClass'>
@@ -3385,17 +3407,32 @@ export type IosAppBuildCredentialsFragment = (
       { __typename?: 'AppleTeam' }
       & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
     )> }
-  )>, appleDevices?: Maybe<Array<Maybe<(
-    { __typename?: 'AppleDevice' }
-    & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'model' | 'deviceClass'>
-    & { appleTeam: (
-      { __typename?: 'AppleTeam' }
-      & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
-    ) }
-  )>>> }
+  )> }
 );
 
 export type IosAppCredentialsFragment = (
   { __typename?: 'IosAppCredentials' }
   & Pick<IosAppCredentials, 'id'>
+);
+
+export type CommonIosAppCredentialsFragment = (
+  { __typename?: 'IosAppCredentials' }
+  & Pick<IosAppCredentials, 'id'>
+  & { app: (
+    { __typename?: 'App' }
+    & Pick<App, 'id'>
+    & AppFragment
+  ), appleTeam?: Maybe<(
+    { __typename?: 'AppleTeam' }
+    & Pick<AppleTeam, 'id'>
+    & AppleTeamFragment
+  )>, appleAppIdentifier: (
+    { __typename?: 'AppleAppIdentifier' }
+    & Pick<AppleAppIdentifier, 'id'>
+    & AppleAppIdentifierFragment
+  ), iosAppBuildCredentialsArray: Array<(
+    { __typename?: 'IosAppBuildCredentials' }
+    & Pick<IosAppBuildCredentials, 'id'>
+    & IosAppBuildCredentialsFragment
+  )> }
 );

--- a/packages/eas-cli/src/graphql/types/App.ts
+++ b/packages/eas-cli/src/graphql/types/App.ts
@@ -3,5 +3,6 @@ import gql from 'graphql-tag';
 export const AppFragmentNode = gql`
   fragment AppFragment on App {
     id
+    fullName
   }
 `;

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
@@ -39,23 +39,5 @@ export const IosAppBuildCredentialsFragmentNode = gql`
         appleTeamName
       }
     }
-    provisioningProfile {
-      id
-      expiration
-      developerPortalIdentifier
-      provisioningProfile
-      appleDevices {
-        id
-        identifier
-        name
-        model
-        deviceClass
-      }
-      appleTeam {
-        id
-        appleTeamIdentifier
-        appleTeamName
-      }
-    }
   }
 `;

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
@@ -12,6 +12,27 @@ export const IosAppBuildCredentialsFragmentNode = gql`
       developerPortalIdentifier
       validityNotBefore
       validityNotAfter
+      updatedAt
+      appleTeam {
+        id
+        appleTeamIdentifier
+        appleTeamName
+      }
+    }
+    provisioningProfile {
+      id
+      expiration
+      developerPortalIdentifier
+      provisioningProfile
+      updatedAt
+      status
+      appleDevices {
+        id
+        identifier
+        name
+        model
+        deviceClass
+      }
       appleTeam {
         id
         appleTeamIdentifier
@@ -30,18 +51,6 @@ export const IosAppBuildCredentialsFragmentNode = gql`
         model
         deviceClass
       }
-      appleTeam {
-        id
-        appleTeamIdentifier
-        appleTeamName
-      }
-    }
-    appleDevices {
-      id
-      identifier
-      name
-      model
-      deviceClass
       appleTeam {
         id
         appleTeamIdentifier

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
@@ -1,7 +1,38 @@
 import gql from 'graphql-tag';
 
+import { AppFragmentNode } from '../App';
+import { AppleAppIdentifierFragmentNode } from './AppleAppIdentifier';
+import { AppleTeamFragmentNode } from './AppleTeam';
+import { IosAppBuildCredentialsFragmentNode } from './IosAppBuildCredentials';
+
 export const IosAppCredentialsFragmentNode = gql`
   fragment IosAppCredentialsFragment on IosAppCredentials {
     id
   }
+`;
+
+export const CommonIosAppCredentialsFragmentNode = gql`
+  fragment CommonIosAppCredentialsFragment on IosAppCredentials {
+    id
+    app {
+      id
+      ...AppFragment
+    }
+    appleTeam {
+      id
+      ...AppleTeamFragment
+    }
+    appleAppIdentifier {
+      id
+      ...AppleAppIdentifierFragment
+    }
+    iosAppBuildCredentialsArray {
+      id
+      ...IosAppBuildCredentialsFragment
+    }
+  }
+  ${AppFragmentNode}
+  ${AppleTeamFragmentNode}
+  ${AppleAppIdentifierFragmentNode}
+  ${IosAppBuildCredentialsFragmentNode}
 `;

--- a/packages/eas-cli/src/utils/date.ts
+++ b/packages/eas-cli/src/utils/date.ts
@@ -1,0 +1,35 @@
+function getBiggestInterval(seconds: number): [number, string] {
+  let interval = seconds / 31536000;
+  if (interval > 1) {
+    return [interval, 'year'];
+  }
+  interval = seconds / 2592000;
+  if (interval > 1) {
+    return [interval, 'month'];
+  }
+  interval = seconds / 86400;
+  if (interval > 1) {
+    return [interval, 'day'];
+  }
+  interval = seconds / 3600;
+  if (interval > 1) {
+    return [interval, 'hour'];
+  }
+  interval = seconds / 60;
+  if (interval > 1) {
+    return [interval, 'minute'];
+  }
+
+  interval = seconds;
+  return [interval, 'second'];
+}
+
+/**
+ * Time elapsed between now and the provided date. For example: '3 months'
+ */
+export function fromNow(date: Date): string {
+  const seconds = Math.floor((new Date().getTime() - date.getTime()) / 1000);
+  const [intervalAmountFloat, intervalType] = getBiggestInterval(seconds);
+  const intervalAmount = Math.floor(intervalAmountFloat);
+  return `${intervalAmount} ${intervalType}${intervalAmount > 1 ? 's' : ''}`;
+}


### PR DESCRIPTION
# Why

This is the start of an effort to move all credential api requests from apiv2 to graphql, and to bring the UX of the credentials manager closer to what we see in the website. This PR fetches all the initial credentials required to print out the user's credentials when they first run `eas credentials`. The excalidraw wireframes are [here](https://excalidraw.com/#json=5197280390938624,q3HFlStPaD1zjYI2WdG_FQ)

<img width="602" alt="Screen Shot 2021-01-12 at 8 34 08 PM" src="https://user-images.githubusercontent.com/6380927/104407052-9fe21480-5515-11eb-97d5-14f820ce3042.png">


# How

- We want the credentials manager to show information in the same way the website's UI does
- I'll be committing these incremental changes in `beta` files. It's a bit difficult to integrate the new API changes to the existing code because of caching issues. The current credentials manager maintains a cache of credentials from apiv2, and it'll be hard to keep the graphql and apiv2 caches in sync. It'll be easier to just build a `beta` credentials manager and switch over to that when it's complete.
