### PR TITLE
[eas-cli] check if tty is attached on prompt

### DIFF
--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -9,7 +9,7 @@ export async function promptAsync<T extends string = string>(
   questions: Question<T> | Question<T>[],
   options: Options = {}
 ): Promise<Answers<T>> {
-  if (process.stdin.readableFlowing === null && !global.test) {
+  if (!process.stdin.isTTY && !global.test) {
     throw new Error('Input is required, but stdin is not readable.');
   }
   return await prompts<T>(questions, {


### PR DESCRIPTION
# Why

bug introduced in https://github.com/expo/eas-cli/commit/256a0e1f226eedb7654cf12940c6d5514d288824

# How

It seems that `process.stdin.readableFlowing === null` was not correct, if the prompt is happening early enough it would be false. checking for tty seems to be more reliable.

# Test Plan

run `eas build` (it shows prompt for platform
run `eas buil < /dev/null ` (it fails with error)
