### PR TITLE
[ENG-444] support internal distribution in non-interactive builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add more build metadata (release channel, build profile name, git commit hash). ([#265](https://github.com/expo/eas-cli/pull/265) by [@dsokal](https://github.com/dsokal))
 - Display App Store link after successful submission. ([#144](https://github.com/expo/eas-cli/pull/144) by [@barthap](https://github.com/barthap))
 - Add `experimental.disableIosBundleIdentifierValidation` flag to eas.json. ([#263](https://github.com/expo/eas-cli/pull/263) by [@wkozyra95](https://github.com/wkozyra95))
+- Support internal distribution in non-interactive builds. ([#269](https://github.com/expo/eas-cli/pull/269) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -11,7 +11,7 @@ import * as credentialsJsonReader from '../credentialsJson/read';
 import type { IosCredentials } from '../credentialsJson/read';
 import { SetupBuildCredentials } from './actions/SetupBuildCredentials';
 import { resolveAppleTeamIfAuthenticatedAsync } from './actions/new/AppleTeamUtils';
-import { AppleUnauthenticatedError, MissingCredentialsNonInteractiveError } from './errors';
+import { AppleTeamMissingError, MissingCredentialsNonInteractiveError } from './errors';
 import { isAdHocProfile } from './utils/provisioningProfile';
 
 export { IosCredentials };
@@ -210,7 +210,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
           },
         };
       } catch (err) {
-        if (err instanceof AppleUnauthenticatedError && this.ctx.nonInteractive) {
+        if (err instanceof AppleTeamMissingError && this.ctx.nonInteractive) {
           throw new MissingCredentialsNonInteractiveError();
         }
         throw err;

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -1,7 +1,7 @@
 import { Platform } from '@expo/eas-build-job';
 import { CredentialsSource, iOSDistributionType } from '@expo/eas-json';
 
-import { IosDistributionType } from '../../graphql/generated';
+import { AppleTeamFragment, IosDistributionType } from '../../graphql/generated';
 import Log from '../../log';
 import { findAccountByName } from '../../user/Account';
 import { CredentialsManager } from '../CredentialsManager';
@@ -10,6 +10,8 @@ import { Context } from '../context';
 import * as credentialsJsonReader from '../credentialsJson/read';
 import type { IosCredentials } from '../credentialsJson/read';
 import { SetupBuildCredentials } from './actions/SetupBuildCredentials';
+import { resolveAppleTeamIfAuthenticatedAsync } from './actions/new/AppleTeamUtils';
+import { AppleUnauthenticatedError, MissingCredentialsNonInteractiveError } from './errors';
 import { isAdHocProfile } from './utils/provisioningProfile';
 
 export { IosCredentials };
@@ -183,31 +185,36 @@ export default class IosCredentialsProvider implements CredentialsProvider {
         projectName: this.options.app.projectName,
       };
 
-      // for now, let's require the user to authenticate with Apple
-      const { team } = await this.ctx.appStore.ensureAuthenticatedAsync();
-      const appleTeam = await this.ctx.newIos.createOrGetExistingAppleTeamAsync(appLookupParams, {
-        appleTeamIdentifier: team.id,
-        appleTeamName: team.name,
-      });
-      const [distCert, provisioningProfile] = await Promise.all([
-        this.ctx.newIos.getDistributionCertificateForAppAsync(
-          appLookupParams,
-          appleTeam,
-          IosDistributionType.AdHoc
-        ),
-        this.ctx.newIos.getProvisioningProfileAsync(
-          appLookupParams,
-          appleTeam,
-          IosDistributionType.AdHoc
-        ),
-      ]);
-      return {
-        provisioningProfile: provisioningProfile?.provisioningProfile ?? undefined,
-        distributionCertificate: {
-          certP12: distCert?.certificateP12 ?? undefined,
-          certPassword: distCert?.certificatePassword ?? undefined,
-        },
-      };
+      let appleTeam: AppleTeamFragment | null = null;
+      if (!this.ctx.nonInteractive) {
+        await this.ctx.appStore.ensureAuthenticatedAsync();
+        appleTeam = await resolveAppleTeamIfAuthenticatedAsync(this.ctx, appLookupParams);
+      }
+
+      try {
+        const [distCert, provisioningProfile] = await Promise.all([
+          this.ctx.newIos.getDistributionCertificateForAppAsync(
+            appLookupParams,
+            IosDistributionType.AdHoc,
+            { appleTeam }
+          ),
+          this.ctx.newIos.getProvisioningProfileAsync(appLookupParams, IosDistributionType.AdHoc, {
+            appleTeam,
+          }),
+        ]);
+        return {
+          provisioningProfile: provisioningProfile?.provisioningProfile ?? undefined,
+          distributionCertificate: {
+            certP12: distCert?.certificateP12 ?? undefined,
+            certPassword: distCert?.certificatePassword ?? undefined,
+          },
+        };
+      } catch (err) {
+        if (err instanceof AppleUnauthenticatedError && this.ctx.nonInteractive) {
+          throw new MissingCredentialsNonInteractiveError();
+        }
+        throw err;
+      }
     } else {
       const [distCert, provisioningProfile] = await Promise.all([
         this.ctx.ios.getDistributionCertificateAsync(this.options.app),

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -37,11 +37,6 @@ export class SetupBuildCredentials implements Action {
         if (!account) {
           throw new Error(`You do not have access to the ${this.app.accountName} account`);
         }
-        if (ctx.nonInteractive) {
-          throw new Error('Internal distribution builds are not supported in non-interactive mode');
-        }
-        // for now, let's require the user to authenticate with Apple
-        await ctx.appStore.ensureAuthenticatedAsync();
         const action = new SetupAdhocProvisioningProfile({
           account,
           projectName: this.app.projectName,

--- a/packages/eas-cli/src/credentials/ios/actions/new/AppleTeamUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/AppleTeamUtils.ts
@@ -1,0 +1,16 @@
+import { AppleTeamFragment } from '../../../../graphql/generated';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+
+export async function resolveAppleTeamIfAuthenticatedAsync(
+  ctx: Context,
+  app: AppLookupParams
+): Promise<AppleTeamFragment | null> {
+  if (!ctx.appStore.authCtx) {
+    return null;
+  }
+  return await ctx.newIos.createOrGetExistingAppleTeamAsync(app, {
+    appleTeamIdentifier: ctx.appStore.authCtx.team.id,
+    appleTeamName: ctx.appStore.authCtx.team.name,
+  });
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
@@ -69,7 +69,6 @@ export class SetupAdhocProvisioningProfile implements Action {
     Log.warn(
       'Provisioning Profile is not validated for non-interactive internal distribution builds.'
     );
-    Log.warn('The build on EAS servers might fail.');
 
     // app credentials should exist here because the profile exists
     const appCredentials = nullthrows(

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
@@ -37,20 +37,20 @@ export class SetupAdhocProvisioningProfile implements Action {
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     if (ctx.nonInteractive) {
-      await this.runNonInteractive(manager, ctx);
-    } else {
       try {
-        await this.runInteractive(manager, ctx);
+        await this.runNonInteractiveAsync(manager, ctx);
       } catch (err) {
-        if (err instanceof AppleUnauthenticatedError && ctx.nonInteractive) {
+        if (err instanceof AppleUnauthenticatedError) {
           throw new MissingCredentialsNonInteractiveError();
         }
         throw err;
       }
+    } else {
+      await this.runInteractiveAsync(manager, ctx);
     }
   }
 
-  private async runNonInteractive(manager: CredentialsManager, ctx: Context): Promise<void> {
+  private async runNonInteractiveAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     // 1. Setup Distribution Certificate
     const distCertAction = new SetupDistributionCertificate(this.app);
     await manager.runActionAsync(distCertAction);
@@ -80,7 +80,7 @@ export class SetupAdhocProvisioningProfile implements Action {
     this._iosAppBuildCredentials = appCredentials.iosAppBuildCredentialsArray[0];
   }
 
-  private async runInteractive(manager: CredentialsManager, ctx: Context): Promise<void> {
+  private async runInteractiveAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     // 0. Ensure the user is authenticated with Apple and resolve the Apple team object
     await ctx.appStore.ensureAuthenticatedAsync();
     const appleTeam = nullthrows(await resolveAppleTeamIfAuthenticatedAsync(ctx, this.app));

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
@@ -16,7 +16,7 @@ import { AppleDeviceFragmentWithAppleTeam } from '../../api/graphql/queries/Appl
 import { AppleProvisioningProfileQueryResult } from '../../api/graphql/queries/AppleProvisioningProfileQuery';
 import { ProvisioningProfileStoreInfo } from '../../appstore/Credentials.types';
 import { ProfileClass } from '../../appstore/provisioningProfile';
-import { AppleUnauthenticatedError, MissingCredentialsNonInteractiveError } from '../../errors';
+import { AppleTeamMissingError, MissingCredentialsNonInteractiveError } from '../../errors';
 import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
 import { chooseDevices } from './DeviceUtils';
 import { doUDIDsMatch, isDevPortalAdhocProfileValid } from './ProvisioningProfileUtils';
@@ -40,7 +40,7 @@ export class SetupAdhocProvisioningProfile implements Action {
       try {
         await this.runNonInteractiveAsync(manager, ctx);
       } catch (err) {
-        if (err instanceof AppleUnauthenticatedError) {
+        if (err instanceof AppleTeamMissingError) {
           throw new MissingCredentialsNonInteractiveError();
         }
         throw err;

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
@@ -13,7 +13,7 @@ import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
 import { AppleDistributionCertificateMutationResult } from '../../api/graphql/mutations/AppleDistributionCertificateMutation';
 import { getValidCertSerialNumbers } from '../../appstore/CredentialsUtils';
-import { AppleUnauthenticatedError, MissingCredentialsNonInteractiveError } from '../../errors';
+import { AppleTeamMissingError, MissingCredentialsNonInteractiveError } from '../../errors';
 import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
 import { CreateDistributionCertificate } from './CreateDistributionCertificate';
 import { formatDistributionCertificate } from './DistributionCertificateUtils';
@@ -48,7 +48,7 @@ export class SetupDistributionCertificate implements Action {
         await this.runInteractiveAsync(ctx, manager, currentCertificate);
       }
     } catch (err) {
-      if (err instanceof AppleUnauthenticatedError && ctx.nonInteractive) {
+      if (err instanceof AppleTeamMissingError && ctx.nonInteractive) {
         throw new MissingCredentialsNonInteractiveError();
       }
       throw err;

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../graphql/generated';
 import { Account } from '../../../user/Account';
 import { DistributionCertificate } from '../appstore/Credentials.types';
-import { AppleUnauthenticatedError } from '../errors';
+import { AppleTeamMissingError } from '../errors';
 import { AppleAppIdentifierMutation } from './graphql/mutations/AppleAppIdentifierMutation';
 import {
   AppleDistributionCertificateMutation,
@@ -204,7 +204,7 @@ export async function createOrGetExistingAppleAppIdentifierAsync(
     return appleAppIdentifier;
   } else {
     if (!appleTeam) {
-      throw new AppleUnauthenticatedError();
+      throw new AppleTeamMissingError();
     }
     return await AppleAppIdentifierMutation.createAppleAppIdentifierAsync(
       { bundleIdentifier, appleTeamId: appleTeam.id },

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../graphql/generated';
 import { Account } from '../../../user/Account';
 import { DistributionCertificate } from '../appstore/Credentials.types';
+import { AppleUnauthenticatedError } from '../errors';
 import { AppleAppIdentifierMutation } from './graphql/mutations/AppleAppIdentifierMutation';
 import {
   AppleDistributionCertificateMutation,
@@ -98,6 +99,25 @@ export async function createOrUpdateIosAppBuildCredentialsAsync(
 }
 
 export async function getIosAppCredentialsWithBuildCredentialsAsync(
+  appLookupParams: AppLookupParams,
+  { iosDistributionType }: { iosDistributionType: IosDistributionType }
+): Promise<IosAppCredentialsWithBuildCredentialsQueryResult | null> {
+  const { account, bundleIdentifier } = appLookupParams;
+  const appleAppIdentifier = await AppleAppIdentifierQuery.byBundleIdentifierAsync(
+    account.name,
+    bundleIdentifier
+  );
+  if (!appleAppIdentifier) {
+    return null;
+  }
+  const projectFullName = formatProjectFullName(appLookupParams);
+  return await IosAppCredentialsQuery.withBuildCredentialsByAppIdentifierIdAsync(projectFullName, {
+    appleAppIdentifierId: appleAppIdentifier.id,
+    iosDistributionType,
+  });
+}
+
+export async function getIosAppCredentialsWithCommonFieldsAsync(
   appLookupParams: AppLookupParams
 ): Promise<CommonIosAppCredentialsFragment | null> {
   const { account, bundleIdentifier } = appLookupParams;
@@ -126,12 +146,12 @@ export async function createOrGetExistingIosAppCredentialsWithBuildCredentialsAs
     iosDistributionType: IosDistributionType;
   }
 ): Promise<IosAppCredentialsWithBuildCredentialsQueryResult> {
-  const projectFullName = formatProjectFullName(appLookupParams);
-  const maybeIosAppCredentials = await IosAppCredentialsQuery.withBuildCredentialsByAppIdentifierIdAsync(
-    projectFullName,
-    { appleAppIdentifierId, iosDistributionType }
+  const maybeIosAppCredentials = await getIosAppCredentialsWithBuildCredentialsAsync(
+    appLookupParams,
+    {
+      iosDistributionType,
+    }
   );
-
   if (maybeIosAppCredentials) {
     return maybeIosAppCredentials;
   } else {
@@ -144,6 +164,7 @@ export async function createOrGetExistingIosAppCredentialsWithBuildCredentialsAs
       app.id,
       appleAppIdentifier.id
     );
+    const projectFullName = formatProjectFullName(appLookupParams);
     return nullthrows(
       await IosAppCredentialsQuery.withBuildCredentialsByAppIdentifierIdAsync(projectFullName, {
         appleAppIdentifierId,
@@ -173,7 +194,7 @@ export async function createOrGetExistingAppleTeamAsync(
 
 export async function createOrGetExistingAppleAppIdentifierAsync(
   { account, bundleIdentifier }: AppLookupParams,
-  appleTeam: AppleTeamFragment
+  appleTeam: AppleTeamFragment | null
 ): Promise<AppleAppIdentifierFragment> {
   const appleAppIdentifier = await AppleAppIdentifierQuery.byBundleIdentifierAsync(
     account.name,
@@ -182,6 +203,9 @@ export async function createOrGetExistingAppleAppIdentifierAsync(
   if (appleAppIdentifier) {
     return appleAppIdentifier;
   } else {
+    if (!appleTeam) {
+      throw new AppleUnauthenticatedError();
+    }
     return await AppleAppIdentifierMutation.createAppleAppIdentifierAsync(
       { bundleIdentifier, appleTeamId: appleTeam.id },
       account.id
@@ -213,8 +237,8 @@ export async function createProvisioningProfileAsync(
 
 export async function getProvisioningProfileAsync(
   appLookupParams: AppLookupParams,
-  appleTeam: AppleTeamFragment,
-  iosDistributionType: IosDistributionType
+  iosDistributionType: IosDistributionType,
+  { appleTeam }: { appleTeam: AppleTeamFragment | null } = { appleTeam: null }
 ): Promise<AppleProvisioningProfileQueryResult | null> {
   const projectFullName = formatProjectFullName(appLookupParams);
   const appleAppIdentifier = await createOrGetExistingAppleAppIdentifierAsync(
@@ -222,7 +246,7 @@ export async function getProvisioningProfileAsync(
     appleTeam
   );
   return await AppleProvisioningProfileQuery.getForAppAsync(projectFullName, {
-    appleAppIdentifierId: appleAppIdentifier?.id,
+    appleAppIdentifierId: appleAppIdentifier.id,
     iosDistributionType,
   });
 }
@@ -250,8 +274,8 @@ export async function deleteProvisioningProfilesAsync(
 
 export async function getDistributionCertificateForAppAsync(
   appLookupParams: AppLookupParams,
-  appleTeam: AppleTeamFragment,
-  iosDistributionType: IosDistributionType
+  iosDistributionType: IosDistributionType,
+  { appleTeam }: { appleTeam: AppleTeamFragment | null } = { appleTeam: null }
 ): Promise<AppleDistributionCertificateFragment | null> {
   const projectFullName = formatProjectFullName(appLookupParams);
   const appleAppIdentifier = await createOrGetExistingAppleAppIdentifierAsync(
@@ -259,7 +283,7 @@ export async function getDistributionCertificateForAppAsync(
     appleTeam
   );
   return await AppleDistributionCertificateQuery.getForAppAsync(projectFullName, {
-    appleAppIdentifierId: appleAppIdentifier?.id,
+    appleAppIdentifierId: appleAppIdentifier.id,
     iosDistributionType,
   });
 }

--- a/packages/eas-cli/src/credentials/ios/errors.ts
+++ b/packages/eas-cli/src/credentials/ios/errors.ts
@@ -1,6 +1,6 @@
 export class AppleTeamMissingError extends Error {
   constructor(message?: string) {
-    super(message ?? 'You need to be authenticated with Apple to set up credentials');
+    super(message ?? 'Apple Team is necessary to create Apple App Identifier');
   }
 }
 

--- a/packages/eas-cli/src/credentials/ios/errors.ts
+++ b/packages/eas-cli/src/credentials/ios/errors.ts
@@ -1,4 +1,4 @@
-export class AppleUnauthenticatedError extends Error {
+export class AppleTeamMissingError extends Error {
   constructor(message?: string) {
     super(message ?? 'You need to be authenticated with Apple to set up credentials');
   }

--- a/packages/eas-cli/src/credentials/ios/errors.ts
+++ b/packages/eas-cli/src/credentials/ios/errors.ts
@@ -1,0 +1,13 @@
+export class AppleUnauthenticatedError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'You need to be authenticated with Apple to set up credentials');
+  }
+}
+
+export class MissingCredentialsNonInteractiveError extends Error {
+  constructor(message?: string) {
+    super(
+      message ?? 'Credentials are not set up. Please run this command again in interactive mode.'
+    );
+  }
+}

--- a/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
@@ -40,7 +40,7 @@ export class ManageIosBeta implements Action {
         }
         if (ctx.hasProjectContext) {
           const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
-          const iosAppCredentials = await ctx.newIos.getIosAppCredentialsWithBuildCredentialsAsync(
+          const iosAppCredentials = await ctx.newIos.getIosAppCredentialsWithCommonFieldsAsync(
             appLookupParams
           );
           if (!iosAppCredentials) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://linear.app/expo/issue/ENG-444/support-internal-distribution-in-non-interactive-builds

We want to support running internal distribution builds in non-interactive mode.

# How

- I removed the requirement of running `eas build` for internal distribution in interactive mode.
- I added a new branch in the `SetupAdhocProvisioningProfile` action. When running in non-interactive mode there is only a simple check for the provisioning profile existence. If the credentials are not set up this action throws an error saying to re-run the command in interactive mode.
- I added a similar branch in the `SetupDistributionCertificate` action. There's a check for the existence of the cert. If it doesn't exist, then an error is thrown.

# Test Plan

- Unit tests are still passing.
- I ran `eas build -p ios` (for a profile with `"distribution": "internal"`) a couple of times:
  - For a freshly inited project:
    - with `--non-interactive` - I saw "Credentials are not set up. Please run this command again in interactive mode."
    - without `--non-interactive` - I walked through the credentials setup process and was able to schedule a build
  - For an existing project that already had the credentials set up
    - with `--non-interactive` flag - I was able to schedule a build
    - without `--non-interactive` flag - I was able to schedule a build