### PR TITLE
Refactor log module so that weird __esModule mocks are not needed

### DIFF
--- a/packages/eas-cli/src/build/android/applicationId.ts
+++ b/packages/eas-cli/src/build/android/applicationId.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import log from '../../log';
+import Log from '../../log';
 import {
   ensureAppIdentifierIsDefinedAsync,
   getAndroidApplicationIdAsync,
@@ -28,10 +28,10 @@ export async function ensureApplicationIdIsValidAsync(projectDir: string) {
   const applicationId = await ensureAppIdentifierIsDefinedAsync(projectDir, Platform.Android);
   if (!isApplicationIdValid(applicationId)) {
     const configDescription = getProjectConfigDescription(projectDir);
-    log.error(
+    Log.error(
       `Invalid format of Android applicationId. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter.`
     );
-    log.error(`Update "android.package" in ${configDescription} and run this command again.`);
+    Log.error(`Update "android.package" in ${configDescription} and run this command again.`);
     throw new Error('Invalid applicationId');
   }
 }
@@ -47,8 +47,8 @@ export async function configureApplicationIdAsync(
 
   if (applicationIdFromAndroidProject && applicationIdFromConfig) {
     if (applicationIdFromConfig !== applicationIdFromAndroidProject) {
-      log.newLine();
-      log.warn(
+      Log.newLine();
+      Log.warn(
         `We detected that your Android project is configured with a different application id than the one defined in ${configDescription}.`
       );
       const hasApplicationIdInStaticConfig = await hasApplicationIdInStaticConfigAsync(
@@ -56,10 +56,10 @@ export async function configureApplicationIdAsync(
         exp
       );
       if (!hasApplicationIdInStaticConfig) {
-        log(`If you choose the one defined in ${configDescription} we'll automatically configure your Android project with it.
+        Log.log(`If you choose the one defined in ${configDescription} we'll automatically configure your Android project with it.
 However, if you choose the one defined in the Android project you'll have to update ${configDescription} on your own.`);
       }
-      log.newLine();
+      Log.newLine();
       const { applicationIdSource } = await promptAsync({
         type: 'select',
         name: 'applicationIdSource',
@@ -102,7 +102,7 @@ However, if you choose the one defined in the Android project you'll have to upd
     }
   } else if (!applicationIdFromAndroidProject && applicationIdFromConfig) {
     // This should never happen, adding warning just in case
-    log.warn(
+    Log.warn(
       'applicationId is not specified in your ./android/app/build.gradle file. Make sure your project is configured correctly before building.'
     );
     return;

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -3,7 +3,7 @@ import { CredentialsSource } from '@expo/eas-json';
 import fs from 'fs-extra';
 
 import { apiClient } from '../api';
-import log from '../log';
+import Log from '../log';
 import { promptAsync } from '../prompts';
 import { UploadType, uploadAsync } from '../uploads';
 import { createProgressTracker } from '../utils/progress';
@@ -65,7 +65,7 @@ export async function prepareBuildRequestForPlatformAsync<
   }
 
   if (!(await isGitStatusCleanAsync())) {
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     const projectType = builder.ctx.platform === Platform.Android ? 'Android' : 'Xcode';
     // Currently we are only updaing runtime version durring build, but if it changes in a future
     // this message should also contain more info on that (or be more generic)
@@ -89,8 +89,8 @@ export async function prepareBuildRequestForPlatformAsync<
     try {
       return await withAnalyticsAsync(
         async () => {
-          if (log.isDebug) {
-            log(`Starting ${platformDisplayNames[job.platform]} build`);
+          if (Log.isDebug) {
+            Log.log(`Starting ${platformDisplayNames[job.platform]} build`);
           }
           const {
             data: { buildId, deprecationInfo },
@@ -114,7 +114,7 @@ export async function prepareBuildRequestForPlatformAsync<
     } catch (error) {
       const body = error?.response?.body;
       if (body && JSON.parse(body)?.errors?.[0]?.code === 'TURTLE_DEPRECATED_JOB_FORMAT') {
-        log.error('EAS Build API has changed, please upgrade to the latest eas-cli');
+        Log.error('EAS Build API has changed, please upgrade to the latest eas-cli');
       }
       throw error;
     }
@@ -213,7 +213,7 @@ async function reviewAndCommitChangesAsync(
     );
   } else if (selected === ShouldCommitChanges.Yes) {
     await commitPromptAsync(commitMessage);
-    log.withTick('Committed changes.');
+    Log.withTick('Committed changes.');
   } else if (selected === ShouldCommitChanges.ShowDiffFirst) {
     await showDiffAsync();
     await reviewAndCommitChangesAsync(commitMessage, { nonInteractive, askedFirstTime: false });

--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 
 import { apiClient } from '../api';
-import log from '../log';
+import Log from '../log';
 import { sleep } from '../utils/promise';
 import { prepareAndroidBuildAsync } from './android/build';
 import { CommandContext } from './context';
@@ -17,16 +17,16 @@ export async function buildAsync(commandCtx: CommandContext): Promise<void> {
   await ensureGitStatusIsCleanAsync(commandCtx.nonInteractive);
 
   const scheduledBuilds = await startBuildsAsync(commandCtx);
-  log.newLine();
+  Log.newLine();
   printLogsUrls(commandCtx.accountName, scheduledBuilds);
-  log.newLine();
+  Log.newLine();
 
   if (commandCtx.waitForBuildEnd) {
     const builds = await waitForBuildEndAsync(
       commandCtx,
       scheduledBuilds.map(i => i.buildId)
     );
-    log.newLine();
+    Log.newLine();
     printBuildResults(commandCtx.accountName, builds);
   }
 }
@@ -70,7 +70,7 @@ async function waitForBuildEndAsync(
   buildIds: string[],
   { timeoutSec = 1800, intervalSec = 30 } = {}
 ): Promise<(Build | null)[]> {
-  log('Waiting for build to complete. You can press Ctrl+C to exit.');
+  Log.log('Waiting for build to complete. You can press Ctrl+C to exit.');
   const spinner = ora().start();
   let time = new Date().getTime();
   const endTime = time + timeoutSec * 1000;

--- a/packages/eas-cli/src/build/credentials.ts
+++ b/packages/eas-cli/src/build/credentials.ts
@@ -3,7 +3,7 @@ import { CredentialsSource } from '@expo/eas-json';
 import chalk from 'chalk';
 
 import { CredentialsProvider } from '../credentials/CredentialsProvider';
-import log from '../log';
+import Log from '../log';
 import { confirmAsync, promptAsync } from '../prompts';
 import { platformDisplayNames } from './constants';
 
@@ -11,7 +11,7 @@ function logCredentials(target: 'local' | 'remote', platform: Platform) {
   let message = `Using ${target} ${platformDisplayNames[platform]} credentials`;
   if (target === 'local') message += ` ${chalk.dim('(credentials.json)')}`;
   if (target === 'remote') message += ` ${chalk.dim('(Expo server)')}`;
-  log.succeed(message);
+  Log.succeed(message);
 }
 
 async function ensureCredentialsAutoAsync(
@@ -37,7 +37,7 @@ async function ensureCredentialsAutoAsync(
               `Contents of your local credentials.json for ${platform} are not the same as credentials on EAS servers. To use the desired credentials, set the "builds.${platform}.{profile}.credentialsSource" field in the credentials.json file to one of the following: "local", "remote".`
             );
           } else {
-            log(
+            Log.log(
               `Contents of your local credentials.json for ${platform} are not the same as credentials on EAS servers`
             );
           }
@@ -66,8 +66,8 @@ async function ensureCredentialsAutoAsync(
           throw new Error(
             `Credentials for this app are not configured and there is no entry in credentials.json for ${platform}. Either configure credentials.json, or launch the build without "--non-interactive" flag to get a prompt to generate credentials automatically.`
           );
-        } else if (log.isDebug) {
-          log.warn(
+        } else if (Log.isDebug) {
+          Log.warn(
             `Credentials for this app are not configured and there is no entry in credentials.json for ${platform}`
           );
         }

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -6,7 +6,7 @@ import fs from 'fs-extra';
 import sortBy from 'lodash/sortBy';
 import path from 'path';
 
-import log from '../../log';
+import Log from '../../log';
 import { promptAsync } from '../../prompts';
 import { prepareBuildRequestForPlatformAsync } from '../build';
 import { BuildContext, CommandContext, createBuildContext } from '../context';
@@ -72,11 +72,11 @@ async function resolveSchemeAsync(ctx: BuildContext<Platform.iOS>): Promise<stri
   }
 
   const sortedSchemes = sortBy(schemes);
-  log.newLine();
-  log(
+  Log.newLine();
+  Log.log(
     `We've found multiple schemes in your Xcode project: ${chalk.bold(sortedSchemes.join(', '))}`
   );
-  log(
+  Log.log(
     `You can specify the scheme you want to build at ${chalk.bold(
       `builds.ios.${ctx.commandCtx.profile}.scheme`
     )} in eas.json.`
@@ -84,8 +84,10 @@ async function resolveSchemeAsync(ctx: BuildContext<Platform.iOS>): Promise<stri
   if (ctx.commandCtx.nonInteractive) {
     const withoutTvOS = sortedSchemes.filter(i => !i.includes('tvOS'));
     const scheme = withoutTvOS.length > 0 ? withoutTvOS[0] : sortedSchemes[0];
-    log(`You've run Expo CLI in non-interactive mode, choosing the ${chalk.bold(scheme)} scheme.`);
-    log.newLine();
+    Log.log(
+      `You've run Expo CLI in non-interactive mode, choosing the ${chalk.bold(scheme)} scheme.`
+    );
+    Log.newLine();
     return scheme;
   } else {
     const { selectedScheme } = await promptAsync({
@@ -94,7 +96,7 @@ async function resolveSchemeAsync(ctx: BuildContext<Platform.iOS>): Promise<stri
       message: 'Which scheme would you like to build now?',
       choices: sortedSchemes.map(scheme => ({ title: scheme, value: scheme })),
     });
-    log.newLine();
+    Log.newLine();
     return selectedScheme as string;
   }
 }

--- a/packages/eas-cli/src/build/ios/bundleIdentifer.ts
+++ b/packages/eas-cli/src/build/ios/bundleIdentifer.ts
@@ -4,7 +4,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
-import log from '../../log';
+import Log from '../../log';
 import {
   ensureAppIdentifierIsDefinedAsync,
   getProjectConfigDescription,
@@ -25,10 +25,10 @@ export async function ensureBundleIdentifierIsValidAsync(projectDir: string) {
   const bundleIdentifier = await ensureAppIdentifierIsDefinedAsync(projectDir, Platform.iOS);
   if (!isBundleIdentifierValid(bundleIdentifier)) {
     const configDescription = getProjectConfigDescription(projectDir);
-    log.error(
+    Log.error(
       `Invalid format of iOS bundleId. Only alphanumeric characters, '.' and '-' are allowed, and each '.' must be followed by a letter.`
     );
-    log.error(`Update "ios.bundleIdentifier" in ${configDescription} and run this command again.`);
+    Log.error(`Update "ios.bundleIdentifier" in ${configDescription} and run this command again.`);
     throw new Error('Invalid bundleIdentifier');
   }
 }
@@ -44,8 +44,8 @@ export async function configureBundleIdentifierAsync(
   const bundleIdentifierFromConfig = IOSConfig.BundleIdenitifer.getBundleIdentifier(exp);
   if (bundleIdentifierFromPbxproj && bundleIdentifierFromConfig) {
     if (bundleIdentifierFromPbxproj !== bundleIdentifierFromConfig) {
-      log.addNewLineIfNone();
-      log.warn(
+      Log.addNewLineIfNone();
+      Log.warn(
         `We detected that your Xcode project is configured with a different bundle identifier than the one defined in ${configDescription}.`
       );
       const hasBundleIdentifierInStaticConfig = await hasBundleIdentifierInStaticConfigAsync(
@@ -53,10 +53,10 @@ export async function configureBundleIdentifierAsync(
         exp
       );
       if (!hasBundleIdentifierInStaticConfig) {
-        log(`If you choose the one defined in ${configDescription} we'll automatically configure your Xcode project with it.
+        Log.log(`If you choose the one defined in ${configDescription} we'll automatically configure your Xcode project with it.
 However, if you choose the one defined in the Xcode project you'll have to update ${configDescription} on your own.`);
       }
-      log.newLine();
+      Log.newLine();
       const { bundleIdentifierSource } = await promptAsync({
         type: 'select',
         name: 'bundleIdentifierSource',

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -2,7 +2,7 @@ import { DistributionType } from '@expo/eas-json';
 import assert from 'assert';
 import chalk from 'chalk';
 
-import log from '../../log';
+import Log from '../../log';
 import { platformDisplayNames, platformEmojis } from '../constants';
 import { Build } from '../types';
 import { getBuildLogsUrl } from './url';
@@ -22,14 +22,14 @@ export function printLogsUrls(
       buildId,
       account: accountName,
     });
-    log(`Build details: ${chalk.underline(logsUrl)}`);
+    Log.log(`Build details: ${chalk.underline(logsUrl)}`);
   } else {
     builds.forEach(({ buildId, platform }) => {
       const logsUrl = getBuildLogsUrl({
         buildId,
         account: accountName,
       });
-      log(`${platformDisplayNames[platform]} build details: ${chalk.underline(logsUrl)}`);
+      Log.log(`${platformDisplayNames[platform]} build details: ${chalk.underline(logsUrl)}`);
     });
   }
 }
@@ -52,20 +52,20 @@ function printBuildResult(accountName: string, build: Build): void {
       buildId: build.id,
       account: accountName,
     });
-    log(
+    Log.log(
       `${platformEmojis[build.platform]} Open this link on your ${
         platformDisplayNames[build.platform]
       } devices to install the app:`
     );
-    log(`${chalk.underline(logsUrl)}`);
-    log.newLine();
+    Log.log(`${chalk.underline(logsUrl)}`);
+    Log.newLine();
   } else {
     // TODO: it looks like buildUrl could possibly be undefined, based on the code below.
     // we should account for this case better if it is possible
     const url = build.artifacts?.buildUrl ?? '';
-    log(`${platformEmojis[build.platform]} ${platformDisplayNames[build.platform]} app:`);
-    log(`${chalk.underline(url)}`);
-    log.newLine();
+    Log.log(`${platformEmojis[build.platform]} ${platformDisplayNames[build.platform]} app:`);
+    Log.log(`${chalk.underline(url)}`);
+    Log.newLine();
   }
 }
 
@@ -74,17 +74,17 @@ export function printDeprecationWarnings(deprecationInfo?: DeprecationInfo): voi
     return;
   }
   if (deprecationInfo.type === 'internal') {
-    log.warn('This command is using API that soon will be deprecated, please update eas-cli.');
-    log.warn("Changes won't affect your project config.");
-    log.warn(deprecationInfo.message);
+    Log.warn('This command is using API that soon will be deprecated, please update eas-cli.');
+    Log.warn("Changes won't affect your project config.");
+    Log.warn(deprecationInfo.message);
   } else if (deprecationInfo.type === 'user-facing') {
-    log.warn('This command is using API that soon will be deprecated, please update eas-cli.');
-    log.warn(
+    Log.warn('This command is using API that soon will be deprecated, please update eas-cli.');
+    Log.warn(
       'There might be some changes necessary to your project config, latest eas-cli will provide more specific error messages.'
     );
-    log.warn(deprecationInfo.message);
+    Log.warn(deprecationInfo.message);
   } else {
-    log.warn('An unexpected warning was encountered. Please report it as a bug:');
-    log.warn(deprecationInfo);
+    Log.warn('An unexpected warning was encountered. Please report it as a bug:');
+    Log.warn(deprecationInfo);
   }
 }

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import tar from 'tar';
 import { v4 as uuidv4 } from 'uuid';
 
-import log from '../../log';
+import Log from '../../log';
 import { confirmAsync, promptAsync } from '../../prompts';
 import {
   doesGitRepoExistAsync,
@@ -28,8 +28,8 @@ async function ensureGitRepoExistsAsync(): Promise<void> {
     return;
   }
 
-  log.warn("It looks like you haven't initialized the git repository yet.");
-  log.warn('EAS Build requires you to use a git repository for your project.');
+  Log.warn("It looks like you haven't initialized the git repository yet.");
+  Log.warn('EAS Build requires you to use a git repository for your project.');
 
   const confirmInit = await confirmAsync({
     message: `Would you like to run 'git init' in the current directory?`,
@@ -41,7 +41,7 @@ async function ensureGitRepoExistsAsync(): Promise<void> {
   }
   await spawnAsync('git', ['init']);
 
-  log("We're going to make an initial commit for you repository.");
+  Log.log("We're going to make an initial commit for you repository.");
 
   await spawnAsync('git', ['add', '-A']);
   await commitPromptAsync('Initial commit');
@@ -56,9 +56,9 @@ async function maybeBailOnGitStatusAsync(): Promise<void> {
   if (await isGitStatusCleanAsync()) {
     return;
   }
-  log.addNewLineIfNone();
-  log.warn(`${chalk.bold('Warning!')} Your git working tree is dirty.`);
-  log(
+  Log.addNewLineIfNone();
+  Log.warn(`${chalk.bold('Warning!')} Your git working tree is dirty.`);
+  Log.log(
     `It's recommended to ${chalk.bold(
       'commit all your changes before proceeding'
     )}, so you can revert the changes made by this command if necessary.`
@@ -76,9 +76,9 @@ async function ensureGitStatusIsCleanAsync(nonInteractive = false): Promise<void
   if (await isGitStatusCleanAsync()) {
     return;
   }
-  log.addNewLineIfNone();
-  log.warn(`${chalk.bold('Warning!')} Your git working tree is dirty.`);
-  log(
+  Log.addNewLineIfNone();
+  Log.warn(`${chalk.bold('Warning!')} Your git working tree is dirty.`);
+  Log.log(
     `This operation needs to be run on a clean working tree, please ${chalk.bold(
       'commit all your changes before proceeding'
     )}.`
@@ -111,7 +111,7 @@ async function makeProjectTarballAsync(): Promise<{ path: string; size: number }
     () => {
       spinner.start();
     },
-    log.isDebug ? 1 : 1000
+    Log.isDebug ? 1 : 1000
   );
   // TODO: Possibly warn after more time about unoptimized assets.
   const compressTimerLabel = 'makeProjectTarballAsync';

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -1,6 +1,6 @@
 import { Command } from '@oclif/command';
 
-import log from '../../log';
+import Log from '../../log';
 import { showLoginPromptAsync } from '../../user/actions';
 
 export default class AccountLogin extends Command {
@@ -9,8 +9,8 @@ export default class AccountLogin extends Command {
   static aliases = ['login'];
 
   async run() {
-    log('Log in to EAS');
+    Log.log('Log in to EAS');
     await showLoginPromptAsync();
-    log('Logged in');
+    Log.log('Logged in');
   }
 }

--- a/packages/eas-cli/src/commands/account/logout.ts
+++ b/packages/eas-cli/src/commands/account/logout.ts
@@ -1,6 +1,6 @@
 import { Command } from '@oclif/command';
 
-import log from '../../log';
+import Log from '../../log';
 import { logoutAsync } from '../../user/User';
 
 export default class AccountLogout extends Command {
@@ -10,6 +10,6 @@ export default class AccountLogout extends Command {
 
   async run() {
     await logoutAsync();
-    log('Logged out');
+    Log.log('Logged out');
   }
 }

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -1,7 +1,7 @@
 import { Command } from '@oclif/command';
 import chalk from 'chalk';
 
-import log from '../../log';
+import Log from '../../log';
 import { getUserAsync } from '../../user/User';
 import { getActorDisplayName } from '../../user/actions';
 
@@ -13,9 +13,9 @@ export default class AccountView extends Command {
   async run() {
     const user = await getUserAsync();
     if (user) {
-      log(chalk.green(getActorDisplayName(user)));
+      Log.log(chalk.green(getActorDisplayName(user)));
     } else {
-      log.warn('Not logged in');
+      Log.warn('Not logged in');
       process.exit(1);
     }
   }

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 
 import { configureAsync } from '../../build/configure';
 import { RequestedPlatform } from '../../build/types';
-import log, { learnMore } from '../../log';
+import Log, { learnMore } from '../../log';
 import { findProjectRootAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';
@@ -25,17 +25,17 @@ export default class BuildConfigure extends Command {
 
   async run() {
     const { flags } = this.parse(BuildConfigure);
-    log(
+    Log.log(
       '💡 The following process will configure your iOS and/or Android project to be compatible with EAS Build. These changes only apply to your local project files and you can safely revert them at any time.'
     );
-    log.newLine();
+    Log.newLine();
 
     const platform =
       (flags.platform as RequestedPlatform | undefined) ?? (await promptForPlatformAsync());
     const allowExperimental = flags['allow-experimental'];
 
     if (allowExperimental) {
-      log.warn(
+      Log.warn(
         `Project configuration will execute some additional steps that might fail if structure of your native project is significantly different from ${chalk.bold(
           'expo eject'
         )} or ${chalk.bold('expo init')}`
@@ -49,7 +49,7 @@ export default class BuildConfigure extends Command {
       projectDir: (await findProjectRootAsync()) ?? process.cwd(),
     });
 
-    log.newLine();
+    Log.newLine();
     logSuccess(platform);
   }
 }
@@ -66,7 +66,7 @@ function logSuccess(platform: RequestedPlatform) {
     storesText = 'the Apple App Store';
   }
 
-  log(`🎉 Your ${platformsText} ready to build.
+  Log.log(`🎉 Your ${platformsText} ready to build.
 
 - Run ${chalk.bold('eas build')} when you are ready to create your first build.
 - Once the build is completed, run ${chalk.bold('eas submit')} to upload the app to ${storesText}

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -14,7 +14,7 @@ import formatBuild from '../../build/utils/formatBuild';
 import { isGitStatusCleanAsync } from '../../build/utils/repository';
 import { AppPlatform } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
-import log, { learnMore } from '../../log';
+import Log, { learnMore } from '../../log';
 import {
   isEasEnabledForProjectAsync,
   warnEasUnavailable,
@@ -131,11 +131,11 @@ async function ensureNoPendingBuildsExistAsync({
   );
   const pendingBuilds = maybePendingBuilds.filter(i => i !== null);
   if (pendingBuilds.length > 0) {
-    log.newLine();
-    log.error(
+    Log.newLine();
+    Log.error(
       'Your other builds are still pending. Wait for them to complete before running this command again.'
     );
-    log.newLine();
+    Log.newLine();
     const results = await Promise.all(
       pendingBuilds.map(pendingBuild => {
         return apiClient.get<{ data: BuildType }>(
@@ -148,7 +148,7 @@ async function ensureNoPendingBuildsExistAsync({
     );
 
     for (const result of results) {
-      log(formatBuild(result.body.data, { accountName }));
+      Log.log(formatBuild(result.body.data, { accountName }));
     }
 
     process.exitCode = 1;

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -5,7 +5,7 @@ import ora from 'ora';
 import { apiClient } from '../../api';
 import { Build } from '../../build/types';
 import formatBuild from '../../build/utils/formatBuild';
-import log from '../../log';
+import Log from '../../log';
 import {
   findProjectRootAsync,
   getProjectAccountNameAsync,
@@ -56,7 +56,7 @@ export default class BuildList extends Command {
           .map(build => formatBuild(build, { accountName }))
           .join(`\n\n${chalk.dim('———')}\n\n`);
 
-        log(`\n${list}`);
+        Log.log(`\n${list}`);
       } else {
         spinner.fail(`Couldn't find any builds for the project ${projectName}`);
       }

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -5,7 +5,7 @@ import ora from 'ora';
 import { apiClient } from '../../api';
 import { Build } from '../../build/types';
 import formatBuild from '../../build/utils/formatBuild';
-import log from '../../log';
+import Log from '../../log';
 import {
   findProjectRootAsync,
   getProjectAccountNameAsync,
@@ -58,7 +58,7 @@ export default class BuildView extends Command {
         spinner.succeed(`Showing the last build for the project ${projectName}`);
       }
 
-      log(`\n${formatBuild(build, { accountName })}`);
+      Log.log(`\n${formatBuild(build, { accountName })}`);
     } catch (e) {
       const error = e as HTTPError;
 

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -5,7 +5,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import { UpdateChannel } from '../../graphql/generated';
-import log from '../../log';
+import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import {
   findProjectRootAsync,
@@ -142,11 +142,11 @@ export default class ChannelCreate extends Command {
     });
 
     if (jsonFlag) {
-      log(newChannel);
+      Log.log(newChannel);
       return;
     }
 
-    log.withTick(
+    Log.withTick(
       `️Created a new channel ${chalk.bold(newChannel.channelName)} on project ${chalk.bold(
         `@${accountName}/${slug}`
       )}. ${releaseMessage} and have pointed the channel at it. You can now update your app by publishing!`

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -6,7 +6,7 @@ import ora from 'ora';
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import { AppleTeamQuery } from '../../credentials/ios/api/graphql/queries/AppleTeamQuery';
 import formatDevice from '../../devices/utils/formatDevice';
-import log from '../../log';
+import Log from '../../log';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 
@@ -79,7 +79,7 @@ export default class BuildList extends Command {
           )
           .join(`\n\n${chalk.dim('———')}\n\n`);
 
-        log(`\n${list}`);
+        Log.log(`\n${list}`);
       } else {
         spinner.fail(`Couldn't find any devices for the team ${appleTeamIdentifier}`);
       }

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -3,7 +3,7 @@ import ora from 'ora';
 
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import formatDevice from '../../devices/utils/formatDevice';
-import log from '../../log';
+import Log from '../../log';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 
 export default class DeviceView extends Command {
@@ -15,7 +15,7 @@ export default class DeviceView extends Command {
     const { UDID } = this.parse(DeviceView).args;
 
     if (!UDID) {
-      log(
+      Log.log(
         `The device UDID is required to view a specific device. For example:
 
    eas device:view 00005787-000872430189501D
@@ -38,7 +38,7 @@ If you are not sure what is the UDID of the device you are looking for, run:
 
       if (device) {
         spinner.succeed('Fetched device details');
-        log(`\n${formatDevice(device, device.appleTeam)}`);
+        Log.log(`\n${formatDevice(device, device.appleTeam)}`);
       } else {
         spinner.fail(`Couldn't find a device with the UDID ${UDID}`);
       }

--- a/packages/eas-cli/src/commands/release/create.ts
+++ b/packages/eas-cli/src/commands/release/create.ts
@@ -5,7 +5,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import { UpdateRelease } from '../../graphql/generated';
-import log from '../../log';
+import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountName } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
@@ -100,11 +100,11 @@ export default class ReleaseCreate extends Command {
     const newRelease = await createUpdateReleaseOnAppAsync({ appId: projectId, releaseName });
 
     if (flags.json) {
-      log(newRelease);
+      Log.log(newRelease);
       return;
     }
 
-    log.withTick(
+    Log.withTick(
       `️Created a new release: ${chalk.bold(newRelease.releaseName)} on project ${chalk.bold(
         `@${accountName}/${exp.slug}`
       )}.`

--- a/packages/eas-cli/src/commands/release/list.ts
+++ b/packages/eas-cli/src/commands/release/list.ts
@@ -6,7 +6,7 @@ import { format } from 'timeago.js';
 
 import { graphqlClient } from '../../graphql/client';
 import { RootQuery, Update, UpdateRelease } from '../../graphql/generated';
-import log from '../../log';
+import Log from '../../log';
 import { findProjectRootAsync, getProjectFullNameAsync } from '../../project/projectUtils';
 import { getActorDisplayName } from '../../user/actions';
 
@@ -34,7 +34,7 @@ export default class ReleaseList extends Command {
     const fullName = await getProjectFullNameAsync(projectDir);
     const releases = await this.listReleasesAsync({ fullName });
     if (flags.json) {
-      log(JSON.stringify(releases, null, 2));
+      Log.log(JSON.stringify(releases, null, 2));
     } else {
       const table = new CliTable({ head: ['Release', 'Latest update'] });
       table.push(
@@ -43,9 +43,9 @@ export default class ReleaseList extends Command {
           formatUpdate(release.updates[0]),
         ])
       );
-      log(table.toString());
+      Log.log(table.toString());
       if (releases.length >= RELEASES_LIMIT) {
-        log.warn(`Showing first ${RELEASES_LIMIT} releases, some results might be omitted.`);
+        Log.warn(`Showing first ${RELEASES_LIMIT} releases, some results might be omitted.`);
       }
     }
   }

--- a/packages/eas-cli/src/commands/release/publish.ts
+++ b/packages/eas-cli/src/commands/release/publish.ts
@@ -5,7 +5,7 @@ import Table from 'cli-table3';
 import ora from 'ora';
 
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
-import log from '../../log';
+import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import {
   findProjectRootAsync,
@@ -128,7 +128,7 @@ export default class ReleasePublish extends Command {
     }
 
     if (jsonFlag) {
-      log(newUpdateGroup);
+      Log.log(newUpdateGroup);
     } else {
       const outputMessage = new Table({
         wordWrap: true,
@@ -158,7 +158,7 @@ export default class ReleasePublish extends Command {
         [chalk.dim('updateGroupID'), newUpdateGroup.updateGroup],
         [chalk.dim('message'), updateMessage]
       );
-      log(outputMessage.toString());
+      Log.log(outputMessage.toString());
     }
   }
 }

--- a/packages/eas-cli/src/commands/release/rename.ts
+++ b/packages/eas-cli/src/commands/release/rename.ts
@@ -5,7 +5,7 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import { EditUpdateReleaseInput, UpdateRelease } from '../../graphql/generated';
-import log from '../../log';
+import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountName } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
@@ -119,11 +119,11 @@ export default class ReleaseRename extends Command {
     });
 
     if (jsonFlag) {
-      log(editedRelease);
+      Log.log(editedRelease);
       return;
     }
 
-    log.withTick(
+    Log.withTick(
       `️Renamed release from ${currentName} to ${chalk.bold(
         editedRelease.releaseName
       )} on project ${chalk.bold(`@${accountName}/${exp.slug}`)}.`

--- a/packages/eas-cli/src/commands/release/view.ts
+++ b/packages/eas-cli/src/commands/release/view.ts
@@ -7,7 +7,7 @@ import { groupBy } from 'lodash';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import { Update } from '../../graphql/generated';
-import log from '../../log';
+import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
@@ -147,7 +147,7 @@ export default class ReleaseView extends Command {
     );
 
     if (jsonFlag) {
-      log({ ...UpdateRelease, updates });
+      Log.log({ ...UpdateRelease, updates });
       return;
     }
 
@@ -165,12 +165,12 @@ export default class ReleaseView extends Command {
       ]);
     }
 
-    log.withTick(
+    Log.withTick(
       `️Release: ${chalk.bold(UpdateRelease.releaseName)} on project ${chalk.bold(
         `@${accountName}/${slug}`
       )}. Release ID: ${chalk.bold(UpdateRelease.id)}`
     );
-    log(chalk.bold('Recent update groups published on this release:'));
-    log(updateGroupTable.toString());
+    Log.log(chalk.bold('Recent update groups published on this release:'));
+    Log.log(updateGroupTable.toString());
   }
 }

--- a/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
@@ -1,7 +1,7 @@
 import { Platform } from '@expo/eas-build-job';
 import { CredentialsSource } from '@expo/eas-json';
 
-import log from '../../log';
+import Log from '../../log';
 import { CredentialsManager } from '../CredentialsManager';
 import { CredentialsProvider } from '../CredentialsProvider';
 import { Context } from '../context';
@@ -46,7 +46,7 @@ export default class AndroidCredentialsProvider implements CredentialsProvider {
       const rawCredentialsJson = await credentialsJsonReader.readRawAsync(this.ctx.projectDir);
       return !!rawCredentialsJson?.android;
     } catch (err) {
-      log.error(err); // malformed json
+      Log.error(err); // malformed json
       return false;
     }
   }

--- a/packages/eas-cli/src/credentials/android/actions/DownloadKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/DownloadKeystore.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { confirmAsync } from '../../../prompts';
 import { maybeRenameExistingFileAsync } from '../../../utils/files';
 import { Action, CredentialsManager } from '../../CredentialsManager';
@@ -18,7 +18,7 @@ export class DownloadKeystore implements Action {
   public async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     const keystore = await ctx.android.fetchKeystoreAsync(this.projectFullName);
     if (!keystore) {
-      log.warn('There is no valid Keystore defined for this app');
+      Log.warn('There is no valid Keystore defined for this app');
       return;
     }
 
@@ -34,11 +34,11 @@ export class DownloadKeystore implements Action {
 
     await maybeRenameExistingFileAsync(ctx.projectDir, keystorePath);
 
-    log(`Saving Keystore to ${keystorePath}`);
+    Log.log(`Saving Keystore to ${keystorePath}`);
     await fs.writeFile(keystorePath, keystore.keystore, 'base64');
 
     if (displayCredentials) {
-      log(`Keystore credentials
+      Log.log(`Keystore credentials
   Keystore password: ${chalk.bold(keystore.keystorePassword)}
   Key alias:         ${chalk.bold(keystore.keyAlias)}
   Key password:      ${chalk.bold(keystore.keyPassword)}
@@ -54,7 +54,7 @@ export class BackupKeystore implements Action {
 
   public async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     if (await ctx.android.fetchKeystoreAsync(this.projectFullName)) {
-      log.warn('Backing up your old Android Keystore now...');
+      Log.warn('Backing up your old Android Keystore now...');
       await manager.runActionAsync(
         new DownloadKeystore(this.projectFullName, {
           displayCredentials: true,

--- a/packages/eas-cli/src/credentials/android/actions/FcmKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/FcmKey.ts
@@ -1,4 +1,4 @@
-import log from '../../../log';
+import Log from '../../../log';
 import { promptAsync } from '../../../prompts';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
@@ -17,6 +17,6 @@ export class UpdateFcmKey implements Action {
     ]);
 
     await ctx.android.updateFcmKeyAsync(this.experienceName, fcmApiKey);
-    log.succeed('Updated successfully');
+    Log.succeed('Updated successfully');
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/RemoveKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveKeystore.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { confirmAsync } from '../../../prompts';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
@@ -11,7 +11,7 @@ export class RemoveKeystore implements Action {
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     if (!(await ctx.android.fetchKeystoreAsync(this.projectFullName))) {
-      log.warn('There is no Keystore defined for this app.');
+      Log.warn('There is no Keystore defined for this app.');
       return;
     }
 
@@ -31,29 +31,29 @@ export class RemoveKeystore implements Action {
       await manager.runActionAsync(new BackupKeystore(this.projectFullName));
 
       await ctx.android.removeKeystoreAsync(this.projectFullName);
-      log.succeed('Keystore removed');
+      Log.succeed('Keystore removed');
     }
   }
 
   displayWarning() {
-    log.newLine();
-    log.warn(
+    Log.newLine();
+    Log.warn(
       `Clearing your Android build credentials from our build servers is a ${chalk.bold(
         'PERMANENT and IRREVERSIBLE action.'
       )}`
     );
-    log.warn(
+    Log.warn(
       chalk.bold(
         'Android Keystore must be identical to the one previously used to submit your app to the Google Play Store.'
       )
     );
-    log.warn(
+    Log.warn(
       'Please read https://docs.expo.io/distribution/building-standalone-apps/#if-you-choose-to-build-for-android for more info before proceeding.'
     );
-    log.newLine();
-    log.warn(
+    Log.newLine();
+    Log.warn(
       chalk.bold('Your Keystore will be backed up to your current directory if you continue.')
     );
-    log.newLine();
+    Log.newLine();
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/actions/SetupBuildCredentials.ts
@@ -1,4 +1,4 @@
-import log from '../../../log';
+import Log from '../../../log';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { readAndroidCredentialsAsync } from '../../credentialsJson/read';
@@ -31,7 +31,7 @@ export class SetupBuildCredentialsFromCredentialsJson implements Action {
     try {
       localCredentials = await readAndroidCredentialsAsync(ctx.projectDir);
     } catch (error) {
-      log.error(
+      Log.error(
         'Reading credentials from credentials.json failed. Make sure this file is correct and all credentials are present there.'
       );
       throw error;
@@ -40,6 +40,6 @@ export class SetupBuildCredentialsFromCredentialsJson implements Action {
       await validateKeystoreAsync(localCredentials.keystore);
     }
     await ctx.android.updateKeystoreAsync(this.projectFullName, localCredentials.keystore);
-    log.succeed('Keystore updated');
+    Log.succeed('Keystore updated');
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts
@@ -1,4 +1,4 @@
-import log from '../../../log';
+import Log from '../../../log';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { updateAndroidCredentialsAsync } from '../../credentialsJson/update';
@@ -7,9 +7,9 @@ export class UpdateCredentialsJson implements Action {
   constructor(private projectFullName: string) {}
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
-    log('Updating Android credentials in credentials.json');
+    Log.log('Updating Android credentials in credentials.json');
     await updateAndroidCredentialsAsync(ctx);
-    log.succeed(
+    Log.succeed(
       'Android part of your local credentials.json is synced with values stored on EAS servers.'
     );
   }

--- a/packages/eas-cli/src/credentials/android/actions/UpdateKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/UpdateKeystore.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { askForUserProvidedAsync } from '../../utils/promptForCredentials';
@@ -17,7 +17,7 @@ export class UpdateKeystore implements Action {
     const keystore = await this.provideOrGenerateAsync();
 
     await ctx.android.updateKeystoreAsync(this.projectFullName, keystore);
-    log.succeed('Keystore updated');
+    Log.succeed('Keystore updated');
   }
 
   private async provideOrGenerateAsync(): Promise<Keystore> {
@@ -30,17 +30,17 @@ export class UpdateKeystore implements Action {
   }
 
   private displayWarning() {
-    log.newLine();
-    log.warn(
+    Log.newLine();
+    Log.warn(
       `Updating your Android build credentials will remove previous version from our servers, this is a ${chalk.bold(
         'PERMANENT and IRREVERSIBLE action.'
       )}`
     );
-    log.warn(
+    Log.warn(
       chalk.bold(
         'Android Keystore must be identical to the one previously used to submit your app to the Google Play Store.'
       )
     );
-    log.newLine();
+    Log.newLine();
   }
 }

--- a/packages/eas-cli/src/credentials/android/utils/keystore.ts
+++ b/packages/eas-cli/src/credentials/android/utils/keystore.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import tempy from 'tempy';
 import { v4 as uuidv4 } from 'uuid';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { getTmpDirectory } from '../../../utils/paths';
 import { Keystore } from '../credentials';
 
@@ -20,9 +20,9 @@ export async function keytoolCommandExistsAsync(): Promise<boolean> {
 
 async function ensureKeytoolCommandExistsAsync(): Promise<void> {
   if (!(await keytoolCommandExistsAsync())) {
-    log.error('keytool is required to run this command, make sure you have it installed?');
-    log.warn('keytool is a part of OpenJDK: https://openjdk.java.net/');
-    log.warn('Also make sure that keytool is in your PATH after installation.');
+    Log.error('keytool is required to run this command, make sure you have it installed?');
+    Log.warn('keytool is a part of OpenJDK: https://openjdk.java.net/');
+    Log.warn('Also make sure that keytool is in your PATH after installation.');
     throw new Error('keytool not found');
   }
 }
@@ -70,12 +70,12 @@ export async function logKeystoreHashesAsync(keystore: Keystore, linePrefix: str
   const googleHash = crypto.createHash('sha1').update(data).digest('hex').toUpperCase();
   const googleHash256 = crypto.createHash('sha256').update(data).digest('hex').toUpperCase();
   const fbHash = crypto.createHash('sha1').update(data).digest('base64');
-  log(
+  Log.log(
     `${linePrefix}Google Certificate Fingerprint:     ${googleHash.replace(/(.{2}(?!$))/g, '$1:')}`
   );
-  log(`${linePrefix}Google Certificate Hash (SHA-1):    ${googleHash}`);
-  log(`${linePrefix}Google Certificate Hash (SHA-256):  ${googleHash256}`);
-  log(`${linePrefix}Facebook Key Hash:                  ${fbHash}`);
+  Log.log(`${linePrefix}Google Certificate Hash (SHA-1):    ${googleHash}`);
+  Log.log(`${linePrefix}Google Certificate Hash (SHA-256):  ${googleHash256}`);
+  Log.log(`${linePrefix}Facebook Key Hash:                  ${fbHash}`);
 }
 
 async function createKeystoreAsync(credentials: {

--- a/packages/eas-cli/src/credentials/android/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/utils/printCredentials.ts
@@ -1,34 +1,34 @@
 import chalk from 'chalk';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { AndroidCredentials } from '../credentials';
 import { keytoolCommandExistsAsync, logKeystoreHashesAsync } from '../utils/keystore';
 
 export async function printAndroidCredentials(credentialsList: AndroidCredentials[]) {
-  log(chalk.bold('Available Android credentials'));
-  log.newLine();
+  Log.log(chalk.bold('Available Android credentials'));
+  Log.newLine();
   for (const credentials of credentialsList) {
     await printAndroidAppCredentials(credentials);
   }
 }
 
 export async function printAndroidAppCredentials(credentials: AndroidCredentials) {
-  log(chalk.green(credentials.experienceName));
-  log(chalk.bold('  Keystore hashes'));
+  Log.log(chalk.green(credentials.experienceName));
+  Log.log(chalk.bold('  Keystore hashes'));
   if (credentials.keystore?.keystore) {
     if (await keytoolCommandExistsAsync()) {
       try {
         await logKeystoreHashesAsync(credentials.keystore, '    ');
       } catch (error) {
-        log.error('    Failed to parse the Keystore', error);
+        Log.error('    Failed to parse the Keystore', error);
       }
     } else {
-      log.warn('    keytool is required to calulate Keystore hashes');
+      Log.warn('    keytool is required to calulate Keystore hashes');
     }
   } else {
-    log('    -----------------------');
+    Log.log('    -----------------------');
   }
-  log(chalk.bold('  Push Notifications credentials'));
-  log('    FCM API Key: ', credentials.pushCredentials?.fcmApiKey ?? '---------------------');
-  log('\n');
+  Log.log(chalk.bold('  Push Notifications credentials'));
+  Log.log('    FCM API Key: ', credentials.pushCredentials?.fcmApiKey ?? '---------------------');
+  Log.log('\n');
 }

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -2,7 +2,7 @@ import { ExpoConfig, getConfig } from '@expo/config';
 import chalk from 'chalk';
 import pick from 'lodash/pick';
 
-import log from '../log';
+import Log from '../log';
 import { getProjectAccountName } from '../project/projectUtils';
 import { confirmAsync } from '../prompts';
 import { Actor } from '../user/User';
@@ -95,13 +95,13 @@ class CredentialsContext implements Context {
       // Figure out if User A is configuring credentials as admin for User B's project
       const isProxyUser = this.user.__typename === 'Robot' || owner !== this.user.username;
 
-      log(
+      Log.log(
         `Accessing credentials ${isProxyUser ? 'on behalf of' : 'for'} ${owner} in project ${
           this.exp.slug
         }`
       );
     } else {
-      log(`Accessing credentials for ${this.exp.owner ?? getActorDisplayName(this.user)}`);
+      Log.log(`Accessing credentials for ${this.exp.owner ?? getActorDisplayName(this.user)}`);
     }
   }
 
@@ -115,12 +115,12 @@ class CredentialsContext implements Context {
       return;
     }
 
-    log(
+    Log.log(
       chalk.green(
         'If you provide your Apple account credentials we will be able to generate all necessary build credentials and fully validate them.'
       )
     );
-    log(
+    Log.log(
       chalk.green(
         'This is optional, but without Apple account access you will need to provide all the values manually and we can only run minimal validation on them.'
       )
@@ -131,7 +131,7 @@ class CredentialsContext implements Context {
     if (confirm) {
       await this.appStore.ensureAuthenticatedAsync();
     } else {
-      log(
+      Log.log(
         chalk.green(
           'No problem! 👌 If you select an action that requires those credentials we will ask you again about it.'
         )

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-import log from '../../log';
+import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
 import { confirmAsync } from '../../prompts';
 import { gitStatusAsync } from '../../utils/git';
@@ -21,8 +21,8 @@ export async function updateAndroidCredentialsAsync(ctx: Context): Promise<void>
       const rawFile = await fs.readFile(credentialsJsonFilePath, 'utf-8');
       rawCredentialsJsonObject = JSON.parse(rawFile);
     } catch (error) {
-      log.error(`Reading credentials.json failed [${error}]`);
-      log.error('Make sure that file is correct (or remove it) and rerun this command.');
+      Log.error(`Reading credentials.json failed [${error}]`);
+      Log.error('Make sure that file is correct (or remove it) and rerun this command.');
       throw error;
     }
   }
@@ -42,14 +42,14 @@ export async function updateAndroidCredentialsAsync(ctx: Context): Promise<void>
         'Credentials on EAS servers might be invalid or incomplete. Are you sure you want to continue?',
     });
     if (!confirm) {
-      log.warn('Aborting...');
+      Log.warn('Aborting...');
       return;
     }
   }
 
   const keystorePath =
     rawCredentialsJsonObject?.android?.keystore?.keystorePath ?? 'android/keystores/keystore.jks';
-  log(`Writing Keystore to ${keystorePath}`);
+  Log.log(`Writing Keystore to ${keystorePath}`);
   await updateFileAsync(ctx.projectDir, keystorePath, keystore.keystore);
   const shouldWarnKeystore = await isFileUntrackedAsync(keystorePath);
 
@@ -94,8 +94,8 @@ export async function updateIosCredentialsAsync(
       const rawFile = await fs.readFile(credentialsJsonFilePath, 'utf-8');
       rawCredentialsJsonObject = JSON.parse(rawFile);
     } catch (error) {
-      log.error(`There was an error while reading credentials.json [${error}]`);
-      log.error('Make sure that file is correct (or remove it) and rerun this command.');
+      Log.error(`There was an error while reading credentials.json [${error}]`);
+      Log.error('Make sure that file is correct (or remove it) and rerun this command.');
       throw error;
     }
 
@@ -106,11 +106,11 @@ export async function updateIosCredentialsAsync(
         key => key !== 'provisioningProfilePath' && key !== 'distributionCertificate'
       );
       if (maybeUnknownKey) {
-        log.error(
+        Log.error(
           `It looks like your credentials.json either contains multi-target credentials or you've made a typo.`
         );
-        log.error(`- The key in 'ios' object that EAS CLI encountered is: ${maybeUnknownKey}`);
-        log.error(
+        Log.error(`- The key in 'ios' object that EAS CLI encountered is: ${maybeUnknownKey}`);
+        Log.error(
           `- Updating credentials.json (for multi-target iOS projects) with credentials stored on EAS servers is not supported at the moment, sorry!`
         );
         throw new Error('Updating credentials.json failed');
@@ -145,12 +145,12 @@ export async function updateIosCredentialsAsync(
         'Credentials on EAS servers might be invalid or incomplete. Are you sure you want to continue?',
     });
     if (!confirm) {
-      log.warn('Aborting...');
+      Log.warn('Aborting...');
       return;
     }
   }
 
-  log(`Writing Provisioning Profile to ${profilePath}`);
+  Log.log(`Writing Provisioning Profile to ${profilePath}`);
   await updateFileAsync(
     ctx.projectDir,
     profilePath,
@@ -158,7 +158,7 @@ export async function updateIosCredentialsAsync(
   );
   const shouldWarnPProfile = await isFileUntrackedAsync(profilePath);
 
-  log(`Writing Distribution Certificate to ${distCertPath}`);
+  Log.log(`Writing Distribution Certificate to ${distCertPath}`);
   await updateFileAsync(ctx.projectDir, distCertPath, distCredentials?.certP12);
   const shouldWarnDistCert = await isFileUntrackedAsync(distCertPath);
 
@@ -217,11 +217,11 @@ async function isFileUntrackedAsync(path: string): Promise<boolean> {
 
 function displayUntrackedFilesWarning(newFilePaths: string[]) {
   if (newFilePaths.length === 1) {
-    log.warn(
+    Log.warn(
       `File ${newFilePaths[0]} is currently untracked, remember to add it to .gitignore or to encrypt it. (e.g. with git-crypt)`
     );
   } else if (newFilePaths.length > 1) {
-    log.warn(
+    Log.warn(
       `Files ${newFilePaths.join(
         ', '
       )} are currently untracked, remember to add them to .gitignore or to encrypt them. (e.g. with git-crypt)`

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -2,7 +2,7 @@ import { Platform } from '@expo/eas-build-job';
 import { CredentialsSource, DistributionType } from '@expo/eas-json';
 
 import { IosDistributionType } from '../../graphql/generated';
-import log from '../../log';
+import Log from '../../log';
 import { findAccountByName } from '../../user/Account';
 import { CredentialsManager } from '../CredentialsManager';
 import { CredentialsProvider } from '../CredentialsProvider';
@@ -59,7 +59,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
       const rawCredentialsJson = await credentialsJsonReader.readRawAsync(this.ctx.projectDir);
       return !!rawCredentialsJson?.ios;
     } catch (err) {
-      log.error(err); // malformed json
+      Log.error(err); // malformed json
       return false;
     }
   }
@@ -111,7 +111,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
 
   private async getRemoteAsync(): Promise<IosCredentials> {
     if (this.options.skipCredentialsCheck) {
-      log('Skipping credentials check');
+      Log.log('Skipping credentials check');
     } else {
       await new CredentialsManager(this.ctx).runActionAsync(
         new SetupBuildCredentials(this.options.app, this.options.distribution)

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 import ora from 'ora';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import {
@@ -36,14 +36,14 @@ export class ConfigureProvisioningProfile implements Action {
     }
 
     if (!profile.provisioningProfileId) {
-      log.warn("The provisioning profile we have on file cannot be validated on Apple's servers.");
+      Log.warn("The provisioning profile we have on file cannot be validated on Apple's servers.");
       return;
     }
 
     if (ctx.appStore.authCtx) {
       const distCert = await ctx.ios.getDistributionCertificateAsync(this.app);
       if (!distCert) {
-        log.warn('There is no distribution certificate for this app.');
+        Log.warn('There is no distribution certificate for this app.');
         return;
       }
       const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
@@ -53,15 +53,15 @@ export class ConfigureProvisioningProfile implements Action {
         appleInfo => appleInfo.provisioningProfileId === profile.provisioningProfileId
       );
       if (!profilesWithMatchingId || profilesWithMatchingId.length < 1) {
-        log.warn('This profile is no longer valid on Apple Developer Portal.');
+        Log.warn('This profile is no longer valid on Apple Developer Portal.');
       }
 
       await this.configureAndUpdateAsync(ctx, this.app, distCert, profilesWithMatchingId[0]);
     } else {
-      log.warn(
+      Log.warn(
         "Without access to your Apple account we can't configure provisioning profiles for you."
       );
-      log.warn('Make sure to recreate the profile if you selected a new distribution certificate.');
+      Log.warn('Make sure to recreate the profile if you selected a new distribution certificate.');
     }
   }
 

--- a/packages/eas-cli/src/credentials/ios/actions/CreateDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateDistributionCertificate.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { IosDistCredentials } from '../credentials';
@@ -14,9 +14,9 @@ export class CreateDistributionCertificateStandaloneManager implements Action {
     const action = new CreateDistributionCertificate(this.accountName);
     await manager.runActionAsync(action);
 
-    log.newLine();
+    Log.newLine();
     displayIosUserCredentials(action.distCredentials);
-    log.newLine();
+    Log.newLine();
   }
 }
 
@@ -40,6 +40,6 @@ export class CreateDistributionCertificate implements Action {
       this.accountName,
       distCert
     );
-    log.succeed('Created distribution certificate');
+    Log.succeed('Created distribution certificate');
   }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { askForUserProvidedAsync } from '../../utils/promptForCredentials';
@@ -17,7 +17,7 @@ export class CreateProvisioningProfileStandaloneManager implements Action {
 
     const appCredentials = await ctx.ios.getAppCredentialsAsync(this.app);
     displayIosAppCredentials(appCredentials);
-    log.newLine();
+    Log.newLine();
   }
 }
 
@@ -28,14 +28,14 @@ export class CreateProvisioningProfile implements Action {
     const provisioningProfile = await this.provideOrGenerateAsync(ctx);
     await ctx.ios.updateProvisioningProfileAsync(this.app, provisioningProfile);
 
-    log.succeed('Created provisioning profile');
+    Log.succeed('Created provisioning profile');
   }
 
   private async provideOrGenerateAsync(ctx: Context): Promise<ProvisioningProfile> {
     const userProvided = await askForUserProvidedAsync(provisioningProfileSchema);
     if (userProvided) {
       // userProvided profiles don't come with ProvisioningProfileId's (only accessible from Apple Portal API)
-      log.warn('Provisioning profile: Unable to validate specified profile.');
+      Log.warn('Provisioning profile: Unable to validate specified profile.');
       return userProvided;
     }
     const distCert = await ctx.ios.getDistributionCertificateAsync(this.app);

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log, { learnMore } from '../../../log';
+import Log, { learnMore } from '../../../log';
 import { promptAsync } from '../../../prompts';
 import { CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
@@ -39,14 +39,14 @@ export async function provideOrGenerateDistributionCertificateAsync(
     const userProvided = await promptForDistCertAsync(ctx);
     if (userProvided) {
       if (!ctx.appStore.authCtx) {
-        log.warn(
+        Log.warn(
           'Unable to validate distribution certificate due to insufficient Apple Credentials'
         );
         return userProvided;
       } else {
         const isValid = await validateDistributionCertificateAsync(ctx, userProvided);
         if (!isValid) {
-          log.warn("Provided Distribution Certificate is no longer valid on Apple's server");
+          Log.warn("Provided Distribution Certificate is no longer valid on Apple's server");
         }
         return isValid
           ? userProvided
@@ -88,8 +88,8 @@ async function generateDistributionCertificateAsync(
   } catch (e) {
     if (e instanceof AppleTooManyCertsError) {
       const distCerts = await ctx.appStore.listDistributionCertificatesAsync();
-      log.warn('Maximum number of Distribution Certificates generated on Apple Developer Portal.');
-      log.warn(APPLE_DIST_CERTS_TOO_MANY_GENERATED_ERROR);
+      Log.warn('Maximum number of Distribution Certificates generated on Apple Developer Portal.');
+      Log.warn(APPLE_DIST_CERTS_TOO_MANY_GENERATED_ERROR);
 
       if (ctx.nonInteractive) {
         throw new Error(
@@ -97,13 +97,13 @@ async function generateDistributionCertificateAsync(
         );
       }
 
-      log(
+      Log.log(
         chalk.grey(
           `✅  Distribution Certificates can be revoked with no side effects for App Store builds.`
         )
       );
-      log(learnMore('https://docs.expo.io/distribution/app-signing/#summary'));
-      log.newLine();
+      Log.log(learnMore('https://docs.expo.io/distribution/app-signing/#summary'));
+      Log.newLine();
 
       const { distCertsToRevoke } = await promptAsync({
         type: 'multiselect',
@@ -151,7 +151,7 @@ export async function selectDistributionCertificateAsync(
     options.filterInvalid && validDistCredentials ? validDistCredentials : distCredentials;
 
   if (distCredentials.length === 0) {
-    log.warn('There are no Distribution Certificates available in your Expo account.');
+    Log.warn('There are no Distribution Certificates available in your Expo account.');
     return null;
   }
 
@@ -241,7 +241,7 @@ export async function getValidDistCertsAsync(
     (cred): cred is IosDistCredentials => cred.type === 'dist-cert'
   );
   if (!ctx.appStore.authCtx) {
-    log(chalk.yellow(`Unable to determine validity of Distribution Certificates.`));
+    Log.log(chalk.yellow(`Unable to determine validity of Distribution Certificates.`));
     return distCredentials;
   }
   const certInfoFromApple = await ctx.appStore.listDistributionCertificatesAsync();

--- a/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { promptAsync } from '../../../prompts';
 import { Context } from '../../context';
 import {
@@ -16,7 +16,7 @@ export async function selectProvisioningProfileFromAppleAsync(
 ): Promise<ProvisioningProfileStoreInfo | null> {
   const profiles = await ctx.appStore.listProvisioningProfilesAsync(bundleIdentifier);
   if (profiles.length === 0) {
-    log.warn(
+    Log.warn(
       `There are no provisioning profiles available on Apple Developer Portal for bundle identifier ${bundleIdentifier}.`
     );
     return null;
@@ -53,7 +53,7 @@ export async function selectProvisioningProfileFromExpoAsync(
     ({ credentials }) => !!credentials.provisioningProfile && !!credentials.provisioningProfileId
   );
   if (profiles.length === 0) {
-    log.warn('There are no provisioning profiles available in your Expo account.');
+    Log.warn('There are no provisioning profiles available in your Expo account.');
     return null;
   }
 

--- a/packages/eas-cli/src/credentials/ios/actions/RemoveDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemoveDistributionCertificate.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { confirmAsync } from '../../../prompts';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
@@ -21,8 +21,8 @@ export class RemoveDistributionCertificate implements Action {
       await manager.runActionAsync(
         new RemoveSpecificDistributionCertificate(selected?.id, this.accountName, this.options)
       );
-      log.succeed('Removed distribution certificate');
-      log.newLine();
+      Log.succeed('Removed distribution certificate');
+      Log.newLine();
     }
   }
 }
@@ -54,12 +54,12 @@ export class RemoveSpecificDistributionCertificate implements Action {
         message: `You are removing certificate used by ${appList}. Do you want to continue?`,
       });
       if (!confirm) {
-        log('Aborting');
+        Log.log('Aborting');
         return;
       }
     }
 
-    log('Removing Distribution Certificate');
+    Log.log('Removing Distribution Certificate');
     await ctx.ios.deleteDistributionCertificateAsync(this.userCredentialsId, this.accountName);
 
     let shouldRevoke = this.options.shouldRevoke;
@@ -91,7 +91,7 @@ export class RemoveSpecificDistributionCertificate implements Action {
       if (!(await ctx.ios.getProvisioningProfileAsync(appLookupParams))) {
         continue;
       }
-      log(
+      Log.log(
         `Removing Provisioning Profile for ${appCredentials.experienceName} (${appCredentials.bundleIdentifier})`
       );
       await manager.runActionAsync(

--- a/packages/eas-cli/src/credentials/ios/actions/RemoveProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemoveProvisioningProfile.ts
@@ -1,4 +1,4 @@
-import log from '../../../log';
+import Log from '../../../log';
 import { confirmAsync } from '../../../prompts';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
@@ -30,7 +30,7 @@ export class RemoveSpecificProvisioningProfile implements Action {
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     await ctx.ios.deleteProvisioningProfileAsync(this.app);
-    log.succeed(
+    Log.succeed(
       `Removed provisioning profile for @${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
     );
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -3,7 +3,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 
 import { AppleDevice, IosAppBuildCredentialsFragment } from '../../../graphql/generated';
-import log from '../../../log';
+import Log from '../../../log';
 import { promptAsync } from '../../../prompts';
 import { findAccountByName } from '../../../user/Account';
 import { Action, CredentialsManager } from '../../CredentialsManager';
@@ -53,7 +53,7 @@ export class SetupBuildCredentials implements Action {
         await manager.runActionAsync(new SetupProvisioningProfile(this.app));
       }
     } catch (error) {
-      log.error('Failed to setup credentials.');
+      Log.error('Failed to setup credentials.');
       throw error;
     }
 
@@ -63,9 +63,9 @@ export class SetupBuildCredentials implements Action {
     );
     const appInfo = `@${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`;
     displayProjectCredentials(this.app, appCredentials, /* pushKey */ null, distCert);
-    log.newLine();
-    log(chalk.green(`All credentials are ready to build ${appInfo}`));
-    log.newLine();
+    Log.newLine();
+    Log.log(chalk.green(`All credentials are ready to build ${appInfo}`));
+    Log.newLine();
   }
 
   async unifyCredentialsFormatAsync(
@@ -121,7 +121,7 @@ export class SetupBuildCredentialsFromCredentialsJson implements Action {
     try {
       localCredentials = await readIosCredentialsAsync(ctx.projectDir);
     } catch (error) {
-      log.error(
+      Log.error(
         'Reading credentials from credentials.json failed. Make sure this file is correct and all credentials are present there.'
       );
       throw error;
@@ -198,8 +198,8 @@ export class SetupBuildCredentialsFromCredentialsJson implements Action {
       undefined,
       await ctx.ios.getDistributionCertificateAsync(this.app)
     );
-    log.newLine();
-    log(chalk.green(`All credentials are ready to build ${appInfo}`));
-    log.newLine();
+    Log.newLine();
+    Log.log(chalk.green(`All credentials are ready to build ${appInfo}`));
+    Log.newLine();
   }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
@@ -1,4 +1,4 @@
-import log from '../../../log';
+import Log from '../../../log';
 import { confirmAsync, promptAsync } from '../../../prompts';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
@@ -54,7 +54,7 @@ export class SetupDistributionCertificateForApp implements Action {
       return;
     }
 
-    log(`Using Distribution Certificate: ${autoselectedCertificate.certId || '-----'}`);
+    Log.log(`Using Distribution Certificate: ${autoselectedCertificate.certId || '-----'}`);
     await manager.runActionAsync(
       new UseSpecificDistributionCertificate(this.app, autoselectedCertificate.id)
     );
@@ -68,7 +68,7 @@ export class SetupDistributionCertificateForApp implements Action {
     if (ctx.appStore.authCtx) {
       const isValid = await validateDistributionCertificateAsync(ctx, currentCertificate);
       if (!isValid) {
-        log.warn("Current Distribution Certificate is no longer valid on Apple's server");
+        Log.warn("Current Distribution Certificate is no longer valid on Apple's server");
       }
       return isValid;
     }

--- a/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import pick from 'lodash/pick';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { confirmAsync, promptAsync } from '../../../prompts';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
@@ -65,7 +65,7 @@ export class SetupProvisioningProfile implements Action {
         return;
       }
     } else {
-      log(`Using provisioning profile: ${autoselectedProfile.provisioningProfileId}`);
+      Log.log(`Using provisioning profile: ${autoselectedProfile.provisioningProfileId}`);
     }
 
     await ctx.ios.updateProvisioningProfileAsync(
@@ -88,7 +88,7 @@ export class SetupProvisioningProfile implements Action {
     }
     if (!ctx.appStore.authCtx || !currentProfile.provisioningProfileId) {
       if (!currentProfile.provisioningProfileId) {
-        log.warn(
+        Log.warn(
           "The provisioning profile we have on file cannot be validated on Apple's servers."
         );
       }
@@ -98,7 +98,7 @@ export class SetupProvisioningProfile implements Action {
         this.app.bundleIdentifier
       );
       if (!validationResult.ok) {
-        log.warn(validationResult.error);
+        Log.warn(validationResult.error);
         return false;
       }
       return true;
@@ -110,7 +110,7 @@ export class SetupProvisioningProfile implements Action {
       this.app.bundleIdentifier
     );
     if (!validationResult.ok) {
-      log.warn(validationResult.error);
+      Log.warn(validationResult.error);
       return false;
     }
     return true;

--- a/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
@@ -1,6 +1,6 @@
 import { Platform } from '@expo/eas-build-job';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { ensureAppIdentifierIsDefinedAsync } from '../../../project/projectUtils';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
@@ -12,9 +12,9 @@ export class UpdateCredentialsJson implements Action {
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     const bundleIdentifer = await ensureAppIdentifierIsDefinedAsync(ctx.projectDir, Platform.iOS);
-    log('Updating iOS credentials in credentials.json');
+    Log.log('Updating iOS credentials in credentials.json');
     await updateIosCredentialsAsync(ctx, bundleIdentifer);
-    log.succeed(
+    Log.succeed(
       'iOS part of your local credentials.json is synced with values stored on EAS servers.'
     );
   }

--- a/packages/eas-cli/src/credentials/ios/actions/UpdateDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/UpdateDistributionCertificate.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { confirmAsync } from '../../../prompts';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
@@ -35,7 +35,7 @@ export class UpdateDistributionCertificate implements Action {
         message: `You are updating certificate used by ${appList}. Do you want to continue?`,
       });
       if (!confirm) {
-        log('Aborting update process');
+        Log.log('Aborting update process');
         return;
       }
     }
@@ -49,7 +49,7 @@ export class UpdateDistributionCertificate implements Action {
       this.accountName
     );
     displayIosUserCredentials(newDistCert);
-    log.newLine();
+    Log.newLine();
   }
 }
 
@@ -72,11 +72,11 @@ export class UpdateSpecificDistributionCertificate implements Action {
       this.accountName,
       newDistCert
     );
-    log.succeed('Updated distribution certificate');
-    log.newLine();
+    Log.succeed('Updated distribution certificate');
+    Log.newLine();
 
     for (const appCredentials of apps) {
-      log(
+      Log.log(
         `Removing provisioning profile for ${appCredentials.experienceName} (${appCredentials.bundleIdentifier})`
       );
       const appLookupParams = getAppLookupParams(

--- a/packages/eas-cli/src/credentials/ios/actions/UseDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/UseDistributionCertificate.ts
@@ -1,4 +1,4 @@
-import log from '../../../log';
+import Log from '../../../log';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { AppLookupParams } from '../credentials';
@@ -27,7 +27,7 @@ export class UseSpecificDistributionCertificate implements Action {
 
   public async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     await ctx.ios.useDistributionCertificateAsync(this.app, this.userCredentialsId);
-    log.succeed(
+    Log.succeed(
       `Assigned distribution certificate to @${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
     );
   }

--- a/packages/eas-cli/src/credentials/ios/actions/new/CreateDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/CreateDistributionCertificate.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import log from '../../../../log';
+import Log from '../../../../log';
 import { Action, CredentialsManager } from '../../../CredentialsManager';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
@@ -30,6 +30,6 @@ export class CreateDistributionCertificate implements Action {
       this.app,
       distCert
     );
-    log.succeed('Created distribution certificate');
+    Log.succeed('Created distribution certificate');
   }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
@@ -6,7 +6,7 @@ import {
   AppleDistributionCertificateFragment,
   AppleTeamFragment,
 } from '../../../../graphql/generated';
-import log from '../../../../log';
+import Log from '../../../../log';
 import { promptAsync } from '../../../../prompts';
 import { Account } from '../../../../user/Account';
 import { fromNow } from '../../../../utils/date';
@@ -79,7 +79,7 @@ export async function selectDistributionCertificateAsync(
 ): Promise<AppleDistributionCertificateFragment | null> {
   const distCertsForAccount = await ctx.newIos.getDistributionCertificatesForAccountAsync(account);
   if (distCertsForAccount.length === 0) {
-    log.warn(`There are no Distribution Certificates available in your EAS account.`);
+    Log.warn(`There are no Distribution Certificates available in your EAS account.`);
     return null;
   }
   if (!ctx.appStore.authCtx) {
@@ -107,7 +107,7 @@ export async function selectValidDistributionCertificateAsync(
     appLookupParams.account
   );
   if (distCertsForAccount.length === 0) {
-    log.warn(`There are no Distribution Certificates available in your EAS account.`);
+    Log.warn(`There are no Distribution Certificates available in your EAS account.`);
     return null;
   }
   if (!ctx.appStore.authCtx) {
@@ -127,7 +127,7 @@ export async function selectValidDistributionCertificateAsync(
     distCertsForAppleTeam,
     certInfoFromApple
   );
-  log(
+  Log.log(
     `${validDistCerts.length}/${distCertsForAccount.length} Distribution Certificates are currently valid for Apple Team ${ctx.appStore.authCtx?.team.id}.`
   );
   return _selectDistributionCertificateAsync(validDistCerts);

--- a/packages/eas-cli/src/credentials/ios/actions/new/ProvisioningProfileUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/ProvisioningProfileUtils.ts
@@ -1,6 +1,6 @@
 import isEqual from 'lodash/isEqual';
 
-import log from '../../../../log';
+import Log from '../../../../log';
 import { AppleDeviceFragmentWithAppleTeam } from '../../api/graphql/queries/AppleDeviceQuery';
 import { AppleDistributionCertificateQueryResult } from '../../api/graphql/queries/AppleDistributionCertificateQuery';
 import { ProvisioningProfileStoreInfo } from '../../appstore/Credentials.types';
@@ -15,7 +15,7 @@ export function isDevPortalAdhocProfileValid(
   }
 
   if (profileFromDevPortal.status === 'Invalid' || profileFromDevPortal.certificates.length === 0) {
-    log('Provisioning Profile is invalid');
+    Log.log('Provisioning Profile is invalid');
     return false;
   }
 
@@ -24,7 +24,7 @@ export function isDevPortalAdhocProfileValid(
     distCert.developerPortalIdentifier &&
     distCert.developerPortalIdentifier !== currentDistCertId
   ) {
-    log(
+    Log.log(
       `Provisioning Profile was generated for Distribution Certificate with ID "${currentDistCertId}", expected ID "${distCert.developerPortalIdentifier}"`
     );
     return false;
@@ -33,7 +33,7 @@ export function isDevPortalAdhocProfileValid(
   const profileDeviceUdids = (profileFromDevPortal.devices ?? []).map(({ udid }) => udid);
   const expectedDeviceUdids = expectedDevices.map(({ identifier }) => identifier);
   if (!doUDIDsMatch(profileDeviceUdids, expectedDeviceUdids)) {
-    log('Provisioning Profile was generated for another set of devices');
+    Log.log('Provisioning Profile was generated for another set of devices');
     return false;
   }
 

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import sortBy from 'lodash/sortBy';
 
 import { AppleDistributionCertificate, IosDistributionType } from '../../../../graphql/generated';
-import log from '../../../../log';
+import Log from '../../../../log';
 import { confirmAsync, promptAsync } from '../../../../prompts';
 import { Action, CredentialsManager } from '../../../CredentialsManager';
 import { Context } from '../../../context';
@@ -68,7 +68,7 @@ export class SetupDistributionCertificate implements Action {
     );
     const isValid = validCertSerialNumbers.includes(currentCertificate.serialNumber);
     if (!isValid) {
-      log.warn('Current distribution certificate is no longer valid in Apple Dev Portal');
+      Log.warn('Current distribution certificate is no longer valid in Apple Dev Portal');
     }
     return isValid;
   }
@@ -87,7 +87,9 @@ export class SetupDistributionCertificate implements Action {
     });
 
     if (useAutoselected) {
-      log(`Using distribution certificate with serial number ${autoselectedDistCert.serialNumber}`);
+      Log.log(
+        `Using distribution certificate with serial number ${autoselectedDistCert.serialNumber}`
+      );
       return autoselectedDistCert;
     }
 

--- a/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
@@ -8,7 +8,7 @@ import {
 import assert from 'assert';
 import chalk from 'chalk';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { toggleConfirmAsync } from '../../../prompts';
 import {
   deletePasswordAsync,
@@ -96,7 +96,7 @@ async function loginAsync(
     });
   } catch (error) {
     if (error instanceof InvalidUserCredentialsError) {
-      log.error(error.message);
+      Log.error(error.message);
       // Remove the invalid password so it isn't automatically used...
       await deletePasswordAsync({ username });
 
@@ -145,7 +145,7 @@ async function loginWithUserCredentialsAsync({
 
 export async function authenticateAsync(options: Options = {}): Promise<AuthCtx> {
   // help keep apple login visually apart from the other operations.
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
 
   try {
     const authState = await loginAsync(
@@ -182,7 +182,7 @@ export async function authenticateAsync(options: Options = {}): Promise<AuthCtx>
     if (error.message === 'ABORTED') {
       process.exit(1);
     }
-    log(chalk.red('Authentication with Apple Developer Portal failed!'));
+    Log.log(chalk.red('Authentication with Apple Developer Portal failed!'));
     throw error;
   }
 }

--- a/packages/eas-cli/src/credentials/ios/appstore/contractMessages.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/contractMessages.ts
@@ -2,7 +2,7 @@ import { ITCAgreements, RequestContext } from '@expo/apple-utils';
 import chalk from 'chalk';
 import { Ora } from 'ora';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { convertHTMLToASCII } from '../utils/convertHTMLToASCII';
 
 async function getContractStatusAsync(
@@ -12,7 +12,7 @@ async function getContractStatusAsync(
     const capabilities = await ITCAgreements.getCapabilitiesAsync(context);
     return capabilities?.contractStatus ?? null;
   } catch (error) {
-    log.warn(`Failed to get iTunes contract status: ${error.message}`);
+    Log.warn(`Failed to get iTunes contract status: ${error.message}`);
     return null;
   }
 }
@@ -21,7 +21,7 @@ async function getContractMessagesAsync(context: RequestContext) {
   try {
     return await ITCAgreements.getContractMessagesAsync(context);
   } catch (error) {
-    log.warn(`Failed to get iTunes contract messages: ${error.message}`);
+    Log.warn(`Failed to get iTunes contract messages: ${error.message}`);
     return null;
   }
 }
@@ -55,10 +55,10 @@ async function getRequiredContractMessagesAsync(
   // There is a small chance that this could result in a false positive if the messages are extraneous, so we'll also
   // prompt the user to open an issue so we can address the new contract state if it ever appears.
   // TODO: Maybe a silent analytic would be better
-  log.error(
+  Log.error(
     `\nUnexpected Apple developer contract status "${status}". Please open an issue on https://github.com/expo/eas-cli`
   );
-  log.newLine();
+  Log.newLine();
   return { messages: (await getContractMessagesAsync(context)) ?? [], isFatal: false };
 }
 
@@ -82,18 +82,18 @@ export async function assertContractMessagesAsync(context: RequestContext, spinn
     if (spinner) {
       spinner.stop();
     }
-    log.newLine();
-    log(chalk.yellow.bold('Messages from App Store Connect:'));
-    log.newLine();
+    Log.newLine();
+    Log.log(chalk.yellow.bold('Messages from App Store Connect:'));
+    Log.newLine();
     for (const message of messages) {
-      if (log.isDebug) {
-        log(JSON.stringify(message, null, 2));
-        log.newLine();
+      if (Log.isDebug) {
+        Log.log(JSON.stringify(message, null, 2));
+        Log.newLine();
       }
-      log.addNewLineIfNone();
-      log(formatContractMessage(message));
+      Log.addNewLineIfNone();
+      Log.log(formatContractMessage(message));
     }
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     // Only throw an error if we know that the status is fatal, otherwise attempt to finish the process.
     if (isFatal) {
       throw new Error('App Store Connect has agreement updates that must be resolved');

--- a/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import dateformat from 'dateformat';
 import ora from 'ora';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { PushKey, PushKeyStoreInfo } from './Credentials.types';
 import { AuthCtx, getRequestContext } from './authenticate';
 
@@ -67,7 +67,7 @@ export async function revokePushKeyAsync(authCtx: AuthCtx, ids: string[]): Promi
 
     spinner.succeed(`Revoked ${name}`);
   } catch (error) {
-    log.error(error);
+    Log.error(error);
     spinner.fail(`Failed to revoke ${name}`);
     throw error;
   }

--- a/packages/eas-cli/src/credentials/ios/appstore/resolveCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/resolveCredentials.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import * as fs from 'fs-extra';
 import wrapAnsi from 'wrap-ansi';
 
-import log, { learnMore } from '../../../log';
+import Log, { learnMore } from '../../../log';
 import { promptAsync } from '../../../prompts';
 import * as Keychain from './keychain';
 
@@ -44,7 +44,7 @@ function getAppleIdFromEnvironmentOrOptions({
 }
 
 async function promptUsernameAsync(): Promise<string> {
-  log('\u203A Log in to your Apple Developer account to continue');
+  Log.log('\u203A Log in to your Apple Developer account to continue');
 
   // Get the email address that was last used and set it as
   // the default value for quicker authentication.
@@ -80,13 +80,13 @@ export async function promptPasswordAsync({
   const cachedPassword = await getCachedPasswordAsync({ username });
 
   if (cachedPassword) {
-    log(`\u203A Using password for ${username} from your local Keychain`);
-    log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
+    Log.log(`\u203A Using password for ${username} from your local Keychain`);
+    Log.log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
     return cachedPassword;
   }
 
   // https://docs.expo.io/distribution/security/#apple-developer-account-credentials
-  log(
+  Log.log(
     wrapAnsi(
       chalk.bold(
         `\u203A The password is only used to authenticate with Apple and never stored on EAS servers`
@@ -94,7 +94,7 @@ export async function promptPasswordAsync({
       process.stdout.columns || 80
     )
   );
-  log(`  ${learnMore('https://bit.ly/2VtGWhU')}`);
+  Log.log(`  ${learnMore('https://bit.ly/2VtGWhU')}`);
 
   const { password } = await promptAsync({
     type: 'password',
@@ -135,7 +135,7 @@ export async function deletePasswordAsync({
   const serviceName = getKeychainServiceName(username);
   const success = await Keychain.deletePasswordAsync({ username, serviceName });
   if (success) {
-    log('\u203A Removed Apple ID password from the native Keychain');
+    Log.log('\u203A Removed Apple ID password from the native Keychain');
   }
   return success;
 }
@@ -155,12 +155,12 @@ async function getCachedPasswordAsync({
 
 async function cachePasswordAsync({ username, password }: Auth.UserCredentials): Promise<boolean> {
   if (Keychain.EXPO_NO_KEYCHAIN) {
-    log('\u203A Skip storing Apple ID password in the local Keychain.');
+    Log.log('\u203A Skip storing Apple ID password in the local Keychain.');
     return false;
   }
 
-  log(`\u203A Saving Apple ID password to the local Keychain`);
-  log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
+  Log.log(`\u203A Saving Apple ID password to the local Keychain`);
+  Log.log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
   const serviceName = getKeychainServiceName(username);
   return Keychain.setPasswordAsync({ username, password, serviceName });
 }

--- a/packages/eas-cli/src/credentials/ios/credentials.ts
+++ b/packages/eas-cli/src/credentials/ios/credentials.ts
@@ -1,5 +1,5 @@
 import { AppleDevice } from '../../graphql/generated';
-import log from '../../log';
+import Log from '../../log';
 import { CredentialSchema } from '../utils/promptForCredentials';
 import {
   DistributionCertificate,
@@ -89,9 +89,9 @@ export const distributionCertificateSchema: CredentialSchema<DistributionCertifi
       const distCertSerialNumber = findP12CertSerialNumber(answers.certP12!, answers.certPassword!);
       return { ...answers, distCertSerialNumber } as DistributionCertificate;
     } catch (error) {
-      log.warn('Unable to access certificate serial number.');
-      log.warn('Make sure that certificate and password are correct.');
-      log.warn(error);
+      Log.warn('Unable to access certificate serial number.');
+      Log.warn('Make sure that certificate and password are correct.');
+      Log.warn(error);
     }
     return answers as DistributionCertificate;
   },

--- a/packages/eas-cli/src/credentials/ios/utils/__tests__/printCredentialsBeta-test.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/__tests__/printCredentialsBeta-test.ts
@@ -1,22 +1,15 @@
 import mockdate from 'mockdate';
 
+import Log from '../../../../log';
 import { IosAppCredentialsQuery } from '../../api/graphql/queries/IosAppCredentialsQuery';
 import { displayIosAppCredentials } from '../printCredentialsBeta';
-const mockLog = {
-  __esModule: true, // this property makes it work
-  default: jest.fn(toLog => toLog),
-};
-(mockLog.default as any).newLine = jest.fn();
-jest.mock('../../../../log', () => mockLog);
-jest.mock('chalk', () => {
-  return {
-    __esModule: true, // this property makes it work
-    default: { bold: jest.fn(log => log) },
-  };
-});
-jest.mock('../../api/graphql/queries/IosAppCredentialsQuery');
 
+jest.mock('../../../../log');
+jest.mock('chalk', () => ({ bold: jest.fn(log => log) }));
+
+jest.mock('../../api/graphql/queries/IosAppCredentialsQuery');
 mockdate.set(new Date('4/20/2021'));
+
 describe('print credentials', () => {
   it('prints the IosAppCredentials fragment', async () => {
     const testIosAppCredentialsData = await IosAppCredentialsQuery.withCommonFieldsByAppIdentifierIdAsync(
@@ -26,9 +19,9 @@ describe('print credentials', () => {
       }
     );
     displayIosAppCredentials(testIosAppCredentialsData);
-    const loggedSoFar = mockLog.default.mock.results
-      .map(mockCall => mockCall.value)
-      .reduce((acc, mockValue) => acc + mockValue);
+    const loggedSoFar = (Log.log as jest.Mock).mock.calls.reduce(
+      (acc, mockValue) => acc + mockValue
+    );
     expect(loggedSoFar).toMatchSnapshot();
   });
 });

--- a/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import { AppleDevice } from '../../../graphql/generated';
 import { APPLE_DEVICE_CLASS_LABELS } from '../../../graphql/types/credentials/AppleDevice';
-import log from '../../../log';
+import Log from '../../../log';
 import {
   AppLookupParams,
   IosAppCredentials,
@@ -20,7 +20,7 @@ export function displayProjectCredentials(
   const experienceName = `@${appLookupParams.accountName}/${appLookupParams.projectName}`;
   const bundleIdentifier = appLookupParams.bundleIdentifier;
   if (!appCredentials) {
-    log(
+    Log.log(
       chalk.bold(
         `No credentials configured for app ${experienceName} with bundle identifier ${bundleIdentifier}\n`
       )
@@ -28,10 +28,10 @@ export function displayProjectCredentials(
     return;
   }
 
-  log();
-  log(chalk.bold('Project Credentials Configuration:'));
+  Log.log();
+  Log.log(chalk.bold('Project Credentials Configuration:'));
   displayIosAppCredentials(appCredentials);
-  log();
+  Log.log();
 
   if (distCert) {
     displayIosUserCredentials(distCert);
@@ -43,54 +43,54 @@ export function displayProjectCredentials(
 }
 
 export async function displayAllIosCredentials(credentials: IosCredentials) {
-  log(chalk.bold('Available credentials for iOS apps'));
-  log.newLine();
+  Log.log(chalk.bold('Available credentials for iOS apps'));
+  Log.newLine();
 
-  log(chalk.bold('Application credentials'));
-  log.newLine();
+  Log.log(chalk.bold('Application credentials'));
+  Log.newLine();
   for (const cred of credentials.appCredentials) {
     displayIosAppCredentials(cred);
-    log();
+    Log.log();
   }
 
-  log(chalk.bold('User credentials\n'));
+  Log.log(chalk.bold('User credentials\n'));
   for (const cred of credentials.userCredentials) {
     displayIosUserCredentials(cred, credentials);
-    log.newLine();
+    Log.newLine();
   }
-  log.newLine();
+  Log.newLine();
 }
 
 export function displayIosAppCredentials(appCredentials: IosAppCredentials) {
-  log(
+  Log.log(
     `  Project: ${chalk.bold(appCredentials.experienceName)}, bundle identifier: ${
       appCredentials.bundleIdentifier
     }`
   );
   if (appCredentials.credentials.provisioningProfile) {
-    log(
+    Log.log(
       `    Provisioning profile (ID: ${chalk.green(
         appCredentials.credentials.provisioningProfileId || '---------'
       )})`
     );
   } else {
-    log('    Provisioning profile is missing. It will be generated during the next build');
+    Log.log('    Provisioning profile is missing. It will be generated during the next build');
   }
   if (appCredentials.credentials.devices && appCredentials.credentials.devices.length > 0) {
-    log(`    Provisioned devices:`);
+    Log.log(`    Provisioned devices:`);
     for (const device of appCredentials.credentials.devices) {
-      log(`    - ${formatDevice(device)}`);
+      Log.log(`    - ${formatDevice(device)}`);
     }
   }
   if (appCredentials.credentials.teamId || appCredentials.credentials.teamName) {
-    log(
+    Log.log(
       `    Apple Team ID: ${chalk.green(
         appCredentials.credentials.teamId || '---------'
       )},  Apple Team Name: ${chalk.green(appCredentials.credentials.teamName || '---------')}`
     );
   }
   if (appCredentials.credentials.pushP12 && appCredentials.credentials.pushPassword) {
-    log(
+    Log.log(
       `    (deprecated) Push Certificate (Push ID: ${chalk.green(
         appCredentials.credentials.pushId || '-----'
       )})`
@@ -130,17 +130,17 @@ export function displayIosUserCredentials(
   credentials?: IosCredentials
 ) {
   if (userCredentials.type === 'push-key') {
-    log(`  Push Notifications Key - Key ID: ${chalk.green(userCredentials.apnsKeyId)}`);
+    Log.log(`  Push Notifications Key - Key ID: ${chalk.green(userCredentials.apnsKeyId)}`);
   } else if (userCredentials.type === 'dist-cert') {
-    log(
+    Log.log(
       `  Distribution Certificate - Certificate ID: ${chalk.green(
         userCredentials.certId || '-----'
       )}`
     );
   } else {
-    log.warn(`  Unknown key type ${(userCredentials as any).type}`);
+    Log.warn(`  Unknown key type ${(userCredentials as any).type}`);
   }
-  log(
+  Log.log(
     `    Apple Team ID: ${chalk.green(
       userCredentials.teamId || '---------'
     )},  Apple Team Name: ${chalk.green(userCredentials.teamName || '---------')}`
@@ -156,6 +156,6 @@ export function displayIosUserCredentials(
       ),
     ].join(',\n      ');
     const usedByAppsText = usedByApps ? `used by\n      ${usedByApps}` : 'not used by any apps';
-    log(`    ${chalk.gray(usedByAppsText)}`);
+    Log.log(`    ${chalk.gray(usedByAppsText)}`);
   }
 }

--- a/packages/eas-cli/src/credentials/ios/utils/printCredentialsBeta.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/printCredentialsBeta.ts
@@ -6,7 +6,7 @@ import {
   IosAppBuildCredentialsFragment,
   IosDistributionType,
 } from '../../../graphql/generated';
-import log from '../../../log';
+import Log from '../../../log';
 import { fromNow } from '../../../utils/date';
 import { AppLookupParams } from '../api/GraphqlClient';
 
@@ -27,10 +27,10 @@ function prettyIosDistributionType(distributionType: IosDistributionType): strin
 
 export function displayEmptyIosCredentials(appLookupParams: AppLookupParams): void {
   const { projectName, bundleIdentifier } = appLookupParams;
-  log(chalk.bold(`iOS Credentials`));
-  log(`  Project: ${projectName}`);
-  log(`  Bundle Identifier: ${bundleIdentifier}`);
-  log(`  No credentials set up yet!`);
+  Log.log(chalk.bold(`iOS Credentials`));
+  Log.log(`  Project: ${projectName}`);
+  Log.log(`  Bundle Identifier: ${bundleIdentifier}`);
+  Log.log(`  No credentials set up yet!`);
 }
 
 /**
@@ -56,19 +56,19 @@ function sortBuildCredentialsByDistributionType(
 }
 
 export function displayIosAppCredentials(credentials: CommonIosAppCredentialsFragment): void {
-  log(chalk.bold(`iOS Credentials`));
-  log(`  Project: ${credentials.app.fullName}`);
-  log(`  Bundle Identifier: ${credentials.appleAppIdentifier.bundleIdentifier}`);
+  Log.log(chalk.bold(`iOS Credentials`));
+  Log.log(`  Project: ${credentials.app.fullName}`);
+  Log.log(`  Bundle Identifier: ${credentials.appleAppIdentifier.bundleIdentifier}`);
   const appleTeam = credentials.appleTeam;
   if (appleTeam) {
     const { appleTeamIdentifier, appleTeamName } = appleTeam;
-    log(`  Apple Team: ${appleTeamIdentifier} ${appleTeamName ? `(${appleTeamName})` : ''}`);
+    Log.log(`  Apple Team: ${appleTeamIdentifier} ${appleTeamName ? `(${appleTeamName})` : ''}`);
   }
-  log.newLine();
+  Log.newLine();
 
   if (credentials.iosAppBuildCredentialsArray.length === 0) {
-    log(`  Configuration: None setup yet`);
-    log.newLine();
+    Log.log(`  Configuration: None setup yet`);
+    Log.newLine();
     return;
   }
   const sortedIosAppBuildCredentialsArray = sortBuildCredentialsByDistributionType(
@@ -80,43 +80,47 @@ export function displayIosAppCredentials(credentials: CommonIosAppCredentialsFra
 }
 
 function displayIosAppBuildCredentials(buildCredentials: IosAppBuildCredentialsFragment): void {
-  log(
+  Log.log(
     chalk.bold(
       `  Configuration: ${prettyIosDistributionType(buildCredentials.iosDistributionType)}`
     )
   );
   const maybeDistCert = buildCredentials.distributionCertificate;
-  log(`  Distribution Certificate:`);
+  Log.log(`  Distribution Certificate:`);
   if (maybeDistCert) {
     const { serialNumber, updatedAt, validityNotAfter, appleTeam } = maybeDistCert;
-    log(`    Serial Number: ${serialNumber}`);
-    log(`    Expiration Date: ${dateformat(validityNotAfter, 'expiresHeaderFormat')}`);
+    Log.log(`    Serial Number: ${serialNumber}`);
+    Log.log(`    Expiration Date: ${dateformat(validityNotAfter, 'expiresHeaderFormat')}`);
     if (appleTeam) {
       const { appleTeamIdentifier, appleTeamName } = appleTeam;
-      log(`    Apple Team: ${appleTeamIdentifier} ${appleTeamName ? `(${appleTeamName})` : ''}`);
+      Log.log(
+        `    Apple Team: ${appleTeamIdentifier} ${appleTeamName ? `(${appleTeamName})` : ''}`
+      );
     }
-    log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
+    Log.log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
   } else {
-    log(`    None assigned yet`);
+    Log.log(`    None assigned yet`);
   }
-  log.newLine();
+  Log.newLine();
 
   const maybeProvProf = buildCredentials.provisioningProfile;
-  log(`  Provisioning Profile:`);
+  Log.log(`  Provisioning Profile:`);
   if (maybeProvProf) {
     const { expiration, updatedAt, status, developerPortalIdentifier, appleTeam } = maybeProvProf;
     if (developerPortalIdentifier) {
-      log(`    Developer Portal ID: ${developerPortalIdentifier}`);
+      Log.log(`    Developer Portal ID: ${developerPortalIdentifier}`);
     }
-    log(`    Status: ${status}`);
-    log(`    Expiration Date: ${dateformat(expiration, 'expiresHeaderFormat')}`);
+    Log.log(`    Status: ${status}`);
+    Log.log(`    Expiration Date: ${dateformat(expiration, 'expiresHeaderFormat')}`);
     if (appleTeam) {
       const { appleTeamIdentifier, appleTeamName } = appleTeam;
-      log(`    Apple Team: ${appleTeamIdentifier} ${appleTeamName ? `(${appleTeamName})` : ''}`);
+      Log.log(
+        `    Apple Team: ${appleTeamIdentifier} ${appleTeamName ? `(${appleTeamName})` : ''}`
+      );
     }
-    log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
+    Log.log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
   } else {
-    log(`    None assigned yet`);
+    Log.log(`    None assigned yet`);
   }
-  log.newLine();
+  Log.newLine();
 }

--- a/packages/eas-cli/src/credentials/manager/HelperActions.ts
+++ b/packages/eas-cli/src/credentials/manager/HelperActions.ts
@@ -1,13 +1,13 @@
-import log from '../../log';
+import Log from '../../log';
 import { pressAnyKeyToContinueAsync } from '../../prompts';
 import { Action, CredentialsManager } from '../CredentialsManager';
 import { Context } from '../context';
 
 export class PressAnyKeyToContinue implements Action {
   public async runAsync(manager: CredentialsManager, context: Context): Promise<void> {
-    log('Press any key to continue...');
+    Log.log('Press any key to continue...');
     await pressAnyKeyToContinueAsync();
-    log.newLine();
-    log.newLine();
+    Log.newLine();
+    Log.newLine();
   }
 }

--- a/packages/eas-cli/src/credentials/manager/ManageAndroidApp.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroidApp.ts
@@ -1,6 +1,6 @@
 import isEmpty from 'lodash/isEmpty';
 
-import log from '../../log';
+import Log from '../../log';
 import { promptAsync } from '../../prompts';
 import { Action, CredentialsManager } from '../CredentialsManager';
 import { DownloadKeystore } from '../android/actions/DownloadKeystore';
@@ -32,9 +32,9 @@ export class ManageAndroidApp implements Action {
         const credentials = await ctx.android.fetchCredentialsAsync(this.projectFullName);
 
         if (isEmpty(credentials.keystore) && isEmpty(credentials.pushCredentials)) {
-          log(`No credentials available for ${this.projectFullName}.\n`);
+          Log.log(`No credentials available for ${this.projectFullName}.\n`);
         } else {
-          log.newLine();
+          Log.newLine();
           await printAndroidAppCredentials(credentials);
         }
 
@@ -71,11 +71,11 @@ export class ManageAndroidApp implements Action {
         try {
           await manager.runActionAsync(this.getAction(ctx, action));
         } catch (err) {
-          log.error(err);
+          Log.error(err);
         }
         await manager.runActionAsync(new PressAnyKeyToContinue());
       } catch (err) {
-        log.error(err);
+        Log.error(err);
         await manager.runActionAsync(new PressAnyKeyToContinue());
       }
     }

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -1,6 +1,6 @@
 import { DistributionType } from '@expo/eas-json';
 
-import log from '../../log';
+import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { ensureActorHasUsername } from '../../user/actions';
@@ -95,11 +95,11 @@ export class ManageIos implements Action {
         try {
           await manager.runActionAsync(this.getAction(manager, ctx, accountName, action));
         } catch (err) {
-          log.error(err);
+          Log.error(err);
         }
         await manager.runActionAsync(new PressAnyKeyToContinue());
       } catch (err) {
-        log.error(err);
+        Log.error(err);
         await manager.runActionAsync(new PressAnyKeyToContinue());
       }
     }

--- a/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
@@ -1,4 +1,4 @@
-import log from '../../log';
+import Log from '../../log';
 import { getProjectAccountName, getProjectConfigDescription } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { findAccountByName } from '../../user/Account';
@@ -69,11 +69,11 @@ export class ManageIosBeta implements Action {
         try {
           await manager.runActionAsync(this.getAction(ctx, accountName, action));
         } catch (err) {
-          log.error(err);
+          Log.error(err);
         }
         await manager.runActionAsync(new PressAnyKeyToContinue());
       } catch (err) {
-        log.error(err);
+        Log.error(err);
         await manager.runActionAsync(new PressAnyKeyToContinue());
       } finally {
         // TODO remove finally block before committing!

--- a/packages/eas-cli/src/credentials/manager/SelectAndroidApp.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectAndroidApp.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log from '../../log';
+import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
 import { confirmAsync, promptAsync } from '../../prompts';
 import { Action, CredentialsManager } from '../CredentialsManager';
@@ -52,7 +52,7 @@ export class SelectAndroidApp implements Action {
         }
         await manager.runActionAsync(new ManageAndroidApp(projectFullName));
       } catch (err) {
-        log.error(err);
+        Log.error(err);
       }
     }
   }

--- a/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
+++ b/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
@@ -3,7 +3,7 @@ import once from 'lodash/once';
 import path from 'path';
 import untildify from 'untildify';
 
-import log from '../../log';
+import Log from '../../log';
 import { Question as PromptQuestion, confirmAsync, promptAsync } from '../../prompts';
 
 export type Question = {
@@ -23,7 +23,7 @@ export type CredentialSchema<T> = {
 };
 
 const EXPERT_PROMPT = once(() =>
-  log.warn(`
+  Log.warn(`
 In this mode, we won't be able to make sure that your credentials are valid.
 Please double check that you're uploading valid files for your app otherwise you may encounter strange errors!
 When building for IOS make sure you've created your App ID on the Apple Developer Portal, that your App ID

--- a/packages/eas-cli/src/devices/actions/create/action.ts
+++ b/packages/eas-cli/src/devices/actions/create/action.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 
 import { AppleTeam } from '../../../graphql/generated';
-import log from '../../../log';
+import Log from '../../../log';
 import { promptAsync } from '../../../prompts';
 import { Account } from '../../../user/Account';
 import { runInputMethodAsync } from './inputMethod';
@@ -26,7 +26,7 @@ export default class DeviceCreateAction {
     } else if (method === RegistrationMethod.INPUT) {
       await runInputMethodAsync(this.account.id, this.appleTeam);
     } else if (method === RegistrationMethod.EXIT) {
-      log('Bye!');
+      Log.log('Bye!');
       process.exit(0);
     }
   }

--- a/packages/eas-cli/src/devices/actions/create/inputMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/inputMethod.ts
@@ -4,7 +4,7 @@ import ora from 'ora';
 
 import { AppleDeviceMutation } from '../../../credentials/ios/api/graphql/mutations/AppleDeviceMutation';
 import { AppleDeviceClass, AppleTeam } from '../../../graphql/generated';
-import log from '../../../log';
+import Log from '../../../log';
 import { confirmAsync, promptAsync } from '../../../prompts';
 import { isValidUDID, normalizeUDID } from '../../udids';
 
@@ -23,14 +23,14 @@ export async function runInputMethodAsync(
   accountId: string,
   appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName' | 'id'>
 ): Promise<void> {
-  log.newLine();
-  log(chalk.yellow('This is an advanced option. Use at your own risk.'));
-  log.newLine();
+  Log.newLine();
+  Log.log(chalk.yellow('This is an advanced option. Use at your own risk.'));
+  Log.newLine();
 
   let registerNextDevice = true;
   while (registerNextDevice) {
     await collectDataAndRegisterDeviceAsync({ accountId, appleTeam });
-    log.newLine();
+    Log.newLine();
     registerNextDevice = await confirmAsync({
       message: 'Do you want to register another device?',
     });
@@ -77,21 +77,21 @@ async function collectDeviceDataAsync(
     deviceClass,
   };
 
-  log.newLine();
-  log(
+  Log.newLine();
+  Log.log(
     `We are going to register the following device in our database.
 This will ${chalk.bold('not')} register the device on the Apple Developer Portal yet.`
   );
-  log.newLine();
+  Log.newLine();
   printDeviceDataSummary(deviceData, appleTeam);
-  log.newLine();
+  Log.newLine();
 
   const registrationConfirmed = await confirmAsync({
     message: 'Is this what you want to register?',
   });
   if (!registrationConfirmed) {
-    log('No worries, just try again.');
-    log.newLine();
+    Log.log('No worries, just try again.');
+    Log.newLine();
     return await collectDeviceDataAsync(appleTeam, deviceData);
   } else {
     return deviceData;
@@ -166,5 +166,5 @@ function printDeviceDataSummary(
     ['Device Name', name ?? '(empty)'],
     ['Device Class', deviceClass ? DEVICE_CLASS_DISPLAY_NAMES[deviceClass] : '(unknown)']
   );
-  log(deviceSummary.toString());
+  Log.log(deviceSummary.toString());
 }

--- a/packages/eas-cli/src/devices/actions/create/registrationUrlMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/registrationUrlMethod.ts
@@ -6,20 +6,20 @@ import { URL } from 'url';
 import { getExpoWebsiteBaseUrl } from '../../../api';
 import { AppleDeviceRegistrationRequestMutation } from '../../../credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation';
 import { AppleTeam } from '../../../graphql/generated';
-import log from '../../../log';
+import Log from '../../../log';
 
 export async function runRegistrationUrlMethodAsync(
   accountId: string,
   appleTeam: Pick<AppleTeam, 'id'>
 ): Promise<void> {
   const registrationURL = await generateDeviceRegistrationURLAsync(accountId, appleTeam);
-  log.newLine();
+  Log.newLine();
   qrcodeTerminal.generate(registrationURL, code => console.log(`${indentString(code, 2)}\n`));
-  log(
+  Log.log(
     'Open the following link on your iOS devices (or scan the QR code) and follow the instructions to install the development profile:'
   );
-  log.newLine();
-  log(chalk.green(`${registrationURL}`));
+  Log.newLine();
+  Log.log(chalk.green(`${registrationURL}`));
 }
 
 async function generateDeviceRegistrationURLAsync(

--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { AppleTeamMutation } from '../credentials/ios/api/graphql/mutations/AppleTeamMutation';
 import { AppleTeamQuery } from '../credentials/ios/api/graphql/queries/AppleTeamQuery';
 import { AppleTeamFragment } from '../graphql/generated';
-import log from '../log';
+import Log from '../log';
 import { getProjectAccountNameAsync } from '../project/projectUtils';
 import { Choice, confirmAsync, promptAsync } from '../prompts';
 import { Account, findAccountByName } from '../user/Account';
@@ -25,8 +25,8 @@ export default class DeviceManager {
   constructor(private ctx: DeviceManagerContext) {}
 
   public async createAsync(): Promise<void> {
-    log(chalk.green(CREATE_COMMAND_DESCRIPTION));
-    log.addNewLineIfNone();
+    Log.log(chalk.green(CREATE_COMMAND_DESCRIPTION));
+    Log.addNewLineIfNone();
 
     const account = await this.resolveAccountAsync();
     const { team } = await this.ctx.appStore.ensureAuthenticatedAsync();
@@ -63,7 +63,7 @@ export class AccountResolver {
     const projectAccountName = await getProjectAccountNameAsync(this.projectDir);
     const projectAccount = findAccountByName(this.user.accounts, projectAccountName);
     if (!projectAccount) {
-      log.warn(
+      Log.warn(
         `Your account (${getActorDisplayName(this.user)}) doesn't have access to the ${chalk.bold(
           projectAccountName
         )} account`

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -6,79 +6,76 @@ import terminalLink from 'terminal-link';
 
 type Color = (...text: string[]) => string;
 
-const IS_DEBUG = boolish('EXPO_DEBUG', false);
+class Log {
+  public static readonly isDebug = boolish('EXPO_DEBUG', false);
 
-let _isLastLineNewLine = false;
-function _updateIsLastLineNewLine(args: any[]) {
-  if (args.length === 0) {
-    _isLastLineNewLine = true;
-  } else {
-    const lastArg = args[args.length - 1];
-    if (typeof lastArg === 'string' && (lastArg === '' || lastArg.match(/[\r\n]$/))) {
-      _isLastLineNewLine = true;
+  public static log(...args: any[]) {
+    this.consoleLog(...args);
+  }
+
+  public static newLine() {
+    this.consoleLog();
+  }
+
+  public static addNewLineIfNone() {
+    if (!this.isLastLineNewLine) {
+      this.newLine();
+    }
+  }
+
+  public static error(...args: any[]) {
+    this.consoleError(...this.withTextColor(args, chalk.red));
+  }
+
+  public static warn(...args: any[]) {
+    this.consoleWarn(...this.withTextColor(args, chalk.yellow));
+  }
+
+  public static gray(...args: any[]) {
+    this.consoleLog(...this.withTextColor(args, chalk.gray));
+  }
+
+  public static succeed(message: string) {
+    ora().succeed(message);
+  }
+
+  public static withTick(...args: any[]) {
+    this.consoleLog(chalk.green(figures.tick), ...args);
+  }
+
+  private static consoleLog(...args: any[]) {
+    this.updateIsLastLineNewLine(args);
+    console.log(...args);
+  }
+
+  private static consoleWarn(...args: any[]) {
+    this.updateIsLastLineNewLine(args);
+    console.warn(...args);
+  }
+
+  private static consoleError(...args: any[]) {
+    this.updateIsLastLineNewLine(args);
+    console.error(...args);
+  }
+
+  private static withTextColor(args: any[], chalkColor: Color) {
+    return args.map(arg => chalkColor(arg));
+  }
+
+  private static isLastLineNewLine = false;
+  private static updateIsLastLineNewLine(args: any[]) {
+    if (args.length === 0) {
+      this.isLastLineNewLine = true;
     } else {
-      _isLastLineNewLine = false;
+      const lastArg = args[args.length - 1];
+      if (typeof lastArg === 'string' && (lastArg === '' || lastArg.match(/[\r\n]$/))) {
+        this.isLastLineNewLine = true;
+      } else {
+        this.isLastLineNewLine = false;
+      }
     }
   }
 }
-
-function consoleLog(...args: any[]) {
-  _updateIsLastLineNewLine(args);
-
-  console.log(...args);
-}
-
-function consoleWarn(...args: any[]) {
-  _updateIsLastLineNewLine(args);
-
-  console.warn(...args);
-}
-
-function consoleError(...args: any[]) {
-  _updateIsLastLineNewLine(args);
-
-  console.error(...args);
-}
-
-function withTextColor(args: any[], chalkColor: Color) {
-  return args.map(arg => chalkColor(arg));
-}
-
-function log(...args: any[]) {
-  consoleLog(...args);
-}
-
-log.newLine = function newLine() {
-  consoleLog();
-};
-
-log.addNewLineIfNone = function addNewLineIfNone() {
-  if (!_isLastLineNewLine) {
-    log.newLine();
-  }
-};
-
-log.error = function error(...args: any[]) {
-  consoleError(...withTextColor(args, chalk.red));
-};
-
-log.warn = function warn(...args: any[]) {
-  consoleWarn(...withTextColor(args, chalk.yellow));
-};
-
-log.gray = function (...args: any[]) {
-  consoleLog(...withTextColor(args, chalk.gray));
-};
-
-log.succeed = function (message: string) {
-  ora().succeed(message);
-};
-
-log.withTick = function (...args: any[]) {
-  consoleLog(chalk.green(figures.tick), ...args);
-};
-
-log.isDebug = IS_DEBUG;
 
 /**
  * Format links as dim with an underline.
@@ -94,4 +91,4 @@ export function learnMore(url: string, learnMoreMessage?: string): string {
   return chalk.dim(`${learnMoreMessage ?? 'Learn more'}: ${chalk.underline(url)}`);
 }
 
-export default log;
+export default Log;

--- a/packages/eas-cli/src/project/isEasEnabledForProject.ts
+++ b/packages/eas-cli/src/project/isEasEnabledForProject.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 
 import { apiClient } from '../api';
-import log from '../log';
+import Log from '../log';
 
 /**
  * Checks if the project is allowed for using EAS services.
@@ -24,7 +24,7 @@ export async function isEasEnabledForProjectAsync(projectId: string): Promise<bo
 }
 
 export function warnEasUnavailable() {
-  log.warn(
+  Log.warn(
     `Your account doesn't have access to Expo Application Services (EAS) features. Enroll in EAS to give it a try: ${chalk.underline(
       'https://expo.io/eas'
     )}`

--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -1,6 +1,6 @@
 import ora from 'ora';
 
-import log from '../log';
+import Log from '../log';
 import { sleep } from '../utils/promise';
 import SubmissionService, { DEFAULT_CHECK_INTERVAL_MS } from './SubmissionService';
 import { Submission, SubmissionConfig, SubmissionStatus } from './SubmissionService.types';
@@ -22,7 +22,7 @@ abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
     submissionConfig: SubmissionConfig,
     verbose: boolean = false
   ) {
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     const scheduleSpinner = ora('Scheduling submission').start();
     let submissionId: string;
     try {

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
@@ -1,7 +1,7 @@
 import { getConfig } from '@expo/config';
 import { Result, result } from '@expo/results';
 
-import log from '../../log';
+import Log from '../../log';
 import { ArchiveSource, ArchiveTypeSource, ArchiveTypeSourceType } from '../archiveSource';
 import { resolveArchiveFileSource } from '../commons';
 import {
@@ -31,7 +31,7 @@ class AndroidSubmitCommand {
   constructor(private ctx: AndroidSubmissionContext) {}
 
   async runAsync(): Promise<void> {
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     const submissionOptions = this.getAndroidSubmissionOptions();
     const submitter = new AndroidSubmitter(this.ctx, submissionOptions);
     await submitter.submitAsync();
@@ -53,7 +53,7 @@ class AndroidSubmitCommand {
     ].filter(r => !r.ok);
     if (errored.length > 0) {
       const message = errored.map(err => err.reason?.message).join('\n');
-      log.error(message);
+      Log.error(message);
       throw new Error('Failed to submit the app');
     }
 

--- a/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
-import log, { learnMore } from '../../log';
+import Log, { learnMore } from '../../log';
 import { promptAsync } from '../../prompts';
 import { isExistingFile } from '../utils/files';
 
@@ -38,7 +38,7 @@ export async function getServiceAccountAsync(source: ServiceAccountSource): Prom
 
 async function handlePathSourceAsync(source: ServiceAccountPathSource): Promise<string> {
   if (!(await isExistingFile(source.path))) {
-    log.warn(`File ${source.path} doesn't exist.`);
+    Log.warn(`File ${source.path} doesn't exist.`);
     return await getServiceAccountAsync({ sourceType: ServiceAccountSourceType.prompt });
   }
   return source.path;
@@ -53,7 +53,7 @@ async function handlePromptSourceAsync(_source: ServiceAccountPromptSource): Pro
 }
 
 async function askForServiceAccountPathAsync(): Promise<string> {
-  log(
+  Log.log(
     `${chalk.bold(
       'A Google Service Account JSON key is required to upload your app to Google Play Store'
     )}.\n` +

--- a/packages/eas-cli/src/submissions/archiveSource/ArchiveFileSource.ts
+++ b/packages/eas-cli/src/submissions/archiveSource/ArchiveFileSource.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { URL, parse as parseUrl } from 'url';
 import * as uuid from 'uuid';
 
-import log from '../../log';
+import Log from '../../log';
 import { promptAsync } from '../../prompts';
 import { SubmissionPlatform } from '../types';
 import { getBuildArtifactUrlByIdAsync, getLatestBuildArtifactUrlAsync } from '../utils/builds';
@@ -89,7 +89,7 @@ async function getArchiveLocationForUrlAsync(url: string): Promise<string> {
   if (!pathIsTar(url)) {
     return url;
   } else {
-    log('Downloading your app archive');
+    Log.log('Downloading your app archive');
     const localPath = await downloadAppArchiveAsync(url);
     return await getArchiveLocationForPathAsync(localPath);
   }
@@ -98,7 +98,7 @@ async function getArchiveLocationForUrlAsync(url: string): Promise<string> {
 async function getArchiveLocationForPathAsync(path: string): Promise<string> {
   const resolvedPath = await extractLocalArchiveAsync(path);
 
-  log('Uploading your app archive to the Expo Submission Service');
+  Log.log('Uploading your app archive to the Expo Submission Service');
   return await uploadAppArchiveAsync(resolvedPath);
 }
 
@@ -111,7 +111,7 @@ async function handleLatestSourceAsync(source: ArchiveFileLatestSource): Promise
     const artifactUrl = await getLatestBuildArtifactUrlAsync(source.platform, source.projectId);
 
     if (!artifactUrl) {
-      log.error(
+      Log.error(
         chalk.bold(
           "Couldn't find any builds for this project on EAS servers. It looks like you haven't run 'eas build' yet."
         )
@@ -124,14 +124,14 @@ async function handleLatestSourceAsync(source: ArchiveFileLatestSource): Promise
 
     return artifactUrl;
   } catch (err) {
-    log.error(err);
+    Log.error(err);
     throw err;
   }
 }
 
 async function handlePathSourceAsync(source: ArchiveFilePathSource): Promise<string> {
   if (!(await isExistingFile(source.path))) {
-    log.error(chalk.bold(`${source.path} doesn't exist`));
+    Log.error(chalk.bold(`${source.path} doesn't exist`));
     return getArchiveFileLocationAsync({
       ...source,
       sourceType: ArchiveFileSourceType.prompt,
@@ -144,8 +144,8 @@ async function handleBuildIdSourceAsync(source: ArchiveFileBuildIdSource): Promi
   try {
     return await getBuildArtifactUrlByIdAsync(source.platform, source.id);
   } catch (err) {
-    log.error(chalk.bold(`Couldn't find build for id ${source.id}`));
-    log.error(err);
+    Log.error(chalk.bold(`Couldn't find build for id ${source.id}`));
+    Log.error(err);
     return getArchiveFileLocationAsync({
       ...source,
       sourceType: ArchiveFileSourceType.prompt,

--- a/packages/eas-cli/src/submissions/archiveSource/ArchiveTypeSource.ts
+++ b/packages/eas-cli/src/submissions/archiveSource/ArchiveTypeSource.ts
@@ -1,4 +1,4 @@
-import log from '../../log';
+import Log from '../../log';
 import { promptAsync } from '../../prompts';
 import { AndroidArchiveType, ArchiveType, IosArchiveType, SubmissionPlatform } from '../types';
 
@@ -59,7 +59,7 @@ async function handleInferSourceAsync(
   if (inferredArchiveType) {
     return inferredArchiveType;
   } else {
-    log.warn("We couldn't auto detect the archive type");
+    Log.warn("We couldn't auto detect the archive type");
     return getArchiveTypeAsync(platform, { sourceType: ArchiveTypeSourceType.prompt }, location);
   }
 }
@@ -74,7 +74,7 @@ async function handleParameterSourceAsync(
     if (source.archiveType === inferredArchiveType) {
       return source.archiveType;
     } else {
-      log.warn(
+      Log.warn(
         `The archive seems to be .${inferredArchiveType} and you passed: --type ${source.archiveType}`
       );
       return getArchiveTypeAsync(platform, { sourceType: ArchiveTypeSourceType.prompt }, location);

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -8,7 +8,7 @@ import {
   ensureAppExistsAsync,
   ensureBundleIdExistsWithNameAsync,
 } from '../../credentials/ios/appstore/ensureAppExists';
-import log from '../../log';
+import Log from '../../log';
 import { getAppIdentifierAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { IosSubmissionContext } from '../types';
@@ -81,7 +81,7 @@ async function createAppStoreConnectAppAsync(options: CreateAppOptions): Promise
   });
   const requestCtx = getRequestContext(authCtx);
 
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
 
   if (await isProvisioningAvailableAsync(requestCtx)) {
     await ensureBundleIdExistsWithNameAsync(authCtx, {
@@ -89,7 +89,7 @@ async function createAppStoreConnectAppAsync(options: CreateAppOptions): Promise
       bundleIdentifier: bundleId,
     });
   } else {
-    log.warn(
+    Log.warn(
       `Provisioning is not available for user "${authCtx.appleId}", skipping bundle identifier check.`
     );
   }
@@ -115,13 +115,13 @@ async function createAppStoreConnectAppAsync(options: CreateAppOptions): Promise
       // UnexpectedAppleResponse: The provided entity includes an attribute with a value that has already been used on a different account. - The App Name you entered is already being used. If you have trademark rights to
       // this name and would like it released for your use, submit a claim.
     ) {
-      log.addNewLineIfNone();
-      log.warn(
+      Log.addNewLineIfNone();
+      Log.warn(
         `Change the name in your app config, or use a custom name with the ${chalk.bold(
           '--app-name'
         )} flag`
       );
-      log.newLine();
+      Log.newLine();
     }
     throw error;
   }

--- a/packages/eas-cli/src/submissions/ios/AppSpecificPasswordSource.ts
+++ b/packages/eas-cli/src/submissions/ios/AppSpecificPasswordSource.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import wrapAnsi from 'wrap-ansi';
 
-import log, { learnMore } from '../../log';
+import Log, { learnMore } from '../../log';
 import { promptAsync } from '../../prompts';
 
 export enum AppSpecificPasswordSourceType {
@@ -30,8 +30,8 @@ export async function getAppSpecificPasswordAsync(source: AppSpecificPasswordSou
   if (source.sourceType === AppSpecificPasswordSourceType.userDefined) {
     return source.appSpecificPassword;
   } else if (source.sourceType === AppSpecificPasswordSourceType.prompt) {
-    log.addNewLineIfNone();
-    log(
+    Log.addNewLineIfNone();
+    Log.log(
       wrapAnsi(
         `Please enter your Apple app-specific password. You can also provide it by using ${chalk.italic(
           'EXPO_APPLE_APP_SPECIFIC_PASSWORD'
@@ -39,7 +39,7 @@ export async function getAppSpecificPasswordAsync(source: AppSpecificPasswordSou
         process.stdout.columns || 80
       )
     );
-    log(learnMore('https://expo.fyi/apple-app-specific-password'));
+    Log.log(learnMore('https://expo.fyi/apple-app-specific-password'));
 
     const { appSpecificPassword } = await promptAsync({
       name: 'appSpecificPassword',

--- a/packages/eas-cli/src/submissions/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitCommand.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import getenv from 'getenv';
 import wrapAnsi from 'wrap-ansi';
 
-import log, { learnMore } from '../../log';
+import Log, { learnMore } from '../../log';
 import { promptAsync } from '../../prompts';
 import UserSettings from '../../user/UserSettings';
 import { ArchiveSource, ArchiveTypeSourceType } from '../archiveSource';
@@ -32,7 +32,7 @@ class IosSubmitCommand {
   constructor(private ctx: IosSubmissionContext) {}
 
   async runAsync(): Promise<void> {
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     const options = await this.resolveSubmissionOptionsAsync();
     const submitter = new IosSubmitter(this.ctx, options);
     await submitter.submitAsync();
@@ -45,7 +45,7 @@ class IosSubmitCommand {
     const errored = [archiveSource, appSpecificPasswordSource].filter(r => !r.ok);
     if (errored.length > 0) {
       const message = errored.map(err => err.reason?.message).join('\n');
-      log.error(message);
+      Log.error(message);
       throw new Error('Failed to submit the app');
     }
 
@@ -101,7 +101,7 @@ class IosSubmitCommand {
       };
     }
 
-    log(
+    Log.log(
       wrapAnsi(
         chalk.italic(
           'Ensuring your app exists on App Store Connect. ' +
@@ -112,7 +112,7 @@ class IosSubmitCommand {
         process.stdout.columns || 80
       )
     );
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     return await ensureAppStoreConnectAppExistsAsync(this.ctx);
   }
 

--- a/packages/eas-cli/src/submissions/ios/utils/language.ts
+++ b/packages/eas-cli/src/submissions/ios/utils/language.ts
@@ -1,4 +1,4 @@
-import log from '../../../log';
+import Log from '../../../log';
 
 type Language = {
   locale: string;
@@ -27,7 +27,7 @@ export function sanitizeLanguage(
 
   const foundLang = findLanguage(lang);
   if (!foundLang) {
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     throw new Error(
       `You must specify a supported language. Supported language codes are:\n${languageListToString()}`
     );

--- a/packages/eas-cli/src/submissions/utils/errors.ts
+++ b/packages/eas-cli/src/submissions/utils/errors.ts
@@ -1,4 +1,4 @@
-import log, { learnMore } from '../../log';
+import Log, { learnMore } from '../../log';
 import { SubmissionError } from '../SubmissionService.types';
 
 enum SubmissionErrorCode {
@@ -52,13 +52,13 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
 export function printSubmissionError(error: SubmissionError): boolean {
   if ((Object.values(SubmissionErrorCode) as string[]).includes(error.errorCode)) {
     const errorCode = error.errorCode as SubmissionErrorCode;
-    log.addNewLineIfNone();
-    log.error(SubmissionErrorMessages[errorCode]);
+    Log.addNewLineIfNone();
+    Log.error(SubmissionErrorMessages[errorCode]);
     return [SubmissionErrorCode.ANDROID_UNKNOWN_ERROR, SubmissionErrorCode.IOS_UNKNOWN_ERROR].some(
       code => code === errorCode
     );
   } else {
-    log(error.message);
+    Log.log(error.message);
     return true;
   }
 }

--- a/packages/eas-cli/src/submissions/utils/logs.ts
+++ b/packages/eas-cli/src/submissions/utils/logs.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import got from 'got';
 
-import log from '../../log';
+import { default as LogModule } from '../../log';
 import { Submission, SubmissionStatus } from '../SubmissionService.types';
 import { printSubmissionError } from './errors';
 
@@ -25,16 +25,16 @@ async function downloadAndPrintSubmissionLogs(submission: Submission): Promise<v
   }
   const { body: data } = await got.get(submission.submissionInfo.logsUrl);
   const logs = parseLogs(data);
-  log.addNewLineIfNone();
+  LogModule.addNewLineIfNone();
   const prefix = chalk.blueBright('[logs] ');
   for (const { level, msg } of logs) {
     const msgWithPrefix = `${prefix}${msg}`;
     if (level === 'error') {
-      log.error(msgWithPrefix);
+      LogModule.error(msgWithPrefix);
     } else if (level === 'warn') {
-      log.warn(msgWithPrefix);
+      LogModule.warn(msgWithPrefix);
     } else {
-      log(msgWithPrefix);
+      LogModule.log(msgWithPrefix);
     }
   }
 }

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log from '../../log';
+import Log from '../../log';
 
 export function printSummary<T>(
   summary: T,
@@ -12,13 +12,13 @@ export function printSummary<T>(
   const tableFormat = (name: string, msg: string) =>
     `${chalk.bold.cyan(pad(`${name}:`, padWidth + 1))} ${msg}`;
 
-  log.newLine();
+  Log.newLine();
   for (const [key, value] of Object.entries(summary)) {
     const displayKey = keyMap[key as keyof T];
     const displayValue = valueRemap[key as keyof T]?.(value) ?? value;
-    log(tableFormat(displayKey, displayValue));
+    Log.log(tableFormat(displayKey, displayValue));
   }
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
 }
 
 function pad(str: string, width: number): string {

--- a/packages/eas-cli/src/user/__tests__/otp-test.ts
+++ b/packages/eas-cli/src/user/__tests__/otp-test.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '../../api';
+import Log from '../../log';
 import { promptAsync, selectAsync } from '../../prompts';
 import { loginAsync } from '../User';
 import { UserSecondFactorDeviceMethod, retryUsernamePasswordAuthWithOTPAsync } from '../otp';
@@ -8,13 +9,7 @@ jest.mock('../../api');
 jest.mock('../User', () => ({
   loginAsync: jest.fn(),
 }));
-
-const logFn = jest.fn();
-const mockLog = {
-  __esModule: true, // this property makes it work
-  default: logFn,
-};
-jest.mock('../../log', () => mockLog);
+jest.mock('../../log');
 
 beforeEach(() => {
   (promptAsync as jest.Mock).mockReset();
@@ -28,8 +23,7 @@ beforeEach(() => {
   });
 
   (loginAsync as jest.Mock).mockReset();
-
-  logFn.mockReset();
+  (Log.log as jest.Mock).mockReset();
 });
 
 describe(retryUsernamePasswordAuthWithOTPAsync, () => {
@@ -52,7 +46,7 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
       smsAutomaticallySent: true,
     });
 
-    expect(logFn).toHaveBeenCalledWith(
+    expect(Log.log).toHaveBeenCalledWith(
       'One-time password was sent to the phone number ending in testphone.'
     );
 
@@ -78,7 +72,7 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
       smsAutomaticallySent: false,
     });
 
-    expect(logFn).toHaveBeenCalledWith('One-time password from authenticator required.');
+    expect(Log.log).toHaveBeenCalledWith('One-time password from authenticator required.');
     expect(loginAsync as jest.Mock).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/eas-cli/src/user/actions.ts
+++ b/packages/eas-cli/src/user/actions.ts
@@ -1,5 +1,5 @@
 import ApiV2Error from '../ApiV2Error';
-import log from '../log';
+import Log from '../log';
 import { promptAsync } from '../prompts';
 import { Actor, getUserAsync, loginAsync } from './User';
 import { retryUsernamePasswordAuthWithOTPAsync } from './otp';
@@ -41,9 +41,9 @@ export async function ensureLoggedInAsync(): Promise<Actor> {
     user = await getUserAsync();
   } catch (_) {}
   if (!user) {
-    log.warn('An Expo user account is required to proceed.');
-    log.newLine();
-    log('Log in to EAS');
+    Log.warn('An Expo user account is required to proceed.');
+    Log.newLine();
+    Log.log('Log in to EAS');
     await showLoginPromptAsync(); // TODO: login or register
     user = await getUserAsync();
     if (!user) {

--- a/packages/eas-cli/src/user/otp.ts
+++ b/packages/eas-cli/src/user/otp.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 
 import { apiClient } from '../api';
-import log from '../log';
+import Log from '../log';
 import { promptAsync, selectAsync } from '../prompts';
 import { loginAsync } from './User';
 
@@ -139,14 +139,14 @@ export async function retryUsernamePasswordAuthWithOTPAsync(
 
   if (smsAutomaticallySent) {
     assert(primaryDevice, 'OTP should only automatically be sent when there is a primary device');
-    log(
+    Log.log(
       `One-time password was sent to the phone number ending in ${primaryDevice.sms_phone_number}.`
     );
     otp = await promptForOTPAsync('menu');
   }
 
   if (primaryDevice?.method === UserSecondFactorDeviceMethod.AUTHENTICATOR) {
-    log('One-time password from authenticator required.');
+    Log.log('One-time password from authenticator required.');
     otp = await promptForOTPAsync('menu');
   }
 

--- a/packages/eas-cli/src/utils/files.ts
+++ b/packages/eas-cli/src/utils/files.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-import log from '../log';
+import Log from '../log';
 
 function getRenamedFilename(filename: string, num: number): string {
   const ext = path.extname(filename);
@@ -17,7 +17,7 @@ export async function maybeRenameExistingFileAsync(projectDir: string, filename:
     while (await fs.pathExists(path.resolve(projectDir, getRenamedFilename(filename, num)))) {
       num++;
     }
-    log(
+    Log.log(
       `\nA file already exists at "${desiredFilePath}"\n  Renaming the existing file to ${getRenamedFilename(
         filename,
         num


### PR DESCRIPTION
# Why

Mocking `log` and verifying results is a common way to unit test a CLI. Until this PR, the only way to mock the `log` module was to do the following due to the way it was set up (custom properties on a function instance, which was copied from expo-cli):
```typescript
const mockLog = {	
  __esModule: true, // this property makes it work	
  default: jest.fn(toLog => toLog),	
};	
(mockLog.default as any).newLine = jest.fn();	
jest.mock('../../../../log', () => mockLog);
```

This PR makes it a better default export (class) for cleaner mocking. I may do a similar refactor for `expo-cli` where this was copied from.

# How

Two commits:
1. Refactor the `Log` module to be a class with all static members. Update all callsites to use the class. `yarn tsc` to verify.
2. Update the tests to use simpler mocks.

# Test Plan

`yarn tsc`
`yarn test`
