### PR TITLE
[eas-cli] set default urql requestPolicy to network-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Make the default urql requestPolicy 'network-only' [#397](https://github.com/expo/eas-cli/pull/397) by [@jkhales](https://github.com/jkhales))
+
 ### 🧹 Chores
 
 ## [0.14.0](https://github.com/expo/eas-cli/releases/tag/v0.14.0) - 2021-05-10

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -69,7 +69,7 @@ ALIASES
   $ eas login
 ```
 
-_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/account/login.ts)_
+_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/account/login.ts)_
 
 ## `eas account:logout`
 
@@ -83,7 +83,7 @@ ALIASES
   $ eas logout
 ```
 
-_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/account/logout.ts)_
+_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/account/logout.ts)_
 
 ## `eas account:view`
 
@@ -97,7 +97,7 @@ ALIASES
   $ eas whoami
 ```
 
-_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/account/view.ts)_
+_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/account/view.ts)_
 
 ## `eas analytics [STATUS]`
 
@@ -108,7 +108,7 @@ USAGE
   $ eas analytics [STATUS]
 ```
 
-_See code: [build/commands/analytics.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/analytics.ts)_
+_See code: [build/commands/analytics.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/analytics.ts)_
 
 ## `eas build`
 
@@ -129,7 +129,7 @@ OPTIONS
   --[no-]wait                       Wait for build(s) to complete
 ```
 
-_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/build/index.ts)_
+_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/build/index.ts)_
 
 ## `eas build:cancel [BUILD_ID]`
 
@@ -140,7 +140,7 @@ USAGE
   $ eas build:cancel [BUILD_ID]
 ```
 
-_See code: [build/commands/build/cancel.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/build/cancel.ts)_
+_See code: [build/commands/build/cancel.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/build/cancel.ts)_
 
 ## `eas build:configure`
 
@@ -155,7 +155,7 @@ OPTIONS
   --allow-experimental              Enable experimental configuration steps.
 ```
 
-_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/build/configure.ts)_
+_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/build/configure.ts)_
 
 ## `eas build:list`
 
@@ -171,7 +171,7 @@ OPTIONS
   --status=(in-queue|in-progress|errored|finished|canceled)
 ```
 
-_See code: [build/commands/build/list.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/build/list.ts)_
+_See code: [build/commands/build/list.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/build/list.ts)_
 
 ## `eas build:view [BUILD_ID]`
 
@@ -182,7 +182,7 @@ USAGE
   $ eas build:view [BUILD_ID]
 ```
 
-_See code: [build/commands/build/view.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/build/view.ts)_
+_See code: [build/commands/build/view.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/build/view.ts)_
 
 ## `eas credentials`
 
@@ -193,7 +193,7 @@ USAGE
   $ eas credentials
 ```
 
-_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/credentials.ts)_
+_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/credentials.ts)_
 
 ## `eas device:create`
 
@@ -204,7 +204,7 @@ USAGE
   $ eas device:create
 ```
 
-_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/device/create.ts)_
+_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/device/create.ts)_
 
 ## `eas device:list`
 
@@ -218,7 +218,7 @@ OPTIONS
   --apple-team-id=apple-team-id
 ```
 
-_See code: [build/commands/device/list.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/device/list.ts)_
+_See code: [build/commands/device/list.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/device/list.ts)_
 
 ## `eas device:view [UDID]`
 
@@ -229,7 +229,7 @@ USAGE
   $ eas device:view [UDID]
 ```
 
-_See code: [build/commands/device/view.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/device/view.ts)_
+_See code: [build/commands/device/view.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/device/view.ts)_
 
 ## `eas help [COMMAND]`
 
@@ -262,7 +262,7 @@ OPTIONS
   --value=value              Value of the secret
 ```
 
-_See code: [build/commands/secret/create.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/secret/create.ts)_
+_See code: [build/commands/secret/create.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/secret/create.ts)_
 
 ## `eas secret:delete`
 
@@ -279,7 +279,7 @@ DESCRIPTION
   Unsure where to find the secret's ID? Run eas secrets:list
 ```
 
-_See code: [build/commands/secret/delete.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/secret/delete.ts)_
+_See code: [build/commands/secret/delete.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/secret/delete.ts)_
 
 ## `eas secret:list`
 
@@ -290,7 +290,7 @@ USAGE
   $ eas secret:list
 ```
 
-_See code: [build/commands/secret/list.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/secret/list.ts)_
+_See code: [build/commands/secret/list.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/secret/list.ts)_
 
 ## `eas submit --platform=(android|ios)`
 
@@ -316,7 +316,8 @@ OPTIONS
 
   iOS specific options=asc-app-id                                    App Store Connect unique application Apple ID
                                                                      number. Providing this param results in skipping
