### PR TITLE
[eas-cli] basic RemoveDistCert (and RemoveProvisioningProfile)

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -5662,6 +5662,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "parentAppleAppIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AppleAppIdentifier",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -11998,6 +12010,16 @@
           },
           {
             "name": "appleTeamId",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "parentAppleAppId",
             "description": "",
             "type": {
               "kind": "SCALAR",

--- a/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
@@ -24,6 +24,7 @@ export function formatDistributionCertificate(
     appleTeam,
     validityNotBefore,
     validityNotAfter,
+    updatedAt,
   } = distributionCertificate;
   let line: string = '';
   if (developerPortalIdentifier) {
@@ -33,11 +34,18 @@ export function formatDistributionCertificate(
     appleTeam ? `, ${formatAppleTeam(appleTeam)}` : ''
   }`;
   line += chalk.gray(
-    `\n    Created: ${fromNow(new Date(validityNotBefore))} ago, Expires: ${dateformat(
-      validityNotAfter,
-      'expiresHeaderFormat'
-    )}`
+    `\n    Created: ${fromNow(new Date(validityNotBefore))} ago, Updated: ${fromNow(
+      new Date(updatedAt)
+    )} ago,`
   );
+  line += chalk.gray(`\n    Expires: ${dateformat(validityNotAfter, 'expiresHeaderFormat')}`);
+  const apps = distributionCertificate.iosAppBuildCredentialsList.map(
+    buildCredentials => buildCredentials.iosAppCredentials.app
+  );
+  if (apps.length) {
+    const appFullNames = apps.map(app => app.fullName).join(',');
+    line += chalk.gray(`\n    📲 Used by: ${appFullNames}`);
+  }
 
   if (validSerialNumbers?.includes(serialNumber)) {
     line += chalk.gray("\n    ✅ Currently valid on Apple's servers.");
@@ -73,7 +81,7 @@ async function _selectDistributionCertificateAsync(
 /**
  * select a distribution certificate from an account (validity status shown on a best effort basis)
  * */
-export async function selectDistributionCertificateAsync(
+export async function selectDistributionCertificateWithDependenciesAsync(
   ctx: Context,
   account: Account
 ): Promise<AppleDistributionCertificateFragment | null> {

--- a/packages/eas-cli/src/credentials/ios/actions/new/ProvisioningProfileUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/ProvisioningProfileUtils.ts
@@ -1,13 +1,13 @@
 import isEqual from 'lodash/isEqual';
 
+import { AppleDistributionCertificateFragment } from '../../../../graphql/generated';
 import Log from '../../../../log';
 import { AppleDeviceFragmentWithAppleTeam } from '../../api/graphql/queries/AppleDeviceQuery';
-import { AppleDistributionCertificateQueryResult } from '../../api/graphql/queries/AppleDistributionCertificateQuery';
 import { ProvisioningProfileStoreInfo } from '../../appstore/Credentials.types';
 
 export function isDevPortalAdhocProfileValid(
   profileFromDevPortal: ProvisioningProfileStoreInfo | null,
-  distCert: AppleDistributionCertificateQueryResult,
+  distCert: AppleDistributionCertificateFragment,
   expectedDevices: AppleDeviceFragmentWithAppleTeam[]
 ): boolean {
   if (!profileFromDevPortal) {

--- a/packages/eas-cli/src/credentials/ios/actions/new/RemoveDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/RemoveDistributionCertificate.ts
@@ -1,0 +1,81 @@
+import { AppleDistributionCertificateFragment } from '../../../../graphql/generated';
+import log from '../../../../log';
+import { confirmAsync } from '../../../../prompts';
+import { Account } from '../../../../user/Account';
+import { Action, CredentialsManager } from '../../../CredentialsManager';
+import { Context } from '../../../context';
+import { selectDistributionCertificateWithDependenciesAsync } from './DistributionCertificateUtils';
+import { RemoveProvisioningProfiles } from './RemoveProvisioningProfile';
+
+export class SelectAndRemoveDistributionCertificate implements Action {
+  constructor(private account: Account) {}
+
+  async runAsync(_manager: CredentialsManager, ctx: Context): Promise<void> {
+    const selected = await selectDistributionCertificateWithDependenciesAsync(ctx, this.account);
+    if (selected) {
+      await new RemoveDistributionCertificate(this.account, selected).runAsync(ctx);
+      log.succeed('Removed distribution certificate');
+      log.newLine();
+    }
+  }
+}
+
+export class RemoveDistributionCertificate {
+  constructor(
+    private account: Account,
+    private distributionCertificate: AppleDistributionCertificateFragment
+  ) {}
+
+  public async runAsync(ctx: Context): Promise<void> {
+    const apps = this.distributionCertificate.iosAppBuildCredentialsList.map(
+      buildCredentials => buildCredentials.iosAppCredentials.app
+    );
+    if (apps.length !== 0 && !ctx.nonInteractive) {
+      const appFullNames = apps.map(app => app.fullName).join(',');
+      const confirm = await confirmAsync({
+        message: `You are removing certificate used by ${appFullNames}. Do you want to continue?`,
+      });
+      if (!confirm) {
+        log('Aborting');
+        return;
+      }
+    }
+
+    log('Removing Distribution Certificate');
+    await ctx.newIos.deleteDistributionCertificateAsync(this.distributionCertificate.id);
+
+    if (this.distributionCertificate.developerPortalIdentifier) {
+      let shouldRevoke = false;
+      if (!ctx.nonInteractive) {
+        shouldRevoke = await confirmAsync({
+          message: `Do you also want to revoke this Distribution Certificate on Apple Developer Portal?`,
+        });
+      }
+      if (shouldRevoke) {
+        await ctx.appStore.revokeDistributionCertificateAsync([
+          this.distributionCertificate.developerPortalIdentifier,
+        ]);
+      }
+    }
+
+    await this.removeInvalidProvisioningProfilesAsync(ctx);
+  }
+
+  private async removeInvalidProvisioningProfilesAsync(ctx: Context): Promise<void> {
+    const buildCredentialsList = this.distributionCertificate.iosAppBuildCredentialsList;
+    const appsWithProfilesToRemove = [];
+    const profilesToRemove = [];
+    for (const buildCredentials of buildCredentialsList) {
+      const projectSlug = buildCredentials.iosAppCredentials.app.slug;
+      const bundleIdentifier =
+        buildCredentials.iosAppCredentials.appleAppIdentifier.bundleIdentifier;
+      const appLookupParams = { account: this.account, projectName: projectSlug, bundleIdentifier };
+      const maybeProvisioningProfile = buildCredentials.provisioningProfile;
+      if (maybeProvisioningProfile) {
+        appsWithProfilesToRemove.push(appLookupParams);
+        profilesToRemove.push(maybeProvisioningProfile);
+      }
+    }
+    await new RemoveProvisioningProfiles(appsWithProfilesToRemove, profilesToRemove).runAsync(ctx);
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/RemoveDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/RemoveDistributionCertificate.ts
@@ -1,8 +1,8 @@
-import Log from '../../../../Log';
 import {
   AppleDistributionCertificateFragment,
   AppleProvisioningProfileIdentifiersFragment,
 } from '../../../../graphql/generated';
+import Log from '../../../../log';
 import { confirmAsync } from '../../../../prompts';
 import { Account } from '../../../../user/Account';
 import { Action, CredentialsManager } from '../../../CredentialsManager';

--- a/packages/eas-cli/src/credentials/ios/actions/new/RemoveProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/RemoveProvisioningProfile.ts
@@ -1,0 +1,44 @@
+import { assert } from '@expo/config';
+
+import { AppleProvisioningProfileIdentifiersFragment } from '../../../../graphql/generated';
+import log from '../../../../log';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+
+/* interface RemoveOptions {
+  shouldRevoke?: boolean;
+}
+
+export class RemoveProvisioningProfile implements Action {
+  constructor(private accountName: string, private options: RemoveOptions = {}) {}
+
+  async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+    const selected = await selectProvisioningProfileFromExpoAsync(ctx, this.accountName);
+    if (selected) {
+      const app = getAppLookupParams(selected.experienceName, selected.bundleIdentifier);
+      await manager.runActionAsync(new RemoveSpecificProvisioningProfile(app, this.options));
+    }
+  }
+} */
+
+export class RemoveProvisioningProfiles {
+  constructor(
+    private apps: AppLookupParams[],
+    private provisioningProfiles: AppleProvisioningProfileIdentifiersFragment[]
+  ) {
+    assert(
+      apps.length === provisioningProfiles.length,
+      'apps must correspond to the provisioning profiles being removed'
+    );
+  }
+
+  async runAsync(ctx: Context): Promise<void> {
+    await ctx.newIos.deleteProvisioningProfilesAsync(
+      this.provisioningProfiles.map(profile => profile.id)
+    );
+    const appAndBundles = this.apps
+      .map(app => `@${app.account.name}/${app.projectName} (${app.bundleIdentifier})`)
+      .join(',');
+    log.succeed(`Successfully removed provisioning profiles for ${appAndBundles}`);
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/RemoveProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/RemoveProvisioningProfile.ts
@@ -1,7 +1,7 @@
 import { assert } from '@expo/config';
 
-import Log from '../../../../Log';
 import { AppleProvisioningProfileIdentifiersFragment } from '../../../../graphql/generated';
+import Log from '../../../../log';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
 

--- a/packages/eas-cli/src/credentials/ios/actions/new/RemoveProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/RemoveProvisioningProfile.ts
@@ -1,25 +1,9 @@
 import { assert } from '@expo/config';
 
+import Log from '../../../../Log';
 import { AppleProvisioningProfileIdentifiersFragment } from '../../../../graphql/generated';
-import log from '../../../../log';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
-
-/* interface RemoveOptions {
-  shouldRevoke?: boolean;
-}
-
-export class RemoveProvisioningProfile implements Action {
-  constructor(private accountName: string, private options: RemoveOptions = {}) {}
-
-  async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
-    const selected = await selectProvisioningProfileFromExpoAsync(ctx, this.accountName);
-    if (selected) {
-      const app = getAppLookupParams(selected.experienceName, selected.bundleIdentifier);
-      await manager.runActionAsync(new RemoveSpecificProvisioningProfile(app, this.options));
-    }
-  }
-} */
 
 export class RemoveProvisioningProfiles {
   constructor(
@@ -33,12 +17,16 @@ export class RemoveProvisioningProfiles {
   }
 
   async runAsync(ctx: Context): Promise<void> {
+    if (this.provisioningProfiles.length === 0) {
+      Log.log(`Skipping deletion of Provisioning Profiles`);
+      return;
+    }
     await ctx.newIos.deleteProvisioningProfilesAsync(
       this.provisioningProfiles.map(profile => profile.id)
     );
     const appAndBundles = this.apps
       .map(app => `@${app.account.name}/${app.projectName} (${app.bundleIdentifier})`)
       .join(',');
-    log.succeed(`Successfully removed provisioning profiles for ${appAndBundles}`);
+    Log.succeed(`Successfully removed provisioning profiles for ${appAndBundles}`);
   }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
@@ -1,25 +1,28 @@
 import assert from 'assert';
 import sortBy from 'lodash/sortBy';
 
-import { AppleDistributionCertificate, IosDistributionType } from '../../../../graphql/generated';
+import {
+  AppleDistributionCertificate,
+  AppleDistributionCertificateFragment,
+  IosDistributionType,
+} from '../../../../graphql/generated';
 import Log from '../../../../log';
 import { confirmAsync, promptAsync } from '../../../../prompts';
 import { Action, CredentialsManager } from '../../../CredentialsManager';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
 import { AppleDistributionCertificateMutationResult } from '../../api/graphql/mutations/AppleDistributionCertificateMutation';
-import { AppleDistributionCertificateQueryResult } from '../../api/graphql/queries/AppleDistributionCertificateQuery';
 import { getValidCertSerialNumbers } from '../../appstore/CredentialsUtils';
 import { CreateDistributionCertificate } from './CreateDistributionCertificate';
 import { formatDistributionCertificate } from './DistributionCertificateUtils';
 
 export class SetupDistributionCertificate implements Action {
-  private validDistCerts?: AppleDistributionCertificateQueryResult[];
-  private _distributionCertificate?: AppleDistributionCertificateQueryResult;
+  private validDistCerts?: AppleDistributionCertificateFragment[];
+  private _distributionCertificate?: AppleDistributionCertificateFragment;
 
   constructor(private app: AppLookupParams) {}
 
-  public get distributionCertificate(): AppleDistributionCertificateQueryResult {
+  public get distributionCertificate(): AppleDistributionCertificateFragment {
     assert(
       this._distributionCertificate,
       'distributionCertificate can be accessed only after calling .runAsync()'
@@ -58,7 +61,7 @@ export class SetupDistributionCertificate implements Action {
 
   private async isCurrentCertificateValidAsync(
     ctx: Context,
-    currentCertificate: AppleDistributionCertificateQueryResult | null
+    currentCertificate: AppleDistributionCertificateFragment | null
   ): Promise<boolean> {
     if (!currentCertificate) {
       return false;
@@ -76,7 +79,7 @@ export class SetupDistributionCertificate implements Action {
   private async createOrReuseDistCert(
     manager: CredentialsManager,
     ctx: Context
-  ): Promise<AppleDistributionCertificateQueryResult> {
+  ): Promise<AppleDistributionCertificateFragment> {
     const validDistCerts = await this.getValidDistCertsAsync(ctx);
     const autoselectedDistCert = validDistCerts[0];
 
@@ -137,7 +140,7 @@ export class SetupDistributionCertificate implements Action {
 
   private async getValidDistCertsAsync(
     ctx: Context
-  ): Promise<AppleDistributionCertificateQueryResult[]> {
+  ): Promise<AppleDistributionCertificateFragment[]> {
     if (this.validDistCerts) {
       return this.validDistCerts;
     }

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/__snapshots__/DistributionCertificateUtils-test.ts.snap
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/__snapshots__/DistributionCertificateUtils-test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`select credentials select an AppleDistributionCertificate fragment 1`] = `
 "Cert ID: 5URSS525PL, Serial number: 3F9CDD6CFC6E52C1, Team ID: 77KQ969CHE
-    Created: 6 months ago, Expires: Wed, 13 Oct 2021 18:28:44 GMT+0000Cert ID: JRH7292L8R, Serial number: 5544BE191B9F949E, Team ID: 77KQ969CHE
-    Created: 10 months ago, Expires: Tue, 22 Jun 2021 20:46:07 GMT+0000"
+    Created: 6 months ago, Updated: 10 months ago,
+    Expires: Wed, 13 Oct 2021 18:28:44 GMT+0000Cert ID: JRH7292L8R, Serial number: 5544BE191B9F949E, Team ID: 77KQ969CHE
+    Created: 10 months ago, Updated: 10 months ago,
+    Expires: Tue, 22 Jun 2021 20:46:07 GMT+0000"
 `;

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -3,6 +3,7 @@ import nullthrows from 'nullthrows';
 import {
   AppFragment,
   AppleAppIdentifierFragment,
+  AppleDistributionCertificateFragment,
   AppleTeamFragment,
   CommonIosAppCredentialsFragment,
   IosAppBuildCredentialsFragment,
@@ -28,10 +29,7 @@ import {
   AppleDeviceFragmentWithAppleTeam,
   AppleDeviceQuery,
 } from './graphql/queries/AppleDeviceQuery';
-import {
-  AppleDistributionCertificateQuery,
-  AppleDistributionCertificateQueryResult,
-} from './graphql/queries/AppleDistributionCertificateQuery';
+import { AppleDistributionCertificateQuery } from './graphql/queries/AppleDistributionCertificateQuery';
 import {
   AppleProvisioningProfileQuery,
   AppleProvisioningProfileQueryResult,
@@ -242,11 +240,19 @@ export async function updateProvisioningProfileAsync(
   );
 }
 
+export async function deleteProvisioningProfilesAsync(
+  appleProvisioningProfileIds: string[]
+): Promise<void> {
+  return await AppleProvisioningProfileMutation.deleteAppleProvisioningProfilesAsync(
+    appleProvisioningProfileIds
+  );
+}
+
 export async function getDistributionCertificateForAppAsync(
   appLookupParams: AppLookupParams,
   appleTeam: AppleTeamFragment,
   iosDistributionType: IosDistributionType
-): Promise<AppleDistributionCertificateQueryResult | null> {
+): Promise<AppleDistributionCertificateFragment | null> {
   const projectFullName = formatProjectFullName(appLookupParams);
   const appleAppIdentifier = await createOrGetExistingAppleAppIdentifierAsync(
     appLookupParams,
@@ -260,7 +266,7 @@ export async function getDistributionCertificateForAppAsync(
 
 export async function getDistributionCertificatesForAccountAsync(
   account: Account
-): Promise<AppleDistributionCertificateQueryResult[]> {
+): Promise<AppleDistributionCertificateFragment[]> {
   return await AppleDistributionCertificateQuery.getAllForAccount(account.name);
 }
 
@@ -282,6 +288,14 @@ export async function createDistributionCertificateAsync(
       appleTeamId: appleTeam.id,
     },
     account.id
+  );
+}
+
+export async function deleteDistributionCertificateAsync(
+  distributionCertificateId: string
+): Promise<void> {
+  return await AppleDistributionCertificateMutation.deleteAppleDistributionCertificate(
+    distributionCertificateId
   );
 }
 

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
@@ -7,6 +7,7 @@ import {
   AppleDistributionCertificateFragment,
   AppleTeamFragment,
   CreateAppleDistributionCertificateMutation,
+  DeleteAppleDistributionCertificateMutation,
 } from '../../../../../graphql/generated';
 import { AppleDistributionCertificateFragmentNode } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
 import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
@@ -63,6 +64,28 @@ const AppleDistributionCertificateMutation = {
       'GraphQL: `createAppleDistributionCertificate` not defined in server response'
     );
     return data.appleDistributionCertificate.createAppleDistributionCertificate;
+  },
+  async deleteAppleDistributionCertificate(appleDistributionCertificateId: string): Promise<void> {
+    await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeleteAppleDistributionCertificateMutation>(
+          gql`
+            mutation DeleteAppleDistributionCertificateMutation(
+              $appleDistributionCertificateId: ID!
+            ) {
+              appleDistributionCertificate {
+                deleteAppleDistributionCertificate(id: $appleDistributionCertificateId) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            appleDistributionCertificateId,
+          }
+        )
+        .toPromise()
+    );
   },
 };
 

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
@@ -102,6 +102,26 @@ const AppleProvisioningProfileMutation = {
     );
     return data.appleProvisioningProfile.updateAppleProvisioningProfile;
   },
