### PR TITLE
don't use graphql cache for polling builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix the issue where the build status never got updated when running `eas build`. ([#310](https://github.com/expo/eas-cli/pull/310) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [0.8.0](https://github.com/expo/eas-cli/releases/tag/v0.8.0) - 2021-04-06

--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -76,7 +76,7 @@ async function waitForBuildEndAsync(
     const builds: (BuildFragment | null)[] = await Promise.all(
       buildIds.map(async buildId => {
         try {
-          return await BuildQuery.byIdAsync(buildId);
+          return await BuildQuery.byIdAsync(buildId, { useCache: false });
         } catch (err) {
           return null;
         }

--- a/packages/eas-cli/src/graphql/queries/BuildQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BuildQuery.ts
@@ -26,7 +26,10 @@ type Filters = {
 type PendingBuildQueryResult = Pick<Build, 'id' | 'platform'>;
 
 export const BuildQuery = {
-  async byIdAsync(buildId: string): Promise<BuildFragment> {
+  async byIdAsync(
+    buildId: string,
+    { useCache = true }: { useCache?: boolean } = {}
+  ): Promise<BuildFragment> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<BuildsByIdQuery, BuildsByIdQueryVariables>(
@@ -41,7 +44,10 @@ export const BuildQuery = {
             }
             ${print(BuildFragmentNode)}
           `,
-          { buildId }
+          { buildId },
+          {
+            requestPolicy: useCache ? 'cache-first' : 'network-only',
+          }
         )
         .toPromise()
     );


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This fixes an issue that I introduced in https://github.com/expo/eas-cli/commit/279dfd00c8f779d3de5db91f1be881f08119aa42
Because of the default graphql cache policy the build status never gets updated when running `eas build`.

# How

I set the cache policy to `network-only` for the `BuildQuery.byIdAsync` query

# Test Plan

I ran a build and observed the build status transitions.