### PR TITLE
[eas-cli] remove trailing whitespace from default branch name

### DIFF
--- a/packages/eas-cli/src/utils/git.ts
+++ b/packages/eas-cli/src/utils/git.ts
@@ -52,7 +52,7 @@ async function isGitInstalledAsync(): Promise<boolean> {
 
 async function getBranchNameAsync(): Promise<string | null> {
   try {
-    return (await spawnAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout;
+    return (await spawnAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.trim();
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
# Why

Remove trailing `\n` for default branch name.

# Testing

Checked it created a branch without a trailing whitespace.
