### PR TITLE
[eas-cli] rename EAS release to branch

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -2713,8 +2713,8 @@
             "deprecationReason": null
           },
           {
-            "name": "updateReleases",
-            "description": "EAS releases owned by an app",
+            "name": "updateBranches",
+            "description": "EAS branches owned by an app",
             "args": [
               {
                 "name": "offset",
@@ -2756,7 +2756,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "UpdateRelease",
+                    "name": "UpdateBranch",
                     "ofType": null
                   }
                 }
@@ -2766,11 +2766,11 @@
             "deprecationReason": null
           },
           {
-            "name": "updateReleaseByReleaseName",
-            "description": "get an EAS release owned by the app by releaseName",
+            "name": "updateBranchByBranchName",
+            "description": "get an EAS branch owned by the app by branchName",
             "args": [
               {
-                "name": "releaseName",
+                "name": "branchName",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -2789,7 +2789,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "UpdateRelease",
+                "name": "UpdateBranch",
                 "ofType": null
               }
             },
@@ -5662,6 +5662,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "parentAppleAppIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AppleAppIdentifier",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -7303,7 +7315,7 @@
             "deprecationReason": null
           },
           {
-            "name": "releaseMapping",
+            "name": "branchMapping",
             "description": "",
             "args": [],
             "type": {
@@ -7351,7 +7363,7 @@
             "deprecationReason": null
           },
           {
-            "name": "updateReleases",
+            "name": "updateBranches",
             "description": "",
             "args": [
               {
@@ -7394,7 +7406,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "UpdateRelease",
+                    "name": "UpdateBranch",
                     "ofType": null
                   }
                 }
@@ -7411,7 +7423,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "UpdateRelease",
+        "name": "UpdateBranch",
         "description": "",
         "fields": [
           {
@@ -7447,7 +7459,7 @@
             "deprecationReason": null
           },
           {
-            "name": "releaseName",
+            "name": "branchName",
             "description": "",
             "args": [],
             "type": {
@@ -7603,7 +7615,7 @@
             "deprecationReason": null
           },
           {
-            "name": "releaseId",
+            "name": "branchId",
             "description": "",
             "args": [],
             "type": {
@@ -7727,7 +7739,7 @@
             "deprecationReason": null
           },
           {
-            "name": "releaseName",
+            "name": "branchName",
             "description": "",
             "args": [],
             "type": {
@@ -10257,7 +10269,7 @@
             "deprecationReason": null
           },
           {
-            "name": "updateRelease",
+            "name": "updateBranch",
             "description": "",
             "args": [],
             "type": {
@@ -10265,7 +10277,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "UpdateReleaseMutation",
+                "name": "UpdateBranchMutation",
                 "ofType": null
               }
             },
@@ -11998,6 +12010,16 @@
           },
           {
             "name": "appleTeamId",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "parentAppleAppId",
             "description": "",
             "type": {
               "kind": "SCALAR",
@@ -13880,7 +13902,7 @@
         "fields": [
           {
             "name": "createUpdateChannelForApp",
-            "description": "Create an EAS channel for an app.\n\nIn order to work with GraphQL formatting, the releaseMapping should be a\nstringified JSON supplied to the mutation as a variable.",
+            "description": "Create an EAS channel for an app.\n\nIn order to work with GraphQL formatting, the branchMapping should be a\nstringified JSON supplied to the mutation as a variable.",
             "args": [
               {
                 "name": "appId",
@@ -13911,7 +13933,7 @@
                 "defaultValue": null
               },
               {
-                "name": "releaseMapping",
+                "name": "branchMapping",
                 "description": null,
                 "type": {
                   "kind": "SCALAR",
@@ -13931,7 +13953,7 @@
           },
           {
             "name": "editUpdateChannel",
-            "description": "Edit an EAS channel.\n\nIn order to work with GraphQL formatting, the releaseMapping should be a\nstringified JSON supplied to the mutation as a variable.",
+            "description": "Edit an EAS channel.\n\nIn order to work with GraphQL formatting, the branchMapping should be a\nstringified JSON supplied to the mutation as a variable.",
             "args": [
               {
                 "name": "channelId",
@@ -13948,7 +13970,7 @@
                 "defaultValue": null
               },
               {
-                "name": "releaseMapping",
+                "name": "branchMapping",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -13972,7 +13994,7 @@
           },
           {
             "name": "deleteUpdateChannel",
-            "description": "delete an EAS channel that doesn't point to any releases",
+            "description": "delete an EAS channel that doesn't point to any branches",
             "args": [
               {
                 "name": "channelId",
@@ -14105,12 +14127,12 @@
       },
       {
         "kind": "OBJECT",
-        "name": "UpdateReleaseMutation",
+        "name": "UpdateBranchMutation",
         "description": "",
         "fields": [
           {
-            "name": "createUpdateReleaseForApp",
-            "description": "Create an EAS release for an app",
+            "name": "createUpdateBranchForApp",
+            "description": "Create an EAS branch for an app",
             "args": [
               {
                 "name": "appId",
@@ -14127,7 +14149,7 @@
                 "defaultValue": null
               },
               {
-                "name": "releaseName",
+                "name": "branchName",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -14143,15 +14165,15 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "UpdateRelease",
+              "name": "UpdateBranch",
               "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "editUpdateRelease",
-            "description": "Edit an EAS release. The release can be specified either by its ID or\nwith the combination of (appId, releaseName).",
+            "name": "editUpdateBranch",
+            "description": "Edit an EAS branch. The branch can be specified either by its ID or\nwith the combination of (appId, branchName).",
             "args": [
               {
                 "name": "input",
@@ -14161,7 +14183,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
-                    "name": "EditUpdateReleaseInput",
+                    "name": "EditUpdateBranchInput",
                     "ofType": null
                   }
                 },
@@ -14173,7 +14195,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "UpdateRelease",
+                "name": "UpdateBranch",
                 "ofType": null
               }
             },
@@ -14181,11 +14203,11 @@
             "deprecationReason": null
           },
           {
-            "name": "deleteUpdateRelease",
-            "description": "Delete an EAS release and all of its updates as long as the release is not being used by any channels",
+            "name": "deleteUpdateBranch",
+            "description": "Delete an EAS branch and all of its updates as long as the branch is not being used by any channels",
             "args": [
               {
-                "name": "releaseId",
+                "name": "branchId",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -14204,7 +14226,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "DeleteUpdateReleaseResult",
+                "name": "DeleteUpdateBranchResult",
                 "ofType": null
               }
             },
@@ -14213,7 +14235,7 @@
           },
           {
             "name": "publishUpdateGroup",
-            "description": "Publish an update group to a release",
+            "description": "Publish an update group to a branch",
             "args": [
               {
                 "name": "publishUpdateGroupInput",
@@ -14250,7 +14272,7 @@
       },
       {
         "kind": "INPUT_OBJECT",
-        "name": "EditUpdateReleaseInput",
+        "name": "EditUpdateBranchInput",
         "description": "",
         "fields": null,
         "inputFields": [
@@ -14275,7 +14297,7 @@
             "defaultValue": null
           },
           {
-            "name": "releaseName",
+            "name": "branchName",
             "description": "",
             "type": {
               "kind": "SCALAR",
@@ -14285,7 +14307,7 @@
             "defaultValue": null
           },
           {
-            "name": "newReleaseName",
+            "name": "newBranchName",
             "description": "",
             "type": {
               "kind": "NON_NULL",
@@ -14305,7 +14327,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "DeleteUpdateReleaseResult",
+        "name": "DeleteUpdateBranchResult",
         "description": "",
         "fields": [
           {
@@ -14337,7 +14359,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "releaseId",
+            "name": "branchId",
             "description": "",
             "type": {
               "kind": "NON_NULL",

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -398,10 +398,10 @@ export type App = Project & {
   updateChannels: Array<UpdateChannel>;
   /** get an EAS channel owned by the app by channelName */
   updateChannelByChannelName: UpdateChannel;
-  /** EAS releases owned by an app */
-  updateReleases: Array<UpdateRelease>;
-  /** get an EAS release owned by the app by releaseName */
-  updateReleaseByReleaseName: UpdateRelease;
+  /** EAS branches owned by an app */
+  updateBranches: Array<UpdateBranch>;
+  /** get an EAS branch owned by the app by branchName */
+  updateBranchByBranchName: UpdateBranch;
   /** Coalesced project activity for an app. Use "createdBefore" to offset a query. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
 };
@@ -464,15 +464,15 @@ export type AppUpdateChannelByChannelNameArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
-export type AppUpdateReleasesArgs = {
+export type AppUpdateBranchesArgs = {
   offset: Scalars['Int'];
   limit: Scalars['Int'];
 };
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
-export type AppUpdateReleaseByReleaseNameArgs = {
-  releaseName: Scalars['String'];
+export type AppUpdateBranchByBranchNameArgs = {
+  branchName: Scalars['String'];
 };
 
 
@@ -836,6 +836,7 @@ export type AppleAppIdentifier = {
   account: Account;
   appleTeam?: Maybe<AppleTeam>;
   bundleIdentifier: Scalars['String'];
+  parentAppleAppIdentifier?: Maybe<AppleAppIdentifier>;
 };
 
 export type AppleDistributionCertificate = {
@@ -1011,30 +1012,30 @@ export type UpdateChannel = {
   id: Scalars['ID'];
   appId: Scalars['ID'];
   channelName: Scalars['String'];
-  releaseMapping: Scalars['String'];
+  branchMapping: Scalars['String'];
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
-  updateReleases: Array<UpdateRelease>;
+  updateBranches: Array<UpdateBranch>;
 };
 
 
-export type UpdateChannelUpdateReleasesArgs = {
+export type UpdateChannelUpdateBranchesArgs = {
   offset: Scalars['Int'];
   limit: Scalars['Int'];
 };
 
-export type UpdateRelease = {
-  __typename?: 'UpdateRelease';
+export type UpdateBranch = {
+  __typename?: 'UpdateBranch';
   id: Scalars['ID'];
   appId: Scalars['ID'];
-  releaseName: Scalars['String'];
+  branchName: Scalars['String'];
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
   updates: Array<Update>;
 };
 
 
-export type UpdateReleaseUpdatesArgs = {
+export type UpdateBranchUpdatesArgs = {
   offset: Scalars['Int'];
   limit: Scalars['Int'];
 };
@@ -1044,7 +1045,7 @@ export type Update = ActivityTimelineProjectActivity & {
   id: Scalars['ID'];
   actor?: Maybe<Actor>;
   activityTimestamp: Scalars['DateTime'];
-  releaseId: Scalars['ID'];
+  branchId: Scalars['ID'];
   platform: Scalars['String'];
   manifestFragment: Scalars['String'];
   runtimeVersion: Scalars['String'];
@@ -1052,7 +1053,7 @@ export type Update = ActivityTimelineProjectActivity & {
   updatedAt: Scalars['DateTime'];
   createdAt: Scalars['DateTime'];
   updateMessage?: Maybe<Scalars['String']>;
-  releaseName: Scalars['String'];
+  branchName: Scalars['String'];
 };
 
 export type UserPermission = {
@@ -1467,7 +1468,7 @@ export type RootMutation = {
   robot: RobotMutation;
   updateChannel: UpdateChannelMutation;
   update: UpdateMutation;
-  updateRelease: UpdateReleaseMutation;
+  updateBranch: UpdateBranchMutation;
   /** Mutations that create, delete, and accept UserInvitations */
   userInvitation: UserInvitationMutation;
   /** Mutations that modify the currently authenticated User */
@@ -1831,6 +1832,7 @@ export type AppleAppIdentifierMutationCreateAppleAppIdentifierArgs = {
 export type AppleAppIdentifierInput = {
   bundleIdentifier: Scalars['String'];
   appleTeamId?: Maybe<Scalars['ID']>;
+  parentAppleAppId?: Maybe<Scalars['ID']>;
 };
 
 export type AppleDeviceMutation = {
@@ -2181,18 +2183,18 @@ export type UpdateChannelMutation = {
   /**
    * Create an EAS channel for an app.
    * 
-   * In order to work with GraphQL formatting, the releaseMapping should be a
+   * In order to work with GraphQL formatting, the branchMapping should be a
    * stringified JSON supplied to the mutation as a variable.
    */
   createUpdateChannelForApp?: Maybe<UpdateChannel>;
   /**
    * Edit an EAS channel.
    * 
-   * In order to work with GraphQL formatting, the releaseMapping should be a
+   * In order to work with GraphQL formatting, the branchMapping should be a
    * stringified JSON supplied to the mutation as a variable.
    */
   editUpdateChannel?: Maybe<UpdateChannel>;
-  /** delete an EAS channel that doesn't point to any releases */
+  /** delete an EAS channel that doesn't point to any branches */
   deleteUpdateChannel: DeleteUpdateChannelResult;
 };
 
@@ -2200,13 +2202,13 @@ export type UpdateChannelMutation = {
 export type UpdateChannelMutationCreateUpdateChannelForAppArgs = {
   appId: Scalars['ID'];
   channelName: Scalars['String'];
-  releaseMapping?: Maybe<Scalars['String']>;
+  branchMapping?: Maybe<Scalars['String']>;
 };
 
 
 export type UpdateChannelMutationEditUpdateChannelArgs = {
   channelId: Scalars['ID'];
-  releaseMapping: Scalars['String'];
+  branchMapping: Scalars['String'];
 };
 
 
@@ -2235,56 +2237,56 @@ export type DeleteUpdateResult = {
   id: Scalars['ID'];
 };
 
-export type UpdateReleaseMutation = {
-  __typename?: 'UpdateReleaseMutation';
-  /** Create an EAS release for an app */
-  createUpdateReleaseForApp?: Maybe<UpdateRelease>;
+export type UpdateBranchMutation = {
+  __typename?: 'UpdateBranchMutation';
+  /** Create an EAS branch for an app */
+  createUpdateBranchForApp?: Maybe<UpdateBranch>;
   /**
-   * Edit an EAS release. The release can be specified either by its ID or
-   * with the combination of (appId, releaseName).
+   * Edit an EAS branch. The branch can be specified either by its ID or
+   * with the combination of (appId, branchName).
    */
-  editUpdateRelease: UpdateRelease;
-  /** Delete an EAS release and all of its updates as long as the release is not being used by any channels */
-  deleteUpdateRelease: DeleteUpdateReleaseResult;
-  /** Publish an update group to a release */
+  editUpdateBranch: UpdateBranch;
+  /** Delete an EAS branch and all of its updates as long as the branch is not being used by any channels */
+  deleteUpdateBranch: DeleteUpdateBranchResult;
+  /** Publish an update group to a branch */
   publishUpdateGroup: Array<Maybe<Update>>;
 };
 
 
-export type UpdateReleaseMutationCreateUpdateReleaseForAppArgs = {
+export type UpdateBranchMutationCreateUpdateBranchForAppArgs = {
   appId: Scalars['ID'];
-  releaseName: Scalars['String'];
+  branchName: Scalars['String'];
 };
 
 
-export type UpdateReleaseMutationEditUpdateReleaseArgs = {
-  input: EditUpdateReleaseInput;
+export type UpdateBranchMutationEditUpdateBranchArgs = {
+  input: EditUpdateBranchInput;
 };
 
 
-export type UpdateReleaseMutationDeleteUpdateReleaseArgs = {
-  releaseId: Scalars['ID'];
+export type UpdateBranchMutationDeleteUpdateBranchArgs = {
+  branchId: Scalars['ID'];
 };
 
 
-export type UpdateReleaseMutationPublishUpdateGroupArgs = {
+export type UpdateBranchMutationPublishUpdateGroupArgs = {
   publishUpdateGroupInput?: Maybe<PublishUpdateGroupInput>;
 };
 
-export type EditUpdateReleaseInput = {
+export type EditUpdateBranchInput = {
   id?: Maybe<Scalars['ID']>;
   appId?: Maybe<Scalars['ID']>;
-  releaseName?: Maybe<Scalars['String']>;
-  newReleaseName: Scalars['String'];
+  branchName?: Maybe<Scalars['String']>;
+  newBranchName: Scalars['String'];
 };
 
-export type DeleteUpdateReleaseResult = {
-  __typename?: 'DeleteUpdateReleaseResult';
+export type DeleteUpdateBranchResult = {
+  __typename?: 'DeleteUpdateBranchResult';
   id: Scalars['ID'];
 };
 
 export type PublishUpdateGroupInput = {
-  releaseId: Scalars['String'];
+  branchId: Scalars['String'];
   updateInfoGroup: UpdateInfoGroup;
   runtimeVersion: Scalars['String'];
   updateMessage?: Maybe<Scalars['String']>;
@@ -3242,8 +3244,8 @@ export type UpdatePublishMutationVariables = Exact<{
 
 export type UpdatePublishMutation = (
   { __typename?: 'RootMutation' }
-  & { updateRelease: (
-    { __typename?: 'UpdateReleaseMutation' }
+  & { updateBranch: (
+    { __typename?: 'UpdateBranchMutation' }
     & { publishUpdateGroup: Array<Maybe<(
       { __typename?: 'Update' }
       & Pick<Update, 'id' | 'updateGroup'>

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -37,7 +37,7 @@ const PublishMutation = {
         .mutation<UpdatePublishMutation>(
           gql`
             mutation UpdatePublishMutation($publishUpdateGroupInput: PublishUpdateGroupInput) {
-              updateRelease {
+              updateBranch {
                 publishUpdateGroup(publishUpdateGroupInput: $publishUpdateGroupInput) {
                   id
                   updateGroup
@@ -49,7 +49,7 @@ const PublishMutation = {
         )
         .toPromise()
     );
-    return data.updateRelease.publishUpdateGroup[0]!;
+    return data.updateBranch.publishUpdateGroup[0]!;
   },
 };
 

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import pkgDir from 'pkg-dir';
 
 import { graphqlClient, withErrorHandlingAsync } from '../graphql/client';
-import { UpdateRelease } from '../graphql/generated';
+import { UpdateBranch } from '../graphql/generated';
 import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import { ensureProjectExistsAsync } from './ensureProjectExists';
@@ -123,36 +123,36 @@ export function getProjectConfigDescription(projectDir: string): string {
   return 'app.config.js/app.json';
 }
 
-export async function getReleaseByNameAsync({
+export async function getBranchByNameAsync({
   appId,
-  releaseName,
+  branchName,
 }: {
   appId: string;
-  releaseName: string;
-}): Promise<UpdateRelease> {
+  branchName: string;
+}): Promise<UpdateBranch> {
   const data = await withErrorHandlingAsync(
     graphqlClient
       .query<
         {
           app: {
             byId: {
-              updateReleaseByReleaseName: UpdateRelease;
+              updateBranchByBranchName: UpdateBranch;
             };
           };
         },
         {
           appId: string;
-          releaseName: string;
+          branchName: string;
         }
       >(
         gql`
-          query ViewRelease($appId: String!, $releaseName: String!) {
+          query ViewBranch($appId: String!, $branchName: String!) {
             app {
               byId(appId: $appId) {
                 id
-                updateReleaseByReleaseName(releaseName: $releaseName) {
+                updateBranchByBranchName(branchName: $branchName) {
                   id
-                  releaseName
+                  branchName
                 }
               }
             }
@@ -160,10 +160,10 @@ export async function getReleaseByNameAsync({
         `,
         {
           appId,
-          releaseName,
+          branchName,
         }
       )
       .toPromise()
   );
-  return data.app.byId.updateReleaseByReleaseName;
+  return data.app.byId.updateBranchByBranchName;
 }


### PR DESCRIPTION
# Why

We are renaming `release` to `branch`.

Just landed the server side PR: https://github.com/expo/universe/pull/6904

# How

search and replace.

note: there are still `releaseChannel` etc. as it is a separate concept from EAS release->branch.

# Test Plan

grep'd and 🤞 
