### PR TITLE
[eas-cli] add support for building multi-target ios projects via credentials.json

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@expo/apple-utils": "0.0.0-alpha.17",
     "@expo/config": "~3.3.19",
-    "@expo/config-plugins": "~1.0.9",
-    "@expo/eas-build-job": "0.1.4",
+    "@expo/config-plugins": "^1.0.14",
+    "@expo/eas-build-job": "^0.2.0",
     "@expo/eas-json": "^0.1.0-alpha.20",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.11",

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -38,15 +38,22 @@ export async function prepareIosBuildAsync(
   }
 
   let iosNativeProjectScheme: string | undefined;
+  let iosApplicationNativeTarget: string | undefined;
   if (buildCtx.buildProfile.workflow === Workflow.Generic) {
     iosNativeProjectScheme = buildCtx.buildProfile.scheme ?? (await resolveSchemeAsync(buildCtx));
+    iosApplicationNativeTarget = await IOSConfig.Target.getApplicationTargetForSchemeAsync(
+      buildCtx.commandCtx.projectDir,
+      iosNativeProjectScheme
+    );
   }
+
   await ensureBundleIdentifierIsValidAsync(commandCtx.projectDir);
 
   return await prepareBuildRequestForPlatformAsync({
     ctx: buildCtx,
     projectConfiguration: {
       iosNativeProjectScheme,
+      iosApplicationNativeTarget,
     },
     ensureCredentialsAsync: ensureIosCredentialsAsync,
     ensureProjectConfiguredAsync: async () => {

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -7,10 +7,15 @@ import {
   sanitizeJob,
 } from '@expo/eas-build-job';
 import { iOSGenericBuildProfile, iOSManagedBuildProfile } from '@expo/eas-json';
+import assert from 'assert';
 import path from 'path';
 
-import { readSecretEnvsAsync } from '../../credentials/credentialsJson/read';
-import { IosCredentials } from '../../credentials/ios/IosCredentialsProvider';
+import {
+  IosCredentials,
+  IosTargetCredentials,
+  isCredentialsMap,
+  readSecretEnvsAsync,
+} from '../../credentials/credentialsJson/read';
 import { getProjectAccountNameAsync } from '../../project/projectUtils';
 import { gitRootDirectoryAsync } from '../../utils/git';
 import { BuildContext } from '../context';
@@ -21,6 +26,7 @@ interface JobData {
   credentials?: IosCredentials;
   projectConfiguration: {
     iosNativeProjectScheme?: string;
+    iosApplicationNativeTarget?: string;
   };
 }
 
@@ -44,43 +50,56 @@ interface CommonJobProperties {
   projectArchive: ArchiveSource;
   releaseChannel: string;
   secrets: {
-    buildCredentials?: {
-      provisioningProfileBase64: string;
-      distributionCertificate: {
-        dataBase64: string;
-        password: string;
-      };
-    };
+    buildCredentials: iOS.BuildCredentials;
     secretEnvs?: Record<string, string>;
   };
 }
 
 async function prepareJobCommonAsync(
   ctx: BuildContext<Platform.iOS>,
-  jobData: JobData
+  {
+    archiveBucketKey,
+    credentials,
+    targetName,
+  }: { archiveBucketKey: string; credentials?: IosCredentials; targetName?: string }
 ): Promise<Partial<CommonJobProperties>> {
   const secretEnvs = await readSecretEnvsAsync(ctx.commandCtx.projectDir);
-  const buildCredentials = jobData.credentials
-    ? {
-        buildCredentials: {
-          provisioningProfileBase64: jobData.credentials.provisioningProfile,
-          distributionCertificate: {
-            dataBase64: jobData.credentials.distributionCertificate.certP12,
-            password: jobData.credentials.distributionCertificate.certPassword,
-          },
-        },
-      }
-    : {};
+
+  let buildCredentials: CommonJobProperties['secrets']['buildCredentials'] = {};
+  if (credentials && isCredentialsMap(credentials)) {
+    const targets = Object.keys(credentials);
+    for (const target of targets) {
+      buildCredentials[target] = prepareTargetCredentials(credentials[target]);
+    }
+  } else if (credentials) {
+    // targetName
+    // - for managed projects: sanitized .name from the app config
+    // - for generic projects: name of the main application target
+    assert(targetName, 'target name should be defined');
+    buildCredentials = {
+      [targetName]: prepareTargetCredentials(credentials),
+    };
+  }
 
   return {
     platform: Platform.iOS,
     projectArchive: {
       type: ArchiveSourceType.S3,
-      bucketKey: jobData.archiveBucketKey,
+      bucketKey: archiveBucketKey,
     },
     secrets: {
       ...(secretEnvs ? { secretEnvs } : {}),
-      ...buildCredentials,
+      buildCredentials,
+    },
+  };
+}
+
+function prepareTargetCredentials(targetCredentials: IosTargetCredentials): iOS.TargetCredentials {
+  return {
+    provisioningProfileBase64: targetCredentials.provisioningProfile,
+    distributionCertificate: {
+      dataBase64: targetCredentials.distributionCertificate.certP12,
+      password: targetCredentials.distributionCertificate.certPassword,
     },
   };
 }
@@ -92,7 +111,11 @@ async function prepareGenericJobAsync(
 ): Promise<Partial<iOS.GenericJob>> {
   const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
   return {
-    ...(await prepareJobCommonAsync(ctx, jobData)),
+    ...(await prepareJobCommonAsync(ctx, {
+      archiveBucketKey: jobData.archiveBucketKey,
+      credentials: jobData.credentials,
+      targetName: jobData.projectConfiguration.iosApplicationNativeTarget,
+    })),
     type: Workflow.Generic,
     scheme: jobData.projectConfiguration.iosNativeProjectScheme,
     artifactPath: buildProfile.artifactPath,
@@ -108,11 +131,25 @@ async function prepareManagedJobAsync(
 ): Promise<Partial<iOS.ManagedJob>> {
   const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
   const accountName = await getProjectAccountNameAsync(ctx.commandCtx.projectDir);
+  const targetName = sanitizedName(ctx.commandCtx.exp.name);
   return {
-    ...(await prepareJobCommonAsync(ctx, jobData)),
+    ...(await prepareJobCommonAsync(ctx, {
+      archiveBucketKey: jobData.archiveBucketKey,
+      credentials: jobData.credentials,
+      targetName,
+    })),
     type: Workflow.Managed,
     username: accountName,
     releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,
   };
+}
+
+// copy-pasted from expo-cli/packages/xdl/src/Exp.ts
+// it's used in eject
+function sanitizedName(name: string) {
+  return name
+    .replace(/[\W_]+/g, '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
 }

--- a/packages/eas-cli/src/credentials/credentialsJson/__tests__/read-test.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/__tests__/read-test.ts
@@ -90,93 +90,140 @@ describe('credentialsJson', () => {
   });
 
   describe('readIosAsync', () => {
-    it('should read ios credentials if everything is correct', async () => {
-      vol.fromJSON({
-        './credentials.json': JSON.stringify({
-          ios: {
-            provisioningProfilePath: 'pprofile',
+    describe('single target credentials', () => {
+      it('should read ios credentials if everything is correct', async () => {
+        vol.fromJSON({
+          './credentials.json': JSON.stringify({
+            ios: {
+              provisioningProfilePath: 'pprofile',
+              distributionCertificate: {
+                path: 'cert.p12',
+                password: 'certPass',
+              },
+            },
+          }),
+          './pprofile': 'somebinarycontent',
+          './cert.p12': 'somebinarycontent2',
+        });
+        const result = await credentialsJsonReader.readIosCredentialsAsync('.');
+        expect(result).toEqual({
+          provisioningProfile: 'c29tZWJpbmFyeWNvbnRlbnQ=',
+          distributionCertificate: {
+            certP12: 'c29tZWJpbmFyeWNvbnRlbnQy',
+            certPassword: 'certPass',
+          },
+        });
+      });
+      it('should throw error when credentials.json is missing', async () => {
+        const promise = credentialsJsonReader.readIosCredentialsAsync('.');
+        await expect(promise).rejects.toThrow(
+          'credentials.json must exist in the project root directory and contain a valid JSON'
+        );
+      });
+      it('should throw error if ios field is missing', async () => {
+        vol.fromJSON({
+          './credentials.json': JSON.stringify({}),
+          './pprofile': 'somebinarycontent',
+          './cert.p12': 'somebinarycontent2',
+        });
+        const promise = credentialsJsonReader.readIosCredentialsAsync('.');
+        await expect(promise).rejects.toThrow('iOS credentials are missing from credentials.json');
+      });
+      it('should throw error if some field is missing', async () => {
+        vol.fromJSON({
+          './credentials.json': JSON.stringify({
+            ios: {
+              distributionCertificate: {
+                path: 'cert.p12',
+                password: 'certPass',
+              },
+            },
+          }),
+          './pprofile': 'somebinarycontent',
+          './cert.p12': 'somebinarycontent2',
+        });
+        const promise = credentialsJsonReader.readIosCredentialsAsync('.');
+        await expect(promise).rejects.toThrow(
+          'credentials.json is not valid [ValidationError: "ios" does not match any of the allowed types]'
+        );
+      });
+      it('should throw error if dist cert file is missing', async () => {
+        vol.fromJSON({
+          './credentials.json': JSON.stringify({
+            ios: {
+              provisioningProfilePath: 'pprofile',
+              distributionCertificate: {
+                path: 'cert.p12',
+                password: 'certPass',
+              },
+            },
+          }),
+          './pprofile': 'somebinarycontent',
+        });
+        const promise = credentialsJsonReader.readIosCredentialsAsync('.');
+        await expect(promise).rejects.toThrow("ENOENT: no such file or directory, open 'cert.p12'");
+      });
+      it('should throw error if provisioningProfile file is missing', async () => {
+        vol.fromJSON({
+          './credentials.json': JSON.stringify({
+            ios: {
+              provisioningProfilePath: 'pprofile',
+              distributionCertificate: {
+                path: 'cert.p12',
+                password: 'certPass',
+              },
+            },
+          }),
+          './cert.p12': 'somebinarycontent2',
+        });
+        const promise = credentialsJsonReader.readIosCredentialsAsync('.');
+        await expect(promise).rejects.toThrow("ENOENT: no such file or directory, open 'pprofile'");
+      });
+    });
+    describe('multi-target credentials', () => {
+      it('should read ios credentials if everything is correct', async () => {
+        vol.fromJSON({
+          './credentials.json': JSON.stringify({
+            ios: {
+              target1: {
+                provisioningProfilePath: 'pprofile-1.mobileprovision',
+                distributionCertificate: {
+                  path: 'dist-cert-1.p12',
+                  password: 'cert-pass-1',
+                },
+              },
+              target2: {
+                provisioningProfilePath: 'pprofile-2.mobileprovision',
+                distributionCertificate: {
+                  path: 'dist-cert-2.p12',
+                  password: 'cert-pass-2',
+                },
+              },
+            },
+          }),
+          './pprofile-1.mobileprovision': 'pprofile-1-somebinarycontent',
+          './pprofile-2.mobileprovision': 'pprofile-2-somebinarycontent',
+          './dist-cert-1.p12': 'cert-1-somebinarycontent',
+          './dist-cert-2.p12': 'cert-2-somebinarycontent',
+        });
+        const result = await credentialsJsonReader.readIosCredentialsAsync('.');
+        expect(result).toEqual({
+          target1: {
+            provisioningProfile: 'cHByb2ZpbGUtMS1zb21lYmluYXJ5Y29udGVudA==',
             distributionCertificate: {
-              path: 'cert.p12',
-              password: 'certPass',
+              certP12: 'Y2VydC0xLXNvbWViaW5hcnljb250ZW50',
+              certPassword: 'cert-pass-1',
             },
           },
-        }),
-        './pprofile': 'somebinarycontent',
-        './cert.p12': 'somebinarycontent2',
-      });
-      const result = await credentialsJsonReader.readIosCredentialsAsync('.');
-      expect(result).toEqual({
-        provisioningProfile: 'c29tZWJpbmFyeWNvbnRlbnQ=',
-        distributionCertificate: {
-          certP12: 'c29tZWJpbmFyeWNvbnRlbnQy',
-          certPassword: 'certPass',
-        },
-      });
-    });
-    it('should throw error when credentials.json is missing', async () => {
-      const promise = credentialsJsonReader.readIosCredentialsAsync('.');
-      await expect(promise).rejects.toThrow(
-        'credentials.json must exist in the project root directory and contain a valid JSON'
-      );
-    });
-    it('should throw error if ios field is missing', async () => {
-      vol.fromJSON({
-        './credentials.json': JSON.stringify({}),
-        './pprofile': 'somebinarycontent',
-        './cert.p12': 'somebinarycontent2',
-      });
-      const promise = credentialsJsonReader.readIosCredentialsAsync('.');
-      await expect(promise).rejects.toThrow('iOS credentials are missing from credentials.json');
-    });
-    it('should throw error if some field is missing', async () => {
-      vol.fromJSON({
-        './credentials.json': JSON.stringify({
-          ios: {
+          target2: {
+            provisioningProfile: 'cHByb2ZpbGUtMi1zb21lYmluYXJ5Y29udGVudA==',
             distributionCertificate: {
-              path: 'cert.p12',
-              password: 'certPass',
+              certP12: 'Y2VydC0yLXNvbWViaW5hcnljb250ZW50',
+              certPassword: 'cert-pass-2',
             },
           },
-        }),
-        './pprofile': 'somebinarycontent',
-        './cert.p12': 'somebinarycontent2',
+        });
       });
-      const promise = credentialsJsonReader.readIosCredentialsAsync('.');
-      await expect(promise).rejects.toThrow(
-        'credentials.json is not valid [ValidationError: "ios.provisioningProfilePath" is required]'
-      );
-    });
-    it('should throw error if dist cert file is missing', async () => {
-      vol.fromJSON({
-        './credentials.json': JSON.stringify({
-          ios: {
-            provisioningProfilePath: 'pprofile',
-            distributionCertificate: {
-              path: 'cert.p12',
-              password: 'certPass',
-            },
-          },
-        }),
-        './pprofile': 'somebinarycontent',
-      });
-      const promise = credentialsJsonReader.readIosCredentialsAsync('.');
-      await expect(promise).rejects.toThrow("ENOENT: no such file or directory, open 'cert.p12'");
-    });
-    it('should throw error if provisioningProfile file is missing', async () => {
-      vol.fromJSON({
-        './credentials.json': JSON.stringify({
-          ios: {
-            provisioningProfilePath: 'pprofile',
-            distributionCertificate: {
-              path: 'cert.p12',
-              password: 'certPass',
-            },
-          },
-        }),
-        './cert.p12': 'somebinarycontent2',
-      });
-      const promise = credentialsJsonReader.readIosCredentialsAsync('.');
-      await expect(promise).rejects.toThrow("ENOENT: no such file or directory, open 'pprofile'");
     });
   });
 

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -98,9 +98,27 @@ export async function updateIosCredentialsAsync(
       log.error('Make sure that file is correct (or remove it) and rerun this command.');
       throw error;
     }
+
+    // TODO: implement updating credentials.json with multi-target credentials from EAS servers
+    if (rawCredentialsJsonObject?.ios) {
+      const keys = Object.keys(rawCredentialsJsonObject.ios);
+      const maybeUnknownKey = keys.find(
+        key => key !== 'provisioningProfilePath' && key !== 'distributionCertificate'
+      );
+      if (maybeUnknownKey) {
+        log.error(
+          `It looks like your credentials.json either contains multi-target credentials or you've made a typo.`
+        );
+        log.error(`- The key in 'ios' object that EAS CLI encountered is: ${maybeUnknownKey}`);
+        log.error(
+          `- Updating credentials.json (for multi-target iOS projects) with credentials stored on EAS servers is not supported at the moment, sorry!`
+        );
+        throw new Error('Updating credentials.json failed');
+      }
+    }
   }
 
-  const accountName = await getProjectAccountName(ctx.exp, ctx.user);
+  const accountName = getProjectAccountName(ctx.exp, ctx.user);
   const appLookupParams = {
     accountName,
     projectName: ctx.exp.slug,

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -8,15 +8,10 @@ import { CredentialsManager } from '../CredentialsManager';
 import { CredentialsProvider } from '../CredentialsProvider';
 import { Context } from '../context';
 import * as credentialsJsonReader from '../credentialsJson/read';
+import type { IosCredentials } from '../credentialsJson/read';
 import { SetupBuildCredentials } from './actions/SetupBuildCredentials';
 
-export interface IosCredentials {
-  provisioningProfile: string;
-  distributionCertificate: {
-    certP12: string;
-    certPassword: string;
-  };
-}
+export { IosCredentials };
 
 interface PartialIosCredentials {
   provisioningProfile?: string;
@@ -74,6 +69,15 @@ export default class IosCredentialsProvider implements CredentialsProvider {
       const [remote, local] = await Promise.all([this.fetchRemoteAsync(), this.getLocalAsync()]);
       const r = remote;
       const l = local;
+
+      // TODO
+      // For now, when credentials.json contains credentials for multi-target project
+      // assume they are synced with the Expo servers.
+      // Change this behavior when we figure out how to store multi-target project credentials in the db.
+      if (credentialsJsonReader.isCredentialsMap(l)) {
+        return true;
+      }
+
       return !!(
         r &&
         l &&

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -127,9 +127,10 @@ export class SetupBuildCredentialsFromCredentialsJson implements Action {
       throw error;
     }
 
+    // TODO: implement storing multi-target credentials on EAS servers
     if (isCredentialsMap(localCredentials)) {
       throw new Error(
-        'Storing multi-target iOS credentials from credentials.json on Expo servers is not yet supported.'
+        'Storing multi-target iOS credentials from credentials.json on EAS servers is not yet supported.'
       );
     }
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -8,7 +8,7 @@ import { promptAsync } from '../../../prompts';
 import { findAccountByName } from '../../../user/Account';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
-import { readIosCredentialsAsync } from '../../credentialsJson/read';
+import { isCredentialsMap, readIosCredentialsAsync } from '../../credentialsJson/read';
 import { AppLookupParams, IosAppCredentials, IosDistCredentials } from '../credentials';
 import { displayProjectCredentials } from '../utils/printCredentials';
 import { readAppleTeam } from '../utils/provisioningProfile';
@@ -125,6 +125,12 @@ export class SetupBuildCredentialsFromCredentialsJson implements Action {
         'Reading credentials from credentials.json failed. Make sure this file is correct and all credentials are present there.'
       );
       throw error;
+    }
+
+    if (isCredentialsMap(localCredentials)) {
+      throw new Error(
+        'Storing multi-target iOS credentials from credentials.json on Expo servers is not yet supported.'
+      );
     }
 
     const team = readAppleTeam(localCredentials.provisioningProfile);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,19 +1093,20 @@
     "@babel/preset-env" "^7.4.4"
     "@babel/preset-typescript" "^7.3.3"
 
-"@expo/config-plugins@~1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.9.tgz#b17053338203706f4e08ff48884697b9b683ec1c"
-  integrity sha512-iv3OQYO8njOeoVF7CYsrFQ7rW/4MZjx5XbKrg8aQ4pazE2IRnhD5rPxDqs4dfgMbU2O2gK3W0+Lw/zvV/V0nAw==
+"@expo/config-plugins@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.14.tgz#95ad608f64fa6c66a352197d7552880d7cc9fa06"
+  integrity sha512-BSzRsBIKWS6bw32eOI/wJCZqschzWSgnvGZGYgDPPtHf/zMariLnnsqoIC5HT4CO1B+sqkSMstK1gy8YVtJABQ==
   dependencies:
     "@expo/config-types" "^40.0.0-beta.2"
-    "@expo/configure-splash-screen" "0.2.1"
-    "@expo/image-utils" "0.3.9"
+    "@expo/configure-splash-screen" "0.3.2"
+    "@expo/image-utils" "0.3.10"
     "@expo/json-file" "8.2.25"
-    "@expo/plist" "0.0.10"
+    "@expo/plist" "0.0.11"
+    find-up "~5.0.0"
     fs-extra "9.0.0"
+    getenv "0.7.0"
     glob "7.1.6"
-    invariant "2.2.4"
     slash "^3.0.0"
     slugify "^1.3.4"
     xcode "^2.1.0"
@@ -1133,10 +1134,10 @@
     semver "^7.1.3"
     slugify "^1.3.4"
 
-"@expo/configure-splash-screen@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.2.1.tgz#de29b781990d32d9f48d630b912aaf017afccbf3"
-  integrity sha512-6n7ji1WKDCdLe2Mto4u4W72kTLhAbhXhC7ydVk1HxDYCcbewNLfgiwhchPtPGyUMnSDizVWph5aDoiKxqVHqNQ==
+"@expo/configure-splash-screen@0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.3.2.tgz#394fc6d5bd11bd592f8035b837c6914dea9d8f91"
+  integrity sha512-+KvcPWv/EpAi9ng7KWsRCHUgN8qYcbpvrY8Pc3AtfPVHBhWuy7FhTdT0HUqjhOvqvwPF2Ygr//DHl8WBVg2ICA==
   dependencies:
     "@react-native-community/cli-platform-android" "^4.10.0"
     "@react-native-community/cli-platform-ios" "^4.10.0"
@@ -1157,17 +1158,17 @@
   dependencies:
     "@hapi/joi" "^17.1.1"
 
-"@expo/eas-build-job@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.4.tgz#71188a68e62ad1ecf1c6d20e4ebcfefa4143a9a2"
-  integrity sha512-wibByQQBu7kREeMmOWXBZXVjLuORUTzxKJSxhSk6aQ8iGC5FhcjSUzpCyi+949iOzhumryu4198ZCjGuQD8+4A==
+"@expo/eas-build-job@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.0.tgz#991b0844835f2f21139026bd5ddded8fa6bf88ed"
+  integrity sha512-B1f74lT1NXfwQAyvZ4yQXCyLGFIehO7klbpARdOro4IGiMectHFHR4b9gDdADMLiQ3kt/OA/L4bYoRM6wbt7hw==
   dependencies:
     "@hapi/joi" "^17.1.1"
 
-"@expo/image-utils@0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.9.tgz#10dc8044943c1bd34fe9658f2835a079e4041a0b"
-  integrity sha512-VarvpeNXtvPexmJSEllDF1RRHrjznsgf2Y0bZ2IehmOZwxdqz/YssGxY2ztMx5pn3utuhc9Enx140BHDBOp8UQ==
+"@expo/image-utils@0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.10.tgz#bdb9d6a2a7280680dd56d7f9dd283863b58d1e1e"
+  integrity sha512-EebukeUnzyk4ts1E1vMQSb0p8otYqWKsZNDZEoqHtERhxMSO7WhQLqa7/z2kB/YMHRJjrhaa3Aa2X5zjYot1kA==
   dependencies:
     "@expo/spawn-async" "1.5.0"
     chalk "^4.0.0"
@@ -1178,7 +1179,7 @@
     node-fetch "^2.6.0"
     parse-png "^2.1.0"
     resolve-from "^5.0.0"
-    semver "6.1.1"
+    semver "7.3.2"
     tempy "0.3.0"
 
 "@expo/json-file@8.2.25", "@expo/json-file@^8.2.24":
@@ -1212,16 +1213,7 @@
     qqjs "^0.3.10"
     tslib "^1.9.3"
 
-"@expo/plist@0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.10.tgz#e126a15543c6c67fd159947ca9e35969657a97f4"
-  integrity sha512-uKbi7ANPCNJqeAvxLa+ZcS/Qf0fTPOySMqw5T2L4TrycSAdiAxV1VUZ69IzIbUsWb7GdriUVR2i38M/xa6+BvA==
-  dependencies:
-    base64-js "^1.2.3"
-    xmlbuilder "^14.0.0"
-    xmldom "~0.1.31"
-
-"@expo/plist@^0.0.11":
+"@expo/plist@0.0.11", "@expo/plist@^0.0.11":
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.11.tgz#5d7900dc31df57d45a3524c061dde34aacc8dabf"
   integrity sha512-yza93QHDkbdkdwu/PXef0eJSCMkMNdrHujK5G1viZLaZt0Rxw2s+geTyjgJsYpwqQEAoOYVpKlVymOenK+bFQg==
@@ -6224,6 +6216,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 find-yarn-workspace-root@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
@@ -7139,7 +7139,7 @@ internal-slot@^1.0.2:
     has "^1.0.3"
     side-channel "^1.0.2"
 
-invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -8498,6 +8498,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -9566,6 +9573,13 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -9586,6 +9600,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map-series@^1.0.0:
   version "1.0.0"
@@ -10789,25 +10810,20 @@ scuid@^1.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
-  integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
-
 semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
+semver@7.3.2, semver@^7.1.3, semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
 semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.1.3, semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -12612,3 +12628,8 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
# Why

This is the second piece adding support for building multi-target iOS projects with EAS Build. Previous PR: https://github.com/expo/expo-cli/pull/3076

This PR adds support for building multi-target iOS projects via credentials.json. This means that if a user specifies the credentials for all native targets in credentials.json, they should be able to successfully build the binary.

Reference: https://www.notion.so/expo/Multi-Target-Support-V1-Credentials-json-8d1c1c934f644ba6b098e33b456ffad8

The last piece (EAS Build) is implemented in https://github.com/expo/turtle-v2/pull/384

# How

- I updated the schema of credentials.json. It's now possible to specify either one credentials set (if the project has only one target) or a map of credentials where the key is the target name and the value is the credentials set for a particular target.
  
  ```
  {
     "ios": {
      "multitarget": {
        "provisioningProfilePath": "ios/certs/multitarget.mobileprovision",
        "distributionCertificate": {
          "path": "ios/certs/dist-cert.p12",
          "password": "password1"
        }
      },
      "shareextension": {
        "provisioningProfilePath": "ios/certs/extension.mobileprovision",
        "distributionCertificate": {
          "path": "ios/certs/dist-cert.p12",
          "password": "password1"
        }
      }
    }
  }
  ```

   or

  ```
  {
     "ios": {
      "provisioningProfilePath": "ios/certs/extension.mobileprovision",
      "distributionCertificate": {
        "path": "ios/certs/dist-cert.p12",
        "password": "password1"
      }
    }
  }
  ```

- I updated the format of the iOS build request's payload so it's always a map (target name -> credentials). 
  - For managed projects, I set the target name to the string derived from the `name` field in `app.json / app.config.js`. This aligns with the implementation of `expo eject`.
  - For generic projects without multiple targets, I set the target name to the target associated with the scheme chosen by the user. 
- If `credentials.json` contains multi-target credentials, syncing them with Expo servers is temporarily disabled (until we figure out how to do that).

# Test Plan

- Existing tests still pass.
- Added new unit tests for reading credentials.json with multiple credentials sets.
- I built a test project with a share extension and it succeeded (on my local machine).
