### PR TITLE
set empty save-prefix

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This is a follow-up to https://github.com/expo/eas-cli/pull/399
We want to avoid adding non-strict versions to package.json

# How

I set an empty `save-prefix` in `.yarnrc`.

# Test Plan

- `yarn add moment`
- I saw that it added `"moment": "2.29.1", ` to package.json
- `yarn remove moment`
- I deleted the `.yarnrc` file.
- I ran `yarn add moment` and saw that `"moment": "^2.29.1", ` was added to package.json.