### PR TITLE
refactor credentials actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Change build credentials summary format. ([#321](https://github.com/expo/eas-cli/pull/321) by [@dsokal](https://github.com/dsokal))
+
 ## [0.9.1](https://github.com/expo/eas-cli/releases/tag/v0.9.1) - 2021-04-09
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -519,6 +519,22 @@
             "deprecationReason": null
           },
           {
+            "name": "submissions",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SubmissionQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userInvitationPublicData",
             "description": "Top-level query object for querying UserInvitationPublicData publicly.",
             "args": [],
@@ -960,6 +976,11 @@
           {
             "kind": "OBJECT",
             "name": "BuildJob",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "Submission",
             "ofType": null
           }
         ]
@@ -2841,6 +2862,73 @@
             "deprecationReason": null
           },
           {
+            "name": "submissions",
+            "description": "EAS Submissions associated with this app",
+            "args": [
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SubmissionFilter",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Submission",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "iosAppCredentials",
             "description": "iOS app credentials for the project",
             "args": [
@@ -2983,13 +3071,9 @@
               }
             ],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UpdateChannel",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "UpdateChannel",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3067,13 +3151,9 @@
               }
             ],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UpdateBranch",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "UpdateBranch",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5789,6 +5869,280 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SubmissionFilter",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "platform",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppPlatform",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "status",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "SubmissionStatus",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SubmissionStatus",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "IN_QUEUE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IN_PROGRESS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FINISHED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ERRORED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Submission",
+        "description": "Represents an EAS Submission",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "actor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activityTimestamp",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiatingActor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SubmissionStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "logsUrl",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SubmissionError",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ActivityTimelineProjectActivity",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SubmissionError",
+        "description": "",
+        "fields": [
+          {
+            "name": "errorCode",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -9916,8 +10270,8 @@
                 }
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use App.builds instead"
           }
         ],
         "inputFields": null,
