### PR TITLE
[eas-cli] handle unknown team name in device list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Print team id in the `device:list` when the team name is unknown. ([#268](https://github.com/expo/eas-cli/pull/268) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [0.5.0](https://github.com/expo/eas-cli/releases/tag/v0.5.0) - 2021-03-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Print team id in the `device:list` when the team name is unknown. ([#268](https://github.com/expo/eas-cli/pull/268) by [@wkozyra95](https://github.com/wkozyra95))
+- Print Apple Team ID in the output of `device:list` when the team name is unknown. ([#268](https://github.com/expo/eas-cli/pull/268) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -42,7 +42,9 @@ export default class BuildList extends Command {
               name: 'appleTeamIdentifier',
               message: 'What Apple Team would you like to list devices for?',
               choices: teams.map(team => ({
-                title: `${team.appleTeamName} (ID: ${team.appleTeamIdentifier})`,
+                title: team.appleTeamName
+                  ? `${team.appleTeamName} (ID: ${team.appleTeamIdentifier})`
+                  : team.appleTeamIdentifier,
                 value: team.appleTeamIdentifier,
               })),
             });
@@ -71,7 +73,9 @@ export default class BuildList extends Command {
       if (result?.appleDevices.length) {
         const { appleTeamName, appleDevices } = result;
 
-        spinner.succeed(`Found ${appleDevices.length} devices for team ${appleTeamName}`);
+        spinner.succeed(
+          `Found ${appleDevices.length} devices for team ${appleTeamName ?? appleTeamIdentifier}`
+        );
 
         const list = appleDevices
           .map(device =>


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://linear.app/expo/issue/ENG-445/eas-devicelist-says-i-am-on-team-null

# How

use id instead of name if not available

# Test Plan

`eas device:list`
