### PR TITLE
make build:view and build:list use GraphQL instead of REST endpoints 

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -313,6 +313,22 @@
             "deprecationReason": null
           },
           {
+            "name": "experimentation",
+            "description": "Top-level query object for querying Experimentation configuration.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ExperimentationQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "project",
             "description": "",
             "args": [],
@@ -2589,6 +2605,22 @@
             "deprecationReason": null
           },
           {
+            "name": "ownerAccount",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "privacy",
             "description": "",
             "args": [],
@@ -2782,7 +2814,7 @@
           },
           {
             "name": "builds",
-            "description": "",
+            "description": "(EAS Build) Builds associated with this app",
             "args": [
               {
                 "name": "offset",
@@ -2818,6 +2850,16 @@
                 "type": {
                   "kind": "ENUM",
                   "name": "BuildStatus",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "platform",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "AppPlatform",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -9681,6 +9723,65 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ExperimentationQuery",
+        "description": "",
+        "fields": [
+          {
+            "name": "userConfig",
+            "description": "Get user experimentation config",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceConfig",
+            "description": "Get device experimentation config",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceExperimentationUnit",
+            "description": "Get experimentation unit to use for device experiments. In this case, it is the IP address.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ProjectQuery",
         "description": "",
         "fields": [
@@ -10466,13 +10567,9 @@
                 "name": "buildId",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 },
                 "defaultValue": null
               }
@@ -11272,6 +11369,51 @@
               "kind": "OBJECT",
               "name": "Account",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rename",
+            "description": "Rename this account",
+            "args": [
+              {
+                "name": "accountID",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "newName",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -13322,9 +13464,24 @@
         "description": "",
         "fields": [
           {
-            "name": "cancel",
-            "description": "Cancel an EAS Build\"",
-            "args": [],
+            "name": "cancelBuild",
+            "description": "Cancel an EAS Build build",
+            "args": [
+              {
+                "name": "buildId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13336,6 +13493,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "cancel",
+            "description": "Cancel an EAS Build build",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Build",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use cancelBuild instead"
           }
         ],
         "inputFields": null,
@@ -16311,9 +16484,13 @@
                 "name": "environmentSecretData",
                 "description": null,
                 "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "CreateEnvironmentSecretInput",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreateEnvironmentSecretInput",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null
               },
@@ -16352,9 +16529,13 @@
                 "name": "environmentSecretData",
                 "description": null,
                 "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "CreateEnvironmentSecretInput",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreateEnvironmentSecretInput",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null
               },

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -8,7 +8,7 @@ import { promptAsync } from '../prompts';
 import { UploadType, uploadAsync } from '../uploads';
 import { formatBytes } from '../utils/files';
 import { createProgressTracker } from '../utils/progress';
-import { platformDisplayNames } from './constants';
+import { requestedPlatformDisplayNames } from './constants';
 import { BuildContext } from './context';
 import { collectMetadata } from './metadata';
 import { AnalyticsEvent, Platform, TrackingContext } from './types';
@@ -69,7 +69,9 @@ export async function prepareBuildRequestForPlatformAsync<
   if (!(await isGitStatusCleanAsync())) {
     Log.addNewLineIfNone();
     await reviewAndCommitChangesAsync(
-      `[EAS Build] Run EAS Build for ${platformDisplayNames[builder.ctx.platform as Platform]}`,
+      `[EAS Build] Run EAS Build for ${
+        requestedPlatformDisplayNames[builder.ctx.platform as Platform]
+      }`,
       {
         nonInteractive: builder.ctx.commandCtx.nonInteractive,
       }
@@ -92,7 +94,7 @@ export async function prepareBuildRequestForPlatformAsync<
       return await withAnalyticsAsync(
         async () => {
           if (Log.isDebug) {
-            Log.log(`Starting ${platformDisplayNames[job.platform]} build`);
+            Log.log(`Starting ${requestedPlatformDisplayNames[job.platform]} build`);
           }
           const {
             data: { buildId, deprecationInfo },

--- a/packages/eas-cli/src/build/constants.ts
+++ b/packages/eas-cli/src/build/constants.ts
@@ -1,9 +1,15 @@
+import { AppPlatform } from '../graphql/generated';
 import { Platform, RequestedPlatform } from './types';
 
-export const platformDisplayNames = {
+export const requestedPlatformDisplayNames: Record<RequestedPlatform, string> = {
   [RequestedPlatform.iOS]: 'iOS',
   [RequestedPlatform.Android]: 'Android',
   [RequestedPlatform.All]: 'Android and iOS',
+};
+
+export const appPlatformDisplayNames: Record<AppPlatform, string> = {
+  [AppPlatform.Android]: 'Android',
+  [AppPlatform.Ios]: 'iOS',
 };
 
 export const platformEmojis = {

--- a/packages/eas-cli/src/build/credentials.ts
+++ b/packages/eas-cli/src/build/credentials.ts
@@ -5,10 +5,10 @@ import chalk from 'chalk';
 import { CredentialsProvider } from '../credentials/CredentialsProvider';
 import Log from '../log';
 import { confirmAsync, promptAsync } from '../prompts';
-import { platformDisplayNames } from './constants';
+import { requestedPlatformDisplayNames } from './constants';
 
 function logCredentials(target: 'local' | 'remote', platform: Platform) {
-  let message = `Using ${target} ${platformDisplayNames[platform]} credentials`;
+  let message = `Using ${target} ${requestedPlatformDisplayNames[platform]} credentials`;
   if (target === 'local') message += ` ${chalk.dim('(credentials.json)')}`;
   if (target === 'remote') message += ` ${chalk.dim('(Expo server)')}`;
   Log.succeed(message);
@@ -19,7 +19,7 @@ async function ensureCredentialsAutoAsync(
   workflow: Workflow,
   nonInteractive: boolean
 ): Promise<CredentialsSource.LOCAL | CredentialsSource.REMOTE> {
-  const platform = platformDisplayNames[provider.platform];
+  const platform = requestedPlatformDisplayNames[provider.platform];
   switch (workflow) {
     case Workflow.MANAGED:
       if (await provider.hasLocalAsync()) {

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -3,7 +3,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 
 import Log, { learnMore } from '../../log';
-import { platformDisplayNames, platformEmojis } from '../constants';
+import { platformEmojis, requestedPlatformDisplayNames } from '../constants';
 import { Build } from '../types';
 import { getBuildLogsUrl } from './url';
 
@@ -29,7 +29,9 @@ export function printLogsUrls(
         buildId,
         account: accountName,
       });
-      Log.log(`${platformDisplayNames[platform]} build details: ${chalk.underline(logsUrl)}`);
+      Log.log(
+        `${requestedPlatformDisplayNames[platform]} build details: ${chalk.underline(logsUrl)}`
+      );
     });
   }
 }
@@ -50,9 +52,9 @@ function printBuildResult(accountName: string, build: Build): void {
   if (build.status === 'errored') {
     const userError = build.error;
     Log.error(
-      `${platformEmojis[build.platform]} ${platformDisplayNames[build.platform]} build failed${
-        userError ? ':' : ''
-      }`
+      `${platformEmojis[build.platform]} ${
+        requestedPlatformDisplayNames[build.platform]
+      } build failed${userError ? ':' : ''}`
     );
     if (userError) {
       printUserError(userError);
@@ -61,7 +63,9 @@ function printBuildResult(accountName: string, build: Build): void {
   }
   if (build.status === 'canceled') {
     Log.error(
-      `${platformEmojis[build.platform]} ${platformDisplayNames[build.platform]} build was canceled`
+      `${platformEmojis[build.platform]} ${
+        requestedPlatformDisplayNames[build.platform]
+      } build was canceled`
     );
     return;
   }
@@ -73,7 +77,7 @@ function printBuildResult(accountName: string, build: Build): void {
     });
     Log.log(
       `${platformEmojis[build.platform]} Open this link on your ${
-        platformDisplayNames[build.platform]
+        requestedPlatformDisplayNames[build.platform]
       } devices to install the app:`
     );
     Log.log(`${chalk.underline(logsUrl)}`);
@@ -81,7 +85,9 @@ function printBuildResult(accountName: string, build: Build): void {
     // TODO: it looks like buildUrl could possibly be undefined, based on the code below.
     // we should account for this case better if it is possible
     const url = build.artifacts?.buildUrl ?? '';
-    Log.log(`${platformEmojis[build.platform]} ${platformDisplayNames[build.platform]} app:`);
+    Log.log(
+      `${platformEmojis[build.platform]} ${requestedPlatformDisplayNames[build.platform]} app:`
+    );
     Log.log(`${chalk.underline(url)}`);
   }
 }

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -11,7 +11,7 @@ import { createCommandContextAsync } from '../../build/context';
 import { buildAsync } from '../../build/create';
 import { AnalyticsEvent, Build as BuildType, RequestedPlatform } from '../../build/types';
 import Analytics from '../../build/utils/analytics';
-import formatBuild from '../../build/utils/formatBuild';
+import { formatBuild } from '../../build/utils/formatBuild';
 import { isGitStatusCleanAsync } from '../../build/utils/repository';
 import { AppPlatform } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -1,15 +1,13 @@
 import { getConfig } from '@expo/config';
 import { Command } from '@oclif/command';
-import { HTTPError } from 'got';
 import ora from 'ora';
 
-import { apiClient } from '../../api';
-import { Build } from '../../build/types';
-import formatBuild from '../../build/utils/formatBuild';
+import { formatGraphQLBuild } from '../../build/utils/formatBuild';
+import { BuildFragment } from '../../graphql/generated';
+import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
 import {
   findProjectRootAsync,
-  getProjectAccountNameAsync,
   getProjectFullNameAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
@@ -25,33 +23,22 @@ export default class BuildView extends Command {
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
-    const accountName = await getProjectAccountNameAsync(exp);
     const projectName = await getProjectFullNameAsync(exp);
 
     const spinner = ora().start('Fetching the build…');
 
     try {
-      let build: Build;
+      let build: BuildFragment;
 
-      if (buildId == null) {
-        const response = await apiClient.get<{ data: { builds: Build[] } }>(
-          `projects/${projectId}/builds`,
-          {
-            searchParams: { limit: 1 },
-            responseType: 'json',
-          }
-        );
-
-        build = response.body.data.builds[0];
+      if (buildId) {
+        build = await BuildQuery.byIdAsync(buildId);
       } else {
-        const response = await apiClient.get<{ data: Build }>(
-          `projects/${projectId}/builds/${buildId}`,
-          {
-            responseType: 'json',
-          }
-        );
-
-        build = response.body.data;
+        const builds = await BuildQuery.allForAppAsync(projectId, { limit: 1 });
+        if (builds.length === 0) {
+          spinner.fail(`Couldn't find any builds for the project ${projectName}`);
+          return;
+        }
+        build = builds[0];
       }
 
       if (buildId) {
@@ -60,29 +47,17 @@ export default class BuildView extends Command {
         spinner.succeed(`Showing the last build for the project ${projectName}`);
       }
 
-      Log.log(`\n${formatBuild(build, { accountName })}`);
-    } catch (e) {
-      const error = e as HTTPError;
-
-      if (error.response.statusCode === 400) {
-        if (buildId) {
-          spinner.fail(
-            `Couldn't find a build for the project ${projectName} matching the id ${buildId}`
-          );
-        } else {
-          spinner.fail(`Couldn't find any builds for the project ${projectName}`);
-        }
+      Log.log(`\n${formatGraphQLBuild(build)}`);
+    } catch (err) {
+      if (buildId) {
+        spinner.fail(`Something went wrong and we couldn't fetch the build with id ${buildId}`);
       } else {
-        if (buildId) {
-          spinner.fail(`Something went wrong and we couldn't fetch the build with id ${buildId}`);
-        } else {
-          spinner.fail(
-            `Something went wrong and we couldn't fetch the last build for the project ${projectName}`
-          );
-        }
+        spinner.fail(
+          `Something went wrong and we couldn't fetch the last build for the project ${projectName}`
+        );
       }
 
-      throw error;
+      throw err;
     }
   }
 }

--- a/packages/eas-cli/src/graphql/types/Build.ts
+++ b/packages/eas-cli/src/graphql/types/Build.ts
@@ -1,0 +1,39 @@
+import gql from 'graphql-tag';
+
+export const BuildFragmentNode = gql`
+  fragment BuildFragment on Build {
+    id
+    status
+    platform
+    error {
+      errorCode
+      message
+    }
+    artifacts {
+      buildUrl
+      xcodeBuildLogsUrl
+    }
+    initiatingActor {
+      __typename
+      id
+      ... on User {
+        username
+      }
+      ... on Robot {
+        firstName
+      }
+    }
+    project {
+      __typename
+      id
+      ... on App {
+        ownerAccount {
+          id
+          name
+        }
+      }
+    }
+    createdAt
+    updatedAt
+  }
+`;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

We want to stop using REST endpoints in EAS CLI. This PR is the first part of the effort.
It makes `eas build:list` and `eas build:view` use GraphQL instead.

# How

This was rather straightforward. I temporarily introduced a new function for formatting builds - `formatGraphQLBuild` - it will later replace the `formatBuild` function when we make build creation work via GraphQL.

# Test Plan

I ran `eas build:list` and `eas build:view` for a project with existing builds and for a one without any builds.
