### PR TITLE
fix first ios build for a project without ios.bundleIdentifier in app.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix the issue where the first iOS build fails for a project without `ios.bundleIdentifier` set in `app.json`. ([#319](https://github.com/expo/eas-cli/pull/319) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [0.8.1](https://github.com/expo/eas-cli/releases/tag/v0.8.1) - 2021-04-06

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig, getConfig } from '@expo/config';
+import { getConfig } from '@expo/config';
 import { EasJsonReader } from '@expo/eas-json';
 import fs from 'fs-extra';
 import path from 'path';
@@ -29,7 +29,7 @@ export async function configureAsync(options: {
   platform: RequestedPlatform;
   projectDir: string;
   allowExperimental: boolean;
-}): Promise<ExpoConfig> {
+}): Promise<void> {
   await ensureGitRepoExistsAsync();
   await maybeBailOnGitStatusAsync();
 
@@ -65,8 +65,6 @@ export async function configureAsync(options: {
     Log.newLine();
     Log.withTick('No changes were necessary, the project is already configured correctly.');
   }
-
-  return exp;
 }
 
 export async function ensureEasJsonExistsAsync(ctx: ConfigureContext): Promise<void> {

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -1,4 +1,4 @@
-import { getConfig } from '@expo/config';
+import { ExpoConfig, getConfig } from '@expo/config';
 import { EasJsonReader } from '@expo/eas-json';
 import fs from 'fs-extra';
 import path from 'path';
@@ -29,7 +29,7 @@ export async function configureAsync(options: {
   platform: RequestedPlatform;
   projectDir: string;
   allowExperimental: boolean;
-}): Promise<void> {
+}): Promise<ExpoConfig> {
   await ensureGitRepoExistsAsync();
   await maybeBailOnGitStatusAsync();
 
@@ -65,6 +65,8 @@ export async function configureAsync(options: {
     Log.newLine();
     Log.withTick('No changes were necessary, the project is already configured correctly.');
   }
+
+  return exp;
 }
 
 export async function ensureEasJsonExistsAsync(ctx: ConfigureContext): Promise<void> {

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -197,7 +197,7 @@ async function ensureProjectConfiguredAsync(projectDir: string): Promise<ExpoCon
     message: 'This app is not set up for building with EAS. Set it up now?',
   });
   if (confirm) {
-    const exp = await configureAsync({
+    await configureAsync({
       projectDir,
       platform: RequestedPlatform.All,
       allowExperimental: false,
@@ -207,6 +207,7 @@ async function ensureProjectConfiguredAsync(projectDir: string): Promise<ExpoCon
         'Build process requires clean git working tree, please commit all your changes and run `eas build` again'
       );
     }
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     return exp;
   } else {
     throw new Error(

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -73,7 +73,7 @@ export default class Build extends Command {
         (flags.platform as RequestedPlatform | undefined) ?? (await promptForPlatformAsync());
 
       const projectDir = (await findProjectRootAsync()) ?? process.cwd();
-      const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+      let { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
       const projectId = await getProjectIdAsync(exp);
 
       if (!(await isEasEnabledForProjectAsync(projectId))) {
@@ -94,6 +94,10 @@ export default class Build extends Command {
       }
 
       await ensureProjectConfiguredAsync(projectDir);
+
+      // the config could've been modified by ensureProjectConfiguredAsync
+      // we need to read it again
+      ({ exp } = getConfig(projectDir, { skipSDKVersionRequirement: true }));
 
       const commandCtx = await createCommandContextAsync({
         requestedPlatform: platform,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Fixes https://linear.app/expo/issue/ENG-835/regression-in-eas-build-configuration-around-bundleidentifier

# How

- `ensureProjectConfiguredAsync` can modify app.json
- We need to re-read the config afterwards.

# Test Plan

Followed the repo steps in https://linear.app/expo/issue/ENG-835/regression-in-eas-build-configuration-around-bundleidentifier