### PR TITLE
use graphql for generating upload sessions

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -10756,6 +10756,22 @@
             "deprecationReason": null
           },
           {
+            "name": "uploadSession",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UploadSession",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userInvitation",
             "description": "Mutations that create, delete, and accept UserInvitations",
             "args": [],
@@ -16518,6 +16534,67 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UploadSession",
+        "description": "",
+        "fields": [
+          {
+            "name": "createUploadSession",
+            "description": "Create an Upload Session",
+            "args": [
+              {
+                "name": "type",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "UploadSessionType",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "UploadSessionType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "EAS_BUILD_PROJECT_SOURCES",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EAS_SUBMIT_APP_ARCHIVE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -41,7 +41,6 @@
     "indent-string": "^4.0.0",
     "keychain": "^1.3.0",
     "lodash": "^4.17.20",
-    "md5-file": "^5.0.0",
     "mime": "^2.4.7",
     "minimatch": "^3.0.4",
     "node-fetch": "^2.6.1",

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -2,10 +2,11 @@ import { Job, Metadata } from '@expo/eas-build-job';
 import { CredentialsSource } from '@expo/eas-json';
 import fs from 'fs-extra';
 
+import { UploadSessionType } from '../graphql/generated';
 import { BuildResult } from '../graphql/mutations/BuildMutation';
 import Log from '../log';
 import { promptAsync } from '../prompts';
-import { UploadType, uploadAsync } from '../uploads';
+import { uploadAsync } from '../uploads';
 import { formatBytes } from '../utils/files';
 import { createProgressTracker } from '../utils/progress';
 import { requestedPlatformDisplayNames } from './constants';
@@ -116,7 +117,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         projectTarballPath = projectTarball.path;
 
         const { bucketKey } = await uploadAsync(
-          UploadType.TURTLE_PROJECT_SOURCES,
+          UploadSessionType.EasBuildProjectSources,
           projectTarball.path,
           createProgressTracker({
             total: projectTarball.size,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1540,6 +1540,7 @@ export type RootMutation = {
   updateChannel: UpdateChannelMutation;
   update: UpdateMutation;
   updateBranch: UpdateBranchMutation;
+  uploadSession: UploadSession;
   /** Mutations that create, delete, and accept UserInvitations */
   userInvitation: UserInvitationMutation;
   /** Mutations that modify the currently authenticated User */
@@ -2574,6 +2575,22 @@ export type PartialManifestAsset = {
   storageBucket: Scalars['String'];
   storageKey: Scalars['String'];
 };
+
+export type UploadSession = {
+  __typename?: 'UploadSession';
+  /** Create an Upload Session */
+  createUploadSession: Scalars['JSONObject'];
+};
+
+
+export type UploadSessionCreateUploadSessionArgs = {
+  type?: Maybe<UploadSessionType>;
+};
+
+export enum UploadSessionType {
+  EasBuildProjectSources = 'EAS_BUILD_PROJECT_SOURCES',
+  EasSubmitAppArchive = 'EAS_SUBMIT_APP_ARCHIVE'
+}
 
 export type UserInvitationMutation = {
   __typename?: 'UserInvitationMutation';
@@ -4058,6 +4075,19 @@ export type UpdatePublishMutation = (
       { __typename?: 'Update' }
       & Pick<Update, 'id' | 'group'>
     )>> }
+  ) }
+);
+
+export type CreateUploadSessionMutationVariables = Exact<{
+  type: UploadSessionType;
+}>;
+
+
+export type CreateUploadSessionMutation = (
+  { __typename?: 'RootMutation' }
+  & { uploadSession: (
+    { __typename?: 'UploadSession' }
+    & Pick<UploadSession, 'createUploadSession'>
   ) }
 );
 

--- a/packages/eas-cli/src/graphql/mutations/UploadSessionMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/UploadSessionMutation.ts
@@ -1,0 +1,35 @@
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../client';
+import {
+  CreateUploadSessionMutation,
+  CreateUploadSessionMutationVariables,
+  UploadSessionType,
+} from '../generated';
+
+export interface PresignedPost {
+  url: string;
+  fields: Record<string, string>;
+}
+
+export const UploadSessionMutation = {
+  async createUploadSession(type: UploadSessionType): Promise<PresignedPost> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateUploadSessionMutation, CreateUploadSessionMutationVariables>(
+          gql`
+            mutation CreateUploadSessionMutation($type: UploadSessionType!) {
+              uploadSession {
+                createUploadSession(type: $type)
+              }
+            }
+          `,
+          {
+            type,
+          }
+        )
+        .toPromise()
+    );
+    return data.uploadSession.createUploadSession;
+  },
+};

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -10,9 +10,10 @@ import path from 'path';
 
 import { AssetMetadataStatus, PartialManifestAsset } from '../graphql/generated';
 import { PublishMutation } from '../graphql/mutations/PublishMutation';
+import { PresignedPost } from '../graphql/mutations/UploadSessionMutation';
 import { PublishQuery } from '../graphql/queries/PublishQuery';
 import Log from '../log';
-import { PresignedPost, uploadWithPresignedPostAsync } from '../uploads';
+import { uploadWithPresignedPostAsync } from '../uploads';
 
 export const TIMEOUT_LIMIT = 60_000; // 1 minute
 const STORAGE_BUCKET = getStorageBucket();

--- a/packages/eas-cli/src/submissions/archiveSource/__tests__/ArchiveFileSource-test.ts
+++ b/packages/eas-cli/src/submissions/archiveSource/__tests__/ArchiveFileSource-test.ts
@@ -3,8 +3,9 @@ import { vol } from 'memfs';
 import { v4 as uuidv4 } from 'uuid';
 
 import { asMock } from '../../../__tests__/utils';
+import { UploadSessionType } from '../../../graphql/generated';
 import { promptAsync } from '../../../prompts';
-import { UploadType, uploadAsync } from '../../../uploads';
+import { uploadAsync } from '../../../uploads';
 import { SubmissionPlatform } from '../../types';
 import { getBuildArtifactUrlByIdAsync, getLatestBuildArtifactUrlAsync } from '../../utils/builds';
 import {
@@ -143,7 +144,11 @@ describe(getArchiveFileLocationAsync, () => {
       path,
     });
 
-    expect(uploadAsync).toBeCalledWith(UploadType.SUBMISSION_APP_ARCHIVE, path, expect.anything());
+    expect(uploadAsync).toBeCalledWith(
+      UploadSessionType.EasSubmitAppArchive,
+      path,
+      expect.anything()
+    );
     assertArchiveResult(resolvedArchive, ArchiveFileSourceType.path);
   });
 

--- a/packages/eas-cli/src/submissions/utils/files.ts
+++ b/packages/eas-cli/src/submissions/utils/files.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 
-import { UploadType, uploadAsync } from '../../uploads';
+import { UploadSessionType } from '../../graphql/generated';
+import { uploadAsync } from '../../uploads';
 import { createProgressTracker } from '../../utils/progress';
 
 export async function isExistingFile(filePath: string) {
@@ -15,7 +16,7 @@ export async function isExistingFile(filePath: string) {
 export async function uploadAppArchiveAsync(path: string): Promise<string> {
   const fileSize = (await fs.stat(path)).size;
   const { url } = await uploadAsync(
-    UploadType.SUBMISSION_APP_ARCHIVE,
+    UploadSessionType.EasSubmitAppArchive,
     path,
     createProgressTracker({
       total: fileSize,

--- a/packages/eas-cli/src/uploads.ts
+++ b/packages/eas-cli/src/uploads.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import FormData from 'form-data';
-import fs from 'fs';
+import fs from 'fs-extra';
 import got, { Progress } from 'got';
 import { Readable } from 'stream';
 
@@ -18,7 +18,7 @@ export async function uploadAsync(
   path: string,
   handleProgressEvent: ProgressHandler
 ): Promise<{ url: string; bucketKey: string }> {
-  const presignedPost = await obtainS3PresignedPostAsync(type);
+  const presignedPost = await UploadSessionMutation.createUploadSession(type);
   const url = await uploadWithPresignedPostAsync(
     fs.createReadStream(path),
     presignedPost,
@@ -26,10 +26,6 @@ export async function uploadAsync(
   );
   assert(presignedPost.fields.key, 'key is not specified in in presigned post');
   return { url, bucketKey: presignedPost.fields.key };
-}
-
-async function obtainS3PresignedPostAsync(type: UploadSessionType): Promise<PresignedPost> {
-  return await UploadSessionMutation.createUploadSession(type);
 }
 
 export async function uploadWithPresignedPostAsync(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8712,11 +8712,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-md5-file@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-5.0.0.tgz#e519f631feca9c39e7f9ea1780b63c4745012e20"
-  integrity sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==
-
 memfs@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.2.0.tgz#f9438e622b5acd1daa8a4ae160c496fdd1325b26"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://github.com/expo/universe/pull/7279 adds GraphQL mutation for generating upload sessions.

# How

I replaced the REST API call with the GraphQL mutation call.

# Test Plan

I ran `eas build` and I noticed the project archive got uploaded to S3.
