### PR TITLE
[eas-cli] hide release:publish command

### DIFF
--- a/packages/eas-cli/src/commands/release/publish.ts
+++ b/packages/eas-cli/src/commands/release/publish.ts
@@ -17,6 +17,7 @@ import { promptAsync } from '../../prompts';
 import { getLastCommitMessageAsync } from '../../utils/git';
 
 export default class ReleasePublish extends Command {
+  static hidden = true;
   static description = 'Publish an update group to a release.';
 
   static flags = {


### PR DESCRIPTION
# Why

I wanted to release a new version of eas-cli and noticed that the `release:publish` command is displayed in the README.
https://github.com/expo/eas-cli/commit/b27590f4f54e532049e365bb55a784f8cbfb8b83#diff-a252b5d7d93d02fa1b5f26d73bb4608c49feefb7c32c6d3b47b0e1d448e042bcR217

# How

Set `ReleasePublish.hidden` to `true`. 

# Test Plan

I'll run `yarn release` one more time.