### PR TITLE
send username as build metadata property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add the initiating user's username to the build metadata. ([#354](https://github.com/expo/eas-cli/pull/354) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
+
+- Fix the bug where the account name was used as the username. ([#354](https://github.com/expo/eas-cli/pull/354) by [@dsokal](https://github.com/dsokal))
 
 ### 🧹 Chores
 
@@ -20,7 +24,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Bump version of `@expo/apple-utils` to fix capabilities sync immediately after initial identifier registration.
+- Bump version of `@expo/apple-utils` to fix capabilities sync immediately after initial identifier registration. ([593c4](https://github.com/expo/eas-cli/commit/593c42f601396deba1751489343ec07b0a8876da) by [@brentvatne](https://github.com/brentvatne))
 
 ## [0.11.0](https://github.com/expo/eas-cli/releases/tag/v0.11.0) - 2021-04-20
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/apple-utils": "0.0.0-alpha.18",
     "@expo/config": "~3.3.19",
     "@expo/config-plugins": "1.0.24",
-    "@expo/eas-build-job": "0.2.22",
+    "@expo/eas-build-job": "0.2.27",
     "@expo/eas-json": "^0.11.0",
     "@expo/json-file": "^8.2.24",
     "@expo/plist": "^0.0.11",

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -4,7 +4,8 @@ import path from 'path';
 
 import { AndroidCredentials } from '../../credentials/android/AndroidCredentialsProvider';
 import { readEnvironmentSecretsAsync } from '../../credentials/credentialsJson/read';
-import { getProjectAccountNameAsync } from '../../project/projectUtils';
+import { getUsername } from '../../project/projectUtils';
+import { ensureLoggedInAsync } from '../../user/actions';
 import { gitRootDirectoryAsync } from '../../utils/git';
 import { BuildContext } from '../context';
 import { Platform } from '../types';
@@ -103,11 +104,11 @@ async function prepareManagedJobAsync(
 ): Promise<Partial<Android.ManagedJob>> {
   const projectRootDirectory =
     path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
-  const accountName = await getProjectAccountNameAsync(ctx.commandCtx.exp);
+  const username = getUsername(ctx.commandCtx.exp, await ensureLoggedInAsync());
   return {
     ...(await prepareJobCommonAsync(ctx, jobData)),
     type: Workflow.MANAGED,
-    username: accountName,
+    username,
     buildType: buildProfile.buildType,
     releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -9,7 +9,8 @@ import {
   isCredentialsMap,
   readEnvironmentSecretsAsync,
 } from '../../credentials/credentialsJson/read';
-import { getProjectAccountNameAsync } from '../../project/projectUtils';
+import { getUsername } from '../../project/projectUtils';
+import { ensureLoggedInAsync } from '../../user/actions';
 import { gitRootDirectoryAsync } from '../../utils/git';
 import { BuildContext } from '../context';
 import { Platform } from '../types';
@@ -140,7 +141,7 @@ async function prepareManagedJobAsync(
 ): Promise<Partial<Ios.ManagedJob>> {
   const projectRootDirectory =
     path.relative(await gitRootDirectoryAsync(), ctx.commandCtx.projectDir) || '.';
-  const accountName = await getProjectAccountNameAsync(ctx.commandCtx.exp);
+  const username = getUsername(ctx.commandCtx.exp, await ensureLoggedInAsync());
   return {
     ...(await prepareJobCommonAsync(ctx, {
       credentials: jobData.credentials,
@@ -149,7 +150,7 @@ async function prepareManagedJobAsync(
     })),
     type: Workflow.MANAGED,
     buildType: buildProfile.buildType,
-    username: accountName,
+    username,
     releaseChannel: buildProfile.releaseChannel,
     projectRootDirectory,
   };

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,7 +1,8 @@
 import { Metadata } from '@expo/eas-build-job';
 import { CredentialsSource } from '@expo/eas-json';
 
-import { getAppIdentifierAsync } from '../project/projectUtils';
+import { getAppIdentifierAsync, getUsername } from '../project/projectUtils';
+import { ensureLoggedInAsync } from '../user/actions';
 import { gitCommitHashAsync } from '../utils/git';
 import { readReleaseChannelSafelyAsync as readAndroidReleaseChannelSafelyAsync } from './android/UpdatesModule';
 import { BuildContext } from './context';
@@ -42,6 +43,7 @@ export async function collectMetadata<T extends Platform>(
       })) ?? undefined,
     buildProfile: ctx.commandCtx.profile,
     gitCommitHash: await gitCommitHashAsync(),
+    username: getUsername(ctx.commandCtx.exp, await ensureLoggedInAsync()),
   };
 }
 

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -26,6 +26,22 @@ export function getProjectAccountName(exp: ExpoConfig, user: Actor): string {
   }
 }
 
+export function getUsername(exp: ExpoConfig, user: Actor): string | undefined {
+  switch (user.__typename) {
+    case 'User':
+      return user.username;
+    case 'Robot':
+      // owner field is necessary to run `expo prebuild`
+      if (!exp.owner) {
+        throw new Error(
+          'The "owner" manifest property is required when using robot users. See: https://docs.expo.io/versions/latest/config/app/#owner'
+        );
+      }
+      // robot users don't have usernames
+      return undefined;
+  }
+}
+
 export async function getProjectAccountNameAsync(exp: ExpoConfig): Promise<string> {
   const user = await ensureLoggedInAsync();
   return getProjectAccountName(exp, user);

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.22",
+    "@expo/eas-build-job": "0.2.27",
     "@hapi/joi": "^17.1.1",
     "fs-extra": "^9.0.1",
     "tslib": "^1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1183,10 +1183,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.22":
-  version "0.2.22"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.22.tgz#8432a8da25e8b8860ff7fec756821c660bcaef13"
-  integrity sha512-a+922tmi9xxA3WclDhvnz8sascqjSO8wX78MOqgLVDW2iyZaT7C7MvUv6Z8Vig3zdKoUsQaTg8QWJyQl1biU8A==
+"@expo/eas-build-job@0.2.27":
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.27.tgz#105cf3019c5936f232758b132aaa27bb4a2bdb9f"
+  integrity sha512-hx53w8TvS6YW6p8TMAqwnwoNwIMSQCRr8UvpeYQKdL6cPK6uLbIS7YH5aGPEFO7JDV+fJRDCeMu0iCHUQ30R2w==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

- We want to expose the `EAS_BUILD_USERNAME` env var for all EAS Build builds https://linear.app/expo/issue/ENG-912/expose-eas-build-username-as-built-in-environment-variable
- https://github.com/expo/eas-cli/pull/159 introduces incorrect behavior where the project account name was used as the username. In some cases, when the `owner` field is set, the project account name is different than the initiating user's username.

# How

- I added the `username` to the build metadata.
- I changed the `username` property used for the managed builds input to reflect the real username. It's set to `undefined` for robots.

# Test Plan

I'll test this manually once the server-side changes are deployed to staging.