### PR TITLE
[eas-cli] move from deprecated iosAppCredentialsArray to iosAppCreden…

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -102,12 +102,12 @@ export const testCommonIosAppCredentialsFragment: CommonIosAppCredentialsFragmen
   app: testAppFragment,
   appleTeam: testAppleTeamFragment,
   appleAppIdentifier: testAppleAppIdentifierFragment,
-  iosAppBuildCredentialsArray: [testIosAppBuildCredentialsFragment],
+  iosAppBuildCredentialsList: [testIosAppBuildCredentialsFragment],
 };
 
 export const testIosAppCredentialsWithBuildCredentialsQueryResult: IosAppCredentialsWithBuildCredentialsQueryResult = {
   id: 'test-app-credential-id',
-  iosAppBuildCredentialsArray: [testIosAppBuildCredentialsFragment],
+  iosAppBuildCredentialsList: [testIosAppBuildCredentialsFragment],
 };
 
 export const testAppleTeam = {

--- a/packages/eas-cli/src/credentials/credentialsJson/__tests__/update-test.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/__tests__/update-test.ts
@@ -222,11 +222,11 @@ describe('update credentials.json', () => {
       const pprofile = await fs.readFile('./pprofile', 'base64');
       const credJson = await fs.readJson('./credentials.json');
       expect(certP12).toEqual(
-        testCommonIosAppCredentialsFragment.iosAppBuildCredentialsArray[0].distributionCertificate
+        testCommonIosAppCredentialsFragment.iosAppBuildCredentialsList[0].distributionCertificate
           ?.certificateP12
       );
       expect(pprofile).toEqual(
-        testCommonIosAppCredentialsFragment.iosAppBuildCredentialsArray[0].provisioningProfile
+        testCommonIosAppCredentialsFragment.iosAppBuildCredentialsList[0].provisioningProfile
           ?.provisioningProfile
       );
       expect(credJson).toEqual({
@@ -307,7 +307,7 @@ describe('update credentials.json', () => {
       const testIosAppCredentialsNoDistCert = JSON.parse(
         JSON.stringify(testCommonIosAppCredentialsFragment)
       );
-      testIosAppCredentialsNoDistCert.iosAppBuildCredentialsArray[0].distributionCertificate = null;
+      testIosAppCredentialsNoDistCert.iosAppBuildCredentialsList[0].distributionCertificate = null;
       const ctx = createCtxMock({
         ios: {
           ...getNewIosApiMockWithoutCredentials(),

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -129,7 +129,7 @@ export async function updateIosCredentialsAsync(
     appLookupParams
   );
   const buildCredentials =
-    iosAppCredentials?.iosAppBuildCredentialsArray.find(
+    iosAppCredentials?.iosAppBuildCredentialsList.find(
       buildCredentials => buildCredentials.iosDistributionType === iosDistributionTypeGraphql
     ) ?? null;
   if (!buildCredentials) {

--- a/packages/eas-cli/src/credentials/ios/__tests__/IosCredentialsProvider-test.ts
+++ b/packages/eas-cli/src/credentials/ios/__tests__/IosCredentialsProvider-test.ts
@@ -87,7 +87,7 @@ describe(IosCredentialsProvider, () => {
             ),
             getDistributionCertificateForAppAsync: jest.fn(
               () =>
-                testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsArray[0]
+                testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsList[0]
                   .distributionCertificate
             ),
           },
@@ -106,7 +106,7 @@ describe(IosCredentialsProvider, () => {
         });
 
         const buildCredentials =
-          testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsArray[0];
+          testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsList[0];
         await expect(provider.getCredentialsAsync(CredentialsSource.REMOTE)).resolves.toMatchObject(
           {
             distributionCertificate: {

--- a/packages/eas-cli/src/credentials/ios/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/BuildCredentialsUtils.ts
@@ -21,7 +21,7 @@ export async function getAllBuildCredentialsAsync(
   if (!appCredentials) {
     return [];
   }
-  return appCredentials.iosAppBuildCredentialsArray;
+  return appCredentials.iosAppBuildCredentialsList;
 }
 
 export async function getBuildCredentialsAsync(
@@ -32,10 +32,10 @@ export async function getBuildCredentialsAsync(
   const appCredentials = await ctx.ios.getIosAppCredentialsWithBuildCredentialsAsync(app, {
     iosDistributionType,
   });
-  if (!appCredentials || appCredentials.iosAppBuildCredentialsArray.length === 0) {
+  if (!appCredentials || appCredentials.iosAppBuildCredentialsList.length === 0) {
     return null;
   }
-  const [buildCredentials] = appCredentials.iosAppBuildCredentialsArray;
+  const [buildCredentials] = appCredentials.iosAppBuildCredentialsList;
   return buildCredentials;
 }
 

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
@@ -48,9 +48,9 @@ describe('SetupBuildCredentialsFromCredentialsJson', () => {
     const testBuildCreds = JSON.parse(
       JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
     );
-    testBuildCreds.iosAppBuildCredentialsArray[0].distributionCertificate.certificateP12 =
+    testBuildCreds.iosAppBuildCredentialsList[0].distributionCertificate.certificateP12 =
       testDistCert.certP12;
-    testBuildCreds.iosAppBuildCredentialsArray[0].provisioningProfile.provisioningProfile =
+    testBuildCreds.iosAppBuildCredentialsList[0].provisioningProfile.provisioningProfile =
       testProvisioningProfile.provisioningProfile;
     const ctx = createCtxMock({
       ios: {
@@ -108,9 +108,9 @@ describe('SetupBuildCredentialsFromCredentialsJson', () => {
     const testBuildCreds = JSON.parse(
       JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
     );
-    testBuildCreds.iosAppBuildCredentialsArray[0].distributionCertificate.certificateP12 =
+    testBuildCreds.iosAppBuildCredentialsList[0].distributionCertificate.certificateP12 =
       'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
-    testBuildCreds.iosAppBuildCredentialsArray[0].provisioningProfile.provisioningProfile =
+    testBuildCreds.iosAppBuildCredentialsList[0].provisioningProfile.provisioningProfile =
       'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
     const ctx = createCtxMock({
       ios: {
@@ -141,9 +141,9 @@ describe('SetupBuildCredentialsFromCredentialsJson', () => {
     const testBuildCreds = JSON.parse(
       JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
     );
-    testBuildCreds.iosAppBuildCredentialsArray[0].distributionCertificate.certificateP12 =
+    testBuildCreds.iosAppBuildCredentialsList[0].distributionCertificate.certificateP12 =
       'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
-    testBuildCreds.iosAppBuildCredentialsArray[0].provisioningProfile.provisioningProfile =
+    testBuildCreds.iosAppBuildCredentialsList[0].provisioningProfile.provisioningProfile =
       'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
     const ctx = createCtxMock({
       nonInteractive: true,

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupProvisioningProfile-test.ts
@@ -33,7 +33,7 @@ describe('SetupProvisioningProfile', () => {
         listProvisioningProfilesAsync: jest.fn(() => [
           {
             provisioningProfileId: nullthrows(
-              testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsArray[0]
+              testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsList[0]
                 .provisioningProfile
             ).developerPortalIdentifier,
           },

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -74,7 +74,7 @@ export async function createOrUpdateIosAppBuildCredentialsAsync(
       iosDistributionType,
     }
   );
-  const iosAppBuildCredentials = iosAppCredentials.iosAppBuildCredentialsArray?.[0];
+  const iosAppBuildCredentials = iosAppCredentials.iosAppBuildCredentialsList?.[0];
   if (!iosAppBuildCredentials) {
     return await IosAppBuildCredentialsMutation.createIosAppBuildCredentialsAsync(
       {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
@@ -34,7 +34,7 @@ const AppleDistributionCertificateQuery = {
                   id
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
                     id
-                    iosAppBuildCredentialsArray(
+                    iosAppBuildCredentialsList(
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
                       id
@@ -67,7 +67,7 @@ const AppleDistributionCertificateQuery = {
     );
     assert(data.app, 'GraphQL: `app` not defined in server response');
     return (
-      data.app.byFullName.iosAppCredentials[0]?.iosAppBuildCredentialsArray[0]
+      data.app.byFullName.iosAppCredentials[0]?.iosAppBuildCredentialsList[0]
         ?.distributionCertificate ?? null
     );
   },

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
@@ -41,7 +41,7 @@ const AppleProvisioningProfileQuery = {
                   id
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
                     id
-                    iosAppBuildCredentialsArray(
+                    iosAppBuildCredentialsList(
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
                       id
@@ -84,7 +84,7 @@ const AppleProvisioningProfileQuery = {
     );
     assert(data.app, 'GraphQL: `app` not defined in server response');
     return (
-      data.app.byFullName.iosAppCredentials[0]?.iosAppBuildCredentialsArray[0]
+      data.app.byFullName.iosAppCredentials[0]?.iosAppBuildCredentialsList[0]
         ?.provisioningProfile ?? null
     );
   },

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
@@ -32,7 +32,7 @@ const IosAppBuildCredentialsQuery = {
                   id
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
                     id
-                    iosAppBuildCredentialsArray(
+                    iosAppBuildCredentialsList(
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
                       id
@@ -56,7 +56,7 @@ const IosAppBuildCredentialsQuery = {
         .toPromise()
     );
     assert(data.app, 'GraphQL: `app` not defined in server response');
-    return data.app.byFullName.iosAppCredentials[0]?.iosAppBuildCredentialsArray[0] ?? null;
+    return data.app.byFullName.iosAppCredentials[0]?.iosAppBuildCredentialsList[0] ?? null;
   },
 };
 

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
@@ -19,7 +19,7 @@ import {
 } from '../../../../../graphql/types/credentials/IosAppCredentials';
 
 export type IosAppCredentialsWithBuildCredentialsQueryResult = IosAppCredentialsFragment & {
-  iosAppBuildCredentialsArray: IosAppBuildCredentialsFragment[];
+  iosAppBuildCredentialsList: IosAppBuildCredentialsFragment[];
 };
 const IosAppCredentialsQuery = {
   async byAppIdentifierIdAsync(
@@ -84,7 +84,7 @@ const IosAppCredentialsQuery = {
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
                     id
                     ...IosAppCredentialsFragment
-                    iosAppBuildCredentialsArray(
+                    iosAppBuildCredentialsList(
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
                       id

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/IosAppCredentialsQuery.ts
@@ -18,7 +18,7 @@ const IosAppCredentialsQuery = {
         bundleIdentifier: 'com.quinlanj.test52',
         __typename: 'AppleAppIdentifier',
       },
-      iosAppBuildCredentialsArray: [
+      iosAppBuildCredentialsList: [
         {
           id: '6f8d0175-0caf-4922-b09b-eae757b83144',
           iosDistributionType: 'APP_STORE',

--- a/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
@@ -39,7 +39,7 @@ export function displayEmptyIosCredentials(appLookupParams: AppLookupParams): vo
  * sort a build credentials array in descending order of preference
  */
 function sortBuildCredentialsByDistributionType(
-  iosAppBuildCredentialsArray: IosAppBuildCredentialsFragment[]
+  iosAppBuildCredentialsList: IosAppBuildCredentialsFragment[]
 ): IosAppBuildCredentialsFragment[] {
   // The order in which we choose the distribution type from least to most preferred
   const typePriority = [
@@ -48,7 +48,7 @@ function sortBuildCredentialsByDistributionType(
     IosDistributionType.Enterprise,
     IosDistributionType.AppStore,
   ];
-  return iosAppBuildCredentialsArray
+  return iosAppBuildCredentialsList
     .sort(
       (buildCredentialsA, buildCredentialsB) =>
         typePriority.indexOf(buildCredentialsA.iosDistributionType) -
@@ -68,15 +68,15 @@ export function displayIosAppCredentials(credentials: CommonIosAppCredentialsFra
   }
   Log.newLine();
 
-  if (credentials.iosAppBuildCredentialsArray.length === 0) {
+  if (credentials.iosAppBuildCredentialsList.length === 0) {
     Log.log(`  Configuration: None setup yet`);
     Log.newLine();
     return;
   }
-  const sortedIosAppBuildCredentialsArray = sortBuildCredentialsByDistributionType(
-    credentials.iosAppBuildCredentialsArray
+  const sortedIosAppBuildCredentialsList = sortBuildCredentialsByDistributionType(
+    credentials.iosAppBuildCredentialsList
   );
-  for (const iosAppBuildCredentials of sortedIosAppBuildCredentialsArray) {
+  for (const iosAppBuildCredentials of sortedIosAppBuildCredentialsList) {
     displayIosAppBuildCredentials(iosAppBuildCredentials);
   }
 }

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -281,7 +281,7 @@ export class ManageIos implements Action {
         return;
       }
       case ActionType.RemoveProvisioningProfile: {
-        const provisioningProfile = iosAppCredentials?.iosAppBuildCredentialsArray.find(
+        const provisioningProfile = iosAppCredentials?.iosAppBuildCredentialsList.find(
           buildCredentials => buildCredentials.iosDistributionType === iosDistributionTypeGraphql
         )?.provisioningProfile;
         if (!provisioningProfile) {

--- a/packages/eas-cli/src/credentials/manager/SelectIosDistributionTypeGraphqlFromBuildProfile.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectIosDistributionTypeGraphqlFromBuildProfile.ts
@@ -51,9 +51,9 @@ export class SelectIosDistributionTypeGraphqlFromBuildProfile {
     }
 
     // extrapolate type from existing app credentials
-    const iosAppBuildCredentialsArray = iosAppCredentials?.iosAppBuildCredentialsArray ?? [];
+    const iosAppBuildCredentialsList = iosAppCredentials?.iosAppBuildCredentialsList ?? [];
     const existingInternalIosDistributionTypes = uniq(
-      iosAppBuildCredentialsArray
+      iosAppBuildCredentialsList
         .map(buildCredentials => buildCredentials.iosDistributionType)
         .filter(
           distributionTypeGraphql =>

--- a/packages/eas-cli/src/credentials/manager/__tests__/SelectIosDistributionTypeGraphqlFromBuildProfile-test.ts
+++ b/packages/eas-cli/src/credentials/manager/__tests__/SelectIosDistributionTypeGraphqlFromBuildProfile-test.ts
@@ -111,7 +111,7 @@ describe('SelectIosDistributionTypeGraphqlFromBuildProfile', () => {
 
     // create deep clone the quick and dirty way
     const testAppCredentials = JSON.parse(JSON.stringify(testCommonIosAppCredentialsFragment));
-    testAppCredentials.iosAppBuildCredentialsArray[0].iosDistributionType =
+    testAppCredentials.iosAppBuildCredentialsList[0].iosDistributionType =
       IosDistributionTypeGraphql.AdHoc;
     const iosDistributionTypeGraphql = await selectIosDistributionTypeGraphqlFromBuildProfileAction.runAsync(
       ctx,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3936,7 +3936,7 @@ export type AppleDistributionCertificateByAppQuery = (
       & { iosAppCredentials: Array<(
         { __typename?: 'IosAppCredentials' }
         & Pick<IosAppCredentials, 'id'>
-        & { iosAppBuildCredentialsArray: Array<(
+        & { iosAppBuildCredentialsList: Array<(
           { __typename?: 'IosAppBuildCredentials' }
           & Pick<IosAppBuildCredentials, 'id'>
           & { distributionCertificate?: Maybe<(
@@ -3993,7 +3993,7 @@ export type AppleProvisioningProfilesByAppQuery = (
       & { iosAppCredentials: Array<(
         { __typename?: 'IosAppCredentials' }
         & Pick<IosAppCredentials, 'id'>
-        & { iosAppBuildCredentialsArray: Array<(
+        & { iosAppBuildCredentialsList: Array<(
           { __typename?: 'IosAppBuildCredentials' }
           & Pick<IosAppBuildCredentials, 'id'>
           & { provisioningProfile?: Maybe<(
@@ -4075,7 +4075,7 @@ export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQuery = (
       & { iosAppCredentials: Array<(
         { __typename?: 'IosAppCredentials' }
         & Pick<IosAppCredentials, 'id'>
-        & { iosAppBuildCredentialsArray: Array<(
+        & { iosAppBuildCredentialsList: Array<(
           { __typename?: 'IosAppBuildCredentials' }
           & Pick<IosAppBuildCredentials, 'id'>
           & IosAppBuildCredentialsFragment
@@ -4124,7 +4124,7 @@ export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = (
       & { iosAppCredentials: Array<(
         { __typename?: 'IosAppCredentials' }
         & Pick<IosAppCredentials, 'id'>
-        & { iosAppBuildCredentialsArray: Array<(
+        & { iosAppBuildCredentialsList: Array<(
           { __typename?: 'IosAppBuildCredentials' }
           & Pick<IosAppBuildCredentials, 'id'>
           & IosAppBuildCredentialsFragment
@@ -4870,7 +4870,7 @@ export type CommonIosAppCredentialsFragment = (
     { __typename?: 'AppleAppIdentifier' }
     & Pick<AppleAppIdentifier, 'id'>
     & AppleAppIdentifierFragment
-  ), iosAppBuildCredentialsArray: Array<(
+  ), iosAppBuildCredentialsList: Array<(
     { __typename?: 'IosAppBuildCredentials' }
     & Pick<IosAppBuildCredentials, 'id'>
     & IosAppBuildCredentialsFragment

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
@@ -26,7 +26,7 @@ export const CommonIosAppCredentialsFragmentNode = gql`
       id
       ...AppleAppIdentifierFragment
     }
-    iosAppBuildCredentialsArray {
+    iosAppBuildCredentialsList {
       id
       ...IosAppBuildCredentialsFragment
     }


### PR DESCRIPTION
…tialsList

<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Apparently the norm is to use `fooList` instead of `fooArray` in Graphql speak. On the servers, we deprecated `iosAppCredentialsArray` and encourage use of `iosAppCredentialsList` instead. This PR makes the switch to `iosAppCredentialsList`


# Test Plan

- [x] tests pass
- [x] quick manual sanity check
