### PR TITLE
[eas-cli] add default bundler for branch:publish

### DIFF
--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -12,7 +12,12 @@ import {
   getBranchByNameAsync,
   getProjectAccountNameAsync,
 } from '../../project/projectUtils';
-import { buildUpdateInfoGroupAsync, collectAssets, uploadAssetsAsync } from '../../project/publish';
+import {
+  buildBundlesAsync,
+  buildUpdateInfoGroupAsync,
+  collectAssets,
+  uploadAssetsAsync,
+} from '../../project/publish';
 import { promptAsync } from '../../prompts';
 import { getLastCommitMessageAsync } from '../../utils/git';
 
@@ -37,11 +42,21 @@ export default class BranchPublish extends Command {
       description: `return a json with the edited branch's ID and name.`,
       default: false,
     }),
+    'skip-bundler': flags.boolean({
+      description: `skip running Expo CLI to bundle the app before publishing`,
+      default: false,
+    }),
   };
 
   async run() {
     let {
-      flags: { json: jsonFlag, branch: name, message, 'input-dir': inputDir },
+      flags: {
+        json: jsonFlag,
+        branch: name,
+        message,
+        'input-dir': inputDir,
+        'skip-bundler': skipBundler,
+      },
     } = this.parse(BranchPublish);
 
     const projectDir = await findProjectRootAsync(process.cwd());
@@ -94,6 +109,10 @@ export default class BranchPublish extends Command {
       appId: projectId,
       name: name!,
     });
+
+    if (!skipBundler) {
+      await buildBundlesAsync({ projectDir, inputDir });
+    }
 
     let updateInfoGroup;
     const assetSpinner = ora('Uploading assets...').start();

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -206,7 +206,9 @@ describe(resolveInputDirectory, () => {
     expect(() => {
       resolveInputDirectory(nonExistentPath);
     }).toThrow(`The input directory "${nonExistentPath}" does not exist.
-    You'll need to run a command to build the JS bundle first (e.g. 'expo export').
+    You can allow us to build it for you by not setting the --skip-bundler flag.
+    If you chose to build it yourself you'll need to run a command to build the JS
+    bundle first.
     You can use '--input-dir' to specify a different input directory.`);
   });
 });

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -1,5 +1,6 @@
 import { Platform } from '@expo/config';
-import JsonFile from '@expo/json-file';
+import JsonFile, { JSONObject } from '@expo/json-file';
+import spawnAsync from '@expo/spawn-async';
 import Joi from '@hapi/joi';
 import crypto from 'crypto';
 import fs from 'fs';
@@ -10,6 +11,7 @@ import path from 'path';
 import { AssetMetadataStatus, PartialManifestAsset } from '../graphql/generated';
 import { PublishMutation } from '../graphql/mutations/PublishMutation';
 import { PublishQuery } from '../graphql/queries/PublishQuery';
+import Log from '../log';
 import { PresignedPost, uploadWithPresignedPostAsync } from '../uploads';
 
 export const TIMEOUT_LIMIT = 60_000; // 1 minute
@@ -140,11 +142,61 @@ export async function buildUpdateInfoGroupAsync(assets: CollectedAssets): Promis
   return updateInfoGroup as UpdateInfoGroup;
 }
 
