### PR TITLE
refactor project utils

### DIFF
--- a/packages/eas-cli/src/build/android/applicationId.ts
+++ b/packages/eas-cli/src/build/android/applicationId.ts
@@ -24,8 +24,12 @@ function isApplicationIdValid(applicationId: string): boolean {
   return /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/.test(applicationId);
 }
 
-export async function ensureApplicationIdIsValidAsync(projectDir: string) {
-  const applicationId = await ensureAppIdentifierIsDefinedAsync(projectDir, Platform.ANDROID);
+export async function ensureApplicationIdIsValidAsync(projectDir: string, exp: ExpoConfig) {
+  const applicationId = await ensureAppIdentifierIsDefinedAsync({
+    projectDir,
+    platform: Platform.ANDROID,
+    exp,
+  });
   if (!isApplicationIdValid(applicationId)) {
     const configDescription = getProjectConfigDescription(projectDir);
     Log.error(

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -60,7 +60,7 @@ This means that it will most likely produce an AAB and you will not be able to i
     }
   }
 
-  await ensureApplicationIdIsValidAsync(commandCtx.projectDir);
+  await ensureApplicationIdIsValidAsync(commandCtx.projectDir, commandCtx.exp);
 
   return await prepareBuildRequestForPlatformAsync({
     ctx: buildCtx,

--- a/packages/eas-cli/src/build/android/configure.ts
+++ b/packages/eas-cli/src/build/android/configure.ts
@@ -15,7 +15,7 @@ export async function configureAndroidAsync(ctx: ConfigureContext): Promise<void
   }
   await AndroidConfig.EasBuild.configureEasBuildAsync(ctx.projectDir);
   await configureApplicationIdAsync(ctx.projectDir, ctx.exp, ctx.allowExperimental);
-  await ensureApplicationIdIsValidAsync(ctx.projectDir);
+  await ensureApplicationIdIsValidAsync(ctx.projectDir, ctx.exp);
 
   const easGradlePath = AndroidConfig.EasBuild.getEasBuildGradlePath(ctx.projectDir);
   await gitAddAsync(easGradlePath, { intentToAdd: true });

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -114,7 +114,7 @@ async function prepareManagedJobAsync(
 ): Promise<Partial<Android.ManagedJob>> {
   const projectRootDirectory =
     path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
-  const accountName = await getProjectAccountNameAsync(ctx.commandCtx.projectDir);
+  const accountName = await getProjectAccountNameAsync(ctx.commandCtx.exp);
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
     type: Workflow.MANAGED,

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig, getConfig } from '@expo/config';
+import { ExpoConfig } from '@expo/config';
 import { AndroidBuildProfile, EasConfig, iOSBuildProfile } from '@expo/eas-json';
 
 import { getProjectAccountName } from '../project/projectUtils';
@@ -25,6 +25,7 @@ export interface CommandContext {
 export async function createCommandContextAsync({
   requestedPlatform,
   profile,
+  exp,
   projectDir,
   projectId,
   trackingCtx,
@@ -35,6 +36,7 @@ export async function createCommandContextAsync({
 }: {
   requestedPlatform: RequestedPlatform;
   profile: string;
+  exp: ExpoConfig;
   projectId: string;
   projectDir: string;
   trackingCtx: TrackingContext;
@@ -44,7 +46,6 @@ export async function createCommandContextAsync({
   waitForBuildEnd: boolean;
 }): Promise<CommandContext> {
   const user = await ensureLoggedInAsync();
-  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
   const accountName = getProjectAccountName(exp, user);
   const projectName = exp.slug;
 

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -47,7 +47,7 @@ export async function prepareIosBuildAsync(
     );
   }
 
-  await ensureBundleIdentifierIsValidAsync(commandCtx.projectDir);
+  await ensureBundleIdentifierIsValidAsync(commandCtx.projectDir, commandCtx.exp);
 
   return await prepareBuildRequestForPlatformAsync({
     ctx: buildCtx,

--- a/packages/eas-cli/src/build/ios/bundleIdentifer.ts
+++ b/packages/eas-cli/src/build/ios/bundleIdentifer.ts
@@ -21,8 +21,12 @@ function isBundleIdentifierValid(bundleIdentifier: string): boolean {
   return /^[a-zA-Z][a-zA-Z0-9\-.]+$/.test(bundleIdentifier);
 }
 
-export async function ensureBundleIdentifierIsValidAsync(projectDir: string) {
-  const bundleIdentifier = await ensureAppIdentifierIsDefinedAsync(projectDir, Platform.IOS);
+export async function ensureBundleIdentifierIsValidAsync(projectDir: string, exp: ExpoConfig) {
+  const bundleIdentifier = await ensureAppIdentifierIsDefinedAsync({
+    projectDir,
+    platform: Platform.IOS,
+    exp,
+  });
   if (!isBundleIdentifierValid(bundleIdentifier)) {
     const configDescription = getProjectConfigDescription(projectDir);
     Log.error(

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -28,7 +28,7 @@ export async function configureIosAsync(ctx: ConfigureContext): Promise<void> {
   )?.experimental?.disableIosBundleIdentifierValidation;
   if (!disableIosBundleIdentifierValidation) {
     await configureBundleIdentifierAsync(ctx.projectDir, ctx.exp);
-    await ensureBundleIdentifierIsValidAsync(ctx.projectDir);
+    await ensureBundleIdentifierIsValidAsync(ctx.projectDir, ctx.exp);
   }
 
   if (isExpoUpdatesInstalled(ctx.projectDir)) {

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -151,7 +151,7 @@ async function prepareManagedJobAsync(
 ): Promise<Partial<Ios.ManagedJob>> {
   const projectRootDirectory =
     path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
-  const accountName = await getProjectAccountNameAsync(ctx.commandCtx.projectDir);
+  const accountName = await getProjectAccountNameAsync(ctx.commandCtx.exp);
   const targetName = sanitizedName(ctx.commandCtx.exp.name);
   return {
     ...(await prepareJobCommonAsync(ctx, {

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -35,7 +35,11 @@ export async function collectMetadata<T extends Platform>(
     distribution: ctx.buildProfile.distribution ?? 'store',
     appName: ctx.commandCtx.exp.name,
     appIdentifier:
-      (await getAppIdentifierAsync(ctx.commandCtx.projectDir, ctx.platform)) ?? undefined,
+      (await getAppIdentifierAsync({
+        projectDir: ctx.commandCtx.projectDir,
+        platform: ctx.platform,
+        exp: ctx.commandCtx.exp,
+      })) ?? undefined,
     buildProfile: ctx.commandCtx.profile,
     gitCommitHash: await gitCommitHashAsync(),
   };

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -1,3 +1,4 @@
+import { getConfig } from '@expo/config';
 import { Command, flags } from '@oclif/command';
 import CliTable from 'cli-table3';
 import gql from 'graphql-tag';
@@ -80,7 +81,8 @@ export default class BranchList extends Command {
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');
     }
-    const fullName = await getProjectFullNameAsync(projectDir);
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const fullName = await getProjectFullNameAsync(exp);
     const branches = await listBranchesAsync({ fullName });
     if (flags.json) {
       Log.log(JSON.stringify(branches, null, 2));

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -115,10 +115,9 @@ export default class BranchPublish extends Command {
       throw new Error('Please run this command inside a project directory.');
     }
 
-    const accountName = await getProjectAccountNameAsync(projectDir);
-    const {
-      exp: { slug, runtimeVersion },
-    } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const accountName = await getProjectAccountNameAsync(exp);
+    const { slug, runtimeVersion } = exp;
     if (!runtimeVersion) {
       throw new Error(
         "Couldn't find 'runtimeVersion'. Please specify it under the 'expo' key in 'app.json'"

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -115,10 +115,10 @@ export default class BranchView extends Command {
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');
     }
-    const accountName = await getProjectAccountNameAsync(projectDir);
-    const {
-      exp: { slug },
-    } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const accountName = await getProjectAccountNameAsync(exp);
+    const { slug } = exp;
     const projectId = await ensureProjectExistsAsync({
       accountName,
       projectName: slug,

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -1,3 +1,4 @@
+import { getConfig } from '@expo/config';
 import { Command } from '@oclif/command';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
@@ -115,8 +116,9 @@ export default class BuildCancel extends Command {
     const { BUILD_ID: buildIdFromArg } = this.parse(BuildCancel).args;
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
-    const projectId = await getProjectIdAsync(projectDir);
-    const projectFullName = await getProjectFullNameAsync(projectDir);
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await getProjectIdAsync(exp);
+    const projectFullName = await getProjectFullNameAsync(exp);
 
     if (buildIdFromArg) {
       await ensureBuildExistsAsync(buildIdFromArg);

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -1,3 +1,4 @@
+import { getConfig } from '@expo/config';
 import { Command, flags } from '@oclif/command';
 import chalk from 'chalk';
 import fs from 'fs-extra';
@@ -68,7 +69,8 @@ export default class Build extends Command {
       (flags.platform as RequestedPlatform | undefined) ?? (await promptForPlatformAsync());
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
-    const projectId = await getProjectIdAsync(projectDir);
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await getProjectIdAsync(exp);
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
       warnEasUnavailable();
@@ -76,7 +78,7 @@ export default class Build extends Command {
       return;
     }
 
-    const accountName = await getProjectAccountNameAsync(projectDir);
+    const accountName = await getProjectAccountNameAsync(exp);
     const accountHasPendingBuilds = await ensureNoPendingBuildsExistAsync({
       accountName,
       platform,
@@ -98,6 +100,7 @@ export default class Build extends Command {
     const commandCtx = await createCommandContextAsync({
       requestedPlatform: platform,
       profile: flags.profile,
+      exp,
       projectDir,
       projectId,
       trackingCtx,

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -1,3 +1,4 @@
+import { getConfig } from '@expo/config';
 import { Command, flags } from '@oclif/command';
 import chalk from 'chalk';
 import ora from 'ora';
@@ -26,9 +27,10 @@ export default class BuildList extends Command {
     const { platform, status, limit = 10 } = this.parse(BuildList).flags;
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
-    const projectId = await getProjectIdAsync(projectDir);
-    const accountName = await getProjectAccountNameAsync(projectDir);
-    const projectName = await getProjectFullNameAsync(projectDir);
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await getProjectIdAsync(exp);
+    const accountName = await getProjectAccountNameAsync(exp);
+    const projectName = await getProjectFullNameAsync(exp);
 
     const spinner = ora().start('Fetching the build list for the project…');
 

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -1,3 +1,4 @@
+import { getConfig } from '@expo/config';
 import { Command } from '@oclif/command';
 import { HTTPError } from 'got';
 import ora from 'ora';
@@ -22,9 +23,10 @@ export default class BuildView extends Command {
     const { BUILD_ID: buildId } = this.parse(BuildView).args;
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
-    const projectId = await getProjectIdAsync(projectDir);
-    const accountName = await getProjectAccountNameAsync(projectDir);
-    const projectName = await getProjectFullNameAsync(projectDir);
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await getProjectIdAsync(exp);
+    const accountName = await getProjectAccountNameAsync(exp);
+    const projectName = await getProjectFullNameAsync(exp);
 
     const spinner = ora().start('Fetching the build…');
 

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -86,10 +86,9 @@ export default class ChannelCreate extends Command {
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');
     }
-    const accountName = await getProjectAccountNameAsync(projectDir);
-    const {
-      exp: { slug },
-    } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const accountName = await getProjectAccountNameAsync(exp);
+    const { slug } = exp;
     const projectId = await ensureProjectExistsAsync({
       accountName,
       projectName: slug,

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -125,10 +125,9 @@ export default class ChannelEdit extends Command {
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');
     }
-    const accountName = await getProjectAccountNameAsync(projectDir);
-    const {
-      exp: { slug },
-    } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const accountName = await getProjectAccountNameAsync(exp);
+    const { slug } = exp;
     const projectId = await ensureProjectExistsAsync({
       accountName,
       projectName: slug,

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -81,10 +81,9 @@ export default class ChannelList extends Command {
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');
     }
-    const accountName = await getProjectAccountNameAsync(projectDir);
-    const {
-      exp: { slug },
-    } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const accountName = await getProjectAccountNameAsync(exp);
+    const { slug } = exp;
     const projectId = await ensureProjectExistsAsync({
       accountName,
       projectName: slug,

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -89,10 +89,9 @@ export default class ChannelView extends Command {
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');
     }
-    const accountName = await getProjectAccountNameAsync(projectDir);
-    const {
-      exp: { slug },
-    } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const accountName = await getProjectAccountNameAsync(exp);
+    const { slug } = exp;
     const projectId = await ensureProjectExistsAsync({
       accountName,
       projectName: slug,

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -1,3 +1,4 @@
+import { getConfig } from '@expo/config';
 import { Command, flags } from '@oclif/command';
 import assert from 'assert';
 import chalk from 'chalk';
@@ -21,7 +22,8 @@ export default class BuildList extends Command {
     let appleTeamIdentifier = this.parse(BuildList).flags['apple-team-id'];
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
-    const accountName = await getProjectAccountNameAsync(projectDir);
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const accountName = await getProjectAccountNameAsync(exp);
 
     let spinner: ora.Ora;
 

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -1,3 +1,4 @@
+import { getConfig } from '@expo/config';
 import { Command } from '@oclif/command';
 import ora from 'ora';
 
@@ -29,7 +30,8 @@ If you are not sure what is the UDID of the device you are looking for, run:
     }
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
-    const accountName = await getProjectAccountNameAsync(projectDir);
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const accountName = await getProjectAccountNameAsync(exp);
 
     const spinner = ora().start(`Fetching device details for ${UDID}…`);
 

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -1,3 +1,4 @@
+import { getConfig } from '@expo/config';
 import { Command, flags } from '@oclif/command';
 
 import { learnMore } from '../log';
@@ -168,7 +169,8 @@ export default class BuildSubmit extends Command {
     const platform = platformFromParams ?? (await promptForPlatformAsync());
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
-    const projectId = await getProjectIdAsync(projectDir);
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await getProjectIdAsync(exp);
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
       warnEasUnavailable();

--- a/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
@@ -11,7 +11,11 @@ export class UpdateCredentialsJson implements Action {
   constructor(private app: AppLookupParams) {}
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
-    const bundleIdentifer = await ensureAppIdentifierIsDefinedAsync(ctx.projectDir, Platform.IOS);
+    const bundleIdentifer = await ensureAppIdentifierIsDefinedAsync({
+      projectDir: ctx.projectDir,
+      platform: Platform.IOS,
+      exp: ctx.exp,
+    });
     Log.log('Updating iOS credentials in credentials.json');
     await updateIosCredentialsAsync(ctx, bundleIdentifer);
     Log.succeed(

--- a/packages/eas-cli/src/devices/context.ts
+++ b/packages/eas-cli/src/devices/context.ts
@@ -1,9 +1,12 @@
+import { ExpoConfig, getConfig } from '@expo/config';
+
 import AppStoreApi from '../credentials/ios/appstore/AppStoreApi';
 import { findProjectRootAsync } from '../project/projectUtils';
 import { Actor } from '../user/User';
 
 export interface DeviceManagerContext {
   appStore: AppStoreApi;
+  exp: ExpoConfig | null;
   projectDir: string | null;
   user: Actor;
 }
@@ -17,9 +20,16 @@ export async function createContext({
   cwd?: string;
   user: Actor;
 }): Promise<DeviceManagerContext> {
+  const projectDir = await findProjectRootAsync(cwd);
+  let exp: ExpoConfig | null = null;
+  if (projectDir) {
+    const config = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    exp = config.exp;
+  }
   return {
     appStore,
-    projectDir: await findProjectRootAsync(cwd),
+    projectDir,
+    exp,
     user,
   };
 }

--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -1,3 +1,4 @@
+import { ExpoConfig } from '@expo/config';
 import assert from 'assert';
 import chalk from 'chalk';
 
@@ -39,16 +40,16 @@ export default class DeviceManager {
   }
 
   private async resolveAccountAsync(): Promise<Account> {
-    const resolver = new AccountResolver(this.ctx.projectDir, this.ctx.user);
+    const resolver = new AccountResolver(this.ctx.exp, this.ctx.user);
     return await resolver.resolveAccountAsync();
   }
 }
 
 export class AccountResolver {
-  constructor(private projectDir: string | null, private user: Actor) {}
+  constructor(private exp: ExpoConfig | null, private user: Actor) {}
 
   public async resolveAccountAsync(): Promise<Account> {
-    if (this.projectDir) {
+    if (this.exp) {
       const account = await this.resolveProjectAccountAsync();
       if (account) {
         return account;
@@ -58,9 +59,9 @@ export class AccountResolver {
   }
 
   private async resolveProjectAccountAsync(): Promise<Account | undefined> {
-    assert(this.projectDir, 'project directory is not set ');
+    assert(this.exp, 'expo config is not set');
 
-    const projectAccountName = await getProjectAccountNameAsync(this.projectDir);
+    const projectAccountName = await getProjectAccountNameAsync(this.exp);
     const projectAccount = findAccountByName(this.user.accounts, projectAccountName);
     if (!projectAccount) {
       Log.warn(

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig, getConfig, getConfigFilePaths } from '@expo/config';
+import { ExpoConfig, getConfigFilePaths } from '@expo/config';
 import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
 import { Platform } from '@expo/eas-build-job';
 import fs from 'fs-extra';
@@ -26,8 +26,7 @@ export function getProjectAccountName(exp: ExpoConfig, user: Actor): string {
   }
 }
 
-export async function getProjectAccountNameAsync(projectDir: string): Promise<string> {
-  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+export async function getProjectAccountNameAsync(exp: ExpoConfig): Promise<string> {
   const user = await ensureLoggedInAsync();
   return getProjectAccountName(exp, user);
 }
@@ -37,8 +36,7 @@ export async function findProjectRootAsync(cwd?: string): Promise<string | null>
   return projectRootDir ?? null;
 }
 
-export async function getProjectIdAsync(projectDir: string): Promise<string> {
-  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+export async function getProjectIdAsync(exp: ExpoConfig): Promise<string> {
   return await ensureProjectExistsAsync({
     accountName: getProjectAccountName(exp, await ensureLoggedInAsync()),
     projectName: exp.slug,
@@ -46,10 +44,8 @@ export async function getProjectIdAsync(projectDir: string): Promise<string> {
   });
 }
 
-export async function getProjectFullNameAsync(projectDir: string): Promise<string> {
-  const accountName = await getProjectAccountNameAsync(projectDir);
-  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-
+export async function getProjectFullNameAsync(exp: ExpoConfig): Promise<string> {
+  const accountName = await getProjectAccountNameAsync(exp);
   return `@${accountName}/${exp.slug}`;
 }
 
@@ -65,11 +61,15 @@ export async function getAndroidApplicationIdAsync(projectDir: string): Promise<
   return matchResult?.[1] ?? null;
 }
 
-export async function getAppIdentifierAsync(
-  projectDir: string,
-  platform: Platform
-): Promise<string | null> {
-  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+export async function getAppIdentifierAsync({
+  projectDir,
+  platform,
+  exp,
+}: {
+  projectDir: string;
+  platform: Platform;
+  exp: ExpoConfig;
+}): Promise<string | null> {
   switch (platform) {
     case Platform.ANDROID: {
       const packageNameFromConfig = AndroidConfig.Package.getPackage(exp);
@@ -89,11 +89,16 @@ export async function getAppIdentifierAsync(
   }
 }
 
-export async function ensureAppIdentifierIsDefinedAsync(
-  projectDir: string,
-  platform: Platform
-): Promise<string> {
-  const appIdentifier = await getAppIdentifierAsync(projectDir, platform);
+export async function ensureAppIdentifierIsDefinedAsync({
+  projectDir,
+  platform,
+  exp,
+}: {
+  projectDir: string;
+  platform: Platform;
+  exp: ExpoConfig;
+}): Promise<string> {
+  const appIdentifier = await getAppIdentifierAsync({ projectDir, platform, exp });
   if (!appIdentifier) {
     const desc = getProjectConfigDescription(projectDir);
     const fieldStr = platform === Platform.ANDROID ? 'android.package' : 'ios.bundleIdentifier';

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -39,7 +39,8 @@ export async function ensureAppStoreConnectAppExistsAsync(
   const { bundleIdentifier, appName, language } = ctx.commandFlags;
 
   const resolvedBundleId =
-    bundleIdentifier ?? (await getAppIdentifierAsync(ctx.projectDir, Platform.IOS));
+    bundleIdentifier ??
+    (await getAppIdentifierAsync({ projectDir: ctx.projectDir, platform: Platform.IOS, exp }));
   if (!resolvedBundleId) {
     throw new Error(
       `Please define "expo.ios.bundleIdentifier" in your app config or provide it using --bundle-identifier param.


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

We call `getConfig` multiple times in functions from `projectUtils.ts`.

# How

I made those functions accept an object of ExpoConfig type.

# Test Plan

- `yarn build`
- `yarn test`
