### PR TITLE
[eas-cli] basic beta android manager

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-android-new.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-android-new.ts
@@ -1,0 +1,61 @@
+import {
+  AndroidAppBuildCredentialsFragment,
+  AndroidKeystoreFragment,
+  AndroidKeystoreType,
+  AppFragment,
+  CommonAndroidAppCredentialsFragment,
+} from '../../graphql/generated';
+import { testKeystore } from './fixtures-android';
+import { testKeystoreBase64 } from './fixtures-base64-data';
+
+export const testAppFragment: AppFragment = {
+  id: 'test-app-id',
+  fullName: '@testuser/testapp',
+  slug: 'testapp',
+};
+
+export const testJksAndroidKeystoreFragment: AndroidKeystoreFragment = {
+  id: 'test-id',
+  type: AndroidKeystoreType.Jks,
+  keystore: testKeystoreBase64,
+  keystorePassword: testKeystore.keystorePassword,
+  keyAlias: testKeystore.keyAlias,
+  keyPassword: testKeystore.keyPassword,
+  md5CertificateFingerprint: 'test-md5',
+  sha1CertificateFingerprint: 'test-sha1',
+  sha256CertificateFingerprint: 'test-sha256',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+export const testLegacyAndroidBuildCredentialsFragment: AndroidAppBuildCredentialsFragment = {
+  id: 'test-id',
+  isDefault: true,
+  isLegacy: true,
+  name: 'legacy',
+  androidKeystore: testJksAndroidKeystoreFragment,
+};
+
+export const testLegacyAndroidAppCredentialsFragment: CommonAndroidAppCredentialsFragment = {
+  id: 'test-id',
+  applicationIdentifier: null,
+  isLegacy: true,
+  app: testAppFragment,
+  androidAppBuildCredentialsList: [testLegacyAndroidBuildCredentialsFragment],
+};
+
+export const testAndroidBuildCredentialsFragment: AndroidAppBuildCredentialsFragment = {
+  id: 'test-id',
+  isDefault: true,
+  isLegacy: false,
+  name: 'Google App Store Build Credentials',
+  androidKeystore: testJksAndroidKeystoreFragment,
+};
+
+export const testAndroidAppCredentialsFragment: CommonAndroidAppCredentialsFragment = {
+  id: 'test-id',
+  applicationIdentifier: null,
+  isLegacy: false,
+  app: testAppFragment,
+  androidAppBuildCredentialsList: [testLegacyAndroidBuildCredentialsFragment],
+};

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-constants.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-constants.ts
@@ -34,6 +34,7 @@ export const testAppJson = {
   slug: testSlug,
   sdkVersion: '38.0.0',
   ios: { bundleIdentifier: testBundleIdentifier },
+  android: { package: testPackageName },
 };
 
 export const testAppJsonWithDifferentOwner = {

--- a/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
@@ -1,0 +1,25 @@
+import { getProjectAccountName, getProjectConfigDescription } from '../../../project/projectUtils';
+import { findAccountByName } from '../../../user/Account';
+import { Context } from '../../context';
+import { AppLookupParams } from '../api/GraphqlClient';
+
+export function getAppLookupParamsFromContext(ctx: Context): AppLookupParams {
+  ctx.ensureProjectContext();
+  const projectName = ctx.exp.slug;
+  const accountName = getProjectAccountName(ctx.exp, ctx.user);
+  const account = findAccountByName(ctx.user.accounts, accountName);
+  if (!account) {
+    throw new Error(`You do not have access to account: ${accountName}`);
+  }
+
+  const androidApplicationIdentifier = ctx.exp.android?.package;
+  if (!androidApplicationIdentifier) {
+    throw new Error(
+      `android.package needs to be defined in your ${getProjectConfigDescription(
+        ctx.projectDir
+      )} file`
+    );
+  }
+
+  return { account, projectName, androidApplicationIdentifier };
+}

--- a/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
@@ -1,0 +1,40 @@
+import { CommonAndroidAppCredentialsFragment } from '../../../graphql/generated';
+import { Account } from '../../../user/Account';
+import { AndroidAppCredentialsQuery } from './graphql/queries/AndroidAppCredentialsQuery';
+
+export interface AppLookupParams {
+  account: Account;
+  projectName: string;
+  androidApplicationIdentifier: string; // 'android.package' field in app.json
+}
+
+export async function getAndroidAppCredentialsWithCommonFieldsAsync(
+  appLookupParams: AppLookupParams
+): Promise<CommonAndroidAppCredentialsFragment | null> {
+  const { androidApplicationIdentifier } = appLookupParams;
+  const projectFullName = formatProjectFullName(appLookupParams);
+  return await AndroidAppCredentialsQuery.withCommonFieldsByApplicationIdentifierAsync(
+    projectFullName,
+    {
+      androidApplicationIdentifier,
+      legacyOnly: false,
+    }
+  );
+}
+
+/* There is at most one set of legacy android app credentials associated with an Expo App */
+export async function getLegacyAndroidAppCredentialsWithCommonFieldsAsync(
+  appLookupParams: AppLookupParams
+): Promise<CommonAndroidAppCredentialsFragment | null> {
+  const projectFullName = formatProjectFullName(appLookupParams);
+  return await AndroidAppCredentialsQuery.withCommonFieldsByApplicationIdentifierAsync(
+    projectFullName,
+    {
+      legacyOnly: true,
+    }
+  );
+}
+
+// TODO; refactor
+const formatProjectFullName = ({ account, projectName }: AppLookupParams): string =>
+  `@${account.name}/${projectName}`;

--- a/packages/eas-cli/src/credentials/android/utils/__tests__/__snapshots__/printCredentialsBeta-test.ts.snap
+++ b/packages/eas-cli/src/credentials/android/utils/__tests__/__snapshots__/printCredentialsBeta-test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`print credentials prints the AndroidAppCredentials fragment 1`] = `"Android Credentials  Project: testApp  Application Identifier: test.com.app  EAS Credentials:  These will take precedence over Expo Classic credentials  Configuration: legacy (Default)  Keystore:    Type: JKS    Key Alias: QHdrb3p5cmEvY3JlZGVudGlhbHMtdGVzdA==    MD5 Fingerprint: TE:ST:-M:D5    SHA1 Fingerprint: TE:ST:-S:HA:1    SHA256 Fingerprint: TE:ST:-S:HA:25:6    Updated 0 second ago  Credentials ported from Expo Classic (expo-cli):  Keystore:    Type: JKS    Key Alias: QHdrb3p5cmEvY3JlZGVudGlhbHMtdGVzdA==    MD5 Fingerprint: TE:ST:-M:D5    SHA1 Fingerprint: TE:ST:-S:HA:1    SHA256 Fingerprint: TE:ST:-S:HA:25:6    Updated 0 second ago"`;

--- a/packages/eas-cli/src/credentials/android/utils/__tests__/printCredentialsBeta-test.ts
+++ b/packages/eas-cli/src/credentials/android/utils/__tests__/printCredentialsBeta-test.ts
@@ -1,0 +1,31 @@
+import mockdate from 'mockdate';
+
+import Log from '../../../../log';
+import {
+  testAndroidAppCredentialsFragment,
+  testLegacyAndroidAppCredentialsFragment,
+} from '../../../__tests__/fixtures-android-new';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { getAppLookupParamsFromContext } from '../../actions/BuildCredentialsUtils';
+import { displayAndroidAppCredentials } from '../printCredentialsBeta';
+
+jest.mock('../../../../log');
+jest.mock('chalk', () => ({ bold: jest.fn(log => log) }));
+
+mockdate.set(new Date('4/20/2021'));
+
+describe('print credentials', () => {
+  it('prints the AndroidAppCredentials fragment', async () => {
+    const ctx = createCtxMock();
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    displayAndroidAppCredentials({
+      appLookupParams,
+      legacyAppCredentials: testLegacyAndroidAppCredentialsFragment,
+      appCredentials: testAndroidAppCredentialsFragment,
+    });
+    const loggedSoFar = (Log.log as jest.Mock).mock.calls.reduce(
+      (acc, mockValue) => acc + mockValue
+    );
+    expect(loggedSoFar).toMatchSnapshot();
+  });
+});

--- a/packages/eas-cli/src/credentials/android/utils/printCredentialsBeta.ts
+++ b/packages/eas-cli/src/credentials/android/utils/printCredentialsBeta.ts
@@ -1,0 +1,143 @@
+import chalk from 'chalk';
+
+import {
+  AndroidAppBuildCredentialsFragment,
+  CommonAndroidAppCredentialsFragment,
+} from '../../../graphql/generated';
+import Log from '../../../log';
+import { fromNow } from '../../../utils/date';
+import { AppLookupParams } from '../api/GraphqlClient';
+
+export function displayEmptyAndroidCredentials(appLookupParams: AppLookupParams): void {
+  const { projectName, androidApplicationIdentifier } = appLookupParams;
+  Log.log(chalk.bold(`Android Credentials`));
+  Log.log(`  Project: ${projectName}`);
+  Log.log(`  Application Identifier: ${androidApplicationIdentifier}`);
+  Log.log(`  No credentials set up yet!`);
+}
+
+/**
+ * sort a build credentials array in descending order of preference
+ * prefer default credentials, then prefer names that come first lexicographically
+ */
+function sortBuildCredentials(
+  androidAppBuildCredentialsList: AndroidAppBuildCredentialsFragment[]
+): AndroidAppBuildCredentialsFragment[] {
+  return androidAppBuildCredentialsList.sort((buildCredentialsA, buildCredentialsB) => {
+    if (buildCredentialsA.isDefault) {
+      return -1;
+    } else if (buildCredentialsB.isDefault) {
+      return 1;
+    }
+    return buildCredentialsA.name.localeCompare(buildCredentialsB.name);
+  });
+}
+
+function displayLegacyAndroidAppCredentials(
+  legacyAppCredentials: CommonAndroidAppCredentialsFragment,
+  appCredentials: CommonAndroidAppCredentialsFragment | null
+): void {
+  if (appCredentials) {
+    // differentiate between old and new if there's both
+    Log.log(chalk.bold(`  Credentials ported from Expo Classic (expo-cli):`));
+  }
+  // There can only be one set of build credentials in legacy app credentials
+  const [legacyBuildCredentials] = legacyAppCredentials.androidAppBuildCredentialsList;
+  if (legacyBuildCredentials) {
+    displayAndroidBuildCredentials(
+      legacyBuildCredentials,
+      /* only one set to show, skip config display */ true
+    );
+  }
+}
+
+function displayEASAndroidAppCredentials(
+  legacyAppCredentials: CommonAndroidAppCredentialsFragment | null,
+  appCredentials: CommonAndroidAppCredentialsFragment
+): void {
+  if (legacyAppCredentials) {
+    // differentiate between old and new if there's both
+    Log.log(chalk.bold(`  EAS Credentials:`));
+    Log.log(`  These will take precedence over Expo Classic credentials`);
+  }
+  const sortedBuildCredentialsList = sortBuildCredentials(
+    appCredentials.androidAppBuildCredentialsList
+  );
+  for (const buildCredentials of sortedBuildCredentialsList) {
+    displayAndroidBuildCredentials(buildCredentials);
+  }
+}
+
+function formatFingerprint(fingerprint: string | null): string {
+  if (!fingerprint) {
+    return 'unavailable';
+  }
+  const uppercaseFingerprint = fingerprint.toUpperCase();
+  const bytes = [];
+  for (let i = 0; i < uppercaseFingerprint.length; i++) {
+    const halfByte = uppercaseFingerprint.charAt(i);
+    if (i % 2 === 0) {
+      bytes.push(halfByte); // first half of the byte
+    } else {
+      bytes[bytes.length - 1] += halfByte; // second half of the byte
+    }
+  }
+  return bytes.join(':');
+}
+function displayAndroidBuildCredentials(
+  buildCredentials: AndroidAppBuildCredentialsFragment,
+  skipConfigurationDisplay?: boolean
+): void {
+  if (!skipConfigurationDisplay) {
+    const { isDefault, name } = buildCredentials;
+    Log.log(chalk.bold(`  Configuration: ${name}${isDefault ? ' (Default)' : ''}`));
+    Log.newLine();
+  }
+
+  const maybeKeystore = buildCredentials.androidKeystore;
+  Log.log(`  Keystore:`);
+  if (maybeKeystore) {
+    const {
+      keyAlias,
+      type,
+      md5CertificateFingerprint,
+      sha1CertificateFingerprint,
+      sha256CertificateFingerprint,
+      updatedAt,
+    } = maybeKeystore;
+    Log.log(`    Type: ${type}`);
+    Log.log(`    Key Alias: ${keyAlias}`);
+
+    Log.log(`    MD5 Fingerprint: ${formatFingerprint(md5CertificateFingerprint ?? null)}`);
+    Log.log(`    SHA1 Fingerprint: ${formatFingerprint(sha1CertificateFingerprint ?? null)}`);
+    Log.log(`    SHA256 Fingerprint: ${formatFingerprint(sha256CertificateFingerprint ?? null)}`);
+    Log.log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
+  } else {
+    Log.log(`    None assigned yet`);
+  }
+  Log.newLine();
+}
+
+export function displayAndroidAppCredentials({
+  appLookupParams,
+  legacyAppCredentials,
+  appCredentials,
+}: {
+  appLookupParams: AppLookupParams;
+  legacyAppCredentials: CommonAndroidAppCredentialsFragment | null;
+  appCredentials: CommonAndroidAppCredentialsFragment | null;
+}): void {
+  const { projectName, androidApplicationIdentifier } = appLookupParams;
+  Log.log(chalk.bold(`Android Credentials`));
+  Log.log(`  Project: ${projectName}`);
+  Log.log(`  Application Identifier: ${androidApplicationIdentifier}`);
+  Log.newLine();
+
+  if (appCredentials) {
+    displayEASAndroidAppCredentials(legacyAppCredentials, appCredentials);
+  }
+
+  if (legacyAppCredentials) {
+    displayLegacyAndroidAppCredentials(legacyAppCredentials, appCredentials);
+  }
+}

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -8,6 +8,7 @@ import { confirmAsync } from '../prompts';
 import { Actor, getActorDisplayName } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import AndroidApi from './android/api/Client';
+import * as AndroidGraphqlClient from './android/api/GraphqlClient';
 import * as IosGraphqlClient from './ios/api/GraphqlClient';
 import AppStoreApi from './ios/appstore/AppStoreApi';
 
@@ -26,6 +27,7 @@ export interface Context {
   readonly user: Actor;
   readonly nonInteractive: boolean;
   readonly android: AndroidApi;
+  readonly newAndroid: typeof AndroidGraphqlClient;
   readonly ios: typeof IosGraphqlClient;
   readonly appStore: AppStoreApi;
   readonly hasProjectContext: boolean;
@@ -54,6 +56,7 @@ export async function createCredentialsContextAsync(
 
 class CredentialsContext implements Context {
   public readonly android = new AndroidApi();
+  public readonly newAndroid = AndroidGraphqlClient;
   public readonly ios = IosGraphqlClient;
   public readonly appStore: AppStoreApi;
   public readonly nonInteractive: boolean;

--- a/packages/eas-cli/src/credentials/manager/ManageAndroidBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroidBeta.ts
@@ -1,0 +1,63 @@
+import Log from '../../log';
+import { getProjectAccountName } from '../../project/projectUtils';
+import { findAccountByName } from '../../user/Account';
+import { ensureActorHasUsername } from '../../user/actions';
+import { Action, CredentialsManager } from '../CredentialsManager';
+import { getAppLookupParamsFromContext } from '../android/actions/BuildCredentialsUtils';
+import {
+  displayAndroidAppCredentials,
+  displayEmptyAndroidCredentials,
+} from '../android/utils/printCredentialsBeta';
+import { Context } from '../context';
+import { PressAnyKeyToContinue } from './HelperActions';
+
+enum ActionType {}
+
+enum Scope {
+  Project,
+  Account,
+  Manager,
+}
+
+type ActionInfo = { value: ActionType; title: string; scope: Scope };
+
+const highLevelActions: ActionInfo[] = [];
+
+export class ManageAndroid implements Action {
+  async runAsync(
+    manager: CredentialsManager,
+    ctx: Context,
+    _currentActions: ActionInfo[] = highLevelActions
+  ): Promise<void> {
+    while (true) {
+      try {
+        const accountName = ctx.hasProjectContext
+          ? getProjectAccountName(ctx.exp, ctx.user)
+          : ensureActorHasUsername(ctx.user);
+
+        const account = findAccountByName(ctx.user.accounts, accountName);
+        if (!account) {
+          throw new Error(`You do not have access to account: ${accountName}`);
+        }
+        if (ctx.hasProjectContext) {
+          const appLookupParams = getAppLookupParamsFromContext(ctx);
+          const legacyAppCredentials = await ctx.newAndroid.getLegacyAndroidAppCredentialsWithCommonFieldsAsync(
+            appLookupParams
+          );
+          const appCredentials = await ctx.newAndroid.getAndroidAppCredentialsWithCommonFieldsAsync(
+            appLookupParams
+          );
+          if (!legacyAppCredentials && !appCredentials) {
+            displayEmptyAndroidCredentials(appLookupParams);
+          } else {
+            displayAndroidAppCredentials({ appLookupParams, legacyAppCredentials, appCredentials });
+          }
+          throw new Error('Not Implemented Yet');
+        }
+      } catch (err) {
+        Log.error(err);
+        await manager.runActionAsync(new PressAnyKeyToContinue());
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This is the start of the beta Android credentials manager. It just prints credentials right now. Unfortunately, in the old Android credentials system, Android things were just logged under the Expo app. This is very different from iOS, which logged credentials under an Expo app and a bundleIdentifier.

The new Android credentials system brings everything to parity with iOS, and credentials are logged under an Expo app and an application identifier (`android.package` in app.json). 

# Simple printing 
When the user has either legacy credentials or modern credentials, but NOT both
<img width="1273" alt="Screen Shot 2021-04-28 at 10 30 23 PM" src="https://user-images.githubusercontent.com/6380927/116506337-e7e13900-a871-11eb-846f-bcae057dc5ce.png">

# Complicated printing
When the user has both legacy credentials AND modern credentials
<img width="1280" alt="Screen Shot 2021-04-28 at 10 30 42 PM" src="https://user-images.githubusercontent.com/6380927/116506363-f4659180-a871-11eb-9aa9-d79082e2b860.png">

# Test Plan

- [ ] new tests pass
