### PR TITLE
add support for adhoc and universal distribution within enterprise teams

### DIFF
--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -1,5 +1,5 @@
 import { Workflow } from '@expo/eas-build-job';
-import { CredentialsSource, iOSDistributionType } from '@expo/eas-json';
+import { CredentialsSource, IosEnterpriseProvisioning, iOSDistributionType } from '@expo/eas-json';
 import assert from 'assert';
 
 import { createCredentialsContextAsync } from '../../credentials/context';
@@ -29,6 +29,7 @@ export async function ensureIosCredentialsAsync(
     workflow: ctx.buildProfile.workflow,
     credentialsSource: ctx.buildProfile.credentialsSource,
     distribution: ctx.buildProfile.distribution ?? 'store',
+    enterpriseProvisioning: ctx.buildProfile.enterpriseProvisioning,
     nonInteractive: ctx.commandCtx.nonInteractive,
     skipCredentialsCheck: ctx.commandCtx.skipCredentialsCheck,
   });
@@ -39,6 +40,7 @@ interface ResolveCredentialsParams {
   workflow: Workflow;
   credentialsSource: CredentialsSource;
   distribution: iOSDistributionType;
+  enterpriseProvisioning?: IosEnterpriseProvisioning;
   nonInteractive: boolean;
   skipCredentialsCheck: boolean;
 }
