### PR TITLE
[eas-cli] Support for local builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Display more friendly error messages when `eas submit` fails. ([#311](https://github.com/expo/eas-cli/pull/297) by [@barthap](https://github.com/barthap))
 - Add support for managing webhooks (new commands: `webhook:create`, `webhook:view`, `webhook:list`, `webhook:update`, and `webhook:delete`). ([#314](https://github.com/expo/eas-cli/pull/314) by [@dsokal](https://github.com/dsokal))
+- Support for local builds [experimental]. ([#305](https://github.com/expo/eas-cli/pull/305) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -24,7 +24,7 @@ import { prepareJobAsync } from './prepareJob';
 export async function prepareAndroidBuildAsync(
   commandCtx: CommandContext,
   easConfig: EasConfig
-): Promise<() => Promise<string>> {
+): Promise<() => Promise<string | undefined>> {
   const buildCtx = createBuildContext<Platform.ANDROID>({
     commandCtx,
     platform: Platform.ANDROID,

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -1,12 +1,4 @@
-import {
-  Android,
-  ArchiveSource,
-  ArchiveSourceType,
-  Cache,
-  Job,
-  Workflow,
-  sanitizeJob,
-} from '@expo/eas-build-job';
+import { Android, ArchiveSource, Cache, Job, Workflow, sanitizeJob } from '@expo/eas-build-job';
 import { AndroidGenericBuildProfile, AndroidManagedBuildProfile } from '@expo/eas-json';
 import path from 'path';
 
@@ -18,7 +10,7 @@ import { BuildContext } from '../context';
 import { Platform } from '../types';
 
 interface JobData {
-  archiveBucketKey: string;
+  projectArchive: ArchiveSource;
   credentials?: AndroidCredentials;
 }
 
@@ -71,10 +63,7 @@ async function prepareJobCommonAsync(
 
   return {
     platform: Platform.ANDROID,
-    projectArchive: {
-      type: ArchiveSourceType.S3,
-      bucketKey: jobData.archiveBucketKey,
-    },
+    projectArchive: jobData.projectArchive,
     builderEnvironment: {
       image: ctx.buildProfile.image,
       node: ctx.buildProfile.node,

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -19,6 +19,7 @@ export interface CommandContext {
   projectName: string;
   exp: ExpoConfig;
   nonInteractive: boolean;
+  local: boolean;
   skipCredentialsCheck: boolean;
   skipProjectConfiguration: boolean;
   waitForBuildEnd: boolean;
@@ -31,6 +32,7 @@ export async function createCommandContextAsync({
   projectDir,
   projectId,
   nonInteractive = false,
+  local,
   skipCredentialsCheck = false,
   skipProjectConfiguration = false,
   waitForBuildEnd,
@@ -41,6 +43,7 @@ export async function createCommandContextAsync({
   projectId: string;
   projectDir: string;
   nonInteractive: boolean;
+  local: boolean;
   skipCredentialsCheck: boolean;
   skipProjectConfiguration: boolean;
   waitForBuildEnd: boolean;
@@ -59,6 +62,7 @@ export async function createCommandContextAsync({
     projectName,
     exp,
     nonInteractive,
+    local,
     skipCredentialsCheck,
     skipProjectConfiguration,
     waitForBuildEnd,

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -22,7 +22,7 @@ import { prepareJobAsync, sanitizedTargetName } from './prepareJob';
 export async function prepareIosBuildAsync(
   commandCtx: CommandContext,
   easConfig: EasConfig
-): Promise<() => Promise<string>> {
+): Promise<() => Promise<string | undefined>> {
   const buildCtx = createBuildContext<Platform.IOS>({
     commandCtx,
     platform: Platform.IOS,

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -1,0 +1,43 @@
+import { Job } from '@expo/eas-build-job';
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+
+import Log from '../log';
+
+export async function runLocalBuildAsync(job: Job): Promise<void> {
+  const execNameOrPath =
+    process.env.EAS_LOCAL_BUILD_PLUGIN_PATH ??
+    (await findWithNodeResolution()) ??
+    'eas-cli-local-build-plugin';
+  try {
+    const arg = Buffer.from(JSON.stringify({ job })).toString('base64');
+    await spawnAsync(execNameOrPath, [arg], {
+      stdio: 'inherit',
+    });
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      Log.warn(`Could not resolve executable ${execNameOrPath}.`);
+      Log.warn(
+        `Install eas-cli-local-build-plugin package from npm e.g. ${chalk.bold(
+          'npm install -g eas-cli-local-build-plugin'
+        )} and make sure it's in PATH.`
+      );
+      throw err;
+    }
+  }
+}
+
+async function findWithNodeResolution(): Promise<string | undefined> {
+  try {
+    const resolvedPath = path.resolve(
+      path.dirname(require.resolve('eas-cli-local-build-plugin')),
+      '../bin/run'
+    );
+    if (await fs.pathExists(resolvedPath)) {
+      return resolvedPath;
+    }
+  } catch {}
+  return undefined;
+}

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -6,11 +6,13 @@ import path from 'path';
 
 import Log from '../log';
 
+const PLUGIN_PACKAGE_NAME = 'eas-cli-local-build-plugin';
+
 export async function runLocalBuildAsync(job: Job): Promise<void> {
   const execNameOrPath =
     process.env.EAS_LOCAL_BUILD_PLUGIN_PATH ??
     (await findWithNodeResolution()) ??
-    'eas-cli-local-build-plugin';
+    PLUGIN_PACKAGE_NAME;
   try {
     const arg = Buffer.from(JSON.stringify({ job })).toString('base64');
     await spawnAsync(execNameOrPath, [arg], {
@@ -20,8 +22,8 @@ export async function runLocalBuildAsync(job: Job): Promise<void> {
     if (err.code === 'ENOENT') {
       Log.warn(`Could not resolve executable ${execNameOrPath}.`);
       Log.warn(
-        `Install eas-cli-local-build-plugin package from npm e.g. ${chalk.bold(
-          'npm install -g eas-cli-local-build-plugin'
+        `Install ${PLUGIN_PACKAGE_NAME} package from npm e.g. ${chalk.bold(
+          `npm install -g ${PLUGIN_PACKAGE_NAME}`
         )} and make sure it's in PATH.`
       );
       throw err;
@@ -32,7 +34,7 @@ export async function runLocalBuildAsync(job: Job): Promise<void> {
 async function findWithNodeResolution(): Promise<string | undefined> {
   try {
     const resolvedPath = path.resolve(
-      path.dirname(require.resolve('eas-cli-local-build-plugin')),
+      path.dirname(require.resolve(PLUGIN_PACKAGE_NAME)),
       '../bin/run'
     );
     if (await fs.pathExists(resolvedPath)) {

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -54,7 +54,7 @@ export default class Build extends Command {
     }),
     local: flags.boolean({
       default: false,
-      description: 'Run build locally',
+      description: 'Run build locally [experimental]',
     }),
     wait: flags.boolean({
       default: true,

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -52,6 +52,10 @@ export default class Build extends Command {
       default: false,
       description: 'Run command in --non-interactive mode',
     }),
+    local: flags.boolean({
+      default: false,
+      description: 'Run build locally',
+    }),
     wait: flags.boolean({
       default: true,
       allowNo: true,
@@ -76,8 +80,13 @@ export default class Build extends Command {
       let { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
       const projectId = await getProjectIdAsync(exp);
 
-      if (!(await isEasEnabledForProjectAsync(projectId))) {
+      if (!flags.local && !(await isEasEnabledForProjectAsync(projectId))) {
         warnEasUnavailable();
+        process.exitCode = 1;
+        return;
+      }
+
+      if (flags.local && !verifyOptionsForLocalBuilds(platform)) {
         process.exitCode = 1;
         return;
       }
@@ -103,6 +112,7 @@ export default class Build extends Command {
         projectId,
         nonInteractive,
         skipCredentialsCheck: flags['skip-credentials-check'],
+        local: flags.local,
         skipProjectConfiguration: flags['skip-project-configuration'],
         waitForBuildEnd: flags.wait,
       });
@@ -154,6 +164,18 @@ async function ensureNoPendingBuildsExistAsync({
     return true;
   }
   return false;
+}
+
+function verifyOptionsForLocalBuilds(platform: RequestedPlatform): boolean {
+  if (platform === RequestedPlatform.All) {
+    Log.error('Builds for multiple platforms are not supported with flag --local');
+    return false;
+  } else if (process.platform !== 'darwin' && platform === RequestedPlatform.iOS) {
+    Log.error('Unsupported platform, macOS is required to build apps for iOS');
+    return false;
+  } else {
+    return true;
+  }
 }
 
 function toAppPlatforms(requestedPlatform: RequestedPlatform): AppPlatform[] {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Support for local builds

# How

- run `eas-build-local`(this name might not be final version) executable and pass job object to stdin
- `eas-build-local` path is resolved by
  - checking EAS_LOCAL_BUILD_PLUGIN_PATH env (for development)
  - using node `require.resolve()` (binnaries installed globally via yarn often are not in PATH)
  - looking for binary in PATH

# Test Plan

run builds
