### PR TITLE
don't update capabilities if there's nothing to change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix the behavior where the provisioning profile was invalidated after syncing bundle id capabilities. ([#334](https://github.com/expo/eas-cli/pull/334) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 - Change build credentials summary format. ([#321](https://github.com/expo/eas-cli/pull/321) by [@dsokal](https://github.com/dsokal))

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/ensureAppExists-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/ensureAppExists-test.ts
@@ -1,0 +1,24 @@
+import { syncCapabilities } from '../ensureAppExists';
+
+describe(syncCapabilities, () => {
+  test("bundleId.updateBundleIdCapabilityAsync should not be called if there's noting to update", async () => {
+    const bundleId = {
+      hasCapabilityAsync: jest.fn().mockImplementation(() => {
+        return {};
+      }),
+      updateBundleIdCapabilityAsync: jest.fn(),
+    } as any;
+    await syncCapabilities(bundleId, { enablePushNotifications: true });
+    expect(bundleId.updateBundleIdCapabilityAsync).not.toHaveBeenCalled();
+  });
+  test('bundleId.updateBundleIdCapabilityAsync should be called if there are some changes to be made', async () => {
+    const bundleId = {
+      hasCapabilityAsync: jest.fn().mockImplementation(() => {
+        return null;
+      }),
+      updateBundleIdCapabilityAsync: jest.fn(),
+    } as any;
+    await syncCapabilities(bundleId, { enablePushNotifications: true });
+    expect(bundleId.updateBundleIdCapabilityAsync).toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -36,7 +36,7 @@ export async function ensureBundleIdExistsWithNameAsync(
   options?: EnsureAppExistsOptions
 ) {
   const context = getRequestContext(authCtx);
-  let spinner = ora(`Linking bundle identifier ${chalk.dim(bundleIdentifier)}`).start();
+  const spinner = ora(`Linking bundle identifier ${chalk.dim(bundleIdentifier)}`).start();
 
   let bundleId: BundleId | null;
   try {
@@ -72,23 +72,33 @@ export async function ensureBundleIdExistsWithNameAsync(
   }
 
   if (options) {
-    try {
-      spinner = ora(`Syncing capabilities`).start();
+    await syncCapabilities(bundleId, options);
+  }
+}
 
-      // Update the capabilities
+async function syncCapabilities(
+  bundleId: BundleId,
+  options: EnsureAppExistsOptions
+): Promise<void> {
+  const spinner = ora(`Syncing capabilities`).start();
+
+  try {
+    const capability = await bundleId.hasCapabilityAsync(CapabilityType.PUSH_NOTIFICATIONS);
+    if (!capability && options.enablePushNotifications) {
       await bundleId.updateBundleIdCapabilityAsync({
         capabilityType: CapabilityType.PUSH_NOTIFICATIONS,
-        option: options.enablePushNotifications
-          ? CapabilityTypeOption.ON
-          : CapabilityTypeOption.OFF,
-        // TODO: Add more capabilities
+        option: CapabilityTypeOption.ON,
       });
-      spinner.succeed(`Synced capabilities`);
-    } catch (err) {
-      spinner.fail(`Failed to sync capabilities ${chalk.dim(bundleIdentifier)}`);
-
-      throw err;
+    } else if (capability && !options.enablePushNotifications) {
+      await bundleId.updateBundleIdCapabilityAsync({
+        capabilityType: CapabilityType.PUSH_NOTIFICATIONS,
+        option: CapabilityTypeOption.OFF,
+      });
     }
+    spinner.succeed(`Synced capabilities`);
+  } catch (err) {
+    spinner.fail(`Failed to sync capabilities ${chalk.dim(bundleId.attributes.identifier)}`);
+    throw err;
   }
 }
 

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -76,7 +76,7 @@ export async function ensureBundleIdExistsWithNameAsync(
   }
 }
 
-async function syncCapabilities(
+export async function syncCapabilities(
   bundleId: BundleId,
   options: EnsureAppExistsOptions
 ): Promise<void> {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

I've noticed that if the provisioning profile had been generated during a previous `eas build` run, it's invalidated at the start of the consecutive build. I've figured out that the reason is the bundle id capabilities synchronization. We run it every time, even if there are no changes to be made. Updating bundle id capabilities somehow invalidates the associated provisioning profile.

# How

Instead of updating capabilities every time, I made a change so they're updated only when needed.

# Test Plan

Added unit tests.