### PR TITLE
[eas-cli] commit all files before build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Make sure all files are commited before build. ([#251](https://github.com/expo/eas-cli/pull/251) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 - Upgrade `@expo/eas-build-job` from `0.2.12` to `0.2.13`. ([#245](https://github.com/expo/eas-cli/pull/245) by [@dsokal](https://github.com/dsokal))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Make sure all files are commited before build. ([#251](https://github.com/expo/eas-cli/pull/251) by [@wkozyra95](https://github.com/wkozyra95))
+- Make sure all files are committed before build. ([#251](https://github.com/expo/eas-cli/pull/251) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -183,7 +183,7 @@ enum ShouldCommitChanges {
 }
 
 async function reviewAndCommitChangesAsync(
-  commitMessage: string,
+  initialCommitMessage: string,
   { nonInteractive, askedFirstTime = true }: { nonInteractive: boolean; askedFirstTime?: boolean }
 ): Promise<void> {
   if (nonInteractive) {
@@ -212,10 +212,13 @@ async function reviewAndCommitChangesAsync(
       "Aborting, run the command again once you're ready. Make sure to commit any changes you've made."
     );
   } else if (selected === ShouldCommitChanges.Yes) {
-    await commitPromptAsync(commitMessage);
+    await commitPromptAsync({ initialCommitMessage });
     Log.withTick('Committed changes.');
   } else if (selected === ShouldCommitChanges.ShowDiffFirst) {
     await showDiffAsync();
-    await reviewAndCommitChangesAsync(commitMessage, { nonInteractive, askedFirstTime: false });
+    await reviewAndCommitChangesAsync(initialCommitMessage, {
+      nonInteractive,
+      askedFirstTime: false,
+    });
   }
 }

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -132,7 +132,7 @@ enum ShouldCommitChanges {
 }
 
 async function reviewAndCommitChangesAsync(
-  commitMessage: string,
+  initialCommitMessage: string,
   askedFirstTime: boolean = true
 ): Promise<void> {
   const { selected } = await promptAsync({
@@ -152,10 +152,10 @@ async function reviewAndCommitChangesAsync(
   });
 
   if (selected === ShouldCommitChanges.Yes) {
-    await commitPromptAsync(commitMessage);
+    await commitPromptAsync({ initialCommitMessage });
     Log.withTick('Committed changes');
   } else if (selected === ShouldCommitChanges.ShowDiffFirst) {
     await showDiffAsync();
-    await reviewAndCommitChangesAsync(commitMessage, false);
+    await reviewAndCommitChangesAsync(initialCommitMessage, false);
   }
 }

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -43,8 +43,7 @@ async function ensureGitRepoExistsAsync(): Promise<void> {
 
   Log.log("We're going to make an initial commit for you repository.");
 
-  await spawnAsync('git', ['add', '-A']);
-  await commitPromptAsync('Initial commit');
+  await commitPromptAsync({ initialCommitMessage: 'Initial commit', commitAllFiles: true });
 }
 
 async function isGitStatusCleanAsync(): Promise<boolean> {
@@ -90,7 +89,7 @@ async function ensureGitStatusIsCleanAsync(nonInteractive = false): Promise<void
     message: `Commit changes to git?`,
   });
   if (answer) {
-    await commitPromptAsync();
+    await commitPromptAsync({ commitAllFiles: true });
   } else {
     throw new Error('Please commit all changes. Aborting...');
   }
@@ -151,7 +150,13 @@ async function showDiffAsync() {
   await gitDiffAsync({ withPager: outputTooLarge });
 }
 
-async function commitPromptAsync(initialCommitMessage?: string): Promise<void> {
+async function commitPromptAsync({
+  initialCommitMessage,
+  commitAllFiles,
+}: {
+  initialCommitMessage?: string;
+  commitAllFiles?: boolean;
+} = {}): Promise<void> {
   const { message } = await promptAsync({
     type: 'text',
     name: 'message',
@@ -159,6 +164,9 @@ async function commitPromptAsync(initialCommitMessage?: string): Promise<void> {
     initial: initialCommitMessage,
     validate: (input: string) => input !== '',
   });
+  if (commitAllFiles) {
+    await spawnAsync('git', ['add', '-A']);
+  }
   await commitChangedFilesAsync(message);
 }
 


### PR DESCRIPTION
# Why

We are not committing untracked files before build in `ensureGitStatusIsCleanAsync`

# How

add `git add -A`
this change does not affect commits that are created as part of the build or as part of the configuration

# Test Plan

run build when there are untracked files in repo
