### PR TITLE
[eas-cli] fix message for deprecation errors

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -112,8 +112,9 @@ export async function prepareBuildRequestForPlatformAsync<
         }
       );
     } catch (error) {
-      if (error.code === 'TURTLE_DEPRECATED_JOB_FORMAT') {
-        log.error('EAS Build API changed, upgrade to latest expo-cli');
+      const body = error?.response?.body;
+      if (body && JSON.parse(body)?.errors?.[0]?.code === 'TURTLE_DEPRECATED_JOB_FORMAT') {
+        log.error('EAS Build API changed, upgrade to latest eas-cli');
       }
       throw error;
     }

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -114,7 +114,7 @@ export async function prepareBuildRequestForPlatformAsync<
     } catch (error) {
       const body = error?.response?.body;
       if (body && JSON.parse(body)?.errors?.[0]?.code === 'TURTLE_DEPRECATED_JOB_FORMAT') {
-        log.error('EAS Build API changed, upgrade to latest eas-cli');
+        log.error('EAS Build API has changed, please upgrade to the latest eas-cli');
       }
       throw error;
     }


### PR DESCRIPTION
# Why

eas-cli does not properly detec `TURTLE_DEPRECATED_JOB_FORMAT` in error response

# How

- check correct field in error
- fix message

# Test Plan

run the same changes on old commit