### PR TITLE
add support for ios simulator builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add support for iOS simulator builds. ([#240](https://github.com/expo/eas-cli/pull/240) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 ## [0.4.2](https://github.com/expo/eas-cli/releases/tag/v0.4.1) - 2021-02-18

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -11,7 +11,7 @@
     "@expo/apple-utils": "0.0.0-alpha.17",
     "@expo/config": "~3.3.19",
     "@expo/config-plugins": "1.0.19-alpha.0",
-    "@expo/eas-build-job": "0.2.11",
+    "@expo/eas-build-job": "0.2.12",
     "@expo/eas-json": "^0.4.1",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.11",

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -1,5 +1,5 @@
 import { Workflow } from '@expo/eas-build-job';
-import { CredentialsSource, DistributionType } from '@expo/eas-json';
+import { CredentialsSource, iOSDistributionType } from '@expo/eas-json';
 import assert from 'assert';
 
 import { createCredentialsContextAsync } from '../../credentials/context';
@@ -27,7 +27,7 @@ export async function ensureIosCredentialsAsync(
     },
     workflow: ctx.buildProfile.workflow,
     credentialsSource: ctx.buildProfile.credentialsSource,
-    distribution: ctx.buildProfile.distribution ?? DistributionType.STORE,
+    distribution: ctx.buildProfile.distribution ?? 'store',
     nonInteractive: ctx.commandCtx.nonInteractive,
     skipCredentialsCheck: ctx.commandCtx.skipCredentialsCheck,
   });
@@ -37,7 +37,7 @@ interface ResolveCredentialsParams {
   app: AppLookupParams;
   workflow: Workflow;
   credentialsSource: CredentialsSource;
-  distribution: DistributionType;
+  distribution: iOSDistributionType;
   nonInteractive: boolean;
   skipCredentialsCheck: boolean;
 }
