### PR TITLE
[eas-cli] filter stale profiles

### DIFF
--- a/packages/eas-cli/src/credentials/ios/appstore/bundleId.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleId.ts
@@ -1,6 +1,6 @@
 import { BundleId, Profile, RequestContext } from '@expo/apple-utils';
 
-export async function getProfilesForBundleIdAsync(
+async function getProfilesForBundleIdDangerousAsync(
   context: RequestContext,
   bundleIdentifier: string
 ): Promise<Profile[]> {
@@ -9,6 +9,34 @@ export async function getProfilesForBundleIdAsync(
     return bundleId.getProfilesAsync();
   }
   return [];
+}
+
+export async function getProfilesForBundleIdAsync(
+  context: RequestContext,
+  bundleIdentifier: string
+): Promise<Profile[]> {
+  const profiles = await getProfilesForBundleIdDangerousAsync(context, bundleIdentifier);
+  // users sometimes have a poisoned Apple cache and receive stale data from the API
+  // we call an arbitrary method, `getBundleIdAsync` on each profile
+  // if it errors, the profile was stale, so we remove it
+  const validProfileIds = new Set();
+  await Promise.all(
+    profiles.map(async profile => {
+      try {
+        await profile.getBundleIdAsync();
+        validProfileIds.add(profile.id);
+      } catch (e) {
+        if (
+          e.name === 'UnexpectedAppleResponse' &&
+          e.message.includes('The specified resource does not exist - There is no resource of type')
+        ) {
+          return;
+        }
+        throw e;
+      }
+    })
+  );
+  return profiles.filter(profile => validProfileIds.has(profile.id));
 }
 
 export async function getBundleIdForIdentifierAsync(


### PR DESCRIPTION
# Why

Users can sometimes find themselves with a poisoned Apple cache. Once the Apple cache is poisoned, they will always get stale data for the forseeable future. We aren't really sure how this happens, but most users get in this state by going through the adhoc credentials build flow (internal distribution build). Getting into a 'poisoned cache state' is non deterministic, which makes repro difficult.

fixes https://github.com/expo/eas-cli/issues/168


# How

- call an arbitrary method on a profile once we receive it from the Apple API
- if it errors, we filter it out before we return them to the user

# Test Plan
Because this bug is hard to reproduce, I have a branch that will fetch the profiles, ask you to delete a profile from your Developer portal, then continue to filter out the stale profile. You can 'repro' the bug and see the fix in action on the [@quin/reproBrentBug](https://github.com/expo/eas-cli/tree/%40quin/reproBrentBug) branch