@@ -54,6 +56,7 @@ export async function resolveIosCredentialsAsync(
   const provider = new IosCredentialsProvider(ctx, {
     app,
     distribution: params.distribution,
+    enterpriseProvisioning: params.enterpriseProvisioning,
     skipCredentialsCheck: params.skipCredentialsCheck,
   });
   const credentialsSource = await ensureCredentialsAsync(

--- a/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
@@ -1,3 +1,4 @@
+import { IosEnterpriseProvisioning, iOSDistributionType } from '@expo/eas-json';
 import nullthrows from 'nullthrows';
 
 import {
@@ -92,4 +93,21 @@ export function getAppLookupParamsFromContext(ctx: Context): AppLookupParams {
   }
 
   return { account, projectName, bundleIdentifier };
+}
+
+export function resolveDistributionType(
+  distribution: iOSDistributionType,
+  enterpriseProvisioning?: IosEnterpriseProvisioning
+): IosDistributionType {
+  if (distribution === 'internal') {
+    if (enterpriseProvisioning === 'adhoc') {
+      return IosDistributionType.AdHoc;
+    } else if (enterpriseProvisioning === 'universal') {
+      return IosDistributionType.Enterprise;
+    } else {
+      return IosDistributionType.AdHoc;
+    }
+  } else {
+    return IosDistributionType.AppStore;
+  }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupInternalProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupInternalProvisioningProfile.ts
@@ -1,0 +1,12 @@
+import { IosAppBuildCredentialsFragment } from '../../../../graphql/generated';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { SetupAdhocProvisioningProfile } from './SetupAdhocProvisioningProfile';
+
+export class SetupInternalProvisioningProfile {
+  constructor(private app: AppLookupParams) {}
+
+  async runAsync(ctx: Context): Promise<IosAppBuildCredentialsFragment> {
+    return await new SetupAdhocProvisioningProfile(this.app).runAsync(ctx);
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
@@ -24,14 +24,10 @@ import { CreateProvisioningProfile } from './CreateProvisioningProfile';
 import { SetupDistributionCertificate } from './SetupDistributionCertificate';
 
 export class SetupProvisioningProfile {
-  constructor(private app: AppLookupParams) {}
+  constructor(private app: AppLookupParams, private distributionType: IosDistributionType) {}
 
   async areBuildCredentialsSetupAsync(ctx: Context): Promise<boolean> {
-    const buildCredentials = await getBuildCredentialsAsync(
-      ctx,
-      this.app,
-      IosDistributionType.AppStore
-    );
+    const buildCredentials = await getBuildCredentialsAsync(ctx, this.app, this.distributionType);
     if (!buildCredentials) {
       return false;
     }
@@ -63,7 +59,7 @@ export class SetupProvisioningProfile {
     return await assignBuildCredentialsAsync(
       ctx,
       this.app,
-      IosDistributionType.AppStore,
+      this.distributionType,
       distCert,
       provisioningProfile
     );
@@ -86,7 +82,7 @@ export class SetupProvisioningProfile {
     return await assignBuildCredentialsAsync(
       ctx,
       this.app,
-      IosDistributionType.AppStore,
+      this.distributionType,
       distCert,
       updatedProvisioningProfile
     );
@@ -95,9 +91,7 @@ export class SetupProvisioningProfile {
   async runAsync(ctx: Context): Promise<IosAppBuildCredentialsFragment> {
     const areBuildCredentialsSetup = await this.areBuildCredentialsSetupAsync(ctx);
     if (areBuildCredentialsSetup) {
-      return nullthrows(
-        await getBuildCredentialsAsync(ctx, this.app, IosDistributionType.AppStore)
-      );
+      return nullthrows(await getBuildCredentialsAsync(ctx, this.app, this.distributionType));
     }
     if (ctx.nonInteractive) {
       throw new MissingCredentialsNonInteractiveError(
@@ -107,14 +101,10 @@ export class SetupProvisioningProfile {
 
     const distCert = await new SetupDistributionCertificate(
       this.app,
-      IosDistributionType.AppStore
+      this.distributionType
     ).runAsync(ctx);
 
-    const currentProfile = await getProvisioningProfileAsync(
-      ctx,
-      this.app,
-      IosDistributionType.AppStore
-    );
+    const currentProfile = await getProvisioningProfileAsync(ctx, this.app, this.distributionType);
     if (!currentProfile) {
       return await this.createAndAssignProfileAsync(ctx, distCert);
     }

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupProvisioningProfile-test.ts
@@ -1,5 +1,6 @@
 import nullthrows from 'nullthrows';
 
+import { IosDistributionType } from '../../../../../graphql/generated';
 import { confirmAsync } from '../../../../../prompts';
 import { getAppstoreMock, testAuthCtx } from '../../../../__tests__/fixtures-appstore';
 import { createCtxMock } from '../../../../__tests__/fixtures-context';
@@ -53,7 +54,10 @@ describe('SetupProvisioningProfile', () => {
       },
     });
     const appLookupParams = getAppLookupParamsFromContext(ctx);
-    const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
+    const setupProvisioningProfileAction = new SetupProvisioningProfile(
+      appLookupParams,
+      IosDistributionType.AppStore
+    );
     await setupProvisioningProfileAction.runAsync(ctx);
 
     // expect build credentials to be created or updated on expo servers
@@ -83,7 +87,10 @@ describe('SetupProvisioningProfile', () => {
       },
     });
     const appLookupParams = getAppLookupParamsFromContext(ctx);
-    const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
+    const setupProvisioningProfileAction = new SetupProvisioningProfile(
+      appLookupParams,
+      IosDistributionType.AppStore
+    );
     await setupProvisioningProfileAction.runAsync(ctx);
 
     // expect build credentials to be created or updated on expo servers
@@ -112,7 +119,10 @@ describe('SetupProvisioningProfile', () => {
       },
     });
     const appLookupParams = getAppLookupParamsFromContext(ctx);
-    const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
+    const setupProvisioningProfileAction = new SetupProvisioningProfile(
+      appLookupParams,
+      IosDistributionType.AppStore
+    );
     await setupProvisioningProfileAction.runAsync(ctx);
 
     // expect build credentials not to be created or updated on expo servers
@@ -134,7 +144,10 @@ describe('SetupProvisioningProfile', () => {
       },
     });
     const appLookupParams = getAppLookupParamsFromContext(ctx);
-    const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
+    const setupProvisioningProfileAction = new SetupProvisioningProfile(
+      appLookupParams,
+      IosDistributionType.AppStore
+    );
     await setupProvisioningProfileAction.runAsync(ctx);
 
     // expect build credentials to be created or updated on expo servers
@@ -147,7 +160,10 @@ describe('SetupProvisioningProfile', () => {
       nonInteractive: true,
     });
     const appLookupParams = getAppLookupParamsFromContext(ctx);
-    const setupProvisioningProfileAction = new SetupProvisioningProfile(appLookupParams);
+    const setupProvisioningProfileAction = new SetupProvisioningProfile(
+      appLookupParams,
+      IosDistributionType.AppStore
+    );
     await expect(setupProvisioningProfileAction.runAsync(ctx)).rejects.toThrowError(
       MissingCredentialsNonInteractiveError
     );

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -134,7 +134,7 @@ export class ManageIos implements Action {
       }
       case ActionType.SetupBuildCredentials: {
         const appLookupParams = getAppLookupParamsFromContext(ctx);
-        return new SetupBuildCredentials(appLookupParams, 'store');
+        return new SetupBuildCredentials({ app: appLookupParams, distribution: 'store' });
       }
       case ActionType.RemoveSpecificProvisioningProfile: {
         const app = this.getAppLookupParamsFromContext(ctx);

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -10,6 +10,8 @@ export type AndroidDistributionType = 'store' | 'internal';
 export type iOSDistributionType = 'store' | 'internal' | 'simulator';
 export type DistributionType = AndroidDistributionType | iOSDistributionType;
 
+export type IosEnterpriseProvisioning = 'adhoc' | 'universal';
+
 export type VersionAutoIncrement = boolean | 'version' | 'buildNumber';
 
 export interface AndroidManagedBuildProfile extends Android.BuilderEnvironment {
@@ -38,6 +40,7 @@ export interface iOSManagedBuildProfile extends Ios.BuilderEnvironment {
   buildType?: Ios.ManagedBuildType;
   releaseChannel?: string;
   distribution?: iOSDistributionType;
+  enterpriseProvisioning?: IosEnterpriseProvisioning;
   autoIncrement: VersionAutoIncrement;
   cache: Cache;
 }
@@ -50,6 +53,7 @@ export interface iOSGenericBuildProfile extends Ios.BuilderEnvironment {
   releaseChannel?: string;
   artifactPath?: string;
   distribution?: iOSDistributionType;
+  enterpriseProvisioning?: IosEnterpriseProvisioning;
   autoIncrement: VersionAutoIncrement;
   cache: Cache;
   disableIosBundleIdentifierValidation?: boolean;

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -74,6 +74,7 @@ const iOSGenericSchema = Joi.object({
   releaseChannel: Joi.string(),
   artifactPath: Joi.string(),
   distribution: Joi.string().valid('store', 'internal', 'simulator').default('store'),
+  enterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
   autoIncrement: Joi.alternatives()
     .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
     .default(false),
@@ -86,6 +87,7 @@ const iOSManagedSchema = Joi.object({
   buildType: Joi.string().valid('release', 'development-client').default('release'),
   releaseChannel: Joi.string(),
   distribution: Joi.string().valid('store', 'internal', 'simulator').default('store'),
+  enterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
   autoIncrement: Joi.alternatives()
     .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
     .default(false),

--- a/packages/eas-json/src/index.ts
+++ b/packages/eas-json/src/index.ts
@@ -8,6 +8,7 @@ export {
   iOSManagedBuildProfile,
   iOSGenericBuildProfile,
   iOSBuildProfile,
+  IosEnterpriseProvisioning,
   DistributionType,
   EasConfig,
   VersionAutoIncrement,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This is the first part of adding support for internal distribution within enterprise teams.
This PR introduces a new property to eas.json (`enterpriseProvisioning: 'adhoc' | 'universe'`) as well as the support for generating adhoc/universal distribution provisioning profiles.

# How

- https://github.com/expo/eas-cli/pull/335/commits/4b42fd861ca5c3be8c91a07f51d1f775aa048af1 adds the new optional prop to eas.json (`enterpriseProvisioning`).
- https://github.com/expo/eas-cli/pull/335/commits/6e7513892f00c71413fe69b5c642c22e9662ab20
  - It makes the `SetupProvisioningProfile` action generic, which means it's now capable of setting up both app store and enterprise provisioning profiles (it's passed as an argument to the constructor).
  - I changed the `SetupBuildCredentials` so it accounts for the `enterpriseProvisioning` property now.
  - It adds the new `SetupInternalProvisioningProfile` action. Right now, it should be considered as a placeholder as it only runs the `SetupAdhocProvisioningProfile` (this is what currently happens when `"distribution": "internal"`). I'll implement this in the follow-up PR. This action is going to work only in the interactive mode and will allow choosing between ad-hoc and universal distribution credentials.

# Test Plan

- I have inited a new project.
- I set `"distribution": "internal"` and `"enterpriseProvisioning": "adhoc"` in eas.json. I ran a build and noticed that proper ad-hoc credentials were generated.
- Later, I set `"distribution": "internal"` and `"enterpriseProvisioning": "universal"` in eas.json. I ran a build and noticed that proper universal distribution credentials were generated.