### PR TITLE
[eas-cli] fix "irreversible" typo

### DIFF
--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -129,7 +129,7 @@ export default class BranchDelete extends Command {
       Log.addNewLineIfNone();
       Log.warn(
         `You are about to permamently delete branch: "${name}" and all of the updates published on it.` +
-          `\nThis action is irreversable.`
+          `\nThis action is irreversible.`
       );
       Log.newLine();
       const confirmed = await toggleConfirmAsync({ message: 'Are you sure you wish to proceed?' });

--- a/packages/eas-cli/src/commands/secrets/delete.ts
+++ b/packages/eas-cli/src/commands/secrets/delete.ts
@@ -45,7 +45,7 @@ Unsure where to find the secret's ID? Run ${'`eas secrets:list`'}
 
     Log.addNewLineIfNone();
     Log.warn(
-      `You are about to permamently delete secret with id: "${id}".\nThis action is irreversable.`
+      `You are about to permamently delete secret with id: "${id}".\nThis action is irreversible.`
     );
     Log.newLine();
     const confirmed = await toggleConfirmAsync({ message: 'Are you sure you wish to proceed?' });


### PR DESCRIPTION
# Why

"irreversable" is correctly spelled "irreversible"