### PR TITLE
[eas-cli] make dist cert setup generic with graphql api

### DIFF
--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
@@ -97,7 +97,7 @@ export class SetupAdhocProvisioningProfile implements Action {
     }
 
     // 2. Setup Distribution Certificate
-    const distCertAction = new SetupDistributionCertificate(this.app);
+    const distCertAction = new SetupDistributionCertificate(this.app, IosDistributionType.AdHoc);
     await manager.runActionAsync(distCertAction);
     const distCert = distCertAction.distributionCertificate;
 

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
@@ -52,7 +52,7 @@ export class SetupAdhocProvisioningProfile implements Action {
 
   private async runNonInteractiveAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
     // 1. Setup Distribution Certificate
-    const distCertAction = new SetupDistributionCertificate(this.app);
+    const distCertAction = new SetupDistributionCertificate(this.app, IosDistributionType.AdHoc);
     await manager.runActionAsync(distCertAction);
 
     // 2. Fetch profile from EAS servers

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
@@ -22,7 +22,7 @@ export class SetupDistributionCertificate implements Action {
   private validDistCerts?: AppleDistributionCertificateFragment[];
   private _distributionCertificate?: AppleDistributionCertificateFragment;
 
-  constructor(private app: AppLookupParams) {}
+  constructor(private app: AppLookupParams, private distributionType: IosDistributionType) {}
 
   public get distributionCertificate(): AppleDistributionCertificateFragment {
     assert(
@@ -38,7 +38,7 @@ export class SetupDistributionCertificate implements Action {
     try {
       const currentCertificate = await ctx.newIos.getDistributionCertificateForAppAsync(
         this.app,
-        IosDistributionType.AdHoc,
+        this.distributionType,
         { appleTeam }
       );
 
@@ -61,9 +61,7 @@ export class SetupDistributionCertificate implements Action {
   ): Promise<void> {
     // TODO: implement validation
     Log.addNewLineIfNone();
-    Log.warn(
-      'Distribution Certificate is not validated for non-interactive internal distribution builds.'
-    );
+    Log.warn('Distribution Certificate is not validated for non-interactive builds.');
     if (!currentCertificate) {
       throw new MissingCredentialsNonInteractiveError();
     }


### PR DESCRIPTION
# Why
This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to setup a dist cert using the new Graphql Api in a generic way -- it is no longer constrained to just Adhoc apps. 


# Test Plan
i manually tested this
