### PR TITLE
[eas-cli] remove --force to fix eas publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Make eas branch:publish work with expo-cli >= 4.4.3 ([#366](https://github.com/expo/eas-cli/pull/366) by [@jkhales](https://github.com/jkhales))
 - Create asset keys without an extension. ([#366](https://github.com/expo/eas-cli/pull/366) by [@jkhales](https://github.com/jkhales))
 
 ### 🎉 New features

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -155,7 +155,7 @@ export async function buildBundlesAsync({
   Log.withTick(`Building bundle with expo-cli...`);
   const spawnPromise = spawnAsync(
     'yarn',
-    ['expo', 'export', '--output-dir', inputDir, '--experimental-bundle', '--force'],
+    ['expo', 'export', '--output-dir', inputDir, '--experimental-bundle'],
     { stdio: ['inherit', 'pipe', 'pipe'] } // inherit stdin so user can install a missing expo-cli from inside this command
   );
   const {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

https://github.com/expo/expo-cli/pull/3395/files breaks `eas branch:publish` since we pass `--force` to `expo export`.

# How

Remove `--force`

This breaks `eas branch:publish` for `expo-cli` <= 4.4.3, but since this is still just in internal testing 🚀 


# Test Plan

Tested publish works.