### PR TITLE
[ENG-326] send more build metadata: release channel, build profile, git commit hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Log the size of the archived project when uploading. ([#264](https://github.com/expo/eas-cli/pull/264) by [@wkozyra95](https://github.com/wkozyra95))
+- Add more build metadata (release channel, build profile name, git commit hash). ([#265](https://github.com/expo/eas-cli/pull/265) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@expo/apple-utils": "0.0.0-alpha.17",
     "@expo/config": "~3.3.19",
-    "@expo/config-plugins": "1.0.19-alpha.0",
+    "@expo/config-plugins": "1.0.21-alpha.0",
     "@expo/eas-build-job": "0.2.14",
     "@expo/eas-json": "^0.5.0",
     "@expo/json-file": "^8.2.24",

--- a/packages/eas-cli/src/build/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/android/UpdatesModule.ts
@@ -90,3 +90,21 @@ async function ensureUpdatesConfiguredAsync(projectDir: string, exp: ExpoConfig)
     throw new Error('Missing values in AndroidManifest.xml');
   }
 }
+
+export async function readReleaseChannelSafelyAsync(projectDir: string): Promise<string | null> {
+  try {
+    const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
+    if (!androidManifestPath) {
+      throw new Error(`Could not find AndroidManifest.xml in project directory: "${projectDir}"`);
+    }
+    const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(
+      androidManifestPath
+    );
+    return AndroidConfig.Manifest.getMainApplicationMetaDataValue(
+      androidManifest,
+      AndroidConfig.Updates.Config.RELEASE_CHANNEL
+    );
+  } catch (err) {
+    return null;
+  }
+}

--- a/packages/eas-cli/src/build/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/ios/UpdatesModule.ts
@@ -86,3 +86,12 @@ async function writeExpoPlistAsync(
   await writePlistAsync(expoPlistPath, expoPlist);
   await gitAddAsync(expoPlistPath, { intentToAdd: true });
 }
+
+export async function readReleaseChannelSafelyAsync(projectDir: string): Promise<string | null> {
+  try {
+    const expoPlist = await readExpoPlistAsync(projectDir);
+    return expoPlist[IOSConfig.Updates.Config.RELEASE_CHANNEL] ?? null;
+  } catch (err) {
+    return null;
+  }
+}

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,4 +1,3 @@
-import { Workflow } from '@expo/eas-build-job';
 import { CredentialsSource } from '@expo/eas-json';
 
 import { getAppIdentifierAsync } from '../project/projectUtils';
@@ -44,6 +43,10 @@ export async function collectMetadata<T extends Platform>(
 async function resolveReleaseChannel<T extends Platform>(
   ctx: BuildContext<T>
 ): Promise<string | undefined> {
+  if (!isExpoUpdatesInstalled(ctx.commandCtx.projectDir)) {
+    return undefined;
+  }
+
   if (ctx.buildProfile.releaseChannel) {
     return ctx.buildProfile.releaseChannel;
   }
@@ -54,17 +57,5 @@ async function resolveReleaseChannel<T extends Platform>(
   } else {
     maybeReleaseChannel = await readIosReleaseChannelSafelyAsync(ctx.commandCtx.projectDir);
   }
-  if (maybeReleaseChannel) {
-    return maybeReleaseChannel;
-  }
-
-  if (ctx.buildProfile.workflow === Workflow.GENERIC) {
-    if (isExpoUpdatesInstalled(ctx.commandCtx.projectDir)) {
-      return 'default';
-    } else {
-      return undefined;
-    }
-  } else {
-    return 'default';
-  }
+  return maybeReleaseChannel ?? 'default';
 }

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,6 +1,7 @@
 import { CredentialsSource } from '@expo/eas-json';
 
 import { getAppIdentifierAsync } from '../project/projectUtils';
+import { gitCommitHashAsync } from '../utils/git';
 import { BuildContext } from './context';
 import { BuildMetadata, Platform } from './types';
 
@@ -20,15 +21,18 @@ export async function collectMetadata<T extends Platform>(
   }
 ): Promise<BuildMetadata> {
   return {
+    trackingContext: ctx.trackingCtx,
     appVersion: ctx.commandCtx.exp.version!,
     cliVersion: packageJSON.version,
     workflow: ctx.buildProfile.workflow,
     credentialsSource,
     sdkVersion: ctx.commandCtx.exp.sdkVersion,
-    trackingContext: ctx.trackingCtx,
+    releaseChannel: ctx.buildProfile.releaseChannel,
     distribution: ctx.buildProfile.distribution ?? 'store',
     appName: ctx.commandCtx.exp.name,
     appIdentifier:
       (await getAppIdentifierAsync(ctx.commandCtx.projectDir, ctx.platform)) ?? undefined,
+    buildProfile: ctx.commandCtx.profile,
+    gitCommitHash: await gitCommitHashAsync(),
   };
 }

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -98,6 +98,16 @@ export type BuildMetadata = {
    * - Android builds: the application id (expo.android.package in app.json/app.config.js)
    */
   appIdentifier?: string;
+
+  /**
+   * Build profile name (e.g. release)
+   */
+  buildProfile?: string;
+
+  /**
+   * Git commit hash (e.g. aab03fbdabb6e536ea78b28df91575ad488f5f21)
+   */
+  gitCommitHash?: string;
 };
 
 export type PlatformBuildProfile<T extends Platform> = T extends Platform.ANDROID

--- a/packages/eas-cli/src/utils/git.ts
+++ b/packages/eas-cli/src/utils/git.ts
@@ -45,7 +45,7 @@ export async function doesGitRepoExistAsync(): Promise<boolean> {
 
 export async function gitCommitHashAsync(): Promise<string | undefined> {
   try {
-    return await (await spawnAsync('git', ['rev-parse', 'HEAD'])).stdout.trim();
+    return (await spawnAsync('git', ['rev-parse', 'HEAD'])).stdout.trim();
   } catch (err) {
     return undefined;
   }

--- a/packages/eas-cli/src/utils/git.ts
+++ b/packages/eas-cli/src/utils/git.ts
@@ -4,20 +4,25 @@ interface GitStatusOptions {
   showUntracked?: boolean;
 }
 
-async function gitStatusAsync({ showUntracked }: GitStatusOptions = {}): Promise<string> {
+export async function gitStatusAsync({ showUntracked }: GitStatusOptions = {}): Promise<string> {
   return (await spawnAsync('git', ['status', '-s', showUntracked ? '-uall' : '-uno'])).stdout;
 }
 
-async function gitDiffAsync({ withPager = false }: { withPager?: boolean } = {}): Promise<void> {
+export async function gitDiffAsync({ withPager = false }: { withPager?: boolean } = {}): Promise<
+  void
+> {
   const options = withPager ? [] : ['--no-pager'];
   await spawnAsync('git', [...options, 'diff'], { stdio: ['ignore', 'inherit', 'inherit'] });
 }
 
-async function getGitDiffOutputAsync(): Promise<string> {
+export async function getGitDiffOutputAsync(): Promise<string> {
   return (await spawnAsync('git', ['--no-pager', 'diff'])).stdout;
 }
 
-async function gitAddAsync(file: string, options?: { intentToAdd?: boolean }): Promise<void> {
+export async function gitAddAsync(
+  file: string,
+  options?: { intentToAdd?: boolean }
+): Promise<void> {
   if (options?.intentToAdd) {
     await spawnAsync('git', ['add', '--intent-to-add', file]);
   } else {
@@ -25,11 +30,11 @@ async function gitAddAsync(file: string, options?: { intentToAdd?: boolean }): P
   }
 }
 
-async function gitRootDirectoryAsync(): Promise<string> {
+export async function gitRootDirectoryAsync(): Promise<string> {
   return (await spawnAsync('git', ['rev-parse', '--show-toplevel'])).stdout.trim();
 }
 
-async function doesGitRepoExistAsync(): Promise<boolean> {
+export async function doesGitRepoExistAsync(): Promise<boolean> {
   try {
     await spawnAsync('git', ['rev-parse', '--git-dir']);
     return true;
@@ -38,7 +43,15 @@ async function doesGitRepoExistAsync(): Promise<boolean> {
   }
 }
 
-async function isGitInstalledAsync(): Promise<boolean> {
+export async function gitCommitHashAsync(): Promise<string | undefined> {
+  try {
+    return await (await spawnAsync('git', ['rev-parse', 'HEAD'])).stdout.trim();
+  } catch (err) {
+    return undefined;
+  }
+}
+
+export async function isGitInstalledAsync(): Promise<boolean> {
   try {
     await spawnAsync('git', ['--help']);
   } catch (error) {
@@ -50,7 +63,7 @@ async function isGitInstalledAsync(): Promise<boolean> {
   return true;
 }
 
-async function getBranchNameAsync(): Promise<string | null> {
+export async function getBranchNameAsync(): Promise<string | null> {
   try {
     return (await spawnAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.trim();
   } catch (e) {
@@ -58,22 +71,10 @@ async function getBranchNameAsync(): Promise<string | null> {
   }
 }
 
-async function getLastCommitMessageAsync(): Promise<string | null> {
+export async function getLastCommitMessageAsync(): Promise<string | null> {
   try {
     return (await spawnAsync('git', ['--no-pager', 'log', '-1', '--pretty=%B'])).stdout.trim();
   } catch (e) {
     return null;
   }
 }
-
-export {
-  gitStatusAsync,
-  gitDiffAsync,
-  getGitDiffOutputAsync,
-  gitAddAsync,
-  doesGitRepoExistAsync,
-  gitRootDirectoryAsync,
-  isGitInstalledAsync,
-  getBranchNameAsync,
-  getLastCommitMessageAsync,
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,10 +1093,10 @@
     "@babel/preset-env" "^7.4.4"
     "@babel/preset-typescript" "^7.3.3"
 
-"@expo/config-plugins@1.0.19-alpha.0":
-  version "1.0.19-alpha.0"
-  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.19-alpha.0.tgz#3d57c266bfae0c7b310ac99e9949c9d03120c103"
-  integrity sha512-mOPIvi1tanMftgeEjDB4vckLKY5dKdJ80R2cg27YyaP4IS1pYGaHtJKBKb6Pr1w5xvyRxd2AlX6C7L8lEzTBaw==
+"@expo/config-plugins@1.0.21-alpha.0":
+  version "1.0.21-alpha.0"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.21-alpha.0.tgz#cc6d428809a8b1f483de1f4ca6b8219308bb3680"
+  integrity sha512-npi9sttSQOxl/NWc/FSlIy+ws9HgUoX3vsbu+rgTmD2ARtF5D8x5NR5upnWWpwoq6ZXaYXwDXNcKZHWLGrCfjA==
   dependencies:
     "@expo/config-types" "^40.0.0-beta.2"
     "@expo/configure-splash-screen" "0.3.4"


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://linear.app/expo/issue/ENG-326/add-build-profile-to-build-metadata

See also https://github.com/expo/universe/pull/7080

# How

I made EAS CLI send more build metadata to www:
- release channel
- build profile
- git commit hash

# Test Plan

I ran a build and used graphql to fetch the metadata.