### PR TITLE
fix api deprecation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Display descriptive error message when API for EAS Build changes. ([#359](https://github.com/expo/eas-cli/pull/359) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [0.12.0](https://github.com/expo/eas-cli/releases/tag/v0.12.0) - 2021-04-22

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -115,7 +115,7 @@ export async function prepareBuildRequestForPlatformAsync<
           Log.error('EAS Build API has changed, please upgrade to the latest eas-cli version.');
         } else if (error?.graphQLErrors) {
           Log.error(
-            'Build request failed. Make sure you are using the latest eas-cli version and if the problem persists, please report the issue.'
+            'Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, please report the issue.'
           );
         }
         throw error;

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -109,10 +109,14 @@ export async function prepareBuildRequestForPlatformAsync<
       return undefined;
     } else {
       try {
-        return sendBuildRequestAsync(builder, job, metadata);
+        return await sendBuildRequestAsync(builder, job, metadata);
       } catch (error) {
-        if (error?.expoApiV2ErrorCode === 'TURTLE_DEPRECATED_JOB_FORMAT') {
-          Log.error('EAS Build API has changed, please upgrade to the latest eas-cli');
+        if (error?.graphQLErrors?.[0]?.extensions?.errorCode === 'TURTLE_DEPRECATED_JOB_FORMAT') {
+          Log.error('EAS Build API has changed, please upgrade to the latest eas-cli version.');
+        } else if (error?.graphQLErrors) {
+          Log.error(
+            'Build request failed. Make sure you are using the latest eas-cli version and if the problem persists, please report the issue.'
+          );
         }
         throw error;
       }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

After switch to graphql we don't detect API incompatibility errors

# How

check for graphql error code

# Test Plan

run local builds when
- grqphql API si not compatible
- turtle returns unsupported error
