### PR TITLE
[eas-cli] select dist certs

### DIFF
--- a/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
@@ -1,23 +1,136 @@
-import { AppleTeamFragment } from '../../../../graphql/generated';
-import { AppleDistributionCertificateQueryResult } from '../../api/graphql/queries/AppleDistributionCertificateQuery';
+import chalk from 'chalk';
+import dateformat from 'dateformat';
 
-export function formatDistributionCertificate({
-  developerPortalIdentifier,
-  serialNumber,
-  appleTeam,
-  validityNotBefore,
-  validityNotAfter,
-}: AppleDistributionCertificateQueryResult): string {
+import {
+  AppleDistributionCertificateFragment,
+  AppleTeamFragment,
+} from '../../../../graphql/generated';
+import log from '../../../../log';
+import { promptAsync } from '../../../../prompts';
+import { Account } from '../../../../user/Account';
+import { fromNow } from '../../../../utils/date';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { filterRevokedDistributionCerts } from '../../appstore/CredentialsUtilsBeta';
+
+export function formatDistributionCertificate(
+  distributionCertificate: AppleDistributionCertificateFragment,
+  validSerialNumbers?: string[]
+): string {
+  const {
+    serialNumber,
+    developerPortalIdentifier,
+    appleTeam,
+    validityNotBefore,
+    validityNotAfter,
+  } = distributionCertificate;
   let line: string = '';
   if (developerPortalIdentifier) {
     line += `Cert ID: ${developerPortalIdentifier}`;
   }
   line += `${line === '' ? '' : ', '}Serial number: ${serialNumber}${
     appleTeam ? `, ${formatAppleTeam(appleTeam)}` : ''
-  }, Created: ${validityNotBefore}, Expires: ${validityNotAfter}`;
+  }`;
+  line += chalk.gray(
+    `\n    Created: ${fromNow(new Date(validityNotBefore))} ago, Expires: ${dateformat(
+      validityNotAfter,
+      'expiresHeaderFormat'
+    )}`
+  );
+
+  if (!validSerialNumbers) {
+    line += '';
+  } else if (validSerialNumbers.includes(serialNumber)) {
+    line += chalk.gray("\n    ✅ Currently valid on Apple's servers.");
+  } else {
+    line += chalk.gray("\n    ❓ Validity of this certificate on Apple's servers is unknown.");
+  }
   return line;
 }
 
 function formatAppleTeam({ appleTeamIdentifier, appleTeamName }: AppleTeamFragment): string {
   return `Team ID: ${appleTeamIdentifier}${appleTeamName ? `, Team name: ${appleTeamName}` : ''}`;
+}
+
+async function _selectDistributionCertificateAsync(
+  distCerts: AppleDistributionCertificateFragment[],
+  validDistributionCertificates?: AppleDistributionCertificateFragment[]
+): Promise<AppleDistributionCertificateFragment | null> {
+  const { credentialsIndex } = await promptAsync({
+    type: 'select',
+    name: 'credentialsIndex',
+    message: 'Select certificate from the list.',
+    choices: distCerts.map((entry, index) => ({
+      title: formatDistributionCertificate(
+        entry,
+        validDistributionCertificates?.map(distCert => distCert.serialNumber)
+      ),
+      value: index,
+    })),
+  });
+  return distCerts[credentialsIndex];
+}
+
+/**
+ * select a distribution certificate from an account (validity status shown on a best effort basis)
+ * */
+export async function selectDistributionCertificateAsync(
+  ctx: Context,
+  account: Account
+): Promise<AppleDistributionCertificateFragment | null> {
+  const distCertsForAccount = await ctx.newIos.getDistributionCertificatesForAccountAsync(account);
+  if (distCertsForAccount.length === 0) {
+    log.warn(`There are no Distribution Certificates available in your Expo account.`);
+    return null;
+  }
+  if (!ctx.appStore.authCtx) {
+    return _selectDistributionCertificateAsync(distCertsForAccount);
+  }
+
+  // get valid certs on the developer portal
+  const certInfoFromApple = await ctx.appStore.listDistributionCertificatesAsync();
+  const validDistCerts = await filterRevokedDistributionCerts(
+    distCertsForAccount,
+    certInfoFromApple
+  );
+
+  return _selectDistributionCertificateAsync(distCertsForAccount, validDistCerts);
+}
+
+/**
+ * select a distribution certificate from a valid set (curated on a best effort basis)
+ * */
+export async function selectValidDistributionCertificateAsync(
+  ctx: Context,
+  appLookupParams: AppLookupParams
+): Promise<AppleDistributionCertificateFragment | null> {
+  const distCertsForAccount = await ctx.newIos.getDistributionCertificatesForAccountAsync(
+    appLookupParams.account
+  );
+  if (distCertsForAccount.length === 0) {
+    log.warn(`There are no Distribution Certificates available in your Expo account.`);
+    return null;
+  }
+  if (!ctx.appStore.authCtx) {
+    return _selectDistributionCertificateAsync(distCertsForAccount);
+  }
+
+  // filter by apple team
+  const distCertsForAppleTeam = distCertsForAccount.filter(distCert => {
+    return (
+      !distCert.appleTeam ||
+      distCert.appleTeam.appleTeamIdentifier === ctx.appStore.authCtx?.team.id
+    );
+  });
+
+  // filter by valid certs on the developer portal
+  const certInfoFromApple = await ctx.appStore.listDistributionCertificatesAsync();
+  const validDistCerts = await filterRevokedDistributionCerts(
+    distCertsForAppleTeam,
+    certInfoFromApple
+  );
+  log(
+    `${validDistCerts.length}/${distCertsForAccount.length} Distribution Certificates are currently valid for Apple Team ${ctx.appStore.authCtx?.team.id}.`
+  );
+  return _selectDistributionCertificateAsync(validDistCerts);
 }

--- a/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
@@ -38,12 +38,10 @@ export function formatDistributionCertificate(
     )}`
   );
 