-                                                                     app creation step. Learn more.
+                                                                     app creation step. Learn more:
+                                                                     https://expo.fyi/asc-app-id
 
   iOS specific options=bundle-identifier                             Your iOS Bundle Identifier (default:
                                                                      expo.ios.bundleIdentifier from app config)
@@ -369,7 +370,7 @@ EXAMPLES
          and provide its App ID
 ```
 
-_See code: [build/commands/submit.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/submit.ts)_
+_See code: [build/commands/submit.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/submit.ts)_
 
 ## `eas webhook:create`
 
@@ -388,7 +389,7 @@ OPTIONS
   --url=url        Webhook URL
 ```
 
-_See code: [build/commands/webhook/create.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/webhook/create.ts)_
+_See code: [build/commands/webhook/create.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/webhook/create.ts)_
 
 ## `eas webhook:delete [ID]`
 
@@ -402,7 +403,7 @@ ARGUMENTS
   ID  ID of the webhook to delete
 ```
 
-_See code: [build/commands/webhook/delete.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/webhook/delete.ts)_
+_See code: [build/commands/webhook/delete.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/webhook/delete.ts)_
 
 ## `eas webhook:list`
 
@@ -416,7 +417,7 @@ OPTIONS
   --event=(BUILD)  Event type that triggers the webhook
 ```
 
-_See code: [build/commands/webhook/list.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/webhook/list.ts)_
+_See code: [build/commands/webhook/list.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/webhook/list.ts)_
 
 ## `eas webhook:update`
 
@@ -436,7 +437,7 @@ OPTIONS
   --url=url        Webhook URL
 ```
 
-_See code: [build/commands/webhook/update.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/webhook/update.ts)_
+_See code: [build/commands/webhook/update.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/webhook/update.ts)_
 
 ## `eas webhook:view ID`
 
@@ -450,5 +451,5 @@ ARGUMENTS
   ID  ID of the webhook to view
 ```
 
-_See code: [build/commands/webhook/view.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/webhook/view.ts)_
+_See code: [build/commands/webhook/view.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/webhook/view.ts)_
 <!-- commandsstop -->

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -69,7 +69,7 @@ ALIASES
   $ eas login
 ```
 
-_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/account/login.ts)_
+_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/account/login.ts)_
 
 ## `eas account:logout`
 
@@ -83,7 +83,7 @@ ALIASES
   $ eas logout
 ```
 
-_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/account/logout.ts)_
+_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/account/logout.ts)_
 
 ## `eas account:view`
 
@@ -97,7 +97,7 @@ ALIASES
   $ eas whoami
 ```
 
-_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/account/view.ts)_
+_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/account/view.ts)_
 
 ## `eas analytics [STATUS]`
 
@@ -108,7 +108,7 @@ USAGE
   $ eas analytics [STATUS]
 ```
 
-_See code: [build/commands/analytics.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/analytics.ts)_
+_See code: [build/commands/analytics.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/analytics.ts)_
 
 ## `eas build`
 
@@ -129,7 +129,7 @@ OPTIONS
   --[no-]wait                       Wait for build(s) to complete
 ```
 
-_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/build/index.ts)_
+_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/build/index.ts)_
 
 ## `eas build:cancel [BUILD_ID]`
 
@@ -140,7 +140,7 @@ USAGE
   $ eas build:cancel [BUILD_ID]
 ```
 
-_See code: [build/commands/build/cancel.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/build/cancel.ts)_
+_See code: [build/commands/build/cancel.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/build/cancel.ts)_
 
 ## `eas build:configure`
 
@@ -155,7 +155,7 @@ OPTIONS
   --allow-experimental              Enable experimental configuration steps.
 ```
 
-_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/build/configure.ts)_
+_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/build/configure.ts)_
 
 ## `eas build:list`
 
@@ -171,7 +171,7 @@ OPTIONS
   --status=(in-queue|in-progress|errored|finished|canceled)
 ```
 
-_See code: [build/commands/build/list.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/build/list.ts)_
+_See code: [build/commands/build/list.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/build/list.ts)_
 
 ## `eas build:view [BUILD_ID]`
 
@@ -182,7 +182,7 @@ USAGE
   $ eas build:view [BUILD_ID]
 ```
 
-_See code: [build/commands/build/view.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/build/view.ts)_
+_See code: [build/commands/build/view.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/build/view.ts)_
 
 ## `eas credentials`
 
@@ -193,7 +193,7 @@ USAGE
   $ eas credentials
 ```
 
-_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/credentials.ts)_
+_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/credentials.ts)_
 
 ## `eas device:create`
 
@@ -204,7 +204,7 @@ USAGE
   $ eas device:create
 ```
 
-_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/device/create.ts)_
+_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/device/create.ts)_
 
 ## `eas device:list`
 
@@ -218,7 +218,7 @@ OPTIONS
   --apple-team-id=apple-team-id
 ```
 
