### PR TITLE
upgrade @expo/eas-build-job 0.2.12 -> 0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+### 🧹 Chores
+
+- Upgrade `@expo/eas-build-job` from `0.2.12` to `0.2.13`. ([#245](https://github.com/expo/eas-cli/pull/245) by [@dsokal](https://github.com/dsokal))
+
 ## [0.4.3](https://github.com/expo/eas-cli/releases/tag/v0.4.3) - 2021-02-23
 
 ### 🎉 New features

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -11,7 +11,7 @@
     "@expo/apple-utils": "0.0.0-alpha.17",
     "@expo/config": "~3.3.19",
     "@expo/config-plugins": "1.0.19-alpha.0",
-    "@expo/eas-build-job": "0.2.12",
+    "@expo/eas-build-job": "0.2.13",
     "@expo/eas-json": "^0.4.3",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.11",

--- a/packages/eas-cli/src/build/__tests__/credentials-test.ts
+++ b/packages/eas-cli/src/build/__tests__/credentials-test.ts
@@ -48,7 +48,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Generic,
+        Workflow.GENERIC,
         CredentialsSource.AUTO,
         false
       );
@@ -61,7 +61,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Generic,
+        Workflow.GENERIC,
         CredentialsSource.AUTO,
         false
       );
@@ -75,7 +75,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Generic,
+        Workflow.GENERIC,
         CredentialsSource.AUTO,
         false
       );
@@ -93,7 +93,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Generic,
+        Workflow.GENERIC,
         CredentialsSource.AUTO,
         false
       );
@@ -111,7 +111,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Generic,
+        Workflow.GENERIC,
         CredentialsSource.AUTO,
         false
       );
@@ -126,7 +126,7 @@ describe(ensureCredentialsAsync, () => {
       });
 
       try {
-        await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO, true);
+        await ensureCredentialsAsync(provider, Workflow.GENERIC, CredentialsSource.AUTO, true);
         throw new Error('ensureCredentialsAsync should throw an Error');
       } catch (e) {
         expect(e.message).toMatch(
@@ -147,7 +147,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Generic,
+        Workflow.GENERIC,
         CredentialsSource.AUTO,
         false
       );
@@ -165,7 +165,7 @@ describe(ensureCredentialsAsync, () => {
       });
 
       try {
-        await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO, false);
+        await ensureCredentialsAsync(provider, Workflow.GENERIC, CredentialsSource.AUTO, false);
         throw new Error('ensureCredentialsAsync should throw an Error');
       } catch (e) {
         expect(e.message).toMatch(
@@ -186,7 +186,7 @@ describe(ensureCredentialsAsync, () => {
       });
 
       try {
-        await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO, true);
+        await ensureCredentialsAsync(provider, Workflow.GENERIC, CredentialsSource.AUTO, true);
         throw new Error('ensureCredentialsAsync should throw an Error');
       } catch (e) {
         expect(e.message).toMatch('Credentials for this app are not configured');
@@ -204,7 +204,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Managed,
+        Workflow.MANAGED,
         CredentialsSource.AUTO,
         false
       );
@@ -217,7 +217,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Managed,
+        Workflow.MANAGED,
         CredentialsSource.AUTO,
         false
       );
@@ -231,7 +231,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Managed,
+        Workflow.MANAGED,
         CredentialsSource.AUTO,
         false
       );
@@ -247,7 +247,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Managed,
+        Workflow.MANAGED,
         CredentialsSource.AUTO,
         false
       );
@@ -265,7 +265,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Generic,
+        Workflow.GENERIC,
         CredentialsSource.LOCAL,
         false
       );
@@ -283,7 +283,7 @@ describe(ensureCredentialsAsync, () => {
       });
       const src = await ensureCredentialsAsync(
         provider,
-        Workflow.Generic,
+        Workflow.GENERIC,
         CredentialsSource.REMOTE,
         false
       );