-  if (!validSerialNumbers) {
-    line += '';
-  } else if (validSerialNumbers.includes(serialNumber)) {
+  if (validSerialNumbers?.includes(serialNumber)) {
     line += chalk.gray("\n    ✅ Currently valid on Apple's servers.");
   } else {
-    line += chalk.gray("\n    ❓ Validity of this certificate on Apple's servers is unknown.");
+    line += '';
   }
   return line;
 }

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
@@ -146,7 +146,7 @@ export class SetupDistributionCertificate implements Action {
     const validDistCertSerialNumberSet = new Set(validDistCertSerialNumbers);
 
     const distCertsForAccount = await ctx.newIos.getDistributionCertificatesForAccountAsync(
-      this.app
+      this.app.account
     );
     const distCertsForAppleTeam = distCertsForAccount.filter(distCert => {
       return (

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/DistributionCertificateUtils-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/DistributionCertificateUtils-test.ts
@@ -1,0 +1,24 @@
+import mockdate from 'mockdate';
+
+import { AppleDistributionCertificateQuery } from '../../../api/graphql/queries/AppleDistributionCertificateQuery';
+import { formatDistributionCertificate } from '../DistributionCertificateUtils';
+jest.mock('../../../api/graphql/queries/AppleDistributionCertificateQuery');
+jest.mock('chalk', () => {
+  return {
+    __esModule: true, // this property makes it work
+    default: { gray: jest.fn(log => log) },
+  };
+});
+
+mockdate.set(new Date('4/20/2021'));
+describe('select credentials', () => {
+  it('select an AppleDistributionCertificate fragment', async () => {
+    const testDistCerts = (
+      await AppleDistributionCertificateQuery.getAllForAccount('quinAccount')
+    ).sort((a, b) => (a.serialNumber > b.serialNumber ? 1 : -1));
+    const loggedSoFar = testDistCerts
+      .map(cert => formatDistributionCertificate(cert))
+      .reduce((acc, certLog) => acc + certLog);
+    expect(loggedSoFar).toMatchSnapshot();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/__snapshots__/DistributionCertificateUtils-test.ts.snap
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/__snapshots__/DistributionCertificateUtils-test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`select credentials select an AppleDistributionCertificate fragment 1`] = `
+"Cert ID: 5URSS525PL, Serial number: 3F9CDD6CFC6E52C1, Team ID: 77KQ969CHE
+    Created: 6 months ago, Expires: Wed, 13 Oct 2021 18:28:44 GMT+0000Cert ID: JRH7292L8R, Serial number: 5544BE191B9F949E, Team ID: 77KQ969CHE
+    Created: 10 months ago, Expires: Tue, 22 Jun 2021 20:46:07 GMT+0000"
+`;

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -258,9 +258,9 @@ export async function getDistributionCertificateForAppAsync(
   });
 }
 
-export async function getDistributionCertificatesForAccountAsync({
-  account,
-}: AppLookupParams): Promise<AppleDistributionCertificateQueryResult[]> {
+export async function getDistributionCertificatesForAccountAsync(
+  account: Account
+): Promise<AppleDistributionCertificateQueryResult[]> {
   return await AppleDistributionCertificateQuery.getAllForAccount(account.name);
 }
 

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/AppleDistributionCertificateQuery.ts
@@ -1,0 +1,40 @@
+const AppleDistributionCertificateQuery = {
+  getAllForAccount: jest.fn().mockImplementation(() => {
+    return [
+      {
+        id: '6a7422cc-392b-451d-984c-b0b4b027680a',
+        certificateP12: 'test-cert-p12-1',
+        certificatePassword: 'test-cert-password-1',
+        serialNumber: '5544BE191B9F949E',
+        developerPortalIdentifier: 'JRH7292L8R',
+        validityNotBefore: '2020-06-22T20:46:07.000Z',
+        validityNotAfter: '2021-06-22T20:46:07.000Z',
+        appleTeam: {
+          id: '6d39dbfe-a30a-44a4-bc36-d562e5963fa3',
+          appleTeamIdentifier: '77KQ969CHE',
+          appleTeamName: null,
+          __typename: 'AppleTeam',
+        },
+        __typename: 'AppleDistributionCertificate',
+      },
+      {
+        id: '8b3baa53-b149-4a1b-842b-75ff6e0bcb1e',
+        certificateP12: 'test-cert-p12-2',
+        certificatePassword: 'test-cert-password-2',
+        serialNumber: '3F9CDD6CFC6E52C1',
+        developerPortalIdentifier: '5URSS525PL',
+        validityNotBefore: '2020-10-13T18:28:44.000Z',
+        validityNotAfter: '2021-10-13T18:28:44.000Z',
+        appleTeam: {
+          id: '6d39dbfe-a30a-44a4-bc36-d562e5963fa3',
+          appleTeamIdentifier: '77KQ969CHE',
+          appleTeamName: null,
+          __typename: 'AppleTeam',
+        },
+        __typename: 'AppleDistributionCertificate',
+      },
+    ];
+  }),
+};
+
+export { AppleDistributionCertificateQuery };

--- a/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtilsBeta.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtilsBeta.ts
@@ -9,15 +9,14 @@ export function filterRevokedDistributionCerts(
     return [];
   }
 
-  // if the credentials are valid, check it against apple to make sure it hasnt been revoked
+  // if the cert is valid, check it against apple to make sure it hasnt been revoked
   const validCertSerialsOnAppleServer = certInfoFromApple
     .filter(
       // remove expired certs
       cert => cert.expires > Math.floor(Date.now() / 1000)
     )
     .map(cert => cert.serialNumber);
-  const validDistributionCerts = distributionCerts.filter(cert => {
-    return validCertSerialsOnAppleServer.includes(cert.serialNumber);
-  });
-  return validDistributionCerts;
+  return distributionCerts.filter(cert =>
+    validCertSerialsOnAppleServer.includes(cert.serialNumber)
+  );
 }

--- a/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtilsBeta.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtilsBeta.ts
@@ -1,0 +1,23 @@
+import { AppleDistributionCertificateQueryResult } from '../api/graphql/queries/AppleDistributionCertificateQuery';
+import { DistributionCertificateStoreInfo } from './Credentials.types';
+
+export function filterRevokedDistributionCerts(
+  distributionCerts: AppleDistributionCertificateQueryResult[],
+  certInfoFromApple: DistributionCertificateStoreInfo[]
+): AppleDistributionCertificateQueryResult[] {
+  if (distributionCerts.length === 0) {
+    return [];
+  }
+
+  // if the credentials are valid, check it against apple to make sure it hasnt been revoked
+  const validCertSerialsOnAppleServer = certInfoFromApple
+    .filter(
+      // remove expired certs
+      cert => cert.expires > Math.floor(Date.now() / 1000)
+    )
+    .map(cert => cert.serialNumber);
+  const validDistributionCerts = distributionCerts.filter(cert => {
+    return validCertSerialsOnAppleServer.includes(cert.serialNumber);
+  });
+  return validDistributionCerts;
+}


### PR DESCRIPTION
# Why

Utility functions to select a distribution certificate

<img width="890" alt="Screen Shot 2021-01-14 at 2 16 31 AM" src="https://user-images.githubusercontent.com/6380927/104577690-a1433800-560e-11eb-85b4-ff8fd6190a93.png">

# How 
- the options are multiline now
- moved a lot of existing utility functions that operated on the old api to the 'new' directory for the new api
- beta files are files that are only used by the WIP credentials manager 

# Test Plan

- [x] new tests pass
