### PR TITLE
[eas-cli] display size of the archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Log the size of the archived project when uploading. ([#264](https://github.com/expo/eas-cli/pull/264) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -6,6 +6,7 @@ import { apiClient } from '../api';
 import Log from '../log';
 import { promptAsync } from '../prompts';
 import { UploadType, uploadAsync } from '../uploads';
+import { formatBytes } from '../utils/files';
 import { createProgressTracker } from '../utils/progress';
 import { platformDisplayNames } from './constants';
 import { BuildContext } from './context';
@@ -135,7 +136,10 @@ async function uploadProjectAsync<TPlatform extends Platform>(
           projectTarball.path,
           createProgressTracker({
             total: projectTarball.size,
-            message: 'Uploading to EAS Build',
+            message: ratio =>
+              `Uploading to EAS Build (${formatBytes(projectTarball.size * ratio)} / ${formatBytes(
+                projectTarball.size
+              )})`,
             completedMessage: `Uploaded to EAS`,
           })
         );

--- a/packages/eas-cli/src/utils/files.ts
+++ b/packages/eas-cli/src/utils/files.ts
@@ -26,3 +26,32 @@ export async function maybeRenameExistingFileAsync(projectDir: string, filename:
     await fs.rename(desiredFilePath, path.resolve(projectDir, getRenamedFilename(filename, num)));
   }
 }
+
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) {
+    return `0`;
+  }
+  let multiplier = 1;
+  if (bytes < 1024 * multiplier) {
+    return `${Math.floor(bytes)} B`;
+  }
+  multiplier *= 1024;
+  if (bytes < 102.4 * multiplier) {
+    return `${(bytes / multiplier).toFixed(1)} KB`;
+  }
+  if (bytes < 1024 * multiplier) {
+    return `${Math.floor(bytes / 1024)} KB`;
+  }
+  multiplier *= 1024;
+  if (bytes < 102.4 * multiplier) {
+    return `${(bytes / multiplier).toFixed(1)} MB`;
+  }
+  if (bytes < 1024 * multiplier) {
+    return `${Math.floor(bytes / multiplier)} MB`;
+  }
+  multiplier *= 1024;
+  if (bytes < 102.4 * multiplier) {
+    return `${(bytes / multiplier).toFixed(1)} GB`;
+  }
+  return `${Math.floor(bytes / 1024)} GB`;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://linear.app/expo/issue/ENG-399/log-the-size-of-the-archived-project-when-uploading

# How

- add size to log after project archive is created
- add size to upload progress bar
- fix unhandled error in the tarball creation
- removed `--local` flag (it's unrelated to this PR, I just noticed that this flag is ignored either way)
- values larger than 100 are displayed as integer and smaller ones with one decimal point (e.g 700 MB , 55.3 MB) 

# Test Plan

![2021-03-03-135217_575x89_scrot](https://user-images.githubusercontent.com/9753141/109810269-9e85bc00-7c29-11eb-86f6-3c3b5c7e2e46.png)

