### PR TITLE
[eas-cli] fix running builds from subdirectory

### DIFF
--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -84,7 +84,8 @@ async function prepareGenericJobAsync(
   jobData: JobData,
   buildProfile: AndroidGenericBuildProfile
 ): Promise<Partial<Android.GenericJob>> {
-  const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
+  const projectRootDirectory =
+    path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
     type: Workflow.Generic,
@@ -100,7 +101,8 @@ async function prepareManagedJobAsync(
   jobData: JobData,
   buildProfile: AndroidManagedBuildProfile
 ): Promise<Partial<Android.ManagedJob>> {
-  const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
+  const projectRootDirectory =
+    path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
   const accountName = await getProjectAccountNameAsync(ctx.commandCtx.projectDir);
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -109,7 +109,8 @@ async function prepareGenericJobAsync(
   jobData: JobData,
   buildProfile: iOSGenericBuildProfile
 ): Promise<Partial<iOS.GenericJob>> {
-  const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
+  const projectRootDirectory =
+    path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
   return {
     ...(await prepareJobCommonAsync(ctx, {
       archiveBucketKey: jobData.archiveBucketKey,
@@ -129,7 +130,8 @@ async function prepareManagedJobAsync(
   jobData: JobData,
   buildProfile: iOSManagedBuildProfile
 ): Promise<Partial<iOS.ManagedJob>> {
-  const projectRootDirectory = path.relative(await gitRootDirectoryAsync(), process.cwd()) || '.';
+  const projectRootDirectory =
+    path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
   const accountName = await getProjectAccountNameAsync(ctx.commandCtx.projectDir);
   const targetName = sanitizedName(ctx.commandCtx.exp.name);
   return {


### PR DESCRIPTION
# Why

If you run `eas build` in the subdirectory of your react-native project, build is started correctly, but a relative path to eas.json is not correct

# How

Do not rely on `process.cwd`

# Test Plan

Run build from `ios` directory