### PR TITLE
[eas-cli] improve monorepo support - fix configuring expo-updates

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@expo/apple-utils": "0.0.0-alpha.17",
     "@expo/config": "~3.3.19",
-    "@expo/config-plugins": "^1.0.14",
+    "@expo/config-plugins": "1.0.15-alpha.0",
     "@expo/eas-build-job": "^0.2.0",
     "@expo/eas-json": "^0.3.0",
     "@expo/json-file": "^8.2.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,10 +1093,10 @@
     "@babel/preset-env" "^7.4.4"
     "@babel/preset-typescript" "^7.3.3"
 
-"@expo/config-plugins@^1.0.14":
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.14.tgz#95ad608f64fa6c66a352197d7552880d7cc9fa06"
-  integrity sha512-BSzRsBIKWS6bw32eOI/wJCZqschzWSgnvGZGYgDPPtHf/zMariLnnsqoIC5HT4CO1B+sqkSMstK1gy8YVtJABQ==
+"@expo/config-plugins@1.0.15-alpha.0":
+  version "1.0.15-alpha.0"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.15-alpha.0.tgz#0f6c4250fa96ec597bb890dddb3502192c705e27"
+  integrity sha512-gWCHnh96RoWdhF7gsdGjuw7PhNOLl6vsB2PWpbANUWA3Y96dLLTv/nVNH3bLQ8KGtlVU/mAZ1Go6AW6u08Jx7A==
   dependencies:
     "@expo/config-types" "^40.0.0-beta.2"
     "@expo/configure-splash-screen" "0.3.2"


### PR DESCRIPTION
# Before merge

- Merge https://github.com/expo/expo-cli/pull/3103
- Publish config-plugins
- Bump config-plugins in EAS CLI.

# Why

This PR fixes configuring expo-updates when the react native project is in a yarn/npm workspace.

# How

- I made some changes in config-plugins (https://github.com/expo/expo-cli/pull/3103). Mainly, I added logic that removes incorrect paths to `create-ios-manifest.ios` / `expo-updates/scripts/create-manifest-android.gradle`.
- I made the logic for configuring expo-updates for Android similar to what we have for iOS. I moved the actual code that modifies the contents of `build.gradle` to config-plugins. EAS CLI is only responsible for overriding the file.

# Test Plan

I ran `eas build:configure` in a monorepo. Both `build.gradle` and `project.pbxproj` had wrong paths to `create-ios-manifest.ios` / `expo-updates/scripts/create-manifest-android.gradle`. After executing the command, they were fixed.

Please note that CI tests are failing because config-plugins needs to be bumped.
