### PR TITLE
[eas-cli] detect untracked files when checking for changes in repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Make sure all files are committed before build. ([#251](https://github.com/expo/eas-cli/pull/251) by [@wkozyra95](https://github.com/wkozyra95))
+- Show untracked files when checking `git status`. ([#259](https://github.com/expo/eas-cli/pull/259) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -47,7 +47,7 @@ async function ensureGitRepoExistsAsync(): Promise<void> {
 }
 
 async function isGitStatusCleanAsync(): Promise<boolean> {
-  const changes = await gitStatusAsync();
+  const changes = await gitStatusAsync({ showUntracked: true });
   return changes.length === 0;
 }
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-370/extend-git-warning-on-running-eas-build-to-also-check-for-untracked

# How

check for untracked files

# Test Plan

`touch file` -> `eas build`