### PR TITLE
unhide secrets:create and secrets:delete

### DIFF
--- a/packages/eas-cli/src/commands/secrets/create.ts
+++ b/packages/eas-cli/src/commands/secrets/create.ts
@@ -20,7 +20,6 @@ export enum EnvironmentSecretTargetLocation {
   PROJECT = 'project',
 }
 export default class EnvironmentSecretCreate extends Command {
-  static hidden = true;
   static description = 'Create an environment secret on the current project or owner account.';
 
   static args = [

--- a/packages/eas-cli/src/commands/secrets/delete.ts
+++ b/packages/eas-cli/src/commands/secrets/delete.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@expo/config';
 import { Command } from '@oclif/command';
+import chalk from 'chalk';
 
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
 import Log from '../../log';
@@ -12,11 +13,8 @@ import { toggleConfirmAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';
 
 export default class EnvironmentSecretDelete extends Command {
-  static hidden = true;
-  static description = `
-Delete an environment secret by ID.
-Unsure where to find the secret's ID? Run ${'`eas secrets:list`'}
-  `;
+  static description = `Delete an environment secret by ID.
+Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
 
   static args = [
     {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

`secrets:list` is already visible in the help output.

# How

- I unhide the `secrets:create` and `secrets:delete` commands.
- I updated the `secrets:delete` description (removed the first empty line) so it's visible in the `eas secrets --help output`.

# Test Plan

Before

<img width="948" alt="Screenshot 2021-04-01 at 10 47 03" src="https://user-images.githubusercontent.com/5256730/113268900-3255b100-92d8-11eb-9e12-049508f92a39.png">

After

<img width="1200" alt="Screenshot 2021-04-01 at 10 53 09" src="https://user-images.githubusercontent.com/5256730/113269168-79dc3d00-92d8-11eb-91d0-d2e986c94370.png">

