### PR TITLE
refactor IosCredentialsProvider to use graphql

### DIFF
--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -6,6 +6,8 @@ import { createCredentialsContextAsync } from '../../credentials/context';
 import IosCredentialsProvider, {
   IosCredentials,
 } from '../../credentials/ios/IosCredentialsProvider';
+import { getAppLookupParamsFromContext } from '../../credentials/ios/actions/new/BuildCredentialsUtils';
+
 import { AppLookupParams } from '../../credentials/ios/credentials';
 import { CredentialsResult } from '../build';
 import { BuildContext } from '../context';
@@ -46,16 +48,15 @@ export async function resolveIosCredentialsAsync(
   projectDir: string,
   params: ResolveCredentialsParams
 ): Promise<CredentialsResult<IosCredentials>> {
-  const provider = new IosCredentialsProvider(
-    await createCredentialsContextAsync(projectDir, {
-      nonInteractive: params.nonInteractive,
-    }),
-    {
-      app: params.app,
-      distribution: params.distribution,
-      skipCredentialsCheck: params.skipCredentialsCheck,
-    }
-  );
+  const ctx = await createCredentialsContextAsync(projectDir, {
+    nonInteractive: params.nonInteractive,
+  });
+  const app = getAppLookupParamsFromContext(ctx);
+  const provider = new IosCredentialsProvider(ctx, {
+    app,
+    distribution: params.distribution,
+    skipCredentialsCheck: params.skipCredentialsCheck,
+  });
   const credentialsSource = await ensureCredentialsAsync(
     provider,
     params.workflow,

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -7,7 +7,6 @@ import IosCredentialsProvider, {
   IosCredentials,
 } from '../../credentials/ios/IosCredentialsProvider';
 import { getAppLookupParamsFromContext } from '../../credentials/ios/actions/new/BuildCredentialsUtils';
-
 import { AppLookupParams } from '../../credentials/ios/credentials';
 import { CredentialsResult } from '../build';
 import { BuildContext } from '../context';

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -9,11 +9,8 @@ import { Context } from '../context';
 import * as credentialsJsonReader from '../credentialsJson/read';
 import type { IosCredentials } from '../credentialsJson/read';
 import { SetupBuildCredentials } from './actions/SetupBuildCredentials';
-import {
-  getAppLookupParamsFromContext,
-  getBuildCredentialsAsync,
-} from './actions/new/BuildCredentialsUtils';
-import { AppLookupParams as GraphQLAppLookupParams } from './api/GraphqlClient';
+import { getBuildCredentialsAsync } from './actions/new/BuildCredentialsUtils';
+import { AppLookupParams } from './api/GraphqlClient';
 import { isAdHocProfile } from './utils/provisioningProfile';
 
 export type { IosCredentials };
@@ -24,19 +21,10 @@ interface Options {
   skipCredentialsCheck?: boolean;
 }
 
-interface AppLookupParams {
-  projectName: string;
-  accountName: string;
-  bundleIdentifier: string;
-}
-
 export default class IosCredentialsProvider implements CredentialsProvider {
   public readonly platform = Platform.IOS;
-  private readonly appLookupParams: GraphQLAppLookupParams;
 
-  constructor(private ctx: Context, private options: Options) {
-    this.appLookupParams = getAppLookupParamsFromContext(this.ctx);
-  }
+  constructor(private ctx: Context, private options: Options) {}
 
   public async hasRemoteAsync(): Promise<boolean> {
     // TODO: this is temporary
@@ -136,7 +124,7 @@ export default class IosCredentialsProvider implements CredentialsProvider {
       Log.log('Skipping credentials check');
     } else {
       await new CredentialsManager(this.ctx).runActionAsync(
-        new SetupBuildCredentials(this.appLookupParams, this.options.distribution)
+        new SetupBuildCredentials(this.options.app, this.options.distribution)
       );
     }
 
@@ -176,6 +164,6 @@ export default class IosCredentialsProvider implements CredentialsProvider {
       this.options.distribution === 'internal'
         ? IosDistributionType.AdHoc
         : IosDistributionType.AppStore;
-    return await getBuildCredentialsAsync(this.ctx, this.appLookupParams, distributionType);
+    return await getBuildCredentialsAsync(this.ctx, this.options.app, distributionType);
   }
 }

--- a/packages/eas-cli/src/credentials/ios/__tests__/IosCredentialsProvider-test.ts
+++ b/packages/eas-cli/src/credentials/ios/__tests__/IosCredentialsProvider-test.ts
@@ -48,7 +48,10 @@ describe(IosCredentialsProvider, () => {
       const appLookupParams = getAppLookupParamsFromContext(ctx);
       const provider = new IosCredentialsProvider(ctx, {
         app: {
-          accountName: appLookupParams.account.name,
+          account: {
+            id: `id-${appLookupParams.account.name}`,
+            name: appLookupParams.account.name,
+          },
           bundleIdentifier: appLookupParams.bundleIdentifier,
           projectName: appLookupParams.projectName,
         },
@@ -72,7 +75,10 @@ describe(IosCredentialsProvider, () => {
       const appLookupParams = getAppLookupParamsFromContext(ctx);
       const provider = new IosCredentialsProvider(ctx, {
         app: {
-          accountName: appLookupParams.account.name,
+          account: {
+            id: `id-${appLookupParams.account.name}`,
+            name: appLookupParams.account.name,
+          },
           bundleIdentifier: appLookupParams.bundleIdentifier,
           projectName: appLookupParams.projectName,
         },
@@ -97,7 +103,10 @@ describe(IosCredentialsProvider, () => {
         const appLookupParams = getAppLookupParamsFromContext(ctx);
         const provider = new IosCredentialsProvider(ctx, {
           app: {
-            accountName: appLookupParams.account.name,
+            account: {
+              id: `id-${appLookupParams.account.name}`,
+              name: appLookupParams.account.name,
+            },
             bundleIdentifier: appLookupParams.bundleIdentifier,
             projectName: appLookupParams.projectName,
           },
@@ -123,7 +132,10 @@ describe(IosCredentialsProvider, () => {
         const appLookupParams = getAppLookupParamsFromContext(ctx);
         const provider = new IosCredentialsProvider(ctx, {
           app: {
-            accountName: appLookupParams.account.name,
+            account: {
+              id: `id-${appLookupParams.account.name}`,
+              name: appLookupParams.account.name,
+            },
             bundleIdentifier: appLookupParams.bundleIdentifier,
             projectName: appLookupParams.projectName,
           },
@@ -136,10 +148,10 @@ describe(IosCredentialsProvider, () => {
         await expect(provider.getCredentialsAsync(CredentialsSource.REMOTE)).resolves.toMatchObject(
           {
             distributionCertificate: {
-              certP12: buildCredentials.distributionCertificate.certificateP12,
-              certPassword: buildCredentials.distributionCertificate.certificatePassword,
+              certP12: buildCredentials.distributionCertificate?.certificateP12,
+              certPassword: buildCredentials.distributionCertificate?.certificatePassword,
             },
-            provisioningProfile: buildCredentials.provisioningProfile.provisioningProfile,
+            provisioningProfile: buildCredentials.provisioningProfile?.provisioningProfile,
           }
         );
       });

--- a/packages/eas-cli/src/credentials/ios/__tests__/IosCredentialsProvider-test.ts
+++ b/packages/eas-cli/src/credentials/ios/__tests__/IosCredentialsProvider-test.ts
@@ -1,0 +1,148 @@
+import { CredentialsSource } from '@expo/eas-json';
+import { vol } from 'memfs';
+
+import { getAppstoreMock } from '../../__tests__/fixtures-appstore';
+import { createCtxMock } from '../../__tests__/fixtures-context';
+import { testIosAppCredentialsWithBuildCredentialsQueryResult } from '../../__tests__/fixtures-ios';
+import { getNewIosApiMockWithoutCredentials } from '../../__tests__/fixtures-new-ios';
+import IosCredentialsProvider from '../IosCredentialsProvider';
+import { getAppLookupParamsFromContext } from '../actions/new/BuildCredentialsUtils';
+
+jest.mock('fs');
+
+const originalConsoleLog = console.log;
+beforeAll(() => {
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+});
+
+beforeEach(() => {
+  vol.reset();
+});
+
+describe(IosCredentialsProvider, () => {
+  describe('#hasRemoteAsync', () => {
+    it('returns false when distribution === internal and there are local credentials', async () => {
+      vol.fromJSON(
+        {
+          './credentials.json': JSON.stringify({
+            ios: {
+              provisioningProfilePath: './ios/certs/profile.mobileprovision',
+              distributionCertificate: {
+                path: './ios/certs/cert.p12',
+                password: 'cert-password',
+              },
+            },
+          }),
+        },
+        '/app'
+      );
+      const ctx = createCtxMock({
+        nonInteractive: false,
+        appStore: getAppstoreMock(),
+        projectDir: '/app',
+      });
+
+      const appLookupParams = getAppLookupParamsFromContext(ctx);
+      const provider = new IosCredentialsProvider(ctx, {
+        app: {
+          accountName: appLookupParams.account.name,
+          bundleIdentifier: appLookupParams.bundleIdentifier,
+          projectName: appLookupParams.projectName,
+        },
+        distribution: 'internal',
+      });
+      await expect(provider.hasRemoteAsync()).resolves.toBe(false);
+    });
+
+    it('returns true when there are remote credentials', async () => {
+      const ctx = createCtxMock({
+        nonInteractive: false,
+        appStore: getAppstoreMock(),
+        projectDir: '/app',
+        newIos: {
+          ...getNewIosApiMockWithoutCredentials(),
+          getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(
+            () => testIosAppCredentialsWithBuildCredentialsQueryResult
+          ),
+        },
+      });
+      const appLookupParams = getAppLookupParamsFromContext(ctx);
+      const provider = new IosCredentialsProvider(ctx, {
+        app: {
+          accountName: appLookupParams.account.name,
+          bundleIdentifier: appLookupParams.bundleIdentifier,
+          projectName: appLookupParams.projectName,
+        },
+        distribution: 'store',
+      });
+      await expect(provider.hasRemoteAsync()).resolves.toBe(true);
+    });
+  });
+
+  describe('#getCredentialsAsync', () => {
+    describe('remote credentials', () => {
+      it('throws an error is credentials do not exist', async () => {
+        const ctx = createCtxMock({
+          nonInteractive: false,
+          appStore: getAppstoreMock(),
+          projectDir: '/app',
+          newIos: {
+            ...getNewIosApiMockWithoutCredentials(),
+            getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(() => null),
+          },
+        });
+        const appLookupParams = getAppLookupParamsFromContext(ctx);
+        const provider = new IosCredentialsProvider(ctx, {
+          app: {
+            accountName: appLookupParams.account.name,
+            bundleIdentifier: appLookupParams.bundleIdentifier,
+            projectName: appLookupParams.projectName,
+          },
+          distribution: 'store',
+          skipCredentialsCheck: true,
+        });
+
+        await expect(provider.getCredentialsAsync(CredentialsSource.REMOTE)).rejects.toThrowError();
+      });
+
+      it('returns credentials if they exist', async () => {
+        const ctx = createCtxMock({
+          nonInteractive: false,
+          appStore: getAppstoreMock(),
+          projectDir: '/app',
+          newIos: {
+            ...getNewIosApiMockWithoutCredentials(),
+            getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(
+              () => testIosAppCredentialsWithBuildCredentialsQueryResult
+            ),
+          },
+        });
+        const appLookupParams = getAppLookupParamsFromContext(ctx);
+        const provider = new IosCredentialsProvider(ctx, {
+          app: {
+            accountName: appLookupParams.account.name,
+            bundleIdentifier: appLookupParams.bundleIdentifier,
+            projectName: appLookupParams.projectName,
+          },
+          distribution: 'store',
+          skipCredentialsCheck: true,
+        });
+
+        const buildCredentials =
+          testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsArray[0];
+        await expect(provider.getCredentialsAsync(CredentialsSource.REMOTE)).resolves.toMatchObject(
+          {
+            distributionCertificate: {
+              certP12: buildCredentials.distributionCertificate.certificateP12,
+              certPassword: buildCredentials.distributionCertificate.certificatePassword,
+            },
+            provisioningProfile: buildCredentials.provisioningProfile.provisioningProfile,
+          }
+        );
+      });
+    });
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/ConfigureProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/ConfigureProvisioningProfile-test.ts
@@ -6,8 +6,8 @@ import {
   testProvisioningProfile,
   testProvisioningProfileFragment,
 } from '../../../../__tests__/fixtures-ios';
-import { ManageIosBeta } from '../../../../manager/ManageIosBeta';
 import { MissingCredentialsNonInteractiveError } from '../../../errors';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { ConfigureProvisioningProfile } from '../ConfigureProvisioningProfile';
 jest.mock('../../../../../prompts');
 (confirmAsync as jest.Mock).mockImplementation(() => true);
@@ -29,7 +29,7 @@ describe('ConfigureProvisioningProfile', () => {
         useExistingProvisioningProfileAsync: jest.fn(() => mockProvisioningProfileFromApple),
       },
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const provProfConfigurator = new ConfigureProvisioningProfile(
       appLookupParams,
       testDistCertFragmentNoDependencies,
@@ -46,7 +46,7 @@ describe('ConfigureProvisioningProfile', () => {
     const ctx = createCtxMock({
       nonInteractive: true,
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const provProfConfigurator = new ConfigureProvisioningProfile(
       appLookupParams,
       testDistCertFragmentNoDependencies,

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/CreateProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/CreateProvisioningProfile-test.ts
@@ -5,8 +5,8 @@ import {
   testDistCertFragmentNoDependencies,
   testProvisioningProfile,
 } from '../../../../__tests__/fixtures-ios';
-import { ManageIosBeta } from '../../../../manager/ManageIosBeta';
 import { MissingCredentialsNonInteractiveError } from '../../../errors';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { CreateProvisioningProfile } from '../CreateProvisioningProfile';
 jest.mock('../../../../../prompts');
 (confirmAsync as jest.Mock).mockImplementation(() => true);
@@ -22,7 +22,7 @@ describe('CreateProvisioningProfile', () => {
         createProvisioningProfileAsync: jest.fn(() => testProvisioningProfile),
       },
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const createProvProfAction = new CreateProvisioningProfile(
       appLookupParams,
       testDistCertFragmentNoDependencies
@@ -38,7 +38,7 @@ describe('CreateProvisioningProfile', () => {
     const ctx = createCtxMock({
       nonInteractive: true,
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const createProvProfAction = new CreateProvisioningProfile(
       appLookupParams,
       testDistCertFragmentNoDependencies

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/RemoveDistributionCertificate-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/RemoveDistributionCertificate-test.ts
@@ -4,7 +4,7 @@ import {
   testDistCertFragmentNoDependencies,
   testDistCertFragmentOneDependency,
 } from '../../../../__tests__/fixtures-ios';
-import { ManageIosBeta } from '../../../../manager/ManageIosBeta';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { RemoveDistributionCertificate } from '../RemoveDistributionCertificate';
 
 jest.mock('../../../../../prompts');
@@ -13,7 +13,7 @@ jest.mock('../../../../../prompts');
 describe('RemoveDistributionCertificate', () => {
   it('deletes the distribution certificate on Expo and Apple servers when there are no App Dependencies in Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: false });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const removeDistCertAction = new RemoveDistributionCertificate(
       appLookupParams.account,
       testDistCertFragmentNoDependencies
@@ -29,7 +29,7 @@ describe('RemoveDistributionCertificate', () => {
   });
   it('deletes the distribution certificate on Expo servers when there are no App Dependencies in Non-Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: true });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const removeDistCertAction = new RemoveDistributionCertificate(
       appLookupParams.account,
       testDistCertFragmentNoDependencies
@@ -45,7 +45,7 @@ describe('RemoveDistributionCertificate', () => {
   });
   it('deletes the distribution certificate and its provisioning profile on Expo and Apple servers when there are App Dependencies in Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: false });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const removeDistCertAction = new RemoveDistributionCertificate(
       appLookupParams.account,
       testDistCertFragmentOneDependency
@@ -61,7 +61,7 @@ describe('RemoveDistributionCertificate', () => {
   });
   it('errors when the distribution certificate has App Dependencies in Non-Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: true });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const removeDistCertAction = new RemoveDistributionCertificate(
       appLookupParams.account,
       testDistCertFragmentOneDependency

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/RemoveProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/RemoveProvisioningProfile-test.ts
@@ -1,11 +1,11 @@
 import { createCtxMock } from '../../../../__tests__/fixtures-context';
-import { ManageIosBeta } from '../../../../manager/ManageIosBeta';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { RemoveProvisioningProfiles } from '../RemoveProvisioningProfile';
 
 describe('RemoveProvisioningProfile', () => {
   it('Basic Case', async () => {
     const ctx = createCtxMock();
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const testProvisioningProfile = {
       id: 'test-id',
       developerPortalIdentifier: 'test-developer-portal-identifier',

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../../__tests__/fixtures-ios';
 import { getNewIosApiMockWithoutCredentials } from '../../../../__tests__/fixtures-new-ios';
 import { readIosCredentialsAsync } from '../../../../credentialsJson/read';
-import { ManageIosBeta } from '../../../../manager/ManageIosBeta';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { SetupBuildCredentialsFromCredentialsJson } from '../SetupBuildCredentialsFromCredentialsJson';
 jest.mock('../../../../../prompts');
 jest.mock('../../../../credentialsJson/read');
@@ -62,7 +62,7 @@ describe('SetupBuildCredentialsFromCredentialsJson', () => {
         createOrUpdateIosAppBuildCredentialsAsync: jest.fn(() => testBuildCreds),
       },
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const setupBuildCredentialsFromCredentialsJsonAction = new SetupBuildCredentialsFromCredentialsJson(
       appLookupParams,
       IosDistributionType.AppStore
@@ -89,7 +89,7 @@ describe('SetupBuildCredentialsFromCredentialsJson', () => {
         ),
       },
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const setupBuildCredentialsFromCredentialsJsonAction = new SetupBuildCredentialsFromCredentialsJson(
       appLookupParams,
       IosDistributionType.AppStore
@@ -120,7 +120,7 @@ describe('SetupBuildCredentialsFromCredentialsJson', () => {
         createOrUpdateIosAppBuildCredentialsAsync: jest.fn(() => testBuildCreds),
       },
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const setupBuildCredentialsFromCredentialsJsonAction = new SetupBuildCredentialsFromCredentialsJson(
       appLookupParams,
       IosDistributionType.AppStore
@@ -152,7 +152,7 @@ describe('SetupBuildCredentialsFromCredentialsJson', () => {
         createOrUpdateIosAppBuildCredentialsAsync: jest.fn(() => testBuildCreds),
       },
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const setupBuildCredentialsFromCredentialsJsonAction = new SetupBuildCredentialsFromCredentialsJson(
       appLookupParams,
       IosDistributionType.AppStore

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupProvisioningProfile-test.ts
@@ -9,9 +9,9 @@ import {
   testIosAppCredentialsWithBuildCredentialsQueryResult,
 } from '../../../../__tests__/fixtures-ios';
 import { getNewIosApiMockWithoutCredentials } from '../../../../__tests__/fixtures-new-ios';
-import { ManageIosBeta } from '../../../../manager/ManageIosBeta';
 import { MissingCredentialsNonInteractiveError } from '../../../errors';
 import { validateProvisioningProfileAsync } from '../../../validators/validateProvisioningProfile';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { SetupProvisioningProfile } from '../SetupProvisioningProfile';
 jest.mock('../../../../../prompts');
 (confirmAsync as jest.Mock).mockImplementation(() => true);
@@ -52,7 +52,7 @@ describe('SetupProvisioningProfile', () => {
         ),
       },
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
     await setupProvisioningProfileAction.runAsync(ctx);
 
@@ -82,7 +82,7 @@ describe('SetupProvisioningProfile', () => {
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
       },
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
     await setupProvisioningProfileAction.runAsync(ctx);
 
@@ -111,7 +111,7 @@ describe('SetupProvisioningProfile', () => {
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
       },
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
     await setupProvisioningProfileAction.runAsync(ctx);
 
@@ -133,7 +133,7 @@ describe('SetupProvisioningProfile', () => {
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
       },
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
     await setupProvisioningProfileAction.runAsync(ctx);
 
@@ -146,7 +146,7 @@ describe('SetupProvisioningProfile', () => {
     const ctx = createCtxMock({
       nonInteractive: true,
     });
-    const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
     const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
     await expect(setupProvisioningProfileAction.runAsync(ctx)).rejects.toThrowError(
       MissingCredentialsNonInteractiveError

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -14,6 +14,7 @@ import {
 import { UpdateCredentialsJson } from '../ios/actions/UpdateCredentialsJson';
 import { UpdateDistributionCertificate } from '../ios/actions/UpdateDistributionCertificate';
 import { UseExistingDistributionCertificate } from '../ios/actions/UseDistributionCertificate';
+import { getAppLookupParamsFromContext } from '../ios/actions/new/BuildCredentialsUtils';
 import { AppLookupParams } from '../ios/credentials';
 import { displayAllIosCredentials } from '../ios/utils/printCredentials';
 import { PressAnyKeyToContinue } from './HelperActions';
@@ -132,8 +133,8 @@ export class ManageIos implements Action {
         return new UseExistingDistributionCertificate(app);
       }
       case ActionType.SetupBuildCredentials: {
-        const app = this.getAppLookupParamsFromContext(ctx);
-        return new SetupBuildCredentials(app, 'store');
+        const appLookupParams = getAppLookupParamsFromContext(ctx);
+        return new SetupBuildCredentials(appLookupParams, 'store');
       }
       case ActionType.RemoveSpecificProvisioningProfile: {
         const app = this.getAppLookupParamsFromContext(ctx);

--- a/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
@@ -1,12 +1,12 @@
 import Log from '../../log';
-import { getProjectAccountName, getProjectConfigDescription } from '../../project/projectUtils';
+import { getProjectAccountName } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { findAccountByName } from '../../user/Account';
 import { ensureActorHasUsername } from '../../user/actions';
 import { Action, CredentialsManager } from '../CredentialsManager';
 import { Context } from '../context';
+import { getAppLookupParamsFromContext } from '../ios/actions/new/BuildCredentialsUtils';
 import { SelectAndRemoveDistributionCertificate } from '../ios/actions/new/RemoveDistributionCertificate';
-import { AppLookupParams } from '../ios/api/GraphqlClient';
 import {
   displayEmptyIosCredentials,
   displayIosAppCredentials,
@@ -39,7 +39,7 @@ export class ManageIosBeta implements Action {
           throw new Error(`You do not have access to account: ${accountName}`);
         }
         if (ctx.hasProjectContext) {
-          const appLookupParams = ManageIosBeta.getAppLookupParamsFromContext(ctx);
+          const appLookupParams = getAppLookupParamsFromContext(ctx);
           const iosAppCredentials = await ctx.newIos.getIosAppCredentialsWithCommonFieldsAsync(
             appLookupParams
           );
@@ -84,26 +84,5 @@ export class ManageIosBeta implements Action {
         return;
       }
     }
-  }
-
-  public static getAppLookupParamsFromContext(ctx: Context): AppLookupParams {
-    ctx.ensureProjectContext();
-    const projectName = ctx.exp.slug;
-    const accountName = getProjectAccountName(ctx.exp, ctx.user);
-    const account = findAccountByName(ctx.user.accounts, accountName);
-    if (!account) {
-      throw new Error(`You do not have access to account: ${accountName}`);
-    }
-
-    const bundleIdentifier = ctx.exp.ios?.bundleIdentifier;
-    if (!bundleIdentifier) {
-      throw new Error(
-        `ios.bundleIdentifier needs to be defined in your ${getProjectConfigDescription(
-          ctx.projectDir
-        )} file`
-      );
-    }
-
-    return { account, projectName, bundleIdentifier };
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This is part of the effort to move all credentials apiv2 calls to our graphql API. This is also the first part of adding support for internal distribution within enterprise teams. This PR refactors the `IosCredentialsProvider` class so it uses GraphQL.

# Notable changes

- I removed all apiv2 calls from `IosCredentialsProvider` and replaced them with a single Graphql query (by calling a util from Quin's PR).
- I moved the `getAppLookupParamsFromContext` method from `MethodIosBeta` to a more generic place as it's widely used.

# Test Plan

Added some unit tests.