### PR TITLE
[eas-cli] Add branch mapping to channel list command

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1399,6 +1399,22 @@
             "deprecationReason": null
           },
           {
+            "name": "appCount",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildJobs",
             "description": "Build Jobs associated with this account",
             "args": [
@@ -5246,15 +5262,35 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "message",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "docsUrl",
             "description": "",
             "args": [],
             "type": {
@@ -13634,11 +13670,1494 @@
             },
             "isDeprecated": true,
             "deprecationReason": "Use cancelBuild instead"
+          },
+          {
+            "name": "createAndroidGenericBuild",
+            "description": "Create an Android generic build",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "job",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AndroidGenericJobInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildMetadataInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateBuildResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createAndroidManagedBuild",
+            "description": "Create an Android managed build",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "job",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AndroidManagedJobInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildMetadataInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateBuildResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createIosGenericBuild",
+            "description": "Create an iOS generic build",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "job",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "IosGenericJobInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildMetadataInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateBuildResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createIosManagedBuild",
+            "description": "Create an iOS managed build",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "job",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "IosManagedJobInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildMetadataInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateBuildResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidGenericJobInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "projectArchive",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectArchiveSourceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secrets",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "builderEnvironment",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidBuilderEnvironmentInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cache",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "gradleCommand",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "artifactPath",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectArchiveSourceInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "type",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProjectArchiveSourceType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "bucketKey",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "url",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ProjectArchiveSourceType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "S3",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "URL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidJobSecretsInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "buildCredentials",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidJobBuildCredentialsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "environmentSecrets",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidJobBuildCredentialsInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "keystore",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "AndroidJobKeystoreInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidJobKeystoreInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "dataBase64",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "keystorePassword",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "keyAlias",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "keyPassword",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidBuilderEnvironmentInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "image",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "node",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "yarn",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "ndk",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "env",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BuildCacheInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "disabled",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "key",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cacheDefaultPaths",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "customPaths",
+            "description": "",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BuildMetadataInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "trackingContext",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "appVersion",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cliVersion",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "workflow",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildWorkflow",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "credentialsSource",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildCredentialsSource",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "sdkVersion",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "distribution",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "DistributionType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "appName",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "appIdentifier",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "buildProfile",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "gitCommitHash",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BuildWorkflow",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "GENERIC",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MANAGED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BuildCredentialsSource",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "LOCAL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REMOTE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CreateBuildResult",
+        "description": "",
+        "fields": [
+          {
+            "name": "build",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Build",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deprecationInfo",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EASBuildDeprecationInfo",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EASBuildDeprecationInfo",
+        "description": "",
+        "fields": [
+          {
+            "name": "type",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASBuildDeprecationInfoType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EASBuildDeprecationInfoType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "USER_FACING",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INTERNAL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidManagedJobInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "projectArchive",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectArchiveSourceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secrets",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "builderEnvironment",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidBuilderEnvironmentInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cache",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "username",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosGenericJobInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "projectArchive",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectArchiveSourceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "distribution",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "DistributionType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secrets",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IosJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "builderEnvironment",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IosBuilderEnvironmentInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cache",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "scheme",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "schemeBuildConfiguration",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "IosSchemeBuildConfiguration",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "artifactPath",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosJobSecretsInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "buildCredentials",
+            "description": "",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "IosJobTargetCredentialsInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "environmentSecrets",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosJobTargetCredentialsInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "targetName",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "provisioningProfileBase64",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "distributionCertificate",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "IosJobDistributionCertificateInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosJobDistributionCertificateInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "dataBase64",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "password",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosBuilderEnvironmentInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "image",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "node",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "yarn",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "bundler",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "fastlane",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cocoapods",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "env",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "IosSchemeBuildConfiguration",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "RELEASE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DEBUG",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosManagedJobInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "projectArchive",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectArchiveSourceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "distribution",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "DistributionType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secrets",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IosJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "builderEnvironment",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IosBuilderEnvironmentInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cache",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "buildType",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "IosManagedBuildType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "username",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "IosManagedBuildType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "RELEASE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DEVELOPMENT_CLIENT",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -6,14 +6,77 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
+  Actor,
   GetAllChannelsForAppQuery,
   GetAllChannelsForAppQueryVariables,
+  Update,
 } from '../../graphql/generated';
 import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 
 const CHANNEL_LIMIT = 10_000;
+
+// TODO(cedric): refactor and reuse original code from channel view commands
+type BranchMapping = {
+  version: number;
+  data: {
+    branchId: string;
+    branchMappingLogic: {
+      operand: number;
+      clientKey: string;
+      branchMappingOperator: string;
+    } & string;
+  }[];
+};
+
+/**
+ * Get the branch mapping and determine whether it is a rollout.
+ * Ensure that the branch mapping is properly formatted.
+ */
+function getBranchMapping(
+  branchMappingString: string
+): { branchMapping: BranchMapping; isRollout: boolean; rolloutPercent?: number } {
+  if (!branchMappingString) {
+    throw new Error('Missing branch mapping.');
+  }
+
+  const branchMapping: BranchMapping = JSON.parse(branchMappingString);
+  if (branchMapping.version !== 0) {
+    throw new Error('Branch mapping must be version 0.');
+  }
+
+  const isRollout = branchMapping.data.length === 2;
+  const rolloutPercent = branchMapping.data[0].branchMappingLogic.operand;
+
+  switch (branchMapping.data.length) {
+    case 0:
+      break;
+    case 1:
+      if (branchMapping.data[0].branchMappingLogic !== 'true') {
+        throw new Error('Branch mapping logic for a single branch must be "true"');
+      }
+      break;
+    case 2:
+      if (branchMapping.data[0].branchMappingLogic.clientKey !== 'rolloutToken') {
+        throw new Error('Client key of initial branch mapping must be "rolloutToken"');
+      }
+      if (branchMapping.data[0].branchMappingLogic.branchMappingOperator !== 'hash_lt') {
+        throw new Error('Branch mapping operator of initial branch mapping must be "hash_lt"');
+      }
+      if (!rolloutPercent) {
+        throw new Error('Branch mapping is missing a "rolloutPercent"');
+      }
+      if (branchMapping.data[1].branchMappingLogic !== 'true') {
+        throw new Error('Branch mapping logic for a the second branch of a rollout must be "true"');
+      }
+      break;
+    default:
+      throw new Error('Branch mapping data must have length less than or equal to 2.');
+  }
+
+  return { branchMapping, isRollout, rolloutPercent };
+}
 
 async function getAllUpdateChannelForAppAsync({
   appId,
@@ -31,6 +94,8 @@ async function getAllUpdateChannelForAppAsync({
                 updateChannels(offset: $offset, limit: $limit) {
                   id
                   name
+                  createdAt
+                  branchMapping
                   updateBranches(offset: 0, limit: 1) {
                     id
                     name
@@ -108,13 +173,41 @@ export default class ChannelList extends Command {
     });
 
     for (const channel of channels) {
-      // TODO (cedric): refactor when multiple branches per channel are available
-      const branch = channel.updateBranches[0];
-      const update = branch.updates[0];
+      const { branchMapping, isRollout, rolloutPercent } = getBranchMapping(channel.branchMapping);
+      const rolloutMapping: string[] = [];
+      let update:
+        | null
+        | (Omit<Partial<Update>, 'actor'> & {
+            actor?: null | Pick<Actor, 'id' | 'firstName'>;
+          }) = null;
+
+      for (const index in branchMapping.data) {
+        if (parseInt(index, 10) > 1) {
+          throw new Error('Branch Mapping data must have length less than or equal to 2.');
+        }
+
+        const { branchId } = branchMapping.data[index];
+        const branch = channel.updateBranches.find(branch => branch.id === branchId);
+        if (!branch) {
+          throw new Error('Branch mapping is pointing at a missing branch.');
+        }
+
+        if (!isRollout) {
+          rolloutMapping.push(branch.name);
+        } else {
+          rolloutMapping.push(
+            parseInt(index, 10) === 0
+              ? `${branch.name} (${rolloutPercent! * 100}%)`
+              : `${branch.name} (${(1 - rolloutPercent!) * 100}%)`
+          );
+        }
+
+        update = branch.updates[0];
+      }
 
       table.push([
         channel.name,
-        branch.name,
+        rolloutMapping.join(' /\n'),
         update?.group,
         update?.message,
         update?.createdAt && new Date(update.createdAt).toLocaleString(),

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -206,6 +206,7 @@ export type Account = {
   snacks: Array<Snack>;
   /** Apps associated with this account */
   apps: Array<App>;
+  appCount: Scalars['Int'];
   /** Build Jobs associated with this account */
   buildJobs: Array<BuildJob>;
   /** (EAS Build) Builds associated with this account */
@@ -2110,12 +2111,214 @@ export type BuildMutation = {
    * @deprecated Use cancelBuild instead
    */
   cancel: Build;
+  /** Create an Android generic build */
+  createAndroidGenericBuild: CreateBuildResult;
+  /** Create an Android managed build */
+  createAndroidManagedBuild: CreateBuildResult;
+  /** Create an iOS generic build */
+  createIosGenericBuild: CreateBuildResult;
+  /** Create an iOS managed build */
+  createIosManagedBuild: CreateBuildResult;
 };
 
 
 export type BuildMutationCancelBuildArgs = {
   buildId: Scalars['ID'];
 };
+
+
+export type BuildMutationCreateAndroidGenericBuildArgs = {
+  appId: Scalars['ID'];
+  job: AndroidGenericJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+};
+
+
+export type BuildMutationCreateAndroidManagedBuildArgs = {
+  appId: Scalars['ID'];
+  job: AndroidManagedJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+};
+
+
+export type BuildMutationCreateIosGenericBuildArgs = {
+  appId: Scalars['ID'];
+  job: IosGenericJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+};
+
+
+export type BuildMutationCreateIosManagedBuildArgs = {
+  appId: Scalars['ID'];
+  job: IosManagedJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+};
+
+export type AndroidGenericJobInput = {
+  projectArchive: ProjectArchiveSourceInput;
+  projectRootDirectory: Scalars['String'];
+  releaseChannel?: Maybe<Scalars['String']>;
+  secrets?: Maybe<AndroidJobSecretsInput>;
+  builderEnvironment?: Maybe<AndroidBuilderEnvironmentInput>;
+  cache?: Maybe<BuildCacheInput>;
+  gradleCommand?: Maybe<Scalars['String']>;
+  artifactPath?: Maybe<Scalars['String']>;
+};
+
+export type ProjectArchiveSourceInput = {
+  type: ProjectArchiveSourceType;
+  bucketKey?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']>;
+};
+
+export enum ProjectArchiveSourceType {
+  S3 = 'S3',
+  Url = 'URL'
+}
+
+export type AndroidJobSecretsInput = {
+  buildCredentials?: Maybe<AndroidJobBuildCredentialsInput>;
+  environmentSecrets?: Maybe<Scalars['JSONObject']>;
+};
+
+export type AndroidJobBuildCredentialsInput = {
+  keystore: AndroidJobKeystoreInput;
+};
+
+export type AndroidJobKeystoreInput = {
+  dataBase64: Scalars['String'];
+  keystorePassword: Scalars['String'];
+  keyAlias: Scalars['String'];
+  keyPassword: Scalars['String'];
+};
+
+export type AndroidBuilderEnvironmentInput = {
+  image?: Maybe<Scalars['String']>;
+  node?: Maybe<Scalars['String']>;
+  yarn?: Maybe<Scalars['String']>;
+  ndk?: Maybe<Scalars['String']>;
+  env?: Maybe<Scalars['JSONObject']>;
+};
+
+export type BuildCacheInput = {
+  disabled?: Maybe<Scalars['Boolean']>;
+  key?: Maybe<Scalars['String']>;
+  cacheDefaultPaths?: Maybe<Scalars['Boolean']>;
+  customPaths?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type BuildMetadataInput = {
+  trackingContext?: Maybe<Scalars['JSONObject']>;
+  appVersion?: Maybe<Scalars['String']>;
+  cliVersion?: Maybe<Scalars['String']>;
+  workflow?: Maybe<BuildWorkflow>;
+  credentialsSource?: Maybe<BuildCredentialsSource>;
+  sdkVersion?: Maybe<Scalars['String']>;
+  releaseChannel?: Maybe<Scalars['String']>;
+  distribution?: Maybe<DistributionType>;
+  appName?: Maybe<Scalars['String']>;
+  appIdentifier?: Maybe<Scalars['String']>;
+  buildProfile?: Maybe<Scalars['String']>;
+  gitCommitHash?: Maybe<Scalars['String']>;
+};
+
+export enum BuildWorkflow {
+  Generic = 'GENERIC',
+  Managed = 'MANAGED'
+}
+
+export enum BuildCredentialsSource {
+  Local = 'LOCAL',
+  Remote = 'REMOTE'
+}
+
+export type CreateBuildResult = {
+  __typename?: 'CreateBuildResult';
+  build: Build;
+  deprecationInfo?: Maybe<EasBuildDeprecationInfo>;
+};
+
+export type EasBuildDeprecationInfo = {
+  __typename?: 'EASBuildDeprecationInfo';
+  type: EasBuildDeprecationInfoType;
+  message: Scalars['String'];
+};
+
+export enum EasBuildDeprecationInfoType {
+  UserFacing = 'USER_FACING',
+  Internal = 'INTERNAL'
+}
+
+export type AndroidManagedJobInput = {
+  projectArchive: ProjectArchiveSourceInput;
+  projectRootDirectory: Scalars['String'];
+  releaseChannel?: Maybe<Scalars['String']>;
+  secrets?: Maybe<AndroidJobSecretsInput>;
+  builderEnvironment?: Maybe<AndroidBuilderEnvironmentInput>;
+  cache?: Maybe<BuildCacheInput>;
+  username?: Maybe<Scalars['String']>;
+};
+
+export type IosGenericJobInput = {
+  projectArchive: ProjectArchiveSourceInput;
+  projectRootDirectory: Scalars['String'];
+  releaseChannel?: Maybe<Scalars['String']>;
+  distribution?: Maybe<DistributionType>;
+  secrets?: Maybe<IosJobSecretsInput>;
+  builderEnvironment?: Maybe<IosBuilderEnvironmentInput>;
+  cache?: Maybe<BuildCacheInput>;
+  scheme: Scalars['String'];
+  schemeBuildConfiguration?: Maybe<IosSchemeBuildConfiguration>;
+  artifactPath?: Maybe<Scalars['String']>;
+};
+
+export type IosJobSecretsInput = {
+  buildCredentials?: Maybe<Array<Maybe<IosJobTargetCredentialsInput>>>;
+  environmentSecrets?: Maybe<Scalars['JSONObject']>;
+};
+
+export type IosJobTargetCredentialsInput = {
+  targetName: Scalars['String'];
+  provisioningProfileBase64: Scalars['String'];
+  distributionCertificate: IosJobDistributionCertificateInput;
+};
+
+export type IosJobDistributionCertificateInput = {
+  dataBase64: Scalars['String'];
+  password: Scalars['String'];
+};
+
+export type IosBuilderEnvironmentInput = {
+  image?: Maybe<Scalars['String']>;
+  node?: Maybe<Scalars['String']>;
+  yarn?: Maybe<Scalars['String']>;
+  bundler?: Maybe<Scalars['String']>;
+  fastlane?: Maybe<Scalars['String']>;
+  cocoapods?: Maybe<Scalars['String']>;
+  env?: Maybe<Scalars['JSONObject']>;
+};
+
+export enum IosSchemeBuildConfiguration {
+  Release = 'RELEASE',
+  Debug = 'DEBUG'
+}
+
+export type IosManagedJobInput = {
+  projectArchive: ProjectArchiveSourceInput;
+  projectRootDirectory: Scalars['String'];
+  releaseChannel?: Maybe<Scalars['String']>;
+  distribution?: Maybe<DistributionType>;
+  secrets?: Maybe<IosJobSecretsInput>;
+  builderEnvironment?: Maybe<IosBuilderEnvironmentInput>;
+  cache?: Maybe<BuildCacheInput>;
+  buildType?: Maybe<IosManagedBuildType>;
+  username?: Maybe<Scalars['String']>;
+};
+
+export enum IosManagedBuildType {
+  Release = 'RELEASE',
+  DevelopmentClient = 'DEVELOPMENT_CLIENT'
+}
 
 export type IosAppBuildCredentialsMutation = {
   __typename?: 'IosAppBuildCredentialsMutation';
@@ -2998,7 +3201,7 @@ export type GetAllChannelsForAppQuery = (
       & Pick<App, 'id'>
       & { updateChannels: Array<(
         { __typename?: 'UpdateChannel' }
-        & Pick<UpdateChannel, 'id' | 'name'>
+        & Pick<UpdateChannel, 'id' | 'name' | 'createdAt' | 'branchMapping'>
         & { updateBranches: Array<(
           { __typename?: 'UpdateBranch' }
           & Pick<UpdateBranch, 'id' | 'name'>

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -779,8 +779,9 @@ export enum DistributionType {
 
 export type BuildError = {
   __typename?: 'BuildError';
-  errorCode?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
+  errorCode: Scalars['String'];
+  message: Scalars['String'];
+  docsUrl?: Maybe<Scalars['String']>;
 };
 
 /** Represents an Standalone App build job */


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This adds the branch mapping description to the `channel:list` commands. As JJ mentioned, I reused the existing code from #289. I don't fully like the code in it's current shape, there is some copied code and a really hard-to-read/use type for `updates`. If it's possible, we should probably validate the `branchMapping` in a shared method, and convert it to something a bit more useful to display the rollout info.

Currently it's displayed like this:

<img width="1335" alt="Screenshot 2021-04-01 at 14 28 50" src="https://user-images.githubusercontent.com/1203991/113293854-98513100-92f6-11eb-9f3d-79dcc58d7ca1.png">

> Note the `\n`, omitting this causes the table to be extremely wide and break. We might need to truncate the `message` column too.

# How

- Reused code from #289
- Iterate over the channels and determine how to present the branch mapping
- Fetch the update from the branches in the same process

# Test Plan

- `$ eas channel:list` (with a rollout channel)
