### PR TITLE
[eas-cli] create provisioning profile using graphql api

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
@@ -1,3 +1,11 @@
+import { AuthCtx } from '../ios/appstore/authenticate';
+
+export const testAuthCtx: AuthCtx = {
+  appleId: 'test-apple-id',
+  appleIdPassword: 'test-apple-password',
+  team: { id: 'test-team-id', name: 'test-team-name', inHouse: false },
+};
+
 export function getAppstoreMock() {
   return {
     ensureAuthenticatedAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-new-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-new-ios.ts
@@ -106,7 +106,7 @@ export function getNewIosApiMockWithoutCredentials() {
     createOrUpdateIosAppBuildCredentialsAsync: jest.fn(),
     getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(),
     createOrGetExistingIosAppCredentialsWithBuildCredentialsAsync: jest.fn(),
-    createOrGetExistingAppleTeamAsync: jest.fn(),
+    createOrGetExistingAppleTeamAsync: () => testAppleTeam,
     createOrGetExistingAppleAppIdentifierAsync: jest.fn(),
     getDevicesForAppleTeamAsync: jest.fn(),
     createProvisioningProfileAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/ios/actions/new/CreateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/CreateProvisioningProfile.ts
@@ -1,0 +1,83 @@
+import assert from 'assert';
+import nullthrows from 'nullthrows';
+
+import { AppleDistributionCertificateFragment } from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { Action, CredentialsManager } from '../../../CredentialsManager';
+import { Context } from '../../../context';
+import { askForUserProvidedAsync } from '../../../utils/promptForCredentials';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { AppleProvisioningProfileMutationResult } from '../../api/graphql/mutations/AppleProvisioningProfileMutation';
+import { ProvisioningProfile } from '../../appstore/Credentials.types';
+import { AuthCtx } from '../../appstore/authenticate';
+import { provisioningProfileSchema } from '../../credentials';
+import { MissingCredentialsNonInteractiveError } from '../../errors';
+import { generateProvisioningProfileAsync } from '../ProvisioningProfileUtils';
+import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
+
+export class CreateProvisioningProfile implements Action {
+  private _provisioningProfile?: AppleProvisioningProfileMutationResult;
+  constructor(
+    private app: AppLookupParams,
+    private distributionCertificate: AppleDistributionCertificateFragment
+  ) {}
+
+  public get provisioningProfile(): AppleProvisioningProfileMutationResult {
+    assert(
+      this._provisioningProfile,
+      'provisioningProfile can be accessed only after calling .runAsync()'
+    );
+    return this._provisioningProfile;
+  }
+
+  async runAsync(_manager: CredentialsManager, ctx: Context): Promise<void> {
+    if (ctx.nonInteractive) {
+      throw new MissingCredentialsNonInteractiveError(
+        'Creating Provisioning Profiles is only supported in interactive mode.'
+      );
+    }
+    const appleAuthCtx = await ctx.appStore.ensureAuthenticatedAsync();
+    const provisioningProfile = await this.provideOrGenerateAsync(ctx, appleAuthCtx);
+    const appleTeam = nullthrows(await resolveAppleTeamIfAuthenticatedAsync(ctx, this.app));
+    const appleAppIdentifier = await ctx.newIos.createOrGetExistingAppleAppIdentifierAsync(
+      this.app,
+      appleTeam
+    );
+    this._provisioningProfile = await ctx.newIos.createProvisioningProfileAsync(
+      this.app,
+      appleAppIdentifier,
+      {
+        appleProvisioningProfile: provisioningProfile.provisioningProfile,
+        developerPortalIdentifier: provisioningProfile.provisioningProfileId,
+      }
+    );
+    Log.succeed('Created provisioning profile');
+  }
+
+  private async provideOrGenerateAsync(
+    ctx: Context,
+    appleAuthCtx: AuthCtx
+  ): Promise<ProvisioningProfile> {
+    const userProvided = await askForUserProvidedAsync(provisioningProfileSchema);
+    if (userProvided) {
+      // userProvided profiles don't come with ProvisioningProfileId's (only accessible from Apple Portal API)
+      Log.warn('Provisioning profile: Unable to validate specified profile.');
+      return userProvided;
+    }
+    assert(
+      this.distributionCertificate.certificateP12,
+      'Distribution Certificate must have p12 certificate'
+    );
+    assert(
+      this.distributionCertificate.certificatePassword,
+      'Distribution Certificate must have certificate password'
+    );
+    return await generateProvisioningProfileAsync(ctx, this.app.bundleIdentifier, {
+      certId: this.distributionCertificate.developerPortalIdentifier ?? undefined,
+      certP12: this.distributionCertificate.certificateP12,
+      certPassword: this.distributionCertificate.certificatePassword,
+      distCertSerialNumber: this.distributionCertificate.serialNumber,
+      teamId: this.distributionCertificate.appleTeam?.appleTeamIdentifier ?? appleAuthCtx.appleId,
+    });
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/CreateProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/CreateProvisioningProfile-test.ts
@@ -1,0 +1,57 @@
+import { confirmAsync } from '../../../../../prompts';
+import { getAppstoreMock, testAuthCtx } from '../../../../__tests__/fixtures-appstore';
+import { createCtxMock, createManagerMock } from '../../../../__tests__/fixtures-context';
+import {
+  testDistCertFragmentNoDependencies,
+  testProvisioningProfile,
+} from '../../../../__tests__/fixtures-ios';
+import { ManageIosBeta } from '../../../../manager/ManageIosBeta';
+import { MissingCredentialsNonInteractiveError } from '../../../errors';
+import { CreateProvisioningProfile } from '../CreateProvisioningProfile';
+jest.mock('../../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+
+describe('CreateProvisioningProfile', () => {
+  it('creates a Provisioning Profile in Interactive Mode', async () => {
+    const manager = createManagerMock();
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+        authCtx: testAuthCtx,
+        createProvisioningProfileAsync: jest.fn(() => testProvisioningProfile),
+      },
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const createProvProfAction = new CreateProvisioningProfile(
+      appLookupParams,
+      testDistCertFragmentNoDependencies
+    );
+    await createProvProfAction.runAsync(manager, ctx);
+
+    // expect provisioning profile not be created on expo servers
+    expect((ctx.newIos.createProvisioningProfileAsync as any).mock.calls.length).toBe(1);
+    // expect provisioning profile not be created on apple portal
+    expect((ctx.appStore.createProvisioningProfileAsync as any).mock.calls.length).toBe(1);
+  });
+  it('errors in Non Interactive Mode', async () => {
+    const manager = createManagerMock();
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const createProvProfAction = new CreateProvisioningProfile(
+      appLookupParams,
+      testDistCertFragmentNoDependencies
+    );
+    await expect(createProvProfAction.runAsync(manager, ctx)).rejects.toThrowError(
+      MissingCredentialsNonInteractiveError
+    );
+
+    // expect provisioning profile not be created on expo servers
+    expect((ctx.newIos.createProvisioningProfileAsync as any).mock.calls.length).toBe(0);
+    // expect provisioning profile not be created on apple portal
+    expect((ctx.appStore.createProvisioningProfileAsync as any).mock.calls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
# Why
This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to create a provisioning profile using the new Graphql Api. This will eventually replace the old `CreateProvisioningProfile` here:  https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts

# Test Plan

- [ ] New tests pass
