### PR TITLE
[eas-cli] setupProvisioningProfile using graphql

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -4,7 +4,12 @@ import {
   AppleDistributionCertificateFragment,
   AppleProvisioningProfileFragment,
   AppleTeamFragment,
+  IosAppBuildCredentials,
+  IosAppBuildCredentialsFragment,
+  IosAppCredentialsFragment,
+  IosDistributionType,
 } from '../../graphql/generated';
+import { IosAppCredentialsWithBuildCredentialsQueryResult } from '../ios/api/graphql/queries/IosAppCredentialsQuery';
 import {
   DistributionCertificate,
   DistributionCertificateStoreInfo,
@@ -105,6 +110,18 @@ export const testDistCertFragmentOneDependency: AppleDistributionCertificateFrag
       },
     },
   ],
+};
+
+export const testIosAppBuildCredentialsFragment: IosAppBuildCredentialsFragment = {
+  id: 'test-ios-app-build-credentials-id',
+  iosDistributionType: IosDistributionType.AppStore,
+  distributionCertificate: testDistCertFragmentNoDependencies,
+  provisioningProfile: testProvisioningProfileFragment,
+};
+
+export const testIosAppCredentialsWithBuildCredentialsQueryResult: IosAppCredentialsWithBuildCredentialsQueryResult = {
+  id: 'test-app-credential-id',
+  iosAppBuildCredentialsArray: [testIosAppBuildCredentialsFragment],
 };
 
 export const testDistCert: DistributionCertificate = {

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -4,9 +4,7 @@ import {
   AppleDistributionCertificateFragment,
   AppleProvisioningProfileFragment,
   AppleTeamFragment,
-  IosAppBuildCredentials,
   IosAppBuildCredentialsFragment,
-  IosAppCredentialsFragment,
   IosDistributionType,
 } from '../../graphql/generated';
 import { IosAppCredentialsWithBuildCredentialsQueryResult } from '../ios/api/graphql/queries/IosAppCredentialsQuery';

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
@@ -24,16 +24,10 @@ export class SetupProvisioningProfile {
   constructor(private app: AppLookupParams) {}
 
   async areBuildCredentialsSetupAsync(ctx: Context): Promise<boolean> {
-    const appCredentials = await ctx.newIos.getIosAppCredentialsWithBuildCredentialsAsync(
-      this.app,
-      {
-        iosDistributionType: IosDistributionType.AppStore,
-      }
-    );
-    if (!appCredentials || appCredentials.iosAppBuildCredentialsArray.length === 0) {
+    const buildCredentials = await this.getBuildCredentialsAsync(ctx);
+    if (!buildCredentials) {
       return false;
     }
-    const [buildCredentials] = appCredentials.iosAppBuildCredentialsArray;
     const { distributionCertificate, provisioningProfile } = buildCredentials;
     if (!distributionCertificate || !provisioningProfile) {
       return false;
@@ -115,16 +109,10 @@ export class SetupProvisioningProfile {
   async getProvisioningProfileAsync(
     ctx: Context
   ): Promise<AppleProvisioningProfileFragment | null> {
-    const appCredentials = await ctx.newIos.getIosAppCredentialsWithBuildCredentialsAsync(
-      this.app,
-      {
-        iosDistributionType: IosDistributionType.AppStore,
-      }
-    );
-    if (!appCredentials || appCredentials.iosAppBuildCredentialsArray.length === 0) {
+    const buildCredentials = await this.getBuildCredentialsAsync(ctx);
+    if (!buildCredentials) {
       return null;
     }
-    const [buildCredentials] = appCredentials.iosAppBuildCredentialsArray;
     return buildCredentials.provisioningProfile ?? null;
   }
 

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
@@ -149,19 +149,19 @@ export class SetupProvisioningProfile {
     if (!currentProfile) {
       return await this.createAndAssignProfileAsync(ctx, distCert);
     }
+
+    // See if the profile we have exists on the Apple Servers
+    // If it does, try to use that one. Else create a new one.
     const existingProfiles = await ctx.appStore.listProvisioningProfilesAsync(
       this.app.bundleIdentifier
     );
-
     if (existingProfiles.length === 0) {
       return await this.assignNewAndDeleteOldProfileAsync(ctx, distCert, currentProfile);
     }
-
     const currentProfileFromServer = this.getCurrentProfileStoreInfo(
       existingProfiles,
       currentProfile
     );
-
     if (!currentProfileFromServer) {
       return await this.assignNewAndDeleteOldProfileAsync(ctx, distCert, currentProfile);
     }
@@ -174,8 +174,12 @@ export class SetupProvisioningProfile {
     if (!confirm) {
       return await this.assignNewAndDeleteOldProfileAsync(ctx, distCert, currentProfile);
     }
+
+    // If we get here, we've verified the current profile still exists on Apple
+    // But something wasn't quite right, so we want to fix and update it
     const updatedProfile = await this.configureAndAssignProfileAsync(ctx, distCert, currentProfile);
     if (!updatedProfile) {
+      // Something went wrong, so just create a new profile instead
       return await this.assignNewAndDeleteOldProfileAsync(ctx, distCert, currentProfile);
     }
     return updatedProfile;

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
@@ -1,0 +1,227 @@
+import assert from 'assert';
+import nullthrows from 'nullthrows';
+
+import {
+  AppleDistributionCertificateFragment,
+  AppleProvisioningProfileFragment,
+  IosAppBuildCredentialsFragment,
+  IosDistributionType,
+} from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { confirmAsync } from '../../../../prompts';
+import { Action, CredentialsManager } from '../../../CredentialsManager';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { AppleProvisioningProfileMutationResult } from '../../api/graphql/mutations/AppleProvisioningProfileMutation';
+import { ProvisioningProfileStoreInfo } from '../../appstore/Credentials.types';
+import { validateProvisioningProfileAsync } from '../../validators/validateProvisioningProfile';
+import { formatProvisioningProfileFromApple } from '../ProvisioningProfileUtils';
+import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
+import { ConfigureProvisioningProfile } from './ConfigureProvisioningProfile';
+import { CreateProvisioningProfile } from './CreateProvisioningProfile';
+import { SetupDistributionCertificate } from './SetupDistributionCertificate';
+
+export class SetupProvisioningProfile implements Action {
+  private _iosAppBuildCredentials?: IosAppBuildCredentialsFragment;
+
+  constructor(private app: AppLookupParams) {}
+
+  public get iosAppBuildCredentials(): IosAppBuildCredentialsFragment {
+    assert(
+      this._iosAppBuildCredentials,
+      'iosAppBuildCredentials can be accessed only after calling .runAsync()'
+    );
+    return this._iosAppBuildCredentials;
+  }
+
+  async areBuildCredentialsSetupAsync(ctx: Context): Promise<boolean> {
+    const appCredentials = await ctx.newIos.getIosAppCredentialsWithBuildCredentialsAsync(
+      this.app,
+      {
+        iosDistributionType: IosDistributionType.AppStore,
+      }
+    );
+    if (!appCredentials || appCredentials.iosAppBuildCredentialsArray.length === 0) {
+      return false;
+    }
+    const [buildCredentials] = appCredentials.iosAppBuildCredentialsArray;
+    const { distributionCertificate, provisioningProfile } = buildCredentials;
+    if (!distributionCertificate || !provisioningProfile) {
+      return false;
+    }
+    return await this.isCurrentProfileValidAsync(ctx, provisioningProfile, distributionCertificate);
+  }
+
+  async assignNewAndDeleteOldProfileAsync(
+    manager: CredentialsManager,
+    ctx: Context,
+    distCert: AppleDistributionCertificateFragment,
+    currentProfile: AppleProvisioningProfileFragment
+  ): Promise<void> {
+    await this.createAndAssignProfileAsync(manager, ctx, distCert);
+    // delete 'currentProfile' since its no longer valid
+    await ctx.newIos.deleteProvisioningProfilesAsync([currentProfile.id]);
+  }
+
+  async createAndAssignProfileAsync(
+    manager: CredentialsManager,
+    ctx: Context,
+    distCert: AppleDistributionCertificateFragment
+  ): Promise<void> {
+    const profileCreator = new CreateProvisioningProfile(this.app, distCert);
+    await manager.runActionAsync(profileCreator);
+    const provisioningProfile = profileCreator.provisioningProfile;
+    await this.assignBuildCredentialsAsync(ctx, distCert, provisioningProfile);
+  }
+
+  async configureAndAssignProfileAsync(
+    ctx: Context,
+    distCert: AppleDistributionCertificateFragment,
+    originalProvisioningProfile: AppleProvisioningProfileFragment
+  ): Promise<AppleProvisioningProfileMutationResult | null> {
+    const profileConfigurator = new ConfigureProvisioningProfile(
+      this.app,
+      distCert,
+      originalProvisioningProfile
+    );
+    const updatedProvisioningProfile = await profileConfigurator.runAsync(ctx);
+    if (!updatedProvisioningProfile) {
+      return null;
+    }
+    await this.assignBuildCredentialsAsync(ctx, distCert, updatedProvisioningProfile);
+    return updatedProvisioningProfile;
+  }
+
+  async assignBuildCredentialsAsync(
+    ctx: Context,
+    distCert: AppleDistributionCertificateFragment,
+    provisioningProfile: AppleProvisioningProfileFragment
+  ): Promise<void> {
+    const appleTeam = nullthrows(await resolveAppleTeamIfAuthenticatedAsync(ctx, this.app));
+    const appleAppIdentifier = await ctx.newIos.createOrGetExistingAppleAppIdentifierAsync(
+      this.app,
+      appleTeam
+    );
+    this._iosAppBuildCredentials = await ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync(
+      this.app,
+      {
+        appleTeam,
+        appleAppIdentifierId: appleAppIdentifier.id,
+        appleDistributionCertificateId: distCert.id,
+        appleProvisioningProfileId: provisioningProfile.id,
+        iosDistributionType: IosDistributionType.AppStore,
+      }
+    );
+  }
+
+  async getProvisioningProfileAsync(
+    ctx: Context
+  ): Promise<AppleProvisioningProfileFragment | null> {
+    const appCredentials = await ctx.newIos.getIosAppCredentialsWithBuildCredentialsAsync(
+      this.app,
+      {
+        iosDistributionType: IosDistributionType.AppStore,
+      }
+    );
+    if (!appCredentials || appCredentials.iosAppBuildCredentialsArray.length === 0) {
+      return null;
+    }
+    const [buildCredentials] = appCredentials.iosAppBuildCredentialsArray;
+    return buildCredentials.provisioningProfile ?? null;
+  }
+
+  async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+    const areBuildCredentialsSetup = await this.areBuildCredentialsSetupAsync(ctx);
+    if (areBuildCredentialsSetup) {
+      return;
+    }
+    if (ctx.nonInteractive) {
+      throw new Error(
+        'Provisioning profile is not configured correctly. Please run this command again in interactive mode.'
+      );
+    }
+
+    const distCertAction = new SetupDistributionCertificate(this.app, IosDistributionType.AppStore);
+    await manager.runActionAsync(distCertAction);
+    const distCert = distCertAction.distributionCertificate;
+
+    const currentProfile = await this.getProvisioningProfileAsync(ctx);
+    if (!currentProfile) {
+      await this.createAndAssignProfileAsync(manager, ctx, distCert);
+      return;
+    }
+    const existingProfiles = await ctx.appStore.listProvisioningProfilesAsync(
+      this.app.bundleIdentifier
+    );
+
+    if (existingProfiles.length === 0) {
+      return await this.assignNewAndDeleteOldProfileAsync(manager, ctx, distCert, currentProfile);
+    }
+
+    const currentProfileFromServer = this.getCurrentProfileStoreInfo(
+      existingProfiles,
+      currentProfile
+    );
+
+    if (!currentProfileFromServer) {
+      return await this.assignNewAndDeleteOldProfileAsync(manager, ctx, distCert, currentProfile);
+    }
+
+    const confirm = await confirmAsync({
+      message: `${formatProvisioningProfileFromApple(
+        currentProfileFromServer
+      )} \n  Would you like to reuse the original profile?`,
+    });
+    if (!confirm) {
+      return await this.assignNewAndDeleteOldProfileAsync(manager, ctx, distCert, currentProfile);
+    }
+    const updatedProfile = await this.configureAndAssignProfileAsync(ctx, distCert, currentProfile);
+    if (!updatedProfile) {
+      return await this.assignNewAndDeleteOldProfileAsync(manager, ctx, distCert, currentProfile);
+    }
+  }
+
+  private async isCurrentProfileValidAsync(
+    ctx: Context,
+    currentProfile: AppleProvisioningProfileFragment,
+    currentCertificate: AppleDistributionCertificateFragment
+  ): Promise<boolean> {
+    const { provisioningProfile, developerPortalIdentifier } = currentProfile;
+    const { certificateP12, certificatePassword } = currentCertificate;
+    if (!provisioningProfile || !certificateP12 || !certificatePassword) {
+      return false;
+    }
+    const validationResult = await validateProvisioningProfileAsync(
+      ctx,
+      {
+        provisioningProfile,
+        ...(developerPortalIdentifier
+          ? { provisioningProfileId: developerPortalIdentifier }
+          : null),
+      },
+      {
+        certP12: certificateP12,
+        certPassword: certificatePassword,
+      },
+      this.app.bundleIdentifier
+    );
+    if (!validationResult.ok) {
+      Log.warn(validationResult.error);
+      return false;
+    }
+    return true;
+  }
+
+  private getCurrentProfileStoreInfo(
+    profiles: ProvisioningProfileStoreInfo[],
+    currentProfile: AppleProvisioningProfileFragment
+  ): ProvisioningProfileStoreInfo | null {
+    return (
+      profiles.find(profile =>
+        currentProfile.developerPortalIdentifier
+          ? currentProfile.developerPortalIdentifier === profile.provisioningProfileId
+          : currentProfile.provisioningProfile === profile.provisioningProfile
+      ) ?? null
+    );
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/__mocks__/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__mocks__/ConfigureProvisioningProfile.ts
@@ -1,0 +1,20 @@
+import {
+  AppleDistributionCertificateFragment,
+  AppleProvisioningProfileFragment,
+} from '../../../../../graphql/generated';
+import { testProvisioningProfileFragment } from '../../../../__tests__/fixtures-ios';
+import { Context } from '../../../../context';
+import { AppLookupParams } from '../../../api/GraphqlClient';
+import { AppleProvisioningProfileMutationResult } from '../../../api/graphql/mutations/AppleProvisioningProfileMutation';
+
+export class ConfigureProvisioningProfile {
+  constructor(
+    private app: AppLookupParams,
+    private distributionCertificate: AppleDistributionCertificateFragment,
+    private originalProvisioningProfile: AppleProvisioningProfileFragment
+  ) {}
+
+  public async runAsync(ctx: Context): Promise<AppleProvisioningProfileMutationResult | null> {
+    return testProvisioningProfileFragment;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/__mocks__/CreateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__mocks__/CreateProvisioningProfile.ts
@@ -1,0 +1,16 @@
+import { AppleDistributionCertificateFragment } from '../../../../../graphql/generated';
+import { testProvisioningProfileFragment } from '../../../../__tests__/fixtures-ios';
+import { Context } from '../../../../context';
+import { AppLookupParams } from '../../../api/GraphqlClient';
+import { AppleProvisioningProfileMutationResult } from '../../../api/graphql/mutations/AppleProvisioningProfileMutation';
+
+export class CreateProvisioningProfile {
+  constructor(
+    private app: AppLookupParams,
+    private distributionCertificate: AppleDistributionCertificateFragment
+  ) {}
+
+  async runAsync(ctx: Context): Promise<AppleProvisioningProfileMutationResult> {
+    return testProvisioningProfileFragment;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/__mocks__/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__mocks__/SetupDistributionCertificate.ts
@@ -1,0 +1,17 @@
+import {
+  AppleDistributionCertificateFragment,
+  IosDistributionType,
+} from '../../../../../graphql/generated';
+import { Action, CredentialsManager } from '../../../../CredentialsManager';
+import { testDistCertFragmentOneDependency } from '../../../../__tests__/fixtures-ios';
+import { Context } from '../../../../context';
+import { AppLookupParams } from '../../../api/GraphqlClient';
+export class SetupDistributionCertificate implements Action {
+  constructor(private app: AppLookupParams, private distributionType: IosDistributionType) {}
+
+  public get distributionCertificate(): AppleDistributionCertificateFragment {
+    return testDistCertFragmentOneDependency;
+  }
+
+  public async runAsync(_manager: CredentialsManager, _ctx: Context): Promise<void> {}
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/CreateProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/CreateProvisioningProfile-test.ts
@@ -13,7 +13,6 @@ jest.mock('../../../../../prompts');
 
 describe('CreateProvisioningProfile', () => {
   it('creates a Provisioning Profile in Interactive Mode', async () => {
-    const manager = createManagerMock();
     const ctx = createCtxMock({
       nonInteractive: false,
       appStore: {
@@ -28,7 +27,7 @@ describe('CreateProvisioningProfile', () => {
       appLookupParams,
       testDistCertFragmentNoDependencies
     );
-    await createProvProfAction.runAsync(manager, ctx);
+    await createProvProfAction.runAsync(ctx);
 
     // expect provisioning profile to be created on expo servers
     expect((ctx.newIos.createProvisioningProfileAsync as any).mock.calls.length).toBe(1);
@@ -36,7 +35,6 @@ describe('CreateProvisioningProfile', () => {
     expect((ctx.appStore.createProvisioningProfileAsync as any).mock.calls.length).toBe(1);
   });
   it('errors in Non Interactive Mode', async () => {
-    const manager = createManagerMock();
     const ctx = createCtxMock({
       nonInteractive: true,
     });
@@ -45,7 +43,7 @@ describe('CreateProvisioningProfile', () => {
       appLookupParams,
       testDistCertFragmentNoDependencies
     );
-    await expect(createProvProfAction.runAsync(manager, ctx)).rejects.toThrowError(
+    await expect(createProvProfAction.runAsync(ctx)).rejects.toThrowError(
       MissingCredentialsNonInteractiveError
     );
 

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/CreateProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/CreateProvisioningProfile-test.ts
@@ -1,6 +1,6 @@
 import { confirmAsync } from '../../../../../prompts';
 import { getAppstoreMock, testAuthCtx } from '../../../../__tests__/fixtures-appstore';
-import { createCtxMock, createManagerMock } from '../../../../__tests__/fixtures-context';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
 import {
   testDistCertFragmentNoDependencies,
   testProvisioningProfile,

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupProvisioningProfile-test.ts
@@ -1,0 +1,162 @@
+import { confirmAsync } from '../../../../../prompts';
+import { getAppstoreMock, testAuthCtx } from '../../../../__tests__/fixtures-appstore';
+import { createCtxMock, createManagerMock } from '../../../../__tests__/fixtures-context';
+import {
+  testAppleAppIdentifierFragment,
+  testIosAppBuildCredentialsFragment,
+  testIosAppCredentialsWithBuildCredentialsQueryResult,
+} from '../../../../__tests__/fixtures-ios';
+import { getNewIosApiMockWithoutCredentials } from '../../../../__tests__/fixtures-new-ios';
+import { ManageIosBeta } from '../../../../manager/ManageIosBeta';
+import { MissingCredentialsNonInteractiveError } from '../../../errors';
+import { validateProvisioningProfileAsync } from '../../../validators/validateProvisioningProfile';
+import { SetupProvisioningProfile } from '../SetupProvisioningProfile';
+jest.mock('../../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+jest.mock('../SetupDistributionCertificate');
+jest.mock('../ConfigureProvisioningProfile');
+jest.mock('../CreateProvisioningProfile');
+jest.mock('../../../validators/validateProvisioningProfile');
+
+describe('SetupProvisioningProfile', () => {
+  it('repairs existing Provisioning Profile with bad build credentials in Interactive Mode', async () => {
+    (validateProvisioningProfileAsync as jest.Mock).mockImplementation(() => ({
+      error: 'testing: everything is fine, ignore this',
+      ok: false,
+    }));
+    const manager = createManagerMock();
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+        authCtx: testAuthCtx,
+        listProvisioningProfilesAsync: jest.fn(() => [
+          {
+            provisioningProfileId:
+              testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsArray[0]
+                .provisioningProfile.developerPortalIdentifier,
+          },
+        ]),
+      },
+      newIos: {
+        ...getNewIosApiMockWithoutCredentials(),
+        getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(
+          () => testIosAppCredentialsWithBuildCredentialsQueryResult
+        ),
+        createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
+        createOrUpdateIosAppBuildCredentialsAsync: jest.fn(
+          () => testIosAppBuildCredentialsFragment
+        ),
+      },
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
+    await setupProvisioningProfileAction.runAsync(manager, ctx);
+
+    // expect build credentials to be created or updated on expo servers
+    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
+    // expect provisioning profile not to be deleted on expo servers
+    expect((ctx.newIos.deleteProvisioningProfilesAsync as any).mock.calls.length).toBe(0);
+  });
+  it('sets up a new Provisioning Profile with bad build credentials in Interactive Mode', async () => {
+    (validateProvisioningProfileAsync as jest.Mock).mockImplementation(() => ({
+      error: 'testing: everything is fine, ignore this',
+      ok: false,
+    }));
+    const manager = createManagerMock();
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+        authCtx: testAuthCtx,
+        listProvisioningProfilesAsync: jest.fn(() => []),
+      },
+      newIos: {
+        ...getNewIosApiMockWithoutCredentials(),
+        getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(
+          () => testIosAppCredentialsWithBuildCredentialsQueryResult
+        ),
+        createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
+      },
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
+    await setupProvisioningProfileAction.runAsync(manager, ctx);
+
+    // expect build credentials to be created or updated on expo servers
+    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
+    // expect provisioning profile to be deleted on expo servers
+    expect((ctx.newIos.deleteProvisioningProfilesAsync as any).mock.calls.length).toBe(1);
+  });
+  it('skips setting up a Provisioning Profile with prior build credentials configured properly in Interactive Mode', async () => {
+    (validateProvisioningProfileAsync as jest.Mock).mockImplementation(() => ({
+      ok: true,
+    }));
+    const manager = createManagerMock();
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+        authCtx: testAuthCtx,
+        //listProvisioningProfilesAsync: jest.fn(() => []),
+      },
+      newIos: {
+        ...getNewIosApiMockWithoutCredentials(),
+        getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(
+          () => testIosAppCredentialsWithBuildCredentialsQueryResult
+        ),
+        createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
+      },
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
+    await setupProvisioningProfileAction.runAsync(manager, ctx);
+
+    // expect build credentials not to be created or updated on expo servers
+    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(0);
+    // expect provisioning profile not to be deleted on expo servers
+    expect((ctx.newIos.deleteProvisioningProfilesAsync as any).mock.calls.length).toBe(0);
+  });
+  it('sets up a Provisioning Profile with no prior build credentials configured in Interactive Mode', async () => {
+    const manager = createManagerMock();
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+        authCtx: testAuthCtx,
+      },
+      newIos: {
+        ...getNewIosApiMockWithoutCredentials(),
+        createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
+      },
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
+    await setupProvisioningProfileAction.runAsync(manager, ctx);
+
+    // expect build credentials to be created or updated on expo servers
+    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
+    // expect provisioning profile not to be deleted on expo servers
+    expect((ctx.newIos.deleteProvisioningProfilesAsync as any).mock.calls.length).toBe(0);
+  });
+  it('errors in Non Interactive Mode', async () => {
+    const manager = createManagerMock();
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
+    await expect(setupProvisioningProfileAction.runAsync(manager, ctx)).rejects.toThrowError(
+      MissingCredentialsNonInteractiveError
+    );
+
+    // expect build credentials not to be created or updated on expo servers
+    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(0);
+    // expect provisioning profile not to be deleted on expo servers
+    expect((ctx.newIos.deleteProvisioningProfilesAsync as any).mock.calls.length).toBe(0);
+  });
+});

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4342,7 +4342,7 @@ export type AppleDistributionCertificateFragment = (
 
 export type AppleProvisioningProfileFragment = (
   { __typename?: 'AppleProvisioningProfile' }
-  & Pick<AppleProvisioningProfile, 'id' | 'expiration' | 'developerPortalIdentifier' | 'provisioningProfile'>
+  & Pick<AppleProvisioningProfile, 'id' | 'expiration' | 'developerPortalIdentifier' | 'provisioningProfile' | 'updatedAt' | 'status'>
   & { appleTeam?: Maybe<(
     { __typename?: 'AppleTeam' }
     & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
@@ -4367,21 +4367,12 @@ export type IosAppBuildCredentialsFragment = (
   & Pick<IosAppBuildCredentials, 'id' | 'iosDistributionType'>
   & { distributionCertificate?: Maybe<(
     { __typename?: 'AppleDistributionCertificate' }
-    & Pick<AppleDistributionCertificate, 'id' | 'certificateP12' | 'certificatePassword' | 'serialNumber' | 'developerPortalIdentifier' | 'validityNotBefore' | 'validityNotAfter' | 'updatedAt'>
-    & { appleTeam?: Maybe<(
-      { __typename?: 'AppleTeam' }
-      & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
-    )> }
+    & Pick<AppleDistributionCertificate, 'id'>
+    & AppleDistributionCertificateFragment
   )>, provisioningProfile?: Maybe<(
     { __typename?: 'AppleProvisioningProfile' }
-    & Pick<AppleProvisioningProfile, 'id' | 'expiration' | 'developerPortalIdentifier' | 'provisioningProfile' | 'updatedAt' | 'status'>
-    & { appleDevices: Array<(
-      { __typename?: 'AppleDevice' }
-      & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'model' | 'deviceClass'>
-    )>, appleTeam?: Maybe<(
-      { __typename?: 'AppleTeam' }
-      & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
-    )> }
+    & Pick<AppleProvisioningProfile, 'id'>
+    & AppleProvisioningProfileFragment
   )> }
 );
 

--- a/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
@@ -6,6 +6,8 @@ export const AppleProvisioningProfileFragmentNode = gql`
     expiration
     developerPortalIdentifier
     provisioningProfile
+    updatedAt
+    status
     appleTeam {
       id
       appleTeamIdentifier

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppBuildCredentials.ts
@@ -1,4 +1,8 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
+
+import { AppleDistributionCertificateFragmentNode } from './AppleDistributionCertificate';
+import { AppleProvisioningProfileFragmentNode } from './AppleProvisioningProfile';
 
 export const IosAppBuildCredentialsFragmentNode = gql`
   fragment IosAppBuildCredentialsFragment on IosAppBuildCredentials {
@@ -6,38 +10,13 @@ export const IosAppBuildCredentialsFragmentNode = gql`
     iosDistributionType
     distributionCertificate {
       id
-      certificateP12
-      certificatePassword
-      serialNumber
-      developerPortalIdentifier
-      validityNotBefore
-      validityNotAfter
-      updatedAt
-      appleTeam {
-        id
-        appleTeamIdentifier
-        appleTeamName
-      }
+      ...AppleDistributionCertificateFragment
     }
     provisioningProfile {
       id
-      expiration
-      developerPortalIdentifier
-      provisioningProfile
-      updatedAt
-      status
-      appleDevices {
-        id
-        identifier
-        name
-        model
-        deviceClass
-      }
-      appleTeam {
-        id
-        appleTeamIdentifier
-        appleTeamName
-      }
+      ...AppleProvisioningProfileFragment
     }
   }
+  ${print(AppleDistributionCertificateFragmentNode)}
+  ${print(AppleProvisioningProfileFragmentNode)}
 `;


### PR DESCRIPTION
# Why

This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to create a provisioning profile using the new Graphql Api. This will eventually replace the old `SetupProvisioningProfile` here:  https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts


# Notable Changes
Flow works the following way now:
- check to see if user has valid build credentials
- continue if build credentials aren't fully configured
- if there is something wrong with current profile, try to fix it
- else just create a new profile

# Test Plan

- [x] new tests pass
