### PR TITLE
[eas-cli] use fixed version of @expo/eas-json

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -12,7 +12,7 @@
     "@expo/config": "~3.3.19",
     "@expo/config-plugins": "1.0.19-alpha.0",
     "@expo/eas-build-job": "0.2.12",
-    "@expo/eas-json": "^0.4.1",
+    "@expo/eas-json": "0.4.1",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.11",
     "@expo/plugin-warn-if-update-available": "^1.7.0",


### PR DESCRIPTION
# Why

https://forums.expo.io/t/eas-build-validationerror-android-and-ios/49117

I'm not sure 100% if the use of `^` was the issue here, but it seems to be most likely.

