### PR TITLE
[eas-cli] use autocomplete list for secrets:delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 - `secrets:create` now uses flags rather than positional arguments ([#300](https://github.com/expo/eas-cli/pull/300) by [@fiberjw](https://github.com/fiberjw))
 - `secrets:create`'s `target` arg is now called `scope` ([#300](https://github.com/expo/eas-cli/pull/300) by [@fiberjw](https://github.com/fiberjw))
 - `secrets:list`'s `target` property is now called `scope` ([#300](https://github.com/expo/eas-cli/pull/300) by [@fiberjw](https://github.com/fiberjw))
+- `secrets:delete`'s `ID` arg is now optional ([#309](https://github.com/expo/eas-cli/pull/309) by [@fiberjw](https://github.com/fiberjw))
+- `secrets:delete`'s now allows users to choose secrets from a list ([#309](https://github.com/expo/eas-cli/pull/309) by [@fiberjw](https://github.com/fiberjw))
 
 ### 🎉 New features
 

--- a/packages/eas-cli/src/commands/secrets/delete.ts
+++ b/packages/eas-cli/src/commands/secrets/delete.ts
@@ -3,13 +3,19 @@ import { Command } from '@oclif/command';
 import chalk from 'chalk';
 
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
+import { EnvironmentSecretsQuery } from '../../graphql/queries/EnvironmentSecretsQuery';
 import Log from '../../log';
 import {
   isEasEnabledForProjectAsync,
   warnEasUnavailable,
 } from '../../project/isEasEnabledForProject';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
-import { toggleConfirmAsync } from '../../prompts';
+import {
+  findProjectRootAsync,
+  getProjectAccountNameAsync,
+  getProjectFullNameAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
+import { promptAsync, toggleConfirmAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';
 
 export default class EnvironmentSecretDelete extends Command {
@@ -19,7 +25,7 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
   static args = [
     {
       name: 'id',
-      required: true,
+      required: false,
       description: `ID of the secret to delete`,
     },
   ];
@@ -30,6 +36,8 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
+    const projectFullName = await getProjectFullNameAsync(exp);
+    const projectAccountName = await getProjectAccountNameAsync(exp);
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
       warnEasUnavailable();
@@ -37,23 +45,42 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
       return;
     }
 
-    const {
+    let {
       args: { id },
     } = this.parse(EnvironmentSecretDelete);
+    let name;
+
+    if (!id) {
+      const secrets = await EnvironmentSecretsQuery.all(projectAccountName, projectFullName);
+
+      const { secret } = await promptAsync({
+        type: 'autocomplete',
+        name: 'secret',
+        message: 'Pick the secret to be deleted:',
+        choices: secrets.map(secret => ({
+          title: `${secret.name} (${secret.scope})`,
+          value: secret,
+        })),
+      });
+
+      ({ id, name } = secret);
+    }
 
     Log.addNewLineIfNone();
     Log.warn(
-      `You are about to permamently delete secret with id: "${id}".\nThis action is irreversible.`
+      `You are about to permamently delete secret${
+        name ? ` "${name}"` : ''
+      } with id: "${id}".\nThis action is irreversible.`
     );
     Log.newLine();
     const confirmed = await toggleConfirmAsync({ message: 'Are you sure you wish to proceed?' });
     if (!confirmed) {
-      Log.error(`Canceled deletion of secret with id: "${id}".`);
+      Log.error(`Canceled deletion of secret${name ? ` "${name}"` : ''} with id: "${id}".`);
       process.exit(1);
     }
 
     await EnvironmentSecretMutation.delete(id);
 
-    Log.withTick(`️Deleted secret with id "${id}".`);
+    Log.withTick(`️Deleted secret${name ? ` "${name}"` : ''} with id "${id}".`);
   }
 }

--- a/packages/eas-cli/src/commands/secrets/delete.ts
+++ b/packages/eas-cli/src/commands/secrets/delete.ts
@@ -3,7 +3,10 @@ import { Command } from '@oclif/command';
 import chalk from 'chalk';
 
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
-import { EnvironmentSecretsQuery } from '../../graphql/queries/EnvironmentSecretsQuery';
+import {
+  EnvironmentSecretWithScope,
+  EnvironmentSecretsQuery,
+} from '../../graphql/queries/EnvironmentSecretsQuery';
 import Log from '../../log';
 import {
   isEasEnabledForProjectAsync,
@@ -17,6 +20,7 @@ import {
 } from '../../project/projectUtils';
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';
+import { EnvironmentSecretScope } from './create';
 
 export default class EnvironmentSecretDelete extends Command {
   static description = `Delete an environment secret by ID.
@@ -48,12 +52,12 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
     let {
       args: { id },
     } = this.parse(EnvironmentSecretDelete);
-    let name;
+    let secret: EnvironmentSecretWithScope | undefined;
 
     if (!id) {
-      const secrets = await EnvironmentSecretsQuery.all(projectAccountName, projectFullName);
+      const secrets = await EnvironmentSecretsQuery.allAsync(projectAccountName, projectFullName);
 
-      const { secret } = await promptAsync({
+      ({ secret } = await promptAsync({
         type: 'autocomplete',
         name: 'secret',
         message: 'Pick the secret to be deleted:',
@@ -61,26 +65,34 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
           title: `${secret.name} (${secret.scope})`,
           value: secret,
         })),
-      });
+      }));
 
-      ({ id, name } = secret);
+      id = secret?.id;
     }
 
     Log.addNewLineIfNone();
     Log.warn(
       `You are about to permamently delete secret${
-        name ? ` "${name}"` : ''
+        secret?.name ? ` "${secret?.name}"` : ''
       } with id: "${id}".\nThis action is irreversible.`
     );
     Log.newLine();
-    const confirmed = await toggleConfirmAsync({ message: 'Are you sure you wish to proceed?' });
+    const confirmed = await toggleConfirmAsync({
+      message: `Are you sure you wish to proceed?${
+        secret?.scope === EnvironmentSecretScope.ACCOUNT
+          ? ' This secret is applied across your whole account and may affect multiple apps.'
+          : ''
+      }`,
+    });
     if (!confirmed) {
-      Log.error(`Canceled deletion of secret${name ? ` "${name}"` : ''} with id: "${id}".`);
+      Log.error(
+        `Canceled deletion of secret${secret?.name ? ` "${secret?.name}"` : ''} with id: "${id}".`
+      );
       process.exit(1);
     }
 
     await EnvironmentSecretMutation.delete(id);
 
-    Log.withTick(`️Deleted secret${name ? ` "${name}"` : ''} with id "${id}".`);
+    Log.withTick(`️Deleted secret${secret?.name ? ` "${secret?.name}"` : ''} with id "${id}".`);
   }
 }

--- a/packages/eas-cli/src/commands/secrets/list.ts
+++ b/packages/eas-cli/src/commands/secrets/list.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 import dateFormat from 'dateformat';
 
-import { EnvironmentSecretFragment } from '../../graphql/generated';
 import { EnvironmentSecretsQuery } from '../../graphql/queries/EnvironmentSecretsQuery';
 import Log from '../../log';
 import {
@@ -18,7 +17,6 @@ import {
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
-import { EnvironmentSecretScope } from './create';
 
 export default class EnvironmentSecretsList extends Command {
   static description = 'Lists environment secrets available for your current app';
@@ -43,15 +41,7 @@ export default class EnvironmentSecretsList extends Command {
       throw new Error("Please run this command inside your project's directory");
     }
 
-    const [accountSecrets, appSecrets] = await Promise.all([
-      EnvironmentSecretsQuery.byAcccountNameAsync(projectAccountName),
-      EnvironmentSecretsQuery.byAppFullNameAsync(projectFullName),
-    ]);
-
-    const secrets = [
-      ...appSecrets.map(s => ({ ...s, scope: EnvironmentSecretScope.PROJECT })),
-      ...accountSecrets.map(s => ({ ...s, scope: EnvironmentSecretScope.ACCOUNT })),
-    ] as (EnvironmentSecretFragment & { scope: EnvironmentSecretScope })[];
+    const secrets = await EnvironmentSecretsQuery.all(projectAccountName, projectFullName);
 
     const table = new Table({
       head: ['Name', 'Scope', 'ID', 'Updated at'],

--- a/packages/eas-cli/src/commands/secrets/list.ts
+++ b/packages/eas-cli/src/commands/secrets/list.ts
@@ -41,7 +41,7 @@ export default class EnvironmentSecretsList extends Command {
       throw new Error("Please run this command inside your project's directory");
     }
 
-    const secrets = await EnvironmentSecretsQuery.all(projectAccountName, projectFullName);
+    const secrets = await EnvironmentSecretsQuery.allAsync(projectAccountName, projectFullName);
 
     const table = new Table({
       head: ['Name', 'Scope', 'ID', 'Updated at'],

--- a/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
@@ -1,6 +1,7 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
+import { EnvironmentSecretScope } from '../../commands/secrets/create';
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import {
   EnvironmentSecretFragment,
@@ -59,5 +60,19 @@ export const EnvironmentSecretsQuery = {
     );
 
     return data.app?.byFullName.environmentSecrets ?? [];
+  },
+  async all(
+    projectAccountName: string,
+    projectFullName: string
+  ): Promise<(EnvironmentSecretFragment & { scope: EnvironmentSecretScope })[]> {
+    const [accountSecrets, appSecrets] = await Promise.all([
+      this.byAcccountNameAsync(projectAccountName),
+      this.byAppFullNameAsync(projectFullName),
+    ]);
+
+    return [
+      ...appSecrets.map(s => ({ ...s, scope: EnvironmentSecretScope.PROJECT })),
+      ...accountSecrets.map(s => ({ ...s, scope: EnvironmentSecretScope.ACCOUNT })),
+    ];
   },
 };

--- a/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
@@ -10,6 +10,10 @@ import {
 } from '../generated';
 import { EnvironmentSecretFragmentNode } from '../types/EnvironmentSecret';
 
+export type EnvironmentSecretWithScope = EnvironmentSecretFragment & {
+  scope: EnvironmentSecretScope;
+};
+
 export const EnvironmentSecretsQuery = {
   async byAcccountNameAsync(accountName: string): Promise<EnvironmentSecretFragment[]> {
     const data = await withErrorHandlingAsync(
@@ -61,10 +65,10 @@ export const EnvironmentSecretsQuery = {
 
     return data.app?.byFullName.environmentSecrets ?? [];
   },
-  async all(
+  async allAsync(
     projectAccountName: string,
     projectFullName: string
-  ): Promise<(EnvironmentSecretFragment & { scope: EnvironmentSecretScope })[]> {
+  ): Promise<EnvironmentSecretWithScope[]> {
     const [accountSecrets, appSecrets] = await Promise.all([
       this.byAcccountNameAsync(projectAccountName),
       this.byAppFullNameAsync(projectFullName),


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

To improve the UX of deleting an environment secret via CLI (which previously involved 2 commands and a copy/paste), we want to allow the user to pick from a list.

# How

- pulled code for getting all secrets for a project and account into a centralized place
- made `delete [ID]` optional
- if ID isn't specified, prompt the user with a list of all of their secrets for the current app and account 

# Test Plan

`easd secrets:delete` in an Expo project directory:

![Screen Shot 2021-04-05 at 19 54 14](https://user-images.githubusercontent.com/12488826/113641323-6409a780-964b-11eb-974f-19faf6ed4efa.png)
![Screen Shot 2021-04-05 at 19 55 24](https://user-images.githubusercontent.com/12488826/113641325-6409a780-964b-11eb-994c-a80e142e07c2.png)