@@ -10119,6 +10473,75 @@
         "description": "",
         "fields": [
           {
+            "name": "byAccountNameAndSlug",
+            "description": "",
+            "args": [
+              {
+                "name": "accountName",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "slug",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "platform",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "AppPlatform",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "sdkVersions",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "Project",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "byUsernameAndSlug",
             "description": "",
             "args": [
@@ -10184,8 +10607,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "See byAccountNameAndSlug"
           },
           {
             "name": "byPaths",
@@ -10219,8 +10642,8 @@
                 }
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           }
         ],
         "inputFields": null,
@@ -10384,6 +10807,48 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Snack",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SubmissionQuery",
+        "description": "",
+        "fields": [
+          {
+            "name": "byId",
+            "description": "Look up EAS Submission by submission ID",
+            "args": [
+              {
+                "name": "submissionId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Submission",
                 "ofType": null
               }
             },
@@ -10995,6 +11460,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "RobotMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "submission",
+            "description": "Mutations that modify an EAS Submit submission",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SubmissionMutation",
                 "ofType": null
               }
             },
@@ -16157,6 +16638,128 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SubmissionMutation",
+        "description": "",
+        "fields": [
+          {
+            "name": "createSubmission",
+            "description": "Create an EAS Submit submission",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreateSubmissionInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateSubmissionResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CreateSubmissionInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "platform",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "config",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CreateSubmissionResult",
+        "description": "",
+        "fields": [
+          {
+            "name": "submission",
+            "description": "Created submission",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Submission",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -44,7 +44,7 @@ async function getBranchInfoAsync({
       )
       .toPromise()
   );
-  const branchId = data.app?.byId.updateBranchByName.id;
+  const branchId = data.app?.byId.updateBranchByName?.id;
   if (!branchId) {
     throw new Error(`Could not find branch ${name} on ${appId}`);
   }

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -46,16 +46,16 @@ function getRolloutInfo(
 } {
   const { branchMapping } = getBranchMapping(getUpdateChannelByNameForAppResult);
   const [newBranchId, oldBranchId] = branchMapping.data.map(d => d.branchId);
-  const newBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
+  const newBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.updateBranches.filter(
     branch => branch.id === newBranchId
   )[0];
-  const oldBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
+  const oldBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.updateBranches.filter(
     branch => branch.id === oldBranchId
   )[0];
 
   if (!newBranch || !oldBranch) {
     throw new Error(
-      `Branch mapping rollout is missing a branch for channel "${getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.name}".`
+      `Branch mapping rollout is missing a branch for channel "${getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.name}".`
     );
   }
 
@@ -134,11 +134,11 @@ async function startRolloutAsync({
     ],
   };
   const newChannelInfo = await updateChannelBranchMappingAsync({
-    channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.id!,
+    channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.id!,
     branchMapping: JSON.stringify(newBranchMapping),
   });
 
-  const oldBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.updateBranches.filter(
+  const oldBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.updateBranches.filter(
     branch => branch.id === oldBranchId
   )[0];
   if (!oldBranch) {
@@ -200,7 +200,7 @@ async function editRolloutAsync({
   newBranchMapping.data[0].branchMappingLogic.operand = percent / 100;
 
   const newChannelInfo = await updateChannelBranchMappingAsync({
-    channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.id!,
+    channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.id!,
     branchMapping: JSON.stringify(newBranchMapping),
   });
 
@@ -290,7 +290,7 @@ async function endRolloutAsync({
   };
 
   const newChannelInfo = await updateChannelBranchMappingAsync({
-    channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName.id!,
+    channelId: getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.id!,
     branchMapping: JSON.stringify(newBranchMapping),
   });
   const logMessage = `️Rollout on channel ${chalk.bold(

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -34,7 +34,7 @@ export function getBranchMapping(
   getChannelByNameForAppQuery: GetChannelByNameForAppQuery
 ): { branchMapping: BranchMapping; isRollout: boolean; rolloutPercent?: number } {
   const branchMappingString =
-    getChannelByNameForAppQuery.app?.byId.updateChannelByName.branchMapping;
+    getChannelByNameForAppQuery.app?.byId.updateChannelByName?.branchMapping;
   if (!branchMappingString) {
     throw new Error('Missing branch mapping.');
   }

--- a/packages/eas-cli/src/credentials/ios/actions/CreateDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateDistributionCertificate.ts
@@ -31,11 +31,7 @@ export class CreateDistributionCertificate implements Action {
   }
 
   public async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
-    const distCert = await provideOrGenerateDistributionCertificateAsync(
-      manager,
-      ctx,
-      this.accountName
-    );
+    const distCert = await provideOrGenerateDistributionCertificateAsync(ctx, this.accountName);
     this._distCredentials = await ctx.ios.createDistributionCertificateAsync(
       this.accountName,
       distCert

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -31,7 +31,6 @@ Please remember that Apple Distribution Certificates are not application specifi
 `;
 
 export async function provideOrGenerateDistributionCertificateAsync(
-  manager: CredentialsManager,
   ctx: Context,
   accountName: string
 ): Promise<DistributionCertificate> {
@@ -50,11 +49,11 @@ export async function provideOrGenerateDistributionCertificateAsync(
         }
         return isValid
           ? userProvided
-          : await provideOrGenerateDistributionCertificateAsync(manager, ctx, accountName);
+          : await provideOrGenerateDistributionCertificateAsync(ctx, accountName);
       }
     }
   }
-  return await generateDistributionCertificateAsync(manager, ctx, accountName);
+  return await generateDistributionCertificateAsync(ctx, accountName);
 }
 
 async function promptForDistCertAsync(ctx: Context): Promise<DistributionCertificate | null> {
@@ -78,7 +77,6 @@ async function promptForDistCertAsync(ctx: Context): Promise<DistributionCertifi
 }
 
 async function generateDistributionCertificateAsync(
-  manager: CredentialsManager,
   ctx: Context,
   accountName: string
 ): Promise<DistributionCertificate> {
@@ -125,7 +123,7 @@ async function generateDistributionCertificateAsync(
       throw e;
     }
   }
-  return await generateDistributionCertificateAsync(manager, ctx, accountName);
+  return await generateDistributionCertificateAsync(ctx, accountName);
 }
 
 interface SelectOptions {
@@ -145,7 +143,7 @@ export async function selectDistributionCertificateAsync(
   let validDistCredentials: IosDistCredentials[] | null = null;
   if (ctx.appStore.authCtx) {
     const certInfoFromApple = await ctx.appStore.listDistributionCertificatesAsync();
-    validDistCredentials = await filterRevokedDistributionCerts(distCredentials, certInfoFromApple);
+    validDistCredentials = filterRevokedDistributionCerts(distCredentials, certInfoFromApple);
   }
   distCredentials =
     options.filterInvalid && validDistCredentials ? validDistCredentials : distCredentials;

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 
 import Log, { learnMore } from '../../../log';
 import { promptAsync } from '../../../prompts';
-import { CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { askForUserProvidedAsync } from '../../utils/promptForCredentials';
 import { AppleTooManyCertsError } from '../appstore/AppStoreApi';

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -37,20 +37,19 @@ export class SetupBuildCredentials implements Action {
         throw new Error(`You do not have access to the ${this.app.accountName} account`);
       }
       if (this.distribution === 'internal') {
-        const action = new SetupAdhocProvisioningProfile({
+        const setupAdhocProvisioningProfileAction = new SetupAdhocProvisioningProfile({
           account,
           projectName: this.app.projectName,
           bundleIdentifier: this.app.bundleIdentifier,
         });
-        await manager.runActionAsync(action);
-        iosAppBuildCredentials = action.iosAppBuildCredentials;
+        iosAppBuildCredentials = await setupAdhocProvisioningProfileAction.runAsync(manager, ctx);
       } else {
         const setupProvisioningProfileAction = new SetupProvisioningProfile({
           account,
           projectName: this.app.projectName,
           bundleIdentifier: this.app.bundleIdentifier,
         });
-        await setupProvisioningProfileAction.runAsync(manager, ctx);
+        iosAppBuildCredentials = await setupProvisioningProfileAction.runAsync(manager, ctx);
       }
     } catch (error) {
       Log.error('Failed to setup credentials.');

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -38,13 +38,11 @@ export class SetupBuildCredentials implements Action {
         bundleIdentifier: this.app.bundleIdentifier,
       };
       if (this.distribution === 'internal') {
-        const setupAdhocProvisioningProfileAction = new SetupAdhocProvisioningProfile(
-          appLookupParams
+        iosAppBuildCredentials = await new SetupAdhocProvisioningProfile(appLookupParams).runAsync(
+          ctx
         );
-        iosAppBuildCredentials = await setupAdhocProvisioningProfileAction.runAsync(manager, ctx);
       } else {
-        const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
-        iosAppBuildCredentials = await setupProvisioningProfileAction.runAsync(manager, ctx);
+        iosAppBuildCredentials = await new SetupProvisioningProfile(appLookupParams).runAsync(ctx);
       }
 
       const appInfo = `@${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`;

--- a/packages/eas-cli/src/credentials/ios/actions/UpdateDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/UpdateDistributionCertificate.ts
@@ -62,11 +62,7 @@ export class UpdateSpecificDistributionCertificate implements Action {
       cred => cred.distCredentialsId === this.userCredentialsId
     );
 
-    const newDistCert = await provideOrGenerateDistributionCertificateAsync(
-      manager,
-      ctx,
-      this.accountName
-    );
+    const newDistCert = await provideOrGenerateDistributionCertificateAsync(ctx, this.accountName);
     await ctx.ios.updateDistributionCertificateAsync(
       this.userCredentialsId,
       this.accountName,

--- a/packages/eas-cli/src/credentials/ios/actions/new/CreateDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/CreateDistributionCertificate.ts
@@ -1,35 +1,19 @@
-import assert from 'assert';
-
 import Log from '../../../../log';
-import { Action, CredentialsManager } from '../../../CredentialsManager';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
 import { AppleDistributionCertificateMutationResult } from '../../api/graphql/mutations/AppleDistributionCertificateMutation';
 import { provideOrGenerateDistributionCertificateAsync } from '../DistributionCertificateUtils';
 
-export class CreateDistributionCertificate implements Action {
-  private _distributionCertificate?: AppleDistributionCertificateMutationResult;
-
+export class CreateDistributionCertificate {
   constructor(private app: AppLookupParams) {}
 
-  public get distributionCertificate(): AppleDistributionCertificateMutationResult {
-    assert(
-      this._distributionCertificate,
-      'distributionCertificate can be accessed only after calling .runAsync()'
-    );
-    return this._distributionCertificate;
-  }
-
-  public async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+  public async runAsync(ctx: Context): Promise<AppleDistributionCertificateMutationResult> {
     const distCert = await provideOrGenerateDistributionCertificateAsync(
-      manager,
       ctx,
       this.app.account.name
     );
-    this._distributionCertificate = await ctx.newIos.createDistributionCertificateAsync(
-      this.app,
-      distCert
-    );
+    const result = await ctx.newIos.createDistributionCertificateAsync(this.app, distCert);
     Log.succeed('Created distribution certificate');
+    return result;
   }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/new/RemoveDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/RemoveDistributionCertificate.ts
@@ -5,16 +5,15 @@ import {
 import Log from '../../../../log';
 import { confirmAsync } from '../../../../prompts';
 import { Account } from '../../../../user/Account';
-import { Action, CredentialsManager } from '../../../CredentialsManager';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
 import { selectDistributionCertificateWithDependenciesAsync } from './DistributionCertificateUtils';
 import { RemoveProvisioningProfiles } from './RemoveProvisioningProfile';
 
-export class SelectAndRemoveDistributionCertificate implements Action {
+export class SelectAndRemoveDistributionCertificate {
   constructor(private account: Account) {}
 
-  async runAsync(_manager: CredentialsManager, ctx: Context): Promise<void> {
+  async runAsync(ctx: Context): Promise<void> {
     const selected = await selectDistributionCertificateWithDependenciesAsync(ctx, this.account);
     if (selected) {
       await new RemoveDistributionCertificate(this.account, selected).runAsync(ctx);

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
@@ -48,7 +48,7 @@ export class SetupAdhocProvisioningProfile {
   ): Promise<IosAppBuildCredentialsFragment> {
     // 1. Setup Distribution Certificate
     const distCertAction = new SetupDistributionCertificate(this.app, IosDistributionType.AdHoc);
-    await manager.runActionAsync(distCertAction);
+    await distCertAction.runAsync(manager, ctx);
 
     // 2. Fetch profile from EAS servers
     const currentProfile = await ctx.newIos.getProvisioningProfileAsync(
@@ -96,8 +96,7 @@ export class SetupAdhocProvisioningProfile {
 
     // 2. Setup Distribution Certificate
     const distCertAction = new SetupDistributionCertificate(this.app, IosDistributionType.AdHoc);
-    await manager.runActionAsync(distCertAction);
-    const distCert = distCertAction.distributionCertificate;
+    const distCert = await distCertAction.runAsync(manager, ctx);
 
     let profileFromExpoServersToUse:
       | AppleProvisioningProfileQueryResult

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
@@ -131,8 +131,7 @@ export class SetupProvisioningProfile {
     }
 
     const distCertAction = new SetupDistributionCertificate(this.app, IosDistributionType.AppStore);
-    await distCertAction.runAsync(manager, ctx);
-    const distCert = distCertAction.distributionCertificate;
+    const distCert = await distCertAction.runAsync(manager, ctx);
 
     const currentProfile = await this.getProvisioningProfileAsync(ctx);
     if (!currentProfile) {

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
@@ -8,7 +8,6 @@ import {
 } from '../../../../graphql/generated';
 import Log from '../../../../log';
 import { confirmAsync } from '../../../../prompts';
-import { CredentialsManager } from '../../../CredentialsManager';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
 import { ProvisioningProfileStoreInfo } from '../../appstore/Credentials.types';
@@ -116,10 +115,7 @@ export class SetupProvisioningProfile {
     return buildCredentials.provisioningProfile ?? null;
   }
 
-  async runAsync(
-    manager: CredentialsManager,
-    ctx: Context
-  ): Promise<IosAppBuildCredentialsFragment> {
+  async runAsync(ctx: Context): Promise<IosAppBuildCredentialsFragment> {
     const areBuildCredentialsSetup = await this.areBuildCredentialsSetupAsync(ctx);
     if (areBuildCredentialsSetup) {
       return nullthrows(await this.getBuildCredentialsAsync(ctx));
@@ -130,8 +126,10 @@ export class SetupProvisioningProfile {
       );
     }
 
-    const distCertAction = new SetupDistributionCertificate(this.app, IosDistributionType.AppStore);
-    const distCert = await distCertAction.runAsync(manager, ctx);
+    const distCert = await new SetupDistributionCertificate(
+      this.app,
+      IosDistributionType.AppStore
+    ).runAsync(ctx);
 
     const currentProfile = await this.getProvisioningProfileAsync(ctx);
     if (!currentProfile) {

--- a/packages/eas-cli/src/credentials/ios/actions/new/__mocks__/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__mocks__/SetupDistributionCertificate.ts
@@ -2,17 +2,13 @@ import {
   AppleDistributionCertificateFragment,
   IosDistributionType,
 } from '../../../../../graphql/generated';
-import { CredentialsManager } from '../../../../CredentialsManager';
 import { testDistCertFragmentOneDependency } from '../../../../__tests__/fixtures-ios';
 import { Context } from '../../../../context';
 import { AppLookupParams } from '../../../api/GraphqlClient';
 export class SetupDistributionCertificate {
   constructor(private app: AppLookupParams, private distributionType: IosDistributionType) {}
 
-  public async runAsync(
-    _manager: CredentialsManager,
-    _ctx: Context
-  ): Promise<AppleDistributionCertificateFragment> {
+  public async runAsync(_ctx: Context): Promise<AppleDistributionCertificateFragment> {
     return testDistCertFragmentOneDependency;
   }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/new/__mocks__/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__mocks__/SetupDistributionCertificate.ts
@@ -2,16 +2,17 @@ import {
   AppleDistributionCertificateFragment,
   IosDistributionType,
 } from '../../../../../graphql/generated';
-import { Action, CredentialsManager } from '../../../../CredentialsManager';
+import { CredentialsManager } from '../../../../CredentialsManager';
 import { testDistCertFragmentOneDependency } from '../../../../__tests__/fixtures-ios';
 import { Context } from '../../../../context';
 import { AppLookupParams } from '../../../api/GraphqlClient';
-export class SetupDistributionCertificate implements Action {
+export class SetupDistributionCertificate {
   constructor(private app: AppLookupParams, private distributionType: IosDistributionType) {}
 
-  public get distributionCertificate(): AppleDistributionCertificateFragment {
+  public async runAsync(
+    _manager: CredentialsManager,
+    _ctx: Context
+  ): Promise<AppleDistributionCertificateFragment> {
     return testDistCertFragmentOneDependency;
   }
-
-  public async runAsync(_manager: CredentialsManager, _ctx: Context): Promise<void> {}
 }

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupProvisioningProfile-test.ts
@@ -1,6 +1,6 @@
 import { confirmAsync } from '../../../../../prompts';
 import { getAppstoreMock, testAuthCtx } from '../../../../__tests__/fixtures-appstore';
-import { createCtxMock, createManagerMock } from '../../../../__tests__/fixtures-context';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
 import {
   testAppleAppIdentifierFragment,
   testIosAppBuildCredentialsFragment,
@@ -24,7 +24,6 @@ describe('SetupProvisioningProfile', () => {
       error: 'testing: everything is fine, ignore this',
       ok: false,
     }));
-    const manager = createManagerMock();
     const ctx = createCtxMock({
       nonInteractive: false,
       appStore: {
@@ -52,7 +51,7 @@ describe('SetupProvisioningProfile', () => {
     });
     const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
     const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
-    await setupProvisioningProfileAction.runAsync(manager, ctx);
+    await setupProvisioningProfileAction.runAsync(ctx);
 
     // expect build credentials to be created or updated on expo servers
     expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
@@ -64,7 +63,6 @@ describe('SetupProvisioningProfile', () => {
       error: 'testing: everything is fine, ignore this',
       ok: false,
     }));
-    const manager = createManagerMock();
     const ctx = createCtxMock({
       nonInteractive: false,
       appStore: {
@@ -83,7 +81,7 @@ describe('SetupProvisioningProfile', () => {
     });
     const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
     const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
-    await setupProvisioningProfileAction.runAsync(manager, ctx);
+    await setupProvisioningProfileAction.runAsync(ctx);
 
     // expect build credentials to be created or updated on expo servers
     expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
@@ -94,7 +92,6 @@ describe('SetupProvisioningProfile', () => {
     (validateProvisioningProfileAsync as jest.Mock).mockImplementation(() => ({
       ok: true,
     }));
-    const manager = createManagerMock();
     const ctx = createCtxMock({
       nonInteractive: false,
       appStore: {
@@ -113,7 +110,7 @@ describe('SetupProvisioningProfile', () => {
     });
     const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
     const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
-    await setupProvisioningProfileAction.runAsync(manager, ctx);
+    await setupProvisioningProfileAction.runAsync(ctx);
 
     // expect build credentials not to be created or updated on expo servers
     expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(0);
@@ -121,7 +118,6 @@ describe('SetupProvisioningProfile', () => {
     expect((ctx.newIos.deleteProvisioningProfilesAsync as any).mock.calls.length).toBe(0);
   });
   it('sets up a Provisioning Profile with no prior build credentials configured in Interactive Mode', async () => {
-    const manager = createManagerMock();
     const ctx = createCtxMock({
       nonInteractive: false,
       appStore: {
@@ -136,7 +132,7 @@ describe('SetupProvisioningProfile', () => {
     });
     const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
     const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
-    await setupProvisioningProfileAction.runAsync(manager, ctx);
+    await setupProvisioningProfileAction.runAsync(ctx);
 
     // expect build credentials to be created or updated on expo servers
     expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
@@ -144,13 +140,12 @@ describe('SetupProvisioningProfile', () => {
     expect((ctx.newIos.deleteProvisioningProfilesAsync as any).mock.calls.length).toBe(0);
   });
   it('errors in Non Interactive Mode', async () => {
-    const manager = createManagerMock();
     const ctx = createCtxMock({
       nonInteractive: true,
     });
     const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
     const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
-    await expect(setupProvisioningProfileAction.runAsync(manager, ctx)).rejects.toThrowError(
+    await expect(setupProvisioningProfileAction.runAsync(ctx)).rejects.toThrowError(
       MissingCredentialsNonInteractiveError
     );
 

--- a/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
@@ -1,7 +1,7 @@
 import Log from '../../log';
 import { getProjectAccountName, getProjectConfigDescription } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import { Account, findAccountByName } from '../../user/Account';
+import { findAccountByName } from '../../user/Account';
 import { ensureActorHasUsername } from '../../user/actions';
 import { Action, CredentialsManager } from '../CredentialsManager';
 import { Context } from '../context';
@@ -67,7 +67,11 @@ export class ManageIosBeta implements Action {
           ],
         });
         try {
-          await manager.runActionAsync(this.getAction(ctx, account, action));
+          if (action === ActionType.RemoveDistributionCertificate) {
+            await new SelectAndRemoveDistributionCertificate(account).runAsync(ctx);
+          } else {
+            throw new Error('Unknown action selected');
+          }
         } catch (err) {
           Log.error(err);
         }
@@ -101,14 +105,5 @@ export class ManageIosBeta implements Action {
     }
 
     return { account, projectName, bundleIdentifier };
-  }
-
-  private getAction(ctx: Context, account: Account, action: ActionType): Action {
-    switch (action) {
-      case ActionType.RemoveDistributionCertificate:
-        return new SelectAndRemoveDistributionCertificate(account);
-      default:
-        throw new Error('Unknown action selected');
-    }
   }
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4610,7 +4610,8 @@ export type AppleProvisioningProfileFragment = (
   & Pick<AppleProvisioningProfile, 'id' | 'expiration' | 'developerPortalIdentifier' | 'provisioningProfile' | 'updatedAt' | 'status'>
   & { appleTeam?: Maybe<(
     { __typename?: 'AppleTeam' }
-    & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
+    & Pick<AppleTeam, 'id'>
+    & AppleTeamFragment
   )>, appleDevices: Array<(
     { __typename?: 'AppleDevice' }
     & Pick<AppleDevice, 'id'>

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -66,6 +66,7 @@ export type RootQuery = {
   /** @deprecated Use 'search' root field. */
   searchUsersAndApps: Array<Maybe<SearchResult>>;
   snack: SnackQuery;
+  submissions: SubmissionQuery;
   /** Top-level query object for querying UserInvitationPublicData publicly. */
   userInvitationPublicData: UserInvitationPublicDataQuery;
   /** Top-level query object for querying Users. */
@@ -413,6 +414,8 @@ export type App = Project & {
   /** (EAS Build) Builds associated with this app */
   builds: Array<Build>;
   buildJobs: Array<BuildJob>;
+  /** EAS Submissions associated with this app */
+  submissions: Array<Submission>;
   /** iOS app credentials for the project */
   iosAppCredentials: Array<IosAppCredentials>;
   /** Android app credentials for the project */
@@ -420,11 +423,11 @@ export type App = Project & {
   /** EAS channels owned by an app */
   updateChannels: Array<UpdateChannel>;
   /** get an EAS channel owned by the app by name */
-  updateChannelByName: UpdateChannel;
+  updateChannelByName?: Maybe<UpdateChannel>;
   /** EAS branches owned by an app */
   updateBranches: Array<UpdateBranch>;
   /** get an EAS branch owned by the app by name */
-  updateBranchByName: UpdateBranch;
+  updateBranchByName?: Maybe<UpdateBranch>;
   /** Coalesced project activity for an app. Use "createdBefore" to offset a query. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   /** Environment secrets for an app */
@@ -476,6 +479,14 @@ export type AppBuildJobsArgs = {
   offset: Scalars['Int'];
   limit: Scalars['Int'];
   status?: Maybe<BuildStatus>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppSubmissionsArgs = {
+  filter: SubmissionFilter;
+  offset: Scalars['Int'];
+  limit: Scalars['Int'];
 };
 
 
@@ -839,6 +850,40 @@ export enum BuildJobStatus {
   Finished = 'FINISHED',
   SentToQueue = 'SENT_TO_QUEUE'
 }
+
+export type SubmissionFilter = {
+  platform?: Maybe<AppPlatform>;
+  status?: Maybe<SubmissionStatus>;
+};
+
+export enum SubmissionStatus {
+  InQueue = 'IN_QUEUE',
+  InProgress = 'IN_PROGRESS',
+  Finished = 'FINISHED',
+  Errored = 'ERRORED'
+}
+
+/** Represents an EAS Submission */
+export type Submission = ActivityTimelineProjectActivity & {
+  __typename?: 'Submission';
+  id: Scalars['ID'];
+  actor?: Maybe<Actor>;
+  activityTimestamp: Scalars['DateTime'];
+  app?: Maybe<App>;
+  initiatingActor?: Maybe<Actor>;
+  platform: AppPlatform;
+  status: SubmissionStatus;
+  logsUrl?: Maybe<Scalars['String']>;
+  error?: Maybe<SubmissionError>;
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+};
+
+export type SubmissionError = {
+  __typename?: 'SubmissionError';
+  errorCode?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
+};
 
 export type IosAppCredentialsFilter = {
   appleAppIdentifierId?: Maybe<Scalars['String']>;
@@ -1376,6 +1421,7 @@ export type BuildQuery = {
   /**
    * Get all builds for a specific app.
    * They are sorted from latest to oldest.
+   * @deprecated Use App.builds instead
    */
   allForApp: Array<Maybe<Build>>;
 };
@@ -1427,8 +1473,19 @@ export type ExperimentationQuery = {
 
 export type ProjectQuery = {
   __typename?: 'ProjectQuery';
+  byAccountNameAndSlug: Project;
+  /** @deprecated See byAccountNameAndSlug */
   byUsernameAndSlug: Project;
+  /** @deprecated Field no longer supported */
   byPaths: Array<Maybe<Project>>;
+};
+
+
+export type ProjectQueryByAccountNameAndSlugArgs = {
+  accountName: Scalars['String'];
+  slug: Scalars['String'];
+  platform?: Maybe<AppPlatform>;
+  sdkVersions?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 
@@ -1476,6 +1533,17 @@ export type SnackQueryByIdArgs = {
 
 export type SnackQueryByHashIdArgs = {
   hashId: Scalars['ID'];
+};
+
+export type SubmissionQuery = {
+  __typename?: 'SubmissionQuery';
+  /** Look up EAS Submission by submission ID */
+  byId: Submission;
+};
+
+
+export type SubmissionQueryByIdArgs = {
+  submissionId: Scalars['ID'];
 };
 
 export type UserInvitationPublicDataQuery = {
@@ -1573,6 +1641,8 @@ export type RootMutation = {
   iosAppCredentials: IosAppCredentialsMutation;
   /** Mutations that create, update, and delete Robots */
   robot: RobotMutation;
+  /** Mutations that modify an EAS Submit submission */
+  submission: SubmissionMutation;
   updateChannel: UpdateChannelMutation;
   update: UpdateMutation;
   updateBranch: UpdateBranchMutation;
@@ -2481,6 +2551,29 @@ export type DeleteRobotResult = {
   id: Scalars['ID'];
 };
 
+export type SubmissionMutation = {
+  __typename?: 'SubmissionMutation';
+  /** Create an EAS Submit submission */
+  createSubmission: CreateSubmissionResult;
+};
+
+
+export type SubmissionMutationCreateSubmissionArgs = {
+  input: CreateSubmissionInput;
+};
+
+export type CreateSubmissionInput = {
+  appId: Scalars['ID'];
+  platform: AppPlatform;
+  config: Scalars['JSONObject'];
+};
+
+export type CreateSubmissionResult = {
+  __typename?: 'CreateSubmissionResult';
+  /** Created submission */
+  submission: Submission;
+};
+
 export type UpdateChannelMutation = {
   __typename?: 'UpdateChannelMutation';
   /**
@@ -3085,10 +3178,10 @@ export type GetBranchInfoQuery = (
     & { byId: (
       { __typename?: 'App' }
       & Pick<App, 'id'>
-      & { updateBranchByName: (
+      & { updateBranchByName?: Maybe<(
         { __typename?: 'UpdateBranch' }
         & Pick<UpdateBranch, 'id' | 'name'>
-      ) }
+      )> }
     ) }
   )> }
 );
@@ -3184,7 +3277,7 @@ export type ViewBranchQuery = (
     & { byId: (
       { __typename?: 'App' }
       & Pick<App, 'id'>
-      & { updateBranchByName: (
+      & { updateBranchByName?: Maybe<(
         { __typename?: 'UpdateBranch' }
         & Pick<UpdateBranch, 'id' | 'name'>
         & { updates: Array<(
@@ -3198,7 +3291,7 @@ export type ViewBranchQuery = (
             & Pick<Robot, 'firstName' | 'id'>
           )> }
         )> }
-      ) }
+      )> }
     ) }
   )> }
 );
@@ -3250,14 +3343,14 @@ export type GetChannelByNameToEditQuery = (
     & { byId: (
       { __typename?: 'App' }
       & Pick<App, 'id'>
-      & { updateChannelByName: (
+      & { updateChannelByName?: Maybe<(
         { __typename?: 'UpdateChannel' }
         & Pick<UpdateChannel, 'id' | 'name'>
         & { updateBranches: Array<(
           { __typename?: 'UpdateBranch' }
           & Pick<UpdateBranch, 'id' | 'name'>
         )> }
-      ) }
+      )> }
     ) }
   )> }
 );
@@ -3329,7 +3422,7 @@ export type GetChannelByNameForAppQuery = (
     & { byId: (
       { __typename?: 'App' }
       & Pick<App, 'id'>
-      & { updateChannelByName: (
+      & { updateChannelByName?: Maybe<(
         { __typename?: 'UpdateChannel' }
         & Pick<UpdateChannel, 'id' | 'name' | 'createdAt' | 'branchMapping'>
         & { updateBranches: Array<(
@@ -3347,7 +3440,7 @@ export type GetChannelByNameForAppQuery = (
             )> }
           )> }
         )> }
-      ) }
+      )> }
     ) }
   )> }
 );
@@ -4520,7 +4613,8 @@ export type AppleProvisioningProfileFragment = (
     & Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'>
   )>, appleDevices: Array<(
     { __typename?: 'AppleDevice' }
-    & Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'model' | 'deviceClass'>
+    & Pick<AppleDevice, 'id'>
+    & AppleDeviceFragment
   )> }
 );
 

--- a/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
@@ -2,6 +2,7 @@ import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { AppleDeviceFragmentNode } from './AppleDevice';
+import { AppleTeamFragmentNode } from './AppleTeam';
 
 export const AppleProvisioningProfileFragmentNode = gql`
   fragment AppleProvisioningProfileFragment on AppleProvisioningProfile {
@@ -13,8 +14,7 @@ export const AppleProvisioningProfileFragmentNode = gql`
     status
     appleTeam {
       id
-      appleTeamIdentifier
-      appleTeamName
+      ...AppleTeamFragment
     }
     appleDevices {
       id
@@ -22,6 +22,7 @@ export const AppleProvisioningProfileFragmentNode = gql`
     }
   }
   ${print(AppleDeviceFragmentNode)}
+  ${print(AppleTeamFragmentNode)}
 `;
 export const AppleProvisioningProfileIdentifiersFragmentNode = gql`
   fragment AppleProvisioningProfileIdentifiersFragment on AppleProvisioningProfile {

--- a/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppleProvisioningProfile.ts
@@ -1,4 +1,7 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
+
+import { AppleDeviceFragmentNode } from './AppleDevice';
 
 export const AppleProvisioningProfileFragmentNode = gql`
   fragment AppleProvisioningProfileFragment on AppleProvisioningProfile {
@@ -15,12 +18,10 @@ export const AppleProvisioningProfileFragmentNode = gql`
     }
     appleDevices {
       id
-      identifier
-      name
-      model
-      deviceClass
+      ...AppleDeviceFragment
     }
   }
+  ${print(AppleDeviceFragmentNode)}
 `;
 export const AppleProvisioningProfileIdentifiersFragmentNode = gql`
   fragment AppleProvisioningProfileIdentifiersFragment on AppleProvisioningProfile {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This is the first part of adding support for internal distribution with Apple Enterprise Teams. This PR refactors some of the new credentials actions so they are more developer-friendly.

# How

- https://github.com/expo/eas-cli/pull/321/commits/d942929a65e8cd1241e36173c5e458ed54049484 makes `SetupAdhocProvisioningProfile.runAsync` return iOS app build credentials. They used to be accessed via a getter.
- https://github.com/expo/eas-cli/pull/321/commits/fc367beeeb5bc2d7201bdbf8fc111e0f9eacbfe7 makes `SetupDistributionCertificate.runAsync` return iOS app build credentials. They also used to be accessed via a getter.
- https://github.com/expo/eas-cli/pull/321/commits/a4f41705cf4af178503995cad4f8c3832696e7ea removes the `unifyCredentialsFormatAsync` method as it's no longer needed because both `SetupAdhocProvisioningProfile` and `SetupDistributionCertificate` return credentials in the same format. It also makes `SetupBuildCredentials` use another function for displaying build credentials that accepts GraphQL fragments. 
- https://github.com/expo/eas-cli/pull/321/commits/0e84ae6fb67aed1b8a3467a9ccfa906243ad9166 contains the generate GraphQL code changes.

# Test Plan

I manually ran two builds:

- For App Store
  <img width="1079" alt="Screenshot 2021-04-09 at 14 21 56" src="https://user-images.githubusercontent.com/5256730/114182666-2bb3e300-9943-11eb-9a26-9ef5a604f905.png">

- For Internal distribution
  <img width="796" alt="Screenshot 2021-04-09 at 14 30 05" src="https://user-images.githubusercontent.com/5256730/114182756-48501b00-9943-11eb-99fd-6f0c5e68bf16.png">

