### PR TITLE
[eas-cli] Fix json output for branch and channel commands

### DIFF
--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -142,7 +142,7 @@ export default class BranchPublish extends Command {
     }
 
     if (jsonFlag) {
-      Log.log(newUpdateGroup);
+      Log.log(JSON.stringify(newUpdateGroup));
     } else {
       const outputMessage = new Table({
         wordWrap: true,

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -119,7 +119,7 @@ export default class BranchRename extends Command {
     });
 
     if (jsonFlag) {
-      Log.log(editedBranch);
+      Log.log(JSON.stringify(editedBranch));
       return;
     }
 

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -147,7 +147,7 @@ export default class BranchView extends Command {
     );
 
     if (jsonFlag) {
-      Log.log({ ...UpdateBranch, updates });
+      Log.log(JSON.stringify({ ...UpdateBranch, updates }));
       return;
     }
 

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -134,7 +134,7 @@ export default class ChannelCreate extends Command {
     });
 
     if (jsonFlag) {
-      Log.log(newChannel);
+      Log.log(JSON.stringify(newChannel));
       return;
     }
 


### PR DESCRIPTION
# Why

Logging JS objects/arrays will return a format provided by `util`, which isn't JSON. This fixes that for:

- `branch:publish`
- `branch:rename`
- `branch:view`
- `channel:create`

# How

- Added `JSON.stringify()` around the content

# Test Plan

You can run the command, with `--json` flag, and parse it with `jq`. E.g.:

- `$ eas channel:create <name> --json | jq '.'`

This should not throw "invalid token" errors.