### PR TITLE
[eas-cli] add tracking analytics for stale profile

### DIFF
--- a/packages/eas-cli/src/credentials/ios/appstore/bundleId.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleId.ts
@@ -1,5 +1,8 @@
 import { BundleId, Profile, RequestContext } from '@expo/apple-utils';
 
+import { AnalyticsEvent } from '../../../build/types';
+import Analytics from '../../../build/utils/analytics';
+
 async function getProfilesForBundleIdDangerousAsync(
   context: RequestContext,
   bundleIdentifier: string
@@ -30,7 +33,7 @@ export async function getProfilesForBundleIdAsync(
           e.name === 'UnexpectedAppleResponse' &&
           e.message.includes('The specified resource does not exist - There is no resource of type')
         ) {
-          // TODO: add tracking analytics here
+          Analytics.logEvent(AnalyticsEvent.GATHER_CREDENTIALS_FAIL, { reason: e.message });
           return;
         }
         throw e;


### PR DESCRIPTION
# Why

- This would log the event to our hypothetical Analytics, but it's missing the `trackingCtx`.
- I noticed in the `build` command, we are wrapping calls with a `withAnalytics` method and then passing in a trackingCtx. When an error occurs, we catch it and feed in the `trackingCtx`. 
- In this case, we aren't actually throwing an error, and this method has a variety of callers. It'd be nice if we could import some default tracking context (maybe initialized with some basic info at the start of every command). The alternative would be to plumb down a `trackingCtx` in the method parameter .