+export async function buildBundlesAsync({
+  projectDir,
+  inputDir,
+}: {
+  projectDir: string;
+  inputDir: string;
+}) {
+  const packageJSON = JsonFile.read(path.resolve(projectDir, 'package.json'));
+  if (!packageJSON) {
+    throw new Error('Could not locate package.json');
+  }
+  const isCLIInstalled =
+    !!(packageJSON.dependencies as JSONObject)['expo-cli'] ||
+    !!(packageJSON.devDependencies as JSONObject)['expo-cli'];
+  if (!isCLIInstalled) {
+    throw new Error(
+      'expo-cli is not installed. To bundle your app, install expo-cli, or skip bundling with --skip-bundle'
+    );
+  }
+
+  Log.withTick(`Building bundle with expo-cli...`);
+  const spawnPromise = spawnAsync('yarn', [
+    'expo',
+    'export',
+    '--output-dir',
+    inputDir,
+    '--experimental-bundle',
+    '--force',
+  ]);
+  const {
+    child: { stdout, stderr },
+  } = spawnPromise;
+  if (!(stdout && stderr)) {
+    throw new Error('Failed to spawn expo-cli');
+  }
+  stdout.on('data', data => {
+    for (const line of data.toString().trim().split('\n')) {
+      Log.log(`[expo-cli]${line}`);
+    }
+  });
+  stderr.on('data', data => {
+    for (const line of data.toString().trim().split('\n')) {
+      Log.warn(`[expo-cli]${line}`);
+    }
+  });
+  await spawnPromise;
+}
+
 export function resolveInputDirectory(customInputDirectory: string): string {
   const distRoot = path.resolve(customInputDirectory);
   if (!fs.existsSync(distRoot)) {
     throw new Error(`The input directory "${customInputDirectory}" does not exist.
-    You'll need to run a command to build the JS bundle first (e.g. 'expo export').
+    You can allow us to build it for you by not setting the --skip-bundler flag.
+    If you chose to build it yourself you'll need to run a command to build the JS
+    bundle first.
     You can use '--input-dir' to specify a different input directory.`);
   }
   return distRoot;

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -1,5 +1,5 @@
 import { Platform } from '@expo/config';
-import JsonFile, { JSONObject } from '@expo/json-file';
+import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
 import Joi from '@hapi/joi';
 import crypto from 'crypto';
@@ -153,24 +153,13 @@ export async function buildBundlesAsync({
   if (!packageJSON) {
     throw new Error('Could not locate package.json');
   }
-  const isCLIInstalled =
-    !!(packageJSON.dependencies as JSONObject)['expo-cli'] ||
-    !!(packageJSON.devDependencies as JSONObject)['expo-cli'];
-  if (!isCLIInstalled) {
-    throw new Error(
-      'expo-cli is not installed. To bundle your app, install expo-cli, or skip bundling with --skip-bundle'
-    );
-  }
 
   Log.withTick(`Building bundle with expo-cli...`);
-  const spawnPromise = spawnAsync('yarn', [
-    'expo',
-    'export',
-    '--output-dir',
-    inputDir,
-    '--experimental-bundle',
-    '--force',
-  ]);
+  const spawnPromise = spawnAsync(
+    'yarn',
+    ['expo', 'export', '--output-dir', inputDir, '--experimental-bundle', '--force'],
+    { stdio: ['inherit', 'pipe', 'pipe'] } // inherit stdin so user can install a missing expo-cli from inside this command
+  );
   const {
     child: { stdout, stderr },
   } = spawnPromise;


### PR DESCRIPTION
# Why

Currently in order to publish we have to go through a 2 step process:
 1. manually create the bundles with `expo-cli export --experimental-bundle --force`.
 2. publish with `eas branch:publish`

The commands are seperate so that a developer can select their preferred bundler. However, we also want the `publish` command to be a short and simple as possible. This PR makes usage of `expo-cli` the default behavior: `eas branch:publish` will automatically check to see if `expo-cli` is installed and then run step (1). 

We use the same expo-cli verison as yarn.

If expo-cli is not installed, the option to install it will be offered via the wrapper in `node_modules/.bin/cli.js`.

If the developer wishes to avoid this behavior and handle bundling on their own, they can set the new `--skip-bundler` flag.

# How

Check in the package.json for `expo-cli` and run it with `@expo/spawn-async`

The output of the `expo-cli` bundling process is prefixed with `[expo-cli]` and passed through:
<img width="1536" alt="Screen Shot 2021-02-16 at 10 27 09 AM" src="https://user-images.githubusercontent.com/1220444/108105488-89ae0380-7041-11eb-9b63-bee2bcfe4fd0.png">

CC: @jon @brentvatne 
# Test Plan

confirmed bundles are build and published.
confirmed --experimental-bundle flag prevents expo-cli from being used.