### PR TITLE
[eas-json] Detect dependency cycle for build profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Fix `eas submit` local archive prompt for `.aab` files when submitting for iOS. ([#273](https://github.com/expo/eas-cli/pull/144) by [@barthap](https://github.com/barthap))
-- Verify whether "name" field in app.json contains any alphanumeric characters. ([#271](https://github.com/expo/eas-cli/pull/280) by [@wkozyra95](https://github.com/wkozyra95))
+- Fix `eas submit` local archive prompt for `.aab` files when submitting for iOS. ([#273](https://github.com/expo/eas-cli/pull/273) by [@barthap](https://github.com/barthap))
+- Verify whether "name" field in app.json contains any alphanumeric characters. ([#280](https://github.com/expo/eas-cli/pull/280) by [@wkozyra95](https://github.com/wkozyra95))
+- Detect dependency cycles in eas.json build profiles. ([#283](https://github.com/expo/eas-cli/pull/283) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores
 

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -150,15 +150,14 @@ export class EasJsonReader {
     if (!buildProfile) {
       throw new Error(`There is no profile named ${buildProfileName} for platform ${platform}`);
     }
-    const baseProfileName = buildProfile.extends;
-    delete buildProfile.extends;
+    const { extends: baseProfileName, ...overrideBuildProfile } = buildProfile;
     if (baseProfileName) {
       return deepMerge(
         this.resolveBuildProfile(platform, baseProfileName, buildProfiles, depth + 1),
-        buildProfile
+        overrideBuildProfile
       );
     } else {
-      return buildProfile;
+      return overrideBuildProfile;
     }
   }
 }

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -150,14 +150,14 @@ export class EasJsonReader {
     if (!buildProfile) {
       throw new Error(`There is no profile named ${buildProfileName} for platform ${platform}`);
     }
-    const { extends: baseProfileName, ...overrideBuildProfile } = buildProfile;
+    const { extends: baseProfileName, ...buildProfileRest } = buildProfile;
     if (baseProfileName) {
       return deepMerge(
         this.resolveBuildProfile(platform, baseProfileName, buildProfiles, depth + 1),
-        overrideBuildProfile
+        buildProfileRest
       );
     } else {
-      return overrideBuildProfile;
+      return buildProfileRest;
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Detecting deps cycle does not work

# How

`delete buildProfile.extends` was removing `extends` keyword on first read fo a profile and by doing that it also removed cycle

# Test Plan

```
“override”: {
  “workflow”: “generic”,
  “extends”: “override”,
```
`eas build`
