### PR TITLE
add sdkVersion as default key for cache

### DIFF
--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -1,4 +1,4 @@
-import { ArchiveSource, Cache, Ios, Job, Workflow, sanitizeJob } from '@expo/eas-build-job';
+import { ArchiveSource, Ios, Job, Workflow, sanitizeJob } from '@expo/eas-build-job';
 import { IosGenericBuildProfile, IosManagedBuildProfile } from '@expo/eas-json';
 import assert from 'assert';
 import path from 'path';
@@ -44,7 +44,6 @@ interface CommonJobProperties {
   builderEnvironment: Ios.BuilderEnvironment;
   releaseChannel?: string;
   distribution?: Ios.DistributionType;
-  cache: Cache;
   secrets: {
     buildCredentials: Ios.BuildCredentials;
     environmentSecrets?: Record<string, string>;
@@ -90,7 +89,6 @@ async function prepareJobCommonAsync(
       fastlane: ctx.buildProfile.fastlane,
       env: ctx.buildProfile.env,
     },
-    cache: ctx.buildProfile.cache,
     secrets: {
       ...(environmentSecrets ? { environmentSecrets } : {}),
       buildCredentials,
@@ -129,6 +127,7 @@ async function prepareGenericJobAsync(
         : buildProfile.schemeBuildConfiguration,
     artifactPath: buildProfile.artifactPath,
     releaseChannel: buildProfile.releaseChannel,
+    cache: ctx.buildProfile.cache,
     projectRootDirectory,
   };
 }
@@ -151,6 +150,10 @@ async function prepareManagedJobAsync(
     buildType: buildProfile.buildType,
     username: accountName,
     releaseChannel: buildProfile.releaseChannel,
+    cache: {
+      ...ctx.buildProfile.cache,
+      key: ctx.buildProfile.cache.key ?? ctx.commandCtx.exp.sdkVersion, // TODO: quickfix
+    },
     projectRootDirectory,
   };
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

When upgrading to sdk 41 default caching is breaking builds because of a updated packages. This is just a quickfix, better solution will be necessary.

# How

add sdkVersion as cache key

# Test Plan

Run build on prod and checks in  logs that cache key was set
.