### PR TITLE
[eas-cli] create keystore action

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -896,6 +896,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "manifestPermalink",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -4489,8 +4505,24 @@
             "deprecationReason": null
           },
           {
-            "name": "accounts",
+            "name": "primaryAccount",
             "description": "Associated accounts",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accounts",
+            "description": "",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6205,6 +6237,30 @@
             "deprecationReason": null
           },
           {
+            "name": "androidConfig",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AndroidSubmissionConfig",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "iosConfig",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "IosSubmissionConfig",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "logsUrl",
             "description": "",
             "args": [],
@@ -6269,6 +6325,213 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AndroidSubmissionConfig",
+        "description": "",
+        "fields": [
+          {
+            "name": "applicationIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archiveType",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SubmissionAndroidArchiveType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "track",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SubmissionAndroidTrack",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "releaseStatus",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "SubmissionAndroidReleaseStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SubmissionAndroidArchiveType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "APK",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "AAB",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SubmissionAndroidTrack",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "PRODUCTION",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INTERNAL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ALPHA",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BETA",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SubmissionAndroidReleaseStatus",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DRAFT",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IN_PROGRESS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HALTED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COMPLETED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "IosSubmissionConfig",
+        "description": "",
+        "fields": [
+          {
+            "name": "ascAppIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appleIdUsername",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -8637,6 +8900,16 @@
                   }
                 },
                 "defaultValue": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "UpdatesFilter",
+                  "ofType": null
+                },
+                "defaultValue": null
               }
             ],
             "type": {
@@ -8662,6 +8935,45 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "UpdatesFilter",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "platform",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppPlatform",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "runtimeVersions",
+            "description": "",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -15896,6 +16208,16 @@
             "type": {
               "kind": "ENUM",
               "name": "IosSchemeBuildConfiguration",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "buildConfiguration",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-android-new.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-android-new.ts
@@ -59,3 +59,11 @@ export const testAndroidAppCredentialsFragment: CommonAndroidAppCredentialsFragm
   app: testAppFragment,
   androidAppBuildCredentialsList: [testLegacyAndroidBuildCredentialsFragment],
 };
+
+export function getNewAndroidApiMockWithoutCredentials() {
+  return {
+    getAndroidAppCredentialsWithCommonFieldsAsync: jest.fn(),
+    getLegacyAndroidAppCredentialsWithCommonFieldsAsync: jest.fn(),
+    createKeystoreAsync: jest.fn(),
+  };
+}

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
@@ -3,6 +3,7 @@ import merge from 'lodash/merge';
 import { CredentialsManager } from '../CredentialsManager';
 import { Context } from '../context';
 import { getAndroidApiMockWithoutCredentials } from './fixtures-android';
+import { getNewAndroidApiMockWithoutCredentials } from './fixtures-android-new';
 import { getAppstoreMock } from './fixtures-appstore';
 import { testAppJson, testUsername } from './fixtures-constants';
 import { getNewIosApiMockWithoutCredentials } from './fixtures-ios';
@@ -11,6 +12,7 @@ export function createCtxMock(mockOverride: Record<string, any> = {}): Context {
   const defaultMock = {
     ios: getNewIosApiMockWithoutCredentials(),
     android: getAndroidApiMockWithoutCredentials(),
+    newAndroid: getNewAndroidApiMockWithoutCredentials(),
     appStore: getAppstoreMock(),
     bestEffortAppStoreAuthenticateAsync: jest.fn(),
     ensureAppleCtx: jest.fn(),

--- a/packages/eas-cli/src/credentials/android/actions/new/CreateKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/CreateKeystore.ts
@@ -1,0 +1,31 @@
+import { AndroidKeystoreFragment } from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { Account } from '../../../../user/Account';
+import { Context } from '../../../context';
+import { askForUserProvidedAsync } from '../../../utils/promptForCredentials';
+import { KeystoreWithType, keystoreSchema } from '../../credentials';
+import { generateRandomKeystoreAsync } from '../../utils/keystore';
+import { getKeystoreWithType, validateKeystore } from '../../utils/keystoreNew';
+
+export class CreateKeystore {
+  constructor(private account: Account) {}
+
+  public async runAsync(ctx: Context): Promise<AndroidKeystoreFragment> {
+    if (ctx.nonInteractive) {
+      throw new Error(`New keystore cannot be created in non-interactive mode.`);
+    }
+    const keystore = await this.provideOrGenerateAsync();
+    const keystoreFragment = await ctx.newAndroid.createKeystoreAsync(this.account, keystore);
+    Log.succeed('Created keystore');
+    return keystoreFragment;
+  }
+
+  private async provideOrGenerateAsync(): Promise<KeystoreWithType> {
+    const providedKeystore = await askForUserProvidedAsync(keystoreSchema);
+    if (providedKeystore) {
+      const providedKeystoreWithType = getKeystoreWithType(providedKeystore);
+      validateKeystore(providedKeystoreWithType);
+    }
+    return await generateRandomKeystoreAsync();
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/new/__tests__/CreateKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/__tests__/CreateKeystore-test.ts
@@ -14,14 +14,14 @@ describe('CreateKeystore', () => {
     await createKeystoreAction.runAsync(ctx);
 
     // expect keystore to be created on expo servers
-    expect((ctx.newAndroid.createKeystoreAsync as any).mock.calls.length).toBe(1);
+    expect(ctx.newAndroid.createKeystoreAsync as any).toHaveBeenCalledTimes(1);
   });
   it('errors in Non-Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: true });
     const appLookupParams = getAppLookupParamsFromContext(ctx);
     const createKeystoreAction = new CreateKeystore(appLookupParams.account);
 
-    // fail if users are trying to delete a dist cert with dependencies in non-interactive mode
+    // fail if users are running in non-interactive mode
     await expect(createKeystoreAction.runAsync(ctx)).rejects.toThrowError();
   });
 });

--- a/packages/eas-cli/src/credentials/android/actions/new/__tests__/CreateKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/__tests__/CreateKeystore-test.ts
@@ -1,0 +1,27 @@
+import { confirmAsync } from '../../../../../prompts';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
+import { getAppLookupParamsFromContext } from '../../BuildCredentialsUtils';
+import { CreateKeystore } from '../CreateKeystore';
+
+jest.mock('../../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+
+describe('CreateKeystore', () => {
+  it('creates a keystore in Interactive Mode', async () => {
+    const ctx = createCtxMock({ nonInteractive: false });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const createKeystoreAction = new CreateKeystore(appLookupParams.account);
+    await createKeystoreAction.runAsync(ctx);
+
+    // expect keystore to be created on expo servers
+    expect((ctx.newAndroid.createKeystoreAsync as any).mock.calls.length).toBe(1);
+  });
+  it('errors in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({ nonInteractive: true });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const createKeystoreAction = new CreateKeystore(appLookupParams.account);
+
+    // fail if users are trying to delete a dist cert with dependencies in non-interactive mode
+    await expect(createKeystoreAction.runAsync(ctx)).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
@@ -1,5 +1,10 @@
-import { CommonAndroidAppCredentialsFragment } from '../../../graphql/generated';
+import {
+  AndroidKeystoreFragment,
+  CommonAndroidAppCredentialsFragment,
+} from '../../../graphql/generated';
 import { Account } from '../../../user/Account';
+import { KeystoreWithType } from '../credentials';
+import { AndroidKeystoreMutation } from './graphql/mutations/AndroidKeystoreMutation';
 import { AndroidAppCredentialsQuery } from './graphql/queries/AndroidAppCredentialsQuery';
 
 export interface AppLookupParams {
@@ -35,6 +40,21 @@ export async function getLegacyAndroidAppCredentialsWithCommonFieldsAsync(
   );
 }
 
-// TODO; refactor
+export async function createKeystoreAsync(
+  account: Account,
+  keystore: KeystoreWithType
+): Promise<AndroidKeystoreFragment> {
+  return await AndroidKeystoreMutation.createAndroidKeystore(
+    {
+      base64EncodedKeystore: keystore.keystore,
+      keystorePassword: keystore.keystorePassword,
+      keyAlias: keystore.keyAlias,
+      keyPassword: keystore.keyPassword,
+      type: keystore.type,
+    },
+    account.id
+  );
+}
+
 const formatProjectFullName = ({ account, projectName }: AppLookupParams): string =>
   `@${account.name}/${projectName}`;

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
@@ -1,0 +1,59 @@
+import assert from 'assert';
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import {
+  AndroidKeystoreFragment,
+  AndroidKeystoreType,
+  CreateAndroidKeystoreMutation,
+} from '../../../../../graphql/generated';
+import { AndroidKeystoreFragmentNode } from '../../../../../graphql/types/credentials/AndroidKeystore';
+
+const AndroidKeystoreMutation = {
+  async createAndroidKeystore(
+    androidKeystoreInput: {
+      base64EncodedKeystore: string;
+      keystorePassword: string;
+      keyAlias: string;
+      keyPassword?: string;
+      type: AndroidKeystoreType;
+    },
+    accountId: string
+  ): Promise<AndroidKeystoreFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateAndroidKeystoreMutation>(
+          gql`
+            mutation CreateAndroidKeystoreMutation(
+              $androidKeystoreInput: AndroidKeystoreInput!
+              $accountId: ID!
+            ) {
+              androidKeystore {
+                createAndroidKeystore(
+                  androidKeystoreInput: $androidKeystoreInput
+                  accountId: $accountId
+                ) {
+                  id
+                  ...AndroidKeystoreFragment
+                }
+              }
+            }
+            ${print(AndroidKeystoreFragmentNode)}
+          `,
+          {
+            androidKeystoreInput,
+            accountId,
+          }
+        )
+        .toPromise()
+    );
+    assert(
+      data.androidKeystore.createAndroidKeystore,
+      'GraphQL: `createAndroidKeystore` not defined in server response'
+    );
+    return data.androidKeystore.createAndroidKeystore;
+  },
+};
+
+export { AndroidKeystoreMutation };

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -152,6 +152,7 @@ export type Update = ActivityTimelineProjectActivity & {
   createdAt: Scalars['DateTime'];
   message?: Maybe<Scalars['String']>;
   branch: UpdateBranch;
+  manifestPermalink: Scalars['String'];
 };
 
 export type ActivityTimelineProjectActivity = {
@@ -666,6 +667,7 @@ export type User = Actor & {
   /** Get all certified second factor authentication methods */
   secondFactorDevices: Array<UserSecondFactorDevice>;
   /** Associated accounts */
+  primaryAccount: Account;
   accounts: Array<Account>;
   /** Access Tokens belonging to this actor */
   accessTokens: Array<AccessToken>;
@@ -900,10 +902,45 @@ export type Submission = ActivityTimelineProjectActivity & {
   initiatingActor?: Maybe<Actor>;
   platform: AppPlatform;
   status: SubmissionStatus;
+  androidConfig?: Maybe<AndroidSubmissionConfig>;
+  iosConfig?: Maybe<IosSubmissionConfig>;
   logsUrl?: Maybe<Scalars['String']>;
   error?: Maybe<SubmissionError>;
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
+};
+
+export type AndroidSubmissionConfig = {
+  __typename?: 'AndroidSubmissionConfig';
+  applicationIdentifier: Scalars['String'];
+  archiveType: SubmissionAndroidArchiveType;
+  track: SubmissionAndroidTrack;
+  releaseStatus?: Maybe<SubmissionAndroidReleaseStatus>;
+};
+
+export enum SubmissionAndroidArchiveType {
+  Apk = 'APK',
+  Aab = 'AAB'
+}
+
+export enum SubmissionAndroidTrack {
+  Production = 'PRODUCTION',
+  Internal = 'INTERNAL',
+  Alpha = 'ALPHA',
+  Beta = 'BETA'
+}
+
+export enum SubmissionAndroidReleaseStatus {
+  Draft = 'DRAFT',
+  InProgress = 'IN_PROGRESS',
+  Halted = 'HALTED',
+  Completed = 'COMPLETED'
+}
+
+export type IosSubmissionConfig = {
+  __typename?: 'IosSubmissionConfig';
+  ascAppIdentifier: Scalars['String'];
+  appleIdUsername: Scalars['String'];
 };
 
 export type SubmissionError = {
@@ -1169,6 +1206,12 @@ export type UpdateBranch = {
 export type UpdateBranchUpdatesArgs = {
   offset: Scalars['Int'];
   limit: Scalars['Int'];
+  filter?: Maybe<UpdatesFilter>;
+};
+
+export type UpdatesFilter = {
+  platform?: Maybe<AppPlatform>;
+  runtimeVersions?: Maybe<Array<Scalars['String']>>;
 };
 
 export type EnvironmentSecret = {
@@ -2435,6 +2478,7 @@ export type IosGenericJobInput = {
   cache?: Maybe<BuildCacheInput>;
   scheme: Scalars['String'];
   schemeBuildConfiguration?: Maybe<IosSchemeBuildConfiguration>;
+  buildConfiguration?: Maybe<Scalars['String']>;
   artifactPath?: Maybe<Scalars['String']>;
 };
 
@@ -3526,6 +3570,24 @@ export type UpdatesByGroupQuery = (
       & Pick<Robot, 'firstName' | 'id'>
     )> }
   )> }
+);
+
+export type CreateAndroidKeystoreMutationVariables = Exact<{
+  androidKeystoreInput: AndroidKeystoreInput;
+  accountId: Scalars['ID'];
+}>;
+
+
+export type CreateAndroidKeystoreMutation = (
+  { __typename?: 'RootMutation' }
+  & { androidKeystore: (
+    { __typename?: 'AndroidKeystoreMutation' }
+    & { createAndroidKeystore?: Maybe<(
+      { __typename?: 'AndroidKeystore' }
+      & Pick<AndroidKeystore, 'id'>
+      & AndroidKeystoreFragment
+    )> }
+  ) }
 );
 
 export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQueryVariables = Exact<{


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to create a new keystore using the new Graphql Api. This is *PARTIALLY* what will eventually replace the old `UpdateKeystore` here:  https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/android/actions/UpdateKeystore.ts

# Test Plan

- [ ] new tests pass
