### PR TITLE
allow for registering devices when building app for internal distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add validation when setting up ad-hoc provisioning profile in non-interactive mode. ([#338](https://github.com/expo/eas-cli/pull/338))
+- Allow for registering devices when running an ad-hoc build for the first time. ([#340](https://github.com/expo/eas-cli/pull/340) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores
@@ -22,7 +25,6 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Use special Expo SDK runtime version for managed projects ([#336](https://github.com/expo/eas-cli/pull/336)) by [@wschurman](https://github.com/wschurman))
-- Add validation when setting up ad-hoc provisioning profile in non-interactive mode. ([#338](https://github.com/expo/eas-cli/pull/338) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -3,6 +3,7 @@ import nullthrows from 'nullthrows';
 import {
   AppFragment,
   AppleAppIdentifierFragment,
+  AppleDeviceFragment,
   AppleDistributionCertificateFragment,
   AppleTeamFragment,
   CommonIosAppCredentialsFragment,
@@ -26,10 +27,7 @@ import { IosAppBuildCredentialsMutation } from './graphql/mutations/IosAppBuildC
 import { IosAppCredentialsMutation } from './graphql/mutations/IosAppCredentialsMutation';
 import { AppQuery } from './graphql/queries/AppQuery';
 import { AppleAppIdentifierQuery } from './graphql/queries/AppleAppIdentifierQuery';
-import {
-  AppleDeviceFragmentWithAppleTeam,
-  AppleDeviceQuery,
-} from './graphql/queries/AppleDeviceQuery';
+import { AppleDeviceQuery } from './graphql/queries/AppleDeviceQuery';
 import { AppleDistributionCertificateQuery } from './graphql/queries/AppleDistributionCertificateQuery';
 import {
   AppleProvisioningProfileQuery,
@@ -215,9 +213,12 @@ export async function createOrGetExistingAppleAppIdentifierAsync(
 
 export async function getDevicesForAppleTeamAsync(
   { account }: AppLookupParams,
-  { appleTeamIdentifier }: AppleTeamFragment
-): Promise<AppleDeviceFragmentWithAppleTeam[]> {
-  return await AppleDeviceQuery.getAllByAppleTeamIdentifierAsync(account.id, appleTeamIdentifier);
+  { appleTeamIdentifier }: AppleTeamFragment,
+  { useCache = true }: { useCache?: boolean } = {}
+): Promise<AppleDeviceFragment[]> {
+  return await AppleDeviceQuery.getAllByAppleTeamIdentifierAsync(account.id, appleTeamIdentifier, {
+    useCache,
+  });
 }
 
 export async function createProvisioningProfileAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -34,7 +34,8 @@ export type AppleDevicesByIdentifierQueryResult = AppleDeviceQueryResult & {
 const AppleDeviceQuery = {
   async getAllByAppleTeamIdentifierAsync(
     accountId: string,
-    appleTeamIdentifier: string
+    appleTeamIdentifier: string,
+    { useCache = true }: { useCache?: boolean } = {}
   ): Promise<AppleDeviceFragmentWithAppleTeam[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
@@ -63,7 +64,10 @@ const AppleDeviceQuery = {
             accountId,
             appleTeamIdentifier,
           },
-          { additionalTypenames: ['AppleDevice'] }
+          {
+            additionalTypenames: ['AppleDevice'],
+            requestPolicy: useCache ? 'cache-first' : 'network-only',
+          }
         )
         .toPromise()
     );

--- a/packages/eas-cli/src/devices/actions/create/action.ts
+++ b/packages/eas-cli/src/devices/actions/create/action.ts
@@ -19,7 +19,7 @@ export default class DeviceCreateAction {
     private appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName' | 'id'>
   ) {}
 
-  public async runAsync(): Promise<void> {
+  public async runAsync(): Promise<RegistrationMethod> {
     const method = await this.askForRegistrationMethodAsync();
     if (method === RegistrationMethod.WEBSITE) {
       await runRegistrationUrlMethodAsync(this.account.id, this.appleTeam);
@@ -29,6 +29,7 @@ export default class DeviceCreateAction {
       Log.log('Bye!');
       process.exit(0);
     }
+    return method;
   }
 
   private async askForRegistrationMethodAsync(): Promise<RegistrationMethod> {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Currently, if the user is running an internal distribution build but they haven't registered any devices yet, we throw an error `Run 'eas device:create' to register your devices first`.
This PR makes it possible to register the devices without the need to run another command.

# How

I reused the device registration logic from `device:create`.

# Test Plan

Tested manually.