### PR TITLE
use graphql to create unpublished app

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -2633,6 +2633,22 @@
                 "ofType": null
               }
             },
+            "isDeprecated": true,
+            "deprecationReason": "Use 'privacySetting' instead."
+          },
+          {
+            "name": "privacySetting",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPrivacy",
+                "ofType": null
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -3475,6 +3491,35 @@
         "inputFields": null,
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppPrivacy",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "PUBLIC",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNLISTED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HIDDEN",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -10497,13 +10542,9 @@
                 "name": "appId",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 },
                 "defaultValue": null
               }
@@ -13255,6 +13296,37 @@
         "description": "",
         "fields": [
           {
+            "name": "createApp",
+            "description": "Create an unpublished app",
+            "args": [
+              {
+                "name": "appInput",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "grantAccess",
             "description": "",
             "args": [
@@ -13335,6 +13407,59 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "accountId",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectName",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "privacy",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPrivacy",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -103,7 +103,7 @@ export default class BranchDelete extends Command {
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');
     }
-    const { exp } = await getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
     const projectId = await ensureProjectExistsAsync({
       accountName,

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -75,8 +75,9 @@ export default class BranchRename extends Command {
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');
     }
-    const { exp } = await getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
+
     const projectId = await ensureProjectExistsAsync({
       accountName,
       projectName: exp.slug,

--- a/packages/eas-cli/src/commands/secrets/create.ts
+++ b/packages/eas-cli/src/commands/secrets/create.ts
@@ -42,7 +42,7 @@ export default class EnvironmentSecretCreate extends Command {
   ];
 
   async run() {
-    const user = await ensureLoggedInAsync();
+    const actor = await ensureLoggedInAsync();
     let {
       args: { name, value: secretValue, target },
     } = this.parse(EnvironmentSecretCreate);
@@ -125,10 +125,10 @@ export default class EnvironmentSecretCreate extends Command {
         )}.`
       );
     } else if (target === EnvironmentSecretTargetLocation.ACCOUNT) {
-      const ownerAccount = findAccountByName(user.accounts, accountName);
+      const ownerAccount = findAccountByName(actor.accounts, accountName);
       if (!ownerAccount) {
         Log.warn(
-          `Your account (${getActorDisplayName(user)}) doesn't have access to the ${chalk.bold(
+          `Your account (${getActorDisplayName(actor)}) doesn't have access to the ${chalk.bold(
             accountName
           )} account`
         );

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -409,7 +409,9 @@ export type App = Project & {
   updated: Scalars['DateTime'];
   pushSecurityEnabled?: Maybe<Scalars['Boolean']>;
   ownerAccount: Account;
+  /** @deprecated Use 'privacySetting' instead. */
   privacy: Scalars['String'];
+  privacySetting: AppPrivacy;
   latestReleaseId: Scalars['ID'];
   /** @deprecated 'likes' have been deprecated. */
   isLikedByMe: Scalars['Boolean'];
@@ -550,6 +552,12 @@ export type AppIcon = {
   colorPalette?: Maybe<Scalars['JSON']>;
 };
 
+
+export enum AppPrivacy {
+  Public = 'PUBLIC',
+  Unlisted = 'UNLISTED',
+  Hidden = 'HIDDEN'
+}
 
 /** Represents a human (not robot) actor. */
 export type User = Actor & {
@@ -1547,7 +1555,7 @@ export type RootMutationAccountArgs = {
 
 
 export type RootMutationAppArgs = {
-  appId: Scalars['ID'];
+  appId?: Maybe<Scalars['ID']>;
 };
 
 
@@ -2036,10 +2044,17 @@ export type AppleTeamInput = {
 
 export type AppMutation = {
   __typename?: 'AppMutation';
+  /** Create an unpublished app */
+  createApp: App;
   /** @deprecated Field no longer supported */
   grantAccess?: Maybe<App>;
   /** Require api token to send push notifs for experience */
   setPushSecurityEnabled?: Maybe<App>;
+};
+
+
+export type AppMutationCreateAppArgs = {
+  appInput: AppInput;
 };
 
 
@@ -2052,6 +2067,12 @@ export type AppMutationGrantAccessArgs = {
 export type AppMutationSetPushSecurityEnabledArgs = {
   appId: Scalars['ID'];
   pushSecurityEnabled: Scalars['Boolean'];
+};
+
+export type AppInput = {
+  accountId: Scalars['ID'];
+  projectName: Scalars['String'];
+  privacy: AppPrivacy;
 };
 
 export type AssetMutation = {
@@ -3636,6 +3657,22 @@ export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = 
         & Pick<IosAppCredentials, 'id'>
         & CommonIosAppCredentialsFragment
       )> }
+    ) }
+  )> }
+);
+
+export type CreateAppMutationVariables = Exact<{
+  appInput: AppInput;
+}>;
+
+
+export type CreateAppMutation = (
+  { __typename?: 'RootMutation' }
+  & { app?: Maybe<(
+    { __typename?: 'AppMutation' }
+    & { createApp: (
+      { __typename?: 'App' }
+      & Pick<App, 'id'>
     ) }
   )> }
 );

--- a/packages/eas-cli/src/graphql/mutations/AppMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/AppMutation.ts
@@ -1,0 +1,37 @@
+import assert from 'assert';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { AppPrivacy, CreateAppMutation, CreateAppMutationVariables } from '../generated';
+
+const AppMutation = {
+  async createAppAsync(appInput: {
+    accountId: string;
+    projectName: string;
+    privacy: AppPrivacy;
+  }): Promise<string> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateAppMutation, CreateAppMutationVariables>(
+          gql`
+            mutation CreateAppMutation($appInput: AppInput!) {
+              app {
+                createApp(appInput: $appInput) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            appInput,
+          }
+        )
+        .toPromise()
+    );
+    const appId = data.app?.createApp.id;
+    assert(appId, 'App ID must be defined');
+    return appId;
+  },
+};
+
+export { AppMutation };

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import pkgDir from 'pkg-dir';
 
 import { graphqlClient, withErrorHandlingAsync } from '../graphql/client';
-import { UpdateBranch } from '../graphql/generated';
+import { AppPrivacy, UpdateBranch } from '../graphql/generated';
 import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import { ensureProjectExistsAsync } from './ensureProjectExists';
@@ -37,12 +37,23 @@ export async function findProjectRootAsync(cwd?: string): Promise<string | null>
 }
 
 export async function getProjectIdAsync(exp: ExpoConfig): Promise<string> {
+  const privacy = toAppPrivacy(exp.privacy);
   return await ensureProjectExistsAsync({
     accountName: getProjectAccountName(exp, await ensureLoggedInAsync()),
     projectName: exp.slug,
-    privacy: exp.privacy,
+    privacy,
   });
 }
+
+const toAppPrivacy = (privacy: ExpoConfig['privacy']) => {
+  if (privacy === 'public') {
+    return AppPrivacy.Public;
+  } else if (privacy === 'hidden') {
+    return AppPrivacy.Hidden;
+  } else {
+    return AppPrivacy.Unlisted;
+  }
+};
 
 export async function getProjectFullNameAsync(exp: ExpoConfig): Promise<string> {
   const accountName = await getProjectAccountNameAsync(exp);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Another part of the refactor to stop using REST endpoints in EAS CLI.
This PR makes EAS CLI use GraphQL to create the app record if it does not exist yet.

# How

I used the mutation added in https://github.com/expo/universe/pull/7218

# Test Plan

- `expo init newproject`
- `eas build:configure`
- `eas build` was able to create the app record in the db 🎉 