### PR TITLE
[eas-cli] refactor UpdateCredentialsJson

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -4,6 +4,7 @@ import {
   AppleDistributionCertificateFragment,
   AppleProvisioningProfileFragment,
   AppleTeamFragment,
+  CommonIosAppCredentialsFragment,
   IosAppBuildCredentialsFragment,
   IosDistributionType,
 } from '../../graphql/generated';
@@ -64,7 +65,7 @@ export const testProvisioningProfileFragment: AppleProvisioningProfileFragment =
   id: 'test-prov-prof-id-1',
   expiration: new Date(),
   developerPortalIdentifier: 'test-developer-identifier',
-  provisioningProfile: 'test-provisioning-profile',
+  provisioningProfile: testProvisioningProfileBase64,
   updatedAt: new Date(),
   status: 'Active',
   appleTeam: { ...testAppleTeamFragment },
@@ -115,6 +116,14 @@ export const testIosAppBuildCredentialsFragment: IosAppBuildCredentialsFragment 
   iosDistributionType: IosDistributionType.AppStore,
   distributionCertificate: testDistCertFragmentNoDependencies,
   provisioningProfile: testProvisioningProfileFragment,
+};
+
+export const testCommonIosAppCredentialsFragment: CommonIosAppCredentialsFragment = {
+  id: 'test-common-ios-app-credentials-id',
+  app: testAppFragment,
+  appleTeam: testAppleTeamFragment,
+  appleAppIdentifier: testAppleAppIdentifierFragment,
+  iosAppBuildCredentialsArray: [testIosAppBuildCredentialsFragment],
 };
 
 export const testIosAppCredentialsWithBuildCredentialsQueryResult: IosAppCredentialsWithBuildCredentialsQueryResult = {

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -1,5 +1,4 @@
 import fs from 'fs-extra';
-import nullthrows from 'nullthrows';
 import path from 'path';
 
 import { IosDistributionType as IosDistributionTypeGraphql } from '../../graphql/generated';

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -1,11 +1,14 @@
 import fs from 'fs-extra';
+import nullthrows from 'nullthrows';
 import path from 'path';
 
+import { IosDistributionType as IosDistributionTypeGraphql } from '../../graphql/generated';
 import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
 import { confirmAsync } from '../../prompts';
 import { gitStatusAsync } from '../../utils/git';
 import { Context } from '../context';
+import { AppLookupParams } from '../ios/api/GraphqlClient';
 import { CredentialsJson } from './read';
 
 /**
@@ -84,7 +87,8 @@ export async function updateAndroidCredentialsAsync(ctx: Context): Promise<void>
  */
 export async function updateIosCredentialsAsync(
   ctx: Context,
-  bundleIdentifier: string
+  appLookupParams: AppLookupParams,
+  iosDistributionTypeGraphql: IosDistributionTypeGraphql
 ): Promise<void> {
   const credentialsJsonFilePath = path.join(ctx.projectDir, 'credentials.json');
   let rawCredentialsJsonObject: any = {};
@@ -118,26 +122,27 @@ export async function updateIosCredentialsAsync(
     }
   }
 
-  const accountName = getProjectAccountName(ctx.exp, ctx.user);
-  const appLookupParams = {
-    accountName,
-    projectName: ctx.exp.slug,
-    bundleIdentifier,
-  };
   const profilePath =
     rawCredentialsJsonObject?.ios?.provisioningProfilePath ?? 'ios/certs/profile.mobileprovision';
   const distCertPath =
     rawCredentialsJsonObject?.ios?.distributionCertificate?.path ?? 'ios/certs/dist-cert.p12';
-  const appCredentials = await ctx.ios.getAppCredentialsAsync(appLookupParams);
-  const distCredentials = await ctx.ios.getDistributionCertificateAsync(appLookupParams);
-  if (!appCredentials?.credentials?.provisioningProfile && !distCredentials) {
-    throw new Error('There are no credentials configured for this project on EAS servers');
+  const iosAppCredentials = await ctx.newIos.getIosAppCredentialsWithCommonFieldsAsync(
+    appLookupParams
+  );
+  const buildCredentials =
+    iosAppCredentials?.iosAppBuildCredentialsArray.find(
+      buildCredentials => buildCredentials.iosDistributionType === iosDistributionTypeGraphql
+    ) ?? null;
+  if (!buildCredentials) {
+    throw new Error(
+      `There are no credentials configured for the ${iosDistributionTypeGraphql} distribution of this project on EAS servers`
+    );
   }
 
   const areCredentialsComplete =
-    appCredentials?.credentials?.provisioningProfile &&
-    distCredentials?.certP12 &&
-    distCredentials?.certPassword;
+    buildCredentials.provisioningProfile?.provisioningProfile &&
+    buildCredentials.distributionCertificate?.certificateP12 &&
+    buildCredentials.distributionCertificate.certificatePassword;
 
   if (!areCredentialsComplete) {
     const confirm = await confirmAsync({
@@ -149,28 +154,27 @@ export async function updateIosCredentialsAsync(
       return;
     }
   }
-
+  const provisioningProfile =
+    buildCredentials.provisioningProfile?.provisioningProfile ?? undefined;
+  const distributionCertificateP12 =
+    buildCredentials.distributionCertificate?.certificateP12 ?? undefined;
+  const distributionCertificatePassword =
+    buildCredentials.distributionCertificate?.certificatePassword ?? undefined;
   Log.log(`Writing Provisioning Profile to ${profilePath}`);
-  await updateFileAsync(
-    ctx.projectDir,
-    profilePath,
-    appCredentials?.credentials?.provisioningProfile
-  );
+  await updateFileAsync(ctx.projectDir, profilePath, provisioningProfile);
   const shouldWarnPProfile = await isFileUntrackedAsync(profilePath);
 
   Log.log(`Writing Distribution Certificate to ${distCertPath}`);
-  await updateFileAsync(ctx.projectDir, distCertPath, distCredentials?.certP12);
+  await updateFileAsync(ctx.projectDir, distCertPath, distributionCertificateP12);
   const shouldWarnDistCert = await isFileUntrackedAsync(distCertPath);
 
   const iosCredentials: Partial<CredentialsJson['ios']> = {
-    ...(appCredentials?.credentials?.provisioningProfile
-      ? { provisioningProfilePath: profilePath }
-      : {}),
-    ...(distCredentials?.certP12 && distCredentials?.certPassword
+    ...(provisioningProfile ? { provisioningProfilePath: profilePath } : {}),
+    ...(distributionCertificateP12 && distributionCertificatePassword
       ? {
           distributionCertificate: {
             path: distCertPath,
-            password: distCredentials?.certPassword,
+            password: distributionCertificatePassword,
           },
         }
       : {}),

--- a/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts
@@ -1,23 +1,18 @@
-import { Platform } from '@expo/eas-build-job';
-
+import { IosDistributionType } from '../../../graphql/generated';
 import Log from '../../../log';
-import { ensureAppIdentifierIsDefinedAsync } from '../../../project/projectUtils';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { updateIosCredentialsAsync } from '../../credentialsJson/update';
 import { AppLookupParams } from '../credentials';
+import { getAppLookupParamsFromContext } from './new/BuildCredentialsUtils';
 
 export class UpdateCredentialsJson implements Action {
   constructor(private app: AppLookupParams) {}
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
-    const bundleIdentifer = await ensureAppIdentifierIsDefinedAsync({
-      projectDir: ctx.projectDir,
-      platform: Platform.IOS,
-      exp: ctx.exp,
-    });
     Log.log('Updating iOS credentials in credentials.json');
-    await updateIosCredentialsAsync(ctx, bundleIdentifer);
+    const appLookupParamsGraphql = getAppLookupParamsFromContext(ctx);
+    await updateIosCredentialsAsync(ctx, appLookupParamsGraphql, IosDistributionType.AppStore);
     Log.succeed(
       'iOS part of your local credentials.json is synced with values stored on EAS servers.'
     );

--- a/packages/eas-cli/src/credentials/ios/actions/new/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/UpdateCredentialsJson.ts
@@ -1,0 +1,20 @@
+import { IosDistributionType as IosDistributionTypeGraphql } from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { Context } from '../../../context';
+import { updateIosCredentialsAsync } from '../../../credentialsJson/update';
+import { AppLookupParams } from '../../api/GraphqlClient';
+
+export class UpdateCredentialsJson {
+  constructor(
+    private app: AppLookupParams,
+    private iosDistributionTypeGraphql: IosDistributionTypeGraphql
+  ) {}
+
+  async runAsync(ctx: Context): Promise<void> {
+    Log.log('Updating iOS credentials in credentials.json');
+    await updateIosCredentialsAsync(ctx, this.app, this.iosDistributionTypeGraphql);
+    Log.succeed(
+      'iOS part of your local credentials.json is synced with values stored on EAS servers.'
+    );
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
@@ -110,6 +110,8 @@ describe('SetupBuildCredentialsFromCredentialsJson', () => {
     );
     testBuildCreds.iosAppBuildCredentialsArray[0].distributionCertificate.certificateP12 =
       'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
+    testBuildCreds.iosAppBuildCredentialsArray[0].provisioningProfile.provisioningProfile =
+      'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
     const ctx = createCtxMock({
       newIos: {
         ...getNewIosApiMockWithoutCredentials(),
@@ -140,6 +142,8 @@ describe('SetupBuildCredentialsFromCredentialsJson', () => {
       JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
     );
     testBuildCreds.iosAppBuildCredentialsArray[0].distributionCertificate.certificateP12 =
+      'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
+    testBuildCreds.iosAppBuildCredentialsArray[0].provisioningProfile.provisioningProfile =
       'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
     const ctx = createCtxMock({
       nonInteractive: true,

--- a/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIosBeta.ts
@@ -11,6 +11,7 @@ import { SetupBuildCredentials } from '../ios/actions/SetupBuildCredentials';
 import { getAppLookupParamsFromContext } from '../ios/actions/new/BuildCredentialsUtils';
 import { SelectAndRemoveDistributionCertificate } from '../ios/actions/new/RemoveDistributionCertificate';
 import { SetupBuildCredentialsFromCredentialsJson } from '../ios/actions/new/SetupBuildCredentialsFromCredentialsJson';
+import { UpdateCredentialsJson } from '../ios/actions/new/UpdateCredentialsJson';
 import { AppLookupParams } from '../ios/api/GraphqlClient';
 import {
   displayEmptyIosCredentials,
@@ -64,6 +65,10 @@ export class ManageIosBeta implements Action {
                 // I'm leaving it here for now to simplify testing
                 value: ActionType.SetupBuildCredentials,
                 title: 'Ensure all credentials for project are valid',
+              },
+              {
+                value: ActionType.UpdateCredentialsJson,
+                title: 'Update credentials.json with values from EAS servers',
               },
               {
                 value: ActionType.SetupBuildCredentialsFromCredentialsJson,
@@ -143,6 +148,16 @@ export class ManageIosBeta implements Action {
           appLookupParams,
           iosDistributionTypeGraphql
         ).runAsync(ctx);
+        return;
+      }
+      case ActionType.UpdateCredentialsJson: {
+        const iosAppCredentials = await ctx.newIos.getIosAppCredentialsWithCommonFieldsAsync(
+          appLookupParams
+        );
+        const iosDistributionTypeGraphql = await new SelectIosDistributionTypeGraphqlFromBuildProfile(
+          easConfig
+        ).runAsync(ctx, iosAppCredentials);
+        await new UpdateCredentialsJson(appLookupParams, iosDistributionTypeGraphql).runAsync(ctx);
         return;
       }
       default:

--- a/packages/eas-cli/src/credentials/manager/__tests__/SelectIosDistributionTypeGraphqlFromBuildProfile-test.ts
+++ b/packages/eas-cli/src/credentials/manager/__tests__/SelectIosDistributionTypeGraphqlFromBuildProfile-test.ts
@@ -1,11 +1,8 @@
 import { EasConfig } from '@expo/eas-json';
 
-import {
-  CommonIosAppCredentialsFragment,
-  IosDistributionType as IosDistributionTypeGraphql,
-} from '../../../graphql/generated';
+import { IosDistributionType as IosDistributionTypeGraphql } from '../../../graphql/generated';
 import { createCtxMock } from '../../__tests__/fixtures-context';
-import { testIosAppCredentialsWithBuildCredentialsQueryResult } from '../../__tests__/fixtures-ios';
+import { testCommonIosAppCredentialsFragment } from '../../__tests__/fixtures-ios';
 import { SelectIosDistributionTypeGraphqlFromBuildProfile } from '../SelectIosDistributionTypeGraphqlFromBuildProfile';
 
 describe('SelectIosDistributionTypeGraphqlFromBuildProfile', () => {
@@ -113,9 +110,7 @@ describe('SelectIosDistributionTypeGraphqlFromBuildProfile', () => {
     );
 
     // create deep clone the quick and dirty way
-    const testAppCredentials = JSON.parse(
-      JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
-    ) as CommonIosAppCredentialsFragment;
+    const testAppCredentials = JSON.parse(JSON.stringify(testCommonIosAppCredentialsFragment));
     testAppCredentials.iosAppBuildCredentialsArray[0].iosDistributionType =
       IosDistributionTypeGraphql.AdHoc;
     const iosDistributionTypeGraphql = await selectIosDistributionTypeGraphqlFromBuildProfileAction.runAsync(


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to update credentials json from data on eas servers using the new Graphql Api. This will eventually replace the old `UpdateCredentialsJson` here:  https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/ios/actions/UpdateCredentialsJson.ts

It also converts the old UpdateCredentialsJson to use the refactored logic in `updateIosCredentialsAsync`

# Test Plan

- [x] amended current tests
- [x] manual test
