### PR TITLE
[eas-cli] add QR code to install internal distribution build on device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
-- Create asset keys without an extension.  ([#366](https://github.com/expo/eas-cli/pull/366) by [@jkhales](https://github.com/jkhales))
+- Create asset keys without an extension. ([#366](https://github.com/expo/eas-cli/pull/366) by [@jkhales](https://github.com/jkhales))
 
 ### 🎉 New features
 
 - Release new credentials manager. ([#363](https://github.com/expo/eas-cli/pull/363) by [@quinlanj](https://github.com/quinlanj))
+- Add QR code to install internal distribution build on device. ([#371](https://github.com/expo/eas-cli/pull/371) by [@axeldelafosse](https://github.com/axeldelafosse))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -1,5 +1,7 @@
 import assert from 'assert';
 import chalk from 'chalk';
+import indentString from 'indent-string';
+import qrcodeTerminal from 'qrcode-terminal';
 
 import {
   BuildError,
@@ -15,7 +17,7 @@ import {
   appPlatformEmojis,
   requestedPlatformDisplayNames,
 } from '../constants';
-import { getBuildLogsUrl } from './url';
+import { getBuildLogsUrl, getInstallUrl } from './url';
 
 export function printLogsUrls(
   accountName: string,
@@ -82,10 +84,14 @@ function printBuildResult(accountName: string, build: BuildFragment): void {
       buildId: build.id,
       account: accountName,
     });
+    const installUrl = getInstallUrl(build);
+    if (installUrl) {
+      qrcodeTerminal.generate(installUrl, code => console.log(`${indentString(code, 2)}\n`));
+    }
     Log.log(
       `${appPlatformEmojis[build.platform]} Open this link on your ${
         appPlatformDisplayNames[build.platform]
-      } devices to install the app:`
+      } devices (or scan the QR code) to install the app:`
     );
     Log.log(`${chalk.underline(logsUrl)}`);
   } else {

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -17,7 +17,7 @@ import {
   appPlatformEmojis,
   requestedPlatformDisplayNames,
 } from '../constants';
-import { getBuildLogsUrl, getInstallUrl } from './url';
+import { getBuildLogsUrl, getInternalDistributionInstallUrl } from './url';
 
 export function printLogsUrls(
   accountName: string,
@@ -84,10 +84,8 @@ function printBuildResult(accountName: string, build: BuildFragment): void {
       buildId: build.id,
       account: accountName,
     });
-    const installUrl = getInstallUrl(build);
-    if (installUrl) {
-      qrcodeTerminal.generate(installUrl, code => console.log(`${indentString(code, 2)}\n`));
-    }
+    const installUrl = getInternalDistributionInstallUrl(build);
+    qrcodeTerminal.generate(installUrl, code => console.log(`${indentString(code, 2)}\n`));
     Log.log(
       `${appPlatformEmojis[build.platform]} Open this link on your ${
         appPlatformDisplayNames[build.platform]

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -15,7 +15,7 @@ export function getArtifactUrl(artifactId: string): string {
   return `${getExpoWebsiteBaseUrl()}/artifacts/${artifactId}`;
 }
 
-export function getInstallUrl(build: BuildFragment) {
+export function getInstallUrl(build: BuildFragment): string | undefined {
   if (build.platform === AppPlatform.Ios) {
     return `itms-services://?action=download-manifest;url=${getExpoApiBaseUrl()}/--/api/v2/projects/${
       build.project.id

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -15,12 +15,12 @@ export function getArtifactUrl(artifactId: string): string {
   return `${getExpoWebsiteBaseUrl()}/artifacts/${artifactId}`;
 }
 
-export function getInstallUrl(build: BuildFragment): string | null | undefined {
+export function getInternalDistributionInstallUrl(build: BuildFragment): string {
   if (build.platform === AppPlatform.Ios) {
     return `itms-services://?action=download-manifest;url=${getExpoApiBaseUrl()}/--/api/v2/projects/${
       build.project.id
     }/builds/${build.id}/manifest.plist`;
   }
 
-  return build.artifacts?.buildUrl;
+  return build.artifacts!.buildUrl!;
 }

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -1,4 +1,4 @@
-import { getExpoWebsiteBaseUrl, getExpoApiBaseUrl } from '../../api';
+import { getExpoApiBaseUrl, getExpoWebsiteBaseUrl } from '../../api';
 import { AppPlatform, BuildFragment } from '../../graphql/generated';
 
 export function getBuildLogsUrl({

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -1,4 +1,5 @@
-import { getExpoWebsiteBaseUrl } from '../../api';
+import { BuildFragment, AppPlatform } from '../../graphql/generated';
+import { getExpoWebsiteBaseUrl, getExpoApiBaseUrl } from '../../api';
 
 export function getBuildLogsUrl({
   buildId,
@@ -12,4 +13,14 @@ export function getBuildLogsUrl({
 
 export function getArtifactUrl(artifactId: string): string {
   return `${getExpoWebsiteBaseUrl()}/artifacts/${artifactId}`;
+}
+
+export function getInstallUrl(build: BuildFragment) {
+  if (build.platform === AppPlatform.Ios) {
+    return `itms-services://?action=download-manifest;url=${getExpoApiBaseUrl()}/--/api/v2/projects/${
+      build.project.id
+    }/builds/${build.id}/manifest.plist`;
+  }
+
+  return build.artifacts?.buildUrl;
 }

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -1,5 +1,5 @@
-import { BuildFragment, AppPlatform } from '../../graphql/generated';
 import { getExpoWebsiteBaseUrl, getExpoApiBaseUrl } from '../../api';
+import { AppPlatform, BuildFragment } from '../../graphql/generated';
 
 export function getBuildLogsUrl({
   buildId,

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -15,7 +15,7 @@ export function getArtifactUrl(artifactId: string): string {
   return `${getExpoWebsiteBaseUrl()}/artifacts/${artifactId}`;
 }
 
-export function getInstallUrl(build: BuildFragment): string | undefined {
+export function getInstallUrl(build: BuildFragment): string | null | undefined {
   if (build.platform === AppPlatform.Ios) {
     return `itms-services://?action=download-manifest;url=${getExpoApiBaseUrl()}/--/api/v2/projects/${
       build.project.id


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

The workflow to download an internal build on your device is not optimal. You need to log into Expo on your phone and find the build you want. OK that's not too bad but we can show a QR code to download or install the internal distribution build to make it easier

# How

Added a QR code before the link to the build details page

# Test Plan

- You should get a QR code after running `eas build --profile preview`
- On iOS it should install the app directly, with a message like this `"exp.host" would like to install "app"`