### PR TITLE
add start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "lerna run build",
     "build:tarballs:linux": "yarn build && yarn workspace eas-cli oclif-dev pack --targets linux-x64",
+    "start": "lerna run watch --parallel",
     "eas": "packages/eas-cli/bin/run",
     "lint": "eslint . --ext .ts",
     "release": "lerna version",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -164,6 +164,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf build && yarn build && yarn oclif-dev manifest && yarn oclif-dev readme",
     "build": "tsc",
+    "watch": "tsc --watch",
     "test": "jest",
     "version": "yarn oclif-dev readme && git add README.md",
     "generate-graphql-code": "graphql-codegen --config graphql-codegen.yml"

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -32,6 +32,7 @@
   "repository": "expo/eas-cli",
   "scripts": {
     "build": "tsc",
+    "watch": "tsc --watch",
     "prepack": "rm -rf build && yarn build",
     "test": "jest"
   },


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

When I'm working on EAS CLI and I need to make some changes in `@expo/eas-json`, I have to run `yarn build --watch` in both `packages/eas-cli` and `packages/eas-json` directories. This PR allows me to type fewer commands to achieve the same.

# How

I added the `start` script in the root package.json. It runs the `watch` scripts in all workspaces, in parallel. 
I also added the `watch` scripts in all workspaces (`tsc --watch`).

# Test Plan

I ran `yarn start` and noticed that it executed `tsc --watch` for both packages in parallel.