### PR TITLE
[eas-cli] use generated graphql types

### DIFF
--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -4,7 +4,12 @@ import chalk from 'chalk';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
-import { EditUpdateBranchInput, UpdateBranch } from '../../graphql/generated';
+import {
+  EditUpdateBranchInput,
+  EditUpdateBranchMutation,
+  EditUpdateBranchMutationVariables,
+  UpdateBranch,
+} from '../../graphql/generated';
 import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountName } from '../../project/projectUtils';
@@ -13,21 +18,12 @@ import { ensureLoggedInAsync } from '../../user/actions';
 
 async function renameUpdateBranchOnAppAsync({
   appId,
-  currentName,
+  name,
   newName,
-}: {
-  appId: string;
-  currentName: string;
-  newName: string;
-}): Promise<UpdateBranch> {
+}: EditUpdateBranchInput): Promise<Pick<UpdateBranch, 'id' | 'name'>> {
   const data = await withErrorHandlingAsync(
     graphqlClient
-      .mutation<
-        { updateBranch: { editUpdateBranch: UpdateBranch } },
-        {
-          input: EditUpdateBranchInput;
-        }
-      >(
+      .mutation<EditUpdateBranchMutation, EditUpdateBranchMutationVariables>(
         gql`
           mutation EditUpdateBranch($input: EditUpdateBranchInput!) {
             updateBranch {
@@ -41,7 +37,7 @@ async function renameUpdateBranchOnAppAsync({
         {
           input: {
             appId,
-            name: currentName,
+            name,
             newName,
           },
         }
@@ -114,7 +110,7 @@ export default class BranchRename extends Command {
 
     const editedBranch = await renameUpdateBranchOnAppAsync({
       appId: projectId,
-      currentName: currentName!,
+      name: currentName!,
       newName: newName!,
     });
 

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -36,7 +36,7 @@ async function viewUpdateBranchAsync({
 > {
   const data = await withErrorHandlingAsync(
     graphqlClient
-      .mutation<ViewBranchQuery, ViewBranchQueryVariables>(
+      .query<ViewBranchQuery, ViewBranchQueryVariables>(
         gql`
           query ViewBranch($appId: String!, $name: String!, $limit: Int!) {
             app {

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -6,7 +6,15 @@ import gql from 'graphql-tag';
 import { groupBy } from 'lodash';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
-import { Update } from '../../graphql/generated';
+import {
+  Maybe,
+  Robot,
+  Update,
+  UpdateBranch,
+  User,
+  ViewBranchQuery,
+  ViewBranchQueryVariables,
+} from '../../graphql/generated';
 import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
@@ -19,34 +27,16 @@ type TruncatedUpdate = Pick<Update, 'group' | 'message' | 'createdAt' | 'actor'>
 async function viewUpdateBranchAsync({
   appId,
   name,
-}: {
-  appId: string;
-  name: string;
-}): Promise<{
-  id: string;
-  name: string;
-  updates: TruncatedUpdate[];
-}> {
+}: Pick<ViewBranchQueryVariables, 'appId' | 'name'>): Promise<
+  Pick<UpdateBranch, 'id' | 'name'> & {
+    updates: (Pick<Update, 'id' | 'group' | 'message' | 'createdAt'> & {
+      actor?: Maybe<Pick<User, 'firstName' | 'id'> | Pick<Robot, 'firstName' | 'id'>>;
+    })[];
+  }
+> {
   const data = await withErrorHandlingAsync(
     graphqlClient
-      .mutation<
-        {
-          app: {
-            byId: {
-              updateBranchByName: {
-                id: string;
-                name: string;
-                updates: TruncatedUpdate[];
-              };
-            };
-          };
-        },
-        {
-          appId: string;
-          name: string;
-          limit: number;
-        }
-      >(
+      .mutation<ViewBranchQuery, ViewBranchQueryVariables>(
         gql`
           query ViewBranch($appId: String!, $name: String!, $limit: Int!) {
             app {
@@ -83,7 +73,11 @@ async function viewUpdateBranchAsync({
       )
       .toPromise()
   );
-  return data.app.byId.updateBranchByName;
+  const updateBranch = data.app?.byId.updateBranchByName;
+  if (!updateBranch) {
+    throw new Error(`Could not find branch "${name}"`);
+  }
+  return updateBranch;
 }
 
 export default class BranchView extends Command {

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -6,7 +6,7 @@ import ora from 'ora';
 import { platformEmojis } from '../../build/constants';
 import { Platform } from '../../build/types';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
-import { AppPlatform, Build, BuildStatus } from '../../graphql/generated';
+import { AppPlatform, Build, BuildStatus, CancelBuildMutation } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
 import {
@@ -19,7 +19,7 @@ import { confirmAsync, selectAsync } from '../../prompts';
 async function cancelBuildAsync(buildId: string): Promise<Pick<Build, 'id' | 'status'>> {
   const data = await withErrorHandlingAsync(
     graphqlClient
-      .mutation<{ build: { cancel: { id: string; status: BuildStatus } } }>(
+      .mutation<CancelBuildMutation>(
         gql`
           mutation CancelBuildMutation($buildId: ID!) {
             build(buildId: $buildId) {

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -6,7 +6,7 @@ import ora from 'ora';
 import { platformEmojis } from '../../build/constants';
 import { Platform } from '../../build/types';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
-import { AppPlatform, Build, BuildStatus, CancelBuildMutation } from '../../graphql/generated';
+import { AppPlatform, Build, BuildStatus, CancelBuildMutation, CancelBuildMutationVariables } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
 import {
@@ -19,7 +19,7 @@ import { confirmAsync, selectAsync } from '../../prompts';
 async function cancelBuildAsync(buildId: string): Promise<Pick<Build, 'id' | 'status'>> {
   const data = await withErrorHandlingAsync(
     graphqlClient
-      .mutation<CancelBuildMutation>(
+      .mutation<CancelBuildMutation, CancelBuildMutationVariables>(
         gql`
           mutation CancelBuildMutation($buildId: ID!) {
             build(buildId: $buildId) {

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -6,7 +6,13 @@ import ora from 'ora';
 import { platformEmojis } from '../../build/constants';
 import { Platform } from '../../build/types';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
-import { AppPlatform, Build, BuildStatus, CancelBuildMutation, CancelBuildMutationVariables } from '../../graphql/generated';
+import {
+  AppPlatform,
+  Build,
+  BuildStatus,
+  CancelBuildMutation,
+  CancelBuildMutationVariables,
+} from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
 import {

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -4,7 +4,10 @@ import chalk from 'chalk';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
-import { UpdateChannel } from '../../graphql/generated';
+import {
+  CreateUpdateChannelOnAppMutation,
+  CreateUpdateChannelOnAppMutationVariables,
+} from '../../graphql/generated';
 import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import {
@@ -23,18 +26,15 @@ async function createUpdateChannelOnAppAsync({
   appId: string;
   channelName: string;
   branchId: string;
-}): Promise<UpdateChannel> {
+}): Promise<CreateUpdateChannelOnAppMutation> {
   // Point the new channel at a branch with its same name.
   const branchMapping = JSON.stringify({
     data: [{ branchId, branchMappingLogic: 'true' }],
     version: 0,
   });
-  const data = await withErrorHandlingAsync(
+  return await withErrorHandlingAsync(
     graphqlClient
-      .mutation<
-        { updateChannel: { createUpdateChannelForApp: UpdateChannel } },
-        { appId: string; name: string; branchMapping: string }
-      >(
+      .mutation<CreateUpdateChannelOnAppMutation, CreateUpdateChannelOnAppMutationVariables>(
         gql`
           mutation CreateUpdateChannelOnApp($appId: ID!, $name: String!, $branchMapping: String!) {
             updateChannel {
@@ -54,7 +54,6 @@ async function createUpdateChannelOnAppAsync({
       )
       .toPromise()
   );
-  return data.updateChannel.createUpdateChannelForApp;
 }
 
 export default class ChannelCreate extends Command {
@@ -127,11 +126,19 @@ export default class ChannelCreate extends Command {
       branchMessage = `We also went ahead and made a branch with the same name`;
     }
 
-    const newChannel = await createUpdateChannelOnAppAsync({
+    const {
+      updateChannel: { createUpdateChannelForApp: newChannel },
+    } = await createUpdateChannelOnAppAsync({
       appId: projectId,
       channelName,
       branchId,
     });
+
+    if (!newChannel) {
+      throw new Error(
+        `Could not create channel with name ${channelName} on app with id ${projectId}`
+      );
+    }
 
     if (jsonFlag) {
       Log.log(JSON.stringify(newChannel));

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2878,6 +2878,121 @@ export type CreateUpdateChannelOnAppMutation = (
   ) }
 );
 
+export type GetChannelByNameToEditQueryVariables = Exact<{
+  appId: Scalars['String'];
+  channelName: Scalars['String'];
+}>;
+
+
+export type GetChannelByNameToEditQuery = (
+  { __typename?: 'RootQuery' }
+  & { app?: Maybe<(
+    { __typename?: 'AppQuery' }
+    & { byId: (
+      { __typename?: 'App' }
+      & Pick<App, 'id'>
+      & { updateChannelByName: (
+        { __typename?: 'UpdateChannel' }
+        & Pick<UpdateChannel, 'id' | 'name'>
+        & { updateBranches: Array<(
+          { __typename?: 'UpdateBranch' }
+          & Pick<UpdateBranch, 'id' | 'name'>
+        )> }
+      ) }
+    ) }
+  )> }
+);
+
+export type UpdateChannelBranchMappingMutationVariables = Exact<{
+  channelId: Scalars['ID'];
+  branchMapping: Scalars['String'];
+}>;
+
+
+export type UpdateChannelBranchMappingMutation = (
+  { __typename?: 'RootMutation' }
+  & { updateChannel: (
+    { __typename?: 'UpdateChannelMutation' }
+    & { editUpdateChannel?: Maybe<(
+      { __typename?: 'UpdateChannel' }
+      & Pick<UpdateChannel, 'id' | 'name' | 'branchMapping'>
+    )> }
+  ) }
+);
+
+export type GetAllChannelsForAppQueryVariables = Exact<{
+  appId: Scalars['String'];
+  offset: Scalars['Int'];
+  limit: Scalars['Int'];
+}>;
+
+
+export type GetAllChannelsForAppQuery = (
+  { __typename?: 'RootQuery' }
+  & { app?: Maybe<(
+    { __typename?: 'AppQuery' }
+    & { byId: (
+      { __typename?: 'App' }
+      & Pick<App, 'id'>
+      & { updateChannels: Array<(
+        { __typename?: 'UpdateChannel' }
+        & Pick<UpdateChannel, 'id' | 'name'>
+        & { updateBranches: Array<(
+          { __typename?: 'UpdateBranch' }
+          & Pick<UpdateBranch, 'id' | 'name'>
+          & { updates: Array<(
+            { __typename?: 'Update' }
+            & Pick<Update, 'id' | 'group' | 'message' | 'createdAt'>
+            & { actor?: Maybe<(
+              { __typename?: 'User' }
+              & Pick<User, 'firstName' | 'id'>
+            ) | (
+              { __typename?: 'Robot' }
+              & Pick<Robot, 'firstName' | 'id'>
+            )> }
+          )> }
+        )> }
+      )> }
+    ) }
+  )> }
+);
+
+export type GetChannelByNameForAppQueryVariables = Exact<{
+  appId: Scalars['String'];
+  channelName: Scalars['String'];
+}>;
+
+
+export type GetChannelByNameForAppQuery = (
+  { __typename?: 'RootQuery' }
+  & { app?: Maybe<(
+    { __typename?: 'AppQuery' }
+    & { byId: (
+      { __typename?: 'App' }
+      & Pick<App, 'id'>
+      & { updateChannelByName: (
+        { __typename?: 'UpdateChannel' }
+        & Pick<UpdateChannel, 'id' | 'name' | 'createdAt'>
+        & { updateBranches: Array<(
+          { __typename?: 'UpdateBranch' }
+          & Pick<UpdateBranch, 'id' | 'name'>
+          & { updates: Array<(
+            { __typename?: 'Update' }
+            & Pick<Update, 'id' | 'group' | 'message' | 'createdAt'>
+            & { actor?: Maybe<(
+              { __typename?: 'User' }
+              & Pick<User, 'firstName' | 'id'>
+            ) | (
+              { __typename?: 'Robot' }
+              & Pick<Robot, 'firstName' | 'id'>
+            )> }
+          )> }
+        )> }
+      ) }
+    ) }
+  )> }
+);
+
 export type CreateAppleAppIdentifierMutationVariables = Exact<{
   appleAppIdentifierInput: AppleAppIdentifierInput;
   accountId: Scalars['ID'];
@@ -3484,45 +3599,6 @@ export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = 
   )> }
 );
 
-export type CreateUpdateChannelForAppMutationVariables = Exact<{
-  appId: Scalars['ID'];
-  name: Scalars['String'];
-  branchMapping: Scalars['String'];
-}>;
-
-
-export type CreateUpdateChannelForAppMutation = (
-  { __typename?: 'RootMutation' }
-  & { updateChannel: (
-    { __typename?: 'UpdateChannelMutation' }
-    & { createUpdateChannelForApp?: Maybe<(
-      { __typename?: 'UpdateChannel' }
-      & Pick<UpdateChannel, 'id' | 'name' | 'branchMapping'>
-    )> }
-  ) }
-);
-
-export type UpdateChannelBranchMappingMutationVariables = Exact<{
-  channelId: Scalars['ID'];
-  branchMapping: Scalars['String'];
-}>;
-
-
-export type UpdateChannelBranchMappingMutation = (
-  { __typename?: 'RootMutation' }
-  & { updateChannel: (
-    { __typename?: 'UpdateChannelMutation' }
-    & { editUpdateChannel?: Maybe<(
-      { __typename?: 'UpdateChannel' }
-      & Pick<UpdateChannel, 'id' | 'name' | 'createdAt' | 'branchMapping'>
-      & { updateBranches: Array<(
-        { __typename?: 'UpdateBranch' }
-        & Pick<UpdateBranch, 'id' | 'name'>
-      )> }
-    )> }
-  ) }
-);
-
 export type GetSignedUploadMutationVariables = Exact<{
   contentTypes: Array<Scalars['String']>;
 }>;
@@ -3621,79 +3697,6 @@ export type PendingBuildsForAccountAndPlatformQuery = (
       )> }
     ) }
   ) }
-);
-
-export type GetChannelByNameForApp123213QueryVariables = Exact<{
-  appId: Scalars['String'];
-  name: Scalars['String'];
-}>;
-
-
-export type GetChannelByNameForApp123213Query = (
-  { __typename?: 'RootQuery' }
-  & { app?: Maybe<(
-    { __typename?: 'AppQuery' }
-    & { byId: (
-      { __typename?: 'App' }
-      & Pick<App, 'id' | 'name'>
-      & { updateChannelByName: (
-        { __typename?: 'UpdateChannel' }
-        & Pick<UpdateChannel, 'id' | 'name' | 'createdAt'>
-        & { updateBranches: Array<(
-          { __typename?: 'UpdateBranch' }
-          & Pick<UpdateBranch, 'id' | 'name'>
-          & { updates: Array<(
-            { __typename?: 'Update' }
-            & Pick<Update, 'id' | 'group' | 'message' | 'createdAt'>
-            & { actor?: Maybe<(
-              { __typename?: 'User' }
-              & Pick<User, 'firstName' | 'id'>
-            ) | (
-              { __typename?: 'Robot' }
-              & Pick<Robot, 'firstName' | 'id'>
-            )> }
-          )> }
-        )> }
-      ) }
-    ) }
-  )> }
-);
-
-export type ListChannelsForAppQueryVariables = Exact<{
-  appId: Scalars['String'];
-  offset: Scalars['Int'];
-  limit: Scalars['Int'];
-}>;
-
-
-export type ListChannelsForAppQuery = (
-  { __typename?: 'RootQuery' }
-  & { app?: Maybe<(
-    { __typename?: 'AppQuery' }
-    & { byId: (
-      { __typename?: 'App' }
-      & Pick<App, 'id' | 'name'>
-      & { updateChannels: Array<(
-        { __typename?: 'UpdateChannel' }
-        & Pick<UpdateChannel, 'id' | 'name'>
-        & { updateBranches: Array<(
-          { __typename?: 'UpdateBranch' }
-          & Pick<UpdateBranch, 'id' | 'name'>
-          & { updates: Array<(
-            { __typename?: 'Update' }
-            & Pick<Update, 'id' | 'group' | 'message' | 'createdAt'>
-            & { actor?: Maybe<(
-              { __typename?: 'User' }
-              & Pick<User, 'firstName' | 'id'>
-            ) | (
-              { __typename?: 'Robot' }
-              & Pick<Robot, 'firstName' | 'id'>
-            )> }
-          )> }
-        )> }
-      )> }
-    ) }
-  )> }
 );
 
 export type ProjectByUsernameAndSlugQueryVariables = Exact<{


### PR DESCRIPTION
# Why

Using generated graphql code types for commands leaves less room for error.

# How

Used pregenerated graphql types where appropriate.

# Test Plan

tested commands still work in a test project.