### PR TITLE
[eas-cli] stop exporting getAppAsync 

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -116,7 +116,6 @@ export const testAppleTeam = {
 
 export function getNewIosApiMockWithoutCredentials() {
   return {
-    getAppAsync: jest.fn(),
     createOrUpdateIosAppBuildCredentialsAsync: jest.fn(),
     getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(),
     createOrGetExistingIosAppCredentialsWithBuildCredentialsAsync: jest.fn(),
@@ -136,7 +135,6 @@ export function getNewIosApiMockWithoutCredentials() {
 
 export function getNewIosApiMockWithCredentials() {
   return {
-    getAppAsync: jest.fn(),
     createOrUpdateIosAppBuildCredentialsAsync: jest.fn(),
     getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(),
     createOrGetExistingIosAppCredentialsWithBuildCredentialsAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -45,7 +45,7 @@ export interface AppLookupParams {
   bundleIdentifier: string;
 }
 
-export async function getAppAsync(appLookupParams: AppLookupParams): Promise<AppFragment> {
+async function getAppAsync(appLookupParams: AppLookupParams): Promise<AppFragment> {
   const projectFullName = formatProjectFullName(appLookupParams);
   return await AppQuery.byFullNameAsync(projectFullName);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

`getAppAsync` is not used anywhere outside the GraphqlClient class, so get rid of it in jest mocks and stop exporting it.

# Test Plan

- [ ] tests still pass
