### PR TITLE
[eas-cli] rename fileHash to fileSHA256

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -14689,7 +14689,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "fileHash",
+            "name": "fileSHA256",
             "description": "",
             "type": {
               "kind": "NON_NULL",

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2334,7 +2334,7 @@ export type PartialManifest = {
 };
 
 export type PartialManifestAsset = {
-  fileHash: Scalars['String'];
+  fileSHA256: Scalars['String'];
   bundleKey: Scalars['String'];
   contentType: Scalars['String'];
   storageBucket: Scalars['String'];

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -140,7 +140,7 @@ describe(convertAssetToUpdateInfoGroupFormatAsync, () => {
     await expect(convertAssetToUpdateInfoGroupFormatAsync(asset)).resolves.toEqual({
       bundleKey: `c939e759656f577c058f445bfb19182e.${type}`,
       contentType: 'image/jpeg',
-      fileHash: 'tzD6J-OQZaHCKnL3GHWV9RbnrpyojnagiOE7r3mSkU4',
+      fileSHA256: 'tzD6J-OQZaHCKnL3GHWV9RbnrpyojnagiOE7r3mSkU4',
       storageBucket: 'update-assets-production',
       storageKey: 'fo8Y08LktVk6qLtGbn8GRWpOUyD13ABMUnbtRCN1L7Y',
     });
@@ -177,7 +177,7 @@ describe(buildUpdateInfoGroupAsync, () => {
           {
             bundleKey: 'c939e759656f577c058f445bfb19182e.jpg',
             contentType: 'image/jpeg',
-            fileHash: 'tzD6J-OQZaHCKnL3GHWV9RbnrpyojnagiOE7r3mSkU4',
+            fileSHA256: 'tzD6J-OQZaHCKnL3GHWV9RbnrpyojnagiOE7r3mSkU4',
             storageBucket: 'update-assets-production',
             storageKey: 'fo8Y08LktVk6qLtGbn8GRWpOUyD13ABMUnbtRCN1L7Y',
           },
@@ -186,7 +186,7 @@ describe(buildUpdateInfoGroupAsync, () => {
         launchAsset: {
           bundleKey: 'ec0dd14670aae108f99a810df9c1482c.bundle',
           contentType: 'bundle/javascript',
-          fileHash: 'KEw79FnKTLOyVbRT1SlohSTjPe5e8FpULy2ST-I5BUg',
+          fileSHA256: 'KEw79FnKTLOyVbRT1SlohSTjPe5e8FpULy2ST-I5BUg',
           storageBucket: 'update-assets-production',
           storageKey: 'aC9N6RZlcHoIYjIsoJd2KUcigBKy98RHvZacDyPNjCQ',
         },

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -102,23 +102,23 @@ async function calculateFileHashAsync(filePath: string, algorithm: string): Prom
  * Convenience function that computes an assets storage key starting from its buffer.
  */
 export async function getStorageKeyForAssetAsync(asset: RawAsset): Promise<string> {
-  const fileHash = getBase64URLEncoding(await calculateFileHashAsync(asset.path, 'sha256'));
-  return getStorageKey(asset.contentType, fileHash);
+  const fileSHA256 = getBase64URLEncoding(await calculateFileHashAsync(asset.path, 'sha256'));
+  return getStorageKey(asset.contentType, fileSHA256);
 }
 
 export async function convertAssetToUpdateInfoGroupFormatAsync(
   asset: RawAsset
 ): Promise<PartialManifestAsset> {
-  const fileHash = getBase64URLEncoding(await calculateFileHashAsync(asset.path, 'sha256'));
+  const fileSHA256 = getBase64URLEncoding(await calculateFileHashAsync(asset.path, 'sha256'));
   const contentType = asset.contentType;
-  const storageKey = getStorageKey(contentType, fileHash);
+  const storageKey = getStorageKey(contentType, fileSHA256);
   const bundleKey = [
     (await calculateFileHashAsync(asset.path, 'md5')).toString('hex'),
     asset.type,
   ].join('.');
 
   return {
-    fileHash,
+    fileSHA256,
     contentType,
     storageBucket: STORAGE_BUCKET,
     storageKey,


### PR DESCRIPTION
# Why
closes https://linear.app/expo/issue/ENG-219/rename-filehash-to-filesha256

`fileHash` has been renamed to the more descriptive `fileSHA256`

# How

search replace

# Test Plan

made a test publish.