### PR TITLE
implement SetupInternalProvisioningProfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Implement offline distribution certificate validation when running a build in non-interactive mode. ([#344](https://github.com/expo/eas-cli/pull/344) by [@dsokal](https://github.com/dsokal))
+- Add support for building internal distribution apps for Apple Enterprise Teams. ([#344](https://github.com/expo/eas-cli/pull/344) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 - Display descriptive error message when API for EAS Build changes. ([#359](https://github.com/expo/eas-cli/pull/359) by [@wkozyra95](https://github.com/wkozyra95))

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
@@ -14,6 +14,7 @@ export function createCtxMock(mockOverride: Record<string, any> = {}): Context {
     newIos: getNewIosApiMockWithoutCredentials(),
     android: getAndroidApiMockWithoutCredentials(),
     appStore: getAppstoreMock(),
+    bestEffortAppStoreAuthenticateAsync: jest.fn(),
     ensureAppleCtx: jest.fn(),
     ensureProjectContext: jest.fn(),
     user: {

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -26,11 +26,10 @@ export default class IosCredentialsProvider {
   public async getCredentialsAsync(
     src: CredentialsSource.LOCAL | CredentialsSource.REMOTE
   ): Promise<IosCredentials> {
-    switch (src) {
-      case CredentialsSource.LOCAL:
-        return await this.getLocalAsync();
-      case CredentialsSource.REMOTE:
-        return await this.getRemoteAsync();
+    if (src === CredentialsSource.LOCAL) {
+      return await this.getLocalAsync();
+    } else {
+      return await this.getRemoteAsync();
     }
   }
 
@@ -65,25 +64,16 @@ export default class IosCredentialsProvider {
 
   private async getRemoteAsync(): Promise<IosCredentials> {
     const manager = new CredentialsManager(this.ctx);
-    const buildCredentials = await new SetupBuildCredentials({
+    const { provisioningProfile, distributionCertificate } = await new SetupBuildCredentials({
       app: this.options.app,
       distribution: this.options.distribution,
       enterpriseProvisioning: this.options.enterpriseProvisioning,
     }).runAsync(manager, this.ctx);
-    if (
-      !buildCredentials?.distributionCertificate?.certificateP12 ||
-      !buildCredentials.distributionCertificate?.certificatePassword
-    ) {
-      throw new Error('Distribution certificate is missing');
-    }
-    if (!buildCredentials.provisioningProfile?.provisioningProfile) {
-      throw new Error('Provisioning profile is missing');
-    }
     return {
-      provisioningProfile: buildCredentials.provisioningProfile.provisioningProfile,
+      provisioningProfile,
       distributionCertificate: {
-        certP12: buildCredentials.distributionCertificate.certificateP12,
-        certPassword: buildCredentials.distributionCertificate.certificatePassword,
+        certP12: distributionCertificate.certificateP12,
+        certPassword: distributionCertificate.certificatePassword,
       },
     };
   }

--- a/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupBuildCredentials.ts
@@ -26,10 +26,13 @@ interface Options {
   skipCredentialsCheck?: boolean;
 }
 
-export class SetupBuildCredentials implements Action {
+export class SetupBuildCredentials implements Action<IosAppBuildCredentialsFragment> {
   constructor(private options: Options) {}
 
-  async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+  async runAsync(
+    manager: CredentialsManager,
+    ctx: Context
+  ): Promise<IosAppBuildCredentialsFragment> {
     const { app } = this.options;
 
     await ctx.bestEffortAppStoreAuthenticateAsync();
@@ -46,12 +49,12 @@ export class SetupBuildCredentials implements Action {
     }
     try {
       const buildCredentials = await this.setupBuildCredentials(ctx);
-
       const appInfo = `@${app.account.name}/${app.projectName} (${app.bundleIdentifier})`;
       displayProjectCredentials(app, buildCredentials);
       Log.newLine();
       Log.log(chalk.green(`All credentials are ready to build ${appInfo}`));
       Log.newLine();
+      return buildCredentials;
     } catch (error) {
       Log.error('Failed to setup credentials.');
       throw error;

--- a/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
@@ -17,6 +17,17 @@ import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
 import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
 
+export async function getAllBuildCredentialsAsync(
+  ctx: Context,
+  app: AppLookupParams
+): Promise<IosAppBuildCredentialsFragment[]> {
+  const appCredentials = await ctx.newIos.getIosAppCredentialsWithBuildCredentialsAsync(app, {});
+  if (!appCredentials) {
+    return [];
+  }
+  return appCredentials.iosAppBuildCredentialsArray;
+}
+
 export async function getBuildCredentialsAsync(
   ctx: Context,
   app: AppLookupParams,

--- a/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/BuildCredentialsUtils.ts
@@ -1,4 +1,3 @@
-import { IosDistributionType, IosEnterpriseProvisioning } from '@expo/eas-json';
 import nullthrows from 'nullthrows';
 
 import {
@@ -104,21 +103,4 @@ export function getAppLookupParamsFromContext(ctx: Context): AppLookupParams {
   }
 
   return { account, projectName, bundleIdentifier };
-}
-
-export function resolveDistributionType(
-  distribution: IosDistributionType,
-  enterpriseProvisioning?: IosEnterpriseProvisioning
-): GraphQLIosDistributionType {
-  if (distribution === 'internal') {
-    if (enterpriseProvisioning === 'adhoc') {
-      return GraphQLIosDistributionType.AdHoc;
-    } else if (enterpriseProvisioning === 'universal') {
-      return GraphQLIosDistributionType.Enterprise;
-    } else {
-      return GraphQLIosDistributionType.AdHoc;
-    }
-  } else {
-    return GraphQLIosDistributionType.AppStore;
-  }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
@@ -80,6 +80,22 @@ export class SetupDistributionCertificate {
     if (!currentCertificate) {
       return false;
     }
+
+    const now = new Date();
+    if (
+      now < new Date(currentCertificate.validityNotBefore) ||
+      now > new Date(currentCertificate.validityNotAfter)
+    ) {
+      return false;
+    }
+
+    if (!ctx.appStore.authCtx) {
+      Log.warn(
+        "Skipping Distribution Certificate validation on Apple Servers because we aren't authenticated."
+      );
+      return true;
+    }
+
     const validCertSerialNumbers = (await this.getValidDistCertsAsync(ctx)).map(
       i => i.serialNumber
     );

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupInternalProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupInternalProvisioningProfile.ts
@@ -7,6 +7,13 @@ import { getAllBuildCredentialsAsync } from './BuildCredentialsUtils';
 import { SetupAdhocProvisioningProfile } from './SetupAdhocProvisioningProfile';
 import { SetupProvisioningProfile } from './SetupProvisioningProfile';
 
+/**
+ * It's used when setting up credentials for internal distribution but `enterpriseProvisioning` is not set.
+ *
+ * TLDR: If the user authenticates with an account with Apple Developer Enterprise Program membership we ask them
+ * to choose if they want to set up an adhoc or universal distribution provisioning profile. Otherwise, always
+ * set up an adhoc provisioning profile.
+ */
 export class SetupInternalProvisioningProfile {
   constructor(private app: AppLookupParams) {}
 

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupInternalProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupInternalProvisioningProfile.ts
@@ -42,7 +42,7 @@ export class SetupInternalProvisioningProfile {
         } else if (adhocBuildCredentialsExist) {
           return await this.setupAdhocProvisioningProfileAsync(ctx);
         } else if (enterpriseBuildCredentialsExist) {
-          return await this.setupUniversalProvisiongProfileAsync(ctx);
+          return await this.setupUniversalProvisioningProfileAsync(ctx);
         } else {
           const { team } = await ctx.appStore.ensureAuthenticatedAsync();
           if (team.inHouse) {
@@ -63,7 +63,7 @@ export class SetupInternalProvisioningProfile {
       } else if (adhocBuildCredentialsExist) {
         return await this.setupAdhocProvisioningProfileAsync(ctx);
       } else if (enterpriseBuildCredentialsExist) {
-        return await this.setupUniversalProvisiongProfileAsync(ctx);
+        return await this.setupUniversalProvisioningProfileAsync(ctx);
       } else {
         throw new Error(
           `You're in non-interactive mode. EAS CLI couldn't any credentials suitable for internal distribution. Please run again in interactive mode.`
@@ -78,7 +78,7 @@ export class SetupInternalProvisioningProfile {
     return await new SetupAdhocProvisioningProfile(this.app).runAsync(ctx);
   }
 
-  private async setupUniversalProvisiongProfileAsync(
+  private async setupUniversalProvisioningProfileAsync(
     ctx: Context
   ): Promise<IosAppBuildCredentialsFragment> {
     return await new SetupProvisioningProfile(this.app, IosDistributionType.Enterprise).runAsync(
@@ -100,7 +100,7 @@ export class SetupInternalProvisioningProfile {
       ],
     });
     if (distributionType === IosDistributionType.Enterprise) {
-      return await this.setupUniversalProvisiongProfileAsync(ctx);
+      return await this.setupUniversalProvisioningProfileAsync(ctx);
     } else {
       return await this.setupAdhocProvisioningProfileAsync(ctx);
     }

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupInternalProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupInternalProvisioningProfile.ts
@@ -1,12 +1,106 @@
-import { IosAppBuildCredentialsFragment } from '../../../../graphql/generated';
+import { IosAppBuildCredentialsFragment, IosDistributionType } from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { promptAsync } from '../../../../prompts';
 import { Context } from '../../../context';
 import { AppLookupParams } from '../../api/GraphqlClient';
+import { getAllBuildCredentialsAsync } from './BuildCredentialsUtils';
 import { SetupAdhocProvisioningProfile } from './SetupAdhocProvisioningProfile';
+import { SetupProvisioningProfile } from './SetupProvisioningProfile';
 
 export class SetupInternalProvisioningProfile {
   constructor(private app: AppLookupParams) {}
 
   async runAsync(ctx: Context): Promise<IosAppBuildCredentialsFragment> {
+    const buildCredentials = await getAllBuildCredentialsAsync(ctx, this.app);
+
+    const adhocBuildCredentials = buildCredentials.filter(
+      ({ iosDistributionType }) => iosDistributionType === IosDistributionType.AdHoc
+    );
+    const enterpriseBuildCredentials = buildCredentials.filter(
+      ({ iosDistributionType }) => iosDistributionType === IosDistributionType.Enterprise
+    );
+
+    if (!ctx.nonInteractive) {
+      if (ctx.appStore.authCtx) {
+        if (ctx.appStore.authCtx.team.inHouse) {
+          return await this.askForDistributionTypeAndSetupAsync(
+            ctx,
+            'Which credentials would you like to set up?'
+          );
+        } else {
+          return await this.setupAdhocProvisioningProfile(ctx);
+        }
+      } else {
+        if (adhocBuildCredentials && enterpriseBuildCredentials) {
+          Log.log('You have set up both adhoc and universal distribution credentials.');
+          return await this.askForDistributionTypeAndSetupAsync(
+            ctx,
+            'Which credentials would you like to use?'
+          );
+        } else if (adhocBuildCredentials) {
+          return await this.setupAdhocProvisioningProfile(ctx);
+        } else if (enterpriseBuildCredentials) {
+          return await this.setupUniversalProvisiongProfile(ctx);
+        } else {
+          const { team } = await ctx.appStore.ensureAuthenticatedAsync();
+          if (team.inHouse) {
+            return await this.askForDistributionTypeAndSetupAsync(
+              ctx,
+              'Which credentials would you like to set up?'
+            );
+          } else {
+            return await this.setupAdhocProvisioningProfile(ctx);
+          }
+        }
+      }
+    } else {
+      if (adhocBuildCredentials && enterpriseBuildCredentials) {
+        throw new Error(
+          `You're in non-interactive mode. You have set up both adhoc and universal distribution credentials. Please set the 'enterpriseProvisioning' property (to 'adhoc' or 'universal') in eas.json to choose the credentials to use.`
+        );
+      } else if (adhocBuildCredentials) {
+        return await this.setupAdhocProvisioningProfile(ctx);
+      } else if (enterpriseBuildCredentials) {
+        return await this.setupUniversalProvisiongProfile(ctx);
+      } else {
+        throw new Error(
+          `You're in non-interactive mode. EAS CLI couldn't any credentials suitable for internal distribution. Please run again in interactive mode.`
+        );
+      }
+    }
+  }
+
+  private async setupAdhocProvisioningProfile(
+    ctx: Context
+  ): Promise<IosAppBuildCredentialsFragment> {
     return await new SetupAdhocProvisioningProfile(this.app).runAsync(ctx);
+  }
+
+  private async setupUniversalProvisiongProfile(
+    ctx: Context
+  ): Promise<IosAppBuildCredentialsFragment> {
+    return await new SetupProvisioningProfile(this.app, IosDistributionType.Enterprise).runAsync(
+      ctx
+    );
+  }
+
+  private async askForDistributionTypeAndSetupAsync(
+    ctx: Context,
+    message: string
+  ): Promise<IosAppBuildCredentialsFragment> {
+    const { distributionType } = await promptAsync({
+      type: 'select',
+      name: 'distributionType',
+      message,
+      choices: [
+        { title: 'Universal Distribution', value: IosDistributionType.Enterprise },
+        { title: 'Adhoc Distribution', value: IosDistributionType.AdHoc },
+      ],
+    });
+    if (distributionType === IosDistributionType.Enterprise) {
+      return await this.setupUniversalProvisiongProfile(ctx);
+    } else {
+      return await this.setupAdhocProvisioningProfile(ctx);
+    }
   }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupInternalProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupInternalProvisioningProfile.ts
@@ -66,7 +66,7 @@ export class SetupInternalProvisioningProfile {
         return await this.setupUniversalProvisioningProfileAsync(ctx);
       } else {
         throw new Error(
-          `You're in non-interactive mode. EAS CLI couldn't any credentials suitable for internal distribution. Please run again in interactive mode.`
+          `You're in non-interactive mode. EAS CLI couldn't find any credentials suitable for internal distribution. Please run again in interactive mode.`
         );
       }
     }

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupInternalProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupInternalProvisioningProfile-test.ts
@@ -1,0 +1,314 @@
+import { asMock } from '../../../../../__tests__/utils';
+import {
+  IosAppBuildCredentialsFragment,
+  IosDistributionType,
+} from '../../../../../graphql/generated';
+import { promptAsync } from '../../../../../prompts';
+import { getAppstoreMock, testAuthCtx } from '../../../../__tests__/fixtures-appstore';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
+import { getAllBuildCredentialsAsync } from '../BuildCredentialsUtils';
+import { SetupAdhocProvisioningProfile } from '../SetupAdhocProvisioningProfile';
+import { SetupInternalProvisioningProfile } from '../SetupInternalProvisioningProfile';
+import { SetupProvisioningProfile } from '../SetupProvisioningProfile';
+
+jest.mock('../../../../../prompts');
+jest.mock('../SetupAdhocProvisioningProfile');
+jest.mock('../SetupProvisioningProfile');
+jest.mock('../BuildCredentialsUtils', () => ({ getAllBuildCredentialsAsync: jest.fn() }));
+
+beforeEach(() => {
+  asMock(promptAsync).mockReset();
+
+  asMock(getAllBuildCredentialsAsync).mockReset();
+  asMock(getAllBuildCredentialsAsync).mockImplementation(() => {
+    throw new Error(
+      `unhandled getAllBuildCredentialsAsync call - this shouldn't happen - fix tests!`
+    );
+  });
+});
+
+const testAdhocBuildCredentials: IosAppBuildCredentialsFragment = {
+  id: 'test-app-build-credentials-id-1',
+  iosDistributionType: IosDistributionType.AdHoc,
+};
+const testEnterpriseBuildCredentials: IosAppBuildCredentialsFragment = {
+  id: 'test-app-build-credentials-id-2',
+  iosDistributionType: IosDistributionType.Enterprise,
+};
+
+describe(SetupInternalProvisioningProfile, () => {
+  describe('interactive mode', () => {
+    describe('when authenticated with apple', () => {
+      it('runs the SetupAdhocProvisioningProfile action for non-enterprise team', async () => {
+        asMock(getAllBuildCredentialsAsync).mockImplementationOnce(() => {
+          const buildCredentials: IosAppBuildCredentialsFragment[] = [];
+          return buildCredentials;
+        });
+        const action = new SetupInternalProvisioningProfile({
+          account: { id: 'account-id', name: 'account-name' },
+          bundleIdentifier: 'com.expo.test',
+          projectName: 'testproject',
+        });
+        const ctx = createCtxMock({
+          nonInteractive: false,
+          appStore: {
+            ...getAppstoreMock(),
+            ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+            authCtx: testAuthCtx,
+          },
+        });
+
+        const runAsync = jest.fn();
+        SetupAdhocProvisioningProfile.prototype.runAsync = runAsync;
+
+        await action.runAsync(ctx);
+
+        expect(runAsync).toHaveBeenCalled();
+      });
+
+      it('asks the user for an action to run when they have access to an enterprise team', async () => {
+        asMock(promptAsync).mockImplementationOnce(() => ({
+          distributionType: IosDistributionType.Enterprise,
+        }));
+        asMock(getAllBuildCredentialsAsync).mockImplementationOnce(() => {
+          const buildCredentials: IosAppBuildCredentialsFragment[] = [];
+          return buildCredentials;
+        });
+
+        const action = new SetupInternalProvisioningProfile({
+          account: { id: 'account-id', name: 'account-name' },
+          bundleIdentifier: 'com.expo.test',
+          projectName: 'testproject',
+        });
+        const ctx = createCtxMock({
+          nonInteractive: false,
+          appStore: {
+            ...getAppstoreMock(),
+            ensureAuthenticatedAsync: jest.fn(() => ({
+              ...testAuthCtx,
+              team: { ...testAuthCtx.team, inHouse: true },
+            })),
+            authCtx: { ...testAuthCtx, team: { ...testAuthCtx.team, inHouse: true } },
+          },
+        });
+
+        const runAsync = jest.fn();
+        SetupProvisioningProfile.prototype.runAsync = runAsync;
+
+        await action.runAsync(ctx);
+
+        expect(runAsync).toHaveBeenCalled();
+      });
+    });
+    describe('when not authenticated with apple', () => {
+      it('asks the user for an action to run when both adhoc and universal distribution credentials exist', async () => {
+        asMock(promptAsync).mockImplementationOnce(() => ({
+          distributionType: IosDistributionType.Enterprise,
+        }));
+        asMock(getAllBuildCredentialsAsync).mockImplementationOnce(() => {
+          const buildCredentials: IosAppBuildCredentialsFragment[] = [
+            testAdhocBuildCredentials,
+            testEnterpriseBuildCredentials,
+          ];
+          return buildCredentials;
+        });
+
+        const action = new SetupInternalProvisioningProfile({
+          account: { id: 'account-id', name: 'account-name' },
+          bundleIdentifier: 'com.expo.test',
+          projectName: 'testproject',
+        });
+        const ctx = createCtxMock({
+          nonInteractive: false,
+          appStore: {
+            ...getAppstoreMock(),
+            ensureAuthenticatedAsync: jest.fn(() => null),
+            authCtx: null,
+          },
+        });
+
+        const runAsync = jest.fn();
+        SetupProvisioningProfile.prototype.runAsync = runAsync;
+
+        await action.runAsync(ctx);
+
+        expect(runAsync).toHaveBeenCalled();
+      });
+
+      it('runs the SetupAdhocProvisioningProfile action when adhoc credentials exist', async () => {
+        asMock(promptAsync).mockImplementationOnce(() => ({
+          distributionType: IosDistributionType.Enterprise,
+        }));
+        asMock(getAllBuildCredentialsAsync).mockImplementationOnce(() => {
+          const buildCredentials: IosAppBuildCredentialsFragment[] = [testAdhocBuildCredentials];
+          return buildCredentials;
+        });
+
+        const action = new SetupInternalProvisioningProfile({
+          account: { id: 'account-id', name: 'account-name' },
+          bundleIdentifier: 'com.expo.test',
+          projectName: 'testproject',
+        });
+        const ctx = createCtxMock({
+          nonInteractive: false,
+          appStore: {
+            ...getAppstoreMock(),
+            ensureAuthenticatedAsync: jest.fn(() => null),
+            authCtx: null,
+          },
+        });
+
+        const runAsync = jest.fn();
+        SetupAdhocProvisioningProfile.prototype.runAsync = runAsync;
+
+        await action.runAsync(ctx);
+
+        expect(runAsync).toHaveBeenCalled();
+      });
+
+      it('runs the SetupProvisioningProfile action when enterprise credentials exist', async () => {
+        asMock(promptAsync).mockImplementationOnce(() => ({
+          distributionType: IosDistributionType.Enterprise,
+        }));
+        asMock(getAllBuildCredentialsAsync).mockImplementationOnce(() => {
+          const buildCredentials: IosAppBuildCredentialsFragment[] = [
+            testEnterpriseBuildCredentials,
+          ];
+          return buildCredentials;
+        });
+
+        const action = new SetupInternalProvisioningProfile({
+          account: { id: 'account-id', name: 'account-name' },
+          bundleIdentifier: 'com.expo.test',
+          projectName: 'testproject',
+        });
+        const ctx = createCtxMock({
+          nonInteractive: false,
+          appStore: {
+            ...getAppstoreMock(),
+            ensureAuthenticatedAsync: jest.fn(() => null),
+            authCtx: null,
+          },
+        });
+
+        const runAsync = jest.fn();
+        SetupProvisioningProfile.prototype.runAsync = runAsync;
+
+        await action.runAsync(ctx);
+
+        expect(runAsync).toHaveBeenCalled();
+      });
+
+      it('forces the apple authentication when neither adhoc nor enterprise credentials exist', async () => {
+        asMock(promptAsync).mockImplementationOnce(() => ({
+          distributionType: IosDistributionType.Enterprise,
+        }));
+        asMock(getAllBuildCredentialsAsync).mockImplementationOnce(() => {
+          const buildCredentials: IosAppBuildCredentialsFragment[] = [];
+          return buildCredentials;
+        });
+
+        const action = new SetupInternalProvisioningProfile({
+          account: { id: 'account-id', name: 'account-name' },
+          bundleIdentifier: 'com.expo.test',
+          projectName: 'testproject',
+        });
+        const ctx = createCtxMock({
+          nonInteractive: false,
+          appStore: {
+            ...getAppstoreMock(),
+            ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+            authCtx: null,
+          },
+        });
+
+        await action.runAsync(ctx);
+
+        expect(ctx.appStore.ensureAuthenticatedAsync).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('non-interactive mode', () => {
+    it('throws an error when both adhoc and enterprise credentials are set up', async () => {
+      asMock(getAllBuildCredentialsAsync).mockImplementationOnce(() => {
+        const buildCredentials: IosAppBuildCredentialsFragment[] = [
+          testAdhocBuildCredentials,
+          testEnterpriseBuildCredentials,
+        ];
+        return buildCredentials;
+      });
+      const action = new SetupInternalProvisioningProfile({
+        account: { id: 'account-id', name: 'account-name' },
+        bundleIdentifier: 'com.expo.test',
+        projectName: 'testproject',
+      });
+      const ctx = createCtxMock({
+        nonInteractive: true,
+      });
+      await expect(action.runAsync(ctx)).rejects.toThrow(
+        /You have set up both adhoc and universal distribution credentials/
+      );
+    });
+
+    it('throws an error when neither adhoc nor enterprise credentials are set up', async () => {
+      asMock(getAllBuildCredentialsAsync).mockImplementationOnce(() => {
+        const buildCredentials: IosAppBuildCredentialsFragment[] = [];
+        return buildCredentials;
+      });
+      const action = new SetupInternalProvisioningProfile({
+        account: { id: 'account-id', name: 'account-name' },
+        bundleIdentifier: 'com.expo.test',
+        projectName: 'testproject',
+      });
+      const ctx = createCtxMock({
+        nonInteractive: true,
+      });
+      await expect(action.runAsync(ctx)).rejects.toThrow(/couldn't find any credentials/);
+    });
+
+    it('runs the SetupAdhocProvisioningProfile action when adhoc credentials exist', async () => {
+      asMock(getAllBuildCredentialsAsync).mockImplementationOnce(() => {
+        const buildCredentials: IosAppBuildCredentialsFragment[] = [testAdhocBuildCredentials];
+        return buildCredentials;
+      });
+      const action = new SetupInternalProvisioningProfile({
+        account: { id: 'account-id', name: 'account-name' },
+        bundleIdentifier: 'com.expo.test',
+        projectName: 'testproject',
+      });
+      const ctx = createCtxMock({
+        nonInteractive: true,
+      });
+
+      const runAsync = jest.fn();
+      SetupAdhocProvisioningProfile.prototype.runAsync = runAsync;
+
+      await action.runAsync(ctx);
+
+      expect(runAsync).toHaveBeenCalled();
+    });
+
+    it('runs the SetupProvisioningProfile action when enterprise credentials exist', async () => {
+      asMock(getAllBuildCredentialsAsync).mockImplementationOnce(() => {
+        const buildCredentials: IosAppBuildCredentialsFragment[] = [testEnterpriseBuildCredentials];
+        return buildCredentials;
+      });
+      const action = new SetupInternalProvisioningProfile({
+        account: { id: 'account-id', name: 'account-name' },
+        bundleIdentifier: 'com.expo.test',
+        projectName: 'testproject',
+      });
+      const ctx = createCtxMock({
+        nonInteractive: true,
+      });
+
+      const runAsync = jest.fn();
+      SetupProvisioningProfile.prototype.runAsync = runAsync;
+
+      await action.runAsync(ctx);
+
+      expect(runAsync).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -98,7 +98,7 @@ export async function createOrUpdateIosAppBuildCredentialsAsync(
 
 export async function getIosAppCredentialsWithBuildCredentialsAsync(
   appLookupParams: AppLookupParams,
-  { iosDistributionType }: { iosDistributionType: IosDistributionType }
+  { iosDistributionType }: { iosDistributionType?: IosDistributionType }
 ): Promise<IosAppCredentialsWithBuildCredentialsQueryResult | null> {
   const { account, bundleIdentifier } = appLookupParams;
   const appleAppIdentifier = await AppleAppIdentifierQuery.byBundleIdentifierAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
@@ -66,7 +66,7 @@ const IosAppCredentialsQuery = {
       iosDistributionType,
     }: {
       appleAppIdentifierId: string;
-      iosDistributionType: IosDistributionType;
+      iosDistributionType?: IosDistributionType;
     }
   ): Promise<IosAppCredentialsWithBuildCredentialsQueryResult | null> {
     const data = await withErrorHandlingAsync(
@@ -76,7 +76,7 @@ const IosAppCredentialsQuery = {
             query IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery(
               $projectFullName: String!
               $appleAppIdentifierId: String!
-              $iosDistributionType: IosDistributionType!
+              $iosDistributionType: IosDistributionType
             ) {
               app {
                 byFullName(fullName: $projectFullName) {

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -1,4 +1,3 @@
-import { IosAppBuildCredentialsFragment } from '../../graphql/generated';
 import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
@@ -116,11 +115,7 @@ export class ManageIos implements Action {
     return { accountName, projectName, bundleIdentifier };
   }
 
-  private getAction(
-    ctx: Context,
-    accountName: string,
-    action: ActionType
-  ): Action<void> | Action<IosAppBuildCredentialsFragment> {
+  private getAction(ctx: Context, accountName: string, action: ActionType): Action<unknown> {
     switch (action) {
       case ActionType.CreateDistributionCertificate:
         return new CreateDistributionCertificateStandaloneManager(accountName);

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -1,3 +1,4 @@
+import { IosAppBuildCredentialsFragment } from '../../graphql/generated';
 import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
@@ -92,7 +93,7 @@ export class ManageIos implements Action {
         });
 
         try {
-          await manager.runActionAsync(this.getAction(manager, ctx, accountName, action));
+          await this.getAction(ctx, accountName, action).runAsync(manager, ctx);
         } catch (err) {
           Log.error(err);
         }
@@ -116,11 +117,10 @@ export class ManageIos implements Action {
   }
 
   private getAction(
-    manager: CredentialsManager,
     ctx: Context,
     accountName: string,
     action: ActionType
-  ): Action {
+  ): Action<void> | Action<IosAppBuildCredentialsFragment> {
     switch (action) {
       case ActionType.CreateDistributionCertificate:
         return new CreateDistributionCertificateStandaloneManager(accountName);

--- a/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
@@ -127,10 +127,11 @@ export class ManageIosBeta implements Action {
         if (!iosDistributionTypeEasConfig) {
           throw new Error(`The distributionType field is required in your iOS build profile`);
         }
-        return await new SetupBuildCredentials({
+        await new SetupBuildCredentials({
           app: appLookupParams,
           distribution: iosDistributionTypeEasConfig,
         }).runAsync(manager, ctx);
+        return;
       }
       case ActionType.SetupBuildCredentialsFromCredentialsJson: {
         const iosAppCredentials = await ctx.newIos.getIosAppCredentialsWithCommonFieldsAsync(

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4058,7 +4058,7 @@ export type IosAppCredentialsByAppIdentifierIdQuery = (
 export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQueryVariables = Exact<{
   projectFullName: Scalars['String'];
   appleAppIdentifierId: Scalars['String'];
-  iosDistributionType: IosDistributionType;
+  iosDistributionType?: Maybe<IosDistributionType>;
 }>;
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

- This PR makes it possible to set up both ad-hoc and enterprise credentials when someone is using an enterprise team but didn't set the `enterpriseProvisioning` property in `eas.json`.
- This also adds offline validation of a distribution certificate.

# How

- I implemented the logic in `SetupInternalProvisioningProfile` - it's run when the user didn't specify the `enterpriseProvisioning` property in eas.json.
- I removed handling of the `--skip-credentials-check` flag for iOS builds. The flag was necessary because we didn't have proper offline validation of the provisioning profile/distribution certificate. This PR adds the offline dist cert validation and makes it possible to get rid of the flag.

# Test Plan

Added unit tests.
