### PR TITLE
[eas-cli] rename updateGroup, updateMessage, branchName, channelName

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1378,6 +1378,49 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "environmentSecrets",
+            "description": "Environment secrets for an account",
+            "args": [
+              {
+                "name": "filterNames",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EnvironmentSecret",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -2682,11 +2725,11 @@
             "deprecationReason": null
           },
           {
-            "name": "updateChannelByChannelName",
-            "description": "get an EAS channel owned by the app by channelName",
+            "name": "updateChannelByName",
+            "description": "get an EAS channel owned by the app by name",
             "args": [
               {
-                "name": "channelName",
+                "name": "name",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -2766,11 +2809,11 @@
             "deprecationReason": null
           },
           {
-            "name": "updateBranchByBranchName",
-            "description": "get an EAS branch owned by the app by branchName",
+            "name": "updateBranchByName",
+            "description": "get an EAS branch owned by the app by name",
             "args": [
               {
-                "name": "branchName",
+                "name": "name",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -2837,6 +2880,49 @@
                   "ofType": {
                     "kind": "INTERFACE",
                     "name": "ActivityTimelineProjectActivity",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environmentSecrets",
+            "description": "Environment secrets for an app",
+            "args": [
+              {
+                "name": "filterNames",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EnvironmentSecret",
                     "ofType": null
                   }
                 }
@@ -4827,6 +4913,12 @@
           },
           {
             "name": "INTERNAL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SIMULATOR",
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null
@@ -7299,7 +7391,7 @@
             "deprecationReason": null
           },
           {
-            "name": "channelName",
+            "name": "name",
             "description": "",
             "args": [],
             "type": {
@@ -7459,7 +7551,7 @@
             "deprecationReason": null
           },
           {
-            "name": "branchName",
+            "name": "name",
             "description": "",
             "args": [],
             "type": {
@@ -7679,7 +7771,7 @@
             "deprecationReason": null
           },
           {
-            "name": "updateGroup",
+            "name": "group",
             "description": "",
             "args": [],
             "type": {
@@ -7727,7 +7819,7 @@
             "deprecationReason": null
           },
           {
-            "name": "updateMessage",
+            "name": "message",
             "description": "",
             "args": [],
             "type": {
@@ -7739,15 +7831,15 @@
             "deprecationReason": null
           },
           {
-            "name": "branchName",
+            "name": "branch",
             "description": "",
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "UpdateBranch",
                 "ofType": null
               }
             },
@@ -7763,6 +7855,81 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EnvironmentSecret",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -10322,6 +10489,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EmailSubscriptionMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environmentSecret",
+            "description": "Mutations that create and delete EnvironmentSecrets",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EnvironmentSecretMutation",
                 "ofType": null
               }
             },
@@ -13919,7 +14102,7 @@
                 "defaultValue": null
               },
               {
-                "name": "channelName",
+                "name": "name",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -14149,7 +14332,7 @@
                 "defaultValue": null
               },
               {
-                "name": "branchName",
+                "name": "name",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -14173,7 +14356,7 @@
           },
           {
             "name": "editUpdateBranch",
-            "description": "Edit an EAS branch. The branch can be specified either by its ID or\nwith the combination of (appId, branchName).",
+            "description": "Edit an EAS branch. The branch can be specified either by its ID or\nwith the combination of (appId, name).",
             "args": [
               {
                 "name": "input",
@@ -14297,7 +14480,7 @@
             "defaultValue": null
           },
           {
-            "name": "branchName",
+            "name": "name",
             "description": "",
             "type": {
               "kind": "SCALAR",
@@ -14307,7 +14490,7 @@
             "defaultValue": null
           },
           {
-            "name": "newBranchName",
+            "name": "newName",
             "description": "",
             "type": {
               "kind": "NON_NULL",
@@ -14401,7 +14584,7 @@
             "defaultValue": null
           },
           {
-            "name": "updateMessage",
+            "name": "message",
             "description": "",
             "type": {
               "kind": "SCALAR",
@@ -16134,6 +16317,196 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EnvironmentSecretMutation",
+        "description": "",
+        "fields": [
+          {
+            "name": "createEnvironmentSecretForAccount",
+            "description": "Create an environment secret for an Account",
+            "args": [
+              {
+                "name": "environmentSecretData",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CreateEnvironmentSecretInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "accountId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EnvironmentSecret",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createEnvironmentSecretForApp",
+            "description": "Create an environment secret for an App",
+            "args": [
+              {
+                "name": "environmentSecretData",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CreateEnvironmentSecretInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EnvironmentSecret",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteEnvironmentSecret",
+            "description": "Delete an environment secret",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteEnvironmentSecretResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CreateEnvironmentSecretInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "name",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "value",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeleteEnvironmentSecretResult",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -14,30 +14,30 @@ import { getBranchNameAsync } from '../../utils/git';
 
 export async function createUpdateBranchOnAppAsync({
   appId,
-  branchName,
+  name,
 }: {
   appId: string;
-  branchName: string;
-}): Promise<Pick<UpdateBranch, 'id' | 'branchName'>> {
+  name: string;
+}): Promise<Pick<UpdateBranch, 'id' | 'name'>> {
   const data = await withErrorHandlingAsync(
     graphqlClient
       .mutation<
-        { updateBranch: { createUpdateBranchForApp: Pick<UpdateBranch, 'id' | 'branchName'> } },
-        { appId: string; branchName: string }
+        { updateBranch: { createUpdateBranchForApp: Pick<UpdateBranch, 'id' | 'name'> } },
+        { appId: string; name: string }
       >(
         gql`
-          mutation createUpdateBranchForApp($appId: ID!, $branchName: String!) {
+          mutation createUpdateBranchForApp($appId: ID!, $name: String!) {
             updateBranch {
-              createUpdateBranchForApp(appId: $appId, branchName: $branchName) {
+              createUpdateBranchForApp(appId: $appId, name: $name) {
                 id
-                branchName
+                name
               }
             }
           }
         `,
         {
           appId,
-          branchName,
+          name: name,
         }
       )
       .toPromise()
@@ -51,7 +51,7 @@ export default class BranchCreate extends Command {
 
   static args = [
     {
-      name: 'branchName',
+      name: 'name',
       required: false,
       description: 'Name of the branch to create',
     },
@@ -66,7 +66,7 @@ export default class BranchCreate extends Command {
 
   async run() {
     let {
-      args: { branchName },
+      args: { name },
       flags,
     } = this.parse(BranchCreate);
 
@@ -82,14 +82,14 @@ export default class BranchCreate extends Command {
       projectName: exp.slug,
     });
 
-    if (!branchName) {
+    if (!name) {
       const validationMessage = 'Branch name may not be empty.';
       if (flags.json) {
         throw new Error(validationMessage);
       }
-      ({ branchName } = await promptAsync({
+      ({ name } = await promptAsync({
         type: 'text',
-        name: 'branchName',
+        name: 'name',
         message: 'Please name the branch:',
         initial:
           (await getBranchNameAsync()) || `branch-${Math.random().toString(36).substr(2, 4)}`,
@@ -97,7 +97,7 @@ export default class BranchCreate extends Command {
       }));
     }
 
-    const newBranch = await createUpdateBranchOnAppAsync({ appId: projectId, branchName });
+    const newBranch = await createUpdateBranchOnAppAsync({ appId: projectId, name: name });
 
     if (flags.json) {
       Log.log(newBranch);
@@ -105,7 +105,7 @@ export default class BranchCreate extends Command {
     }
 
     Log.withTick(
-      `️Created a new branch: ${chalk.bold(newBranch.branchName)} on project ${chalk.bold(
+      `️Created a new branch: ${chalk.bold(newBranch.name)} on project ${chalk.bold(
         `@${accountName}/${exp.slug}`
       )}.`
     );

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -37,7 +37,7 @@ export async function createUpdateBranchOnAppAsync({
         `,
         {
           appId,
-          name: name,
+          name,
         }
       )
       .toPromise()
@@ -97,7 +97,7 @@ export default class BranchCreate extends Command {
       }));
     }
 
-    const newBranch = await createUpdateBranchOnAppAsync({ appId: projectId, name: name });
+    const newBranch = await createUpdateBranchOnAppAsync({ appId: projectId, name });
 
     if (flags.json) {
       Log.log(newBranch);

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -39,7 +39,7 @@ export default class BranchList extends Command {
       const table = new CliTable({ head: ['Branch', 'Latest update'] });
       table.push(
         ...branches.map((branch: UpdateBranch) => [
-          branch.branchName,
+          branch.name,
           formatUpdate(branch.updates[0]),
         ])
       );
@@ -61,7 +61,7 @@ export default class BranchList extends Command {
                 fullName
                 updateBranches(offset: 0, limit: $limit) {
                   id
-                  branchName
+                  name
                   updates(offset: 0, limit: 1) {
                     id
                     actor {
@@ -75,7 +75,7 @@ export default class BranchList extends Command {
                       }
                     }
                     updatedAt
-                    updateMessage
+                    message
                   }
                 }
               }
@@ -105,7 +105,7 @@ function formatUpdate(update: Update | undefined): string {
   if (!update) {
     return 'N/A';
   }
-  const message = update.updateMessage ? `"${update.updateMessage}" ` : '';
+  const message = update.message ? `"${update.message}" ` : '';
   return `${message}(${format(update.updatedAt, 'en_US')} by ${getActorDisplayName(
     update.actor as any
   )})`;

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -38,10 +38,7 @@ export default class BranchList extends Command {
     } else {
       const table = new CliTable({ head: ['Branch', 'Latest update'] });
       table.push(
-        ...branches.map((branch: UpdateBranch) => [
-          branch.name,
-          formatUpdate(branch.updates[0]),
-        ])
+        ...branches.map((branch: UpdateBranch) => [branch.name, formatUpdate(branch.updates[0])])
       );
       Log.log(table.toString());
       if (branches.length >= BRANCHES_LIMIT) {

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -41,7 +41,7 @@ export default class BranchPublish extends Command {
 
   async run() {
     let {
-      flags: { json: jsonFlag, branch: branchName, message: updateMessage, 'input-dir': inputDir },
+      flags: { json: jsonFlag, branch: name, message: message, 'input-dir': inputDir },
     } = this.parse(BranchPublish);
 
     const projectDir = await findProjectRootAsync(process.cwd());
@@ -63,25 +63,25 @@ export default class BranchPublish extends Command {
       projectName: slug,
     });
 
-    if (!branchName) {
+    if (!name) {
       const validationMessage = 'branch name may not be empty.';
       if (jsonFlag) {
         throw new Error(validationMessage);
       }
-      ({ branchName } = await promptAsync({
+      ({ name } = await promptAsync({
         type: 'text',
-        name: 'branchName',
+        name: 'name',
         message: 'Please enter the name of the branch to publish on:',
         validate: value => (value ? true : validationMessage),
       }));
     }
 
-    if (!updateMessage) {
+    if (!message) {
       const validationMessage = 'publish message may not be empty.';
       if (jsonFlag) {
         throw new Error(validationMessage);
       }
-      ({ publishMessage: updateMessage } = await promptAsync({
+      ({ publishMessage: message } = await promptAsync({
         type: 'text',
         name: 'publishMessage',
         message: `Please enter a publication message.`,
@@ -92,7 +92,7 @@ export default class BranchPublish extends Command {
 
     const { id: branchId } = await getBranchByNameAsync({
       appId: projectId,
-      branchName: branchName!,
+      name: name!,
     });
 
     let updateInfoGroup;
@@ -114,7 +114,7 @@ export default class BranchPublish extends Command {
         branchId,
         updateInfoGroup,
         runtimeVersion,
-        updateMessage,
+        message,
       });
       publishSpinner.succeed('Published!');
     } catch (e) {
@@ -148,10 +148,10 @@ export default class BranchPublish extends Command {
       });
       outputMessage.push(
         [chalk.dim('project'), `@${accountName}/${slug}`],
-        [chalk.dim('branch'), branchName],
+        [chalk.dim('branch'), name],
         [chalk.dim('runtimeVersion'), runtimeVersion],
-        [chalk.dim('updateGroupID'), newUpdateGroup.updateGroup],
-        [chalk.dim('message'), updateMessage]
+        [chalk.dim('groupID'), newUpdateGroup.group],
+        [chalk.dim('message'), message]
       );
       Log.log(outputMessage.toString());
     }

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -41,7 +41,7 @@ export default class BranchPublish extends Command {
 
   async run() {
     let {
-      flags: { json: jsonFlag, branch: name, message: message, 'input-dir': inputDir },
+      flags: { json: jsonFlag, branch: name, message, 'input-dir': inputDir },
     } = this.parse(BranchPublish);
 
     const projectDir = await findProjectRootAsync(process.cwd());

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -33,7 +33,7 @@ async function renameUpdateBranchOnAppAsync({
             updateBranch {
               editUpdateBranch(input: $input) {
                 id
-                branchName
+                name
               }
             }
           }
@@ -41,8 +41,8 @@ async function renameUpdateBranchOnAppAsync({
         {
           input: {
             appId,
-            branchName: currentName,
-            newBranchName: newName,
+            name: currentName,
+            newName,
           },
         }
       )
@@ -125,7 +125,7 @@ export default class BranchRename extends Command {
 
     Log.withTick(
       `️Renamed branch from ${currentName} to ${chalk.bold(
-        editedBranch.branchName
+        editedBranch.name
       )} on project ${chalk.bold(`@${accountName}/${exp.slug}`)}.`
     );
   }

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -17,11 +17,11 @@ import { createUpdateBranchOnAppAsync } from '../branch/create';
 
 async function createUpdateChannelOnAppAsync({
   appId,
-  name,
+  channelName,
   branchId,
 }: {
   appId: string;
-  name: string;
+  channelName: string;
   branchId: string;
 }): Promise<UpdateChannel> {
   // Point the new channel at a branch with its same name.
@@ -48,7 +48,7 @@ async function createUpdateChannelOnAppAsync({
         `,
         {
           appId,
-          name,
+          name: channelName,
           branchMapping,
         }
       )
@@ -129,7 +129,7 @@ export default class ChannelCreate extends Command {
 
     const newChannel = await createUpdateChannelOnAppAsync({
       appId: projectId,
-      name: channelName,
+      channelName,
       branchId,
     });
 

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -79,7 +79,7 @@ export default class ChannelCreate extends Command {
 
   async run() {
     let {
-      args: { name },
+      args: { name: channelName },
       flags: { json: jsonFlag },
     } = this.parse(ChannelCreate);
 
@@ -96,12 +96,12 @@ export default class ChannelCreate extends Command {
       projectName: slug,
     });
 
-    if (!name) {
+    if (!channelName) {
       const validationMessage = 'Channel name may not be empty.';
       if (jsonFlag) {
         throw new Error(validationMessage);
       }
-      ({ name } = await promptAsync({
+      ({ name: channelName } = await promptAsync({
         type: 'text',
         name: 'name',
         message: 'Please name the channel:',
@@ -114,14 +114,14 @@ export default class ChannelCreate extends Command {
     try {
       const existingBranch = await getBranchByNameAsync({
         appId: projectId,
-        name,
+        name: channelName,
       });
       branchId = existingBranch.id;
       branchMessage = `We found a branch with the same name`;
     } catch (e) {
       const newBranch = await createUpdateBranchOnAppAsync({
         appId: projectId,
-        name,
+        name: channelName,
       });
       branchId = newBranch.id;
       branchMessage = `We also went ahead and made a branch with the same name`;
@@ -129,7 +129,7 @@ export default class ChannelCreate extends Command {
 
     const newChannel = await createUpdateChannelOnAppAsync({
       appId: projectId,
-      name,
+      name: channelName,
       branchId,
     });
 

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -17,11 +17,11 @@ import { createUpdateBranchOnAppAsync } from '../branch/create';
 
 async function createUpdateChannelOnAppAsync({
   appId,
-  channelName,
+  name,
   branchId,
 }: {
   appId: string;
-  channelName: string;
+  name: string;
   branchId: string;
 }): Promise<UpdateChannel> {
   // Point the new channel at a branch with its same name.
@@ -33,22 +33,14 @@ async function createUpdateChannelOnAppAsync({
     graphqlClient
       .mutation<
         { updateChannel: { createUpdateChannelForApp: UpdateChannel } },
-        { appId: string; channelName: string; branchMapping: string }
+        { appId: string; name: string; branchMapping: string }
       >(
         gql`
-          mutation CreateUpdateChannelForApp(
-            $appId: ID!
-            $channelName: String!
-            $branchMapping: String!
-          ) {
+          mutation CreateUpdateChannelForApp($appId: ID!, $name: String!, $branchMapping: String!) {
             updateChannel {
-              createUpdateChannelForApp(
-                appId: $appId
-                channelName: $channelName
-                branchMapping: $branchMapping
-              ) {
+              createUpdateChannelForApp(appId: $appId, name: $name, branchMapping: $branchMapping) {
                 id
-                channelName
+                name
                 branchMapping
               }
             }
@@ -56,7 +48,7 @@ async function createUpdateChannelOnAppAsync({
         `,
         {
           appId,
-          channelName,
+          name,
           branchMapping,
         }
       )
@@ -71,7 +63,7 @@ export default class ChannelCreate extends Command {
 
   static args = [
     {
-      name: 'channelName',
+      name: 'name',
       required: false,
       description: 'Name of the channel to create',
     },
@@ -87,7 +79,7 @@ export default class ChannelCreate extends Command {
 
   async run() {
     let {
-      args: { channelName },
+      args: { name },
       flags: { json: jsonFlag },
     } = this.parse(ChannelCreate);
 
@@ -104,14 +96,14 @@ export default class ChannelCreate extends Command {
       projectName: slug,
     });
 
-    if (!channelName) {
+    if (!name) {
       const validationMessage = 'Channel name may not be empty.';
       if (jsonFlag) {
         throw new Error(validationMessage);
       }
-      ({ channelName } = await promptAsync({
+      ({ name } = await promptAsync({
         type: 'text',
-        name: 'channelName',
+        name: 'name',
         message: 'Please name the channel:',
         validate: value => (value ? true : validationMessage),
       }));
@@ -122,14 +114,14 @@ export default class ChannelCreate extends Command {
     try {
       const existingBranch = await getBranchByNameAsync({
         appId: projectId,
-        branchName: channelName,
+        name,
       });
       branchId = existingBranch.id;
       branchMessage = `We found a branch with the same name`;
     } catch (e) {
       const newBranch = await createUpdateBranchOnAppAsync({
         appId: projectId,
-        branchName: channelName,
+        name,
       });
       branchId = newBranch.id;
       branchMessage = `We also went ahead and made a branch with the same name`;
@@ -137,7 +129,7 @@ export default class ChannelCreate extends Command {
 
     const newChannel = await createUpdateChannelOnAppAsync({
       appId: projectId,
-      channelName,
+      name,
       branchId,
     });
 
@@ -147,7 +139,7 @@ export default class ChannelCreate extends Command {
     }
 
     Log.withTick(
-      `️Created a new channel ${chalk.bold(newChannel.channelName)} on project ${chalk.bold(
+      `️Created a new channel ${chalk.bold(newChannel.name)} on project ${chalk.bold(
         `@${accountName}/${slug}`
       )}. ${branchMessage} and have pointed the channel at it. You can now update your app by publishing!`
     );

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -195,6 +195,8 @@ export type Account = {
   applePushKeys: Array<ApplePushKey>;
   appleProvisioningProfiles: Array<AppleProvisioningProfile>;
   appleDevices: Array<AppleDevice>;
+  /** Environment secrets for an account */
+  environmentSecrets: Array<EnvironmentSecret>;
 };
 
 
@@ -274,6 +276,15 @@ export type AccountAppleProvisioningProfilesArgs = {
  */
 export type AccountAppleDevicesArgs = {
   identifier?: Maybe<Scalars['String']>;
+};
+
+
+/**
+ * An account is a container owning projects, credentials, billing and other organization
+ * data and settings. Actors may own and be members of accounts.
+ */
+export type AccountEnvironmentSecretsArgs = {
+  filterNames?: Maybe<Array<Scalars['String']>>;
 };
 
 
@@ -396,14 +407,16 @@ export type App = Project & {
   androidAppCredentials: Array<AndroidAppCredentials>;
   /** EAS channels owned by an app */
   updateChannels: Array<UpdateChannel>;
-  /** get an EAS channel owned by the app by channelName */
-  updateChannelByChannelName: UpdateChannel;
+  /** get an EAS channel owned by the app by name */
+  updateChannelByName: UpdateChannel;
   /** EAS branches owned by an app */
   updateBranches: Array<UpdateBranch>;
-  /** get an EAS branch owned by the app by branchName */
-  updateBranchByBranchName: UpdateBranch;
+  /** get an EAS branch owned by the app by name */
+  updateBranchByName: UpdateBranch;
   /** Coalesced project activity for an app. Use "createdBefore" to offset a query. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
+  /** Environment secrets for an app */
+  environmentSecrets: Array<EnvironmentSecret>;
 };
 
 
@@ -458,8 +471,8 @@ export type AppUpdateChannelsArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
-export type AppUpdateChannelByChannelNameArgs = {
-  channelName: Scalars['String'];
+export type AppUpdateChannelByNameArgs = {
+  name: Scalars['String'];
 };
 
 
@@ -471,8 +484,8 @@ export type AppUpdateBranchesArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
-export type AppUpdateBranchByBranchNameArgs = {
-  branchName: Scalars['String'];
+export type AppUpdateBranchByNameArgs = {
+  name: Scalars['String'];
 };
 
 
@@ -480,6 +493,12 @@ export type AppUpdateBranchByBranchNameArgs = {
 export type AppActivityTimelineProjectActivitiesArgs = {
   limit: Scalars['Int'];
   createdBefore?: Maybe<Scalars['DateTime']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppEnvironmentSecretsArgs = {
+  filterNames?: Maybe<Array<Scalars['String']>>;
 };
 
 export type AppIcon = {
@@ -730,7 +749,8 @@ export type BuildMetrics = {
 
 export enum DistributionType {
   Store = 'STORE',
-  Internal = 'INTERNAL'
+  Internal = 'INTERNAL',
+  Simulator = 'SIMULATOR'
 }
 
 /** Represents an Standalone App build job */
@@ -1011,7 +1031,7 @@ export type UpdateChannel = {
   __typename?: 'UpdateChannel';
   id: Scalars['ID'];
   appId: Scalars['ID'];
-  channelName: Scalars['String'];
+  name: Scalars['String'];
   branchMapping: Scalars['String'];
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
@@ -1028,7 +1048,7 @@ export type UpdateBranch = {
   __typename?: 'UpdateBranch';
   id: Scalars['ID'];
   appId: Scalars['ID'];
-  branchName: Scalars['String'];
+  name: Scalars['String'];
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
   updates: Array<Update>;
@@ -1049,11 +1069,19 @@ export type Update = ActivityTimelineProjectActivity & {
   platform: Scalars['String'];
   manifestFragment: Scalars['String'];
   runtimeVersion: Scalars['String'];
-  updateGroup: Scalars['String'];
+  group: Scalars['String'];
   updatedAt: Scalars['DateTime'];
   createdAt: Scalars['DateTime'];
-  updateMessage?: Maybe<Scalars['String']>;
-  branchName: Scalars['String'];
+  message?: Maybe<Scalars['String']>;
+  branch: UpdateBranch;
+};
+
+export type EnvironmentSecret = {
+  __typename?: 'EnvironmentSecret';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
 };
 
 export type UserPermission = {
@@ -1475,6 +1503,8 @@ export type RootMutation = {
   me?: Maybe<MeMutation>;
   /** Mutations that modify an EmailSubscription */
   emailSubscription: EmailSubscriptionMutation;
+  /** Mutations that create and delete EnvironmentSecrets */
+  environmentSecret: EnvironmentSecretMutation;
 };
 
 
@@ -2201,7 +2231,7 @@ export type UpdateChannelMutation = {
 
 export type UpdateChannelMutationCreateUpdateChannelForAppArgs = {
   appId: Scalars['ID'];
-  channelName: Scalars['String'];
+  name: Scalars['String'];
   branchMapping?: Maybe<Scalars['String']>;
 };
 
@@ -2243,7 +2273,7 @@ export type UpdateBranchMutation = {
   createUpdateBranchForApp?: Maybe<UpdateBranch>;
   /**
    * Edit an EAS branch. The branch can be specified either by its ID or
-   * with the combination of (appId, branchName).
+   * with the combination of (appId, name).
    */
   editUpdateBranch: UpdateBranch;
   /** Delete an EAS branch and all of its updates as long as the branch is not being used by any channels */
@@ -2255,7 +2285,7 @@ export type UpdateBranchMutation = {
 
 export type UpdateBranchMutationCreateUpdateBranchForAppArgs = {
   appId: Scalars['ID'];
-  branchName: Scalars['String'];
+  name: Scalars['String'];
 };
 
 
@@ -2276,8 +2306,8 @@ export type UpdateBranchMutationPublishUpdateGroupArgs = {
 export type EditUpdateBranchInput = {
   id?: Maybe<Scalars['ID']>;
   appId?: Maybe<Scalars['ID']>;
-  branchName?: Maybe<Scalars['String']>;
-  newBranchName: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  newName: Scalars['String'];
 };
 
 export type DeleteUpdateBranchResult = {
@@ -2289,7 +2319,7 @@ export type PublishUpdateGroupInput = {
   branchId: Scalars['String'];
   updateInfoGroup: UpdateInfoGroup;
   runtimeVersion: Scalars['String'];
-  updateMessage?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
 };
 
 export type UpdateInfoGroup = {
@@ -2596,6 +2626,43 @@ export type MailchimpTagPayload = {
   __typename?: 'MailchimpTagPayload';
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
+};
+
+export type EnvironmentSecretMutation = {
+  __typename?: 'EnvironmentSecretMutation';
+  /** Create an environment secret for an Account */
+  createEnvironmentSecretForAccount: EnvironmentSecret;
+  /** Create an environment secret for an App */
+  createEnvironmentSecretForApp: EnvironmentSecret;
+  /** Delete an environment secret */
+  deleteEnvironmentSecret: DeleteEnvironmentSecretResult;
+};
+
+
+export type EnvironmentSecretMutationCreateEnvironmentSecretForAccountArgs = {
+  environmentSecretData?: Maybe<CreateEnvironmentSecretInput>;
+  accountId: Scalars['String'];
+};
+
+
+export type EnvironmentSecretMutationCreateEnvironmentSecretForAppArgs = {
+  environmentSecretData?: Maybe<CreateEnvironmentSecretInput>;
+  appId: Scalars['String'];
+};
+
+
+export type EnvironmentSecretMutationDeleteEnvironmentSecretArgs = {
+  id: Scalars['String'];
+};
+
+export type CreateEnvironmentSecretInput = {
+  name: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type DeleteEnvironmentSecretResult = {
+  __typename?: 'DeleteEnvironmentSecretResult';
+  id: Scalars['ID'];
 };
 
 export type BaseSearchResult = SearchResult & {
@@ -3275,7 +3342,7 @@ export type UpdatePublishMutation = (
     { __typename?: 'UpdateBranchMutation' }
     & { publishUpdateGroup: Array<Maybe<(
       { __typename?: 'Update' }
-      & Pick<Update, 'id' | 'updateGroup'>
+      & Pick<Update, 'id' | 'group'>
     )>> }
   ) }
 );

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -31,7 +31,7 @@ const PublishMutation = {
 
   async publishUpdateGroupAsync(
     publishUpdateGroupInput: PublishUpdateGroupInput
-  ): Promise<Pick<Update, 'id' | 'updateGroup'>> {
+  ): Promise<Pick<Update, 'id' | 'group'>> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<UpdatePublishMutation>(
@@ -40,7 +40,7 @@ const PublishMutation = {
               updateBranch {
                 publishUpdateGroup(publishUpdateGroupInput: $publishUpdateGroupInput) {
                   id
-                  updateGroup
+                  group
                 }
               }
             }

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -125,10 +125,10 @@ export function getProjectConfigDescription(projectDir: string): string {
 
 export async function getBranchByNameAsync({
   appId,
-  branchName,
+  name,
 }: {
   appId: string;
-  branchName: string;
+  name: string;
 }): Promise<UpdateBranch> {
   const data = await withErrorHandlingAsync(
     graphqlClient
@@ -136,23 +136,23 @@ export async function getBranchByNameAsync({
         {
           app: {
             byId: {
-              updateBranchByBranchName: UpdateBranch;
+              updateBranchByName: UpdateBranch;
             };
           };
         },
         {
           appId: string;
-          branchName: string;
+          name: string;
         }
       >(
         gql`
-          query ViewBranch($appId: String!, $branchName: String!) {
+          query ViewBranch($appId: String!, $name: String!) {
             app {
               byId(appId: $appId) {
                 id
-                updateBranchByBranchName(branchName: $branchName) {
+                updateBranchByName(name: $name) {
                   id
-                  branchName
+                  name
                 }
               }
             }
@@ -160,10 +160,10 @@ export async function getBranchByNameAsync({
         `,
         {
           appId,
-          branchName,
+          name,
         }
       )
       .toPromise()
   );
-  return data.app.byId.updateBranchByBranchName;
+  return data.app.byId.updateBranchByName;
 }


### PR DESCRIPTION
# Why

Following @fson observation about excessively verbose attribute names, we refactored a bunch of the graphQL methods server side.

This PR brings the eas-cli up to speed.

# How

renamed and ran `yarn generate-graphql-code`

# Test Plan

tested that all of the `eas branch:*` and `eas channel:create` commands work.