### PR TITLE
[ENG-392][eas-cli] use Metadata type from @expo/eas-build-job

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -11,7 +11,7 @@
     "@expo/apple-utils": "0.0.0-alpha.17",
     "@expo/config": "~3.3.19",
     "@expo/config-plugins": "1.0.21-alpha.0",
-    "@expo/eas-build-job": "0.2.14",
+    "@expo/eas-build-job": "0.2.16",
     "@expo/eas-json": "^0.5.0",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.11",

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,3 +1,4 @@
+import { Metadata } from '@expo/eas-build-job';
 import { CredentialsSource } from '@expo/eas-json';
 
 import { getAppIdentifierAsync } from '../project/projectUtils';
@@ -5,7 +6,7 @@ import { gitCommitHashAsync } from '../utils/git';
 import { readReleaseChannelSafelyAsync as readAndroidReleaseChannelSafelyAsync } from './android/UpdatesModule';
 import { BuildContext } from './context';
 import { readReleaseChannelSafelyAsync as readIosReleaseChannelSafelyAsync } from './ios/UpdatesModule';
-import { BuildMetadata, Platform } from './types';
+import { Platform } from './types';
 import { isExpoUpdatesInstalled } from './utils/updates';
 
 /**
@@ -22,7 +23,7 @@ export async function collectMetadata<T extends Platform>(
   }: {
     credentialsSource?: CredentialsSource.LOCAL | CredentialsSource.REMOTE;
   }
-): Promise<BuildMetadata> {
+): Promise<Metadata> {
   return {
     trackingContext: ctx.trackingCtx,
     appVersion: ctx.commandCtx.exp.version!,

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -1,10 +1,5 @@
-import { Platform, Workflow } from '@expo/eas-build-job';
-import {
-  AndroidBuildProfile,
-  CredentialsSource,
-  DistributionType,
-  iOSBuildProfile,
-} from '@expo/eas-json';
+import { Metadata, Platform } from '@expo/eas-build-job';
+import { AndroidBuildProfile, iOSBuildProfile } from '@expo/eas-json';
 
 export enum RequestedPlatform {
   Android = 'android',
@@ -31,84 +26,13 @@ export interface Build {
   createdAt: string;
   updatedAt: string;
   artifacts?: BuildArtifacts;
-  metadata?: Partial<BuildMetadata>;
+  metadata?: Partial<Metadata>;
 }
 
 interface BuildArtifacts {
   buildUrl?: string;
   logsUrl: string;
 }
-
-export type BuildMetadata = {
-  /**
-   * Application version (the expo.version key in app.json/app.config.js)
-   */
-  appVersion: string;
-
-  /**
-   * EAS CLI version
-   */
-  cliVersion: string;
-
-  /**
-   * Build workflow
-   * It's either 'generic' or 'managed'
-   */
-  workflow: Workflow;
-
-  /**
-   * Credentials source
-   * Credentials could be obtained either from credential.json or EAS servers.
-   */
-  credentialsSource?: CredentialsSource.LOCAL | CredentialsSource.REMOTE;
-
-  /**
-   * Expo SDK version
-   * It's determined by the expo package version in package.json.
-   * It's undefined if the expo package is not installed for the project.
-   */
-  sdkVersion?: string;
-
-  /**
-   * Release channel (for expo-updates)
-   * It's undefined if the expo-updates package is not installed for the project.
-   */
-  releaseChannel?: string;
-
-  /**
-   * Tracking context
-   * It's used to track build process across different Expo services and tools.
-   */
-  trackingContext: TrackingContext;
-
-  /**
-   * Distribution type
-   * Indicates whether this is a build for store, internal distribution, or simulator (iOS).
-   */
-  distribution: DistributionType;
-
-  /**
-   * App name (expo.name in app.json/app.config.js)
-   */
-  appName?: string;
-
-  /**
-   * App identifier:
-   * - iOS builds: the bundle identifier (expo.ios.bundleIdentifier in app.json/app.config.js)
-   * - Android builds: the application id (expo.android.package in app.json/app.config.js)
-   */
-  appIdentifier?: string;
-
-  /**
-   * Build profile name (e.g. release)
-   */
-  buildProfile?: string;
-
-  /**
-   * Git commit hash (e.g. aab03fbdabb6e536ea78b28df91575ad488f5f21)
-   */
-  gitCommitHash?: string;
-};
 
 export type PlatformBuildProfile<T extends Platform> = T extends Platform.ANDROID
   ? AndroidBuildProfile

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.14",
+    "@expo/eas-build-job": "0.2.16",
     "@hapi/joi": "^17.1.1",
     "fs-extra": "^9.0.1",
     "tslib": "^1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.14":
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.14.tgz#10402f8c2cdd3e8c7ebc6f8773270295e7993771"
-  integrity sha512-+msVy5CgyQwZrUJeiV6hvg3Sjx4Fc1CHDF0jY0LxXSsRDGQDM7qde6ukHRyPvGuGxv/+PzwlWolv2kOP6GFcFQ==
+"@expo/eas-build-job@0.2.16":
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.16.tgz#490be96d32f4b9ef4501d117796f523680ce5a00"
+  integrity sha512-PJRYwk3phLDpqtIKTEBgyqvJsxCoa55CHYRJguRJ9lYHxqxL/litUruxu1Y5cjF+iGXw/ElpN2C75wuboUdjcw==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Part 1 of https://linear.app/expo/issue/ENG-392/expose-system-environment-variables-with-context-about-the-build
`@expo/eas-build-job` exports the metadata type now.

# How

I used the `Metadata` type from `@expo/eas-build-job` instead of the one defined in eas-cli.

# Test Plan

Tests are still passing.