### PR TITLE
print common error messages when builds fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Print common error messages when builds fail. ([#272](https://github.com/expo/eas-cli/pull/272) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -11,7 +11,7 @@
     "@expo/apple-utils": "0.0.0-alpha.17",
     "@expo/config": "~3.3.19",
     "@expo/config-plugins": "1.0.21-alpha.0",
-    "@expo/eas-build-job": "0.2.16",
+    "@expo/eas-build-job": "0.2.18",
     "@expo/eas-json": "^0.6.0",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.11",

--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -32,6 +32,7 @@ export async function buildAsync(commandCtx: CommandContext): Promise<void> {
       exitWithNonZeroCodeIfSomeBuildsFailed(builds);
     } catch (err) {
       if (err instanceof errors.UserError) {
+        Log.addNewLineIfNone();
         printUserError(err);
         process.exit(1);
       } else {

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -27,11 +27,17 @@ export interface Build {
   updatedAt: string;
   artifacts?: BuildArtifacts;
   metadata?: Partial<Metadata>;
+  error?: BuildError;
 }
 
 interface BuildArtifacts {
   buildUrl?: string;
   logsUrl: string;
+}
+
+interface BuildError {
+  errorCode: string;
+  message: string;
 }
 
 export type PlatformBuildProfile<T extends Platform> = T extends Platform.ANDROID

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -59,6 +59,12 @@ function printBuildResult(accountName: string, build: Build): void {
     }
     return;
   }
+  if (build.status === 'canceled') {
+    Log.error(
+      `${platformEmojis[build.platform]} ${platformDisplayNames[build.platform]} was canceled`
+    );
+    return;
+  }
 
   if (build.metadata?.distribution === 'internal') {
     const logsUrl = getBuildLogsUrl({

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -1,7 +1,8 @@
+import { errors } from '@expo/eas-build-job';
 import assert from 'assert';
 import chalk from 'chalk';
 
-import Log from '../../log';
+import Log, { learnMore } from '../../log';
 import { platformDisplayNames, platformEmojis } from '../constants';
 import { Build } from '../types';
 import { getBuildLogsUrl } from './url';
@@ -34,18 +35,31 @@ export function printLogsUrls(
 }
 
 export function printBuildResults(accountName: string, builds: (Build | null)[]): void {
+  Log.newLine();
   if (builds.length === 1) {
     const [build] = builds;
     assert(build, 'Build should be defined');
     printBuildResult(accountName, build);
   } else {
-    (builds.filter(i => i) as Build[])
-      .filter(build => build.status === 'finished')
-      .forEach(build => printBuildResult(accountName, build));
+    (builds.filter(i => i) as Build[]).forEach(build => printBuildResult(accountName, build));
   }
 }
 
 function printBuildResult(accountName: string, build: Build): void {
+  Log.addNewLineIfNone();
+  if (build.status === 'errored') {
+    const userError = build.error && errors.fromExternalError(build.error);
+    Log.error(
+      `${platformEmojis[build.platform]} ${platformDisplayNames[build.platform]} build failed${
+        userError ? ':' : ''
+      }`
+    );
+    if (userError) {
+      printUserError(userError, { printNewLine: false });
+    }
+    return;
+  }
+
   if (build.metadata?.distribution === 'internal') {
     const logsUrl = getBuildLogsUrl({
       buildId: build.id,
@@ -57,14 +71,12 @@ function printBuildResult(accountName: string, build: Build): void {
       } devices to install the app:`
     );
     Log.log(`${chalk.underline(logsUrl)}`);
-    Log.newLine();
   } else {
     // TODO: it looks like buildUrl could possibly be undefined, based on the code below.
     // we should account for this case better if it is possible
     const url = build.artifacts?.buildUrl ?? '';
     Log.log(`${platformEmojis[build.platform]} ${platformDisplayNames[build.platform]} app:`);
     Log.log(`${chalk.underline(url)}`);
-    Log.newLine();
   }
 }
 
@@ -85,5 +97,15 @@ export function printDeprecationWarnings(deprecationInfo?: DeprecationInfo): voi
   } else {
     Log.warn('An unexpected warning was encountered. Please report it as a bug:');
     Log.warn(deprecationInfo);
+  }
+}
+
+export function printUserError(error: errors.UserError, { printNewLine = true } = {}): void {
+  if (printNewLine) {
+    Log.addNewLineIfNone();
+  }
+  Log.error(error.message);
+  if (error.fyiURL) {
+    Log.error(learnMore(error.fyiURL, { dim: false }));
   }
 }

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -55,7 +55,7 @@ function printBuildResult(accountName: string, build: Build): void {
       }`
     );
     if (userError) {
-      printUserError(userError, { printNewLine: false });
+      printUserError(userError);
     }
     return;
   }
@@ -100,10 +100,7 @@ export function printDeprecationWarnings(deprecationInfo?: DeprecationInfo): voi
   }
 }
 
-export function printUserError(error: errors.UserError, { printNewLine = true } = {}): void {
-  if (printNewLine) {
-    Log.addNewLineIfNone();
-  }
+export function printUserError(error: errors.UserError): void {
   Log.error(error.message);
   if (error.fyiURL) {
     Log.error(learnMore(error.fyiURL, { dim: false }));

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -70,10 +70,9 @@ function logSuccess(platform: RequestedPlatform) {
 
 - Run ${chalk.bold('eas build')} when you are ready to create your first build.
 - Once the build is completed, run ${chalk.bold('eas submit')} to upload the app to ${storesText}
-- ${learnMore(
-    'https://docs.expo.io/build/introduction',
-    'Learn more about other capabilities of EAS Build'
-  )}`);
+- ${learnMore('https://docs.expo.io/build/introduction', {
+    learnMoreMessage: 'Learn more about other capabilities of EAS Build',
+  })}`);
 }
 
 async function promptForPlatformAsync(): Promise<RequestedPlatform> {

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -78,15 +78,20 @@ export default class Log {
 }
 
 /**
- * Format links as dim with an underline.
+ * Format links as dim (unless disabled) with an underline.
  *
  * @example Learn more: https://expo.io
  * @param url
  */
-export function learnMore(url: string, learnMoreMessage?: string): string {
+export function learnMore(
+  url: string,
+  { learnMoreMessage, dim = true }: { learnMoreMessage?: string; dim?: boolean } = {}
+): string {
   // Links can be disabled via env variables https://github.com/jamestalmage/supports-hyperlinks/blob/master/index.js
   if (terminalLink.isSupported) {
-    return chalk.dim(terminalLink(learnMoreMessage ?? 'Learn more.', url));
+    const text = terminalLink(learnMoreMessage ?? 'Learn more.', url);
+    return dim ? chalk.dim(text) : text;
   }
-  return chalk.dim(`${learnMoreMessage ?? 'Learn more'}: ${chalk.underline(url)}`);
+  const text = `${learnMoreMessage ?? 'Learn more'}: ${chalk.underline(url)}`;
+  return dim ? chalk.dim(text) : text;
 }

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -60,7 +60,7 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
           '- When it’s done, you can see your build here' +
           learnMore(
             `https://appstoreconnect.apple.com/apps/${this.options.ascAppId}/appstore/ios`,
-            ''
+            { learnMoreMessage: '' }
           )
       );
     }

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.16",
+    "@expo/eas-build-job": "0.2.18",
     "@hapi/joi": "^17.1.1",
     "fs-extra": "^9.0.1",
     "tslib": "^1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,12 +1151,13 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.16":
-  version "0.2.16"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.16.tgz#490be96d32f4b9ef4501d117796f523680ce5a00"
-  integrity sha512-PJRYwk3phLDpqtIKTEBgyqvJsxCoa55CHYRJguRJ9lYHxqxL/litUruxu1Y5cjF+iGXw/ElpN2C75wuboUdjcw==
+"@expo/eas-build-job@0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.18.tgz#ece45849139a6395356424047eca9854af55b7fd"
+  integrity sha512-kFd1pLjtwKL2MgqOq8ECxY9MmN8vZd55QHmDelp/i7a7D3uOBmINcU0c2Axsq8HzaC27hZHbSBPQFDWY+FWItA==
   dependencies:
     "@hapi/joi" "^17.1.1"
+    es6-error "^4.1.1"
 
 "@expo/image-utils@0.3.10":
   version "0.3.10"
@@ -5547,6 +5548,11 @@ es5-ext@^0.10.35, es5-ext@^0.10.50:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.3"
     next-tick "~1.0.0"
+
+es6-error@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
+  integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
 es6-iterator@~2.0.3:
   version "2.0.3"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

We want to provide users with meaningful error messages when their builds fail.

# How

I added printing the common error messages (if detected). The list of the errors (with messages and FYI URLs) is defined in `@expo/eas-build-job`.

# Test Plan

<img width="975" alt="ios-failed" src="https://user-images.githubusercontent.com/5256730/110801881-f2be1b00-827d-11eb-89b4-f04e955bd219.png">

<img width="1275" alt="one-failed" src="https://user-images.githubusercontent.com/5256730/110801886-f5207500-827d-11eb-8a64-8b14fb852131.png">

<img width="1192" alt="two-failed" src="https://user-images.githubusercontent.com/5256730/110801890-f6ea3880-827d-11eb-984c-c1813bfa67d8.png">