+  async deleteAppleProvisioningProfilesAsync(appleProvisioningProfileIds: string[]): Promise<void> {
+    await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<UpdateAppleProvisioningProfileMutation>(
+          gql`
+            mutation DeleteAppleProvisioningProfilesMutation($appleProvisioningProfileIds: [ID!]!) {
+              appleProvisioningProfile {
+                deleteAppleProvisioningProfiles(ids: $appleProvisioningProfileIds) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            appleProvisioningProfileIds,
+          }
+        )
+        .toPromise()
+    );
+  },
 };
 
 export { AppleProvisioningProfileMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
@@ -7,15 +7,11 @@ import {
   AppleDistributionCertificateByAccountQuery,
   AppleDistributionCertificateByAppQuery,
   AppleDistributionCertificateFragment,
-  AppleTeamFragment,
   IosDistributionType,
 } from '../../../../../graphql/generated';
 import { AppleDistributionCertificateFragmentNode } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
 import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
-export type AppleDistributionCertificateQueryResult = AppleDistributionCertificateFragment & {
-  appleTeam?: AppleTeamFragment | null;
-};
 const AppleDistributionCertificateQuery = {
   async getForAppAsync(
     projectFullName: string,
@@ -23,7 +19,7 @@ const AppleDistributionCertificateQuery = {
       appleAppIdentifierId,
       iosDistributionType,
     }: { appleAppIdentifierId: string; iosDistributionType: IosDistributionType }
-  ): Promise<AppleDistributionCertificateQueryResult | null> {
+  ): Promise<AppleDistributionCertificateFragment | null> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<AppleDistributionCertificateByAppQuery>(
@@ -75,7 +71,7 @@ const AppleDistributionCertificateQuery = {
         ?.distributionCertificate ?? null
     );
   },
-  async getAllForAccount(accountName: string): Promise<AppleDistributionCertificateQueryResult[]> {
+  async getAllForAccount(accountName: string): Promise<AppleDistributionCertificateFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<AppleDistributionCertificateByAccountQuery>(
@@ -87,16 +83,11 @@ const AppleDistributionCertificateQuery = {
                   appleDistributionCertificates {
                     id
                     ...AppleDistributionCertificateFragment
-                    appleTeam {
-                      id
-                      ...AppleTeamFragment
-                    }
                   }
                 }
               }
             }
             ${print(AppleDistributionCertificateFragmentNode)}
-            ${print(AppleTeamFragmentNode)}
           `,
           {
             accountName,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/AppleDistributionCertificateQuery.ts
@@ -15,6 +15,8 @@ const AppleDistributionCertificateQuery = {
           appleTeamName: null,
           __typename: 'AppleTeam',
         },
+        iosAppBuildCredentialsList: [],
+        updatedAt: '2020-06-22T20:46:07.000Z',
         __typename: 'AppleDistributionCertificate',
       },
       {
@@ -31,6 +33,8 @@ const AppleDistributionCertificateQuery = {
           appleTeamName: null,
           __typename: 'AppleTeam',
         },
+        iosAppBuildCredentialsList: [],
+        updatedAt: '2020-06-22T20:46:07.000Z',
         __typename: 'AppleDistributionCertificate',
       },
     ];

--- a/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtilsBeta.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtilsBeta.ts
@@ -1,10 +1,10 @@
-import { AppleDistributionCertificateQueryResult } from '../api/graphql/queries/AppleDistributionCertificateQuery';
+import { AppleDistributionCertificateFragment } from '../../../graphql/generated';
 import { DistributionCertificateStoreInfo } from './Credentials.types';
 
 export function filterRevokedDistributionCerts(
-  distributionCerts: AppleDistributionCertificateQueryResult[],
+  distributionCerts: AppleDistributionCertificateFragment[],
   certInfoFromApple: DistributionCertificateStoreInfo[]
-): AppleDistributionCertificateQueryResult[] {
+): AppleDistributionCertificateFragment[] {
   if (distributionCerts.length === 0) {
     return [];
   }

--- a/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
@@ -1,11 +1,11 @@
 import Log from '../../log';
 import { getProjectAccountName, getProjectConfigDescription } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import { findAccountByName } from '../../user/Account';
+import { Account, findAccountByName } from '../../user/Account';
 import { ensureActorHasUsername } from '../../user/actions';
 import { Action, CredentialsManager } from '../CredentialsManager';
 import { Context } from '../context';
-//import { RemoveDistributionCertificateBeta } from '../ios/actions/RemoveDistributionCertificateBeta';
+import { SelectAndRemoveDistributionCertificate } from '../ios/actions/new/RemoveDistributionCertificate';
 import { AppLookupParams } from '../ios/api/GraphqlClient';
 import {
   displayEmptyIosCredentials,
@@ -67,7 +67,7 @@ export class ManageIosBeta implements Action {
           ],
         });
         try {
-          await manager.runActionAsync(this.getAction(ctx, accountName, action));
+          await manager.runActionAsync(this.getAction(ctx, account, action));
         } catch (err) {
           Log.error(err);
         }
@@ -104,10 +104,10 @@ export class ManageIosBeta implements Action {
     return { account, projectName, bundleIdentifier };
   }
 
-  private getAction(ctx: Context, accountName: string, action: ActionType): Action {
+  private getAction(ctx: Context, account: Account, action: ActionType): Action {
     switch (action) {
-      /*       case ActionType.RemoveDistributionCertificate:
-        return new RemoveDistributionCertificateBeta(accountName); */
+      case ActionType.RemoveDistributionCertificate:
+        return new SelectAndRemoveDistributionCertificate(account);
       default:
         throw new Error('Unknown action selected');
     }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -836,6 +836,7 @@ export type AppleAppIdentifier = {
   account: Account;
   appleTeam?: Maybe<AppleTeam>;
   bundleIdentifier: Scalars['String'];
+  parentAppleAppIdentifier?: Maybe<AppleAppIdentifier>;
 };
 
 export type AppleDistributionCertificate = {
@@ -1831,6 +1832,7 @@ export type AppleAppIdentifierMutationCreateAppleAppIdentifierArgs = {
 export type AppleAppIdentifierInput = {
   bundleIdentifier: Scalars['String'];
   appleTeamId?: Maybe<Scalars['ID']>;
+  parentAppleAppId?: Maybe<Scalars['ID']>;
 };
 
 export type AppleDeviceMutation = {
@@ -2717,6 +2719,22 @@ export type CreateAppleDistributionCertificateMutation = (
   ) }
 );
 
+export type DeleteAppleDistributionCertificateMutationVariables = Exact<{
+  appleDistributionCertificateId: Scalars['ID'];
+}>;
+
+
+export type DeleteAppleDistributionCertificateMutation = (
+  { __typename?: 'RootMutation' }
+  & { appleDistributionCertificate: (
+    { __typename?: 'AppleDistributionCertificateMutation' }
+    & { deleteAppleDistributionCertificate: (
+      { __typename?: 'DeleteAppleDistributionCertificateResult' }
+      & Pick<DeleteAppleDistributionCertificateResult, 'id'>
+    ) }
+  ) }
+);
+
 export type CreateAppleProvisioningProfileMutationVariables = Exact<{
   appleProvisioningProfileInput: AppleProvisioningProfileInput;
   accountId: Scalars['ID'];
@@ -2761,6 +2779,22 @@ export type UpdateAppleProvisioningProfileMutation = (
       )> }
       & AppleProvisioningProfileFragment
     ) }
+  ) }
+);
+
+export type DeleteAppleProvisioningProfilesMutationVariables = Exact<{
+  appleProvisioningProfileIds: Array<Scalars['ID']>;
+}>;
+
+
+export type DeleteAppleProvisioningProfilesMutation = (
+  { __typename?: 'RootMutation' }
+  & { appleProvisioningProfile: (
+    { __typename?: 'AppleProvisioningProfileMutation' }
+    & { deleteAppleProvisioningProfiles: Array<(
+      { __typename?: 'DeleteAppleProvisioningProfileResult' }
+      & Pick<DeleteAppleProvisioningProfileResult, 'id'>
+    )> }
   ) }
 );
 
