### PR TITLE
[eas-cli] support `canceled` build status

### DIFF
--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -96,7 +96,7 @@ async function waitForBuildEndAsync(
           spinner.text = 'Build queued...';
           break;
         case BuildStatus.CANCELED:
-          spinner.text = 'Build was canceled';
+          spinner.text = 'Build canceled';
           spinner.stopAndPersist();
           break;
         case BuildStatus.IN_PROGRESS:

--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -95,6 +95,10 @@ async function waitForBuildEndAsync(
         case BuildStatus.IN_QUEUE:
           spinner.text = 'Build queued...';
           break;
+        case BuildStatus.CANCELED:
+          spinner.text = 'Build was canceled';
+          spinner.stopAndPersist();
+          break;
         case BuildStatus.IN_PROGRESS:
           spinner.text = 'Build in progress...';
           break;
@@ -111,20 +115,26 @@ async function waitForBuildEndAsync(
         return builds;
       } else if (
         builds.filter(build =>
-          build?.status ? [BuildStatus.FINISHED, BuildStatus.ERRORED].includes(build.status) : false
+          build?.status
+            ? [BuildStatus.FINISHED, BuildStatus.ERRORED, BuildStatus.CANCELED].includes(
+                build.status
+              )
+            : false
         ).length === builds.length
       ) {
-        spinner.fail('Some of the builds failed');
+        spinner.fail('Some of the builds were canceled or failed.');
         return builds;
       } else {
         const inQueue = builds.filter(build => build?.status === BuildStatus.IN_QUEUE).length;
         const inProgress = builds.filter(build => build?.status === BuildStatus.IN_PROGRESS).length;
         const errored = builds.filter(build => build?.status === BuildStatus.ERRORED).length;
         const finished = builds.filter(build => build?.status === BuildStatus.FINISHED).length;
+        const canceled = builds.filter(build => build?.status === BuildStatus.CANCELED).length;
         const unknownState = builds.length - inQueue - inProgress - errored - finished;
         spinner.text = [
           inQueue && `Builds in queue: ${inQueue}`,
           inProgress && `Builds in progress: ${inProgress}`,
+          canceled && `Builds canceled: ${canceled}`,
           errored && chalk.red(`Builds failed: ${errored}`),
           finished && chalk.green(`Builds finished: ${finished}`),
           unknownState && chalk.red(`Builds in unknown state: ${unknownState}`),

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -19,6 +19,7 @@ export enum BuildStatus {
   IN_PROGRESS = 'in-progress',
   ERRORED = 'errored',
   FINISHED = 'finished',
+  CANCELED = 'canceled',
 }
 
 export type TrackingContext = Record<string, string | number>;

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -24,6 +24,8 @@ export default function formatBuild(build: Build, { accountName }: Options) {
             return chalk.blue('in queue');
           case BuildStatus.IN_PROGRESS:
             return chalk.blue('in progress');
+          case BuildStatus.CANCELED:
+            return chalk.gray('canceled');
           case BuildStatus.FINISHED:
             return chalk.green('finished');
           case BuildStatus.ERRORED:
@@ -41,16 +43,21 @@ export default function formatBuild(build: Build, { accountName }: Options) {
       label: 'Artifact',
       get value() {
         if (build.status === BuildStatus.IN_QUEUE || build.status === BuildStatus.IN_PROGRESS) {
-          return '<in progress>';
         }
-
-        const url = build.artifacts?.buildUrl;
-
-        if (!url) {
-          return chalk.red('not found');
+        switch (build.status) {
+          case BuildStatus.IN_QUEUE:
+          case BuildStatus.IN_PROGRESS:
+            return '<in progress>';
+          case BuildStatus.CANCELED:
+          case BuildStatus.ERRORED:
+            return '---------';
+          case BuildStatus.FINISHED: {
+            const url = build.artifacts?.buildUrl;
+            return url ? url : chalk.red('not found');
+          }
+          default:
+            return 'unknown';
         }
-
-        return url;
       },
     },
     { label: 'Started at', value: new Date(build.createdAt).toLocaleString() },

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -18,7 +18,7 @@ export default class BuildList extends Command {
 
   static flags = {
     platform: flags.enum({ options: ['all', 'android', 'ios'] }),
-    status: flags.enum({ options: ['in-queue', 'in-progress', 'errored', 'finished'] }),
+    status: flags.enum({ options: ['in-queue', 'in-progress', 'errored', 'finished', 'canceled'] }),
     limit: flags.integer(),
   };
 


### PR DESCRIPTION
# Why

Support `canceled` build status

# How

Add cases for canceled build status: 
- when displaying build info
- when waiting for a build to finish
- as value for status param in `build:list` command

# Test Plan

Run `eas build` -> cancel builds on website -> `eas build:list` -> `eas build:list  --status=canceled` -> `eas build:view someid`