### PR TITLE
[eas-cli] fix submit with tar.gz files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Make sure all files are committed before build. ([#251](https://github.com/expo/eas-cli/pull/251) by [@wkozyra95](https://github.com/wkozyra95))
+- Fix `eas submit` support for tar.gz files. ([#257](https://github.com/expo/eas-cli/pull/257)) by [@wkozyra95](https://github.com/wkozyra95))
 - Show untracked files when checking `git status`. ([#259](https://github.com/expo/eas-cli/pull/259) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/submissions/utils/files.ts
+++ b/packages/eas-cli/src/submissions/utils/files.ts
@@ -26,7 +26,7 @@ async function moveFileOfTypeAsync(
   extension: string,
   dest: string
 ): Promise<string> {
-  const [matching] = await glob(`*.${extension}`, {
+  const [matching] = await glob(`**/*.${extension}`, {
     absolute: true,
     cwd: directory,
   });


### PR DESCRIPTION
# Why

If ipa/apk/aab is in subdir inside tar.gz file, submit can't detect it
https://linear.app/expo/issue/ENG-325/handle-eas-build-tar-artifacts

# How

fix wildcard

# Test Plan

ios build with artifactPath: './ios/build/**/*' + eas submit
