### PR TITLE
[eas-cli] use autogen graphql types

### DIFF
--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3177,12 +3177,12 @@ export type GetSignedUploadMutation = (
   ) }
 );
 
-export type PublishMutationVariables = Exact<{
+export type UpdatePublishMutationVariables = Exact<{
   publishUpdateGroupInput?: Maybe<PublishUpdateGroupInput>;
 }>;
 
 
-export type PublishMutation = (
+export type UpdatePublishMutation = (
   { __typename?: 'RootMutation' }
   & { updateRelease: (
     { __typename?: 'UpdateReleaseMutation' }

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
-import { PublishUpdateGroupInput, Update } from '../generated';
+import { PublishUpdateGroupInput, Update, UpdatePublishMutation } from '../generated';
 
 const PublishMutation = {
   async getUploadURLsAsync(contentTypes: string[]): Promise<{ specifications: string[] }> {
@@ -31,15 +31,12 @@ const PublishMutation = {
 
   async publishUpdateGroupAsync(
     publishUpdateGroupInput: PublishUpdateGroupInput
-  ): Promise<Pick<Update, 'updateGroup'>> {
+  ): Promise<Pick<Update, 'id' | 'updateGroup'>> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .mutation<
-          { updateRelease: { publishUpdateGroup: Pick<Update, 'updateGroup'>[] } },
-          { publishUpdateGroupInput: PublishUpdateGroupInput }
-        >(
+        .mutation<UpdatePublishMutation>(
           gql`
-            mutation PublishMutation($publishUpdateGroupInput: PublishUpdateGroupInput) {
+            mutation UpdatePublishMutation($publishUpdateGroupInput: PublishUpdateGroupInput) {
               updateRelease {
                 publishUpdateGroup(publishUpdateGroupInput: $publishUpdateGroupInput) {
                   id
@@ -52,7 +49,7 @@ const PublishMutation = {
         )
         .toPromise()
     );
-    return data.updateRelease.publishUpdateGroup[0];
+    return data.updateRelease.publishUpdateGroup[0]!;
   },
 };
 

--- a/packages/eas-cli/src/graphql/queries/ProjectQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ProjectQuery.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
-import { Project } from '../generated';
+import { Project, ProjectByUsernameAndSlugQuery } from '../generated';
 
 type ProjectQueryResult = Pick<Project, 'id'>;
 
@@ -9,7 +9,7 @@ const ProjectQuery = {
   async byUsernameAndSlugAsync(username: string, slug: string): Promise<ProjectQueryResult> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<{ project: { byUsernameAndSlug: ProjectQueryResult } }>(
+        .query<ProjectByUsernameAndSlugQuery>(
           gql`
             query ProjectByUsernameAndSlugQuery($username: String!, $slug: String!) {
               project {

--- a/packages/eas-cli/src/graphql/queries/PublishQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/PublishQuery.ts
@@ -1,13 +1,13 @@
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
-import { AssetMetadataResult } from '../generated';
+import { AssetMetadataResult, GetAssetMetadataQuery } from '../generated';
 
 const PublishQuery = {
   async getAssetMetadataAsync(storageKeys: string[]): Promise<AssetMetadataResult[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<{ asset: { metadata: AssetMetadataResult[] } }, { storageKeys: string[] }>(
+        .query<GetAssetMetadataQuery>(
           gql`
             query GetAssetMetadataQuery($storageKeys: [String!]!) {
               asset {


### PR DESCRIPTION
# Why
1. Use autogenerated query/mutation types instead of having to manually write it out
2. Return a more accurate Graphql type (ie) a `FooQueryResult` or `FooFragment` type instead of the entire `Foo` object defined by www. 

In the case of duplicate identifiers, I've renamed the graphql operations as needed.

# Test Plan

- [ ] current tests still pass
