### PR TITLE
[eas-cli] add update:delete command

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -16939,11 +16939,11 @@
         "description": "",
         "fields": [
           {
-            "name": "deleteUpdate",
-            "description": "Delete an EAS update",
+            "name": "deleteUpdateGroup",
+            "description": "Delete an EAS update group",
             "args": [
               {
-                "name": "updateId",
+                "name": "group",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -16962,7 +16962,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "DeleteUpdateResult",
+                "name": "DeleteUpdateGroupResult",
                 "ofType": null
               }
             },
@@ -16977,11 +16977,11 @@
       },
       {
         "kind": "OBJECT",
-        "name": "DeleteUpdateResult",
+        "name": "DeleteUpdateGroupResult",
         "description": "",
         "fields": [
           {
-            "name": "id",
+            "name": "group",
             "description": "",
             "args": [],
             "type": {

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -12176,6 +12176,57 @@
             "deprecationReason": null
           },
           {
+            "name": "extendOffer",
+            "description": "Extend offer to account",
+            "args": [
+              {
+                "name": "accountName",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offer",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "StandardOffer",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "suppressMessage",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sendEmail",
             "description": "Send an email to primary account email",
             "args": [
@@ -12259,7 +12310,7 @@
           },
           {
             "name": "rename",
-            "description": "Rename this account",
+            "description": "Rename this account and the primary user's username if this account is a personal account",
             "args": [
               {
                 "name": "accountID",
@@ -12306,6 +12357,41 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "StandardOffer",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DEFAULT",
+            "description": "$29 USD per month, 30 day trial",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "YEARLY_SUB",
+            "description": "$348 USD per year, 30 day trial",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "YC_DEALS",
+            "description": "$29 USD per month, 1 year trial",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUPPORT",
+            "description": "$800 USD per month",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -19525,35 +19611,6 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "StandardOffer",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "DEFAULT",
-            "description": "$29 USD per month, 30 day trial",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "YC_DEALS",
-            "description": "$29 USD per month, 1 year trial",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SUPPORT",
-            "description": "$800 USD per month",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/src/commands/update/delete.ts
+++ b/packages/eas-cli/src/commands/update/delete.ts
@@ -1,0 +1,88 @@
+import { Command, flags } from '@oclif/command';
+import chalk from 'chalk';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
+import {
+  DeleteUpdateGroupMutation,
+  UpdateMutationDeleteUpdateGroupArgs,
+} from '../../graphql/generated';
+import Log from '../../log';
+import { confirmAsync } from '../../prompts';
+
+async function deleteUpdateGroupAsync({
+  group,
+}: {
+  group: string;
+}): Promise<DeleteUpdateGroupMutation> {
+  return await withErrorHandlingAsync(
+    graphqlClient
+      .mutation<DeleteUpdateGroupMutation, UpdateMutationDeleteUpdateGroupArgs>(
+        gql`
+          mutation DeleteUpdateGroup($group: ID!) {
+            update {
+              deleteUpdateGroup(group: $group) {
+                group
+              }
+            }
+          }
+        `,
+        { group }
+      )
+      .toPromise()
+  );
+}
+
+export default class UpdateDelete extends Command {
+  static hidden = true;
+  static description = 'Delete all the updates in an update Group.';
+
+  static args = [
+    {
+      name: 'groupId',
+      required: true,
+      description: 'The ID of an update group to delete.',
+    },
+  ];
+
+  static flags = {
+    json: flags.boolean({
+      description: `Return a json with the group ID of the deleted updates.`,
+      default: false,
+    }),
+  };
+
+  async run() {
+    const {
+      args: { groupId: group },
+      flags: { json: jsonFlag },
+    } = this.parse(UpdateDelete);
+
+    if (!jsonFlag) {
+      const shouldAbort = await confirmAsync({
+        message:
+          `🚨${chalk.red('CAUTION')}🚨\n\n` +
+          `${chalk.yellow(`This will delete all of the updates in group "${group}".`)} ${chalk.red(
+            'This is a permanent operation.'
+          )}\n\n` +
+          `If you want to revert to a previous publish, you should use 'branch:publish --republish' targeted at the last working update group instead.\n\n` +
+          `An update group should only be deleted in an emergency like an accidental publish of a secret. In this case user 'branch:publish --republish' to revert to the last working update group first and then proceed with the deletion. Deleting an update group when it is the latest publish can lead to inconsistent cacheing behavior by clients.\n\n` +
+          `Would you like to abort?`,
+      });
+
+      if (shouldAbort) {
+        Log.log('Aborted.');
+        return;
+      }
+    }
+
+    await deleteUpdateGroupAsync({ group });
+
+    if (jsonFlag) {
+      Log.log(JSON.stringify({ group }));
+      return;
+    }
+
+    Log.withTick(`Deleted update group ${group}`);
+  }
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1745,11 +1745,13 @@ export type AccountMutation = {
   setBuildAutoRenew?: Maybe<Account>;
   /** Set payment details */
   setPaymentSource?: Maybe<Account>;
+  /** Extend offer to account */
+  extendOffer?: Maybe<Account>;
   /** Send an email to primary account email */
   sendEmail?: Maybe<Account>;
   /** Require authorization to send push notifications for experiences owned by this account */
   setPushSecurityEnabled?: Maybe<Account>;
-  /** Rename this account */
+  /** Rename this account and the primary user's username if this account is a personal account */
   rename: Account;
 };
 
@@ -1800,6 +1802,13 @@ export type AccountMutationSetPaymentSourceArgs = {
 };
 
 
+export type AccountMutationExtendOfferArgs = {
+  accountName: Scalars['ID'];
+  offer: StandardOffer;
+  suppressMessage?: Maybe<Scalars['Boolean']>;
+};
+
+
 export type AccountMutationSendEmailArgs = {
   accountName: Scalars['ID'];
   emailTemplate: EmailTemplate;
@@ -1816,6 +1825,17 @@ export type AccountMutationRenameArgs = {
   accountID: Scalars['ID'];
   newName: Scalars['String'];
 };
+
+export enum StandardOffer {
+  /** $29 USD per month, 30 day trial */
+  Default = 'DEFAULT',
+  /** $348 USD per year, 30 day trial */
+  YearlySub = 'YEARLY_SUB',
+  /** $29 USD per month, 1 year trial */
+  YcDeals = 'YC_DEALS',
+  /** $800 USD per month */
+  Support = 'SUPPORT'
+}
 
 export enum EmailTemplate {
   /** Able to purchase Developer Services */
@@ -3095,15 +3115,6 @@ export type DeleteWebhookResult = {
   id: Scalars['ID'];
 };
 
-export enum StandardOffer {
-  /** $29 USD per month, 30 day trial */
-  Default = 'DEFAULT',
-  /** $29 USD per month, 1 year trial */
-  YcDeals = 'YC_DEALS',
-  /** $800 USD per month */
-  Support = 'SUPPORT'
-}
-
 export type BaseSearchResult = SearchResult & {
   __typename?: 'BaseSearchResult';
   /** @deprecated Use SearchResult instead */
@@ -3445,6 +3456,22 @@ export type GetChannelByNameForAppQuery = (
   )> }
 );
 
+export type DeleteUpdateGroupMutationVariables = Exact<{
+  group: Scalars['ID'];
+}>;
+
+
+export type DeleteUpdateGroupMutation = (
+  { __typename?: 'RootMutation' }
+  & { update: (
+    { __typename?: 'UpdateMutation' }
+    & { deleteUpdateGroup: (
+      { __typename?: 'DeleteUpdateGroupResult' }
+      & Pick<DeleteUpdateGroupResult, 'group'>
+    ) }
+  ) }
+);
+
 export type UpdatesByGroupQueryVariables = Exact<{
   groupId: Scalars['ID'];
 }>;
@@ -3463,22 +3490,6 @@ export type UpdatesByGroupQuery = (
       & Pick<Robot, 'firstName' | 'id'>
     )> }
   )> }
-);
-
-export type DeleteUpdateGroupMutationVariables = Exact<{
-  group: Scalars['ID'];
-}>;
-
-
-export type DeleteUpdateGroupMutation = (
-  { __typename?: 'RootMutation' }
-  & { update: (
-    { __typename?: 'UpdateMutation' }
-    & { deleteUpdateGroup: (
-      { __typename?: 'DeleteUpdateGroupResult' }
-      & Pick<DeleteUpdateGroupResult, 'group'>
-    ) }
-  ) }
 );
 
 export type CreateAppleAppIdentifierMutationVariables = Exact<{

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2619,18 +2619,18 @@ export type DeleteUpdateChannelResult = {
 
 export type UpdateMutation = {
   __typename?: 'UpdateMutation';
-  /** Delete an EAS update */
-  deleteUpdate: DeleteUpdateResult;
+  /** Delete an EAS update group */
+  deleteUpdateGroup: DeleteUpdateGroupResult;
 };
 
 
-export type UpdateMutationDeleteUpdateArgs = {
-  updateId: Scalars['ID'];
+export type UpdateMutationDeleteUpdateGroupArgs = {
+  group: Scalars['ID'];
 };
 
-export type DeleteUpdateResult = {
-  __typename?: 'DeleteUpdateResult';
-  id: Scalars['ID'];
+export type DeleteUpdateGroupResult = {
+  __typename?: 'DeleteUpdateGroupResult';
+  group: Scalars['ID'];
 };
 
 export type UpdateBranchMutation = {
@@ -3463,6 +3463,22 @@ export type UpdatesByGroupQuery = (
       & Pick<Robot, 'firstName' | 'id'>
     )> }
   )> }
+);
+
+export type DeleteUpdateGroupMutationVariables = Exact<{
+  group: Scalars['ID'];
+}>;
+
+
+export type DeleteUpdateGroupMutation = (
+  { __typename?: 'RootMutation' }
+  & { update: (
+    { __typename?: 'UpdateMutation' }
+    & { deleteUpdateGroup: (
+      { __typename?: 'DeleteUpdateGroupResult' }
+      & Pick<DeleteUpdateGroupResult, 'group'>
+    ) }
+  ) }
 );
 
 export type CreateAppleAppIdentifierMutationVariables = Exact<{


### PR DESCRIPTION
# Why

Add update:delete

# How

Since this is a dangerous operation that a user should avoid unless in situations like accidental secret publication an extensive warning message is included.

<img width="1673" alt="Screen Shot 2021-04-13 at 7 42 35 PM" src="https://user-images.githubusercontent.com/1220444/114646605-68a80e80-9c90-11eb-8640-411442d8f39b.png">

Note the default is to abort.

# Test Plan

Tested on sample repo.

#Note 
This replaces PR https://github.com/expo/eas-cli/pull/261 which was targeted at deleting a single update. However after discussion we decided that this would lead to confusing errors and thus we should only expose the update *group* to developers.
