### PR TITLE
[eas-cli] return non-zero exit code if prompt is displayed on CI

### DIFF
--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -9,6 +9,9 @@ export async function promptAsync<T extends string = string>(
   questions: Question<T> | Question<T>[],
   options: Options = {}
 ): Promise<Answers<T>> {
+  if (process.stdin.readableFlowing === null && !global.test) {
+    throw new Error('Input is required, but stdin is not readable.');
+  }
   return await prompts<T>(questions, {
     onCancel() {
       process.exit(constants.signals.SIGINT + 128); // Exit code 130 used when process is interrupted with ctrl+c.


### PR DESCRIPTION
# Why

When prompts is called on ci it exits from the process with 0 exit code

The error does not need to be descriptive because all commands that might be run on CI should support `--non-interactive` flag, this change is only to ensure non-zero exit code.

# How

- if stdin is not readable before prompts call, then throw an error.
- skip check if running in test `!global.test` (explained in a comment below)

# Test Plan

Reproduced with `eas build -p andorid < /dev/null`
