### PR TITLE
[eas-cli] add --platform flag to branch:publish command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add a --platform flag to branch:publish command ([#389](https://github.com/expo/eas-cli/pull/389) by [@jkhales](https://github.com/jkhales))
 - Release new credentials manager. ([#363](https://github.com/expo/eas-cli/pull/363) by [@quinlanj](https://github.com/quinlanj))
 - Add QR code to install internal distribution build on device. ([#371](https://github.com/expo/eas-cli/pull/371) by [@axeldelafosse](https://github.com/axeldelafosse))
 

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -33,7 +33,7 @@ import { getLastCommitMessageAsync } from '../../utils/git';
 import { formatUpdate, listBranchesAsync } from './list';
 import { viewUpdateBranchAsync } from './view';
 
-const Platforms: PublishPlatform[] = ['android', 'ios'];
+export const Platforms: PublishPlatform[] = ['android', 'ios'];
 
 async function getUpdateGroupAsync({
   group,

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -3,7 +3,7 @@ import mockdate from 'mockdate';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Platforms } from '../../commands/branch/publish';
+import { defaultPublishPlatforms } from '../../commands/branch/publish';
 import { AssetMetadataStatus } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import { PublishQuery } from '../../graphql/queries/PublishQuery';
@@ -231,7 +231,7 @@ describe(collectAssets, () => {
     const assetDir = path.resolve(`${inputDir}/assets`);
     fs.mkdirSync(bundleDir, { recursive: true });
     fs.mkdirSync(assetDir, { recursive: true });
-    Platforms.forEach(platform => {
+    defaultPublishPlatforms.forEach(platform => {
       fs.writeFileSync(path.resolve(inputDir, `bundles/${platform}.js`), bundles[platform]);
     });
     fs.writeFileSync(path.resolve(`${inputDir}/assets/${fakeHash}`), dummyFileBuffer);
@@ -253,7 +253,7 @@ describe(collectAssets, () => {
       })
     );
 
-    expect(collectAssets({ inputDir, platforms: Platforms })).toEqual({
+    expect(collectAssets({ inputDir, platforms: defaultPublishPlatforms })).toEqual({
       android: {
         launchAsset: {
           type: 'bundle',

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -3,12 +3,12 @@ import mockdate from 'mockdate';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
+import { Platforms } from '../../commands/branch/publish';
 import { AssetMetadataStatus } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import { PublishQuery } from '../../graphql/queries/PublishQuery';
 import {
   MetadataJoi,
-  Platforms,
   TIMEOUT_LIMIT,
   buildUpdateInfoGroupAsync,
   collectAssets,
@@ -253,7 +253,7 @@ describe(collectAssets, () => {
       })
     );
 
-    expect(collectAssets(inputDir)).toEqual({
+    expect(collectAssets({ inputDir, platforms: Platforms })).toEqual({
       android: {
         launchAsset: {
           type: 'bundle',
@@ -262,6 +262,17 @@ describe(collectAssets, () => {
         },
         assets: userDefinedAssets,
       },
+      ios: {
+        launchAsset: {
+          type: 'bundle',
+          contentType: 'application/javascript',
+          path: path.resolve(`${inputDir}/bundles/ios.js`),
+        },
+        assets: userDefinedAssets,
+      },
+    });
+
+    expect(collectAssets({ inputDir, platforms: ['ios'] })).toEqual({
       ios: {
         launchAsset: {
           type: 'bundle',

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -17,7 +17,6 @@ import { uploadWithPresignedPostAsync } from '../uploads';
 
 export const TIMEOUT_LIMIT = 60_000; // 1 minute
 const STORAGE_BUCKET = getStorageBucket();
-export const Platforms: PublishPlatform[] = ['android', 'ios']; // TODO-JJ allow users to specify this in app.js
 
 function getStorageBucket(): string {
   if (process.env.EXPO_STAGING || process.env.EXPO_LOCAL) {
@@ -206,12 +205,18 @@ export function loadMetadata(distRoot: string): Metadata {
   return metadata;
 }
 
-export function collectAssets(inputDir: string): CollectedAssets {
+export function collectAssets({
+  inputDir,
+  platforms,
+}: {
+  inputDir: string;
+  platforms: PublishPlatform[];
+}): CollectedAssets {
   const distRoot = resolveInputDirectory(inputDir);
   const metadata = loadMetadata(distRoot);
 
   const assetsFinal: CollectedAssets = {};
-  for (const platform of Platforms) {
+  for (const platform of platforms) {
     assetsFinal[platform] = {
       launchAsset: {
         type: 'bundle',


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

We want to be able to publish/republish to specific platforms.

# How

Added a --platform flag:

`eas branch:publish main --platform ios`
 will publish an update group with a single update in it. 

# Test Plan
On a demo project:

* published to a single platform
* republished a multiplatform update to a single platform.
* confirmed publish and republish still work without the --platform flag

updated publish-test.ts