### PR TITLE
remove requested_platform from tracking context

### DIFF
--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -93,7 +93,6 @@ export default class Build extends Command {
 
     const trackingCtx = {
       tracking_id: uuidv4(),
-      requested_platform: flags.platform,
     };
     Analytics.logEvent(AnalyticsEvent.BUILD_COMMAND, trackingCtx);
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

I've realized that `requested_platform` in the tracking context can be undefined (when running `eas build` without any flags). According to @wkozyra95, this is a left-over field.

# How

I removed `requested_platform` from the tracking context.

# Test Plan

I haven't tested it.