@@ -69,5 +69,5 @@ export async function resolveIosCredentialsAsync(
 }
 
 function shouldProvideCredentials(ctx: BuildContext<Platform.iOS>): boolean {
-  return true;
+  return ctx.buildProfile.distribution !== 'simulator';
 }

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -50,6 +50,7 @@ interface CommonJobProperties {
   projectArchive: ArchiveSource;
   builderEnvironment: iOS.BuilderEnvironment;
   releaseChannel: string;
+  distribution?: iOS.DistributionType;
   secrets: {
     buildCredentials: iOS.BuildCredentials;
     secretEnvs?: Record<string, string>;
@@ -88,6 +89,7 @@ async function prepareJobCommonAsync(
       type: ArchiveSourceType.S3,
       bucketKey: archiveBucketKey,
     },
+    distribution: ctx.buildProfile.distribution,
     builderEnvironment: {
       image: ctx.buildProfile.image,
       node: ctx.buildProfile.node,

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,4 +1,4 @@
-import { CredentialsSource, DistributionType } from '@expo/eas-json';
+import { CredentialsSource } from '@expo/eas-json';
 
 import { getAppIdentifierAsync } from '../project/projectUtils';
 import { BuildContext } from './context';
@@ -26,7 +26,7 @@ export async function collectMetadata<T extends Platform>(
     credentialsSource,
     sdkVersion: ctx.commandCtx.exp.sdkVersion,
     trackingContext: ctx.trackingCtx,
-    distribution: ctx.buildProfile.distribution ?? DistributionType.STORE,
+    distribution: ctx.buildProfile.distribution ?? 'store',
     appName: ctx.commandCtx.exp.name,
     appIdentifier:
       (await getAppIdentifierAsync(ctx.commandCtx.projectDir, ctx.platform)) ?? undefined,

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -83,7 +83,7 @@ export type BuildMetadata = {
 
   /**
    * Distribution type
-   * Indicates whether this is a build for store or internal distribution.
+   * Indicates whether this is a build for store, internal distribution, or simulator (iOS).
    */
   distribution: DistributionType;
 

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -1,4 +1,3 @@
-import { DistributionType } from '@expo/eas-json';
 import assert from 'assert';
 import chalk from 'chalk';
 

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -47,7 +47,7 @@ export function printBuildResults(accountName: string, builds: (Build | null)[])
 }
 
 function printBuildResult(accountName: string, build: Build): void {
-  if (build.metadata?.distribution === DistributionType.INTERNAL) {
+  if (build.metadata?.distribution === 'internal') {
     const logsUrl = getBuildLogsUrl({
       buildId: build.id,
       account: accountName,

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -1,5 +1,5 @@
 import { Platform } from '@expo/eas-build-job';
-import { CredentialsSource, DistributionType } from '@expo/eas-json';
+import { CredentialsSource, iOSDistributionType } from '@expo/eas-json';
 
 import { IosDistributionType } from '../../graphql/generated';
 import Log from '../../log';
@@ -23,7 +23,7 @@ interface PartialIosCredentials {
 
 interface Options {
   app: AppLookupParams;
-  distribution: DistributionType;
+  distribution: iOSDistributionType;
   skipCredentialsCheck?: boolean;
 }
 
@@ -48,7 +48,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   }
 
   public async hasLocalAsync(): Promise<boolean> {
-    if (this.options.distribution === DistributionType.INTERNAL) {
+    if (this.options.distribution === 'internal') {
       // TODO: add support for using credentials.json for internal distribution
       return false;
     }
@@ -102,7 +102,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   }
 
   private async getLocalAsync(): Promise<IosCredentials> {
-    if (this.options.distribution === DistributionType.INTERNAL) {
+    if (this.options.distribution === 'internal') {
       // TODO: add support for using credentials.json for internal distribution
       throw new Error('Using credentials.json for internal distribution is not supported yet.');
     }
@@ -147,7 +147,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   }
 
   private async fetchRemoteAsync(): Promise<PartialIosCredentials> {
-    if (this.options.distribution === DistributionType.INTERNAL) {
+    if (this.options.distribution === 'internal') {
       const { app } = this.options;
       const account = findAccountByName(this.ctx.user.accounts, app.accountName);
       if (!account) {

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -1,4 +1,4 @@
-import { DistributionType } from '@expo/eas-json';
+import { iOSDistributionType } from '@expo/eas-json';
 import assert from 'assert';
 import chalk from 'chalk';
 
@@ -21,7 +21,7 @@ type AppCredentialsAndDistCert = {
 };
 
 export class SetupBuildCredentials implements Action {
-  constructor(private app: AppLookupParams, private distribution: DistributionType) {}
+  constructor(private app: AppLookupParams, private distribution: iOSDistributionType) {}
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     await ctx.bestEffortAppStoreAuthenticateAsync();
@@ -32,7 +32,7 @@ export class SetupBuildCredentials implements Action {
 
     let iosAppBuildCredentials: IosAppBuildCredentialsFragment | null = null;
     try {
-      if (this.distribution === DistributionType.INTERNAL) {
+      if (this.distribution === 'internal') {
         const account = findAccountByName(ctx.user.accounts, this.app.accountName);
         if (!account) {
           throw new Error(`You do not have access to the ${this.app.accountName} account`);

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -1,5 +1,3 @@
-import { iOSDistributionType } from '@expo/eas-json';
-
 import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -1,4 +1,4 @@
-import { DistributionType } from '@expo/eas-json';
+import { iOSDistributionType } from '@expo/eas-json';
 
 import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
@@ -135,7 +135,7 @@ export class ManageIos implements Action {
       }
       case ActionType.SetupBuildCredentials: {
         const app = this.getAppLookupParamsFromContext(ctx);
-        return new SetupBuildCredentials(app, DistributionType.STORE);
+        return new SetupBuildCredentials(app, 'store');
       }
       case ActionType.RemoveSpecificProvisioningProfile: {
         const app = this.getAppLookupParamsFromContext(ctx);

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.11",
+    "@expo/eas-build-job": "0.2.12",
     "@hapi/joi": "^17.1.1",
     "fs-extra": "^9.0.1",
     "tslib": "^1"

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -43,7 +43,7 @@ export interface iOSGenericBuildProfile extends iOS.BuilderEnvironment {
   workflow: Workflow.Generic;
   credentialsSource: CredentialsSource;
   scheme?: string;
-  schemeBuildConfiguration?: iOS.GenericSchemeBuildConfiguration;
+  schemeBuildConfiguration?: iOS.SchemeBuildConfiguration;
   releaseChannel?: string;
   artifactPath?: string;
   distribution?: iOSDistributionType;

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -6,10 +6,9 @@ export enum CredentialsSource {
   AUTO = 'auto',
 }
 
-export enum DistributionType {
-  STORE = 'store',
-  INTERNAL = 'internal',
-}
+export type AndroidDistributionType = 'store' | 'internal';
+export type iOSDistributionType = 'store' | 'internal' | 'simulator';
+export type DistributionType = AndroidDistributionType | iOSDistributionType;
 
 export type VersionAutoIncrement = boolean | 'version' | 'buildNumber';
 
@@ -18,7 +17,7 @@ export interface AndroidManagedBuildProfile extends Android.BuilderEnvironment {
   credentialsSource: CredentialsSource;
   buildType?: Android.ManagedBuildType;
   releaseChannel?: string;
-  distribution?: DistributionType;
+  distribution?: AndroidDistributionType;
 }
 
 export interface AndroidGenericBuildProfile extends Android.BuilderEnvironment {
@@ -28,7 +27,7 @@ export interface AndroidGenericBuildProfile extends Android.BuilderEnvironment {
   releaseChannel?: string;
   artifactPath?: string;
   withoutCredentials?: boolean;
-  distribution?: DistributionType;
+  distribution?: AndroidDistributionType;
 }
 
 export interface iOSManagedBuildProfile extends iOS.BuilderEnvironment {
@@ -36,7 +35,7 @@ export interface iOSManagedBuildProfile extends iOS.BuilderEnvironment {
   credentialsSource: CredentialsSource;
   buildType?: iOS.ManagedBuildType;
   releaseChannel?: string;
-  distribution?: DistributionType;
+  distribution?: iOSDistributionType;
   autoIncrement: VersionAutoIncrement;
 }
 
@@ -47,7 +46,7 @@ export interface iOSGenericBuildProfile extends iOS.BuilderEnvironment {
   schemeBuildConfiguration?: iOS.GenericSchemeBuildConfiguration;
   releaseChannel?: string;
   artifactPath?: string;
-  distribution?: DistributionType;
+  distribution?: iOSDistributionType;
   autoIncrement: VersionAutoIncrement;
 }
 

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -63,7 +63,7 @@ const iOSGenericSchema = Joi.object({
   schemeBuildConfiguration: Joi.string().valid('Debug', 'Release'),
   releaseChannel: Joi.string(),
   artifactPath: Joi.string(),
-  distribution: Joi.string().valid('store', 'internal').default('store'),
+  distribution: Joi.string().valid('store', 'internal', 'simulator').default('store'),
   autoIncrement: Joi.alternatives()
     .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
     .default(false),
@@ -74,7 +74,7 @@ const iOSManagedSchema = Joi.object({
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
   buildType: Joi.string().valid('release', 'development-client'),
   releaseChannel: Joi.string(),
-  distribution: Joi.string().valid('store', 'internal').default('store'),
+  distribution: Joi.string().valid('store', 'internal', 'simulator').default('store'),
   autoIncrement: Joi.alternatives()
     .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
     .default(false),

--- a/packages/eas-json/src/index.ts
+++ b/packages/eas-json/src/index.ts
@@ -1,12 +1,14 @@
 export {
   CredentialsSource,
-  DistributionType,
+  AndroidDistributionType,
   AndroidManagedBuildProfile,
   AndroidGenericBuildProfile,
   AndroidBuildProfile,
+  iOSDistributionType,
   iOSManagedBuildProfile,
   iOSGenericBuildProfile,
   iOSBuildProfile,
+  DistributionType,
   EasConfig,
   VersionAutoIncrement,
 } from './Config.types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.11":
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.11.tgz#cc4c9816c1e3cea29bca7b2eac4de99c6e6b804d"
-  integrity sha512-IeG37+10OteIG2RpKTA0ClxFxQVuRx9QYu8qbesMpmroKSDyrRZQFD9DdAho2CFr+WCUG5vLVfJpGuw17LrQ+Q==
+"@expo/eas-build-job@0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.12.tgz#35224e8ad7e9d6f70d76172b75c3b6824293470e"
+  integrity sha512-a70/NZfsnQFnEqt+b6DK8g1OAExRjHSDf4MFOVAXg7DlhIIB9cAhRiJE/5ksfZfaJ7CI/RdEysU7fCWkspcNig==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
# Why

We want to enable users to build simulator builds.
The server-side was implemented in https://github.com/expo/turtle-v2/pull/417

# How

- I added a new `distribution` type for iOS builds - `simulator`
- Credentials are not required for `simulator`.

# Test Plan

Tested by building both managed and generic projects with `distribution` set to `simulator` (and also set to `store`).