### PR TITLE
[eas-cli] rework expected bundle format for eas publish

### DIFF
--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -7,6 +7,7 @@ import { AssetMetadataStatus } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import { PublishQuery } from '../../graphql/queries/PublishQuery';
 import {
+  MetadataJoi,
   Platforms,
   TIMEOUT_LIMIT,
   buildUpdateInfoGroupAsync,
@@ -28,6 +29,59 @@ const dummyFileBuffer = Buffer.from('dummy-file');
 fs.mkdirSync(path.resolve(), { recursive: true });
 fs.writeFileSync(path.resolve('md5-hash-of-file'), dummyFileBuffer);
 
+describe('MetadataJoi', () => {
+  it('passes correctly structured metadata', () => {
+    const { error } = MetadataJoi.validate({
+      version: 0,
+      bundler: 'metro',
+      fileMetadata: {
+        android: {
+          assets: [{ path: 'assets/3261e570d51777be1e99116562280926', ext: 'png' }],
+          bundle: 'bundles/android.js',
+        },
+        ios: {
+          assets: [{ path: 'assets/3261e570d51777be1e99116562280926', ext: 'png' }],
+          bundle: 'bundles/ios.js',
+        },
+      },
+    });
+    expect(error).toBe(undefined);
+  });
+  it('fails if a bundle is missing', () => {
+    const { error } = MetadataJoi.validate({
+      version: 0,
+      bundler: 'metro',
+      fileMetadata: {
+        android: {
+          assets: [{ path: 'assets/3261e570d51777be1e99116562280926', ext: 'png' }],
+          bundle: 'bundles/android.js',
+        },
+        ios: {
+          assets: [{ path: 'assets/3261e570d51777be1e99116562280926', ext: 'png' }],
+          bundle: undefined,
+        },
+      },
+    });
+    expect(error).toBeDefined();
+  });
+  it('passes metadata with no assets', () => {
+    const { error } = MetadataJoi.validate({
+      version: 0,
+      bundler: 'metro',
+      fileMetadata: {
+        android: {
+          assets: [],
+          bundle: 'bundles/android.js',
+        },
+        ios: {
+          assets: [],
+          bundle: 'bundles/ios.js',
+        },
+      },
+    });
+    expect(error).toBe(undefined);
+  });
+});
 describe(guessContentTypeFromExtension, () => {
   it('returns the correct content type for jpg', () => {
     expect(guessContentTypeFromExtension('jpg')).toBe('image/jpeg');

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -176,11 +176,11 @@ describe(collectAssets, () => {
     fs.mkdirSync(bundleDir, { recursive: true });
     fs.mkdirSync(assetDir, { recursive: true });
     Platforms.forEach(platform => {
-      fs.writeFileSync(path.resolve(`${inputDir}/bundles/${platform}.js`), bundles[platform]);
+      fs.writeFileSync(path.resolve(inputDir, `bundles/${platform}.js`), bundles[platform]);
     });
     fs.writeFileSync(path.resolve(`${inputDir}/assets/${fakeHash}`), dummyFileBuffer);
     fs.writeFileSync(
-      path.resolve(`${inputDir}/metadata.json`),
+      path.resolve(inputDir, 'metadata.json'),
       JSON.stringify({
         version: 0,
         bundler: 'metro',

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -140,7 +140,7 @@ export function loadMetadata(distRoot: string): Metadata {
     throw new Error('Only bundles with metadata version 0 are supported');
   }
   if (metadata.bundler !== 'metro') {
-    throw new Error('Only bundles created by metro are supported');
+    throw new Error('Only bundles created with Metro are currently supported');
   }
   return metadata;
 }

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -137,7 +137,7 @@ export function resolveInputDirectory(customInputDirectory: string): string {
 export function loadMetadata(distRoot: string): Metadata {
   const metadata: Metadata = JsonFile.read(path.join(distRoot, 'metadata.json'));
   if (metadata.version !== 0) {
-    throw new Error('Only bundles with storage version 0 are supported');
+    throw new Error('Only bundles with metadata version 0 are supported');
   }
   if (metadata.bundler !== 'metro') {
     throw new Error('Only bundles created by metro are supported');


### PR DESCRIPTION
# Why

Previously we were relying on `expo export` to build the bundles published by `eas publish`. `expo export` turns out to do a lot of unrelated stuff with the assumption the developer is going to use the output for privately hosted static endpoints. The core elements of `expo export` were factored out and put into a new command `expo bundle` https://github.com/expo/expo-cli/pull/3074. 

`expo bundle` outputs the bundle in a new format. This PR updates `eas publish` to expect this new format.

# How

Rewrote `collectAssets`.

# Test Plan

Confirmed the `collectAssets` output test still passed after updating it to the new formate.

Made a test publish after building the bundle in the new format.