### PR TITLE
[eas-cli] add CreateDistCert and UseExistingDistCert to beta manager

### DIFF
--- a/packages/eas-cli/src/credentials/ios/actions/new/AppleTeamUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/AppleTeamUtils.ts
@@ -9,7 +9,7 @@ export async function resolveAppleTeamIfAuthenticatedAsync(
   if (!ctx.appStore.authCtx) {
     return null;
   }
-  return await ctx.newIos.createOrGetExistingAppleTeamAsync(app, {
+  return await ctx.newIos.createOrGetExistingAppleTeamAsync(app.account, {
     appleTeamIdentifier: ctx.appStore.authCtx.team.id,
     appleTeamName: ctx.appStore.authCtx.team.name,
   });

--- a/packages/eas-cli/src/credentials/ios/actions/new/CreateDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/CreateDistributionCertificate.ts
@@ -1,18 +1,15 @@
 import Log from '../../../../log';
+import { Account } from '../../../../user/Account';
 import { Context } from '../../../context';
-import { AppLookupParams } from '../../api/GraphqlClient';
 import { AppleDistributionCertificateMutationResult } from '../../api/graphql/mutations/AppleDistributionCertificateMutation';
 import { provideOrGenerateDistributionCertificateAsync } from '../DistributionCertificateUtils';
 
 export class CreateDistributionCertificate {
-  constructor(private app: AppLookupParams) {}
+  constructor(private account: Account) {}
 
   public async runAsync(ctx: Context): Promise<AppleDistributionCertificateMutationResult> {
-    const distCert = await provideOrGenerateDistributionCertificateAsync(
-      ctx,
-      this.app.account.name
-    );
-    const result = await ctx.newIos.createDistributionCertificateAsync(this.app, distCert);
+    const distCert = await provideOrGenerateDistributionCertificateAsync(ctx, this.account.name);
+    const result = await ctx.newIos.createDistributionCertificateAsync(this.account, distCert);
     Log.succeed('Created distribution certificate');
     return result;
   }

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
@@ -7,6 +7,7 @@ import nullthrows from 'nullthrows';
 import DeviceCreateAction, { RegistrationMethod } from '../../../../devices/actions/create/action';
 import {
   AppleDeviceFragment,
+  AppleDistributionCertificateFragment,
   AppleProvisioningProfileFragment,
   AppleTeamFragment,
   IosAppBuildCredentialsFragment,
@@ -55,6 +56,19 @@ export class SetupAdhocProvisioningProfile {
         return buildCredentials;
       }
     }
+
+    return await this.runWithDistributionCertificateAsync(ctx, distCert);
+  }
+
+  async runWithDistributionCertificateAsync(
+    ctx: Context,
+    distCert: AppleDistributionCertificateFragment
+  ): Promise<IosAppBuildCredentialsFragment> {
+    const currentBuildCredentials = await getBuildCredentialsAsync(
+      ctx,
+      this.app,
+      IosDistributionType.AdHoc
+    );
 
     // 1. Resolve Apple Team
     let appleTeam: AppleTeamFragment | null =

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupBuildCredentialsFromCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupBuildCredentialsFromCredentialsJson.ts
@@ -39,7 +39,7 @@ export class SetupBuildCredentialsFromCredentialsJson {
     const { certP12, certPassword } = distributionCertificate;
 
     if (!currentDistributionCertificate) {
-      return await ctx.newIos.createDistributionCertificateAsync(this.app, {
+      return await ctx.newIos.createDistributionCertificateAsync(this.app.account, {
         certP12,
         certPassword,
         teamId: appleTeam.appleTeamIdentifier,
@@ -49,7 +49,7 @@ export class SetupBuildCredentialsFromCredentialsJson {
 
     const isSameCertificate = currentDistributionCertificate.certificateP12 === certP12;
     if (!isSameCertificate) {
-      return await ctx.newIos.createDistributionCertificateAsync(this.app, {
+      return await ctx.newIos.createDistributionCertificateAsync(this.app.account, {
         certP12,
         certPassword,
         teamId: appleTeam.appleTeamIdentifier,
@@ -128,7 +128,7 @@ export class SetupBuildCredentialsFromCredentialsJson {
 
     // new credentials from local json
     const appleTeamFromProvisioningProfile = readAppleTeam(localCredentials.provisioningProfile);
-    const appleTeam = await ctx.newIos.createOrGetExistingAppleTeamAsync(this.app, {
+    const appleTeam = await ctx.newIos.createOrGetExistingAppleTeamAsync(this.app.account, {
       appleTeamIdentifier: appleTeamFromProvisioningProfile.teamId,
       appleTeamName: appleTeamFromProvisioningProfile.teamName,
     });

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupDistributionCertificate.ts
@@ -146,10 +146,10 @@ export class SetupDistributionCertificate {
   private async createNewDistCertAsync(
     ctx: Context
   ): Promise<AppleDistributionCertificateMutationResult> {
-    return new CreateDistributionCertificate(this.app).runAsync(ctx);
+    return new CreateDistributionCertificate(this.app.account).runAsync(ctx);
   }
 
-  private async reuseDistCertAsync(ctx: Context): Promise<AppleDistributionCertificate> {
+  async reuseDistCertAsync(ctx: Context): Promise<AppleDistributionCertificate> {
     const validDistCerts = await this.getValidDistCertsAsync(ctx);
     const { distCert } = await promptAsync({
       type: 'select',

--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupProvisioningProfile.ts
@@ -22,6 +22,9 @@ import { ConfigureProvisioningProfile } from './ConfigureProvisioningProfile';
 import { CreateProvisioningProfile } from './CreateProvisioningProfile';
 import { SetupDistributionCertificate } from './SetupDistributionCertificate';
 
+/**
+ * Sets up either APP_STORE or ENTERPRISE provisioning profiles
+ */
 export class SetupProvisioningProfile {
   constructor(private app: AppLookupParams, private distributionType: IosDistributionType) {}
 

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -173,7 +173,7 @@ export async function createOrGetExistingIosAppCredentialsWithBuildCredentialsAs
 }
 
 export async function createOrGetExistingAppleTeamAsync(
-  { account }: AppLookupParams,
+  account: Account,
   { appleTeamIdentifier, appleTeamName }: { appleTeamIdentifier: string; appleTeamName?: string }
 ): Promise<AppleTeamFragment> {
   const appleTeam = await AppleTeamQuery.getByAppleTeamIdentifierAsync(
@@ -296,14 +296,13 @@ export async function getDistributionCertificatesForAccountAsync(
 }
 
 export async function createDistributionCertificateAsync(
-  appLookupParams: AppLookupParams,
+  account: Account,
   distCert: DistributionCertificate
 ): Promise<AppleDistributionCertificateMutationResult> {
-  const appleTeam = await createOrGetExistingAppleTeamAsync(appLookupParams, {
+  const appleTeam = await createOrGetExistingAppleTeamAsync(account, {
     appleTeamIdentifier: distCert.teamId,
     appleTeamName: distCert.teamName,
   });
-  const { account } = appLookupParams;
   return await AppleDistributionCertificateMutation.createAppleDistributionCertificate(
     {
       certP12: distCert.certP12,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

The current credentials manager has CreateDistCert and UseExistingDistCert functionalities. This PR adds this functionality to the beta manager. `CreateDistCert` is slightly different here, as we made an optimization in `expo-cli` where if we were in a project context, we would also assign it to the project. We do something similar, but we setup build credentials with the new dist cert if we detect the user to be in project context.


# Test Plan

- [x] do manual testing
