### PR TITLE
[ENG-509][submit] Fix local archive prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix `eas submit` local archive prompt for `.aab` files when submitting for iOS. ([#273](https://github.com/expo/eas-cli/pull/144) by [@barthap](https://github.com/barthap))
+
 ### 🧹 Chores
 
 ## [0.6.0](https://github.com/expo/eas-cli/releases/tag/v0.6.0) - 2021-03-09

--- a/packages/eas-cli/src/submissions/archiveSource/ArchiveFileSource.ts
+++ b/packages/eas-cli/src/submissions/archiveSource/ArchiveFileSource.ts
@@ -210,7 +210,7 @@ async function handlePromptSourceAsync(source: ArchiveFilePromptSource): Promise
       });
     }
     case ArchiveFileSourceType.path: {
-      const path = await askForArchivePathAsync();
+      const path = await askForArchivePathAsync(source.platform);
       return getArchiveFileLocationAsync({
         ...source,
         sourceType: ArchiveFileSourceType.path,
@@ -258,11 +258,12 @@ async function askForArchiveUrlAsync(): Promise<string> {
   return url;
 }
 
-async function askForArchivePathAsync(): Promise<string> {
-  const defaultArchivePath = '/path/to/your/archive.aab';
+async function askForArchivePathAsync(platform: SubmissionPlatform): Promise<string> {
+  const isIos = platform === SubmissionPlatform.iOS;
+  const defaultArchivePath = `/path/to/your/archive.${isIos ? 'ipa' : 'aab'}`;
   const { path } = await promptAsync({
     name: 'path',
-    message: 'Path to the app archive file (aab or apk):',
+    message: `Path to the app archive file (${isIos ? 'ipa' : 'aab or apk'}):`,
     initial: defaultArchivePath,
     type: 'text',
     validate: async (path: string): Promise<boolean | string> => {


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Fixes ENG-509. When running `eas submit -p ios` and selected local archive path, the prompt asked for `.aab` file instead of `.ipa`.

# How

Modified prompt messages to be platform-dependant.

# Test Plan

Tested by running command locally for both platforms.