### PR TITLE
[ENG-438] allow for installing custom bundler version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Print common error messages when builds fail. ([#272](https://github.com/expo/eas-cli/pull/272) by [@dsokal](https://github.com/dsokal))
 - Commit automatically if `EAS_BUILD_AUTOCOMMIT` is set. ([#271](https://github.com/expo/eas-cli/pull/271) by [@wkozyra95](https://github.com/wkozyra95))
+- Allow for installing custom `bundler` version on EAS Build. ([#277](https://github.com/expo/eas-cli/pull/277) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -11,7 +11,7 @@
     "@expo/apple-utils": "0.0.0-alpha.17",
     "@expo/config": "~3.3.19",
     "@expo/config-plugins": "1.0.21-alpha.0",
-    "@expo/eas-build-job": "0.2.19",
+    "@expo/eas-build-job": "0.2.20",
     "@expo/eas-json": "^0.6.0",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.11",

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -96,6 +96,7 @@ async function prepareJobCommonAsync(
       image: ctx.buildProfile.image,
       node: ctx.buildProfile.node,
       yarn: ctx.buildProfile.yarn,
+      bundler: ctx.buildProfile.bundler,
       cocoapods: ctx.buildProfile.cocoapods,
       fastlane: ctx.buildProfile.fastlane,
       env: ctx.buildProfile.env,

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -108,7 +108,7 @@ export function printDeprecationWarnings(deprecationInfo?: DeprecationInfo): voi
 
 export function printUserError(error: errors.ExternalUserError): void {
   Log.error(error.message);
-  if (error.docsURL) {
-    Log.error(learnMore(error.docsURL, { dim: false }));
+  if (error.docsUrl) {
+    Log.error(learnMore(error.docsUrl, { dim: false }));
   }
 }

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.19",
+    "@expo/eas-build-job": "0.2.20",
     "@hapi/joi": "^17.1.1",
     "fs-extra": "^9.0.1",
     "tslib": "^1"

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -25,6 +25,7 @@ const IosBuilderEnvironmentSchema = Joi.object({
     .default('default'),
   node: Joi.string().empty(null).custom(semverSchemaCheck),
   yarn: Joi.string().empty(null).custom(semverSchemaCheck),
+  bundler: Joi.string().empty(null).custom(semverSchemaCheck),
   fastlane: Joi.string().empty(null).custom(semverSchemaCheck),
   cocoapods: Joi.string().empty(null).custom(semverSchemaCheck),
   env: Joi.object().pattern(Joi.string(), Joi.string().empty(null)).default({}),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.19":
-  version "0.2.19"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.19.tgz#1851df71c0ff4373f36b0d196d9340f6ad369578"
-  integrity sha512-Q+kfQxDsTTDDZtnA/LJwMMuXd86vYu2nowoAdR0Gd3REyA6ubHHxouHkeXBsYfZ4UxrzxlJ2NojWg6j55vC//w==
+"@expo/eas-build-job@0.2.20":
+  version "0.2.20"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.20.tgz#e93d2ef97b49979b97d720eb27c705d674a1ea75"
+  integrity sha512-es9E59Rzjx+QLXxQk+LgW8BdVhdkbi9Z6PXCceslKGUISTajo8rF0udVW2ySdY09Y5cFVlR8aOI8FzLuFZUnfw==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://linear.app/expo/issue/ENG-438/play-nicely-with-existing-fastlane-installations

# How

I added a new config option for iOS builds - `bundler`. It allows for specifying the https://bundler.io/ version

# Test Plan

Tested by building a project with `Gemfile` and `Gemfile.lock`. I specified the `bundler` version in eas.json and it was successfully installed.