-_See code: [build/commands/device/list.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/device/list.ts)_
+_See code: [build/commands/device/list.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/device/list.ts)_
 
 ## `eas device:view [UDID]`
 
@@ -229,7 +229,7 @@ USAGE
   $ eas device:view [UDID]
 ```
 
-_See code: [build/commands/device/view.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/device/view.ts)_
+_See code: [build/commands/device/view.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/device/view.ts)_
 
 ## `eas help [COMMAND]`
 
@@ -262,7 +262,7 @@ OPTIONS
   --value=value              Value of the secret
 ```
 
-_See code: [build/commands/secret/create.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/secret/create.ts)_
+_See code: [build/commands/secret/create.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/secret/create.ts)_
 
 ## `eas secret:delete`
 
@@ -279,7 +279,7 @@ DESCRIPTION
   Unsure where to find the secret's ID? Run eas secrets:list
 ```
 
-_See code: [build/commands/secret/delete.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/secret/delete.ts)_
+_See code: [build/commands/secret/delete.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/secret/delete.ts)_
 
 ## `eas secret:list`
 
@@ -290,7 +290,7 @@ USAGE
   $ eas secret:list
 ```
 
-_See code: [build/commands/secret/list.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/secret/list.ts)_
+_See code: [build/commands/secret/list.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/secret/list.ts)_
 
 ## `eas submit --platform=(android|ios)`
 
@@ -316,8 +316,7 @@ OPTIONS
 
   iOS specific options=asc-app-id                                    App Store Connect unique application Apple ID
                                                                      number. Providing this param results in skipping
-                                                                     app creation step. Learn more:
-                                                                     https://expo.fyi/asc-app-id
+                                                                     app creation step. Learn more.
 
   iOS specific options=bundle-identifier                             Your iOS Bundle Identifier (default:
                                                                      expo.ios.bundleIdentifier from app config)
@@ -370,7 +369,7 @@ EXAMPLES
          and provide its App ID
 ```
 
-_See code: [build/commands/submit.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/submit.ts)_
+_See code: [build/commands/submit.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/submit.ts)_
 
 ## `eas webhook:create`
 
@@ -389,7 +388,7 @@ OPTIONS
   --url=url        Webhook URL
 ```
 
-_See code: [build/commands/webhook/create.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/webhook/create.ts)_
+_See code: [build/commands/webhook/create.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/webhook/create.ts)_
 
 ## `eas webhook:delete [ID]`
 
@@ -403,7 +402,7 @@ ARGUMENTS
   ID  ID of the webhook to delete
 ```
 
-_See code: [build/commands/webhook/delete.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/webhook/delete.ts)_
+_See code: [build/commands/webhook/delete.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/webhook/delete.ts)_
 
 ## `eas webhook:list`
 
@@ -417,7 +416,7 @@ OPTIONS
   --event=(BUILD)  Event type that triggers the webhook
 ```
 
-_See code: [build/commands/webhook/list.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/webhook/list.ts)_
+_See code: [build/commands/webhook/list.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/webhook/list.ts)_
 
 ## `eas webhook:update`
 
@@ -437,7 +436,7 @@ OPTIONS
   --url=url        Webhook URL
 ```
 
-_See code: [build/commands/webhook/update.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/webhook/update.ts)_
+_See code: [build/commands/webhook/update.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/webhook/update.ts)_
 
 ## `eas webhook:view ID`
 
@@ -451,5 +450,5 @@ ARGUMENTS
   ID  ID of the webhook to view
 ```
 
-_See code: [build/commands/webhook/view.ts](https://github.com/expo/eas-cli/blob/v0.14.1/build/commands/webhook/view.ts)_
+_See code: [build/commands/webhook/view.ts](https://github.com/expo/eas-cli/blob/v0.14.0/build/commands/webhook/view.ts)_
 <!-- commandsstop -->

--- a/packages/eas-cli/src/graphql/client.ts
+++ b/packages/eas-cli/src/graphql/client.ts
@@ -33,6 +33,7 @@ export const graphqlClient = createUrqlClient({
     }),
     fetchExchange,
   ],
+  requestPolicy: 'network-only',
   // @ts-expect-error Type 'typeof fetch' is not assignable to type '(input: RequestInfo, init?: RequestInit | undefined) => Promise<Response>'.
   fetch,
   fetchOptions: (): { headers?: AccessTokenHeaders | SessionHeaders } => {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

network requests are failing opaquely.

# How

Change the default urql requestPolicy to `network-only`

Perhaps we can roll this back to a less aggressive policy, but for now priority is to get things working.

# Test Plan

In a demo project, installed the output of `npm pack`

confirmed that builds were failing.

Adjusted default request policy. cleaned node_modules and installed new `npm pack`

confirmed that builds are no longer failing.