### PR TITLE
[eas-cli] create asset keys without an extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Create asset keys without an extension.  ([#366](https://github.com/expo/eas-cli/pull/366) by [@jkhales](https://github.com/jkhales))
+
 ### 🎉 New features
 
 - Redesign UX in beta credentials manager. ([#360](https://github.com/expo/eas-cli/pull/360) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -138,7 +138,7 @@ describe(convertAssetToUpdateInfoGroupFormatAsync, () => {
       path,
     };
     await expect(convertAssetToUpdateInfoGroupFormatAsync(asset)).resolves.toEqual({
-      bundleKey: `c939e759656f577c058f445bfb19182e.${type}`,
+      bundleKey: 'c939e759656f577c058f445bfb19182e',
       contentType: 'image/jpeg',
       fileSHA256: 'tzD6J-OQZaHCKnL3GHWV9RbnrpyojnagiOE7r3mSkU4',
       storageBucket: 'update-assets-production',
@@ -175,7 +175,7 @@ describe(buildUpdateInfoGroupAsync, () => {
       android: {
         assets: [
           {
-            bundleKey: 'c939e759656f577c058f445bfb19182e.jpg',
+            bundleKey: 'c939e759656f577c058f445bfb19182e',
             contentType: 'image/jpeg',
             fileSHA256: 'tzD6J-OQZaHCKnL3GHWV9RbnrpyojnagiOE7r3mSkU4',
             storageBucket: 'update-assets-production',
@@ -184,7 +184,7 @@ describe(buildUpdateInfoGroupAsync, () => {
         ],
 
         launchAsset: {
-          bundleKey: 'ec0dd14670aae108f99a810df9c1482c.bundle',
+          bundleKey: 'ec0dd14670aae108f99a810df9c1482c',
           contentType: 'bundle/javascript',
           fileSHA256: 'KEw79FnKTLOyVbRT1SlohSTjPe5e8FpULy2ST-I5BUg',
           storageBucket: 'update-assets-production',

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -115,10 +115,7 @@ export async function convertAssetToUpdateInfoGroupFormatAsync(
   const fileSHA256 = getBase64URLEncoding(await calculateFileHashAsync(asset.path, 'sha256'));
   const contentType = asset.contentType;
   const storageKey = getStorageKey(contentType, fileSHA256);
-  const bundleKey = [
-    (await calculateFileHashAsync(asset.path, 'md5')).toString('hex'),
-    asset.type,
-  ].join('.');
+  const bundleKey = (await calculateFileHashAsync(asset.path, 'md5')).toString('hex');
 
   return {
     fileSHA256,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

We want to make the new EAS Update manifest compliant with the Expo Updates protocal. This requires the asset key be defined purely by the bundler.

We used to add a file extension to deal with pecularities of expo-asset
that has been fixed here: #12624 


# How

This removes the addition of a file extension.

# Test Plan

update tests
publish to sample project and observer that the manifest no longer has extensions appended to its keys.