### PR TITLE
add commands for managing webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Display more friendly error messages when `eas submit` fails. ([#311](https://github.com/expo/eas-cli/pull/297) by [@barthap](https://github.com/barthap))
+- Add support for managing environment secrets (new commands: `webhook:create`, `webhook:view`, `webhook:list`, `webhook:update`, and `webhook:delete`). ([#314](https://github.com/expo/eas-cli/pull/314) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 
@@ -34,7 +35,6 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - `build:view` and `build:list` now showing the distribution type (store / internal) and release channel. ([#284](https://github.com/expo/eas-cli/pull/284) by [@vthibault](https://github.com/vthibault))
-
 - Add analytics to EAS Build. ([#162](https://github.com/expo/eas-cli/pull/162) by [@wkozyra95](https://github.com/wkozyra95))
 - Improve tar archive support in EAS Submit. ([#297](https://github.com/expo/eas-cli/pull/297) by [@barthap](https://github.com/barthap))
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -639,6 +639,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "webhook",
+            "description": "Top-level query object for querying Webhooks.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WebhookQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -986,9 +1002,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -998,9 +1018,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1167,69 +1191,29 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "availableBuilds",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Build packs are no longer supported"
-          },
-          {
-            "name": "unlimitedBuilds",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "subscriptionChangesPending",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer needed"
-          },
-          {
-            "name": "willAutoRenewBuilds",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Build packs are no longer supported"
           },
           {
             "name": "pushSecurityEnabled",
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1268,15 +1252,19 @@
           },
           {
             "name": "offers",
-            "description": "short lived property for test",
+            "description": "Offers set on this account",
             "args": [],
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "Offer",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Offer",
+                  "ofType": null
+                }
               }
             },
             "isDeprecated": false,
@@ -1623,42 +1611,6 @@
             "deprecationReason": null
           },
           {
-            "name": "accessTokens",
-            "description": "Api tokens made for project",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AccessToken",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Legacy access tokens are deprecated"
-          },
-          {
-            "name": "requiresAccessTokenForPushSecurity",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Legacy access tokens are deprecated"
-          },
-          {
             "name": "appleTeams",
             "description": "iOS credentials for account",
             "args": [
@@ -1888,6 +1840,94 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "accessTokens",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AccessToken",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Legacy access tokens are deprecated"
+          },
+          {
+            "name": "requiresAccessTokenForPushSecurity",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Legacy access tokens are deprecated"
+          },
+          {
+            "name": "unlimitedBuilds",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "See isCurrent"
+          },
+          {
+            "name": "availableBuilds",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Build packs are no longer supported"
+          },
+          {
+            "name": "subscriptionChangesPending",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer needed"
+          },
+          {
+            "name": "willAutoRenewBuilds",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Build packs are no longer supported"
           }
         ],
         "inputFields": null,
@@ -2311,35 +2351,7 @@
             "deprecationReason": null
           },
           {
-            "name": "iconUrl",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
             "name": "slug",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "username",
             "description": "",
             "args": [],
             "type": {
@@ -2385,6 +2397,34 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "username",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "iconUrl",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           }
         ],
         "inputFields": null,
@@ -2473,6 +2513,70 @@
             "deprecationReason": null
           },
           {
+            "name": "slug",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "published",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ownerAccount",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "githubUrl",
             "description": "",
             "args": [],
@@ -2509,18 +2613,6 @@
             "deprecationReason": null
           },
           {
-            "name": "iconUrl",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
             "name": "icon",
             "description": "",
             "args": [],
@@ -2528,22 +2620,6 @@
               "kind": "OBJECT",
               "name": "AppIcon",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2569,88 +2645,16 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "username",
-            "description": "",
-            "args": [],
-            "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Boolean",
                 "ofType": null
               }
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "updated",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pushSecurityEnabled",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ownerAccount",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "privacy",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Use 'privacySetting' instead."
           },
           {
             "name": "privacySetting",
@@ -2685,23 +2689,7 @@
             "deprecationReason": null
           },
           {
-            "name": "isLikedByMe",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "'likes' have been deprecated."
-          },
-          {
-            "name": "published",
+            "name": "pushSecurityEnabled",
             "description": "",
             "args": [],
             "type": {
@@ -2715,134 +2703,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "likeCount",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "'likes' have been deprecated."
-          },
-          {
-            "name": "trendScore",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "'likes' have been deprecated."
-          },
-          {
-            "name": "likedBy",
-            "description": "",
-            "args": [
-              {
-                "name": "offset",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "User",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "'likes' have been deprecated."
-          },
-          {
-            "name": "releases",
-            "description": "",
-            "args": [
-              {
-                "name": "platform",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "AppPlatform",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "offset",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AppRelease",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
           },
           {
             "name": "builds",
@@ -2979,106 +2839,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "users",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "User",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
-            "name": "lastPublishedTime",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
-            "name": "packageUsername",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
-            "name": "packageName",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
-            "name": "accessTokens",
-            "description": "Api tokens made for project",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AccessToken",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Legacy access tokens are deprecated"
-          },
-          {
-            "name": "requiresAccessTokenForPushSecurity",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Legacy access tokens are deprecated"
           },
           {
             "name": "iosAppCredentials",
@@ -3409,6 +3169,329 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "webhooks",
+            "description": "Webhooks for an app",
+            "args": [
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "WebhookFilter",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Webhook",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "username",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use ownerAccount.name instead"
+          },
+          {
+            "name": "iconUrl",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "privacy",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use 'privacySetting' instead."
+          },
+          {
+            "name": "lastPublishedTime",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "packageUsername",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "packageName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "accessTokens",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AccessToken",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Legacy access tokens are deprecated"
+          },
+          {
+            "name": "requiresAccessTokenForPushSecurity",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Legacy access tokens are deprecated"
+          },
+          {
+            "name": "isLikedByMe",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "'likes' have been deprecated."
+          },
+          {
+            "name": "likeCount",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "'likes' have been deprecated."
+          },
+          {
+            "name": "trendScore",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "'likes' have been deprecated."
+          },
+          {
+            "name": "likedBy",
+            "description": "",
+            "args": [
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "User",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "'likes' have been deprecated."
+          },
+          {
+            "name": "users",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "releases",
+            "description": "",
+            "args": [
+              {
+                "name": "platform",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "AppPlatform",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AppRelease",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           }
         ],
         "inputFields": null,
@@ -3539,6 +3622,371 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "BuildStatus",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "IN_QUEUE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IN_PROGRESS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ERRORED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FINISHED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CANCELED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppPlatform",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "IOS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ANDROID",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Build",
+        "description": "Represents an EAS Build",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "actor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activityTimestamp",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "Project",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiatingUser",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "User type is deprecated"
+          },
+          {
+            "name": "initiatingActor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "artifacts",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "BuildArtifacts",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "logFiles",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BuildStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expirationDate",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sdkVersion",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metrics",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "BuildMetrics",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "distribution",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "DistributionType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildProfile",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "gitCommitHash",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "BuildError",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ActivityTimelineProjectActivity",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "User",
         "description": "Represents a human (not robot) actor.",
@@ -3628,9 +4076,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3640,33 +4092,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "lastLogin",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "lastPasswordReset",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3700,9 +4132,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3748,45 +4184,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "isOnboarded",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "isLegacy",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "wasLegacy",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3796,9 +4200,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3808,9 +4216,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4020,51 +4432,6 @@
             "deprecationReason": null
           },
           {
-            "name": "likes",
-            "description": "Likes this user has made",
-            "args": [
-              {
-                "name": "offset",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "App",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "'likes' have been deprecated."
-          },
-          {
             "name": "hasPendingUserInvitations",
             "description": "Whether this user has any pending user invitations. Only resolves for the viewer.",
             "args": [],
@@ -4138,6 +4505,111 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "lastPasswordReset",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "lastLogin",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "isOnboarded",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "isLegacy",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "wasLegacy",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "likes",
+            "description": "",
+            "args": [
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "'likes' have been deprecated."
           }
         ],
         "inputFields": null,
@@ -4666,494 +5138,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "ENUM",
-        "name": "AppPlatform",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "IOS",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ANDROID",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AppRelease",
-        "description": "",
-        "fields": [
-          {
-            "name": "id",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hash",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "publishedTime",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "publishingUsername",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sdkVersion",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "version",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "s3Key",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "s3Url",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "manifest",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "JSON",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "BuildStatus",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "IN_QUEUE",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "IN_PROGRESS",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ERRORED",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "FINISHED",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "CANCELED",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "Build",
-        "description": "Represents an EAS Build",
-        "fields": [
-          {
-            "name": "id",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "actor",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "INTERFACE",
-              "name": "Actor",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "activityTimestamp",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "project",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INTERFACE",
-                "name": "Project",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "initiatingUser",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "User",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "User type is deprecated"
-          },
-          {
-            "name": "initiatingActor",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "INTERFACE",
-              "name": "Actor",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "artifacts",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "BuildArtifacts",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "logFiles",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "status",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "BuildStatus",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "expirationDate",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "platform",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "AppPlatform",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "appVersion",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sdkVersion",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "releaseChannel",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "metrics",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "BuildMetrics",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "distribution",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "DistributionType",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "buildProfile",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "gitCommitHash",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "error",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "BuildError",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "ActivityTimelineProjectActivity",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "OBJECT",
         "name": "BuildArtifacts",
         "description": "",
@@ -5537,6 +5521,129 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppRelease",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hash",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedTime",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishingUsername",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sdkVersion",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "s3Key",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "s3Url",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "manifest",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -8114,6 +8221,151 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "WebhookFilter",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "event",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "WebhookType",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WebhookType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILD",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Webhook",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appId",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WebhookType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "UserPermission",
         "description": "",
@@ -10336,6 +10588,48 @@
       },
       {
         "kind": "OBJECT",
+        "name": "WebhookQuery",
+        "description": "",
+        "fields": [
+          {
+            "name": "byId",
+            "description": "",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Webhook",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "RootMutation",
         "description": "",
         "fields": [
@@ -10825,6 +11119,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EnvironmentSecretMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webhook",
+            "description": "Mutations that create, delete, update Webhooks",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WebhookMutation",
                 "ofType": null
               }
             },
@@ -15710,9 +16020,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -15722,9 +16036,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -16549,9 +16867,13 @@
                 "name": "type",
                 "description": null,
                 "type": {
-                  "kind": "ENUM",
-                  "name": "UploadSessionType",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "UploadSessionType",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null
               }
@@ -18366,6 +18688,218 @@
       {
         "kind": "OBJECT",
         "name": "DeleteEnvironmentSecretResult",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WebhookMutation",
+        "description": "",
+        "fields": [
+          {
+            "name": "createWebhook",
+            "description": "Create a Webhook",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "webhookInput",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "WebhookInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Webhook",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateWebhook",
+            "description": "Update a Webhook",
+            "args": [
+              {
+                "name": "webhookId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "webhookInput",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "WebhookInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Webhook",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteWebhook",
+            "description": "Delete a Webhook",
+            "args": [
+              {
+                "name": "webhookId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteWebhookResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "WebhookInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "url",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secret",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "event",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WebhookType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeleteWebhookResult",
         "description": "",
         "fields": [
           {

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -6,7 +6,7 @@ import { WebhookType } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
-import { prepareInputParams } from '../../webhooks/input';
+import { prepareInputParamsAsync } from '../../webhooks/input';
 
 export default class WebhookCreate extends Command {
   static description = 'Create a webhook on the current project.';
@@ -29,7 +29,7 @@ export default class WebhookCreate extends Command {
   async run() {
     await ensureLoggedInAsync();
     const { flags } = this.parse(WebhookCreate);
-    const webhookInputParams = await prepareInputParams(flags);
+    const webhookInputParams = await prepareInputParamsAsync(flags);
 
     const projectDir = await findProjectRootAsync(process.cwd());
     if (!projectDir) {

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -1,0 +1,114 @@
+import { getConfig } from '@expo/config';
+import { Command, flags } from '@oclif/command';
+import nullthrows from 'nullthrows';
+import ora from 'ora';
+import { URL } from 'url';
+
+import { WebhookInput, WebhookType } from '../../graphql/generated';
+import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
+import Log from '../../log';
+import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
+import { promptAsync } from '../../prompts';
+import { ensureLoggedInAsync } from '../../user/actions';
+
+export default class WebhookCreate extends Command {
+  static description = 'Create a webhook on the current project.';
+
+  static flags = {
+    event: flags.enum({
+      description: 'Event type that triggers the webhook',
+      options: [WebhookType.Build],
+      default: WebhookType.Build,
+    }),
+    url: flags.string({
+      description: 'Webhook URL',
+    }),
+    secret: flags.string({
+      description:
+        "Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header.",
+    }),
+  };
+
+  async run() {
+    await ensureLoggedInAsync();
+    const { flags } = this.parse(WebhookCreate);
+    const webhookInputParams = await this.prepareInputParams(flags);
+
+    const projectDir = await findProjectRootAsync(process.cwd());
+    if (!projectDir) {
+      throw new Error('Please run this command inside a project directory.');
+    }
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await getProjectIdAsync(exp);
+
+    const spinner = ora('Creating a webhook').start();
+    try {
+      await WebhookMutation.createWebhookAsync(projectId, webhookInputParams);
+      spinner.succeed('Successfully created a webhook');
+    } catch (err) {
+      spinner.fail('Failed to create a webhook');
+      throw err;
+    }
+  }
+
+  private async prepareInputParams({
+    event,
+    url: maybeUrl,
+    secret: maybeSecret,
+  }: {
+    event: WebhookType;
+    url?: string;
+    secret?: string;
+  }): Promise<WebhookInput> {
+    let url: string | undefined = maybeUrl;
+    let secret: string | undefined = maybeSecret;
+
+    if (!url || !validateURL(url)) {
+      const urlValidationMessage =
+        'The provided webhook URL is invalid and must be an absolute URL, including a scheme.';
+      if (url && !validateURL(url)) {
+        Log.error(urlValidationMessage);
+      }
+      ({ url } = await promptAsync({
+        type: 'text',
+        name: 'url',
+        message: 'Webhook URL:',
+        validate: value => validateURL(value) || urlValidationMessage,
+      }));
+    }
+
+    if (!secret || !validateSecret(secret)) {
+      const secretValidationMessage =
+        'Webhook secret has be at least 16 and not more than 1000 characters long';
+      if (secret && !validateSecret(secret)) {
+        Log.error(secretValidationMessage);
+      }
+      ({ secret } = await promptAsync({
+        type: 'text',
+        name: 'secret',
+        message: 'Webhook secret:',
+        validate: value => validateSecret(value) || secretValidationMessage,
+      }));
+    }
+
+    return {
+      event,
+      url: nullthrows(url),
+      secret: nullthrows(secret),
+    };
+  }
+}
+
+function validateURL(url: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+function validateSecret(secret: string): boolean {
+  return secret.length >= 16 && secret.length <= 1000;
+}

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -41,7 +41,7 @@ export default class WebhookDelete extends Command {
     let webhook: WebhookFragment | undefined =
       webhookId && (await WebhookQuery.byIdAsync(webhookId));
     if (!webhookId) {
-      const webhooks = await fetchWebhooksByAppId(projectId);
+      const webhooks = await fetchWebhooksByAppIdAsync(projectId);
       if (webhooks.length === 0) {
         process.exit(1);
       }
@@ -84,7 +84,7 @@ export default class WebhookDelete extends Command {
   }
 }
 
-async function fetchWebhooksByAppId(appId: string): Promise<WebhookFragment[]> {
+async function fetchWebhooksByAppIdAsync(appId: string): Promise<WebhookFragment[]> {
   const spinner = ora('Fetching webhooks').start();
   try {
     const webhooks = await WebhookQuery.byAppIdAsync(appId);

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -1,0 +1,102 @@
+import { getConfig } from '@expo/config';
+import { Command } from '@oclif/command';
+import assert from 'assert';
+import chalk from 'chalk';
+import nullthrows from 'nullthrows';
+import ora from 'ora';
+
+import { WebhookFragment } from '../../graphql/generated';
+import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
+import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
+import Log from '../../log';
+import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
+import { promptAsync, toggleConfirmAsync } from '../../prompts';
+import { ensureLoggedInAsync } from '../../user/actions';
+import { formatWebhook } from '../../webhooks/formatWebhook';
+
+export default class WebhookDelete extends Command {
+  static description = 'Delete a webhook on the current project.';
+
+  static args = [
+    {
+      name: 'ID',
+      required: false,
+      description: 'ID of the webhook to delete',
+    },
+  ];
+
+  async run() {
+    await ensureLoggedInAsync();
+    let {
+      args: { ID: webhookId },
+    } = this.parse(WebhookDelete);
+
+    const projectDir = await findProjectRootAsync(process.cwd());
+    if (!projectDir) {
+      throw new Error('Please run this command inside a project directory.');
+    }
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await getProjectIdAsync(exp);
+
+    let webhook: WebhookFragment | undefined =
+      webhookId && (await WebhookQuery.byIdAsync(webhookId));
+    if (!webhookId) {
+      const webhooks = await fetchWebhooksByAppId(projectId);
+      if (webhooks.length === 0) {
+        process.exit(1);
+      }
+      ({ webhook } = await promptAsync({
+        type: 'autocomplete',
+        name: 'webhook',
+        message: 'Pick the webhook to be deleted:',
+        choices: webhooks.map(i => ({
+          title: `${chalk.bold(i.url)} (Event: ${i.event}, ID: ${i.id})`,
+          value: i,
+        })),
+      }));
+      webhookId = nullthrows(webhook).id;
+    }
+
+    assert(webhook, 'Webhook must be defined here');
+
+    Log.addNewLineIfNone();
+    Log.log(formatWebhook(webhook));
+    Log.newLine();
+    Log.warn(`You are about to permamently delete this webhook.\nThis action is irreversible.`);
+    Log.newLine();
+    const confirmed = await toggleConfirmAsync({
+      message: 'Are you sure you wish to proceed?',
+    });
+
+    if (!confirmed) {
+      Log.error(`Canceled deletion of the webhook`);
+      process.exit(1);
+    }
+
+    const spinner = ora('Deleting the webhook').start();
+    try {
+      await WebhookMutation.deleteWebhookAsync(webhookId);
+      spinner.succeed('Successfully deleted the webhook');
+    } catch (err) {
+      spinner.fail('Failed to delete the webhook');
+      throw err;
+    }
+  }
+}
+
+async function fetchWebhooksByAppId(appId: string): Promise<WebhookFragment[]> {
+  const spinner = ora('Fetching webhooks').start();
+  try {
+    const webhooks = await WebhookQuery.byAppIdAsync(appId);
+    if (webhooks.length === 0) {
+      spinner.fail('There are no webhooks on the project');
+      return [];
+    } else {
+      spinner.succeed(`Successfully fetched ${webhooks.length} webhooks`);
+      return webhooks;
+    }
+  } catch (err) {
+    spinner.fail("Something went wrong and we couldn't fetch the webhook list");
+    throw err;
+  }
+}

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -52,7 +52,7 @@ export default class WebhookList extends Command {
       }
     } catch (err) {
       spinner.fail(
-        `Something went wrong and we couldn't fetch the webhook list ${projectFullName}`
+        `Something went wrong and we couldn't fetch the webhook list for the project ${projectFullName}`
       );
       throw err;
     }

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -1,0 +1,60 @@
+import { getConfig } from '@expo/config';
+import { Command, flags } from '@oclif/command';
+import chalk from 'chalk';
+import ora from 'ora';
+
+import { WebhookType } from '../../graphql/generated';
+import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
+import Log from '../../log';
+import {
+  findProjectRootAsync,
+  getProjectFullNameAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
+import { ensureLoggedInAsync } from '../../user/actions';
+import { formatWebhook } from '../../webhooks/formatWebhook';
+
+export default class WebhookList extends Command {
+  static description = 'List webhooks on the current project.';
+
+  static flags = {
+    event: flags.enum({
+      description: 'Event type that triggers the webhook',
+      options: [WebhookType.Build],
+    }),
+  };
+
+  async run() {
+    await ensureLoggedInAsync();
+    const {
+      flags: { event },
+    } = this.parse(WebhookList);
+
+    const projectDir = await findProjectRootAsync(process.cwd());
+    if (!projectDir) {
+      throw new Error('Please run this command inside a project directory.');
+    }
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await getProjectIdAsync(exp);
+    const projectFullName = await getProjectFullNameAsync(exp);
+
+    const spinner = ora(`Fetching the list of webhook on project ${projectFullName}`).start();
+    try {
+      const webhooks = await WebhookQuery.byAppIdAsync(projectId, event && { event });
+      if (webhooks.length === 0) {
+        spinner.fail(`There are no webhooks on project ${projectFullName}`);
+      } else {
+        spinner.succeed(`Found ${webhooks.length} webhooks on project ${projectFullName}`);
+        const list = webhooks
+          .map(webhook => formatWebhook(webhook))
+          .join(`\n\n${chalk.dim('———')}\n\n`);
+        Log.log(`\n${list}`);
+      }
+    } catch (err) {
+      spinner.fail(
+        `Something went wrong and we couldn't fetch the webhook list ${projectFullName}`
+      );
+      throw err;
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/webhook/update.ts
+++ b/packages/eas-cli/src/commands/webhook/update.ts
@@ -1,17 +1,21 @@
-import { getConfig } from '@expo/config';
 import { Command, flags } from '@oclif/command';
+import pick from 'lodash/pick';
 import ora from 'ora';
 
 import { WebhookType } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
+import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import { ensureLoggedInAsync } from '../../user/actions';
 import { prepareInputParams } from '../../webhooks/input';
 
-export default class WebhookCreate extends Command {
+export default class WebhookUpdate extends Command {
   static description = 'Create a webhook on the current project.';
 
   static flags = {
+    id: flags.string({
+      description: 'Webhook ID',
+      required: true,
+    }),
     event: flags.enum({
       description: 'Event type that triggers the webhook',
       options: [WebhookType.Build],
@@ -28,22 +32,22 @@ export default class WebhookCreate extends Command {
 
   async run() {
     await ensureLoggedInAsync();
-    const { flags } = this.parse(WebhookCreate);
-    const webhookInputParams = await prepareInputParams(flags);
+    const { flags } = this.parse(WebhookUpdate);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
-    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    const projectId = await getProjectIdAsync(exp);
+    const webhookId = flags.id;
 
-    const spinner = ora('Creating a webhook').start();
+    const webhook = await WebhookQuery.byIdAsync(webhookId);
+    const webhookInputParams = await prepareInputParams(
+      pick(flags, ['event', 'url', 'secret']),
+      webhook
+    );
+
+    const spinner = ora('Updating a webhook').start();
     try {
-      await WebhookMutation.createWebhookAsync(projectId, webhookInputParams);
-      spinner.succeed('Successfully created a webhook');
+      await WebhookMutation.updateWebhookAsync(webhookId, webhookInputParams);
+      spinner.succeed('Successfully updated a webhook');
     } catch (err) {
-      spinner.fail('Failed to create a webhook');
+      spinner.fail('Failed to update a webhook');
       throw err;
     }
   }

--- a/packages/eas-cli/src/commands/webhook/update.ts
+++ b/packages/eas-cli/src/commands/webhook/update.ts
@@ -6,7 +6,7 @@ import { WebhookType } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import { ensureLoggedInAsync } from '../../user/actions';
-import { prepareInputParams } from '../../webhooks/input';
+import { prepareInputParamsAsync } from '../../webhooks/input';
 
 export default class WebhookUpdate extends Command {
   static description = 'Create a webhook on the current project.';
@@ -37,7 +37,7 @@ export default class WebhookUpdate extends Command {
     const webhookId = flags.id;
 
     const webhook = await WebhookQuery.byIdAsync(webhookId);
-    const webhookInputParams = await prepareInputParams(
+    const webhookInputParams = await prepareInputParamsAsync(
       pick(flags, ['event', 'url', 'secret']),
       webhook
     );

--- a/packages/eas-cli/src/commands/webhook/view.ts
+++ b/packages/eas-cli/src/commands/webhook/view.ts
@@ -1,0 +1,36 @@
+import { Command } from '@oclif/command';
+import ora from 'ora';
+
+import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
+import Log from '../../log';
+import { ensureLoggedInAsync } from '../../user/actions';
+import { formatWebhook } from '../../webhooks/formatWebhook';
+
+export default class WebhookView extends Command {
+  static description = 'View a webhook on the current project.';
+
+  static args = [
+    {
+      name: 'ID',
+      required: true,
+      description: 'ID of the webhook to view',
+    },
+  ];
+
+  async run() {
+    await ensureLoggedInAsync();
+    const {
+      args: { ID: webhookId },
+    } = this.parse(WebhookView);
+
+    const spinner = ora(`Fetching the webhook details for ID ${webhookId}`).start();
+    try {
+      const webhook = await WebhookQuery.byIdAsync(webhookId);
+      spinner.succeed(`Found the webhook details`);
+      Log.log(`\n${formatWebhook(webhook)}`);
+    } catch (err) {
+      spinner.fail(`Couldn't find the webhook with ID ${webhookId}`);
+      throw err;
+    }
+  }
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -89,6 +89,8 @@ export type RootQuery = {
    * query object
    */
   meActor?: Maybe<Actor>;
+  /** Top-level query object for querying Webhooks. */
+  webhook: WebhookQuery;
 };
 
 
@@ -161,8 +163,8 @@ export type ActivityTimelineProjectActivity = {
 export type Actor = {
   id: Scalars['ID'];
   firstName?: Maybe<Scalars['String']>;
-  created?: Maybe<Scalars['DateTime']>;
-  isExpoAdmin?: Maybe<Scalars['Boolean']>;
+  created: Scalars['DateTime'];
+  isExpoAdmin: Scalars['Boolean'];
   /** Associated accounts */
   accounts: Array<Account>;
   /** Access Tokens belonging to this actor */
@@ -189,19 +191,12 @@ export type Account = {
   __typename?: 'Account';
   id: Scalars['ID'];
   name: Scalars['String'];
-  isCurrent?: Maybe<Scalars['Boolean']>;
-  /** @deprecated Build packs are no longer supported */
-  availableBuilds?: Maybe<Scalars['Int']>;
-  unlimitedBuilds?: Maybe<Scalars['Boolean']>;
-  /** @deprecated No longer needed */
-  subscriptionChangesPending?: Maybe<Scalars['Boolean']>;
-  /** @deprecated Build packs are no longer supported */
-  willAutoRenewBuilds?: Maybe<Scalars['Boolean']>;
-  pushSecurityEnabled?: Maybe<Scalars['Boolean']>;
+  isCurrent: Scalars['Boolean'];
+  pushSecurityEnabled: Scalars['Boolean'];
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
-  /** short lived property for test */
-  offers?: Maybe<Array<Maybe<Offer>>>;
+  /** Offers set on this account */
+  offers?: Maybe<Array<Offer>>;
   /** Snacks associated with this account */
   snacks: Array<Snack>;
   /** Apps associated with this account */
@@ -219,13 +214,6 @@ export type Account = {
   userInvitations: Array<UserInvitation>;
   /** Billing information */
   billing?: Maybe<Billing>;
-  /**
-   * Api tokens made for project
-   * @deprecated Legacy access tokens are deprecated
-   */
-  accessTokens: Array<Maybe<AccessToken>>;
-  /** @deprecated Legacy access tokens are deprecated */
-  requiresAccessTokenForPushSecurity: Scalars['Boolean'];
   /** iOS credentials for account */
   appleTeams: Array<AppleTeam>;
   appleAppIdentifiers: Array<AppleAppIdentifier>;
@@ -235,6 +223,18 @@ export type Account = {
   appleDevices: Array<AppleDevice>;
   /** Environment secrets for an account */
   environmentSecrets: Array<EnvironmentSecret>;
+  /** @deprecated Legacy access tokens are deprecated */
+  accessTokens: Array<Maybe<AccessToken>>;
+  /** @deprecated Legacy access tokens are deprecated */
+  requiresAccessTokenForPushSecurity: Scalars['Boolean'];
+  /** @deprecated See isCurrent */
+  unlimitedBuilds: Scalars['Boolean'];
+  /** @deprecated Build packs are no longer supported */
+  availableBuilds?: Maybe<Scalars['Int']>;
+  /** @deprecated No longer needed */
+  subscriptionChangesPending?: Maybe<Scalars['Boolean']>;
+  /** @deprecated Build packs are no longer supported */
+  willAutoRenewBuilds?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -382,12 +382,12 @@ export type Project = {
   name: Scalars['String'];
   fullName: Scalars['String'];
   description: Scalars['String'];
-  /** @deprecated Field no longer supported */
-  iconUrl?: Maybe<Scalars['String']>;
   slug: Scalars['String'];
-  username: Scalars['String'];
   updated: Scalars['DateTime'];
   published: Scalars['Boolean'];
+  username: Scalars['String'];
+  /** @deprecated Field no longer supported */
+  iconUrl?: Maybe<Scalars['String']>;
 };
 
 /** Represents an Exponent App (or Experience in legacy terms) */
@@ -397,52 +397,22 @@ export type App = Project & {
   name: Scalars['String'];
   fullName: Scalars['String'];
   description: Scalars['String'];
+  slug: Scalars['String'];
+  updated: Scalars['DateTime'];
+  published: Scalars['Boolean'];
+  ownerAccount: Account;
   githubUrl?: Maybe<Scalars['String']>;
   playStoreUrl?: Maybe<Scalars['String']>;
   appStoreUrl?: Maybe<Scalars['String']>;
-  /** @deprecated Field no longer supported */
-  iconUrl?: Maybe<Scalars['String']>;
   icon?: Maybe<AppIcon>;
-  slug: Scalars['String'];
   sdkVersion: Scalars['String'];
-  isDeprecated?: Maybe<Scalars['Boolean']>;
-  username: Scalars['String'];
-  updated: Scalars['DateTime'];
-  pushSecurityEnabled?: Maybe<Scalars['Boolean']>;
-  ownerAccount: Account;
-  /** @deprecated Use 'privacySetting' instead. */
-  privacy: Scalars['String'];
+  isDeprecated: Scalars['Boolean'];
   privacySetting: AppPrivacy;
   latestReleaseId: Scalars['ID'];
-  /** @deprecated 'likes' have been deprecated. */
-  isLikedByMe: Scalars['Boolean'];
-  published: Scalars['Boolean'];
-  /** @deprecated 'likes' have been deprecated. */
-  likeCount: Scalars['Int'];
-  /** @deprecated 'likes' have been deprecated. */
-  trendScore: Scalars['Float'];
-  /** @deprecated 'likes' have been deprecated. */
-  likedBy: Array<Maybe<User>>;
-  /** @deprecated Field no longer supported */
-  releases: Array<Maybe<AppRelease>>;
+  pushSecurityEnabled: Scalars['Boolean'];
   /** (EAS Build) Builds associated with this app */
   builds: Array<Build>;
   buildJobs: Array<BuildJob>;
-  /** @deprecated Field no longer supported */
-  users?: Maybe<Array<Maybe<User>>>;
-  /** @deprecated Field no longer supported */
-  lastPublishedTime: Scalars['DateTime'];
-  /** @deprecated Field no longer supported */
-  packageUsername: Scalars['String'];
-  /** @deprecated Field no longer supported */
-  packageName: Scalars['String'];
-  /**
-   * Api tokens made for project
-   * @deprecated Legacy access tokens are deprecated
-   */
-  accessTokens: Array<Maybe<AccessToken>>;
-  /** @deprecated Legacy access tokens are deprecated */
-  requiresAccessTokenForPushSecurity: Scalars['Boolean'];
   /** iOS app credentials for the project */
   iosAppCredentials: Array<IosAppCredentials>;
   /** Android app credentials for the project */
@@ -459,21 +429,36 @@ export type App = Project & {
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   /** Environment secrets for an app */
   environmentSecrets: Array<EnvironmentSecret>;
-};
-
-
-/** Represents an Exponent App (or Experience in legacy terms) */
-export type AppLikedByArgs = {
-  offset?: Maybe<Scalars['Int']>;
-  limit?: Maybe<Scalars['Int']>;
-};
-
-
-/** Represents an Exponent App (or Experience in legacy terms) */
-export type AppReleasesArgs = {
-  platform: AppPlatform;
-  offset?: Maybe<Scalars['Int']>;
-  limit?: Maybe<Scalars['Int']>;
+  /** Webhooks for an app */
+  webhooks: Array<Webhook>;
+  /** @deprecated Use ownerAccount.name instead */
+  username: Scalars['String'];
+  /** @deprecated Field no longer supported */
+  iconUrl?: Maybe<Scalars['String']>;
+  /** @deprecated Use 'privacySetting' instead. */
+  privacy: Scalars['String'];
+  /** @deprecated Field no longer supported */
+  lastPublishedTime: Scalars['DateTime'];
+  /** @deprecated Field no longer supported */
+  packageUsername: Scalars['String'];
+  /** @deprecated Field no longer supported */
+  packageName: Scalars['String'];
+  /** @deprecated Legacy access tokens are deprecated */
+  accessTokens: Array<Maybe<AccessToken>>;
+  /** @deprecated Legacy access tokens are deprecated */
+  requiresAccessTokenForPushSecurity: Scalars['Boolean'];
+  /** @deprecated 'likes' have been deprecated. */
+  isLikedByMe: Scalars['Boolean'];
+  /** @deprecated 'likes' have been deprecated. */
+  likeCount: Scalars['Int'];
+  /** @deprecated 'likes' have been deprecated. */
+  trendScore: Scalars['Float'];
+  /** @deprecated 'likes' have been deprecated. */
+  likedBy: Array<Maybe<User>>;
+  /** @deprecated Field no longer supported */
+  users?: Maybe<Array<Maybe<User>>>;
+  /** @deprecated Field no longer supported */
+  releases: Array<Maybe<AppRelease>>;
 };
 
 
@@ -544,6 +529,27 @@ export type AppEnvironmentSecretsArgs = {
   filterNames?: Maybe<Array<Scalars['String']>>;
 };
 
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWebhooksArgs = {
+  filter?: Maybe<WebhookFilter>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppLikedByArgs = {
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppReleasesArgs = {
+  platform: AppPlatform;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
 export type AppIcon = {
   __typename?: 'AppIcon';
   url: Scalars['String'];
@@ -560,6 +566,46 @@ export enum AppPrivacy {
   Hidden = 'HIDDEN'
 }
 
+export enum BuildStatus {
+  InQueue = 'IN_QUEUE',
+  InProgress = 'IN_PROGRESS',
+  Errored = 'ERRORED',
+  Finished = 'FINISHED',
+  Canceled = 'CANCELED'
+}
+
+export enum AppPlatform {
+  Ios = 'IOS',
+  Android = 'ANDROID'
+}
+
+/** Represents an EAS Build */
+export type Build = ActivityTimelineProjectActivity & {
+  __typename?: 'Build';
+  id: Scalars['ID'];
+  actor?: Maybe<Actor>;
+  activityTimestamp: Scalars['DateTime'];
+  project: Project;
+  /** @deprecated User type is deprecated */
+  initiatingUser?: Maybe<User>;
+  initiatingActor?: Maybe<Actor>;
+  artifacts?: Maybe<BuildArtifacts>;
+  logFiles: Array<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  createdAt?: Maybe<Scalars['DateTime']>;
+  status: BuildStatus;
+  expirationDate?: Maybe<Scalars['DateTime']>;
+  platform: AppPlatform;
+  appVersion?: Maybe<Scalars['String']>;
+  sdkVersion?: Maybe<Scalars['String']>;
+  releaseChannel?: Maybe<Scalars['String']>;
+  metrics?: Maybe<BuildMetrics>;
+  distribution?: Maybe<DistributionType>;
+  buildProfile?: Maybe<Scalars['String']>;
+  gitCommitHash?: Maybe<Scalars['String']>;
+  error?: Maybe<BuildError>;
+};
+
 /** Represents a human (not robot) actor. */
 export type User = Actor & {
   __typename?: 'User';
@@ -569,22 +615,17 @@ export type User = Actor & {
   firstName?: Maybe<Scalars['String']>;
   lastName?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
-  profilePhoto?: Maybe<Scalars['String']>;
-  created?: Maybe<Scalars['DateTime']>;
-  lastLogin?: Maybe<Scalars['DateTime']>;
-  lastPasswordReset?: Maybe<Scalars['DateTime']>;
+  profilePhoto: Scalars['String'];
+  created: Scalars['DateTime'];
   industry?: Maybe<Scalars['String']>;
   location?: Maybe<Scalars['String']>;
-  appCount?: Maybe<Scalars['Int']>;
+  appCount: Scalars['Int'];
   githubUsername?: Maybe<Scalars['String']>;
   twitterUsername?: Maybe<Scalars['String']>;
   appetizeCode?: Maybe<Scalars['String']>;
-  emailVerified?: Maybe<Scalars['Boolean']>;
-  isOnboarded?: Maybe<Scalars['Boolean']>;
-  isLegacy?: Maybe<Scalars['Boolean']>;
-  wasLegacy?: Maybe<Scalars['Boolean']>;
-  isEmailUnsubscribed?: Maybe<Scalars['Boolean']>;
-  isExpoAdmin?: Maybe<Scalars['Boolean']>;
+  emailVerified: Scalars['Boolean'];
+  isEmailUnsubscribed: Scalars['Boolean'];
+  isExpoAdmin: Scalars['Boolean'];
   isSecondFactorAuthenticationEnabled: Scalars['Boolean'];
   /** Get all certified second factor authentication methods */
   secondFactorDevices: Array<UserSecondFactorDevice>;
@@ -596,11 +637,6 @@ export type User = Actor & {
   snacks: Array<Snack>;
   /** Apps this user has published */
   apps: Array<App>;
-  /**
-   * Likes this user has made
-   * @deprecated 'likes' have been deprecated.
-   */
-  likes?: Maybe<Array<Maybe<App>>>;
   /** Whether this user has any pending user invitations. Only resolves for the viewer. */
   hasPendingUserInvitations: Scalars['Boolean'];
   /** Pending UserInvitations for this user. Only resolves for the viewer. */
@@ -610,6 +646,18 @@ export type User = Actor & {
    * Only resolves for the viewer.
    */
   featureGates: Scalars['JSONObject'];
+  /** @deprecated Field no longer supported */
+  lastPasswordReset?: Maybe<Scalars['DateTime']>;
+  /** @deprecated Field no longer supported */
+  lastLogin?: Maybe<Scalars['DateTime']>;
+  /** @deprecated Field no longer supported */
+  isOnboarded?: Maybe<Scalars['Boolean']>;
+  /** @deprecated Field no longer supported */
+  isLegacy?: Maybe<Scalars['Boolean']>;
+  /** @deprecated Field no longer supported */
+  wasLegacy?: Maybe<Scalars['Boolean']>;
+  /** @deprecated 'likes' have been deprecated. */
+  likes?: Maybe<Array<Maybe<App>>>;
 };
 
 
@@ -629,15 +677,15 @@ export type UserAppsArgs = {
 
 
 /** Represents a human (not robot) actor. */
-export type UserLikesArgs = {
-  offset: Scalars['Int'];
-  limit: Scalars['Int'];
+export type UserFeatureGatesArgs = {
+  filter?: Maybe<Array<Scalars['String']>>;
 };
 
 
 /** Represents a human (not robot) actor. */
-export type UserFeatureGatesArgs = {
-  filter?: Maybe<Array<Scalars['String']>>;
+export type UserLikesArgs = {
+  offset: Scalars['Int'];
+  limit: Scalars['Int'];
 };
 
 /** A second factor device belonging to a User */
@@ -706,59 +754,6 @@ export enum Role {
 }
 
 
-export enum AppPlatform {
-  Ios = 'IOS',
-  Android = 'ANDROID'
-}
-
-export type AppRelease = {
-  __typename?: 'AppRelease';
-  id: Scalars['ID'];
-  hash?: Maybe<Scalars['String']>;
-  publishedTime?: Maybe<Scalars['DateTime']>;
-  publishingUsername?: Maybe<Scalars['String']>;
-  sdkVersion?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['String']>;
-  s3Key?: Maybe<Scalars['String']>;
-  s3Url?: Maybe<Scalars['String']>;
-  manifest?: Maybe<Scalars['JSON']>;
-};
-
-export enum BuildStatus {
-  InQueue = 'IN_QUEUE',
-  InProgress = 'IN_PROGRESS',
-  Errored = 'ERRORED',
-  Finished = 'FINISHED',
-  Canceled = 'CANCELED'
-}
-
-/** Represents an EAS Build */
-export type Build = ActivityTimelineProjectActivity & {
-  __typename?: 'Build';
-  id: Scalars['ID'];
-  actor?: Maybe<Actor>;
-  activityTimestamp: Scalars['DateTime'];
-  project: Project;
-  /** @deprecated User type is deprecated */
-  initiatingUser?: Maybe<User>;
-  initiatingActor?: Maybe<Actor>;
-  artifacts?: Maybe<BuildArtifacts>;
-  logFiles: Array<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  createdAt?: Maybe<Scalars['DateTime']>;
-  status: BuildStatus;
-  expirationDate?: Maybe<Scalars['DateTime']>;
-  platform: AppPlatform;
-  appVersion?: Maybe<Scalars['String']>;
-  sdkVersion?: Maybe<Scalars['String']>;
-  releaseChannel?: Maybe<Scalars['String']>;
-  metrics?: Maybe<BuildMetrics>;
-  distribution?: Maybe<DistributionType>;
-  buildProfile?: Maybe<Scalars['String']>;
-  gitCommitHash?: Maybe<Scalars['String']>;
-  error?: Maybe<BuildError>;
-};
-
 export type BuildArtifacts = {
   __typename?: 'BuildArtifacts';
   buildUrl?: Maybe<Scalars['String']>;
@@ -804,6 +799,19 @@ export type BuildJob = ActivityTimelineProjectActivity & {
   platform: AppPlatform;
   sdkVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
+};
+
+export type AppRelease = {
+  __typename?: 'AppRelease';
+  id: Scalars['ID'];
+  hash?: Maybe<Scalars['String']>;
+  publishedTime?: Maybe<Scalars['DateTime']>;
+  publishingUsername?: Maybe<Scalars['String']>;
+  sdkVersion?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['String']>;
+  s3Key?: Maybe<Scalars['String']>;
+  s3Url?: Maybe<Scalars['String']>;
+  manifest?: Maybe<Scalars['JSON']>;
 };
 
 export type BuildArtifact = {
@@ -1095,6 +1103,24 @@ export type EnvironmentSecret = {
   __typename?: 'EnvironmentSecret';
   id: Scalars['ID'];
   name: Scalars['String'];
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+};
+
+export type WebhookFilter = {
+  event?: Maybe<WebhookType>;
+};
+
+export enum WebhookType {
+  Build = 'BUILD'
+}
+
+export type Webhook = {
+  __typename?: 'Webhook';
+  id: Scalars['ID'];
+  appId: Scalars['ID'];
+  event: WebhookType;
+  url: Scalars['String'];
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
 };
@@ -1491,6 +1517,16 @@ export type UserQueryByUsernameArgs = {
   username: Scalars['String'];
 };
 
+export type WebhookQuery = {
+  __typename?: 'WebhookQuery';
+  byId: Webhook;
+};
+
+
+export type WebhookQueryByIdArgs = {
+  id: Scalars['ID'];
+};
+
 export type RootMutation = {
   __typename?: 'RootMutation';
   /**
@@ -1549,6 +1585,8 @@ export type RootMutation = {
   emailSubscription: EmailSubscriptionMutation;
   /** Mutations that create and delete EnvironmentSecrets */
   environmentSecret: EnvironmentSecretMutation;
+  /** Mutations that create, delete, update Webhooks */
+  webhook: WebhookMutation;
 };
 
 
@@ -2419,8 +2457,8 @@ export type Robot = Actor & {
   __typename?: 'Robot';
   id: Scalars['ID'];
   firstName?: Maybe<Scalars['String']>;
-  created?: Maybe<Scalars['DateTime']>;
-  isExpoAdmin?: Maybe<Scalars['Boolean']>;
+  created: Scalars['DateTime'];
+  isExpoAdmin: Scalars['Boolean'];
   /** Associated accounts */
   accounts: Array<Account>;
   /** Access Tokens belonging to this actor */
@@ -2584,7 +2622,7 @@ export type UploadSession = {
 
 
 export type UploadSessionCreateUploadSessionArgs = {
-  type?: Maybe<UploadSessionType>;
+  type: UploadSessionType;
 };
 
 export enum UploadSessionType {
@@ -2923,6 +2961,44 @@ export type CreateEnvironmentSecretInput = {
 
 export type DeleteEnvironmentSecretResult = {
   __typename?: 'DeleteEnvironmentSecretResult';
+  id: Scalars['ID'];
+};
+
+export type WebhookMutation = {
+  __typename?: 'WebhookMutation';
+  /** Create a Webhook */
+  createWebhook: Webhook;
+  /** Update a Webhook */
+  updateWebhook: Webhook;
+  /** Delete a Webhook */
+  deleteWebhook: DeleteWebhookResult;
+};
+
+
+export type WebhookMutationCreateWebhookArgs = {
+  appId: Scalars['String'];
+  webhookInput: WebhookInput;
+};
+
+
+export type WebhookMutationUpdateWebhookArgs = {
+  webhookId: Scalars['ID'];
+  webhookInput: WebhookInput;
+};
+
+
+export type WebhookMutationDeleteWebhookArgs = {
+  webhookId: Scalars['ID'];
+};
+
+export type WebhookInput = {
+  url: Scalars['String'];
+  secret: Scalars['String'];
+  event: WebhookType;
+};
+
+export type DeleteWebhookResult = {
+  __typename?: 'DeleteWebhookResult';
   id: Scalars['ID'];
 };
 
@@ -4091,6 +4167,58 @@ export type CreateUploadSessionMutation = (
   ) }
 );
 
+export type CreateWebhookMutationVariables = Exact<{
+  appId: Scalars['String'];
+  webhookInput: WebhookInput;
+}>;
+
+
+export type CreateWebhookMutation = (
+  { __typename?: 'RootMutation' }
+  & { webhook: (
+    { __typename?: 'WebhookMutation' }
+    & { createWebhook: (
+      { __typename?: 'Webhook' }
+      & Pick<Webhook, 'id'>
+      & WebhookFragment
+    ) }
+  ) }
+);
+
+export type UpdateWebhookMutationVariables = Exact<{
+  webhookId: Scalars['ID'];
+  webhookInput: WebhookInput;
+}>;
+
+
+export type UpdateWebhookMutation = (
+  { __typename?: 'RootMutation' }
+  & { webhook: (
+    { __typename?: 'WebhookMutation' }
+    & { updateWebhook: (
+      { __typename?: 'Webhook' }
+      & Pick<Webhook, 'id'>
+      & WebhookFragment
+    ) }
+  ) }
+);
+
+export type DeleteWebhookMutationVariables = Exact<{
+  webhookId: Scalars['ID'];
+}>;
+
+
+export type DeleteWebhookMutation = (
+  { __typename?: 'RootMutation' }
+  & { webhook: (
+    { __typename?: 'WebhookMutation' }
+    & { deleteWebhook: (
+      { __typename?: 'DeleteWebhookResult' }
+      & Pick<DeleteWebhookResult, 'id'>
+    ) }
+  ) }
+);
+
 export type BuildsByIdQueryVariables = Exact<{
   buildId: Scalars['ID'];
 }>;
@@ -4257,6 +4385,45 @@ export type CurrentUserQuery = (
   )> }
 );
 
+export type WebhooksByAppIdQueryVariables = Exact<{
+  appId: Scalars['String'];
+  webhookFilter?: Maybe<WebhookFilter>;
+}>;
+
+
+export type WebhooksByAppIdQuery = (
+  { __typename?: 'RootQuery' }
+  & { app?: Maybe<(
+    { __typename?: 'AppQuery' }
+    & { byId: (
+      { __typename?: 'App' }
+      & Pick<App, 'id'>
+      & { webhooks: Array<(
+        { __typename?: 'Webhook' }
+        & Pick<Webhook, 'id'>
+        & WebhookFragment
+      )> }
+    ) }
+  )> }
+);
+
+export type WebhookByIdQueryVariables = Exact<{
+  webhookId: Scalars['ID'];
+}>;
+
+
+export type WebhookByIdQuery = (
+  { __typename?: 'RootQuery' }
+  & { webhook: (
+    { __typename?: 'WebhookQuery' }
+    & { byId: (
+      { __typename?: 'Webhook' }
+      & Pick<Webhook, 'id'>
+      & WebhookFragment
+    ) }
+  ) }
+);
+
 export type AppFragment = (
   { __typename?: 'App' }
   & Pick<App, 'id' | 'fullName' | 'slug'>
@@ -4293,6 +4460,11 @@ export type BuildFragment = (
 export type EnvironmentSecretFragment = (
   { __typename?: 'EnvironmentSecret' }
   & Pick<EnvironmentSecret, 'id' | 'name' | 'createdAt'>
+);
+
+export type WebhookFragment = (
+  { __typename?: 'Webhook' }
+  & Pick<Webhook, 'id' | 'event' | 'url' | 'createdAt' | 'updatedAt'>
 );
 
 export type AppleAppIdentifierFragment = (

--- a/packages/eas-cli/src/graphql/mutations/WebhookMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/WebhookMutation.ts
@@ -5,6 +5,8 @@ import { graphqlClient, withErrorHandlingAsync } from '../client';
 import {
   CreateWebhookMutation,
   CreateWebhookMutationVariables,
+  DeleteWebhookMutation,
+  DeleteWebhookMutationVariables,
   UpdateWebhookMutation,
   UpdateWebhookMutationVariables,
   WebhookFragment,
@@ -57,5 +59,23 @@ export const WebhookMutation = {
         .toPromise()
     );
     return data.webhook.updateWebhook;
+  },
+  async deleteWebhookAsync(webhookId: string): Promise<void> {
+    await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeleteWebhookMutation, DeleteWebhookMutationVariables>(
+          gql`
+            mutation DeleteWebhookMutation($webhookId: ID!) {
+              webhook {
+                deleteWebhook(webhookId: $webhookId) {
+                  id
+                }
+              }
+            }
+          `,
+          { webhookId }
+        )
+        .toPromise()
+    );
   },
 };

--- a/packages/eas-cli/src/graphql/mutations/WebhookMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/WebhookMutation.ts
@@ -1,0 +1,36 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../client';
+import {
+  CreateWebhookMutation,
+  CreateWebhookMutationVariables,
+  WebhookFragment,
+  WebhookInput,
+} from '../generated';
+import { WebhookFragmentNode } from '../types/Webhook';
+
+export const WebhookMutation = {
+  async createWebhookAsync(appId: string, webhookInput: WebhookInput): Promise<WebhookFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateWebhookMutation, CreateWebhookMutationVariables>(
+          gql`
+            mutation CreateWebhookMutation($appId: String!, $webhookInput: WebhookInput!) {
+              webhook {
+                createWebhook(appId: $appId, webhookInput: $webhookInput) {
+                  id
+                  ...WebhookFragment
+                }
+              }
+            }
+            ${print(WebhookFragmentNode)}
+          `,
+          { appId, webhookInput }
+        )
+        .toPromise()
+    );
+
+    return data.webhook.createWebhook;
+  },
+};

--- a/packages/eas-cli/src/graphql/mutations/WebhookMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/WebhookMutation.ts
@@ -5,6 +5,8 @@ import { graphqlClient, withErrorHandlingAsync } from '../client';
 import {
   CreateWebhookMutation,
   CreateWebhookMutationVariables,
+  UpdateWebhookMutation,
+  UpdateWebhookMutationVariables,
   WebhookFragment,
   WebhookInput,
 } from '../generated';
@@ -30,7 +32,30 @@ export const WebhookMutation = {
         )
         .toPromise()
     );
-
     return data.webhook.createWebhook;
+  },
+  async updateWebhookAsync(
+    webhookId: string,
+    webhookInput: WebhookInput
+  ): Promise<WebhookFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<UpdateWebhookMutation, UpdateWebhookMutationVariables>(
+          gql`
+            mutation UpdateWebhookMutation($webhookId: ID!, $webhookInput: WebhookInput!) {
+              webhook {
+                updateWebhook(webhookId: $webhookId, webhookInput: $webhookInput) {
+                  id
+                  ...WebhookFragment
+                }
+              }
+            }
+            ${print(WebhookFragmentNode)}
+          `,
+          { webhookId, webhookInput }
+        )
+        .toPromise()
+    );
+    return data.webhook.updateWebhook;
   },
 };

--- a/packages/eas-cli/src/graphql/queries/WebhookQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/WebhookQuery.ts
@@ -3,6 +3,8 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import {
+  WebhookByIdQuery,
+  WebhookByIdQueryVariables,
   WebhookFilter,
   WebhookFragment,
   WebhooksByAppIdQuery,
@@ -34,5 +36,26 @@ export const WebhookQuery = {
         .toPromise()
     );
     return data.app?.byId.webhooks ?? [];
+  },
+  async byIdAsync(webhookId: string): Promise<WebhookFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<WebhookByIdQuery, WebhookByIdQueryVariables>(
+          gql`
+            query WebhookById($webhookId: ID!) {
+              webhook {
+                byId(id: $webhookId) {
+                  id
+                  ...WebhookFragment
+                }
+              }
+            }
+            ${print(WebhookFragmentNode)}
+          `,
+          { webhookId }
+        )
+        .toPromise()
+    );
+    return data.webhook.byId;
   },
 };

--- a/packages/eas-cli/src/graphql/queries/WebhookQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/WebhookQuery.ts
@@ -1,0 +1,38 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../client';
+import {
+  WebhookFilter,
+  WebhookFragment,
+  WebhooksByAppIdQuery,
+  WebhooksByAppIdQueryVariables,
+} from '../generated';
+import { WebhookFragmentNode } from '../types/Webhook';
+
+export const WebhookQuery = {
+  async byAppIdAsync(appId: string, webhookFilter?: WebhookFilter): Promise<WebhookFragment[]> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<WebhooksByAppIdQuery, WebhooksByAppIdQueryVariables>(
+          gql`
+            query WebhooksByAppId($appId: String!, $webhookFilter: WebhookFilter) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  webhooks(filter: $webhookFilter) {
+                    id
+                    ...WebhookFragment
+                  }
+                }
+              }
+            }
+            ${print(WebhookFragmentNode)}
+          `,
+          { appId, webhookFilter }
+        )
+        .toPromise()
+    );
+    return data.app?.byId.webhooks ?? [];
+  },
+};

--- a/packages/eas-cli/src/graphql/types/Webhook.ts
+++ b/packages/eas-cli/src/graphql/types/Webhook.ts
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag';
+
+export const WebhookFragmentNode = gql`
+  fragment WebhookFragment on Webhook {
+    id
+    event
+    url
+    createdAt
+    updatedAt
+  }
+`;

--- a/packages/eas-cli/src/webhooks/formatWebhook.ts
+++ b/packages/eas-cli/src/webhooks/formatWebhook.ts
@@ -1,0 +1,12 @@
+import { WebhookFragment } from '../graphql/generated';
+import formatFields from '../utils/formatFields';
+
+export function formatWebhook(webhook: WebhookFragment): string {
+  return formatFields([
+    { label: 'ID', value: webhook.id },
+    { label: 'Event', value: webhook.event },
+    { label: 'URL', value: webhook.url },
+    { label: 'Created at', value: new Date(webhook.createdAt).toLocaleString() },
+    { label: 'Updated at', value: new Date(webhook.updatedAt).toLocaleString() },
+  ]);
+}

--- a/packages/eas-cli/src/webhooks/input.ts
+++ b/packages/eas-cli/src/webhooks/input.ts
@@ -1,0 +1,71 @@
+import nullthrows from 'nullthrows';
+import { URL } from 'url';
+
+import { WebhookFragment, WebhookInput, WebhookType } from '../graphql/generated';
+import Log from '../log';
+import { promptAsync } from '../prompts';
+
+export async function prepareInputParams(
+  {
+    event,
+    url: maybeUrl,
+    secret: maybeSecret,
+  }: {
+    event: WebhookType;
+    url?: string;
+    secret?: string;
+  },
+  existingWebhook?: WebhookFragment
+): Promise<WebhookInput> {
+  let url: string | undefined = maybeUrl;
+  let secret: string | undefined = maybeSecret;
+
+  if (!url || !validateURL(url)) {
+    const urlValidationMessage =
+      'The provided webhook URL is invalid and must be an absolute URL, including a scheme.';
+    if (url && !validateURL(url)) {
+      Log.error(urlValidationMessage);
+    }
+    ({ url } = await promptAsync({
+      type: 'text',
+      name: 'url',
+      message: 'Webhook URL:',
+      initial: url ? undefined : existingWebhook?.url,
+      validate: (value: string) => validateURL(value) || urlValidationMessage,
+    }));
+  }
+
+  if (!secret || !validateSecret(secret)) {
+    const secretValidationMessage =
+      'Webhook secret has be at least 16 and not more than 1000 characters long';
+    if (secret && !validateSecret(secret)) {
+      Log.error(secretValidationMessage);
+    }
+    ({ secret } = await promptAsync({
+      type: 'text',
+      name: 'secret',
+      message: 'Webhook secret:',
+      validate: (value: string) => validateSecret(value) || secretValidationMessage,
+    }));
+  }
+
+  return {
+    event,
+    url: nullthrows(url),
+    secret: nullthrows(secret),
+  };
+}
+
+export function validateURL(url: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+export function validateSecret(secret: string): boolean {
+  return secret.length >= 16 && secret.length <= 1000;
+}

--- a/packages/eas-cli/src/webhooks/input.ts
+++ b/packages/eas-cli/src/webhooks/input.ts
@@ -5,7 +5,7 @@ import { WebhookFragment, WebhookInput, WebhookType } from '../graphql/generated
 import Log from '../log';
 import { promptAsync } from '../prompts';
 
-export async function prepareInputParams(
+export async function prepareInputParamsAsync(
   {
     event,
     url: maybeUrl,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://github.com/expo/universe/pull/7305 added infra for webhooks management.
This PR adds a bunch of new commands for webhooks management: `webhook:create`, `webhook:view`, `webhook:list`, `webhook:update`, `webhook:delete`.
 
# How

- https://github.com/expo/eas-cli/pull/314/commits/93836ad71fba3064e32c292c4bd70e350d653b30 adds `webhook:create`.
- https://github.com/expo/eas-cli/pull/314/commits/af003b1e5de64caa8667610d13434b3d8843cf1a adds `webhook:list`.
- https://github.com/expo/eas-cli/pull/314/commits/482bf46c8852957030f475420145609007d2b493 adds `webhook:view`.
- https://github.com/expo/eas-cli/pull/314/commits/460d9777797c592fbb9594c7b65cbf9ee5b7381a adds `webhook:update`.
- https://github.com/expo/eas-cli/pull/314/commits/700623a34d6ef5c384d0c32af1aef91318e3f676 adds `webhook:delete`
- https://github.com/expo/eas-cli/pull/314/commits/3725b987d6b4f3194bc5ca58e437ee193a94e4ef contains the generated GraphQL code changes.

# Test Plan

Tested manually.

<img width="1064" alt="Screenshot 2021-04-08 at 14 56 02" src="https://user-images.githubusercontent.com/5256730/114030235-99e0a300-987a-11eb-864c-5dac622a4672.png">