--- a/packages/eas-cli/src/build/android/applicationId.ts
+++ b/packages/eas-cli/src/build/android/applicationId.ts
@@ -25,7 +25,7 @@ function isApplicationIdValid(applicationId: string): boolean {
 }
 
 export async function ensureApplicationIdIsValidAsync(projectDir: string) {
-  const applicationId = await ensureAppIdentifierIsDefinedAsync(projectDir, Platform.Android);
+  const applicationId = await ensureAppIdentifierIsDefinedAsync(projectDir, Platform.ANDROID);
   if (!isApplicationIdValid(applicationId)) {
     const configDescription = getProjectConfigDescription(projectDir);
     Log.error(

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -22,15 +22,15 @@ export async function prepareAndroidBuildAsync(
   commandCtx: CommandContext,
   easConfig: EasConfig
 ): Promise<() => Promise<string>> {
-  const buildCtx = createBuildContext<Platform.Android>({
+  const buildCtx = createBuildContext<Platform.ANDROID>({
     commandCtx,
-    platform: Platform.Android,
+    platform: Platform.ANDROID,
     easConfig,
   });
   const { buildProfile } = buildCtx;
 
   if (
-    buildProfile.workflow === Workflow.Generic &&
+    buildProfile.workflow === Workflow.GENERIC &&
     !(await fs.pathExists(path.join(commandCtx.projectDir, 'android')))
   ) {
     throw new Error(
@@ -41,7 +41,7 @@ export async function prepareAndroidBuildAsync(
   }
 
   if (
-    buildProfile.workflow === Workflow.Generic &&
+    buildProfile.workflow === Workflow.GENERIC &&
     buildProfile.distribution === 'internal' &&
     buildProfile.gradleCommand?.match(/bundle/)
   ) {
@@ -67,7 +67,7 @@ This means that it will most likely produce an AAB and you will not be able to i
     projectConfiguration: {},
     ensureCredentialsAsync: ensureAndroidCredentialsAsync,
     ensureProjectConfiguredAsync: async () => {
-      if (buildCtx.buildProfile.workflow === Workflow.Generic) {
+      if (buildCtx.buildProfile.workflow === Workflow.GENERIC) {
         await validateAndSyncProjectConfigurationAsync(commandCtx.projectDir, commandCtx.exp);
       }
     },
@@ -75,15 +75,15 @@ This means that it will most likely produce an AAB and you will not be able to i
   });
 }
 
-function shouldProvideCredentials(ctx: BuildContext<Platform.Android>): boolean {
+function shouldProvideCredentials(ctx: BuildContext<Platform.ANDROID>): boolean {
   return (
-    ctx.buildProfile.workflow === Workflow.Managed ||
-    (ctx.buildProfile.workflow === Workflow.Generic && !ctx.buildProfile.withoutCredentials)
+    ctx.buildProfile.workflow === Workflow.MANAGED ||
+    (ctx.buildProfile.workflow === Workflow.GENERIC && !ctx.buildProfile.withoutCredentials)
   );
 }
 
 async function ensureAndroidCredentialsAsync(
-  ctx: BuildContext<Platform.Android>
+  ctx: BuildContext<Platform.ANDROID>
 ): Promise<CredentialsResult<AndroidCredentials> | undefined> {
   if (!shouldProvideCredentials(ctx)) {
     return;

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -22,13 +22,13 @@ interface JobData {
 }
 
 export async function prepareJobAsync(
-  ctx: BuildContext<Platform.Android>,
+  ctx: BuildContext<Platform.ANDROID>,
   jobData: JobData
 ): Promise<Job> {
-  if (ctx.buildProfile.workflow === Workflow.Generic) {
+  if (ctx.buildProfile.workflow === Workflow.GENERIC) {
     const partialJob = await prepareGenericJobAsync(ctx, jobData, ctx.buildProfile);
     return sanitizeJob(partialJob);
-  } else if (ctx.buildProfile.workflow === Workflow.Managed) {
+  } else if (ctx.buildProfile.workflow === Workflow.MANAGED) {
     const partialJob = await prepareManagedJobAsync(ctx, jobData, ctx.buildProfile);
     return sanitizeJob(partialJob);
   } else {
@@ -37,7 +37,7 @@ export async function prepareJobAsync(
 }
 
 interface CommonJobProperties {
-  platform: Platform.Android;
+  platform: Platform.ANDROID;
   projectArchive: ArchiveSource;
   builderEnvironment: Android.BuilderEnvironment;
   secrets: {
@@ -49,7 +49,7 @@ interface CommonJobProperties {
 }
 
 async function prepareJobCommonAsync(
-  ctx: BuildContext<Platform.Android>,
+  ctx: BuildContext<Platform.ANDROID>,
   jobData: JobData
 ): Promise<Partial<CommonJobProperties>> {
   const secretEnvs = await readSecretEnvsAsync(ctx.commandCtx.projectDir);
@@ -68,7 +68,7 @@ async function prepareJobCommonAsync(
     : {};
 
   return {
-    platform: Platform.Android,
+    platform: Platform.ANDROID,
     projectArchive: {
       type: ArchiveSourceType.S3,
       bucketKey: jobData.archiveBucketKey,
@@ -88,7 +88,7 @@ async function prepareJobCommonAsync(
 }
 
 async function prepareGenericJobAsync(
-  ctx: BuildContext<Platform.Android>,
+  ctx: BuildContext<Platform.ANDROID>,
   jobData: JobData,
   buildProfile: AndroidGenericBuildProfile
 ): Promise<Partial<Android.GenericJob>> {
@@ -96,7 +96,7 @@ async function prepareGenericJobAsync(
     path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
-    type: Workflow.Generic,
+    type: Workflow.GENERIC,
     gradleCommand: buildProfile.gradleCommand,
     artifactPath: buildProfile.artifactPath,
     releaseChannel: buildProfile.releaseChannel,
@@ -105,7 +105,7 @@ async function prepareGenericJobAsync(
 }
 
 async function prepareManagedJobAsync(
-  ctx: BuildContext<Platform.Android>,
+  ctx: BuildContext<Platform.ANDROID>,
   jobData: JobData,
   buildProfile: AndroidManagedBuildProfile
 ): Promise<Partial<Android.ManagedJob>> {
@@ -114,7 +114,7 @@ async function prepareManagedJobAsync(
   const accountName = await getProjectAccountNameAsync(ctx.commandCtx.projectDir);
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
-    type: Workflow.Managed,
+    type: Workflow.MANAGED,
     username: accountName,
     buildType: buildProfile.buildType,
     releaseChannel: buildProfile.releaseChannel,

--- a/packages/eas-cli/src/build/constants.ts
+++ b/packages/eas-cli/src/build/constants.ts
@@ -7,6 +7,6 @@ export const platformDisplayNames = {
 };
 
 export const platformEmojis = {
-  [Platform.iOS]: '🍎',
-  [Platform.Android]: '🤖',
+  [Platform.IOS]: '🍎',
+  [Platform.ANDROID]: '🤖',
 };

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -77,7 +77,7 @@ export interface ConfigureContext {
   hasIosNativeProject: boolean;
 }
 
-type PlatformBuildProfile<T extends Platform> = T extends Platform.Android
+type PlatformBuildProfile<T extends Platform> = T extends Platform.ANDROID
   ? AndroidBuildProfile
   : iOSBuildProfile;
 

--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -51,11 +51,11 @@ async function startBuildsAsync(
   }[] = [];
   if (shouldBuildAndroid) {
     const sendBuildRequestAsync = await prepareAndroidBuildAsync(commandCtx, easConfig);
-    builds.push({ platform: Platform.Android, sendBuildRequestAsync });
+    builds.push({ platform: Platform.ANDROID, sendBuildRequestAsync });
   }
   if (shouldBuildiOS) {
     const sendBuildRequestAsync = await prepareIosBuildAsync(commandCtx, easConfig);
-    builds.push({ platform: Platform.iOS, sendBuildRequestAsync });
+    builds.push({ platform: Platform.IOS, sendBuildRequestAsync });
   }
   return Promise.all(
     builds.map(async ({ platform, sendBuildRequestAsync }) => ({

--- a/packages/eas-cli/src/build/credentials.ts
+++ b/packages/eas-cli/src/build/credentials.ts
@@ -21,13 +21,13 @@ async function ensureCredentialsAutoAsync(
 ): Promise<CredentialsSource.LOCAL | CredentialsSource.REMOTE> {
   const platform = platformDisplayNames[provider.platform];
   switch (workflow) {
-    case Workflow.Managed:
+    case Workflow.MANAGED:
       if (await provider.hasLocalAsync()) {
         return CredentialsSource.LOCAL;
       } else {
         return CredentialsSource.REMOTE;
       }
-    case Workflow.Generic: {
+    case Workflow.GENERIC: {
       const hasLocal = await provider.hasLocalAsync();
       const hasRemote = await provider.hasRemoteAsync();
       if (hasRemote && hasLocal) {

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -20,14 +20,14 @@ export async function prepareIosBuildAsync(
   commandCtx: CommandContext,
   easConfig: EasConfig
 ): Promise<() => Promise<string>> {
-  const buildCtx = createBuildContext<Platform.iOS>({
+  const buildCtx = createBuildContext<Platform.IOS>({
     commandCtx,
-    platform: Platform.iOS,
+    platform: Platform.IOS,
     easConfig,
   });
 
   if (
-    buildCtx.buildProfile.workflow === Workflow.Generic &&
+    buildCtx.buildProfile.workflow === Workflow.GENERIC &&
     !(await fs.pathExists(path.join(commandCtx.projectDir, 'ios')))
   ) {
     throw new Error(
@@ -39,7 +39,7 @@ export async function prepareIosBuildAsync(
 
   let iosBuildScheme: string | undefined;
   let iosApplicationTarget: string | undefined;
-  if (buildCtx.buildProfile.workflow === Workflow.Generic) {
+  if (buildCtx.buildProfile.workflow === Workflow.GENERIC) {
     iosBuildScheme = buildCtx.buildProfile.scheme ?? (await resolveSchemeAsync(buildCtx));
     iosApplicationTarget = await IOSConfig.BuildScheme.getApplicationTargetForSchemeAsync(
       buildCtx.commandCtx.projectDir,
@@ -67,7 +67,7 @@ export async function prepareIosBuildAsync(
   });
 }
 
-async function resolveSchemeAsync(ctx: BuildContext<Platform.iOS>): Promise<string> {
+async function resolveSchemeAsync(ctx: BuildContext<Platform.IOS>): Promise<string> {
   const schemes = IOSConfig.BuildScheme.getSchemesFromXcodeproj(ctx.commandCtx.projectDir);
   if (schemes.length === 1) {
     return schemes[0];

--- a/packages/eas-cli/src/build/ios/bundleIdentifer.ts
+++ b/packages/eas-cli/src/build/ios/bundleIdentifer.ts
@@ -22,7 +22,7 @@ function isBundleIdentifierValid(bundleIdentifier: string): boolean {
 }
 
 export async function ensureBundleIdentifierIsValidAsync(projectDir: string) {
-  const bundleIdentifier = await ensureAppIdentifierIsDefinedAsync(projectDir, Platform.iOS);
+  const bundleIdentifier = await ensureAppIdentifierIsDefinedAsync(projectDir, Platform.IOS);
   if (!isBundleIdentifierValid(bundleIdentifier)) {
     const configDescription = getProjectConfigDescription(projectDir);
     Log.error(

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -38,7 +38,7 @@ export async function validateAndSyncProjectConfigurationAsync({
   const { workflow, autoIncrement } = buildProfile;
   const versionBumpStrategy = resolveVersionBumpStrategy(autoIncrement);
 
-  if (workflow === Workflow.Generic) {
+  if (workflow === Workflow.GENERIC) {
     const bundleIdentifierFromPbxproj = IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj(
       projectDir
     );

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -13,7 +13,7 @@ import { ensureCredentialsAsync } from '../credentials';
 import { Platform } from '../types';
 
 export async function ensureIosCredentialsAsync(
-  ctx: BuildContext<Platform.iOS>
+  ctx: BuildContext<Platform.IOS>
 ): Promise<CredentialsResult<IosCredentials> | undefined> {
   if (!shouldProvideCredentials(ctx)) {
     return;
@@ -68,6 +68,6 @@ export async function resolveIosCredentialsAsync(
   };
 }
 
-function shouldProvideCredentials(ctx: BuildContext<Platform.iOS>): boolean {
+function shouldProvideCredentials(ctx: BuildContext<Platform.IOS>): boolean {
   return ctx.buildProfile.distribution !== 'simulator';
 }

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -1,9 +1,9 @@
 import {
   ArchiveSource,
   ArchiveSourceType,
+  Ios,
   Job,
   Workflow,
-  iOS,
   sanitizeJob,
 } from '@expo/eas-build-job';
 import { iOSGenericBuildProfile, iOSManagedBuildProfile } from '@expo/eas-json';
@@ -31,13 +31,13 @@ interface JobData {
 }
 
 export async function prepareJobAsync(
-  ctx: BuildContext<Platform.iOS>,
+  ctx: BuildContext<Platform.IOS>,
   jobData: JobData
 ): Promise<Job> {
-  if (ctx.buildProfile.workflow === Workflow.Generic) {
+  if (ctx.buildProfile.workflow === Workflow.GENERIC) {
     const partialJob = await prepareGenericJobAsync(ctx, jobData, ctx.buildProfile);
     return sanitizeJob(partialJob);
-  } else if (ctx.buildProfile.workflow === Workflow.Managed) {
+  } else if (ctx.buildProfile.workflow === Workflow.MANAGED) {
     const partialJob = await prepareManagedJobAsync(ctx, jobData, ctx.buildProfile);
     return sanitizeJob(partialJob);
   } else {
@@ -46,19 +46,19 @@ export async function prepareJobAsync(
 }
 
 interface CommonJobProperties {
-  platform: Platform.iOS;
+  platform: Platform.IOS;
   projectArchive: ArchiveSource;
-  builderEnvironment: iOS.BuilderEnvironment;
+  builderEnvironment: Ios.BuilderEnvironment;
   releaseChannel: string;
-  distribution?: iOS.DistributionType;
+  distribution?: Ios.DistributionType;
   secrets: {
-    buildCredentials: iOS.BuildCredentials;
+    buildCredentials: Ios.BuildCredentials;
     secretEnvs?: Record<string, string>;
   };
 }
 
 async function prepareJobCommonAsync(
-  ctx: BuildContext<Platform.iOS>,
+  ctx: BuildContext<Platform.IOS>,
   {
     archiveBucketKey,
     credentials,
@@ -84,7 +84,7 @@ async function prepareJobCommonAsync(
   }
 
   return {
-    platform: Platform.iOS,
+    platform: Platform.IOS,
     projectArchive: {
       type: ArchiveSourceType.S3,
       bucketKey: archiveBucketKey,
@@ -105,7 +105,7 @@ async function prepareJobCommonAsync(
   };
 }
 
-function prepareTargetCredentials(targetCredentials: IosTargetCredentials): iOS.TargetCredentials {
+function prepareTargetCredentials(targetCredentials: IosTargetCredentials): Ios.TargetCredentials {
   return {
     provisioningProfileBase64: targetCredentials.provisioningProfile,
     distributionCertificate: {
@@ -116,10 +116,10 @@ function prepareTargetCredentials(targetCredentials: IosTargetCredentials): iOS.
 }
 
 async function prepareGenericJobAsync(
-  ctx: BuildContext<Platform.iOS>,
+  ctx: BuildContext<Platform.IOS>,
   jobData: JobData,
   buildProfile: iOSGenericBuildProfile
-): Promise<Partial<iOS.GenericJob>> {
+): Promise<Partial<Ios.GenericJob>> {
   const projectRootDirectory =
     path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
   return {
@@ -128,7 +128,7 @@ async function prepareGenericJobAsync(
       credentials: jobData.credentials,
       targetName: jobData.projectConfiguration.iosApplicationTarget,
     })),
-    type: Workflow.Generic,
+    type: Workflow.GENERIC,
     scheme: jobData.projectConfiguration.iosBuildScheme,
     schemeBuildConfiguration: buildProfile.schemeBuildConfiguration,
     artifactPath: buildProfile.artifactPath,
@@ -138,10 +138,10 @@ async function prepareGenericJobAsync(
 }
 
 async function prepareManagedJobAsync(
-  ctx: BuildContext<Platform.iOS>,
+  ctx: BuildContext<Platform.IOS>,
   jobData: JobData,
   buildProfile: iOSManagedBuildProfile
-): Promise<Partial<iOS.ManagedJob>> {
+): Promise<Partial<Ios.ManagedJob>> {
   const projectRootDirectory =
     path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
   const accountName = await getProjectAccountNameAsync(ctx.commandCtx.projectDir);
@@ -152,7 +152,7 @@ async function prepareManagedJobAsync(
       credentials: jobData.credentials,
       targetName,
     })),
-    type: Workflow.Managed,
+    type: Workflow.MANAGED,
     buildType: buildProfile.buildType,
     username: accountName,
     releaseChannel: buildProfile.releaseChannel,

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -100,7 +100,7 @@ export type BuildMetadata = {
   appIdentifier?: string;
 };
 
-export type PlatformBuildProfile<T extends Platform> = T extends Platform.Android
+export type PlatformBuildProfile<T extends Platform> = T extends Platform.ANDROID
   ? AndroidBuildProfile
   : iOSBuildProfile;
 

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -38,8 +38,8 @@ async function cancelBuildAsync(buildId: string): Promise<Pick<Build, 'id' | 'st
 }
 
 const appPlatformMap = {
-  [AppPlatform.Android]: Platform.Android,
-  [AppPlatform.Ios]: Platform.iOS,
+  [AppPlatform.Android]: Platform.ANDROID,
+  [AppPlatform.Ios]: Platform.IOS,
 };
 
 function formatUnfinishedBuild(

--- a/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
@@ -24,7 +24,7 @@ interface Options {
 }
 
 export default class AndroidCredentialsProvider implements CredentialsProvider {
-  public readonly platform = Platform.Android;
+  public readonly platform = Platform.ANDROID;
 
   constructor(private ctx: Context, private options: Options) {}
 

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -34,7 +34,7 @@ interface AppLookupParams {
 }
 
 export default class IosCredentialsProvider implements CredentialsProvider {
-  public readonly platform = Platform.iOS;
+  public readonly platform = Platform.IOS;
 
   constructor(private ctx: Context, private options: Options) {}
 

--- a/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
@@ -11,7 +11,7 @@ export class UpdateCredentialsJson implements Action {
   constructor(private app: AppLookupParams) {}
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
-    const bundleIdentifer = await ensureAppIdentifierIsDefinedAsync(ctx.projectDir, Platform.iOS);
+    const bundleIdentifer = await ensureAppIdentifierIsDefinedAsync(ctx.projectDir, Platform.IOS);
     Log.log('Updating iOS credentials in credentials.json');
     await updateIosCredentialsAsync(ctx, bundleIdentifer);
     Log.succeed(

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -71,7 +71,7 @@ export async function getAppIdentifierAsync(
 ): Promise<string | null> {
   const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
   switch (platform) {
-    case Platform.Android: {
+    case Platform.ANDROID: {
       const packageNameFromConfig = AndroidConfig.Package.getPackage(exp);
       if (packageNameFromConfig) {
         return packageNameFromConfig;
@@ -80,7 +80,7 @@ export async function getAppIdentifierAsync(
         ? await getAndroidApplicationIdAsync(projectDir)
         : null;
     }
-    case Platform.iOS: {
+    case Platform.IOS: {
       return (
         IOSConfig.BundleIdentifier.getBundleIdentifier(exp) ??
         IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj(projectDir)
@@ -96,7 +96,7 @@ export async function ensureAppIdentifierIsDefinedAsync(
   const appIdentifier = await getAppIdentifierAsync(projectDir, platform);
   if (!appIdentifier) {
     const desc = getProjectConfigDescription(projectDir);
-    const fieldStr = platform === Platform.Android ? 'android.package' : 'ios.bundleIdentifier';
+    const fieldStr = platform === Platform.ANDROID ? 'android.package' : 'ios.bundleIdentifier';
     throw new Error(`Please define "${fieldStr}" in your ${desc}.`);
   }
   return appIdentifier;

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -39,7 +39,7 @@ export async function ensureAppStoreConnectAppExistsAsync(
   const { bundleIdentifier, appName, language } = ctx.commandFlags;
 
   const resolvedBundleId =
-    bundleIdentifier ?? (await getAppIdentifierAsync(ctx.projectDir, Platform.iOS));
+    bundleIdentifier ?? (await getAppIdentifierAsync(ctx.projectDir, Platform.IOS));
   if (!resolvedBundleId) {
     throw new Error(
       `Please define "expo.ios.bundleIdentifier" in your app config or provide it using --bundle-identifier param.

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.12",
+    "@expo/eas-build-job": "0.2.13",
     "@hapi/joi": "^17.1.1",
     "fs-extra": "^9.0.1",
     "tslib": "^1"

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -1,4 +1,4 @@
-import { Android, Workflow, iOS } from '@expo/eas-build-job';
+import { Android, Ios, Workflow } from '@expo/eas-build-job';
 
 export enum CredentialsSource {
   LOCAL = 'local',
@@ -13,7 +13,7 @@ export type DistributionType = AndroidDistributionType | iOSDistributionType;
 export type VersionAutoIncrement = boolean | 'version' | 'buildNumber';
 
 export interface AndroidManagedBuildProfile extends Android.BuilderEnvironment {
-  workflow: Workflow.Managed;
+  workflow: Workflow.MANAGED;
   credentialsSource: CredentialsSource;
   buildType?: Android.ManagedBuildType;
   releaseChannel?: string;
@@ -21,7 +21,7 @@ export interface AndroidManagedBuildProfile extends Android.BuilderEnvironment {
 }
 
 export interface AndroidGenericBuildProfile extends Android.BuilderEnvironment {
-  workflow: Workflow.Generic;
+  workflow: Workflow.GENERIC;
   credentialsSource: CredentialsSource;
   gradleCommand?: string;
   releaseChannel?: string;
@@ -30,20 +30,20 @@ export interface AndroidGenericBuildProfile extends Android.BuilderEnvironment {
   distribution?: AndroidDistributionType;
 }
 
-export interface iOSManagedBuildProfile extends iOS.BuilderEnvironment {
-  workflow: Workflow.Managed;
+export interface iOSManagedBuildProfile extends Ios.BuilderEnvironment {
+  workflow: Workflow.MANAGED;
   credentialsSource: CredentialsSource;
-  buildType?: iOS.ManagedBuildType;
+  buildType?: Ios.ManagedBuildType;
   releaseChannel?: string;
   distribution?: iOSDistributionType;
   autoIncrement: VersionAutoIncrement;
 }
 
-export interface iOSGenericBuildProfile extends iOS.BuilderEnvironment {
-  workflow: Workflow.Generic;
+export interface iOSGenericBuildProfile extends Ios.BuilderEnvironment {
+  workflow: Workflow.GENERIC;
   credentialsSource: CredentialsSource;
   scheme?: string;
-  schemeBuildConfiguration?: iOS.SchemeBuildConfiguration;
+  schemeBuildConfiguration?: Ios.SchemeBuildConfiguration;
   releaseChannel?: string;
   artifactPath?: string;
   distribution?: iOSDistributionType;

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -26,7 +26,7 @@ export class EasJsonReader {
     let androidConfig;
     if (['android', 'all'].includes(this.platform)) {
       androidConfig = this.validateBuildProfile<AndroidBuildProfile>(
-        Platform.Android,
+        Platform.ANDROID,
         buildProfileName,
         easJson.builds?.android || {}
       );
@@ -34,7 +34,7 @@ export class EasJsonReader {
     let iosConfig;
     if (['ios', 'all'].includes(this.platform)) {
       iosConfig = this.validateBuildProfile<iOSBuildProfile>(
-        Platform.iOS,
+        Platform.IOS,
         buildProfileName,
         easJson.builds?.ios || {}
       );
@@ -53,8 +53,8 @@ export class EasJsonReader {
     const androidProfiles = easJson.builds?.android ?? {};
     for (const name of Object.keys(androidProfiles)) {
       try {
-        if (this.isWorkflowKeySpecified(Platform.Android, name, androidProfiles)) {
-          await this.validateBuildProfile(Platform.Android, name, androidProfiles);
+        if (this.isWorkflowKeySpecified(Platform.ANDROID, name, androidProfiles)) {
+          await this.validateBuildProfile(Platform.ANDROID, name, androidProfiles);
         }
       } catch (err) {
         err.msg = `Failed to validate Android build profile "${name}"\n${err.msg}`;
@@ -64,8 +64,8 @@ export class EasJsonReader {
     const iosProfiles = easJson.builds?.ios ?? {};
     for (const name of Object.keys(iosProfiles)) {
       try {
-        if (this.isWorkflowKeySpecified(Platform.iOS, name, iosProfiles)) {
-          await this.validateBuildProfile(Platform.iOS, name, iosProfiles);
+        if (this.isWorkflowKeySpecified(Platform.IOS, name, iosProfiles)) {
+          await this.validateBuildProfile(Platform.IOS, name, iosProfiles);
         }
       } catch (err) {
         err.msg = `Failed to validate iOS build profile "${name}"\n${err.msg}`;
@@ -94,7 +94,7 @@ export class EasJsonReader {
     buildProfiles: Record<string, BuildProfilePreValidation>
   ): T {
     const buildProfile = this.resolveBuildProfile(platform, buildProfileName, buildProfiles);
-    if (![Workflow.Generic, Workflow.Managed].includes(buildProfile.workflow)) {
+    if (![Workflow.GENERIC, Workflow.MANAGED].includes(buildProfile.workflow)) {
       throw new Error(
         '"workflow" key is required in a build profile and has to be one of ["generic", "managed"].'
       );

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -1,4 +1,4 @@
-import { Android, iOS } from '@expo/eas-build-job';
+import { Android, Ios } from '@expo/eas-build-job';
 import Joi, { CustomHelpers } from '@hapi/joi';
 
 const semverSchemaCheck = (value: any, helpers: CustomHelpers) => {
@@ -21,7 +21,7 @@ const AndroidBuilderEnvironmentSchema = Joi.object({
 
 const IosBuilderEnvironmentSchema = Joi.object({
   image: Joi.string()
-    .valid(...iOS.builderBaseImages)
+    .valid(...Ios.builderBaseImages)
     .default('default'),
   node: Joi.string().custom(semverSchemaCheck),
   yarn: Joi.string().custom(semverSchemaCheck),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.12":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.12.tgz#35224e8ad7e9d6f70d76172b75c3b6824293470e"
-  integrity sha512-a70/NZfsnQFnEqt+b6DK8g1OAExRjHSDf4MFOVAXg7DlhIIB9cAhRiJE/5ksfZfaJ7CI/RdEysU7fCWkspcNig==
+"@expo/eas-build-job@0.2.13":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.13.tgz#fc77e26c93748ee689df310e12e80efe5cf45dbd"
+  integrity sha512-Xxdb02rqX+cSWi/k0vxzGpK94avrsbopuy+fmB8jdj2hr/0SvanU6KpQtBaqtt4DSJCCQGaGtw5kOvzr4QrOjg==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
# Why

To upgrade `@expo/eas-build-job` to the latest version. There were a lot of changes there, related to the changed eslint configuration.

# How

- I upgraded `@expo/eas-build-job` from `0.2.12` to `0.2.13`.
- I made all necessary changes to the codebase.

# Test Plan

Tests are still passing.