### PR TITLE
[eas-json] add experimental.disableBundleIdValidation flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Log the size of the archived project when uploading. ([#264](https://github.com/expo/eas-cli/pull/264) by [@wkozyra95](https://github.com/wkozyra95))
 - Add more build metadata (release channel, build profile name, git commit hash). ([#265](https://github.com/expo/eas-cli/pull/265) by [@dsokal](https://github.com/dsokal))
 - Display App Store link after successful submission. ([#144](https://github.com/expo/eas-cli/pull/144) by [@barthap](https://github.com/barthap))
+- Add `experimental.disableIosBundleIdentifierValidation` flag to eas.json. ([#263](https://github.com/expo/eas-cli/pull/263) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -1,7 +1,12 @@
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
 import { Workflow } from '@expo/eas-build-job';
-import { VersionAutoIncrement, iOSBuildProfile } from '@expo/eas-json';
+import {
+  EasJsonReader,
+  VersionAutoIncrement,
+  iOSBuildProfile,
+  iOSGenericBuildProfile,
+} from '@expo/eas-json';
 
 import Log from '../../log';
 import { ConfigureContext } from '../context';
@@ -17,8 +22,14 @@ export async function configureIosAsync(ctx: ConfigureContext): Promise<void> {
   if (!ctx.hasIosNativeProject) {
     return;
   }
-  await configureBundleIdentifierAsync(ctx.projectDir, ctx.exp);
-  await ensureBundleIdentifierIsValidAsync(ctx.projectDir);
+
+  const disableIosBundleIdentifierValidation = (
+    await new EasJsonReader(ctx.projectDir, 'all').readRawAsync()
+  )?.experimental?.disableIosBundleIdentifierValidation;
+  if (!disableIosBundleIdentifierValidation) {
+    await configureBundleIdentifierAsync(ctx.projectDir, ctx.exp);
+    await ensureBundleIdentifierIsValidAsync(ctx.projectDir);
+  }
 
   if (isExpoUpdatesInstalled(ctx.projectDir)) {
     await configureUpdatesAsync(ctx.projectDir, ctx.exp);
@@ -39,13 +50,19 @@ export async function validateAndSyncProjectConfigurationAsync({
   const versionBumpStrategy = resolveVersionBumpStrategy(autoIncrement);
 
   if (workflow === Workflow.GENERIC) {
-    const bundleIdentifierFromPbxproj = IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj(
-      projectDir
-    );
-    if (!bundleIdentifierFromPbxproj || bundleIdentifierFromPbxproj !== exp.ios?.bundleIdentifier) {
-      throw new Error(
-        'Bundle identifier is not configured correctly in your Xcode project. Please run "eas build:configure" to configure it.'
+    const genericBuildProfile = buildProfile as iOSGenericBuildProfile;
+    if (!genericBuildProfile.disableIosBundleIdentifierValidation) {
+      const bundleIdentifierFromPbxproj = IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj(
+        projectDir
       );
+      if (
+        !bundleIdentifierFromPbxproj ||
+        bundleIdentifierFromPbxproj !== exp.ios?.bundleIdentifier
+      ) {
+        throw new Error(
+          'Bundle identifier is not configured correctly in your Xcode project. Please run "eas build:configure" to configure it.'
+        );
+      }
     }
     if (isExpoUpdatesInstalled(projectDir)) {
       await syncUpdatesConfigurationAsync(projectDir, exp);

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -52,6 +52,7 @@ export interface iOSGenericBuildProfile extends Ios.BuilderEnvironment {
   distribution?: iOSDistributionType;
   autoIncrement: VersionAutoIncrement;
   cache: Cache | null;
+  disableIosBundleIdentifierValidation?: boolean;
 }
 
 export type AndroidBuildProfile = AndroidManagedBuildProfile | AndroidGenericBuildProfile;

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -6,6 +6,9 @@ import { AndroidBuildProfile, BuildProfile, EasConfig, iOSBuildProfile } from '.
 import { EasJsonSchema, schemaBuildProfileMap } from './EasJsonSchema';
 
 interface EasJson {
+  experimental?: {
+    disableIosBundleIdentifierValidation?: boolean;
+  };
   builds: {
     android?: { [key: string]: BuildProfilePreValidation };
     ios?: { [key: string]: BuildProfilePreValidation };
@@ -39,10 +42,16 @@ export class EasJsonReader {
         easJson.builds?.ios || {}
       );
     }
+    const iosExperimental = easJson.experimental?.disableIosBundleIdentifierValidation
+      ? {
+          disableIosBundleIdentifierValidation:
+            easJson.experimental.disableIosBundleIdentifierValidation,
+        }
+      : {};
     return {
       builds: {
         ...(androidConfig ? { android: androidConfig } : {}),
-        ...(iosConfig ? { ios: iosConfig } : {}),
+        ...(iosConfig ? { ios: { ...iosConfig, ...iosExperimental } } : {}),
       },
     };
   }

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -102,6 +102,9 @@ const schemaBuildProfileMap: Record<string, Record<string, Joi.Schema>> = {
 };
 
 const EasJsonSchema = Joi.object({
+  experimental: Joi.object({
+    disableIosBundleIdentifierValidation: Joi.boolean(),
+  }),
   builds: Joi.object({
     android: Joi.object().pattern(
       Joi.string(),


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://linear.app/expo/issue/ENG-357/support-for-schemes-with-different-bundle-identifiers-in-generic-apps

# How

- if `experimental.disableBundleIdValidation` is set then skip bundleIdedentifier validation or configuration
- user needs to specify a scheme explicitly
- this solution is not enough to support multiple slugs if you use expo-updates, because there is only one file that contains URL to project, build will work but configure will override project URL with new slug

# Test Plan

build and build configure on https://github.com/brentvatne/myapp
