### PR TITLE
[eas-cli] update channel:list to handle rollouts

### DIFF
--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -18,6 +18,10 @@ import Log from '../../log';
 import { findProjectRootAsync, getProjectFullNameAsync } from '../../project/projectUtils';
 import { getActorDisplayName } from '../../user/User';
 
+export type FormatUpdateParameter = Pick<Update, 'id' | 'createdAt' | 'message'> & {
+  actor?: Maybe<Pick<User, 'username' | 'id'> | Pick<Robot, 'firstName' | 'id'>>;
+};
+
 export const UPDATE_COLUMNS = ['update description', 'update runtime version', 'update group ID'];
 const BRANCHES_LIMIT = 10_000;
 
@@ -113,11 +117,7 @@ export default class BranchList extends Command {
   }
 }
 
-export function formatUpdate(
-  update: Pick<Update, 'id' | 'createdAt' | 'message'> & {
-    actor?: Maybe<Pick<User, 'username' | 'id'> | Pick<Robot, 'firstName' | 'id'>>;
-  }
-): string {
+export function formatUpdate(update: FormatUpdateParameter): string {
   if (!update) {
     return 'N/A';
   }

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -11,7 +11,7 @@ import {
 import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
-import { getBranchMapping, logChannelDetails } from './view';
+import { logChannelDetails } from './view';
 
 const CHANNEL_LIMIT = 10_000;
 
@@ -106,9 +106,8 @@ export default class ChannelList extends Command {
 
     Log.log(); // spacing
     for (const channel of channels) {
-      const { branchMapping, isRollout, rolloutPercent } = getBranchMapping(channel.branchMapping);
       Log.log(`Details of channel ${chalk.bold(chalk.cyan(channel.name))}:`);
-      logChannelDetails({ branchMapping, isRollout, rolloutPercent, channel });
+      logChannelDetails(channel);
     }
   }
 }

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -1,7 +1,6 @@
 import { getConfig } from '@expo/config';
 import { Command, flags } from '@oclif/command';
 import chalk from 'chalk';
-import Table from 'cli-table3';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
@@ -12,7 +11,7 @@ import {
 import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
-import { UPDATE_COLUMNS, formatUpdate } from '../branch/list';
+import { getBranchMapping, logChannelDetails } from './view';
 
 const CHANNEL_LIMIT = 10_000;
 
@@ -32,7 +31,8 @@ async function getAllUpdateChannelForAppAsync({
                 updateChannels(offset: $offset, limit: $limit) {
                   id
                   name
-                  updateBranches(offset: 0, limit: 1) {
+                  branchMapping
+                  updateBranches(offset: 0, limit: $limit) {
                     id
                     name
                     updates(offset: 0, limit: 1) {
@@ -104,26 +104,11 @@ export default class ChannelList extends Command {
       return;
     }
 
-    const table = new Table({
-      head: ['channel', 'branch', ...UPDATE_COLUMNS],
-      wordWrap: true,
-    });
-
+    Log.log(); // spacing
     for (const channel of channels) {
-      // TODO (cedric): refactor when multiple branches per channel are available
-      const branch = channel.updateBranches[0];
-      const update = branch.updates[0];
-
-      table.push([
-        channel.name,
-        branch.name,
-        formatUpdate(update),
-        update?.runtimeVersion ?? 'N/A',
-        update?.group ?? 'N/A',
-      ]);
+      const { branchMapping, isRollout, rolloutPercent } = getBranchMapping(channel.branchMapping);
+      Log.log(`Details of channel ${chalk.bold(chalk.cyan(channel.name))}:`);
+      logChannelDetails({ branchMapping, isRollout, rolloutPercent, channel });
     }
-
-    Log.log(chalk`{bold Channels with their branches and their most recent update group:}`);
-    Log.log(table.toString());
   }
 }

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -44,7 +44,9 @@ function getRolloutInfo(
   oldBranch: Pick<UpdateBranch, 'name' | 'id'>;
   currentPercent: number;
 } {
-  const { branchMapping } = getBranchMapping(getUpdateChannelByNameForAppResult);
+  const { branchMapping } = getBranchMapping(
+    getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.branchMapping
+  );
   const [newBranchId, oldBranchId] = branchMapping.data.map(d => d.branchId);
   const newBranch = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.updateBranches.filter(
     branch => branch.id === newBranchId
@@ -359,7 +361,7 @@ export default class ChannelRollout extends Command {
       channelName: channelName!,
     });
     const { branchMapping: currentBranchMapping, isRollout } = getBranchMapping(
-      getUpdateChannelByNameForAppResult
+      getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.branchMapping
     );
 
     if (currentBranchMapping.data.length === 0) {

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -130,23 +130,16 @@ export async function getUpdateChannelByNameForAppAsync({
   );
 }
 
-export function logChannelDetails({
-  branchMapping,
-  isRollout,
-  rolloutPercent,
-  channel,
-}: {
-  branchMapping: BranchMapping;
-  isRollout: boolean;
-  rolloutPercent?: number;
-  channel: {
-    updateBranches: {
-      updates: (FormatUpdateParameter & { runtimeVersion?: string; group?: string })[];
-      name: string;
-      id: string;
-    }[];
-  };
+export function logChannelDetails(channel: {
+  branchMapping: string;
+  updateBranches: {
+    updates: (FormatUpdateParameter & { runtimeVersion?: string; group?: string })[];
+    name: string;
+    id: string;
+  }[];
 }): void {
+  const { branchMapping, isRollout, rolloutPercent } = getBranchMapping(channel.branchMapping);
+
   const table = new Table({
     head: ['branch', ...(isRollout ? ['rollout percent'] : []), ...UPDATE_COLUMNS],
     wordWrap: true,
@@ -250,10 +243,6 @@ export default class ChannelView extends Command {
     Log.log(
       chalk`{bold Branches, pointed at by this channel, and their most recent update group:}`
     );
-
-    const { branchMapping, isRollout, rolloutPercent } = getBranchMapping(
-      getUpdateChannelByNameForAppresult.app?.byId.updateChannelByName?.branchMapping
-    );
-    logChannelDetails({ branchMapping, isRollout, rolloutPercent, channel });
+    logChannelDetails(channel);
   }
 }

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -2,6 +2,7 @@ import { getConfig } from '@expo/config';
 import { Command, flags } from '@oclif/command';
 import chalk from 'chalk';
 import Table from 'cli-table3';
+import { assert } from 'console';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
@@ -13,7 +14,7 @@ import Log from '../../log';
 import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import { UPDATE_COLUMNS, formatUpdate } from '../branch/list';
+import { FormatUpdateParameter, UPDATE_COLUMNS, formatUpdate } from '../branch/list';
 
 export type BranchMapping = {
   version: number;
@@ -32,15 +33,19 @@ export type BranchMapping = {
  * Ensure that the branch mapping is properly formatted.
  */
 export function getBranchMapping(
-  getChannelByNameForAppQuery: GetChannelByNameForAppQuery
+  branchMappingString?: string
 ): { branchMapping: BranchMapping; isRollout: boolean; rolloutPercent?: number } {
-  const branchMappingString =
-    getChannelByNameForAppQuery.app?.byId.updateChannelByName?.branchMapping;
   if (!branchMappingString) {
     throw new Error('Missing branch mapping.');
   }
+  let branchMapping: BranchMapping;
+  try {
+    branchMapping = JSON.parse(branchMappingString);
+  } catch (e) {
+    throw new Error(`Could not parse branchMapping string into a JSON: "${branchMappingString}"`);
+  }
+  assert(branchMapping, 'Branch Mapping must be defined.');
 
-  const branchMapping: BranchMapping = JSON.parse(branchMappingString);
   if (branchMapping.version !== 0) {
     throw new Error('Branch mapping must be version 0.');
   }
@@ -125,6 +130,56 @@ export async function getUpdateChannelByNameForAppAsync({
   );
 }
 
+export function logChannelDetails({
+  branchMapping,
+  isRollout,
+  rolloutPercent,
+  channel,
+}: {
+  branchMapping: BranchMapping;
+  isRollout: boolean;
+  rolloutPercent?: number;
+  channel: {
+    updateBranches: {
+      updates: (FormatUpdateParameter & { runtimeVersion?: string; group?: string })[];
+      name: string;
+      id: string;
+    }[];
+  };
+}): void {
+  const table = new Table({
+    head: ['branch', ...(isRollout ? ['rollout percent'] : []), ...UPDATE_COLUMNS],
+    wordWrap: true,
+  });
+
+  for (const index in branchMapping.data) {
+    if (parseInt(index, 10) > 1) {
+      throw new Error('Branch Mapping data must have length less than or equal to 2.');
+    }
+
+    const { branchId } = branchMapping.data[index];
+    const branch = channel.updateBranches.filter(branch => branch.id === branchId)[0];
+    if (!branch) {
+      throw new Error('Branch mapping is pointing at a missing branch.');
+    }
+    const update = branch.updates[0];
+    table.push([
+      branch.name,
+      ...(isRollout
+        ? [
+            parseInt(index, 10) === 0
+              ? `${rolloutPercent! * 100}%`
+              : `${(1 - rolloutPercent!) * 100}%`,
+          ]
+        : []),
+      formatUpdate(update),
+      update?.runtimeVersion ?? 'N/A',
+      update?.group ?? 'N/A,',
+    ]);
+  }
+  Log.log(table.toString());
+}
+
 export default class ChannelView extends Command {
   static hidden = true;
   static description = 'View a channel on the current project.';
@@ -189,47 +244,16 @@ export default class ChannelView extends Command {
       return;
     }
 
-    const { branchMapping, isRollout, rolloutPercent } = getBranchMapping(
-      getUpdateChannelByNameForAppresult
-    );
-
-    const table = new Table({
-      head: ['branch', ...(isRollout ? ['rollout percent'] : []), ...UPDATE_COLUMNS],
-      wordWrap: true,
-    });
-
-    for (const index in branchMapping.data) {
-      if (parseInt(index, 10) > 1) {
-        throw new Error('Branch Mapping data must have length less than or equal to 2.');
-      }
-
-      const { branchId } = branchMapping.data[index];
-      const branch = channel.updateBranches.filter(branch => branch.id === branchId)[0];
-      if (!branch) {
-        throw new Error('Branch mapping is pointing at a missing branch.');
-      }
-      const update = branch.updates[0];
-      table.push([
-        branch.name,
-        ...(isRollout
-          ? [
-              parseInt(index, 10) === 0
-                ? `${rolloutPercent! * 100}%`
-                : `${(1 - rolloutPercent!) * 100}%`,
-            ]
-          : []),
-        formatUpdate(update),
-        update?.runtimeVersion,
-        update?.group,
-      ]);
-    }
-
     Log.withTick(
       chalk`Channel: {bold ${channel.name}} on project {bold ${accountName}/${slug}}. Channel ID: {bold ${channel.id}}`
     );
     Log.log(
       chalk`{bold Branches, pointed at by this channel, and their most recent update group:}`
     );
-    Log.log(table.toString());
+
+    const { branchMapping, isRollout, rolloutPercent } = getBranchMapping(
+      getUpdateChannelByNameForAppresult.app?.byId.updateChannelByName?.branchMapping
+    );
+    logChannelDetails({ branchMapping, isRollout, rolloutPercent, channel });
   }
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3388,7 +3388,7 @@ export type GetAllChannelsForAppQuery = (
       & Pick<App, 'id'>
       & { updateChannels: Array<(
         { __typename?: 'UpdateChannel' }
-        & Pick<UpdateChannel, 'id' | 'name'>
+        & Pick<UpdateChannel, 'id' | 'name' | 'branchMapping'>
         & { updateBranches: Array<(
           { __typename?: 'UpdateBranch' }
           & Pick<UpdateBranch, 'id' | 'name'>


### PR DESCRIPTION
# Why

Currently we only display a single branch for each channel. This PR updates the command to display multiple branches when a rollout is present:

<img width="1635" alt="Screen Shot 2021-04-13 at 11 15 45 AM" src="https://user-images.githubusercontent.com/1220444/114600784-99b12080-9c49-11eb-9fe2-0c6d89adc053.png">


# How

We iterate of the channels and use the same function to display rollouts as is used in `eas channel:view`

# Test Plan

Tested on sample repo.

# Note
This PR replaces this in progress PR: https://github.com/expo/eas-cli/pull/304