### PR TITLE
Add distribution/channel informations in build:view/list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-- `build:view` and `build:list` now showing **distribution** and **release channel** informations. ([#284](https://github.com/expo/eas-cli/pull/284) by [@vthibault](https://github.com/vthibault))
+- `build:view` and `build:list` now showing the distribution type (store / internal) and release channel. ([#284](https://github.com/expo/eas-cli/pull/284) by [@vthibault](https://github.com/vthibault))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+- `build:view` and `build:list` now showing **distribution** and **release channel** informations. ([#284](https://github.com/expo/eas-cli/pull/284) by [@vthibault](https://github.com/vthibault))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -36,6 +36,14 @@ export default function formatBuild(build: Build, { accountName }: Options) {
       },
     },
     {
+      label: 'Distribution',
+      value: build.metadata?.distribution || chalk.gray('unknown'),
+    },
+    {
+      label: 'Release Channel',
+      value: build.metadata?.releaseChannel || chalk.gray('unknown'),
+    },
+    {
       label: 'Logs',
       value: getBuildLogsUrl({ buildId: build.id, account: accountName }),
     },

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -37,11 +37,11 @@ export default function formatBuild(build: Build, { accountName }: Options) {
     },
     {
       label: 'Distribution',
-      value: build.metadata?.distribution || chalk.gray('unknown'),
+      value: build.metadata?.distribution ?? chalk.gray('unknown'),
     },
     {
       label: 'Release Channel',
-      value: build.metadata?.releaseChannel || chalk.gray('unknown'),
+      value: build.metadata?.releaseChannel ?? chalk.gray('unknown'),
     },
     {
       label: 'Logs',


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

I need to see distribution and release channels in `eas build:list` and `eas build:view` helping me to differentiate production build with staging build.
Helpful for some internal CI doing different things based of this flags.

# How

- Updated formatBuild.ts used by `build:list` and `build:view.` by using `build.metadata` informations.
- Fallback to "unknown" if metadata not specified.

![eas-build-info](https://user-images.githubusercontent.com/4102403/111998553-697bd380-8b1c-11eb-9ce9-5c6332029793.png)

