### PR TITLE
[eas-cli] add command `eas channel:rollout`

### DIFF
--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -147,7 +147,11 @@ export default class ChannelEdit extends Command {
     }
 
     const existingChannel = await getChannelByNameForAppAsync({ appId: projectId, channelName });
-    // todo: refactor when multiple branches per channel are available
+    if (existingChannel.updateBranches.length > 1) {
+      throw new Error(
+        'There is a rollout in progress. Please manage it with "channel:rollout" instead.'
+      );
+    }
     const existingBranch = existingChannel.updateBranches[0];
 
     Log.addNewLineIfNone();
@@ -170,7 +174,6 @@ export default class ChannelEdit extends Command {
     }
 
     const branch = await getBranchByNameAsync({ appId: projectId, name: branchName! });
-
     const channel = await updateChannelBranchMappingAsync({
       channelId: existingChannel.id,
       // todo: move branch mapping logic to utility

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -60,7 +60,7 @@ async function getChannelByNameForAppAsync({
   return updateChannelByNameResult;
 }
 
-async function updateChannelBranchMappingAsync({
+export async function updateChannelBranchMappingAsync({
   channelId,
   branchMapping,
 }: UpdateChannelBranchMappingMutationVariables): Promise<{

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -266,7 +266,7 @@ export default class ChannelRollout extends Command {
               break;
             default:
               throw new Error(
-                `The branch "${branchName}"specified by --branch must be one of the branches involved in the rollout: "${newBranch.name}" or "${oldBranch.name}".`
+                `The branch "${branchName}" specified by --branch must be one of the branches involved in the rollout: "${newBranch.name}" or "${oldBranch.name}".`
               );
           }
         } else {

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -1,0 +1,185 @@
+import { getConfig } from '@expo/config';
+import { Command, flags } from '@oclif/command';
+import chalk from 'chalk';
+
+import Log from '../../log';
+import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
+import {
+  findProjectRootAsync,
+  getBranchByNameAsync,
+  getProjectAccountNameAsync,
+} from '../../project/projectUtils';
+import { promptAsync } from '../../prompts';
+import { updateChannelBranchMappingAsync } from './edit';
+import { getBranchMapping, getUpdateChannelByNameForAppAsync } from './view';
+
+export default class ChannelRollout extends Command {
+  static hidden = true;
+  static description = 'Rollout a new branch out to a channel incrementally.';
+
+  static args = [
+    {
+      name: 'action',
+      required: true,
+      description: 'rollout action',
+      options: ['start', 'edit', 'end'],
+    },
+  ];
+
+  static flags = {
+    channel: flags.string({
+      description: 'channel on which to rollout',
+    }),
+    branch: flags.string({
+      description: 'branch to rollout',
+      required: false,
+    }),
+    percent: flags.integer({
+      description: 'percent of traffic to redirect to the new branch',
+      required: false,
+    }),
+    json: flags.boolean({
+      description:
+        'print output as a JSON object with the new channel ID, name and branch mapping.',
+      default: false,
+    }),
+  };
+
+  async run() {
+    const {
+      args: { action },
+      flags: { json: jsonFlag },
+    } = this.parse(ChannelRollout);
+    let {
+      flags: { channel: channelName, branch: branchName, percent },
+    } = this.parse(ChannelRollout);
+
+    if (!channelName) {
+      const validationMessage = 'The rollout channel must be specified.';
+      if (jsonFlag) {
+        throw new Error(validationMessage);
+      }
+      ({ name: channelName } = await promptAsync({
+        type: 'text',
+        name: 'name',
+        message: 'Please name the channel:',
+        validate: value => (value ? true : validationMessage),
+      }));
+    }
+
+    const projectDir = await findProjectRootAsync(process.cwd());
+    if (!projectDir) {
+      throw new Error('Please run this command inside a project directory.');
+    }
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const accountName = await getProjectAccountNameAsync(exp);
+    const { slug } = exp;
+    const projectId = await ensureProjectExistsAsync({
+      accountName,
+      projectName: slug,
+    });
+
+    const getUpdateChannelByNameForAppResult = await getUpdateChannelByNameForAppAsync({
+      appId: projectId,
+      channelName: channelName!,
+    });
+    const { branchMapping: currentBranchMapping, isRollout } = getBranchMapping(
+      getUpdateChannelByNameForAppResult
+    );
+
+    if (currentBranchMapping.data.length === 0) {
+      throw new Error('The channel is not pointing at any branches.');
+    }
+    if (currentBranchMapping.data.length > 2) {
+      throw new Error('This CLI cannot handle branch mappings with more than 2 branches.');
+    }
+
+    let newChannelInfo, logMessage;
+    switch (action) {
+      case 'start': {
+        if (isRollout) {
+          throw new Error('There is already a rollout in progress.');
+        }
+        if (!branchName) {
+          const validationMessage = 'A branch must be specified.';
+          if (jsonFlag) {
+            throw new Error(validationMessage);
+          }
+          ({ name: branchName } = await promptAsync({
+            type: 'text',
+            name: 'name',
+            message: `Select a branch to rollout onto ${channelName}`,
+            validate: value => (value ? true : validationMessage),
+          }));
+        }
+        const branch = await getBranchByNameAsync({ appId: projectId, name: branchName! });
+
+        if (percent === undefined) {
+          const validationMessage =
+            'The rollout percentage must be an integer between 0 and 99 inclusive.';
+          if (jsonFlag) {
+            throw new Error(validationMessage);
+          }
+          ({ name: percent } = await promptAsync({
+            type: 'text',
+            name: 'name',
+            format: value => {
+              return parseInt(value, 10);
+            },
+            message: `What percent of users should be directed to the new branch ${branchName}?`,
+            initial: 0,
+            validate: value => {
+              const floatValue = parseFloat(value);
+              return Number.isInteger(floatValue) && floatValue >= 0 && floatValue <= 99
+                ? true
+                : validationMessage;
+            },
+          }));
+        }
+
+        const newBranchMapping = {
+          version: 0,
+          data: [
+            {
+              branchId: branch.id,
+              branchMappingLogic: {
+                operand: percent! / 100,
+                clientKey: 'rolloutToken',
+                branchMappingOperator: 'hash_lt',
+              },
+            },
+            currentBranchMapping.data[0],
+          ],
+        };
+        newChannelInfo = await updateChannelBranchMappingAsync({
+          channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.id!,
+          branchMapping: JSON.stringify(newBranchMapping),
+        });
+
+        logMessage = `️Started a rollout of branch ${chalk.bold(
+          branchName
+        )} onto channel ${chalk.bold(channelName!)}! ${chalk.bold(
+          percent
+        )}% of users will be directed to ${chalk.bold(branchName)}, ${chalk.bold(
+          100 - percent!
+        )}% to ${chalk.bold(
+          getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.name
+        )}.`;
+        break;
+      }
+      case 'edit':
+        throw new Error('Not implemented yet.');
+      case 'end':
+        throw new Error('Not implemented yet.');
+      default:
+        throw new Error(`${action} is not a supported action.`);
+    }
+
+    if (jsonFlag) {
+      Log.log(JSON.stringify(newChannelInfo));
+      return;
+    }
+
+    Log.withTick(logMessage);
+  }
+}

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -182,7 +182,7 @@ export default class ChannelRollout extends Command {
           {
             branchId: branch.id,
             branchMappingLogic: {
-              operand: percent! / 100,
+              operand: percent / 100,
               clientKey: 'rolloutToken',
               branchMappingOperator: 'hash_lt',
             },
@@ -209,7 +209,7 @@ export default class ChannelRollout extends Command {
       )} onto channel ${chalk.bold(channelName!)}! ${chalk.bold(
         percent
       )}% of users will be directed to branch ${chalk.bold(branchName)}, ${chalk.bold(
-        100 - percent!
+        100 - percent
       )}% to branch ${chalk.bold(oldBranch.name)}.`;
     } else {
       // edit active rollout
@@ -245,7 +245,7 @@ export default class ChannelRollout extends Command {
         )} updated from ${chalk.bold(currentPercent)}% to ${chalk.bold(percent)}%. ${chalk.bold(
           percent
         )}% of users will be directed to branch ${chalk.bold(newBranch.name)}, ${chalk.bold(
-          100 - percent!
+          100 - percent
         )}% to branch ${chalk.bold(oldBranch.name)}.`;
       } else {
         // end rollout

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -163,7 +163,7 @@ export default class ChannelRollout extends Command {
       const oldBranchId = currentBranchMapping.data[0].branchId;
       if (branch.id === oldBranchId) {
         throw new Error(
-          `${channelName} is already pointing at ${branchName}. Rollouts must be done with distinct branches.`
+          `channel "${channelName}" is already pointing at branch "${branchName}". Rollouts must be done with distinct branches.`
         );
       }
 
@@ -173,7 +173,7 @@ export default class ChannelRollout extends Command {
             'You must specify a percent with the --percent flag when initiating a rollout with the --json flag.'
           );
         }
-        const promptMessage = `What percent of users should be directed to the branch ${branchName}?`;
+        const promptMessage = `What percent of users should be directed to the branch "${branchName}"?`;
         percent = await promptForRolloutPercentAsync({ promptMessage });
       }
 
@@ -209,9 +209,9 @@ export default class ChannelRollout extends Command {
         branchName
       )} onto channel ${chalk.bold(channelName!)}! ${chalk.bold(
         percent
-      )}% of users will be directed to ${chalk.bold(branchName)}, ${chalk.bold(
+      )}% of users will be directed to branch ${chalk.bold(branchName)}, ${chalk.bold(
         100 - percent!
-      )}% to ${chalk.bold(oldBranch.name)}.`;
+      )}% to branch ${chalk.bold(oldBranch.name)}.`;
     } else {
       // edit active rollout
       if (!endFlag) {
@@ -245,9 +245,9 @@ export default class ChannelRollout extends Command {
           channelName!
         )} updated from ${chalk.bold(currentPercent)}% to ${chalk.bold(percent)}%. ${chalk.bold(
           percent
-        )}% of users will be directed to ${chalk.bold(newBranch.name)}, ${chalk.bold(
+        )}% of users will be directed to branch ${chalk.bold(newBranch.name)}, ${chalk.bold(
           100 - percent!
-        )}% to ${chalk.bold(oldBranch.name)}.`;
+        )}% to branch ${chalk.bold(oldBranch.name)}.`;
       } else {
         // end rollout
         const { newBranch, oldBranch, currentPercent } = getRolloutInfo(
@@ -311,7 +311,7 @@ export default class ChannelRollout extends Command {
         });
         logMessage = `️Rollout on channel ${chalk.bold(
           channelName
-        )} ended. All traffic is now sent to ${chalk.bold(
+        )} ended. All traffic is now sent to branch ${chalk.bold(
           endOnNewBranch ? newBranch.name : oldBranch.name
         )}`;
       }

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -166,7 +166,7 @@ export default class ChannelRollout extends Command {
         );
       }
 
-      if (percent === undefined) {
+      if (percent == null) {
         if (jsonFlag) {
           throw new Error(
             'You must specify a percent with the --percent flag when initiating a rollout with the --json flag.'
@@ -218,7 +218,7 @@ export default class ChannelRollout extends Command {
           getUpdateChannelByNameForAppResult
         );
 
-        if (percent === undefined) {
+        if (percent == null) {
           if (jsonFlag) {
             throw new Error(
               'A rollout is already in progress. If you wish to modify it you must use specify the new rollout percentage with the --percent flag.'
@@ -290,7 +290,7 @@ export default class ChannelRollout extends Command {
             ]
           );
         }
-        if (endOnNewBranch === undefined) {
+        if (endOnNewBranch == null) {
           throw new Error('Branch to end on is undefined.');
         }
 

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -160,6 +160,12 @@ export default class ChannelRollout extends Command {
         }));
       }
       const branch = await getBranchByNameAsync({ appId: projectId, name: branchName! });
+      const oldBranchId = currentBranchMapping.data[0].branchId;
+      if (branch.id === oldBranchId) {
+        throw new Error(
+          `${channelName} is already pointing at ${branchName}. Rollouts must be done with distinct branches.`
+        );
+      }
 
       if (percent === undefined) {
         if (jsonFlag) {
@@ -190,7 +196,6 @@ export default class ChannelRollout extends Command {
         branchMapping: JSON.stringify(newBranchMapping),
       });
 
-      const oldBranchId = currentBranchMapping.data[0].branchId;
       const oldBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
         branch => branch.id === oldBranchId
       )[0];
@@ -206,7 +211,7 @@ export default class ChannelRollout extends Command {
         percent
       )}% of users will be directed to ${chalk.bold(branchName)}, ${chalk.bold(
         100 - percent!
-      )}% to ${oldBranch.name}.`;
+      )}% to ${chalk.bold(oldBranch.name)}.`;
     } else {
       // edit active rollout
       if (!endFlag) {
@@ -242,7 +247,7 @@ export default class ChannelRollout extends Command {
           percent
         )}% of users will be directed to ${chalk.bold(newBranch.name)}, ${chalk.bold(
           100 - percent!
-        )}% to ${oldBranch.name}.`;
+        )}% to ${chalk.bold(oldBranch.name)}.`;
       } else {
         // end rollout
         const { newBranch, oldBranch, currentPercent } = getRolloutInfo(

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -13,14 +13,14 @@ import { promptAsync, selectAsync } from '../../prompts';
 import { updateChannelBranchMappingAsync } from './edit';
 import { getBranchMapping, getUpdateChannelByNameForAppAsync } from './view';
 
-async function getPercentAsync({
+async function getRolloutPercentAsync({
   validationMessage,
   promptMessage,
 }: {
   validationMessage: string;
   promptMessage: string;
 }): Promise<number> {
-  const { name: percent } = await promptAsync({
+  const { name: rolloutPercent } = await promptAsync({
     type: 'text',
     name: 'name',
     format: value => {
@@ -28,7 +28,7 @@ async function getPercentAsync({
     },
     message: promptMessage,
     initial: 0,
-    validate: (percent: string): true | string => {
+    validate: (rolloutPercent: string): true | string => {
       /**
        * Don't allow 100 to emphasise to the developer that rollouts have an open right hand endpoint: [0,N)
        *
@@ -36,13 +36,13 @@ async function getPercentAsync({
        * comparison would result in (0,100]. Assuming the new branch is more dangerous, we choose [0,N) to allow
        * '0 percent' rollouts.
        */
-      const floatValue = parseFloat(percent);
+      const floatValue = parseFloat(rolloutPercent);
       return Number.isInteger(floatValue) && floatValue >= 0 && floatValue <= 99
         ? true
         : validationMessage;
     },
   });
-  return percent;
+  return rolloutPercent;
 }
 
 export default class ChannelRollout extends Command {
@@ -110,19 +110,25 @@ export default class ChannelRollout extends Command {
       throw new Error('The channel is not pointing at any branches.');
     }
     if (currentBranchMapping.data.length > 2) {
-      throw new Error('This CLI cannot handle branch mappings with more than 2 branches.');
+      throw new Error('"channel:rollout" cannot handle branch mappings with more than 2 branches.');
     }
 
+    // This combination doesn't make sense. Throw an error explaining the options.
     if (isRollout && branchName && !endFlag) {
       throw new Error(
         `There is a rollout in progress. You can only either edit the rollout percent or 'end' it.`
       );
     }
 
+    /**
+     * This if/else block has three branches:
+     *  1. The branch mapping is not a rollout, i.e. it is pointing to a single branch.
+     *  2. The branch mapping is a rollout.
+     *    a. increase/decrease the rollout percentage.
+     *    b. end the rollout.
+     */
     let newChannelInfo, logMessage;
     if (!isRollout) {
-      // start a rollout
-      // this will likely be removed as more commands fill out
       if (!branchName) {
         const validationMessage = 'A branch must be specified.';
         if (jsonFlag) {
@@ -144,7 +150,7 @@ export default class ChannelRollout extends Command {
         if (jsonFlag) {
           throw new Error(validationMessage);
         }
-        percent = await getPercentAsync({ promptMessage, validationMessage });
+        percent = await getRolloutPercentAsync({ promptMessage, validationMessage });
       }
 
       const newBranchMapping = {
@@ -183,106 +189,109 @@ export default class ChannelRollout extends Command {
       )}% of users will be directed to ${chalk.bold(branchName)}, ${chalk.bold(
         100 - percent!
       )}% to ${oldBranch.name}.`;
-    } else if (!endFlag) {
-      if (jsonFlag && !percent) {
-        throw new Error(
-          'A rollout is already in progress. You can either end it with the --end flag or modify it with the --percent flag.'
-        );
-      }
-      const currentPercent = 100 * currentBranchMapping.data[0].branchMappingLogic.operand;
-      const [newBranchId, oldBranchId] = currentBranchMapping.data.map(d => d.branchId);
-      const newBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
-        branch => branch.id === newBranchId
-      )[0];
-      const oldBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
-        branch => branch.id === oldBranchId
-      )[0];
-      if (!newBranch || !oldBranch) {
-        throw new Error(
-          `Branch mapping rollout is missing a branch for channel "${channelName}" on app "@${accountName}/${slug}"`
-        );
-      }
-
-      if (percent === undefined) {
-        const promptMessage = `Currently ${currentPercent}% of all users are routed to branch ${
-          newBranch.name
-        } and ${100 - currentPercent}% of all users are routed to branch ${
-          oldBranch.name
-        }. What percent of users should be directed to the branch ${newBranch.name}?`;
-        const validationMessage =
-          'The rollout percentage must be an integer between 0 and 99 inclusive.';
-        if (jsonFlag) {
-          throw new Error(validationMessage);
-        }
-        percent = await getPercentAsync({ promptMessage, validationMessage });
-      }
-
-      const newBranchMapping = { ...currentBranchMapping };
-      newBranchMapping.data[0].branchMappingLogic.operand = percent / 100;
-
-      newChannelInfo = await updateChannelBranchMappingAsync({
-        channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.id!,
-        branchMapping: JSON.stringify(newBranchMapping),
-      });
-
-      logMessage = `️Rollout of branch ${chalk.bold(newBranch.name)} onto channel ${chalk.bold(
-        channelName!
-      )} updated from ${chalk.bold(currentPercent)}% to ${chalk.bold(percent)}%. ${chalk.bold(
-        percent
-      )}% of users will be directed to ${chalk.bold(newBranch.name)}, ${chalk.bold(
-        100 - percent!
-      )}% to ${oldBranch.name}.`;
-    } else if (endFlag) {
-      // end the rollout to the branch that is specified. check it is at 100% and throw if not interactive
-      const currentPercent = 100 * currentBranchMapping.data[0].branchMappingLogic.operand;
-      const [newBranchId, oldBranchId] = currentBranchMapping.data.map(d => d.branchId);
-      const newBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
-        branch => branch.id === newBranchId
-      )[0];
-      const oldBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
-        branch => branch.id === oldBranchId
-      )[0];
-      if (!newBranch || !oldBranch) {
-        throw new Error(
-          `Branch mapping rollout is missing a branch for channel "${channelName}" on app "@${accountName}/${slug}"`
-        );
-      }
-
-      const endOnNewBranch = await selectAsync<boolean>(
-        'Ending the rollout will send all traffic to a single branch. Which one should that be?',
-        [
-          {
-            title: `${newBranch.name} ${chalk.grey(`- current percent: ${100 - currentPercent}%`)}`,
-            value: true,
-          },
-          {
-            title: `${oldBranch.name} ${chalk.grey(`- current percent: ${currentPercent}%`)}`,
-            value: false,
-          },
-        ]
-      );
-
-      const newBranchMapping = {
-        version: 0,
-        data: [
-          {
-            branchId: endOnNewBranch ? newBranchId : oldBranchId,
-            branchMappingLogic: 'true',
-          },
-        ],
-      };
-
-      newChannelInfo = await updateChannelBranchMappingAsync({
-        channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.id!,
-        branchMapping: JSON.stringify(newBranchMapping),
-      });
-      logMessage = `️Rollout on channel ${chalk.bold(
-        channelName
-      )} ended. All traffic is now sent to ${chalk.bold(
-        endOnNewBranch ? newBranch.name : oldBranch.name
-      )}`;
     } else {
-      throw new Error('');
+      // not a rollout
+      if (!endFlag) {
+        const currentPercent = 100 * currentBranchMapping.data[0].branchMappingLogic.operand;
+        const [newBranchId, oldBranchId] = currentBranchMapping.data.map(d => d.branchId);
+        const newBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
+          branch => branch.id === newBranchId
+        )[0];
+        const oldBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
+          branch => branch.id === oldBranchId
+        )[0];
+        if (!newBranch || !oldBranch) {
+          throw new Error(
+            `Branch mapping rollout is missing a branch for channel "${channelName}" on app "@${accountName}/${slug}"`
+          );
+        }
+
+        if (percent === undefined) {
+          if (jsonFlag) {
+            throw new Error(
+              'A rollout is already in progress. If you wish to modify it you must use specify the new rollout percentage with the --percent flag.'
+            );
+          }
+          const promptMessage = `Currently ${currentPercent}% of all users are routed to branch ${
+            newBranch.name
+          } and ${100 - currentPercent}% of all users are routed to branch ${
+            oldBranch.name
+          }. What percent of users should be directed to the branch ${newBranch.name}?`;
+          const validationMessage =
+            'The rollout percentage must be an integer between 0 and 99 inclusive.';
+          if (jsonFlag) {
+            throw new Error(validationMessage);
+          }
+          percent = await getRolloutPercentAsync({ promptMessage, validationMessage });
+        }
+
+        const newBranchMapping = { ...currentBranchMapping };
+        newBranchMapping.data[0].branchMappingLogic.operand = percent / 100;
+
+        newChannelInfo = await updateChannelBranchMappingAsync({
+          channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.id!,
+          branchMapping: JSON.stringify(newBranchMapping),
+        });
+
+        logMessage = `️Rollout of branch ${chalk.bold(newBranch.name)} onto channel ${chalk.bold(
+          channelName!
+        )} updated from ${chalk.bold(currentPercent)}% to ${chalk.bold(percent)}%. ${chalk.bold(
+          percent
+        )}% of users will be directed to ${chalk.bold(newBranch.name)}, ${chalk.bold(
+          100 - percent!
+        )}% to ${oldBranch.name}.`;
+      } else {
+        // end flag is true
+        const currentPercent = 100 * currentBranchMapping.data[0].branchMappingLogic.operand;
+        const [newBranchId, oldBranchId] = currentBranchMapping.data.map(d => d.branchId);
+        const newBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
+          branch => branch.id === newBranchId
+        )[0];
+        const oldBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
+          branch => branch.id === oldBranchId
+        )[0];
+        if (!newBranch || !oldBranch) {
+          throw new Error(
+            `Branch mapping rollout is missing a branch for channel "${channelName}" on app "@${accountName}/${slug}"`
+          );
+        }
+
+        const endOnNewBranch = await selectAsync<boolean>(
+          'Ending the rollout will send all traffic to a single branch. Which one should that be?',
+          [
+            {
+              title: `${newBranch.name} ${chalk.grey(
+                `- current percent: ${100 - currentPercent}%`
+              )}`,
+              value: true,
+            },
+            {
+              title: `${oldBranch.name} ${chalk.grey(`- current percent: ${currentPercent}%`)}`,
+              value: false,
+            },
+          ]
+        );
+
+        const newBranchMapping = {
+          version: 0,
+          data: [
+            {
+              branchId: endOnNewBranch ? newBranchId : oldBranchId,
+              branchMappingLogic: 'true',
+            },
+          ],
+        };
+
+        newChannelInfo = await updateChannelBranchMappingAsync({
+          channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.id!,
+          branchMapping: JSON.stringify(newBranchMapping),
+        });
+        logMessage = `️Rollout on channel ${chalk.bold(
+          channelName
+        )} ended. All traffic is now sent to ${chalk.bold(
+          endOnNewBranch ? newBranch.name : oldBranch.name
+        )}`;
+      }
     }
 
     if (jsonFlag) {

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -404,24 +404,22 @@ export default class ChannelRollout extends Command {
         currentBranchMapping,
         getUpdateChannelByNameForAppResult,
       });
+    } else if (endFlag) {
+      rolloutMutationResult = await endRolloutAsync({
+        channelName,
+        branchName,
+        jsonFlag,
+        projectId,
+        getUpdateChannelByNameForAppResult,
+      });
     } else {
-      if (!endFlag) {
-        rolloutMutationResult = await editRolloutAsync({
-          channelName,
-          percent,
-          jsonFlag,
-          currentBranchMapping,
-          getUpdateChannelByNameForAppResult,
-        });
-      } else {
-        rolloutMutationResult = await endRolloutAsync({
-          channelName,
-          branchName,
-          jsonFlag,
-          projectId,
-          getUpdateChannelByNameForAppResult,
-        });
-      }
+      rolloutMutationResult = await editRolloutAsync({
+        channelName,
+        percent,
+        jsonFlag,
+        currentBranchMapping,
+        getUpdateChannelByNameForAppResult,
+      });
     }
     if (!rolloutMutationResult) {
       throw new Error('rollout result is empty');

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -69,8 +69,7 @@ async function startRolloutAsync({
   percent,
   jsonFlag,
   projectId,
-  accountName,
-  slug,
+  fullName,
   currentBranchMapping,
   getUpdateChannelByNameForAppResult,
 }: {
@@ -79,8 +78,7 @@ async function startRolloutAsync({
   percent?: number;
   jsonFlag: boolean;
   projectId: string;
-  accountName: string;
-  slug: string;
+  fullName: string;
   currentBranchMapping: BranchMapping;
   getUpdateChannelByNameForAppResult: GetChannelByNameForAppQuery;
 }): Promise<{
@@ -145,7 +143,7 @@ async function startRolloutAsync({
   )[0];
   if (!oldBranch) {
     throw new Error(
-      `Branch mapping is missing its only branch for channel "${channelName}" on app "@${accountName}/${slug}"`
+      `Branch mapping is missing its only branch for channel "${channelName}" on app "${fullName}"`
     );
   }
 
@@ -399,8 +397,7 @@ export default class ChannelRollout extends Command {
         percent,
         jsonFlag,
         projectId,
-        accountName,
-        slug,
+        fullName: `@${accountName}/${slug}`,
         currentBranchMapping,
         getUpdateChannelByNameForAppResult,
       });

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -85,12 +85,11 @@ export default class ChannelRollout extends Command {
       required: false,
     }),
     end: flags.boolean({
-      description: 'End the rollout.',
+      description: 'end the rollout',
       default: false,
     }),
     json: flags.boolean({
-      description:
-        'print output as a JSON object with the new channel ID, name and branch mapping.',
+      description: 'print output as a JSON object with the new channel ID, name and branch mapping',
       default: false,
     }),
   };

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -14,7 +14,7 @@ import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 
-type BranchMapping = {
+export type BranchMapping = {
   version: number;
   data: {
     branchId: string;

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -30,7 +30,7 @@ type BranchMapping = {
  * Get the branch mapping and determine whether it is a rollout.
  * Ensure that the branch mapping is properly formatted.
  */
-function getBranchMapping(
+export function getBranchMapping(
   getChannelByNameForAppQuery: GetChannelByNameForAppQuery
 ): { branchMapping: BranchMapping; isRollout: boolean; rolloutPercent?: number } {
   const branchMappingString =
@@ -62,7 +62,7 @@ function getBranchMapping(
       if (branchMapping.data[0].branchMappingLogic.branchMappingOperator !== 'hash_lt') {
         throw new Error('Branch mapping operator of initial branch mapping must be "hash_lt"');
       }
-      if (!rolloutPercent) {
+      if (rolloutPercent === undefined) {
         throw new Error('Branch mapping is missing a "rolloutPercent"');
       }
       if (branchMapping.data[1].branchMappingLogic !== 'true') {
@@ -76,7 +76,7 @@ function getBranchMapping(
   return { branchMapping, isRollout, rolloutPercent };
 }
 
-async function getUpdateChannelByNameForAppAsync({
+export async function getUpdateChannelByNameForAppAsync({
   appId,
   channelName,
 }: GetChannelByNameForAppQueryVariables): Promise<GetChannelByNameForAppQuery> {

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -62,7 +62,7 @@ export function getBranchMapping(
       if (branchMapping.data[0].branchMappingLogic.branchMappingOperator !== 'hash_lt') {
         throw new Error('Branch mapping operator of initial branch mapping must be "hash_lt"');
       }
-      if (rolloutPercent === undefined) {
+      if (rolloutPercent == null) {
         throw new Error('Branch mapping is missing a "rolloutPercent"');
       }
       if (branchMapping.data[1].branchMappingLogic !== 'true') {


### PR DESCRIPTION
# Why

Create a command to manage rollout on a channel.

closes #684
closes #685
closes #686

# How

There are three possible branches:

1. if there is no active rollout, a new one is started based on the `branch` and `percent` specified by the user.
2. if there is an active rollout
  a. user can modify it by changing the percent
  b. user can end it by setting the --end flag and specifying a branch to consolidate to.

# Note

~~There is a bit of of confusing nuance. In a rollout a user is converted to a number in the unit interval and sent to the new Branch if they are less than the rollout percent, old branch otherwis.~~

~~If we use a strict inequality then we get `[0,rolloutPercent)` a weak inequality, `[0,rolloutPercent]`.~~

~~When the rollout percent is `0`, then the strict inequality sends 0 to the new branch since `[0,0)` is the empty set. However in the weak case, `[0,0]` will send a very small number of users to to the new branch.~~

~~Conversely when the rollout percent is `100` we get the opposite confusion.~~

~~Since the new branch is, in general, the more dangerous one, we stick with the strict inequality `[0,rolloutPercent)` so that the a rollout percent of `0` matches user expectations while `100` does not quite.~~

~~We can perhaps treat this server side by continuing to use a strict inequality, but also passing users mapped to 100 on the edge case where the rollout percent is 100 as well.~~

fixed server side: https://github.com/expo/universe/pull/7242

# Test Plan

Manually started/managed/ended a rollout:

<img width="1376" alt="Screen Shot 2021-03-26 at 10 34 11 AM" src="https://user-images.githubusercontent.com/1220444/112670960-d1813100-8e1e-11eb-8c08-76aec0c76874.png">
