### PR TITLE
[eas-cli] adhoc opposite name

### DIFF
--- a/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/new/SetupAdhocProvisioningProfile.ts
@@ -51,7 +51,7 @@ export class SetupAdhocProvisioningProfile {
     );
     if (areBuildCredentialsSetup) {
       const buildCredentials = nullthrows(currentBuildCredentials);
-      if (await this.shouldGenerateNewProfileAsync(ctx, buildCredentials)) {
+      if (await this.shouldUseExistingProfileAsync(ctx, buildCredentials)) {
         return buildCredentials;
       }
     }
@@ -150,7 +150,7 @@ export class SetupAdhocProvisioningProfile {
     return await validateProvisioningProfileAsync(ctx, this.app, buildCredentials);
   }
 
-  private async shouldGenerateNewProfileAsync(
+  private async shouldUseExistingProfileAsync(
     ctx: Context,
     buildCredentials: IosAppBuildCredentialsFragment
   ): Promise<boolean> {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

is it just me or does the function look like it is doing the opposite of the original name? ❓ ❔ 