### PR TITLE
[eas-cli][eas-json] add schemeBuildConfiguration to eas.json

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@expo/apple-utils": "0.0.0-alpha.17",
     "@expo/config": "~3.3.19",
-    "@expo/config-plugins": "^1.0.18",
-    "@expo/eas-build-job": "^0.2.0",
+    "@expo/config-plugins": "1.0.18",
+    "@expo/eas-build-job": "0.2.10",
     "@expo/eas-json": "^0.3.0",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.11",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@expo/apple-utils": "0.0.0-alpha.17",
     "@expo/config": "~3.3.19",
-    "@expo/config-plugins": "1.0.15-alpha.0",
-    "@expo/eas-build-job": "0.2.9",
+    "@expo/config-plugins": "^1.0.18",
+    "@expo/eas-build-job": "^0.2.0",
     "@expo/eas-json": "^0.3.0",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.11",

--- a/packages/eas-cli/src/build/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/android/UpdatesModule.ts
@@ -13,10 +13,9 @@ export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig)
   const buildGradlePath = AndroidConfig.Paths.getAppBuildGradle(projectDir);
   const buildGradleContents = await fs.readFile(buildGradlePath, 'utf8');
 
-  if (!AndroidConfig.Updates.isBuildGradleConfigured(projectDir, exp, buildGradleContents)) {
+  if (!AndroidConfig.Updates.isBuildGradleConfigured(projectDir, buildGradleContents)) {
     const updatedBuildGradleContents = AndroidConfig.Updates.ensureBuildGradleContainsConfigurationScript(
       projectDir,
-      exp,
       buildGradleContents
     );
     await fs.writeFile(buildGradlePath, updatedBuildGradleContents);
@@ -74,8 +73,8 @@ async function ensureUpdatesConfiguredAsync(projectDir: string, exp: ExpoConfig)
   const buildGradlePath = AndroidConfig.Paths.getAppBuildGradle(projectDir);
   const buildGradleContents = await fs.readFile(buildGradlePath, 'utf8');
 
-  if (!AndroidConfig.Updates.isBuildGradleConfigured(projectDir, exp, buildGradleContents)) {
-    const gradleScriptApply = AndroidConfig.Updates.formatApplyLineForBuildGradle(projectDir, exp);
+  if (!AndroidConfig.Updates.isBuildGradleConfigured(projectDir, buildGradleContents)) {
+    const gradleScriptApply = AndroidConfig.Updates.formatApplyLineForBuildGradle(projectDir);
     throw new Error(`Missing ${gradleScriptApply} in ${buildGradlePath}`);
   }
 

--- a/packages/eas-cli/src/build/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/ios/UpdatesModule.ts
@@ -14,10 +14,9 @@ export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig)
   const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
   let xcodeProject = IOSConfig.XcodeUtils.getPbxproj(projectDir);
 
-  if (!IOSConfig.Updates.isShellScriptBuildPhaseConfigured(projectDir, exp, xcodeProject)) {
+  if (!IOSConfig.Updates.isShellScriptBuildPhaseConfigured(projectDir, xcodeProject)) {
     xcodeProject = IOSConfig.Updates.ensureBundleReactNativePhaseContainsConfigurationScript(
       projectDir,
-      exp,
       xcodeProject
     );
     await fs.writeFile(IOSConfig.Paths.getPBXProjectPath(projectDir), xcodeProject.writeSync());
@@ -62,7 +61,7 @@ export async function syncUpdatesConfigurationAsync(
 async function ensureUpdatesConfiguredAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
   const xcodeProject = IOSConfig.XcodeUtils.getPbxproj(projectDir);
 
-  if (!IOSConfig.Updates.isShellScriptBuildPhaseConfigured(projectDir, exp, xcodeProject)) {
+  if (!IOSConfig.Updates.isShellScriptBuildPhaseConfigured(projectDir, xcodeProject)) {
     const script = 'expo-updates/scripts/create-manifest-ios.sh';
     const buildPhase = '"Bundle React Native code and images"';
     throw new Error(`Path to ${script} is missing in a ${buildPhase} build phase.`);

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -1,6 +1,6 @@
 import { IOSConfig } from '@expo/config-plugins';
 import { Workflow } from '@expo/eas-build-job';
-import { BuildConfiguration, EasConfig } from '@expo/eas-json';
+import { EasConfig } from '@expo/eas-json';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import sortBy from 'lodash/sortBy';
@@ -39,21 +39,12 @@ export async function prepareIosBuildAsync(
 
   let iosBuildScheme: string | undefined;
   let iosApplicationTarget: string | undefined;
-  let iosBuildConfiguration: BuildConfiguration | undefined;
   if (buildCtx.buildProfile.workflow === Workflow.Generic) {
     iosBuildScheme = buildCtx.buildProfile.scheme ?? (await resolveSchemeAsync(buildCtx));
-    iosApplicationTarget = await IOSConfig.BuildScheme.getApplicationTargetForSchemeAsync(
+    iosApplicationTarget = await IOSConfig.Target.getApplicationTargetForSchemeAsync(
       buildCtx.commandCtx.projectDir,
       iosBuildScheme
     );
-    iosBuildConfiguration =
-      buildCtx.buildProfile.buildConfiguration ??
-      (await IOSConfig.BuildScheme.getBuildConfigurationForSchemeAsync(
-        buildCtx.commandCtx.projectDir,
-        iosBuildScheme
-      ));
-  } else {
-    iosBuildConfiguration = buildCtx.buildProfile.buildConfiguration ?? BuildConfiguration.RELEASE;
   }
 
   await ensureBundleIdentifierIsValidAsync(commandCtx.projectDir);
@@ -63,7 +54,6 @@ export async function prepareIosBuildAsync(
     projectConfiguration: {
       iosBuildScheme,
       iosApplicationTarget,
-      iosBuildConfiguration,
     },
     ensureCredentialsAsync: ensureIosCredentialsAsync,
     ensureProjectConfiguredAsync: async () => {
@@ -78,7 +68,7 @@ export async function prepareIosBuildAsync(
 }
 
 async function resolveSchemeAsync(ctx: BuildContext<Platform.iOS>): Promise<string> {
-  const schemes = IOSConfig.BuildScheme.getBuildSchemesFromXcodeproj(ctx.commandCtx.projectDir);
+  const schemes = IOSConfig.Scheme.getSchemesFromXcodeproj(ctx.commandCtx.projectDir);
   if (schemes.length === 1) {
     return schemes[0];
   }

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -41,7 +41,7 @@ export async function prepareIosBuildAsync(
   let iosApplicationNativeTarget: string | undefined;
   if (buildCtx.buildProfile.workflow === Workflow.Generic) {
     iosNativeProjectScheme = buildCtx.buildProfile.scheme ?? (await resolveSchemeAsync(buildCtx));
-    iosApplicationNativeTarget = await IOSConfig.Target.getApplicationTargetForSchemeAsync(
+    iosApplicationNativeTarget = await IOSConfig.BuildScheme.getApplicationTargetForSchemeAsync(
       buildCtx.commandCtx.projectDir,
       iosNativeProjectScheme
     );
@@ -68,7 +68,7 @@ export async function prepareIosBuildAsync(
 }
 
 async function resolveSchemeAsync(ctx: BuildContext<Platform.iOS>): Promise<string> {
-  const schemes = IOSConfig.Scheme.getSchemesFromXcodeproj(ctx.commandCtx.projectDir);
+  const schemes = IOSConfig.BuildScheme.getBuildSchemesFromXcodeproj(ctx.commandCtx.projectDir);
   if (schemes.length === 1) {
     return schemes[0];
   }

--- a/packages/eas-cli/src/build/ios/bundleIdentifer.ts
+++ b/packages/eas-cli/src/build/ios/bundleIdentifer.ts
@@ -38,10 +38,10 @@ export async function configureBundleIdentifierAsync(
   exp: ExpoConfig
 ): Promise<void> {
   const configDescription = getProjectConfigDescription(projectDir);
-  const bundleIdentifierFromPbxproj = IOSConfig.BundleIdenitifer.getBundleIdentifierFromPbxproj(
+  const bundleIdentifierFromPbxproj = IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj(
     projectDir
   );
-  const bundleIdentifierFromConfig = IOSConfig.BundleIdenitifer.getBundleIdentifier(exp);
+  const bundleIdentifierFromConfig = IOSConfig.BundleIdentifier.getBundleIdentifier(exp);
   if (bundleIdentifierFromPbxproj && bundleIdentifierFromConfig) {
     if (bundleIdentifierFromPbxproj !== bundleIdentifierFromConfig) {
       Log.addNewLineIfNone();
@@ -74,7 +74,7 @@ However, if you choose the one defined in the Xcode project you'll have to updat
       });
       switch (bundleIdentifierSource) {
         case BundleIdentiferSource.AppJson: {
-          IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(
+          IOSConfig.BundleIdentifier.setBundleIdentifierForPbxproj(
             projectDir,
             bundleIdentifierFromConfig
           );
@@ -103,7 +103,7 @@ However, if you choose the one defined in the Xcode project you'll have to updat
       throw new Error(missingBundleIdentifierMessage(configDescription));
     }
   } else if (!bundleIdentifierFromPbxproj && bundleIdentifierFromConfig) {
-    IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(
+    IOSConfig.BundleIdentifier.setBundleIdentifierForPbxproj(
       projectDir,
       bundleIdentifierFromConfig
     );

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -39,7 +39,7 @@ export async function validateAndSyncProjectConfigurationAsync({
   const versionBumpStrategy = resolveVersionBumpStrategy(autoIncrement);
 
   if (workflow === Workflow.Generic) {
-    const bundleIdentifierFromPbxproj = IOSConfig.BundleIdenitifer.getBundleIdentifierFromPbxproj(
+    const bundleIdentifierFromPbxproj = IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj(
       projectDir
     );
     if (!bundleIdentifierFromPbxproj || bundleIdentifierFromPbxproj !== exp.ios?.bundleIdentifier) {

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -27,7 +27,6 @@ interface JobData {
   projectConfiguration: {
     iosBuildScheme?: string;
     iosApplicationTarget?: string;
-    iosBuildConfiguration: iOS.BuildConfiguration;
   };
 }
 
@@ -129,7 +128,7 @@ async function prepareGenericJobAsync(
     })),
     type: Workflow.Generic,
     scheme: jobData.projectConfiguration.iosBuildScheme,
-    buildConfiguration: jobData.projectConfiguration.iosBuildConfiguration,
+    schemeBuildConfiguration: buildProfile.schemeBuildConfiguration,
     artifactPath: buildProfile.artifactPath,
     releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,
@@ -152,7 +151,7 @@ async function prepareManagedJobAsync(
       targetName,
     })),
     type: Workflow.Managed,
-    buildConfiguration: jobData.projectConfiguration.iosBuildConfiguration,
+    buildType: buildProfile.buildType,
     username: accountName,
     releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -25,8 +25,9 @@ interface JobData {
   archiveBucketKey: string;
   credentials?: IosCredentials;
   projectConfiguration: {
-    iosNativeProjectScheme?: string;
-    iosApplicationNativeTarget?: string;
+    iosBuildScheme?: string;
+    iosApplicationTarget?: string;
+    iosBuildConfiguration: iOS.BuildConfiguration;
   };
 }
 
@@ -75,7 +76,7 @@ async function prepareJobCommonAsync(
   } else if (credentials) {
     // targetName
     // - for managed projects: sanitized .name from the app config
-    // - for generic projects: name of the main application target
+    // - for generic projects: name of the application target
     assert(targetName, 'target name should be defined');
     buildCredentials = {
       [targetName]: prepareTargetCredentials(credentials),
@@ -124,10 +125,11 @@ async function prepareGenericJobAsync(
     ...(await prepareJobCommonAsync(ctx, {
       archiveBucketKey: jobData.archiveBucketKey,
       credentials: jobData.credentials,
-      targetName: jobData.projectConfiguration.iosApplicationNativeTarget,
+      targetName: jobData.projectConfiguration.iosApplicationTarget,
     })),
     type: Workflow.Generic,
-    scheme: jobData.projectConfiguration.iosNativeProjectScheme,
+    scheme: jobData.projectConfiguration.iosBuildScheme,
+    buildConfiguration: jobData.projectConfiguration.iosBuildConfiguration,
     artifactPath: buildProfile.artifactPath,
     releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,
@@ -150,6 +152,7 @@ async function prepareManagedJobAsync(
       targetName,
     })),
     type: Workflow.Managed,
+    buildConfiguration: jobData.projectConfiguration.iosBuildConfiguration,
     username: accountName,
     releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -82,8 +82,8 @@ export async function getAppIdentifierAsync(
     }
     case Platform.iOS: {
       return (
-        IOSConfig.BundleIdenitifer.getBundleIdentifier(exp) ??
-        IOSConfig.BundleIdenitifer.getBundleIdentifierFromPbxproj(projectDir)
+        IOSConfig.BundleIdentifier.getBundleIdentifier(exp) ??
+        IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj(projectDir)
       );
     }
   }

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.9",
+    "@expo/eas-build-job": "0.2.10",
     "@hapi/joi": "^17.1.1",
     "fs-extra": "^9.0.1",
     "tslib": "^1"

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -13,11 +13,6 @@ export enum DistributionType {
 
 export type VersionAutoIncrement = boolean | 'version' | 'buildNumber';
 
-export enum SchemeBuildConfiguration {
-  RELEASE = 'Release',
-  DEBUG = 'Debug',
-}
-
 export interface AndroidManagedBuildProfile extends Android.BuilderEnvironment {
   workflow: Workflow.Managed;
   credentialsSource: CredentialsSource;
@@ -49,7 +44,7 @@ export interface iOSGenericBuildProfile extends iOS.BuilderEnvironment {
   workflow: Workflow.Generic;
   credentialsSource: CredentialsSource;
   scheme?: string;
-  schemeBuildConfiguration?: SchemeBuildConfiguration;
+  schemeBuildConfiguration?: iOS.GenericSchemeBuildConfiguration;
   releaseChannel?: string;
   artifactPath?: string;
   distribution?: DistributionType;

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -13,7 +13,7 @@ export enum DistributionType {
 
 export type VersionAutoIncrement = boolean | 'version' | 'buildNumber';
 
-export enum BuildConfiguration {
+export enum SchemeBuildConfiguration {
   RELEASE = 'Release',
   DEBUG = 'Debug',
 }
@@ -39,21 +39,21 @@ export interface AndroidGenericBuildProfile extends Android.BuilderEnvironment {
 export interface iOSManagedBuildProfile extends iOS.BuilderEnvironment {
   workflow: Workflow.Managed;
   credentialsSource: CredentialsSource;
+  buildType?: iOS.ManagedBuildType;
   releaseChannel?: string;
   distribution?: DistributionType;
   autoIncrement: VersionAutoIncrement;
-  buildConfiguration?: BuildConfiguration;
 }
 
 export interface iOSGenericBuildProfile extends iOS.BuilderEnvironment {
   workflow: Workflow.Generic;
   credentialsSource: CredentialsSource;
   scheme?: string;
+  schemeBuildConfiguration?: SchemeBuildConfiguration;
   releaseChannel?: string;
   artifactPath?: string;
   distribution?: DistributionType;
   autoIncrement: VersionAutoIncrement;
-  buildConfiguration?: BuildConfiguration;
 }
 
 export type AndroidBuildProfile = AndroidManagedBuildProfile | AndroidGenericBuildProfile;

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -13,6 +13,11 @@ export enum DistributionType {
 
 export type VersionAutoIncrement = boolean | 'version' | 'buildNumber';
 
+export enum BuildConfiguration {
+  RELEASE = 'Release',
+  DEBUG = 'Debug',
+}
+
 export interface AndroidManagedBuildProfile extends Android.BuilderEnvironment {
   workflow: Workflow.Managed;
   credentialsSource: CredentialsSource;
@@ -37,6 +42,7 @@ export interface iOSManagedBuildProfile extends iOS.BuilderEnvironment {
   releaseChannel?: string;
   distribution?: DistributionType;
   autoIncrement: VersionAutoIncrement;
+  buildConfiguration?: BuildConfiguration;
 }
 
 export interface iOSGenericBuildProfile extends iOS.BuilderEnvironment {
@@ -47,6 +53,7 @@ export interface iOSGenericBuildProfile extends iOS.BuilderEnvironment {
   artifactPath?: string;
   distribution?: DistributionType;
   autoIncrement: VersionAutoIncrement;
+  buildConfiguration?: BuildConfiguration;
 }
 
 export type AndroidBuildProfile = AndroidManagedBuildProfile | AndroidGenericBuildProfile;

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -66,6 +66,7 @@ const iOSGenericSchema = Joi.object({
   autoIncrement: Joi.alternatives()
     .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
     .default(false),
+  buildConfiguration: Joi.string().valid('Debug', 'Release'),
 }).concat(IosBuilderEnvironmentSchema);
 
 const iOSManagedSchema = Joi.object({
@@ -76,6 +77,7 @@ const iOSManagedSchema = Joi.object({
   autoIncrement: Joi.alternatives()
     .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
     .default(false),
+  buildConfiguration: Joi.string().valid('Debug', 'Release'),
 }).concat(IosBuilderEnvironmentSchema);
 
 const schemaBuildProfileMap: Record<string, Record<string, Joi.Schema>> = {

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -60,24 +60,24 @@ const iOSGenericSchema = Joi.object({
   workflow: Joi.string().valid('generic').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
   scheme: Joi.string(),
+  schemeBuildConfiguration: Joi.string().valid('Debug', 'Release'),
   releaseChannel: Joi.string(),
   artifactPath: Joi.string(),
   distribution: Joi.string().valid('store', 'internal').default('store'),
   autoIncrement: Joi.alternatives()
     .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
     .default(false),
-  buildConfiguration: Joi.string().valid('Debug', 'Release'),
 }).concat(IosBuilderEnvironmentSchema);
 
 const iOSManagedSchema = Joi.object({
   workflow: Joi.string().valid('managed').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
+  buildType: Joi.string().valid('release', 'development-client'),
   releaseChannel: Joi.string(),
   distribution: Joi.string().valid('store', 'internal').default('store'),
   autoIncrement: Joi.alternatives()
     .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
     .default(false),
-  buildConfiguration: Joi.string().valid('Debug', 'Release'),
 }).concat(IosBuilderEnvironmentSchema);
 
 const schemaBuildProfileMap: Record<string, Record<string, Joi.Schema>> = {

--- a/packages/eas-json/src/__tests__/EasJsonReader-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-test.ts
@@ -121,19 +121,18 @@ test('valid eas.json with both platform, but reading only android', async () => 
   }).toEqual(easJson);
 });
 
-test('valid eas.json for debug builds', async () => {
+test('valid eas.json for development client builds', async () => {
   await fs.writeJson('/project/eas.json', {
     builds: {
       ios: {
         release: { workflow: 'managed' },
-        debug: { workflow: 'managed', buildType: 'simulator' },
+        debug: { workflow: 'managed', buildType: 'development-client' },
       },
       android: {
-        release: { workflow: 'generic' },
+        release: { workflow: 'managed' },
         debug: {
-          workflow: 'generic',
-          gradleCommand: ':app:assembleDebug',
-          withoutCredentials: true,
+          workflow: 'managed',
+          buildType: 'development-client',
         },
       },
     },
@@ -145,12 +144,11 @@ test('valid eas.json for debug builds', async () => {
     builds: {
       android: {
         credentialsSource: 'auto',
-        workflow: 'generic',
-        gradleCommand: ':app:assembleDebug',
-        withoutCredentials: true,
+        workflow: 'managed',
         distribution: 'store',
         env: {},
         image: 'default',
+        buildType: 'development-client',
       },
       ios: {
         credentialsSource: 'auto',
@@ -159,6 +157,7 @@ test('valid eas.json for debug builds', async () => {
         autoIncrement: false,
         env: {},
         image: 'default',
+        buildType: 'development-client',
       },
     },
   }).toEqual(easJson);

--- a/packages/eas-json/src/index.ts
+++ b/packages/eas-json/src/index.ts
@@ -1,5 +1,4 @@
 export {
-  SchemeBuildConfiguration,
   CredentialsSource,
   DistributionType,
   AndroidManagedBuildProfile,

--- a/packages/eas-json/src/index.ts
+++ b/packages/eas-json/src/index.ts
@@ -1,5 +1,5 @@
 export {
-  BuildConfiguration,
+  SchemeBuildConfiguration,
   CredentialsSource,
   DistributionType,
   AndroidManagedBuildProfile,

--- a/packages/eas-json/src/index.ts
+++ b/packages/eas-json/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  BuildConfiguration,
   CredentialsSource,
   DistributionType,
   AndroidManagedBuildProfile,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,7 +1093,7 @@
     "@babel/preset-env" "^7.4.4"
     "@babel/preset-typescript" "^7.3.3"
 
-"@expo/config-plugins@^1.0.18":
+"@expo/config-plugins@1.0.18":
   version "1.0.18"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.18.tgz#f0f7d36316d60ea67b4cc6394bffef6d6904345d"
   integrity sha512-8Ey+22cEAOxK+SBJY+OazaLsPyL5FXdsykfBg/QQJE2Y/DTFebUVlr5bQyeqavbASDvmDxg3Fd71A8Se8+qT1g==
@@ -1151,10 +1151,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.9":
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.9.tgz#e635904da2deb65c4912b5241a20da98879a7aaa"
-  integrity sha512-WkoQ7ZBgoNVuBywNv36R6ixjqyV8P4fNKRWXC/WgSl1H42pZ31Uc8tK2XO6zddc+PxeGmrXXTjSQyW6XAZ5B3g==
+"@expo/eas-build-job@0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.10.tgz#ed6ac5e094e62167c0afeaae929aab6be68b48b4"
+  integrity sha512-AEbMlvbF/ugZFHDuMY9Bpojm8LgZIL7IIES+jevkG1ftzoPpRXP+q1Ioch+KPFdG6SyPrqvGa2NBK5Oyq/MtTA==
   dependencies:
     "@hapi/joi" "^17.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,20 +1093,21 @@
     "@babel/preset-env" "^7.4.4"
     "@babel/preset-typescript" "^7.3.3"
 
-"@expo/config-plugins@1.0.15-alpha.0":
-  version "1.0.15-alpha.0"
-  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.15-alpha.0.tgz#0f6c4250fa96ec597bb890dddb3502192c705e27"
-  integrity sha512-gWCHnh96RoWdhF7gsdGjuw7PhNOLl6vsB2PWpbANUWA3Y96dLLTv/nVNH3bLQ8KGtlVU/mAZ1Go6AW6u08Jx7A==
+"@expo/config-plugins@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.18.tgz#f0f7d36316d60ea67b4cc6394bffef6d6904345d"
+  integrity sha512-8Ey+22cEAOxK+SBJY+OazaLsPyL5FXdsykfBg/QQJE2Y/DTFebUVlr5bQyeqavbASDvmDxg3Fd71A8Se8+qT1g==
   dependencies:
     "@expo/config-types" "^40.0.0-beta.2"
-    "@expo/configure-splash-screen" "0.3.2"
+    "@expo/configure-splash-screen" "0.3.3"
     "@expo/image-utils" "0.3.10"
-    "@expo/json-file" "8.2.25"
+    "@expo/json-file" "8.2.27"
     "@expo/plist" "0.0.11"
     find-up "~5.0.0"
     fs-extra "9.0.0"
     getenv "0.7.0"
     glob "7.1.6"
+    resolve-from "^5.0.0"
     slash "^3.0.0"
     slugify "^1.3.4"
     xcode "^2.1.0"
@@ -1134,12 +1135,11 @@
     semver "^7.1.3"
     slugify "^1.3.4"
 
-"@expo/configure-splash-screen@0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.3.2.tgz#394fc6d5bd11bd592f8035b837c6914dea9d8f91"
-  integrity sha512-+KvcPWv/EpAi9ng7KWsRCHUgN8qYcbpvrY8Pc3AtfPVHBhWuy7FhTdT0HUqjhOvqvwPF2Ygr//DHl8WBVg2ICA==
+"@expo/configure-splash-screen@0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.3.3.tgz#ef44ba4d62443297f9d8a9326a71b40b8b413528"
+  integrity sha512-fWy6Z52Mj2a7yjdvpIJkP9G3kfkoXE79aHvTDwgggIE0KLhwnPF27v+KS0wJUf7b4JM6w0zKOlUZjQhn0kSNyA==
   dependencies:
-    "@react-native-community/cli-platform-android" "^4.10.0"
     "@react-native-community/cli-platform-ios" "^4.10.0"
     color-string "^1.5.3"
     commander "^5.1.0"
@@ -1184,6 +1184,17 @@
     fs-extra "9.0.0"
     json5 "^1.0.1"
     lodash "^4.17.15"
+    write-file-atomic "^2.3.0"
+
+"@expo/json-file@8.2.27":
+  version "8.2.27"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.27.tgz#548ff0a9989f9f789cdb2b689d17a4faf491de67"
+  integrity sha512-Iyqg1jbXOTg0JfCGwMrkaaRmVFjQrWDBQAhYLTdvOD3GrXYuKI1vUV+3Wqw0NnU+TYoNUpi7aB8dNzPvLj0oag==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    fs-extra "9.0.0"
+    json5 "^1.0.1"
+    lodash "^4.17.19"
     write-file-atomic "^2.3.0"
 
 "@expo/oclif-dev-cli@1.24.0-expo":
@@ -3062,22 +3073,6 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@react-native-community/cli-platform-android@^4.10.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-4.13.0.tgz#922681ec82ee1aadd993598b814df1152118be02"
-  integrity sha512-3i8sX8GklEytUZwPnojuoFbCjIRzMugCdzDIdZ9UNmi/OhD4/8mLGO0dgXfT4sMWjZwu3qjy45sFfk2zOAgHbA==
-  dependencies:
-    "@react-native-community/cli-tools" "^4.13.0"
-    chalk "^3.0.0"
-    execa "^1.0.0"
-    fs-extra "^8.1.0"
-    glob "^7.1.3"
-    jetifier "^1.6.2"
-    lodash "^4.17.15"
-    logkitty "^0.7.1"
-    slash "^3.0.0"
-    xmldoc "^1.1.2"
-
 "@react-native-community/cli-platform-ios@^4.10.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-4.13.0.tgz#a738915c68cac86df54e578b59a1311ea62b1aef"
@@ -3657,15 +3652,6 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0, ansi-escapes@^4.3.1:
   integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
   dependencies:
     type-fest "^0.11.0"
-
-ansi-fragments@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-fragments/-/ansi-fragments-0.2.1.tgz#24409c56c4cc37817c3d7caa99d8969e2de5a05e"
-  integrity sha512-DykbNHxuXQwUDRv5ibc2b0x7uw7wmwOGLBUd5RmaQ5z8Lhx19vwvKV+FAsM5rEA6dEcHxX+/Ad5s9eF2k2bB+w==
-  dependencies:
-    colorette "^1.0.7"
-    slice-ansi "^2.0.0"
-    strip-ansi "^5.0.0"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -4736,11 +4722,6 @@ color-string@^1.5.3:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-colorette@^1.0.7:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
-  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
-
 colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
@@ -5121,11 +5102,6 @@ dateformat@^3.0.0, dateformat@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
-
-dayjs@^1.8.15:
-  version "1.9.6"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.6.tgz#6f0c77d76ac1ff63720dd1197e5cb87b67943d70"
-  integrity sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw==
 
 de-indent@^1.0.2:
   version "1.0.2"
@@ -8037,11 +8013,6 @@ jest@^26.4.2:
     import-local "^3.0.2"
     jest-cli "^26.4.2"
 
-jetifier@^1.6.2:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/jetifier/-/jetifier-1.6.6.tgz#fec8bff76121444c12dc38d2dad6767c421dab68"
-  integrity sha512-JNAkmPeB/GS2tCRqUzRPsTOHpGDah7xP18vGJfIjZC+W2sxEHbxgJxetIjIqhjQ3yYbYNEELkM/spKLtwoOSUQ==
-
 jimp@0.12.1:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/jimp/-/jimp-0.12.1.tgz#3e58fdd16ebb2b8f00a09be3dd5c54f79ffae04a"
@@ -8625,15 +8596,6 @@ log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
-
-logkitty@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/logkitty/-/logkitty-0.7.1.tgz#8e8d62f4085a826e8d38987722570234e33c6aa7"
-  integrity sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==
-  dependencies:
-    ansi-fragments "^0.2.1"
-    dayjs "^1.8.15"
-    yargs "^15.1.0"
 
 loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -10808,7 +10770,7 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@>=0.6.0, sax@^1.2.1, sax@^1.2.4:
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -10972,7 +10934,7 @@ slice-ansi@0.0.4:
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
   integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
-slice-ansi@^2.0.0, slice-ansi@^2.1.0:
+slice-ansi@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
   integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
@@ -12531,13 +12493,6 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmldoc@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/xmldoc/-/xmldoc-1.1.2.tgz#6666e029fe25470d599cd30e23ff0d1ed50466d7"
-  integrity sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==
-  dependencies:
-    sax "^1.2.1"
-
 xmldom@0.1.x, xmldom@~0.1.31:
   version "0.1.31"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
@@ -12621,7 +12576,7 @@ yargs@^14.2.2:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^15.1.0, yargs@^15.3.1:
+yargs@^15.3.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
# Why

Another part of https://linear.app/expo/issue/ENG-27/buildconfiguration-option-for-ios-builds
See also https://github.com/expo/turtle-v2/pull/412

We want to allow users to override the build configuration (release/debug) for a particular build scheme.

# How

- I updated `@expo/config-plugins` and made appropriate changes in EAS CLI.
- I added a new config option for generic iOS build profiles - `schemeBuildConfiguration` (`Release`/`Debug`). That field is optional. If it's not passed, then fastlane proceeds with its default behavior.
- I added a new config option for managed iOS build profiles - `buildType` (`release` / `development-client`). It's not used yet by EAS Build workers.

# Test Plan

I ran three generic builds:
- with `schemeBuildConfiguration` set to `Release` - the value was successfully propagated to fastlane
- with `schemeBuildConfiguration` set to `Debug` - the value was successfully propagated to fastlane
- without `schemeBuildConfiguration` - `fastlane gym` was run with `configuration` property