@@ -3027,11 +3061,6 @@ export type AppleDistributionCertificateByAccountQuery = (
       & { appleDistributionCertificates: Array<(
         { __typename?: 'AppleDistributionCertificate' }
         & Pick<AppleDistributionCertificate, 'id'>
-        & { appleTeam?: Maybe<(
-          { __typename?: 'AppleTeam' }
-          & Pick<AppleTeam, 'id'>
-          & AppleTeamFragment
-        )> }
         & AppleDistributionCertificateFragment
       )> }
     ) }
@@ -3379,7 +3408,7 @@ export type CurrentUserQuery = (
 
 export type AppFragment = (
   { __typename?: 'App' }
-  & Pick<App, 'id' | 'fullName'>
+  & Pick<App, 'id' | 'fullName' | 'slug'>
 );
 
 export type AppleAppIdentifierFragment = (
@@ -3399,10 +3428,31 @@ export type AppleDeviceRegistrationRequestFragment = (
 
 export type AppleDistributionCertificateFragment = (
   { __typename?: 'AppleDistributionCertificate' }
-  & Pick<AppleDistributionCertificate, 'id' | 'certificateP12' | 'certificatePassword' | 'serialNumber' | 'developerPortalIdentifier' | 'validityNotBefore' | 'validityNotAfter'>
+  & Pick<AppleDistributionCertificate, 'id' | 'certificateP12' | 'certificatePassword' | 'serialNumber' | 'developerPortalIdentifier' | 'validityNotBefore' | 'validityNotAfter' | 'updatedAt'>
   & { appleTeam?: Maybe<(
     { __typename?: 'AppleTeam' }
-    & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
+    & Pick<AppleTeam, 'id'>
+    & AppleTeamFragment
+  )>, iosAppBuildCredentialsList: Array<(
+    { __typename?: 'IosAppBuildCredentials' }
+    & Pick<IosAppBuildCredentials, 'id'>
+    & { iosAppCredentials: (
+      { __typename?: 'IosAppCredentials' }
+      & Pick<IosAppCredentials, 'id'>
+      & { app: (
+        { __typename?: 'App' }
+        & Pick<App, 'id'>
+        & AppFragment
+      ), appleAppIdentifier: (
+        { __typename?: 'AppleAppIdentifier' }
+        & Pick<AppleAppIdentifier, 'id'>
+        & AppleAppIdentifierFragment
+      ) }
+    ), provisioningProfile?: Maybe<(
+      { __typename?: 'AppleProvisioningProfile' }
+      & Pick<AppleProvisioningProfile, 'id'>
+      & AppleProvisioningProfileIdentifiersFragment
+    )> }
   )> }
 );
 
@@ -3416,6 +3466,11 @@ export type AppleProvisioningProfileFragment = (
     { __typename?: 'AppleDevice' }
     & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'model' | 'deviceClass'>
   )> }
+);
+
+export type AppleProvisioningProfileIdentifiersFragment = (
+  { __typename?: 'AppleProvisioningProfile' }
+  & Pick<AppleProvisioningProfile, 'id' | 'developerPortalIdentifier'>
 );
 
 export type AppleTeamFragment = (

--- a/packages/eas-cli/src/graphql/types/App.ts
+++ b/packages/eas-cli/src/graphql/types/App.ts
@@ -4,5 +4,6 @@ export const AppFragmentNode = gql`
   fragment AppFragment on App {
     id
     fullName
+    slug
   }
 `;

--- a/packages/eas-cli/src/graphql/types/credentials/AppleDistributionCertificate.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleDistributionCertificate.ts
@@ -1,4 +1,10 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
+
+import { AppFragmentNode } from '../App';
+import { AppleAppIdentifierFragmentNode } from './AppleAppIdentifier';
+import { AppleProvisioningProfileIdentifiersFragmentNode } from './AppleProvisioningProfile';
+import { AppleTeamFragmentNode } from './AppleTeam';
 
 export const AppleDistributionCertificateFragmentNode = gql`
   fragment AppleDistributionCertificateFragment on AppleDistributionCertificate {
@@ -9,10 +15,32 @@ export const AppleDistributionCertificateFragmentNode = gql`
     developerPortalIdentifier
     validityNotBefore
     validityNotAfter
+    updatedAt
     appleTeam {
       id
-      appleTeamIdentifier
-      appleTeamName
+      ...AppleTeamFragment
+    }
+    iosAppBuildCredentialsList {
+      id
+      iosAppCredentials {
+        id
+        app {
+          id
+          ...AppFragment
+        }
+        appleAppIdentifier {
+          id
+          ...AppleAppIdentifierFragment
+        }
+      }
+      provisioningProfile {
+        id
+        ...AppleProvisioningProfileIdentifiersFragment
+      }
     }
   }
+  ${print(AppleTeamFragmentNode)}
+  ${print(AppFragmentNode)}
+  ${print(AppleAppIdentifierFragmentNode)}
+  ${print(AppleProvisioningProfileIdentifiersFragmentNode)}
 `;

--- a/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
@@ -20,3 +20,9 @@ export const AppleProvisioningProfileFragmentNode = gql`
     }
   }
 `;
+export const AppleProvisioningProfileIdentifiersFragmentNode = gql`
+  fragment AppleProvisioningProfileIdentifiersFragment on AppleProvisioningProfile {
+    id
+    developerPortalIdentifier
+  }
+`;


### PR DESCRIPTION
# Why

This is a basic implementation of RemoveDistributionCertificate with the new graphql api. This version does NOT have caching implemented yet.  

Core changes:
- basic implementation of RemoveDistCert, RemoveSpecificDistCert, RemoveSpecificProvisioningProfile
- Added build dependencies to `AppleDistributionCertificateFragment`. When we fetch a dist cert, we usually need to know the apps that depend on it (ie) UX purposes like telling developer that `this dist cert is used by apps x,y,z`, or functional purposes like removing the provisioning profiles that depend on the dist cert. 
- UX changes to select dist cert
<img width="1036" alt="Screen Shot 2021-01-26 at 4 37 21 PM" src="https://user-images.githubusercontent.com/6380927/105925349-d11e1280-5ff4-11eb-876c-118441e608a2.png">

# Test Plan

- [ ] TODO
