### PR TITLE
Fix potential broken this binding when passing logger function

### DIFF
--- a/packages/eas-cli/src/build/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/android/UpdatesModule.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config';
 import { AndroidConfig } from '@expo/config-plugins';
 import fs from 'fs-extra';
 
-import log from '../../log';
+import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
 import { ensureValidVersions } from '../utils/updates';
@@ -46,7 +46,7 @@ export async function syncUpdatesConfigurationAsync(
   try {
     await ensureUpdatesConfiguredAsync(projectDir, exp);
   } catch (error) {
-    log.error(
+    Log.error(
       'expo-updates module is not configured. Please run "eas build:configure" first to configure the project'
     );
     throw error;
@@ -64,7 +64,7 @@ export async function syncUpdatesConfigurationAsync(
   }
 
   if (!AndroidConfig.Updates.isMainApplicationMetaDataSynced(exp, androidManifest, accountName)) {
-    log.warn(
+    Log.warn(
       'Native project configuration is not synced with values present in your app.json, run "eas build:configure" to make sure all values are applied in the native project'
     );
   }

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -8,7 +8,7 @@ import AndroidCredentialsProvider, {
   AndroidCredentials,
 } from '../../credentials/android/AndroidCredentialsProvider';
 import { createCredentialsContextAsync } from '../../credentials/context';
-import log from '../../log';
+import Log from '../../log';
 import { toggleConfirmAsync } from '../../prompts';
 import { CredentialsResult, prepareBuildRequestForPlatformAsync } from '../build';
 import { BuildContext, CommandContext, createBuildContext } from '../context';
@@ -45,17 +45,17 @@ export async function prepareAndroidBuildAsync(
     buildProfile.distribution === 'internal' &&
     buildProfile.gradleCommand?.match(/bundle/)
   ) {
-    log.addNewLineIfNone();
-    log.warn(
+    Log.addNewLineIfNone();
+    Log.warn(
       `You're building your Android app for internal distribution. However, we've detected that the Gradle command you defined (${chalk.underline(
         buildProfile.gradleCommand
       )}) includes string 'bundle'.
 This means that it will most likely produce an AAB and you will not be able to install it on your Android devices straight from the Expo website.`
     );
-    log.newLine();
+    Log.newLine();
     const confirmed = await toggleConfirmAsync({ message: 'Would you like to proceed?' });
     if (!confirmed) {
-      log.error('Please update eas.json and come back again.');
+      Log.error('Please update eas.json and come back again.');
       process.exit(1);
     }
   }

--- a/packages/eas-cli/src/build/android/configure.ts
+++ b/packages/eas-cli/src/build/android/configure.ts
@@ -1,7 +1,7 @@
 import { ExpoConfig } from '@expo/config';
 import { AndroidConfig } from '@expo/config-plugins';
 
-import log from '../../log';
+import Log from '../../log';
 import { getAndroidApplicationIdAsync } from '../../project/projectUtils';
 import { gitAddAsync } from '../../utils/git';
 import { ConfigureContext } from '../context';
@@ -23,7 +23,7 @@ export async function configureAndroidAsync(ctx: ConfigureContext): Promise<void
   if (isExpoUpdatesInstalled(ctx.projectDir)) {
     await configureUpdatesAsync(ctx.projectDir, ctx.exp);
   }
-  log.withTick('Android project configured');
+  Log.withTick('Android project configured');
 }
 
 export async function validateAndSyncProjectConfigurationAsync(

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -3,7 +3,7 @@ import { EasJsonReader } from '@expo/eas-json';
 import fs from 'fs-extra';
 import path from 'path';
 
-import log from '../log';
+import Log from '../log';
 import { promptAsync } from '../prompts';
 import { ensureLoggedInAsync } from '../user/actions';
 import { gitAddAsync } from '../utils/git';
@@ -49,7 +49,7 @@ export async function configureAsync(options: {
     hasIosNativeProject: await fs.pathExists(path.join(options.projectDir, 'ios')),
   };
 
-  log.newLine();
+  Log.newLine();
   await ensureEasJsonExistsAsync(ctx);
   if (ctx.shouldConfigureAndroid) {
     await configureAndroidAsync(ctx);
@@ -59,11 +59,11 @@ export async function configureAsync(options: {
   }
 
   if (!(await isGitStatusCleanAsync())) {
-    log.newLine();
+    Log.newLine();
     await reviewAndCommitChangesAsync(configureCommitMessage[options.platform]);
   } else {
-    log.newLine();
-    log.withTick('No changes were necessary, the project is already configured correctly.');
+    Log.newLine();
+    Log.withTick('No changes were necessary, the project is already configured correctly.');
   }
 }
 
@@ -76,7 +76,7 @@ export async function ensureEasJsonExistsAsync(ctx: ConfigureContext): Promise<v
     await reader.validateAsync();
 
     existingEasJson = await reader.readRawAsync();
-    log.withTick('Validated eas.json');
+    Log.withTick('Validated eas.json');
 
     // If we have already populated eas.json with the default fields for the
     // platform then proceed
@@ -122,7 +122,7 @@ export async function ensureEasJsonExistsAsync(ctx: ConfigureContext): Promise<v
 
   await fs.writeFile(easJsonPath, `${JSON.stringify(easJson, null, 2)}\n`);
   await gitAddAsync(easJsonPath, { intentToAdd: true });
-  log.withTick(`${existingEasJson ? 'Updated' : 'Generated'} eas.json`);
+  Log.withTick(`${existingEasJson ? 'Updated' : 'Generated'} eas.json`);
 }
 
 enum ShouldCommitChanges {
@@ -153,7 +153,7 @@ async function reviewAndCommitChangesAsync(
 
   if (selected === ShouldCommitChanges.Yes) {
     await commitPromptAsync(commitMessage);
-    log.withTick('Committed changes');
+    Log.withTick('Committed changes');
   } else if (selected === ShouldCommitChanges.ShowDiffFirst) {
     await showDiffAsync();
     await reviewAndCommitChangesAsync(commitMessage, false);

--- a/packages/eas-cli/src/build/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/ios/UpdatesModule.ts
@@ -4,7 +4,7 @@ import plist from '@expo/plist';
 import fs from 'fs-extra';
 import path from 'path';
 
-import log from '../../log';
+import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
 import { gitAddAsync } from '../../utils/git';
@@ -41,7 +41,7 @@ export async function syncUpdatesConfigurationAsync(
   try {
     await ensureUpdatesConfiguredAsync(projectDir, exp);
   } catch (error) {
-    log.error(
+    Log.error(
       'expo-updates module is not configured. Please run "eas build:configure" first to configure the project'
     );
     throw error;
@@ -54,7 +54,7 @@ export async function syncUpdatesConfigurationAsync(
   }
 
   if (!IOSConfig.Updates.isPlistConfigurationSynced(exp, expoPlist, accountName)) {
-    log.warn(
+    Log.warn(
       'Native project configuration is not synced with values present in your app.json, run "eas build:configure" to make sure all values are applied in the native project'
     );
   }

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -1,7 +1,7 @@
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
 
-import log from '../../log';
+import Log from '../../log';
 import { ConfigureContext } from '../context';
 import { isExpoUpdatesInstalled } from '../utils/updates';
 import { configureUpdatesAsync, syncUpdatesConfigurationAsync } from './UpdatesModule';
@@ -20,7 +20,7 @@ export async function configureIosAsync(ctx: ConfigureContext): Promise<void> {
   if (isExpoUpdatesInstalled(ctx.projectDir)) {
     await configureUpdatesAsync(ctx.projectDir, ctx.exp);
   }
-  log.withTick('iOS project configured');
+  Log.withTick('iOS project configured');
 }
 
 export async function validateAndSyncProjectConfigurationAsync(

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -6,33 +6,33 @@ import terminalLink from 'terminal-link';
 
 type Color = (...text: string[]) => string;
 
-class Log {
+export default class Log {
   public static readonly isDebug = boolish('EXPO_DEBUG', false);
 
   public static log(...args: any[]) {
-    this.consoleLog(...args);
+    Log.consoleLog(...args);
   }
 
   public static newLine() {
-    this.consoleLog();
+    Log.consoleLog();
   }
 
   public static addNewLineIfNone() {
-    if (!this.isLastLineNewLine) {
-      this.newLine();
+    if (!Log.isLastLineNewLine) {
+      Log.newLine();
     }
   }
 
   public static error(...args: any[]) {
-    this.consoleError(...this.withTextColor(args, chalk.red));
+    Log.consoleError(...Log.withTextColor(args, chalk.red));
   }
 
   public static warn(...args: any[]) {
-    this.consoleWarn(...this.withTextColor(args, chalk.yellow));
+    Log.consoleWarn(...Log.withTextColor(args, chalk.yellow));
   }
 
   public static gray(...args: any[]) {
-    this.consoleLog(...this.withTextColor(args, chalk.gray));
+    Log.consoleLog(...Log.withTextColor(args, chalk.gray));
   }
 
   public static succeed(message: string) {
@@ -40,21 +40,21 @@ class Log {
   }
 
   public static withTick(...args: any[]) {
-    this.consoleLog(chalk.green(figures.tick), ...args);
+    Log.consoleLog(chalk.green(figures.tick), ...args);
   }
 
   private static consoleLog(...args: any[]) {
-    this.updateIsLastLineNewLine(args);
+    Log.updateIsLastLineNewLine(args);
     console.log(...args);
   }
 
   private static consoleWarn(...args: any[]) {
-    this.updateIsLastLineNewLine(args);
+    Log.updateIsLastLineNewLine(args);
     console.warn(...args);
   }
 
   private static consoleError(...args: any[]) {
-    this.updateIsLastLineNewLine(args);
+    Log.updateIsLastLineNewLine(args);
     console.error(...args);
   }
 
@@ -65,13 +65,13 @@ class Log {
   private static isLastLineNewLine = false;
   private static updateIsLastLineNewLine(args: any[]) {
     if (args.length === 0) {
-      this.isLastLineNewLine = true;
+      Log.isLastLineNewLine = true;
     } else {
       const lastArg = args[args.length - 1];
       if (typeof lastArg === 'string' && (lastArg === '' || lastArg.match(/[\r\n]$/))) {
-        this.isLastLineNewLine = true;
+        Log.isLastLineNewLine = true;
       } else {
-        this.isLastLineNewLine = false;
+        Log.isLastLineNewLine = false;
       }
     }
   }
@@ -90,5 +90,3 @@ export function learnMore(url: string, learnMoreMessage?: string): string {
   }
   return chalk.dim(`${learnMoreMessage ?? 'Learn more'}: ${chalk.underline(url)}`);
 }
-
-export default Log;


### PR DESCRIPTION
# Why

When refactoring `expo-cli` in a similar manner to https://github.com/expo/eas-cli/pull/223, I noticed some places where `Log.log` was being passed as an argument which would cause the this binding to not be correct. To fix this, we could change the callsites to `Log.log.bind(Log)`, change the functions to arrow functions (doesn't work with static properties as far as I can tell), or just explicitly use `Log` internal to the class to reference the static type rather than `this`. I chose the latter.

# How

Replace calls to `this` in `Log` to `Log`.

Also fix the casing of some imports (merge conflict from the last PR).

# Test Plan

`yarn tsc`
