### PR TITLE
Added support for EXPO_APPLE_TEAM_ID

### DIFF
--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -112,7 +112,8 @@ export default class BuildSubmit extends Command {
       helpLabel: IOS_FLAGS,
     }),
     'apple-team-id': flags.string({
-      description: 'Your Apple Developer Team ID',
+      description:
+        'Your Apple Developer Team ID (you can also set EXPO_APPLE_TEAM_ID env variable)',
       helpLabel: IOS_FLAGS,
     }),
     'app-name': flags.string({

--- a/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
@@ -67,7 +67,7 @@ async function loginAsync(
   }
 
   // Resolve the user credentials, optimizing for password-less login.
-  const { username, password } = await resolveCredentialsAsync(userCredentials);
+  const { username, password, teamId } = await resolveCredentialsAsync(userCredentials);
   assert(username);
 
   // Clear data
@@ -79,7 +79,7 @@ async function loginAsync(
       {
         username,
         providerId: userCredentials.providerId,
-        teamId: userCredentials.teamId,
+        teamId,
       },
       options
     );
@@ -92,7 +92,7 @@ async function loginAsync(
       username,
       password,
       providerId: userCredentials.providerId,
-      teamId: userCredentials.teamId,
+      teamId,
     });
   } catch (error) {
     if (error instanceof InvalidUserCredentialsError) {
@@ -104,7 +104,7 @@ async function loginAsync(
         // Don't pass credentials back or the method will throw
         return loginAsync(
           {
-            teamId: userCredentials.teamId,
+            teamId,
             providerId: userCredentials.providerId,
           },
           options

--- a/packages/eas-cli/src/credentials/ios/appstore/resolveCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/resolveCredentials.ts
@@ -28,16 +28,18 @@ export async function resolveCredentialsAsync(
 function getAppleIdFromEnvironmentOrOptions({
   username,
   password,
+  teamId,
   ...userCredentials
 }: Partial<Auth.UserCredentials>): Partial<Auth.UserCredentials> {
+  const passedAppleTeamId = teamId || process.env.EXPO_APPLE_TEAM_ID;
   const passedAppleId = username || process.env.EXPO_APPLE_ID;
   // Only resolve the password if the username was provided.
   const passedAppleIdPassword = passedAppleId
     ? password || process.env.EXPO_APPLE_PASSWORD
     : undefined;
-
   return {
     ...userCredentials,
+    teamId: passedAppleTeamId,
     username: passedAppleId,
     password: passedAppleIdPassword,
   };


### PR DESCRIPTION
# Why

In order for `expo prebuild` to have parity with `expo build` we need a way for users to define their team ID so that config plugins which require Team ID can be setup. An example of this is [expo-document-picker plugin](https://github.com/expo/expo/blob/b8e143593c8ca65966930e0b3d901aabbf8ca2ca/packages/expo-document-picker/plugin/src/withDocumentPicker.ts#L9) which uses the team ID in the entitlements when `ios.usesIcloudStorage` is enabled. For now, we'll opt towards using an environment variable. 
~~Before introducing that in an expo config plugin, we should ensure EAS supports it.~~ The config plugin just expects it now and we should set it automatically for users.

# How

- Resolve `EXPO_APPLE_TEAM_ID` as the Apple team ID if defined.

# Test Plan

```
export EXPO_APPLE_TEAM_ID=FOOBAR
eas credentials
- iOS
...
Authentication with Apple Developer Portal failed!
AssertionError [ERR_ASSERTION]: Your account is not associated with Apple Team ID: FOOBAR. Valid team IDs are: QQ57RJ5UTD
```