### PR TITLE
[eas-cli] use new graphql api in SetupBuildCredentialsFromCredentials…

### DIFF
--- a/packages/eas-cli/src/commands/ilovecats.ts
+++ b/packages/eas-cli/src/commands/ilovecats.ts
@@ -1,0 +1,23 @@
+import { Command } from '@oclif/command';
+
+import { createCredentialsContextAsync } from '../credentials/context';
+import { SetupBuildCredentialsFromCredentialsJson } from '../credentials/ios/actions/new/SetupBuildCredentialsFromCredentialsJson';
+import { ManageIosBeta } from '../credentials/manager/ManageIosBeta';
+import { IosDistributionType } from '../graphql/generated';
+
+export default class ilovecats extends Command {
+  static description = 'i love cats!';
+
+  async run() {
+    const ctx = await createCredentialsContextAsync(process.cwd(), {});
+    const app = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    //await ctx.appStore.ensureAuthenticatedAsync();
+    const someAction = new SetupBuildCredentialsFromCredentialsJson(
+      app,
+      IosDistributionType.AppStore
+    );
+    await someAction.runAsync(ctx);
+
+    //console.log('DEBUG build credentials ', buildCredentials);
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
@@ -1,0 +1,65 @@
+import nullthrows from 'nullthrows';
+
+import {
+  AppleDistributionCertificateFragment,
+  AppleProvisioningProfileFragment,
+  IosAppBuildCredentialsFragment,
+  IosDistributionType,
+} from '../../../../graphql/generated';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
+
+export async function getBuildCredentialsAsync(
+  ctx: Context,
+  app: AppLookupParams,
+  iosDistributionType: IosDistributionType
+): Promise<IosAppBuildCredentialsFragment | null> {
+  const appCredentials = await ctx.newIos.getIosAppCredentialsWithBuildCredentialsAsync(app, {
+    iosDistributionType,
+  });
+  if (!appCredentials || appCredentials.iosAppBuildCredentialsArray.length === 0) {
+    return null;
+  }
+  const [buildCredentials] = appCredentials.iosAppBuildCredentialsArray;
+  return buildCredentials;
+}
+
+export async function getProvisioningProfileAsync(
+  ctx: Context,
+  app: AppLookupParams,
+  iosDistributionType: IosDistributionType
+): Promise<AppleProvisioningProfileFragment | null> {
+  const buildCredentials = await getBuildCredentialsAsync(ctx, app, iosDistributionType);
+  return buildCredentials?.provisioningProfile ?? null;
+}
+
+export async function getDistributionCertificateAsync(
+  ctx: Context,
+  app: AppLookupParams,
+  iosDistributionType: IosDistributionType
+): Promise<AppleDistributionCertificateFragment | null> {
+  const buildCredentials = await getBuildCredentialsAsync(ctx, app, iosDistributionType);
+  return buildCredentials?.distributionCertificate ?? null;
+}
+
+export async function assignBuildCredentialsAsync(
+  ctx: Context,
+  app: AppLookupParams,
+  iosDistributionType: IosDistributionType,
+  distCert: AppleDistributionCertificateFragment,
+  provisioningProfile: AppleProvisioningProfileFragment
+): Promise<IosAppBuildCredentialsFragment> {
+  const appleTeam = nullthrows(await resolveAppleTeamIfAuthenticatedAsync(ctx, app));
+  const appleAppIdentifier = await ctx.newIos.createOrGetExistingAppleAppIdentifierAsync(
+    app,
+    appleTeam
+  );
+  return await ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync(app, {
+    appleTeam,
+    appleAppIdentifierId: appleAppIdentifier.id,
+    appleDistributionCertificateId: distCert.id,
+    appleProvisioningProfileId: provisioningProfile.id,
+    iosDistributionType,
+  });
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
@@ -3,6 +3,7 @@ import nullthrows from 'nullthrows';
 import {
   AppleDistributionCertificateFragment,
   AppleProvisioningProfileFragment,
+  AppleTeamFragment,
   IosAppBuildCredentialsFragment,
   IosDistributionType,
 } from '../../../../graphql/generated';
@@ -48,15 +49,17 @@ export async function assignBuildCredentialsAsync(
   app: AppLookupParams,
   iosDistributionType: IosDistributionType,
   distCert: AppleDistributionCertificateFragment,
-  provisioningProfile: AppleProvisioningProfileFragment
+  provisioningProfile: AppleProvisioningProfileFragment,
+  appleTeam?: AppleTeamFragment
 ): Promise<IosAppBuildCredentialsFragment> {
-  const appleTeam = nullthrows(await resolveAppleTeamIfAuthenticatedAsync(ctx, app));
+  const resolvedAppleTeam =
+    appleTeam ?? nullthrows(await resolveAppleTeamIfAuthenticatedAsync(ctx, app));
   const appleAppIdentifier = await ctx.newIos.createOrGetExistingAppleAppIdentifierAsync(
     app,
-    appleTeam
+    resolvedAppleTeam
   );
   return await ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync(app, {
-    appleTeam,
+    appleTeam: resolvedAppleTeam,
     appleAppIdentifierId: appleAppIdentifier.id,
     appleDistributionCertificateId: distCert.id,
     appleProvisioningProfileId: provisioningProfile.id,

--- a/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
@@ -52,8 +52,9 @@ export async function assignBuildCredentialsAsync(
   provisioningProfile: AppleProvisioningProfileFragment,
   appleTeam?: AppleTeamFragment
 ): Promise<IosAppBuildCredentialsFragment> {
-  const resolvedAppleTeam =
-    nullthrows(appleTeam ?? await resolveAppleTeamIfAuthenticatedAsync(ctx, app));
+  const resolvedAppleTeam = nullthrows(
+    appleTeam ?? (await resolveAppleTeamIfAuthenticatedAsync(ctx, app))
+  );
   const appleAppIdentifier = await ctx.newIos.createOrGetExistingAppleAppIdentifierAsync(
     app,
     resolvedAppleTeam

--- a/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
@@ -53,7 +53,7 @@ export async function assignBuildCredentialsAsync(
   appleTeam?: AppleTeamFragment
 ): Promise<IosAppBuildCredentialsFragment> {
   const resolvedAppleTeam =
-    appleTeam ?? nullthrows(await resolveAppleTeamIfAuthenticatedAsync(ctx, app));
+    nullthrows(appleTeam ?? await resolveAppleTeamIfAuthenticatedAsync(ctx, app));
   const appleAppIdentifier = await ctx.newIos.createOrGetExistingAppleAppIdentifierAsync(
     app,
     resolvedAppleTeam

--- a/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import chalk from 'chalk';
 import dateformat from 'dateformat';
+import { pki } from 'node-forge';
 
 import {
   AppleDistributionCertificateFragment,
@@ -13,6 +14,17 @@ import { fromNow } from '../../../../utils/date';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
 import { filterRevokedDistributionCerts } from '../../appstore/CredentialsUtilsBeta';
+
+export function formatPkiCertificate(certificate: pki.Certificate): string {
+  const { serialNumber, validity } = certificate;
+  const { notBefore, notAfter } = validity;
+
+  let line: string = '';
+  line += `Serial Number: ${serialNumber} `;
+  line += chalk.gray(`\n    Created: ${fromNow(notBefore)} ago`);
+  line += chalk.gray(`\n    Expires: ${dateformat(notAfter, 'expiresHeaderFormat')}`);
+  return line;
+}
 
 export function formatDistributionCertificate(
   distributionCertificate: AppleDistributionCertificateFragment,

--- a/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/DistributionCertificateUtils.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 import chalk from 'chalk';
 import dateformat from 'dateformat';
-import { pki } from 'node-forge';
 
 import {
   AppleDistributionCertificateFragment,
@@ -14,17 +13,6 @@ import { fromNow } from '../../../../utils/date';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
 import { filterRevokedDistributionCerts } from '../../appstore/CredentialsUtilsBeta';
-
-export function formatPkiCertificate(certificate: pki.Certificate): string {
-  const { serialNumber, validity } = certificate;
-  const { notBefore, notAfter } = validity;
-
-  let line: string = '';
-  line += `Serial Number: ${serialNumber} `;
-  line += chalk.gray(`\n    Created: ${fromNow(notBefore)} ago`);
-  line += chalk.gray(`\n    Expires: ${dateformat(notAfter, 'expiresHeaderFormat')}`);
-  return line;
-}
 
 export function formatDistributionCertificate(
   distributionCertificate: AppleDistributionCertificateFragment,

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupBuildCredentialsFromCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupBuildCredentialsFromCredentialsJson.ts
@@ -8,6 +8,7 @@ import {
   IosDistributionType,
 } from '../../../../graphql/generated';
 import Log from '../../../../log';
+import { confirmAsync } from '../../../../prompts';
 import { Context } from '../../../context';
 import {
   IosTargetCredentials,
@@ -133,6 +134,14 @@ export class SetupBuildCredentialsFromCredentialsJson {
     if (buildCredentials) {
       Log.log('Currently configured credentials:');
       displayProjectCredentials(this.app, buildCredentials);
+      if (!ctx.nonInteractive) {
+        const confirm = await confirmAsync({
+          message: `Would you like to replace this configuration with credentials from credentials json?`,
+        });
+        if (!confirm) {
+          throw new Error('Aborting setup of build credentials from credentials json');
+        }
+      }
     }
 
     Log.log(`Assigning credentials from credentials json to ${appInfo}...`);
@@ -153,7 +162,8 @@ export class SetupBuildCredentialsFromCredentialsJson {
       this.app,
       this.distributionType,
       distributionCertificateToAssign,
-      provisioningProfileToAssign
+      provisioningProfileToAssign,
+      appleTeam
     );
 
     const didCredentialsChange =

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupBuildCredentialsFromCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupBuildCredentialsFromCredentialsJson.ts
@@ -1,0 +1,192 @@
+import chalk from 'chalk';
+
+import {
+  AppleDistributionCertificateFragment,
+  AppleProvisioningProfileFragment,
+  AppleTeamFragment,
+  IosAppBuildCredentialsFragment,
+  IosDistributionType,
+} from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { confirmAsync } from '../../../../prompts';
+import { Context } from '../../../context';
+import {
+  IosTargetCredentials,
+  isCredentialsMap,
+  readIosCredentialsAsync,
+} from '../../../credentialsJson/read';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { getCertData } from '../../utils/p12Certificate';
+import { displayProjectCredentials } from '../../utils/printCredentialsBeta';
+import { readAppleTeam } from '../../utils/provisioningProfile';
+import {
+  assignBuildCredentialsAsync,
+  getBuildCredentialsAsync,
+  getDistributionCertificateAsync,
+  getProvisioningProfileAsync,
+} from './BuildCredentialsUtils';
+import { formatPkiCertificate } from './DistributionCertificateUtils';
+
+export class SetupBuildCredentialsFromCredentialsJson {
+  constructor(private app: AppLookupParams, private distributionType: IosDistributionType) {}
+
+  async getDistributionCertificateToAssignAsync(
+    ctx: Context,
+    appInfo: string,
+    targetCredentials: IosTargetCredentials,
+    appleTeam: AppleTeamFragment,
+    currentDistributionCertificate: AppleDistributionCertificateFragment | null
+  ): Promise<AppleDistributionCertificateFragment> {
+    const { distributionCertificate } = targetCredentials;
+    const { certP12, certPassword } = distributionCertificate;
+
+    if (!currentDistributionCertificate) {
+      return await ctx.newIos.createDistributionCertificateAsync(this.app, {
+        certP12,
+        certPassword,
+        teamId: appleTeam.appleTeamIdentifier,
+        teamName: appleTeam.appleTeamName ?? undefined,
+      });
+    }
+
+    const isSameCertificate = currentDistributionCertificate.certificateP12 === certP12;
+    if (!isSameCertificate) {
+      const pkiCertificate = getCertData(certP12, certPassword);
+      const confirm = await confirmAsync({
+        message: `${formatPkiCertificate(
+          pkiCertificate
+        )} \n  There is already a Distribution Certificate assigned to this project. Would you like to assign this certificate to ${appInfo}?`,
+      });
+      if (!confirm) {
+        throw new Error('Aborting setup of Build Credentials from credentials json');
+      }
+
+      return await ctx.newIos.createDistributionCertificateAsync(this.app, {
+        certP12,
+        certPassword,
+        teamId: appleTeam.appleTeamIdentifier,
+        teamName: appleTeam.appleTeamName ?? undefined,
+      });
+    }
+
+    // If the configured Distribution Certificate is the same as the new one, just use the currently configured certificate
+    return currentDistributionCertificate;
+  }
+
+  async createNewProvisioningProfileAsync(
+    ctx: Context,
+    targetCredentials: IosTargetCredentials,
+    appleTeam: AppleTeamFragment
+  ): Promise<AppleProvisioningProfileFragment> {
+    const { provisioningProfile } = targetCredentials;
+
+    const appleAppIdentifier = await ctx.newIos.createOrGetExistingAppleAppIdentifierAsync(
+      this.app,
+      appleTeam
+    );
+    return await ctx.newIos.createProvisioningProfileAsync(this.app, appleAppIdentifier, {
+      appleProvisioningProfile: provisioningProfile,
+    });
+  }
+
+  /**
+   * We intentionally don't prompt the user if the old and new Provisioning Profiles differ.
+   * We assume that they already opted to use the new Distribution Certificate in their credentials
+   * json, and the new Provisioning Profile is only compatible with the new Distribution Certificate
+   */
+  async getProvisioningProfileToAssignAsync(
+    ctx: Context,
+    targetCredentials: IosTargetCredentials,
+    appleTeam: AppleTeamFragment,
+    currentProvisioningProfile: AppleProvisioningProfileFragment | null
+  ): Promise<AppleProvisioningProfileFragment> {
+    const { provisioningProfile } = targetCredentials;
+
+    if (!currentProvisioningProfile) {
+      return await this.createNewProvisioningProfileAsync(ctx, targetCredentials, appleTeam);
+    }
+
+    const isSameProfile = currentProvisioningProfile.provisioningProfile === provisioningProfile;
+    if (!isSameProfile) {
+      return await this.createNewProvisioningProfileAsync(ctx, targetCredentials, appleTeam);
+    }
+
+    // If the configured Provisioning Profile is the same as the new one, just use the currently configured profile
+    return currentProvisioningProfile;
+  }
+
+  async runAsync(ctx: Context): Promise<IosAppBuildCredentialsFragment> {
+    let localCredentials;
+    try {
+      localCredentials = await readIosCredentialsAsync(ctx.projectDir);
+    } catch (error) {
+      Log.error(
+        'Reading credentials from credentials.json failed. Make sure this file is correct and all credentials are present there.'
+      );
+      throw error;
+    }
+
+    // TODO: implement storing multi-target credentials on EAS servers
+    if (isCredentialsMap(localCredentials)) {
+      throw new Error(
+        'Storing multi-target iOS credentials from credentials.json on EAS servers is not yet supported.'
+      );
+    }
+
+    // currently configured credentials
+    const buildCredentials = await getBuildCredentialsAsync(
+      ctx,
+      this.app,
+      IosDistributionType.AppStore
+    );
+    const currentDistributionCertificate = await getDistributionCertificateAsync(
+      ctx,
+      this.app,
+      IosDistributionType.AppStore
+    );
+    const currentProfile = await getProvisioningProfileAsync(
+      ctx,
+      this.app,
+      IosDistributionType.AppStore
+    );
+    const appInfo = `@${this.app.account.name}/${this.app.projectName} (${this.app.bundleIdentifier})`;
+
+    // new credentials from local json
+    const appleTeamFromProvisioningProfile = readAppleTeam(localCredentials.provisioningProfile);
+    const appleTeam = await ctx.newIos.createOrGetExistingAppleTeamAsync(this.app, {
+      appleTeamIdentifier: appleTeamFromProvisioningProfile.teamId,
+      appleTeamName: appleTeamFromProvisioningProfile.teamName,
+    });
+    if (buildCredentials) {
+      displayProjectCredentials(this.app, buildCredentials);
+    }
+
+    const distributionCertificateToAssign = await this.getDistributionCertificateToAssignAsync(
+      ctx,
+      appInfo,
+      localCredentials,
+      appleTeam,
+      currentDistributionCertificate
+    );
+    const provisioningProfileToAssign = await this.getProvisioningProfileToAssignAsync(
+      ctx,
+      localCredentials,
+      appleTeam,
+      currentProfile
+    );
+    const newBuildCredentials = await assignBuildCredentialsAsync(
+      ctx,
+      this.app,
+      this.distributionType,
+      distributionCertificateToAssign,
+      provisioningProfileToAssign
+    );
+
+    displayProjectCredentials(this.app, newBuildCredentials);
+
+    Log.newLine();
+    Log.log(chalk.green(`All credentials are ready to build ${appInfo}`));
+    Log.newLine();
+    return newBuildCredentials;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
@@ -1,0 +1,171 @@
+import { asMock } from '../../../../../__tests__/utils';
+import { IosDistributionType } from '../../../../../graphql/generated';
+import { confirmAsync } from '../../../../../prompts';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
+import {
+  testAppleAppIdentifierFragment,
+  testDistCert,
+  testDistCertFragmentNoDependencies,
+  testIosAppCredentialsWithBuildCredentialsQueryResult,
+  testProvisioningProfile,
+  testProvisioningProfileFragment,
+} from '../../../../__tests__/fixtures-ios';
+import { getNewIosApiMockWithoutCredentials } from '../../../../__tests__/fixtures-new-ios';
+import { readIosCredentialsAsync } from '../../../../credentialsJson/read';
+import { ManageIosBeta } from '../../../../manager/ManageIosBeta';
+import { SetupBuildCredentialsFromCredentialsJson } from '../SetupBuildCredentialsFromCredentialsJson';
+jest.mock('../../../../../prompts');
+jest.mock('../../../../credentialsJson/read');
+
+const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+beforeAll(() => {
+  console.log = jest.fn();
+  console.warn = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+  console.warn = originalConsoleWarn;
+});
+
+beforeEach(() => {
+  asMock(confirmAsync).mockReset();
+  asMock(readIosCredentialsAsync).mockReset();
+  (confirmAsync as jest.Mock).mockImplementation(() => true);
+  (readIosCredentialsAsync as jest.Mock).mockImplementation(() => ({
+    provisioningProfile: testProvisioningProfile.provisioningProfile,
+    distributionCertificate: {
+      certP12: testDistCert.certP12,
+      certPassword: testDistCert.certPassword,
+    },
+  }));
+});
+
+describe('SetupBuildCredentialsFromCredentialsJson', () => {
+  it('sets up build credentials with same prior configuration in Interactive Mode', async () => {
+    // configure to be the same creds that are returned by readIosCredentialsAsync in the mock above
+    // create deep clone the quick and dirty way
+    const testBuildCreds = JSON.parse(
+      JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
+    );
+    testBuildCreds.iosAppBuildCredentialsArray[0].distributionCertificate.certificateP12 =
+      testDistCert.certP12;
+    testBuildCreds.iosAppBuildCredentialsArray[0].provisioningProfile.provisioningProfile =
+      testProvisioningProfile.provisioningProfile;
+    const ctx = createCtxMock({
+      newIos: {
+        ...getNewIosApiMockWithoutCredentials(),
+        getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(() => testBuildCreds),
+        createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
+        createDistributionCertificateAsync: jest.fn(() => ({ testDistCertFragmentNoDependencies })),
+        createProvisioningProfileAsync: jest.fn(() => testProvisioningProfileFragment),
+        createOrUpdateIosAppBuildCredentialsAsync: jest.fn(() => testBuildCreds),
+      },
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsFromCredentialsJsonAction = new SetupBuildCredentialsFromCredentialsJson(
+      appLookupParams,
+      IosDistributionType.AppStore
+    );
+    await setupBuildCredentialsFromCredentialsJsonAction.runAsync(ctx);
+
+    // expect build credentials to be created or updated on expo servers
+    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
+    // expect distribution certificate not to be uploaded on expo servers
+    expect((ctx.newIos.createDistributionCertificateAsync as any).mock.calls.length).toBe(0);
+    // expect provisioning profile not to be uploaded on expo servers
+    expect((ctx.newIos.createProvisioningProfileAsync as any).mock.calls.length).toBe(0);
+  });
+  it('sets up build credentials with no prior configuration in Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      newIos: {
+        ...getNewIosApiMockWithoutCredentials(),
+        getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(() => null),
+        createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
+        createDistributionCertificateAsync: jest.fn(() => ({ testDistCertFragmentNoDependencies })),
+        createProvisioningProfileAsync: jest.fn(() => testProvisioningProfileFragment),
+        createOrUpdateIosAppBuildCredentialsAsync: jest.fn(
+          () => testIosAppCredentialsWithBuildCredentialsQueryResult
+        ),
+      },
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsFromCredentialsJsonAction = new SetupBuildCredentialsFromCredentialsJson(
+      appLookupParams,
+      IosDistributionType.AppStore
+    );
+    await setupBuildCredentialsFromCredentialsJsonAction.runAsync(ctx);
+
+    // expect build credentials to be created or updated on expo servers
+    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
+    // expect distribution certificate to be uploaded on expo servers
+    expect((ctx.newIos.createDistributionCertificateAsync as any).mock.calls.length).toBe(1);
+    // expect provisioning profile to be uploaded on expo servers
+    expect((ctx.newIos.createProvisioningProfileAsync as any).mock.calls.length).toBe(1);
+  });
+  it('sets up build credentials with different prior configuration in Interactive Mode', async () => {
+    // create deep clone the quick and dirty way
+    const testBuildCreds = JSON.parse(
+      JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
+    );
+    testBuildCreds.iosAppBuildCredentialsArray[0].distributionCertificate.certificateP12 =
+      'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
+    const ctx = createCtxMock({
+      newIos: {
+        ...getNewIosApiMockWithoutCredentials(),
+        getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(() => testBuildCreds),
+        createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
+        createDistributionCertificateAsync: jest.fn(() => ({ testDistCertFragmentNoDependencies })),
+        createProvisioningProfileAsync: jest.fn(() => testProvisioningProfileFragment),
+        createOrUpdateIosAppBuildCredentialsAsync: jest.fn(() => testBuildCreds),
+      },
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsFromCredentialsJsonAction = new SetupBuildCredentialsFromCredentialsJson(
+      appLookupParams,
+      IosDistributionType.AppStore
+    );
+    await setupBuildCredentialsFromCredentialsJsonAction.runAsync(ctx);
+
+    // expect build credentials to be created or updated on expo servers
+    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
+    // expect distribution certificate to be uploaded on expo servers
+    expect((ctx.newIos.createDistributionCertificateAsync as any).mock.calls.length).toBe(1);
+    // expect provisioning profile to be uploaded on expo servers
+    expect((ctx.newIos.createProvisioningProfileAsync as any).mock.calls.length).toBe(1);
+  });
+  it('works in Non Interactive Mode - sets up build credentials with different prior configuration', async () => {
+    // create deep clone the quick and dirty way
+    const testBuildCreds = JSON.parse(
+      JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
+    );
+    testBuildCreds.iosAppBuildCredentialsArray[0].distributionCertificate.certificateP12 =
+      'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
+    const ctx = createCtxMock({
+      nonInteractive: true,
+      newIos: {
+        ...getNewIosApiMockWithoutCredentials(),
+        getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(() => testBuildCreds),
+        createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
+        createDistributionCertificateAsync: jest.fn(() => ({ testDistCertFragmentNoDependencies })),
+        createProvisioningProfileAsync: jest.fn(() => testProvisioningProfileFragment),
+        createOrUpdateIosAppBuildCredentialsAsync: jest.fn(() => testBuildCreds),
+      },
+    });
+    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsFromCredentialsJsonAction = new SetupBuildCredentialsFromCredentialsJson(
+      appLookupParams,
+      IosDistributionType.AppStore
+    );
+    await setupBuildCredentialsFromCredentialsJsonAction.runAsync(ctx);
+
+    // expect no prompts to be called
+    expect((confirmAsync as any).mock.calls.length).toBe(0);
+    // expect build credentials to be created or updated on expo servers
+    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
+    // expect distribution certificate to be uploaded on expo servers
+    expect((ctx.newIos.createDistributionCertificateAsync as any).mock.calls.length).toBe(1);
+    // expect provisioning profile to be uploaded on expo servers
+    expect((ctx.newIos.createProvisioningProfileAsync as any).mock.calls.length).toBe(1);
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
@@ -69,8 +69,8 @@ describe('SetupBuildCredentialsFromCredentialsJson', () => {
     );
     await setupBuildCredentialsFromCredentialsJsonAction.runAsync(ctx);
 
-    // expect build credentials to be created or updated on expo servers
-    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(1);
+    // expect build credentials not to be created or updated on expo servers
+    expect((ctx.newIos.createOrUpdateIosAppBuildCredentialsAsync as any).mock.calls.length).toBe(0);
     // expect distribution certificate not to be uploaded on expo servers
     expect((ctx.newIos.createDistributionCertificateAsync as any).mock.calls.length).toBe(0);
     // expect provisioning profile not to be uploaded on expo servers


### PR DESCRIPTION
…Json

<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to setup build credentials from some credentials json using the new Graphql Api. This will eventually replace the old `SetupBuildCredentialsFromCredentialsJson` here:  https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts#L60

# Notable Changes
`SetupBuildCredentialsFromCredentialsJson` works slightly differently:
- If there are no credentials configured already, just assign new credentials
- If there are different credentials configured already, prompt user to confirm that they want to assign new credentials
- If the configured credentials are the same as the ones in credentials json, stick with the old credentials

# Test Plan

- [x] added new tests
