### PR TITLE
[eas-cli] Allow wait to be set to false for eas build

### DIFF
--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -51,6 +51,7 @@ export default class Build extends Command {
     }),
     wait: flags.boolean({
       default: true,
+      allowNo: true,
       description: 'Wait for build(s) to complete',
     }),
   };


### PR DESCRIPTION
# Why

Fixes #225 

# How

Allowed no to be specified overriding the true wait default

# Test Plan

Run `eas build -p all --no-wait` from an EAS enabled project:

```
❯ eas build -p all --no-wait
✔ Linked to project @...
✔ Uploaded to EAS 14s

[ snip ]

✔ Uploaded to EAS 6s

Android build details: https://expo.io/accounts/xxx
iOS build details: https://expo.io/accounts/xxx


```


