### PR TITLE
[eas-cli] fix secret name validation when prompted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Fix environment secret creation prompt ([#298](https://github.com/expo/eas-cli/pull/298) by [@fiberjw](https://github.com/fiberjw))
+- Fix environment secret creation prompt. ([#298](https://github.com/expo/eas-cli/pull/298) by [@fiberjw](https://github.com/fiberjw))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+
 - `build:view` and `build:list` now showing the distribution type (store / internal) and release channel. ([#284](https://github.com/expo/eas-cli/pull/284) by [@vthibault](https://github.com/vthibault))
 
 - Add analytics to EAS Build. ([#162](https://github.com/expo/eas-cli/pull/162) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
+
+- Fix environment secret creation prompt ([#298](https://github.com/expo/eas-cli/pull/298) by [@fiberjw](https://github.com/fiberjw))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/secrets/create.ts
+++ b/packages/eas-cli/src/commands/secrets/create.ts
@@ -89,7 +89,7 @@ export default class EnvironmentSecretCreate extends Command {
             return 'Secret name may not be empty.';
           }
 
-          if (value.match(/^\w+$/)) {
+          if (!value.match(/^\w+$/)) {
             return 'Names may contain only letters, numbers, and underscores.';
           }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Creating a secret from the prompt flow was broken because of a missing `!` in the validation code.

# Test Plan

`easd secrets:create` without args and it should now accept valid names.
