### PR TITLE
iOS builds: default to build configuration 'Release'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Generic iOS projects: build release builds by default. ([#266](https://github.com/expo/eas-cli/pull/266) by [@dsokal](https://github.com/dsokal))
+
 ### 🎉 New features
 
 - Log the size of the archived project when uploading. ([#264](https://github.com/expo/eas-cli/pull/264) by [@wkozyra95](https://github.com/wkozyra95))

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -133,7 +133,10 @@ async function prepareGenericJobAsync(
     })),
     type: Workflow.GENERIC,
     scheme: jobData.projectConfiguration.iosBuildScheme,
-    schemeBuildConfiguration: buildProfile.schemeBuildConfiguration,
+    schemeBuildConfiguration:
+      buildProfile.schemeBuildConfiguration === 'Auto'
+        ? undefined
+        : buildProfile.schemeBuildConfiguration,
     artifactPath: buildProfile.artifactPath,
     releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -46,7 +46,7 @@ export interface iOSGenericBuildProfile extends Ios.BuilderEnvironment {
   workflow: Workflow.GENERIC;
   credentialsSource: CredentialsSource;
   scheme?: string;
-  schemeBuildConfiguration?: Ios.SchemeBuildConfiguration;
+  schemeBuildConfiguration?: Ios.SchemeBuildConfiguration | 'Auto';
   releaseChannel?: string;
   artifactPath?: string;
   distribution?: iOSDistributionType;

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -68,7 +68,7 @@ const iOSGenericSchema = Joi.object({
   workflow: Joi.string().valid('generic').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
   scheme: Joi.string(),
-  schemeBuildConfiguration: Joi.string().valid('Debug', 'Release'),
+  schemeBuildConfiguration: Joi.string().valid('Debug', 'Release', 'Auto').default('Release'),
   releaseChannel: Joi.string(),
   artifactPath: Joi.string(),
   distribution: Joi.string().valid('store', 'internal', 'simulator').default('store'),

--- a/packages/eas-json/src/__tests__/EasJsonReader-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-test.ts
@@ -57,6 +57,7 @@ test('minimal valid ios eas.json', async () => {
         env: {},
         cache: { key: '', cacheDefaultPaths: true, customPaths: [] },
         image: 'default',
+        schemeBuildConfiguration: 'Release',
       },
     },
   }).toEqual(easJson);
@@ -95,6 +96,7 @@ test('minimal valid eas.json for both platforms', async () => {
         env: {},
         cache: { key: '', cacheDefaultPaths: true, customPaths: [] },
         image: 'default',
+        schemeBuildConfiguration: 'Release',
       },
     },
   }).toEqual(easJson);


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://linear.app/expo/issue/ENG-406/ejected-project-with-simulator-distribution-type-does-debug-build-by

# How

- I set the default value for `schemeBuildConfiguration` to `Release`.
- I introduced a new value for `schemeBuildConfiguration`: `Auto`. It means that the build configuration will be set to the value defined in the chosen scheme.

# Test Plan

I followed the repro steps from https://linear.app/expo/issue/ENG-406/ejected-project-with-simulator-distribution-type-does-debug-build-by:
- I inited a managed project with `expo init`.
- I ran `expo eject`.
- I ran `eas build:configure` and then modified eas.json to build a simulator build (`"distribution": "simulator"`).
- I ran `eas build`.
- I downloaded the archive, ran the app in the simulator, and I observed it was built for release.
