### PR TITLE
eas build - use GraphQL instead of REST endpoints for build queries

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -5262,15 +5262,35 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "message",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "docsUrl",
             "description": "",
             "args": [],
             "type": {

--- a/packages/eas-cli/src/build/constants.ts
+++ b/packages/eas-cli/src/build/constants.ts
@@ -16,3 +16,8 @@ export const platformEmojis = {
   [Platform.IOS]: '🍎',
   [Platform.ANDROID]: '🤖',
 };
+
+export const appPlatformEmojis = {
+  [AppPlatform.Ios]: '🍎',
+  [AppPlatform.Android]: '🤖',
+};

--- a/packages/eas-cli/src/build/constants.ts
+++ b/packages/eas-cli/src/build/constants.ts
@@ -1,5 +1,5 @@
 import { AppPlatform } from '../graphql/generated';
-import { Platform, RequestedPlatform } from './types';
+import { RequestedPlatform } from './types';
 
 export const requestedPlatformDisplayNames: Record<RequestedPlatform, string> = {
   [RequestedPlatform.iOS]: 'iOS',
@@ -10,11 +10,6 @@ export const requestedPlatformDisplayNames: Record<RequestedPlatform, string> = 
 export const appPlatformDisplayNames: Record<AppPlatform, string> = {
   [AppPlatform.Android]: 'Android',
   [AppPlatform.Ios]: 'iOS',
-};
-
-export const platformEmojis = {
-  [Platform.IOS]: '🍎',
-  [Platform.ANDROID]: '🤖',
 };
 
 export const appPlatformEmojis = {

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -1,13 +1,10 @@
-import { Metadata, Platform, errors } from '@expo/eas-build-job';
-import { AndroidBuildProfile, iOSBuildProfile } from '@expo/eas-json';
+export { Platform } from '@expo/eas-build-job';
 
 export enum RequestedPlatform {
   Android = 'android',
   iOS = 'ios',
   All = 'all',
 }
-
-export { Platform };
 
 export enum BuildStatus {
   IN_QUEUE = 'in-queue',
@@ -18,23 +15,3 @@ export enum BuildStatus {
 }
 
 export type TrackingContext = Record<string, string | number>;
-
-export interface Build {
-  id: string;
-  status: BuildStatus;
-  platform: Platform;
-  createdAt: string;
-  updatedAt: string;
-  artifacts?: BuildArtifacts;
-  metadata?: Partial<Metadata>;
-  error?: errors.ExternalUserError;
-}
-
-interface BuildArtifacts {
-  buildUrl?: string;
-  logsUrl: string;
-}
-
-export type PlatformBuildProfile<T extends Platform> = T extends Platform.ANDROID
-  ? AndroidBuildProfile
-  : iOSBuildProfile;

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -2,87 +2,8 @@ import chalk from 'chalk';
 
 import { BuildFragment, BuildStatus as GraphQLBuildStatus } from '../../graphql/generated';
 import formatFields from '../../utils/formatFields';
-import { appPlatformDisplayNames, requestedPlatformDisplayNames } from '../constants';
-import { Build, BuildStatus } from '../types';
+import { appPlatformDisplayNames } from '../constants';
 import { getBuildLogsUrl } from './url';
-
-interface Options {
-  accountName: string;
-}
-/**
- * @deprecated remove this once we don't use REST endpoints for EAS Build
- */
-export function formatBuild(build: Build, { accountName }: Options) {
-  const fields: { label: string; value: string }[] = [
-    { label: 'ID', value: build.id },
-    {
-      label: 'Platform',
-      value: requestedPlatformDisplayNames[build.platform],
-    },
-    {
-      label: 'Status',
-      get value() {
-        switch (build.status) {
-          case BuildStatus.IN_QUEUE:
-            return chalk.blue('in queue');
-          case BuildStatus.IN_PROGRESS:
-            return chalk.blue('in progress');
-          case BuildStatus.CANCELED:
-            return chalk.gray('canceled');
-          case BuildStatus.FINISHED:
-            return chalk.green('finished');
-          case BuildStatus.ERRORED:
-            return chalk.red('errored');
-          default:
-            return 'unknown';
-        }
-      },
-    },
-    {
-      label: 'Distribution',
-      value: build.metadata?.distribution ?? chalk.gray('unknown'),
-    },
-    {
-      label: 'Release Channel',
-      value: build.metadata?.releaseChannel ?? chalk.gray('unknown'),
-    },
-    {
-      label: 'Logs',
-      value: getBuildLogsUrl({ buildId: build.id, account: accountName }),
-    },
-    {
-      label: 'Artifact',
-      get value() {
-        if (build.status === BuildStatus.IN_QUEUE || build.status === BuildStatus.IN_PROGRESS) {
-        }
-        switch (build.status) {
-          case BuildStatus.IN_QUEUE:
-          case BuildStatus.IN_PROGRESS:
-            return '<in progress>';
-          case BuildStatus.CANCELED:
-          case BuildStatus.ERRORED:
-            return '---------';
-          case BuildStatus.FINISHED: {
-            const url = build.artifacts?.buildUrl;
-            return url ? url : chalk.red('not found');
-          }
-          default:
-            return 'unknown';
-        }
-      },
-    },
-    { label: 'Started at', value: new Date(build.createdAt).toLocaleString() },
-    {
-      label: 'Finished at',
-      value:
-        build.status === BuildStatus.IN_QUEUE || build.status === BuildStatus.IN_PROGRESS
-          ? '<in progress>'
-          : new Date(build.updatedAt).toLocaleString(),
-    },
-  ];
-
-  return formatFields(fields);
-}
 
 export function formatGraphQLBuild(build: BuildFragment) {
   const actor = getActorName(build);

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -4,11 +4,9 @@ import chalk from 'chalk';
 import gql from 'graphql-tag';
 import ora from 'ora';
 
-import { platformEmojis } from '../../build/constants';
-import { Platform } from '../../build/types';
+import { appPlatformEmojis } from '../../build/constants';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
-  AppPlatform,
   Build,
   BuildStatus,
   CancelBuildMutation,
@@ -44,15 +42,10 @@ async function cancelBuildAsync(buildId: string): Promise<Pick<Build, 'id' | 'st
   return data.build!.cancel;
 }
 
-const appPlatformMap = {
-  [AppPlatform.Android]: Platform.ANDROID,
-  [AppPlatform.Ios]: Platform.IOS,
-};
-
 function formatUnfinishedBuild(
   build: Pick<Build, 'id' | 'platform' | 'status' | 'createdAt'>
 ): string {
-  const platform = platformEmojis[appPlatformMap[build.platform]];
+  const platform = appPlatformEmojis[build.platform];
   const startTime = new Date(build.createdAt).toLocaleString();
   const status = chalk.blue(build.status === BuildStatus.InQueue ? 'in-queue' : 'in-progress');
   return `${platform} Started at: ${startTime}, Status: ${status}, Id: ${build.id}`;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -779,8 +779,9 @@ export enum DistributionType {
 
 export type BuildError = {
   __typename?: 'BuildError';
-  errorCode?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
+  errorCode: Scalars['String'];
+  message: Scalars['String'];
+  docsUrl?: Maybe<Scalars['String']>;
 };
 
 /** Represents an Standalone App build job */
@@ -4236,7 +4237,7 @@ export type BuildFragment = (
   & Pick<Build, 'id' | 'status' | 'platform' | 'releaseChannel' | 'distribution' | 'createdAt' | 'updatedAt'>
   & { error?: Maybe<(
     { __typename?: 'BuildError' }
-    & Pick<BuildError, 'errorCode' | 'message'>
+    & Pick<BuildError, 'errorCode' | 'message' | 'docsUrl'>
   )>, artifacts?: Maybe<(
     { __typename?: 'BuildArtifacts' }
     & Pick<BuildArtifacts, 'buildUrl' | 'xcodeBuildLogsUrl'>

--- a/packages/eas-cli/src/graphql/types/Build.ts
+++ b/packages/eas-cli/src/graphql/types/Build.ts
@@ -8,6 +8,7 @@ export const BuildFragmentNode = gql`
     error {
       errorCode
       message
+      docsUrl
     }
     artifacts {
       buildUrl


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This PR replaces the remaining REST endpoint calls with GraphQL counterparts.

# How

I replaced the calls for querying builds.

# Test Plan

- I ran `eas build` a couple of times and everything seemed to be working fine.
- I also checked that these changes work fine when the user has pending builds and EAS CLI prints the details for them.