### PR TITLE
simplify credentials manager

### DIFF
--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -1,6 +1,6 @@
 import { Command } from '@oclif/command';
 
-import { runStandaloneCredentialsManagerAsync } from '../credentials/CredentialsManager';
+import { CredentialsManager } from '../credentials/CredentialsManager';
 import { createCredentialsContextAsync } from '../credentials/context';
 import { SelectPlatform } from '../credentials/manager/SelectPlatform';
 
@@ -9,6 +9,6 @@ export default class Credentials extends Command {
 
   async run() {
     const ctx = await createCredentialsContextAsync(process.cwd(), {});
-    await runStandaloneCredentialsManagerAsync(ctx, new SelectPlatform());
+    new CredentialsManager(ctx).runActionAsync(new SelectPlatform());
   }
 }

--- a/packages/eas-cli/src/credentials/CredentialsManager.ts
+++ b/packages/eas-cli/src/credentials/CredentialsManager.ts
@@ -1,78 +1,13 @@
-import log from '../log';
 import { Context } from './context';
 
-export interface CredentialsManager {
-  runActionAsync(action: Action): Promise<void>;
-
-  pushNextAction(action: Action): void;
-
-  popAction(): Action | null;
+export interface Action<T = void> {
+  runAsync(manager: CredentialsManager, ctx: Context): Promise<T>;
 }
 
-export interface Action {
-  runAsync(manager: CredentialsManager, ctx: Context): Promise<void>;
-}
+export class CredentialsManager {
+  constructor(private ctx: Context) {}
 
-export class QuitError extends Error {}
-
-export async function runStandaloneCredentialsManagerAsync(
-  ctx: Context,
-  startAction: Action
-): Promise<void> {
-  const manager = new CredentialsManagerImpl(ctx, startAction);
-  await manager.runManagerAsync(true);
-}
-
-export async function runCredentialsManagerAsync(ctx: Context, startAction: Action): Promise<void> {
-  const manager = new CredentialsManagerImpl(ctx, startAction);
-  await manager.runManagerAsync();
-}
-
-class CredentialsManagerImpl implements CredentialsManager {
-  private actionStack: Action[] = [];
-
-  constructor(private ctx: Context, startAction: Action) {
-    this.actionStack.push(startAction);
-  }
-
-  public pushNextAction(action: Action): void {
-    this.actionStack.push(action);
-  }
-
-  public popAction(): Action | null {
-    return this.actionStack.pop() ?? null;
-  }
-
-  public async runActionAsync(action: Action) {
-    await new CredentialsManagerImpl(this.ctx, action).doRunManagerAsync();
-  }
-
-  public async runManagerAsync(isStandaloneManager: boolean = false): Promise<void> {
-    try {
-      await this.doRunManagerAsync(isStandaloneManager);
-    } catch (error) {
-      if (error instanceof QuitError) {
-        return;
-      }
-      throw error;
-    }
-  }
-
-  private async doRunManagerAsync(isStandaloneManager: boolean = false): Promise<void> {
-    while (true) {
-      try {
-        const currentAction = this.popAction();
-        if (!currentAction) {
-          return;
-        }
-        await currentAction.runAsync(this, this.ctx);
-      } catch (error) {
-        if (!isStandaloneManager || error instanceof QuitError) {
-          throw error;
-        } else {
-          log.error(error);
-        }
-      }
-    }
+  public async runActionAsync<T>(action: Action<T>): Promise<T> {
+    return await action.runAsync(this, this.ctx);
   }
 }

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
@@ -29,10 +29,6 @@ export function createManagerMock(mockOverride: Record<string, any> = {}): Crede
       runActionAsync: jest.fn(() => {
         throw new Error('unexpected call'); // should be implemented in test directly
       }),
-      pushNextAction: jest.fn(() => {
-        throw new Error('unexpected call'); // should be implemented in test directly
-      }),
-      popAction: jest.fn(),
     },
     mockOverride
   );

--- a/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
@@ -2,7 +2,7 @@ import { Platform } from '@expo/eas-build-job';
 import { CredentialsSource } from '@expo/eas-json';
 
 import log from '../../log';
-import { runCredentialsManagerAsync } from '../CredentialsManager';
+import { CredentialsManager } from '../CredentialsManager';
 import { CredentialsProvider } from '../CredentialsProvider';
 import { Context } from '../context';
 import * as credentialsJsonReader from '../credentialsJson/read';
@@ -85,7 +85,9 @@ export default class AndroidCredentialsProvider implements CredentialsProvider {
   }
 
   private async getRemoteAsync(): Promise<AndroidCredentials> {
-    await runCredentialsManagerAsync(this.ctx, new SetupBuildCredentials(this.projectFullName));
+    await new CredentialsManager(this.ctx).runActionAsync(
+      new SetupBuildCredentials(this.projectFullName)
+    );
     const keystore = await this.ctx.android.fetchKeystoreAsync(this.projectFullName);
     if (!keystore) {
       throw new Error('Unable to set up credentials, failed to fetch keystore from Expo servers');

--- a/packages/eas-cli/src/credentials/android/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/actions/SetupBuildCredentials.ts
@@ -16,7 +16,7 @@ export class SetupBuildCredentials implements Action {
       throw new Error('Generating a new Keystore is not supported in --non-interactive mode');
     }
 
-    manager.pushNextAction(new UpdateKeystore(this.projectFullName));
+    await manager.runActionAsync(new UpdateKeystore(this.projectFullName));
   }
 }
 

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveKeystore-test.ts
@@ -38,7 +38,7 @@ describe('run RemoveKeystore when keystore does exist', () => {
 
     await new RemoveKeystore(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
+    expect(manager.runActionAsync).not.toHaveBeenCalled();
     expect(prompts).toHaveBeenCalledTimes(1);
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.removeKeystoreAsync).not.toHaveBeenCalled();
@@ -59,7 +59,6 @@ describe('run RemoveKeystore when keystore does exist', () => {
 
     await new RemoveKeystore(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
     expect(manager.runActionAsync).toHaveBeenCalledTimes(1);
     expect(prompts).toHaveBeenCalledTimes(1);
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
@@ -83,7 +82,7 @@ describe('run RemoveKeystore when keystore does exist', () => {
     }
 
     expect(prompts).not.toHaveBeenCalled();
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
+    expect(manager.runActionAsync).not.toHaveBeenCalled();
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.removeKeystoreAsync).not.toHaveBeenCalled();
   });
@@ -100,7 +99,7 @@ describe('run RemoveKeystore when keystore does not exist', () => {
 
     await new RemoveKeystore(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
+    expect(manager.runActionAsync).not.toHaveBeenCalled();
     expect(prompts).not.toHaveBeenCalled();
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.removeKeystoreAsync).not.toHaveBeenCalled();
@@ -115,7 +114,7 @@ describe('run RemoveKeystore when keystore does not exist', () => {
 
     await new RemoveKeystore(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
+    expect(manager.runActionAsync).not.toHaveBeenCalled();
     expect(prompts).not.toHaveBeenCalled();
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.removeKeystoreAsync).not.toHaveBeenCalled();

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetupBuildCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetupBuildCredentials-test.ts
@@ -38,7 +38,7 @@ describe('run SetupBuildCredentials when www has valid credentials', () => {
 
     await new SetupBuildCredentials(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
+    expect(manager.runActionAsync).not.toHaveBeenCalled();
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.updateKeystoreAsync).not.toHaveBeenCalled();
   });
@@ -54,7 +54,7 @@ describe('run SetupBuildCredentials when www has valid credentials', () => {
 
     await new SetupBuildCredentials(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
+    expect(manager.runActionAsync).not.toHaveBeenCalled();
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.updateKeystoreAsync).not.toHaveBeenCalled();
   });
@@ -69,12 +69,12 @@ describe('run SetupBuildCredentials when www has no credentials', () => {
     });
     const manager = createManagerMock();
 
-    (manager.pushNextAction as any).mockImplementationOnce((action: Action) => {
+    (manager.runActionAsync as any).mockImplementationOnce((action: Action) => {
       expect(action).toBeInstanceOf(UpdateKeystore);
     });
     await new SetupBuildCredentials(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).toHaveBeenCalledTimes(1);
+    expect(manager.runActionAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.updateKeystoreAsync).toHaveBeenCalledTimes(0); // will be called in UpdateKeystore
   });

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/UpdateKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/UpdateKeystore-test.ts
@@ -42,7 +42,7 @@ describe('run UpdateKeystore when keystore exist on www', () => {
 
     await new UpdateKeystore(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
+    expect(manager.runActionAsync).not.toHaveBeenCalled();
     expect(prompts).toHaveBeenCalledTimes(1);
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.updateKeystoreAsync).toHaveBeenCalledTimes(1);
@@ -66,7 +66,7 @@ describe('run UpdateKeystore when keystore exist on www', () => {
 
     await new UpdateKeystore(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
+    expect(manager.runActionAsync).not.toHaveBeenCalled();
     expect(prompts).toHaveBeenCalledTimes(5);
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.updateKeystoreAsync).toHaveBeenCalledTimes(1);
@@ -86,7 +86,7 @@ describe('run UpdateKeystore when keystore does not exist on www', () => {
 
     await new UpdateKeystore(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
+    expect(manager.runActionAsync).not.toHaveBeenCalled();
     expect(prompts).toHaveBeenCalledTimes(1);
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.updateKeystoreAsync).toHaveBeenCalledTimes(1);
@@ -110,7 +110,7 @@ describe('run UpdateKeystore when keystore does not exist on www', () => {
 
     await new UpdateKeystore(testExperienceName).runAsync(manager, ctx);
 
-    expect(manager.pushNextAction).not.toHaveBeenCalled();
+    expect(manager.runActionAsync).not.toHaveBeenCalled();
     expect(prompts).toHaveBeenCalledTimes(5);
     expect(ctx.android.fetchKeystoreAsync).toHaveBeenCalledTimes(1);
     expect(ctx.android.updateKeystoreAsync).toHaveBeenCalledTimes(1);

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -4,7 +4,7 @@ import { CredentialsSource, DistributionType } from '@expo/eas-json';
 import { IosDistributionType } from '../../graphql/generated';
 import log from '../../log';
 import { findAccountByName } from '../../user/Account';
-import { runCredentialsManagerAsync } from '../CredentialsManager';
+import { CredentialsManager } from '../CredentialsManager';
 import { CredentialsProvider } from '../CredentialsProvider';
 import { Context } from '../context';
 import * as credentialsJsonReader from '../credentialsJson/read';
@@ -109,8 +109,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
     if (this.options.skipCredentialsCheck) {
       log('Skipping credentials check');
     } else {
-      await runCredentialsManagerAsync(
-        this.ctx,
+      await new CredentialsManager(this.ctx).runActionAsync(
         new SetupBuildCredentials(this.options.app, this.options.distribution)
       );
     }

--- a/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
@@ -35,7 +35,7 @@ export class SetupProvisioningProfile implements Action {
     }
 
     if (!ctx.appStore.authCtx) {
-      manager.pushNextAction(new CreateProvisioningProfile(this.app));
+      await manager.runActionAsync(new CreateProvisioningProfile(this.app));
       return;
     }
 
@@ -44,7 +44,7 @@ export class SetupProvisioningProfile implements Action {
     );
 
     if (existingProfiles.length === 0) {
-      manager.pushNextAction(new CreateProvisioningProfile(this.app));
+      await manager.runActionAsync(new CreateProvisioningProfile(this.app));
       return;
     }
 
@@ -144,9 +144,9 @@ export class SetupProvisioningProfile implements Action {
     });
 
     if (action === 'GENERATE') {
-      manager.pushNextAction(new CreateProvisioningProfile(this.app));
+      await manager.runActionAsync(new CreateProvisioningProfile(this.app));
     } else if (action === 'CHOOSE_EXISTING') {
-      manager.pushNextAction(new UseExistingProvisioningProfile(this.app));
+      await manager.runActionAsync(new UseExistingProvisioningProfile(this.app));
     }
   }
 }

--- a/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
@@ -1,3 +1,4 @@
+import log from '../../log';
 import { getProjectAccountName, getProjectConfigDescription } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { findAccountByName } from '../../user/Account';
@@ -25,49 +26,60 @@ enum ActionType {
 
 export class ManageIosBeta implements Action {
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
-    // TODO uncomment this before committing!
-    //manager.pushNextAction(this);
-    await ctx.bestEffortAppStoreAuthenticateAsync();
+    while (true) {
+      try {
+        await ctx.bestEffortAppStoreAuthenticateAsync();
 
-    const accountName = ctx.hasProjectContext
-      ? getProjectAccountName(ctx.exp, ctx.user)
-      : ensureActorHasUsername(ctx.user);
+        const accountName = ctx.hasProjectContext
+          ? getProjectAccountName(ctx.exp, ctx.user)
+          : ensureActorHasUsername(ctx.user);
 
-    const account = findAccountByName(ctx.user.accounts, accountName);
-    if (!account) {
-      throw new Error(`You do not have access to account: ${accountName}`);
-    }
-    if (ctx.hasProjectContext) {
-      const appLookupParams = this.getAppLookupParamsFromContext(ctx);
-      const iosAppCredentials = await ctx.newIos.getIosAppCredentialsWithBuildCredentialsAsync(
-        appLookupParams
-      );
-      if (!iosAppCredentials) {
-        displayEmptyIosCredentials(appLookupParams);
-      } else {
-        displayIosAppCredentials(iosAppCredentials);
+        const account = findAccountByName(ctx.user.accounts, accountName);
+        if (!account) {
+          throw new Error(`You do not have access to account: ${accountName}`);
+        }
+        if (ctx.hasProjectContext) {
+          const appLookupParams = this.getAppLookupParamsFromContext(ctx);
+          const iosAppCredentials = await ctx.newIos.getIosAppCredentialsWithBuildCredentialsAsync(
+            appLookupParams
+          );
+          if (!iosAppCredentials) {
+            displayEmptyIosCredentials(appLookupParams);
+          } else {
+            displayIosAppCredentials(iosAppCredentials);
+          }
+        }
+
+        const projectSpecificActions: { value: ActionType; title: string }[] = ctx.hasProjectContext
+          ? []
+          : [];
+
+        const { action } = await promptAsync({
+          type: 'select',
+          name: 'action',
+          message: 'What do you want to do?',
+          choices: [
+            ...projectSpecificActions,
+            {
+              value: ActionType.RemoveDistributionCertificate,
+              title: 'Remove Distribution Certificate',
+            },
+          ],
+        });
+        try {
+          await manager.runActionAsync(this.getAction(ctx, accountName, action));
+        } catch (err) {
+          log.error(err);
+        }
+        await manager.runActionAsync(new PressAnyKeyToContinue());
+      } catch (err) {
+        log.error(err);
+        await manager.runActionAsync(new PressAnyKeyToContinue());
+      } finally {
+        // TODO remove finally block before committing!
+        return;
       }
     }
-
-    const projectSpecificActions: { value: ActionType; title: string }[] = ctx.hasProjectContext
-      ? []
-      : [];
-
-    const { action } = await promptAsync({
-      type: 'select',
-      name: 'action',
-      message: 'What do you want to do?',
-      choices: [
-        ...projectSpecificActions,
-        {
-          value: ActionType.RemoveDistributionCertificate,
-          title: 'Remove Distribution Certificate',
-        },
-      ],
-    });
-
-    manager.pushNextAction(new PressAnyKeyToContinue());
-    manager.pushNextAction(this.getAction(ctx, accountName, action));
   }
 
   private getAppLookupParamsFromContext(ctx: Context): AppLookupParams {

--- a/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
@@ -16,6 +16,6 @@ export class SelectPlatform implements Action {
       ],
     });
     const action = platform === 'ios' ? new ManageIos() : new SelectAndroidApp();
-    manager.pushNextAction(action);
+    await manager.runActionAsync(action);
   }
 }


### PR DESCRIPTION
# Why

Simplify credentials manager logic

# How

- use only runActionAsync
- replace pushNextAction with similar logic in actions that need that
- CredentialsManager just runs `runAsync` (Left that class there to simplify mocking in tests)
- runActionAsync can return values

# Test Plan

run build and few actions in credentials manager