### PR TITLE
[eas-cli] handle branch with no updates gracefully

### DIFF
--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -100,8 +100,8 @@ export default class BranchList extends Command {
         ...branches.map(branch => [
           branch.name,
           formatUpdate(branch.updates[0]),
-          branch.updates[0].runtimeVersion,
-          branch.updates[0].group,
+          branch.updates[0]?.runtimeVersion ?? 'N/A',
+          branch.updates[0]?.group ?? 'N/A',
         ])
       );
       Log.log(chalk.bold('Branches with their most recent update group:'));

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -118,8 +118,8 @@ export default class ChannelList extends Command {
         channel.name,
         branch.name,
         formatUpdate(update),
-        update?.runtimeVersion,
-        update?.group,
+        update?.runtimeVersion ?? 'N/A',
+        update?.group ?? 'N/A',
       ]);
     }
 


### PR DESCRIPTION
# Why

A branch with no updates throws an error during `eas branch:list`

<img width="817" alt="Screen Shot 2021-04-13 at 6 48 21 AM" src="https://user-images.githubusercontent.com/1220444/114564500-37debf80-9c25-11eb-8d57-0af28b6e7dd8.png">

Also `eas channel:list` does not display an informative message when the update is missing.

<img width="1490" alt="Screen Shot 2021-04-13 at 7 05 26 AM" src="https://user-images.githubusercontent.com/1220444/114565953-a1ab9900-9c26-11eb-9c03-bf0b12990970.png">


# How

switched to optional chaining and nullish coalescing.

# Test Plan

tested on sample repo:
<img width="1375" alt="Screen Shot 2021-04-13 at 7 00 50 AM" src="https://user-images.githubusercontent.com/1220444/114565361-0b777300-9c26-11eb-8cdb-01eee47fa0f0.png">
<img width="1494" alt="Screen Shot 2021-04-13 at 7 00 57 AM" src="https://user-images.githubusercontent.com/1220444/114565367-0ca8a000-9c26-11eb-8310-de5870442575.png">

