### PR TITLE
[eas-cli] use error.expoApiV2ErrorCode to check error code

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -112,8 +112,7 @@ export async function prepareBuildRequestForPlatformAsync<
         }
       );
     } catch (error) {
-      const body = error?.response?.body;
-      if (body && JSON.parse(body)?.errors?.[0]?.code === 'TURTLE_DEPRECATED_JOB_FORMAT') {
+      if (error?.expoApiV2ErrorCode === 'TURTLE_DEPRECATED_JOB_FORMAT') {
         Log.error('EAS Build API has changed, please upgrade to the latest eas-cli');
       }
       throw error;


### PR DESCRIPTION
# Why

got instance is creating error with `expoApiV2ErrorCode` field, so we don't need to use raw response to parse that

# How

use expoApiV2ErrorCode

I didn't update CHANGELOG because that change does not affect anything userfacing

# Test Plan

run build where www returned TURTLE_DEPRECATED_JOB_FORMAT
