### PR TITLE
[eas-cli] make test output cleaner

### DIFF
--- a/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
@@ -14,6 +14,17 @@ jest.mock('fs');
 
 jest.mock('../../user/User');
 
+const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+beforeAll(() => {
+  console.log = jest.fn();
+  console.warn = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+  console.warn = originalConsoleWarn;
+});
+
 describe(findProjectRootAsync, () => {
   beforeEach(() => {
     vol.reset();

--- a/packages/eas-cli/src/submissions/ios/utils/__tests__/language-test.ts
+++ b/packages/eas-cli/src/submissions/ios/utils/__tests__/language-test.ts
@@ -1,5 +1,13 @@
 import { sanitizeLanguage } from '../language';
 
+const originalConsoleLog = console.log;
+beforeAll(() => {
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+});
+
 describe(sanitizeLanguage, () => {
   it('throws when language not found', () => {
     expect(() => sanitizeLanguage('Ponglish')).toThrowError();


### PR DESCRIPTION
# Why

There are some unmocked console.logs and console.warns in test output

```
 PASS  src/submissions/ios/utils/__tests__/language-test.ts
  ● Console

    console.log
      undefined

      at consoleLog (src/log.ts:28:11)

 PASS  src/credentials/android/actions/__tests__/RemoveKeystore-test.ts
 PASS  src/project/__tests__/projectUtils-test.ts
  ● Console

    console.warn
      An Expo user account is required to proceed.

      32 |   _updateIsLastLineNewLine(args);
      33 | 
    > 34 |   console.warn(...args);
         |           ^
      35 | }
      36 | 
      37 | function consoleError(...args: any[]) {

      at consoleWarn (src/log.ts:34:11)
      at Function.warn (src/log.ts:66:3)
      at ensureLoggedInAsync (src/user/actions.ts:30:9)
      at getProjectAccountNameAsync (src/project/projectUtils.ts:31:16)
      at Object.<anonymous> (src/project/__tests__/projectUtils-test.ts:141:5)

    console.log
      undefined

      at consoleLog (src/log.ts:28:11)

    console.log
      Log in to EAS

      at consoleLog (src/log.ts:28:11)

```

# How

I mocked `console.log` and `console.warn` in two test suites.

# Test Plan

```
yarn run v1.22.5
$ jest
 PASS  src/submissions/ios/utils/__tests__/language-test.ts
 PASS  src/submissions/android/__tests__/ServiceAccountSource-test.ts
 PASS  src/project/__tests__/projectUtils-test.ts
 PASS  src/submissions/ios/__tests__/IosSubmitCommand-test.ts
 PASS  src/credentials/android/actions/__tests__/RemoveKeystore-test.ts
 PASS  src/credentials/ios/appstore/__tests__/contractMessages-test.ts
 PASS  src/credentials/android/actions/__tests__/UpdateKeystore-test.ts
 PASS  src/user/__tests__/sessionStorage-test.ts
 PASS  src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
 PASS  src/credentials/credentialsJson/__tests__/read-test.ts
 PASS  src/user/__tests__/User-test.ts
 PASS  src/submissions/utils/__tests__/files-test.ts
 PASS  src/project/__tests__/publish-test.ts
 PASS  src/build/__tests__/credentials-test.ts
 PASS  src/credentials/credentialsJson/__tests__/update-test.ts
 PASS  src/devices/actions/create/__tests__/inputMethod-test.ts
 PASS  src/credentials/ios/utils/__tests__/provisioningProfile-test.ts
 PASS  src/credentials/android/actions/__tests__/SetupBuildCredentials-test.ts
 PASS  src/devices/__tests__/manager-test.ts
 PASS  src/devices/actions/create/__tests__/action-test.ts
 PASS  src/devices/__tests__/udids-test.ts
 PASS  src/user/__tests__/actions-test.ts

Test Suites: 22 passed, 22 total
Tests:       134 passed, 134 total
Snapshots:   1 passed, 1 total
Time:        3.21 s
Ran all test suites.
✨  Done in 3.92s.
```