### PR TITLE
[eas-cli] verify that "name" in app.sjon can be used as iOS target name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix `eas submit` local archive prompt for `.aab` files when submitting for iOS. ([#273](https://github.com/expo/eas-cli/pull/144) by [@barthap](https://github.com/barthap))
+- Verify whether "name" field in app.json contains any alphanumeric characters. ([#271](https://github.com/expo/eas-cli/pull/280) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -14,7 +14,7 @@ import { Platform } from '../types';
 import { ensureBundleIdentifierIsValidAsync } from './bundleIdentifer';
 import { validateAndSyncProjectConfigurationAsync } from './configure';
 import { ensureIosCredentialsAsync } from './credentials';
-import { prepareJobAsync } from './prepareJob';
+import { prepareJobAsync, sanitizedTargetName } from './prepareJob';
 
 export async function prepareIosBuildAsync(
   commandCtx: CommandContext,
@@ -45,6 +45,14 @@ export async function prepareIosBuildAsync(
       buildCtx.commandCtx.projectDir,
       iosBuildScheme
     );
+  } else {
+    if (!commandCtx.exp.name) {
+      throw new Error('"expo.name" is required in your app.json');
+    }
+    iosApplicationTarget = sanitizedTargetName(commandCtx.exp.name);
+    if (!iosApplicationTarget) {
+      throw new Error('"expo.name" needs to contain some alphanumeric characters');
+    }
   }
 
   await ensureBundleIdentifierIsValidAsync(commandCtx.projectDir, commandCtx.exp);

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -152,12 +152,11 @@ async function prepareManagedJobAsync(
   const projectRootDirectory =
     path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
   const accountName = await getProjectAccountNameAsync(ctx.commandCtx.exp);
-  const targetName = sanitizedName(ctx.commandCtx.exp.name);
   return {
     ...(await prepareJobCommonAsync(ctx, {
       archiveBucketKey: jobData.archiveBucketKey,
       credentials: jobData.credentials,
-      targetName,
+      targetName: jobData.projectConfiguration.iosApplicationTarget,
     })),
     type: Workflow.MANAGED,
     buildType: buildProfile.buildType,
@@ -169,7 +168,7 @@ async function prepareManagedJobAsync(
 
 // copy-pasted from expo-cli/packages/xdl/src/Exp.ts
 // it's used in eject
-function sanitizedName(name: string) {
+export function sanitizedTargetName(name: string) {
   return name
     .replace(/[\W_]+/g, '')
     .normalize('NFD')


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

If the name does not contain any alphanumeric characters sanitized version is empty string and can't be used as target name

# How

verify before and after sanitization whether `exp.name` is empty

# Test Plan

run build with invalid name
