### PR TITLE
Use special Expo SDK runtime version for managed projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Use special Expo SDK runtime version for managed projects ([#336](https://github.com/expo/eas-cli/pull/336)) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -19,6 +19,7 @@
     "@expo/plist": "^0.0.11",
     "@expo/plugin-warn-if-update-available": "^1.7.0",
     "@expo/results": "^1.0.0",
+    "@expo/sdk-runtime-versions": "^1.0.0",
     "@expo/spawn-async": "^1.5.0",
     "@hapi/joi": "^17.1.1",
     "@oclif/command": "^1",

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -130,6 +130,7 @@ export default class BranchPublish extends Command {
     // Expo SDK preset runtime that can be launched in Expo Go.
     const isManagedProject = getDefaultTarget(projectDir) === 'managed';
     if (!runtimeVersion && sdkVersion && isManagedProject) {
+      Log.withTick('Generating runtime version from sdk version');
       runtimeVersion = getRuntimeVersionForSDKVersion(sdkVersion);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,6 +1286,11 @@
   resolved "https://registry.yarnpkg.com/@expo/results/-/results-1.0.0.tgz#fd4b22f936ceafce23b04799f54b87fe2a9e18d1"
   integrity sha512-qECzzXX5oJot3m2Gu9pfRDz50USdBieQVwYAzeAtQRUTD3PVeTK1tlRUoDcrK8PSruDLuVYdKkLebX4w/o55VA==
 
+"@expo/sdk-runtime-versions@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz#d7ebd21b19f1c6b0395e50d78da4416941c57f7c"
+  integrity sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==
+
 "@expo/spawn-async@1.5.0", "@expo/spawn-async@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.5.0.tgz#799827edd8c10ef07eb1a2ff9dcfe081d596a395"


### PR DESCRIPTION
# Why

This PR adds support for a special runtime version indicating that the runtime is an expo SDK preset runtime (SDK version). With this special runtime version the user will be able to load the app in Expo Go (as long as expo go has that runtime version). Otherwise the user will need to use the dev client to develop their app.

From https://github.com/expo/universe/pull/7299:
> - In eas-cli (this PR) publish default to the `runtimeVersion` returned from `getRuntimeVersionForSDKVersion` when one isn't supplied and the project is managed.
> - In native code, parse this runtime version to extract the sdk version. https://github.com/expo/expo/pull/12521
> - In home query for EAS updates and parse their runtime versions. If a runtime version is this special format, allow it to be launched in Expo Go with the parsed SDK version. If not, tell the user that a custom client build (dev client) must be used to run the project. https://github.com/expo/expo/pull/12525

# How

Add code to default the runtimeVersion to the SDK version if in managed and the runtime version is not specified.

# Test Plan
In a managed project without runtimeVersion specified:
```sh
> /Users/wschurman/expo/eas-cli/node_modules/.bin/eas branch:publish main
✔ Generating runtime version from sdk version
✔ Linked to project @wschurman/watwat
✔ Building bundle with expo-cli...
...
✔ Uploaded assets!
✔ Please enter a publication message. … woo2
✔ Published!
project        @wschurman/watwat
branch         main
runtimeVersion exposdk:40.0.0
groupID        c2ad7581-5e10-41a6-9c1d-e01eeb604dce
message        woo2

> /Users/wschurman/expo/eas-cli/node_modules/.bin/eas branch:list
Branches with their most recent update group:
┌────────┬─────────────────────────────────────┬────────────────────────┬──────────────────────────────────────┐
│ branch │ update description                  │ update runtime version │ update group ID                      │
├────────┼─────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┤
│ main   │ "woo2" (2 minutes ago by wschurman) │ exposdk:40.0.0         │ c2ad7581-5e10-41a6-9c1d-e01eeb604dce │
└────────┴─────────────────────────────────────┴────────────────────────┴──────────────────────────────────────┘
```
