### PR TITLE
[eas-cli] use flags for secrets:create and rename target to scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 - Change the way of disabling cache - add `cache.disabled` field. ([#295](https://github.com/expo/eas-cli/pull/295) by [@dsokal](https://github.com/dsokal))
+- `secrets:create` now uses flags rather than positional arguments ([#300](https://github.com/expo/eas-cli/pull/300) by [@fiberjw](https://github.com/fiberjw))
+- `secrets:create`'s `target` arg is now called `scope` ([#300](https://github.com/expo/eas-cli/pull/300) by [@fiberjw](https://github.com/fiberjw))
+- `secrets:list`'s `target` property is now called `scope` ([#300](https://github.com/expo/eas-cli/pull/300) by [@fiberjw](https://github.com/fiberjw))
 
 ### 🎉 New features
 

--- a/packages/eas-cli/src/commands/secrets/create.ts
+++ b/packages/eas-cli/src/commands/secrets/create.ts
@@ -83,6 +83,8 @@ export default class EnvironmentSecretCreate extends Command {
             return 'Secret name may not be empty.';
           }
 
+          // this validation regex here is just to shorten the feedback loop
+          // the source of truth is in www's EnvironmentSecretValidator class
           if (!value.match(/^\w+$/)) {
             return 'Names may contain only letters, numbers, and underscores.';
           }

--- a/packages/eas-cli/src/commands/secrets/list.ts
+++ b/packages/eas-cli/src/commands/secrets/list.ts
@@ -54,13 +54,13 @@ export default class EnvironmentSecretsList extends Command {
     ] as (EnvironmentSecretFragment & { scope: EnvironmentSecretScope })[];
 
     const table = new Table({
-      head: ['Name', 'Scope', 'Updated at', 'ID'],
+      head: ['Name', 'Scope', 'ID', 'Updated at'],
       wordWrap: true,
     });
 
     for (const secret of secrets) {
       const { name, createdAt: updatedAt, scope, id } = secret;
-      table.push([name, scope, dateFormat(updatedAt, 'mmm dd HH:MM:ss'), id]);
+      table.push([name, scope, id, dateFormat(updatedAt, 'mmm dd HH:MM:ss')]);
     }
 
     Log.log(chalk`{bold Secrets for this account and project:}`);

--- a/packages/eas-cli/src/commands/secrets/list.ts
+++ b/packages/eas-cli/src/commands/secrets/list.ts
@@ -18,7 +18,7 @@ import {
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
-import { EnvironmentSecretTargetLocation } from './create';
+import { EnvironmentSecretScope } from './create';
 
 export default class EnvironmentSecretsList extends Command {
   static description = 'Lists environment secrets available for your current app';
@@ -49,18 +49,18 @@ export default class EnvironmentSecretsList extends Command {
     ]);
 
     const secrets = [
-      ...appSecrets.map(s => ({ ...s, target: EnvironmentSecretTargetLocation.PROJECT })),
-      ...accountSecrets.map(s => ({ ...s, target: EnvironmentSecretTargetLocation.ACCOUNT })),
-    ] as (EnvironmentSecretFragment & { target: EnvironmentSecretTargetLocation })[];
+      ...appSecrets.map(s => ({ ...s, scope: EnvironmentSecretScope.PROJECT })),
+      ...accountSecrets.map(s => ({ ...s, scope: EnvironmentSecretScope.ACCOUNT })),
+    ] as (EnvironmentSecretFragment & { scope: EnvironmentSecretScope })[];
 
     const table = new Table({
-      head: ['Name', 'Target', 'Updated at', 'ID'],
+      head: ['Name', 'Scope', 'Updated at', 'ID'],
       wordWrap: true,
     });
 
     for (const secret of secrets) {
-      const { name, createdAt: updatedAt, target, id } = secret;
-      table.push([name, target, dateFormat(updatedAt, 'mmm dd HH:MM:ss'), id]);
+      const { name, createdAt: updatedAt, scope, id } = secret;
+      table.push([name, scope, dateFormat(updatedAt, 'mmm dd HH:MM:ss'), id]);
     }
 
     Log.log(chalk`{bold Secrets for this account and project:}`);


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

@brentvatne had really good feedback stating that the CLI command should take flags rather than positional args for better UX.

Also Closes ENG-758

# How

- used the flags feature in oclif for user input
- renamed target to scope since that is simpler to understand
- reordered secrets:list table columns to show ID before the timestamp

# Test Plan

![Screen Shot 2021-03-31 at 23 59 27](https://user-images.githubusercontent.com/12488826/113241666-238de080-927d-11eb-875a-1658a77fc265.png)

