### PR TITLE
eas build - use GraphQL instead of REST endpoints

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -13650,11 +13650,1494 @@
             },
             "isDeprecated": true,
             "deprecationReason": "Use cancelBuild instead"
+          },
+          {
+            "name": "createAndroidGenericBuild",
+            "description": "Create an Android generic build",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "job",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AndroidGenericJobInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildMetadataInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateBuildResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createAndroidManagedBuild",
+            "description": "Create an Android managed build",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "job",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AndroidManagedJobInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildMetadataInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateBuildResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createIosGenericBuild",
+            "description": "Create an iOS generic build",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "job",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "IosGenericJobInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildMetadataInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateBuildResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createIosManagedBuild",
+            "description": "Create an iOS managed build",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "job",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "IosManagedJobInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildMetadataInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateBuildResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidGenericJobInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "projectArchive",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectArchiveSourceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secrets",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "builderEnvironment",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidBuilderEnvironmentInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cache",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "gradleCommand",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "artifactPath",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectArchiveSourceInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "type",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProjectArchiveSourceType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "bucketKey",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "url",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ProjectArchiveSourceType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "S3",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "URL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidJobSecretsInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "buildCredentials",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidJobBuildCredentialsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "environmentSecrets",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidJobBuildCredentialsInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "keystore",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "AndroidJobKeystoreInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidJobKeystoreInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "dataBase64",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "keystorePassword",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "keyAlias",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "keyPassword",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidBuilderEnvironmentInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "image",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "node",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "yarn",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "ndk",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "env",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BuildCacheInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "disabled",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "key",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cacheDefaultPaths",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "customPaths",
+            "description": "",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BuildMetadataInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "trackingContext",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "appVersion",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cliVersion",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "workflow",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildWorkflow",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "credentialsSource",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildCredentialsSource",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "sdkVersion",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "distribution",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "DistributionType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "appName",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "appIdentifier",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "buildProfile",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "gitCommitHash",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BuildWorkflow",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "GENERIC",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MANAGED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BuildCredentialsSource",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "LOCAL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REMOTE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CreateBuildResult",
+        "description": "",
+        "fields": [
+          {
+            "name": "build",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Build",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deprecationInfo",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EASBuildDeprecationInfo",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EASBuildDeprecationInfo",
+        "description": "",
+        "fields": [
+          {
+            "name": "type",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASBuildDeprecationInfoType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EASBuildDeprecationInfoType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "USER_FACING",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INTERNAL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidManagedJobInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "projectArchive",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectArchiveSourceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secrets",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "builderEnvironment",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidBuilderEnvironmentInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cache",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "username",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosGenericJobInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "projectArchive",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectArchiveSourceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "distribution",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "DistributionType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secrets",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IosJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "builderEnvironment",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IosBuilderEnvironmentInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cache",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "scheme",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "schemeBuildConfiguration",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "IosSchemeBuildConfiguration",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "artifactPath",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosJobSecretsInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "buildCredentials",
+            "description": "",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "IosJobTargetCredentialsInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "environmentSecrets",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosJobTargetCredentialsInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "targetName",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "provisioningProfileBase64",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "distributionCertificate",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "IosJobDistributionCertificateInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosJobDistributionCertificateInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "dataBase64",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "password",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosBuilderEnvironmentInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "image",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "node",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "yarn",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "bundler",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "fastlane",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cocoapods",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "env",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "IosSchemeBuildConfiguration",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "RELEASE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DEBUG",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosManagedJobInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "projectArchive",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectArchiveSourceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "distribution",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "DistributionType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secrets",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IosJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "builderEnvironment",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IosBuilderEnvironmentInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cache",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "buildType",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "IosManagedBuildType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "username",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "IosManagedBuildType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "RELEASE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DEVELOPMENT_CLIENT",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/src/build/android/graphql.ts
+++ b/packages/eas-cli/src/build/android/graphql.ts
@@ -1,0 +1,29 @@
+import { Android } from '@expo/eas-build-job';
+
+import { AndroidGenericJobInput, AndroidManagedJobInput } from '../../graphql/generated';
+import { transformProjectArchive } from '../graphql';
+
+export function transformGenericJob(job: Android.GenericJob): AndroidGenericJobInput {
+  return {
+    projectArchive: transformProjectArchive(job.projectArchive),
+    projectRootDirectory: job.projectRootDirectory,
+    releaseChannel: job.releaseChannel,
+    secrets: job.secrets,
+    builderEnvironment: job.builderEnvironment,
+    cache: job.cache,
+    gradleCommand: job.gradleCommand,
+    artifactPath: job.artifactPath,
+  };
+}
+
+export function transformManagedJob(job: Android.ManagedJob): AndroidManagedJobInput {
+  return {
+    projectArchive: transformProjectArchive(job.projectArchive),
+    projectRootDirectory: job.projectRootDirectory,
+    releaseChannel: job.releaseChannel,
+    secrets: job.secrets,
+    builderEnvironment: job.builderEnvironment,
+    cache: job.cache,
+    username: job.username,
+  };
+}

--- a/packages/eas-cli/src/build/graphql.ts
+++ b/packages/eas-cli/src/build/graphql.ts
@@ -1,0 +1,72 @@
+import { ArchiveSource, ArchiveSourceType, Metadata, Workflow } from '@expo/eas-build-job';
+
+import {
+  BuildCredentialsSource,
+  BuildMetadataInput,
+  BuildWorkflow,
+  DistributionType,
+  ProjectArchiveSourceInput,
+  ProjectArchiveSourceType,
+} from '../graphql/generated';
+
+export function transformProjectArchive(archiveSource: ArchiveSource): ProjectArchiveSourceInput {
+  if (archiveSource.type === ArchiveSourceType.S3) {
+    return {
+      type: ProjectArchiveSourceType.S3,
+      bucketKey: archiveSource.bucketKey,
+    };
+  } else if (archiveSource.type === ArchiveSourceType.URL) {
+    return {
+      type: ProjectArchiveSourceType.Url,
+      url: archiveSource.url,
+    };
+  } else {
+    throw new Error(`Unsupported project archive source type: '${archiveSource.type}'`);
+  }
+}
+
+export function transformMetadata(metadata: Metadata): BuildMetadataInput {
+  return {
+    appIdentifier: metadata.appIdentifier,
+    appName: metadata.appName,
+    appVersion: metadata.appVersion,
+    buildProfile: metadata.buildProfile,
+    cliVersion: metadata.cliVersion,
+    credentialsSource:
+      metadata.credentialsSource && transformCredentialsSource(metadata.credentialsSource),
+    distribution: metadata.distribution && transformDistribution(metadata.distribution),
+    gitCommitHash: metadata.gitCommitHash,
+    releaseChannel: metadata.releaseChannel,
+    sdkVersion: metadata.sdkVersion,
+    trackingContext: metadata.trackingContext,
+    workflow: metadata.workflow && transformWorkflow(metadata.workflow),
+  };
+}
+
+function transformCredentialsSource(
+  credentialsSource: Metadata['credentialsSource']
+): BuildCredentialsSource {
+  if (credentialsSource === 'local') {
+    return BuildCredentialsSource.Local;
+  } else {
+    return BuildCredentialsSource.Remote;
+  }
+}
+
+function transformDistribution(distribution: Metadata['distribution']): DistributionType {
+  if (distribution === 'internal') {
+    return DistributionType.Internal;
+  } else if (distribution === 'simulator') {
+    return DistributionType.Simulator;
+  } else {
+    return DistributionType.Store;
+  }
+}
+
+function transformWorkflow(workflow: Metadata['workflow']): BuildWorkflow {
+  if (workflow === Workflow.GENERIC) {
+    return BuildWorkflow.Generic;
+  } else {
+    return BuildWorkflow.Managed;
+  }
+}

--- a/packages/eas-cli/src/build/ios/graphql.ts
+++ b/packages/eas-cli/src/build/ios/graphql.ts
@@ -1,0 +1,93 @@
+import { Env, Ios } from '@expo/eas-build-job';
+import nullthrows from 'nullthrows';
+
+import {
+  DistributionType,
+  IosGenericJobInput,
+  IosJobSecretsInput,
+  IosManagedBuildType,
+  IosManagedJobInput,
+  IosSchemeBuildConfiguration,
+} from '../../graphql/generated';
+import { transformProjectArchive } from '../graphql';
+
+export function transformGenericJob(job: Ios.GenericJob): IosGenericJobInput {
+  return {
+    projectArchive: transformProjectArchive(job.projectArchive),
+    projectRootDirectory: job.projectRootDirectory,
+    releaseChannel: job.releaseChannel,
+    distribution: job.distribution && transformDistributionType(job.distribution),
+    secrets: transformIosSecrets(job.secrets),
+    builderEnvironment: job.builderEnvironment,
+    cache: job.cache,
+    scheme: job.scheme,
+    schemeBuildConfiguration:
+      job.schemeBuildConfiguration &&
+      transformSchemeBuildConfiguration(job.schemeBuildConfiguration),
+    artifactPath: job.artifactPath,
+  };
+}
+
+export function transformManagedJob(job: Ios.ManagedJob): IosManagedJobInput {
+  return {
+    projectArchive: transformProjectArchive(job.projectArchive),
+    projectRootDirectory: job.projectRootDirectory,
+    releaseChannel: job.releaseChannel,
+    distribution: job.distribution && transformDistributionType(job.distribution),
+    secrets: transformIosSecrets(job.secrets),
+    builderEnvironment: job.builderEnvironment,
+    cache: job.cache,
+    buildType: job.buildType && transformBuildType(job.buildType),
+    username: job.username,
+  };
+}
+
+function transformDistributionType(distributionType: Ios.DistributionType): DistributionType {
+  if (distributionType === 'store') {
+    return DistributionType.Store;
+  } else if (distributionType === 'internal') {
+    return DistributionType.Internal;
+  } else {
+    return DistributionType.Simulator;
+  }
+}
+
+function transformIosSecrets(secrets: {
+  buildCredentials?: Ios.BuildCredentials;
+  env?: Env;
+}): IosJobSecretsInput {
+  const buildCredentials: IosJobSecretsInput['buildCredentials'] = [];
+
+  for (const targetName of Object.keys(secrets.buildCredentials ?? {})) {
+    buildCredentials.push({
+      targetName,
+      provisioningProfileBase64: nullthrows(secrets.buildCredentials?.[targetName])
+        .provisioningProfileBase64,
+      distributionCertificate: nullthrows(secrets.buildCredentials?.[targetName])
+        .distributionCertificate,
+    });
+  }
+
+  return {
+    buildCredentials,
+    environmentSecrets: secrets.env,
+  };
+}
+
+function transformSchemeBuildConfiguration(
+  schemeBuildConfiguration: Ios.SchemeBuildConfiguration
+): IosSchemeBuildConfiguration {
+  if (schemeBuildConfiguration === Ios.SchemeBuildConfiguration.DEBUG) {
+    return IosSchemeBuildConfiguration.Debug;
+  } else {
+    return IosSchemeBuildConfiguration.Release;
+  }
+}
+
+function transformBuildType(buildType: Ios.ManagedBuildType): IosManagedBuildType {
+  if (buildType === Ios.ManagedBuildType.DEVELOPMENT_CLIENT) {
+    return IosManagedBuildType.DevelopmentClient;
+  } else {
+    return IosManagedBuildType.Release;
+  }
+}

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -2,15 +2,11 @@ import { errors } from '@expo/eas-build-job';
 import assert from 'assert';
 import chalk from 'chalk';
 
+import { EasBuildDeprecationInfo, EasBuildDeprecationInfoType } from '../../graphql/generated';
 import Log, { learnMore } from '../../log';
 import { platformEmojis, requestedPlatformDisplayNames } from '../constants';
 import { Build } from '../types';
 import { getBuildLogsUrl } from './url';
-
-export interface DeprecationInfo {
-  type: 'user-facing' | 'internal';
-  message: string;
-}
 
 export function printLogsUrls(
   accountName: string,
@@ -92,15 +88,15 @@ function printBuildResult(accountName: string, build: Build): void {
   }
 }
 
-export function printDeprecationWarnings(deprecationInfo?: DeprecationInfo): void {
+export function printDeprecationWarnings(deprecationInfo?: EasBuildDeprecationInfo | null): void {
   if (!deprecationInfo) {
     return;
   }
-  if (deprecationInfo.type === 'internal') {
+  if (deprecationInfo.type === EasBuildDeprecationInfoType.Internal) {
     Log.warn('This command is using API that soon will be deprecated, please update eas-cli.');
     Log.warn("Changes won't affect your project config.");
     Log.warn(deprecationInfo.message);
-  } else if (deprecationInfo.type === 'user-facing') {
+  } else if (deprecationInfo.type === EasBuildDeprecationInfoType.UserFacing) {
     Log.warn('This command is using API that soon will be deprecated, please update eas-cli.');
     Log.warn(
       'There might be some changes necessary to your project config, latest eas-cli will provide more specific error messages.'

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2111,12 +2111,214 @@ export type BuildMutation = {
    * @deprecated Use cancelBuild instead
    */
   cancel: Build;
+  /** Create an Android generic build */
+  createAndroidGenericBuild: CreateBuildResult;
+  /** Create an Android managed build */
+  createAndroidManagedBuild: CreateBuildResult;
+  /** Create an iOS generic build */
+  createIosGenericBuild: CreateBuildResult;
+  /** Create an iOS managed build */
+  createIosManagedBuild: CreateBuildResult;
 };
 
 
 export type BuildMutationCancelBuildArgs = {
   buildId: Scalars['ID'];
 };
+
+
+export type BuildMutationCreateAndroidGenericBuildArgs = {
+  appId: Scalars['ID'];
+  job: AndroidGenericJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+};
+
+
+export type BuildMutationCreateAndroidManagedBuildArgs = {
+  appId: Scalars['ID'];
+  job: AndroidManagedJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+};
+
+
+export type BuildMutationCreateIosGenericBuildArgs = {
+  appId: Scalars['ID'];
+  job: IosGenericJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+};
+
+
+export type BuildMutationCreateIosManagedBuildArgs = {
+  appId: Scalars['ID'];
+  job: IosManagedJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+};
+
+export type AndroidGenericJobInput = {
+  projectArchive: ProjectArchiveSourceInput;
+  projectRootDirectory: Scalars['String'];
+  releaseChannel?: Maybe<Scalars['String']>;
+  secrets?: Maybe<AndroidJobSecretsInput>;
+  builderEnvironment?: Maybe<AndroidBuilderEnvironmentInput>;
+  cache?: Maybe<BuildCacheInput>;
+  gradleCommand?: Maybe<Scalars['String']>;
+  artifactPath?: Maybe<Scalars['String']>;
+};
+
+export type ProjectArchiveSourceInput = {
+  type: ProjectArchiveSourceType;
+  bucketKey?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']>;
+};
+
+export enum ProjectArchiveSourceType {
+  S3 = 'S3',
+  Url = 'URL'
+}
+
+export type AndroidJobSecretsInput = {
+  buildCredentials?: Maybe<AndroidJobBuildCredentialsInput>;
+  environmentSecrets?: Maybe<Scalars['JSONObject']>;
+};
+
+export type AndroidJobBuildCredentialsInput = {
+  keystore: AndroidJobKeystoreInput;
+};
+
+export type AndroidJobKeystoreInput = {
+  dataBase64: Scalars['String'];
+  keystorePassword: Scalars['String'];
+  keyAlias: Scalars['String'];
+  keyPassword: Scalars['String'];
+};
+
+export type AndroidBuilderEnvironmentInput = {
+  image?: Maybe<Scalars['String']>;
+  node?: Maybe<Scalars['String']>;
+  yarn?: Maybe<Scalars['String']>;
+  ndk?: Maybe<Scalars['String']>;
+  env?: Maybe<Scalars['JSONObject']>;
+};
+
+export type BuildCacheInput = {
+  disabled?: Maybe<Scalars['Boolean']>;
+  key?: Maybe<Scalars['String']>;
+  cacheDefaultPaths?: Maybe<Scalars['Boolean']>;
+  customPaths?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type BuildMetadataInput = {
+  trackingContext?: Maybe<Scalars['JSONObject']>;
+  appVersion?: Maybe<Scalars['String']>;
+  cliVersion?: Maybe<Scalars['String']>;
+  workflow?: Maybe<BuildWorkflow>;
+  credentialsSource?: Maybe<BuildCredentialsSource>;
+  sdkVersion?: Maybe<Scalars['String']>;
+  releaseChannel?: Maybe<Scalars['String']>;
+  distribution?: Maybe<DistributionType>;
+  appName?: Maybe<Scalars['String']>;
+  appIdentifier?: Maybe<Scalars['String']>;
+  buildProfile?: Maybe<Scalars['String']>;
+  gitCommitHash?: Maybe<Scalars['String']>;
+};
+
+export enum BuildWorkflow {
+  Generic = 'GENERIC',
+  Managed = 'MANAGED'
+}
+
+export enum BuildCredentialsSource {
+  Local = 'LOCAL',
+  Remote = 'REMOTE'
+}
+
+export type CreateBuildResult = {
+  __typename?: 'CreateBuildResult';
+  build: Build;
+  deprecationInfo?: Maybe<EasBuildDeprecationInfo>;
+};
+
+export type EasBuildDeprecationInfo = {
+  __typename?: 'EASBuildDeprecationInfo';
+  type: EasBuildDeprecationInfoType;
+  message: Scalars['String'];
+};
+
+export enum EasBuildDeprecationInfoType {
+  UserFacing = 'USER_FACING',
+  Internal = 'INTERNAL'
+}
+
+export type AndroidManagedJobInput = {
+  projectArchive: ProjectArchiveSourceInput;
+  projectRootDirectory: Scalars['String'];
+  releaseChannel?: Maybe<Scalars['String']>;
+  secrets?: Maybe<AndroidJobSecretsInput>;
+  builderEnvironment?: Maybe<AndroidBuilderEnvironmentInput>;
+  cache?: Maybe<BuildCacheInput>;
+  username?: Maybe<Scalars['String']>;
+};
+
+export type IosGenericJobInput = {
+  projectArchive: ProjectArchiveSourceInput;
+  projectRootDirectory: Scalars['String'];
+  releaseChannel?: Maybe<Scalars['String']>;
+  distribution?: Maybe<DistributionType>;
+  secrets?: Maybe<IosJobSecretsInput>;
+  builderEnvironment?: Maybe<IosBuilderEnvironmentInput>;
+  cache?: Maybe<BuildCacheInput>;
+  scheme: Scalars['String'];
+  schemeBuildConfiguration?: Maybe<IosSchemeBuildConfiguration>;
+  artifactPath?: Maybe<Scalars['String']>;
+};
+
+export type IosJobSecretsInput = {
+  buildCredentials?: Maybe<Array<Maybe<IosJobTargetCredentialsInput>>>;
+  environmentSecrets?: Maybe<Scalars['JSONObject']>;
+};
+
+export type IosJobTargetCredentialsInput = {
+  targetName: Scalars['String'];
+  provisioningProfileBase64: Scalars['String'];
+  distributionCertificate: IosJobDistributionCertificateInput;
+};
+
+export type IosJobDistributionCertificateInput = {
+  dataBase64: Scalars['String'];
+  password: Scalars['String'];
+};
+
+export type IosBuilderEnvironmentInput = {
+  image?: Maybe<Scalars['String']>;
+  node?: Maybe<Scalars['String']>;
+  yarn?: Maybe<Scalars['String']>;
+  bundler?: Maybe<Scalars['String']>;
+  fastlane?: Maybe<Scalars['String']>;
+  cocoapods?: Maybe<Scalars['String']>;
+  env?: Maybe<Scalars['JSONObject']>;
+};
+
+export enum IosSchemeBuildConfiguration {
+  Release = 'RELEASE',
+  Debug = 'DEBUG'
+}
+
+export type IosManagedJobInput = {
+  projectArchive: ProjectArchiveSourceInput;
+  projectRootDirectory: Scalars['String'];
+  releaseChannel?: Maybe<Scalars['String']>;
+  distribution?: Maybe<DistributionType>;
+  secrets?: Maybe<IosJobSecretsInput>;
+  builderEnvironment?: Maybe<IosBuilderEnvironmentInput>;
+  cache?: Maybe<BuildCacheInput>;
+  buildType?: Maybe<IosManagedBuildType>;
+  username?: Maybe<Scalars['String']>;
+};
+
+export enum IosManagedBuildType {
+  Release = 'RELEASE',
+  DevelopmentClient = 'DEVELOPMENT_CLIENT'
+}
 
 export type IosAppBuildCredentialsMutation = {
   __typename?: 'IosAppBuildCredentialsMutation';
@@ -3674,6 +3876,102 @@ export type CreateAppMutation = (
     & { createApp: (
       { __typename?: 'App' }
       & Pick<App, 'id'>
+    ) }
+  )> }
+);
+
+export type CreateAndroidGenericBuildMutationVariables = Exact<{
+  appId: Scalars['ID'];
+  job: AndroidGenericJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+}>;
+
+
+export type CreateAndroidGenericBuildMutation = (
+  { __typename?: 'RootMutation' }
+  & { build?: Maybe<(
+    { __typename?: 'BuildMutation' }
+    & { createAndroidGenericBuild: (
+      { __typename?: 'CreateBuildResult' }
+      & { build: (
+        { __typename?: 'Build' }
+        & Pick<Build, 'id'>
+      ), deprecationInfo?: Maybe<(
+        { __typename?: 'EASBuildDeprecationInfo' }
+        & Pick<EasBuildDeprecationInfo, 'type' | 'message'>
+      )> }
+    ) }
+  )> }
+);
+
+export type CreateAndroidManagedBuildMutationVariables = Exact<{
+  appId: Scalars['ID'];
+  job: AndroidManagedJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+}>;
+
+
+export type CreateAndroidManagedBuildMutation = (
+  { __typename?: 'RootMutation' }
+  & { build?: Maybe<(
+    { __typename?: 'BuildMutation' }
+    & { createAndroidManagedBuild: (
+      { __typename?: 'CreateBuildResult' }
+      & { build: (
+        { __typename?: 'Build' }
+        & Pick<Build, 'id'>
+      ), deprecationInfo?: Maybe<(
+        { __typename?: 'EASBuildDeprecationInfo' }
+        & Pick<EasBuildDeprecationInfo, 'type' | 'message'>
+      )> }
+    ) }
+  )> }
+);
+
+export type CreateIosGenericBuildMutationVariables = Exact<{
+  appId: Scalars['ID'];
+  job: IosGenericJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+}>;
+
+
+export type CreateIosGenericBuildMutation = (
+  { __typename?: 'RootMutation' }
+  & { build?: Maybe<(
+    { __typename?: 'BuildMutation' }
+    & { createIosGenericBuild: (
+      { __typename?: 'CreateBuildResult' }
+      & { build: (
+        { __typename?: 'Build' }
+        & Pick<Build, 'id'>
+      ), deprecationInfo?: Maybe<(
+        { __typename?: 'EASBuildDeprecationInfo' }
+        & Pick<EasBuildDeprecationInfo, 'type' | 'message'>
+      )> }
+    ) }
+  )> }
+);
+
+export type CreateIosManagedBuildMutationVariables = Exact<{
+  appId: Scalars['ID'];
+  job: IosManagedJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+}>;
+
+
+export type CreateIosManagedBuildMutation = (
+  { __typename?: 'RootMutation' }
+  & { build?: Maybe<(
+    { __typename?: 'BuildMutation' }
+    & { createIosManagedBuild: (
+      { __typename?: 'CreateBuildResult' }
+      & { build: (
+        { __typename?: 'Build' }
+        & Pick<Build, 'id'>
+      ), deprecationInfo?: Maybe<(
+        { __typename?: 'EASBuildDeprecationInfo' }
+        & Pick<EasBuildDeprecationInfo, 'type' | 'message'>
+      )> }
     ) }
   )> }
 );

--- a/packages/eas-cli/src/graphql/mutations/BuildMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/BuildMutation.ts
@@ -1,0 +1,162 @@
+import gql from 'graphql-tag';
+import nullthrows from 'nullthrows';
+
+import { graphqlClient, withErrorHandlingAsync } from '../client';
+import {
+  AndroidGenericJobInput,
+  AndroidManagedJobInput,
+  BuildMetadataInput,
+  CreateAndroidGenericBuildMutation,
+  CreateAndroidGenericBuildMutationVariables,
+  CreateAndroidManagedBuildMutation,
+  CreateAndroidManagedBuildMutationVariables,
+  CreateIosGenericBuildMutation,
+  CreateIosGenericBuildMutationVariables,
+  CreateIosManagedBuildMutation,
+  CreateIosManagedBuildMutationVariables,
+  EasBuildDeprecationInfo,
+  IosGenericJobInput,
+  IosManagedJobInput,
+} from '../generated';
+
+export interface BuildResult {
+  build: { id: string };
+  deprecationInfo?: EasBuildDeprecationInfo | null;
+}
+
+const BuildMutation = {
+  async createAndroidGenericBuildAsync(input: {
+    appId: string;
+    job: AndroidGenericJobInput;
+    metadata: BuildMetadataInput;
+  }): Promise<BuildResult> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateAndroidGenericBuildMutation, CreateAndroidGenericBuildMutationVariables>(
+          gql`
+            mutation CreateAndroidGenericBuildMutation(
+              $appId: ID!
+              $job: AndroidGenericJobInput!
+              $metadata: BuildMetadataInput
+            ) {
+              build {
+                createAndroidGenericBuild(appId: $appId, job: $job, metadata: $metadata) {
+                  build {
+                    id
+                  }
+                  deprecationInfo {
+                    type
+                    message
+                  }
+                }
+              }
+            }
+          `,
+          input
+        )
+        .toPromise()
+    );
+    return nullthrows(data.build?.createAndroidGenericBuild);
+  },
+  async createAndroidManagedBuildAsync(input: {
+    appId: string;
+    job: AndroidManagedJobInput;
+    metadata: BuildMetadataInput;
+  }): Promise<BuildResult> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateAndroidManagedBuildMutation, CreateAndroidManagedBuildMutationVariables>(
+          gql`
+            mutation CreateAndroidManagedBuildMutation(
+              $appId: ID!
+              $job: AndroidManagedJobInput!
+              $metadata: BuildMetadataInput
+            ) {
+              build {
+                createAndroidManagedBuild(appId: $appId, job: $job, metadata: $metadata) {
+                  build {
+                    id
+                  }
+                  deprecationInfo {
+                    type
+                    message
+                  }
+                }
+              }
+            }
+          `,
+          input
+        )
+        .toPromise()
+    );
+    return nullthrows(data.build?.createAndroidManagedBuild);
+  },
+  async createIosGenericBuildAsync(input: {
+    appId: string;
+    job: IosGenericJobInput;
+    metadata: BuildMetadataInput;
+  }): Promise<BuildResult> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateIosGenericBuildMutation, CreateIosGenericBuildMutationVariables>(
+          gql`
+            mutation CreateIosGenericBuildMutation(
+              $appId: ID!
+              $job: IosGenericJobInput!
+              $metadata: BuildMetadataInput
+            ) {
+              build {
+                createIosGenericBuild(appId: $appId, job: $job, metadata: $metadata) {
+                  build {
+                    id
+                  }
+                  deprecationInfo {
+                    type
+                    message
+                  }
+                }
+              }
+            }
+          `,
+          input
+        )
+        .toPromise()
+    );
+    return nullthrows(data.build?.createIosGenericBuild);
+  },
+  async createIosManagedBuildAsync(input: {
+    appId: string;
+    job: IosManagedJobInput;
+    metadata: BuildMetadataInput;
+  }): Promise<BuildResult> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateIosManagedBuildMutation, CreateIosManagedBuildMutationVariables>(
+          gql`
+            mutation CreateIosManagedBuildMutation(
+              $appId: ID!
+              $job: IosManagedJobInput!
+              $metadata: BuildMetadataInput
+            ) {
+              build {
+                createIosManagedBuild(appId: $appId, job: $job, metadata: $metadata) {
+                  build {
+                    id
+                  }
+                  deprecationInfo {
+                    type
+                    message
+                  }
+                }
+              }
+            }
+          `,
+          input
+        )
+        .toPromise()
+    );
+    return nullthrows(data.build?.createIosManagedBuild);
+  },
+};
+
+export { BuildMutation };


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://github.com/expo/universe/pull/7247 added graphql mutations for creating builds.
This PR uses those instead of the REST endpoints.

# How

I replaced the REST endpoint calls with graphql mutation calls.

# Test Plan

I ran `eas build` for both platforms for two projects: managed and generic. 