### PR TITLE
enable internal distribution support for self-managed credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add support for build cache. ([#247](https://github.com/expo/eas-cli/pull/247) by [@wkozyra95](https://github.com/wkozyra95))
+- Enable internal distribution support for self-managed credentials. ([#256](https://github.com/expo/eas-cli/pull/256) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -39,6 +39,11 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   constructor(private ctx: Context, private options: Options) {}
 
   public async hasRemoteAsync(): Promise<boolean> {
+    // TODO: this is temporary
+    // remove this check when we implement syncing local credentials for internal distribution
+    if (this.options.distribution === 'internal' && (await this.hasLocalAsync())) {
+      return false;
+    }
     const { distributionCertificate, provisioningProfile } = await this.fetchRemoteAsync();
     return !!(
       distributionCertificate?.certP12 ||
@@ -48,10 +53,6 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   }
 
   public async hasLocalAsync(): Promise<boolean> {
-    if (this.options.distribution === 'internal') {
-      // TODO: add support for using credentials.json for internal distribution
-      return false;
-    }
     if (!(await credentialsJsonReader.fileExistsAsync(this.ctx.projectDir))) {
       return false;
     }
@@ -102,10 +103,6 @@ export default class IosCredentialsProvider implements CredentialsProvider {
   }
 
   private async getLocalAsync(): Promise<IosCredentials> {
-    if (this.options.distribution === 'internal') {
-      // TODO: add support for using credentials.json for internal distribution
-      throw new Error('Using credentials.json for internal distribution is not supported yet.');
-    }
     return await credentialsJsonReader.readIosCredentialsAsync(this.ctx.projectDir);
   }
 

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -107,15 +107,15 @@ export default class IosCredentialsProvider implements CredentialsProvider {
     const credentials = await credentialsJsonReader.readIosCredentialsAsync(this.ctx.projectDir);
     if (credentialsJsonReader.isCredentialsMap(credentials)) {
       for (const targetName of Object.keys(credentials)) {
-        this.assertProvioningProfileType(credentials[targetName].provisioningProfile, targetName);
+        this.assertProvisioningProfileType(credentials[targetName].provisioningProfile, targetName);
       }
     } else {
-      this.assertProvioningProfileType(credentials.provisioningProfile);
+      this.assertProvisioningProfileType(credentials.provisioningProfile);
     }
     return credentials;
   }
 
-  private assertProvioningProfileType(provisionigProfile: string, targetName?: string) {
+  private assertProvisioningProfileType(provisionigProfile: string, targetName?: string) {
     const isAdHoc = isAdHocProfile(provisionigProfile);
     if (this.options.distribution === 'internal' && !isAdHoc) {
       throw new Error(

--- a/packages/eas-cli/src/credentials/ios/utils/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/provisioningProfile.ts
@@ -20,6 +20,12 @@ function readProfileName(dataBase64: string): string {
   return profilePlist['Name'] as string;
 }
 
+function isAdHocProfile(dataBase64: string): boolean {
+  const profilePlist = parse(dataBase64);
+  const provisionedDevices = profilePlist['ProvisionedDevices'] as string[] | undefined;
+  return Array.isArray(provisionedDevices);
+}
+
 function parse(dataBase64: string): PlistObject {
   try {
     const buffer = Buffer.from(dataBase64, 'base64');
@@ -30,4 +36,4 @@ function parse(dataBase64: string): PlistObject {
   }
 }
 
-export { readAppleTeam, readProfileName, parse };
+export { readAppleTeam, readProfileName, isAdHocProfile, parse };


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-285/internal-distribution-support-for-self-managed-credentials

> A user has expressed interest in being able to have access to shareable app download links available with internal distribution without using automatically managed credentials.

# How

This was pretty straightforward. The only "hack" is that I disabled checking for remote credentials in the case where credentials.json exists and it's an internal distribution build.

# Test Plan

I ran an internal distribution build with credentials defined in credentials.json and it worked fine.
