### PR TITLE
[eas-cli] configure provisioning profile using new api

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -2,6 +2,7 @@ import {
   AppFragment,
   AppleAppIdentifierFragment,
   AppleDistributionCertificateFragment,
+  AppleProvisioningProfileFragment,
   AppleTeamFragment,
 } from '../../graphql/generated';
 import {
@@ -54,6 +55,17 @@ export const testAppFragment: AppFragment = {
   id: 'test-app-id',
   fullName: '@testuser/testapp',
   slug: 'testapp',
+};
+
+export const testProvisioningProfileFragment: AppleProvisioningProfileFragment = {
+  id: 'test-prov-prof-id-1',
+  expiration: new Date(),
+  developerPortalIdentifier: 'test-developer-identifier',
+  provisioningProfile: 'test-provisioning-profile',
+  updatedAt: new Date(),
+  status: 'Active',
+  appleTeam: { ...testAppleTeamFragment },
+  appleDevices: [],
 };
 
 export const testDistCertFragmentNoDependencies: AppleDistributionCertificateFragment = {

--- a/packages/eas-cli/src/credentials/ios/actions/new/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/ConfigureProvisioningProfile.ts
@@ -1,0 +1,123 @@
+import assert from 'assert';
+import chalk from 'chalk';
+import ora from 'ora';
+
+import {
+  AppleDistributionCertificateFragment,
+  AppleProvisioningProfileFragment,
+} from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { Action, CredentialsManager } from '../../../CredentialsManager';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { AppleProvisioningProfileMutationResult } from '../../api/graphql/mutations/AppleProvisioningProfileMutation';
+import { ProvisioningProfileStoreInfo } from '../../appstore/Credentials.types';
+import { AuthCtx } from '../../appstore/authenticate';
+import {
+  MissingCredentialsNonInteractiveError,
+  ProvisioningProfileNotFoundOnAppleServersError,
+} from '../../errors';
+
+export class ConfigureProvisioningProfile implements Action {
+  private _configuredProvisioningProfile?: AppleProvisioningProfileMutationResult;
+  constructor(
+    private app: AppLookupParams,
+    private distributionCertificate: AppleDistributionCertificateFragment,
+    private originalProvisioningProfile: AppleProvisioningProfileFragment
+  ) {}
+
+  public get provisioningProfile(): AppleProvisioningProfileMutationResult {
+    assert(
+      this._configuredProvisioningProfile,
+      'provisioningProfile can be accessed only after calling .runAsync()'
+    );
+    return this._configuredProvisioningProfile;
+  }
+
+  public async runAsync(_manager: CredentialsManager, ctx: Context): Promise<void> {
+    if (ctx.nonInteractive) {
+      throw new MissingCredentialsNonInteractiveError(
+        'Configuring Provisioning Profiles is only supported in interactive mode.'
+      );
+    }
+    const { developerPortalIdentifier, provisioningProfile } = this.originalProvisioningProfile;
+    if (!developerPortalIdentifier && !provisioningProfile) {
+      Log.warn("The provisioning profile we have on file cannot be validated on Apple's servers.");
+      return;
+    }
+
+    if (ctx.appStore.authCtx) {
+      const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
+        this.app.bundleIdentifier
+      );
+      const [matchingProfile] = profilesFromApple.filter(appleInfo =>
+        developerPortalIdentifier
+          ? appleInfo.provisioningProfileId === developerPortalIdentifier
+          : appleInfo.provisioningProfile === provisioningProfile
+      );
+      if (!matchingProfile) {
+        throw new ProvisioningProfileNotFoundOnAppleServersError(
+          `Profile ${
+            developerPortalIdentifier ? developerPortalIdentifier + ' ' : null
+          }not found on Apple Developer Portal.`
+        );
+      }
+
+      await this.configureAndUpdateAsync(ctx, ctx.appStore.authCtx, this.app, matchingProfile);
+    } else {
+      Log.warn(
+        "Without access to your Apple account we can't configure provisioning profiles for you."
+      );
+      Log.warn('Make sure to recreate the profile if you selected a new distribution certificate.');
+    }
+  }
+
+  private async configureAndUpdateAsync(
+    ctx: Context,
+    authCtx: AuthCtx,
+    app: AppLookupParams,
+    profileFromApple: ProvisioningProfileStoreInfo
+  ) {
+    const {
+      developerPortalIdentifier,
+      certificateP12,
+      certificatePassword,
+      serialNumber,
+    } = this.distributionCertificate;
+    assert(
+      certificateP12 && certificatePassword,
+      'Distribution Certificate P12 and Password is required'
+    );
+    // configure profile on Apple's Server to use our distCert
+    const updatedProfile = await ctx.appStore.useExistingProvisioningProfileAsync(
+      app.bundleIdentifier,
+      profileFromApple,
+      {
+        certId: developerPortalIdentifier ?? undefined,
+        certP12: certificateP12,
+        certPassword: certificatePassword,
+        distCertSerialNumber: serialNumber,
+        teamId: authCtx.appleId,
+      }
+    );
+
+    const bundleIdTag = `(${app.bundleIdentifier})`;
+    const slugTag = `@${app.account.name}/${app.projectName}`;
+    const projectTag = `${chalk.bold(slugTag)} ${chalk.dim(bundleIdTag)}`;
+
+    const spinner = ora(`Updating Expo profile for ${projectTag}`).start();
+    try {
+      this._configuredProvisioningProfile = await ctx.newIos.updateProvisioningProfileAsync(
+        this.originalProvisioningProfile.id,
+        {
+          appleProvisioningProfile: updatedProfile.provisioningProfile,
+          developerPortalIdentifier: updatedProfile.provisioningProfileId,
+        }
+      );
+      spinner.succeed(`Updated Expo profile for ${projectTag}`);
+    } catch (error) {
+      spinner.fail();
+      throw error;
+    }
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/ConfigureProvisioningProfile.ts
@@ -7,7 +7,6 @@ import {
   AppleProvisioningProfileFragment,
 } from '../../../../graphql/generated';
 import Log from '../../../../log';
-import { Action, CredentialsManager } from '../../../CredentialsManager';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
 import { AppleProvisioningProfileMutationResult } from '../../api/graphql/mutations/AppleProvisioningProfileMutation';

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/ConfigureProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/ConfigureProvisioningProfile-test.ts
@@ -1,0 +1,66 @@
+import { confirmAsync } from '../../../../../prompts';
+import { getAppstoreMock, testAuthCtx } from '../../../../__tests__/fixtures-appstore';
+import { createCtxMock, createManagerMock } from '../../../../__tests__/fixtures-context';
+import {
+  testDistCertFragmentNoDependencies,
+  testProvisioningProfile,
+  testProvisioningProfileFragment,
+} from '../../../../__tests__/fixtures-ios';
+import { ManageIosBeta } from '../../../../manager/ManageIosBeta';
+import { MissingCredentialsNonInteractiveError } from '../../../errors';
+import { ConfigureProvisioningProfile } from '../ConfigureProvisioningProfile';
+jest.mock('../../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+
+describe('ConfigureProvisioningProfile', () => {
+  it('configures a Provisioning Profile in Interactive Mode', async () => {
+    const manager = createManagerMock();
+    const mockProvisioningProfileFromApple = {
+      provisioningProfileId: testProvisioningProfileFragment.developerPortalIdentifier,
+      provisioningProfile: testProvisioningProfileFragment.provisioningProfile,
+    };
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+        authCtx: testAuthCtx,
+        createProvisioningProfileAsync: jest.fn(() => testProvisioningProfile),
+        listProvisioningProfilesAsync: jest.fn(() => [mockProvisioningProfileFromApple]),
+        useExistingProvisioningProfileAsync: jest.fn(() => mockProvisioningProfileFromApple),
+      },
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const configureProvProfAction = new ConfigureProvisioningProfile(
+      appLookupParams,
+      testDistCertFragmentNoDependencies,
+      testProvisioningProfileFragment
+    );
+    await configureProvProfAction.runAsync(manager, ctx);
+
+    // expect provisioning profile not to be updated on expo servers
+    expect((ctx.newIos.updateProvisioningProfileAsync as any).mock.calls.length).toBe(1);
+    // expect provisioning profile not to be updated on apple portal
+    expect((ctx.appStore.useExistingProvisioningProfileAsync as any).mock.calls.length).toBe(1);
+  });
+  it('errors in Non Interactive Mode', async () => {
+    const manager = createManagerMock();
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const configureProvProfAction = new ConfigureProvisioningProfile(
+      appLookupParams,
+      testDistCertFragmentNoDependencies,
+      testProvisioningProfileFragment
+    );
+    await expect(configureProvProfAction.runAsync(manager, ctx)).rejects.toThrowError(
+      MissingCredentialsNonInteractiveError
+    );
+
+    // expect provisioning profile not to be updated on expo servers
+    expect((ctx.newIos.updateProvisioningProfileAsync as any).mock.calls.length).toBe(0);
+    // expect provisioning profile not to be updated on apple portal
+    expect((ctx.appStore.useExistingProvisioningProfileAsync as any).mock.calls.length).toBe(0);
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/ConfigureProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/ConfigureProvisioningProfile-test.ts
@@ -1,6 +1,6 @@
 import { confirmAsync } from '../../../../../prompts';
 import { getAppstoreMock, testAuthCtx } from '../../../../__tests__/fixtures-appstore';
-import { createCtxMock, createManagerMock } from '../../../../__tests__/fixtures-context';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
 import {
   testDistCertFragmentNoDependencies,
   testProvisioningProfile,
@@ -14,7 +14,6 @@ jest.mock('../../../../../prompts');
 
 describe('ConfigureProvisioningProfile', () => {
   it('configures a Provisioning Profile in Interactive Mode', async () => {
-    const manager = createManagerMock();
     const mockProvisioningProfileFromApple = {
       provisioningProfileId: testProvisioningProfileFragment.developerPortalIdentifier,
       provisioningProfile: testProvisioningProfileFragment.provisioningProfile,
@@ -31,12 +30,12 @@ describe('ConfigureProvisioningProfile', () => {
       },
     });
     const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
-    const configureProvProfAction = new ConfigureProvisioningProfile(
+    const provProfConfigurator = new ConfigureProvisioningProfile(
       appLookupParams,
       testDistCertFragmentNoDependencies,
       testProvisioningProfileFragment
     );
-    await configureProvProfAction.runAsync(manager, ctx);
+    await provProfConfigurator.runAsync(ctx);
 
     // expect provisioning profile not to be updated on expo servers
     expect((ctx.newIos.updateProvisioningProfileAsync as any).mock.calls.length).toBe(1);
@@ -44,17 +43,16 @@ describe('ConfigureProvisioningProfile', () => {
     expect((ctx.appStore.useExistingProvisioningProfileAsync as any).mock.calls.length).toBe(1);
   });
   it('errors in Non Interactive Mode', async () => {
-    const manager = createManagerMock();
     const ctx = createCtxMock({
       nonInteractive: true,
     });
     const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
-    const configureProvProfAction = new ConfigureProvisioningProfile(
+    const provProfConfigurator = new ConfigureProvisioningProfile(
       appLookupParams,
       testDistCertFragmentNoDependencies,
       testProvisioningProfileFragment
     );
-    await expect(configureProvProfAction.runAsync(manager, ctx)).rejects.toThrowError(
+    await expect(provProfConfigurator.runAsync(ctx)).rejects.toThrowError(
       MissingCredentialsNonInteractiveError
     );
 

--- a/packages/eas-cli/src/credentials/ios/errors.ts
+++ b/packages/eas-cli/src/credentials/ios/errors.ts
@@ -11,3 +11,9 @@ export class MissingCredentialsNonInteractiveError extends Error {
     );
   }
 }
+
+export class ProvisioningProfileNotFoundOnAppleServersError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Provisioning Profile not found on Apple Developer Portal.');
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/errors.ts
+++ b/packages/eas-cli/src/credentials/ios/errors.ts
@@ -11,9 +11,3 @@ export class MissingCredentialsNonInteractiveError extends Error {
     );
   }
 }
-
-export class ProvisioningProfileNotFoundOnAppleServersError extends Error {
-  constructor(message?: string) {
-    super(message ?? 'Provisioning Profile not found on Apple Developer Portal.');
-  }
-}


### PR DESCRIPTION
# Why
This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to create a provisioning profile using the new Graphql Api. This will eventually replace the old `ConfigureProvisioningProfile` here:  https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts

# Notable Changes
- Throw a specialized error if provisioning profile on Expo servers isn't found on Apple Developer portal. We can recover from this particular error in `SetupProvisioningProfile` later.

# Test Plan

- [x] New tests pass
