### PR TITLE
[eas-cli][eas-json] add getBuildProfileNamesAsync helper

### DIFF
--- a/packages/eas-cli/src/credentials/manager/SelectBuildProfileFromEasJson.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectBuildProfileFromEasJson.ts
@@ -14,8 +14,7 @@ export class SelectBuildProfileFromEasJson {
   }
 
   async getProfileNameFromEasConfigAsync(ctx: Context): Promise<string> {
-    const easJson = await this.easJsonReader.readRawAsync();
-    const buildProfileNames = Object.keys(easJson.builds?.ios || {});
+    const buildProfileNames = await this.easJsonReader.getBuildProfileNamesAsync();
     if (buildProfileNames.length === 0) {
       throw new Error(
         'You need at least one iOS build profile declared in eas.json. Go to https://docs.expo.io/build/eas-json/ for more details'

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -23,7 +23,7 @@ interface BuildProfilePreValidation {
 export class EasJsonReader {
   constructor(private projectDir: string, private platform: 'android' | 'ios' | 'all') {}
 
-  public async getProfileNamesAsync(): Promise<string[]> {
+  public async getBuildProfileNamesAsync(): Promise<string[]> {
     const easJson = await this.readRawAsync();
     let profileNames: string[] = [];
     if (['android', 'all'].includes(this.platform)) {

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -23,6 +23,20 @@ interface BuildProfilePreValidation {
 export class EasJsonReader {
   constructor(private projectDir: string, private platform: 'android' | 'ios' | 'all') {}
 
+  public async getProfileNamesAsync(): Promise<string[]> {
+    const easJson = await this.readRawAsync();
+    let profileNames: string[] = [];
+    if (['android', 'all'].includes(this.platform)) {
+      const androidProfiles = easJson.builds?.android ?? {};
+      profileNames = profileNames.concat(Object.keys(androidProfiles));
+    }
+    if (['ios', 'all'].includes(this.platform)) {
+      const iosProfiles = easJson.builds?.ios ?? {};
+      profileNames = profileNames.concat(Object.keys(iosProfiles));
+    }
+    return profileNames;
+  }
+
   public async readAsync(buildProfileName: string): Promise<EasConfig> {
     const easJson = await this.readRawAsync();
 

--- a/packages/eas-json/src/__tests__/EasJsonReader-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-test.ts
@@ -329,3 +329,29 @@ test('invalid semver value', async () => {
     'Object "android.release" in eas.json is not valid [ValidationError: "node" failed custom validation because 12.0.0-alpha is not a valid version]'
   );
 });
+
+test('get profile names', async () => {
+  await fs.writeJson('/project/eas.json', {
+    builds: {
+      android: {
+        release: { workflow: 'generic', node: '12.0.0-alpha' },
+        blah: { workflow: 'generic', node: '12.0.0-alpha' },
+      },
+      ios: {
+        test: { workflow: 'generic', node: '12.0.0-alpha' },
+      },
+    },
+  });
+
+  const androidReader = new EasJsonReader('/project', 'android');
+  const androidProfileNames = await androidReader.getProfileNamesAsync();
+  expect(androidProfileNames.sort()).toEqual(['release', 'blah'].sort());
+
+  const iosReader = new EasJsonReader('/project', 'ios');
+  const iosProfileNames = await iosReader.getProfileNamesAsync();
+  expect(iosProfileNames.sort()).toEqual(['test'].sort());
+
+  const allReader = new EasJsonReader('/project', 'all');
+  const allProfileNames = await allReader.getProfileNamesAsync();
+  expect(allProfileNames.sort()).toEqual(['test', 'release', 'blah'].sort());
+});

--- a/packages/eas-json/src/__tests__/EasJsonReader-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-test.ts
@@ -339,6 +339,7 @@ test('get profile names', async () => {
       },
       ios: {
         test: { workflow: 'generic', node: '12.0.0-alpha' },
+        blah: { workflow: 'generic', node: '12.0.0-alpha' },
       },
     },
   });
@@ -349,9 +350,9 @@ test('get profile names', async () => {
 
   const iosReader = new EasJsonReader('/project', 'ios');
   const iosProfileNames = await iosReader.getBuildProfileNamesAsync();
-  expect(iosProfileNames.sort()).toEqual(['test'].sort());
+  expect(iosProfileNames.sort()).toEqual(['test', 'blah'].sort());
 
   const allReader = new EasJsonReader('/project', 'all');
   const allProfileNames = await allReader.getBuildProfileNamesAsync();
-  expect(allProfileNames.sort()).toEqual(['test', 'release', 'blah'].sort());
+  expect(allProfileNames.sort()).toEqual(['blah'].sort());
 });

--- a/packages/eas-json/src/__tests__/EasJsonReader-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-test.ts
@@ -344,14 +344,14 @@ test('get profile names', async () => {
   });
 
   const androidReader = new EasJsonReader('/project', 'android');
-  const androidProfileNames = await androidReader.getProfileNamesAsync();
+  const androidProfileNames = await androidReader.getBuildProfileNamesAsync();
   expect(androidProfileNames.sort()).toEqual(['release', 'blah'].sort());
 
   const iosReader = new EasJsonReader('/project', 'ios');
-  const iosProfileNames = await iosReader.getProfileNamesAsync();
+  const iosProfileNames = await iosReader.getBuildProfileNamesAsync();
   expect(iosProfileNames.sort()).toEqual(['test'].sort());
 
   const allReader = new EasJsonReader('/project', 'all');
-  const allProfileNames = await allReader.getProfileNamesAsync();
+  const allProfileNames = await allReader.getBuildProfileNamesAsync();
   expect(allProfileNames.sort()).toEqual(['test', 'release', 'blah'].sort());
 });


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Add a convenience method, `getBuildProfileNamesAsync ` to eas-json, based on wojtek's feedback here: https://github.com/expo/eas-cli/pull/348#discussion_r616548554


# Test Plan

- [ ] added new tests