### PR TITLE
[eas-cli] replace ensureProjectExistsAsync with getProjectIdAsync

### DIFF
--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -10,10 +10,12 @@ import {
   UpdateBranch,
 } from '../../graphql/generated';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
-import { findProjectRootAsync, getProjectAccountName } from '../../project/projectUtils';
+import {
+  findProjectRootAsync,
+  getProjectFullNameAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import { ensureLoggedInAsync } from '../../user/actions';
 import { getBranchNameAsync } from '../../utils/git';
 
 export async function createUpdateBranchOnAppAsync({
@@ -78,11 +80,8 @@ export default class BranchCreate extends Command {
     }
 
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: exp.slug,
-    });
+    const fullName = await getProjectFullNameAsync(exp);
+    const projectId = await getProjectIdAsync(exp);
 
     if (!name) {
       const validationMessage = 'Branch name may not be empty.';
@@ -107,9 +106,7 @@ export default class BranchCreate extends Command {
     }
 
     Log.withTick(
-      `️Created a new branch: ${chalk.bold(newBranch.name)} on project ${chalk.bold(
-        `@${accountName}/${exp.slug}`
-      )}.`
+      `️Created a new branch: ${chalk.bold(newBranch.name)} on project ${chalk.bold(fullName)}.`
     );
   }
 }

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -12,10 +12,12 @@ import {
   GetBranchInfoQueryVariables,
 } from '../../graphql/generated';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
-import { findProjectRootAsync, getProjectAccountName } from '../../project/projectUtils';
+import {
+  findProjectRootAsync,
+  getProjectFullNameAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
-import { ensureLoggedInAsync } from '../../user/actions';
 
 async function getBranchInfoAsync({
   appId,
@@ -104,11 +106,8 @@ export default class BranchDelete extends Command {
       throw new Error('Please run this command inside a project directory.');
     }
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: exp.slug,
-    });
+    const fullName = await getProjectFullNameAsync(exp);
+    const projectId = await getProjectIdAsync(exp);
 
     if (!name) {
       const validationMessage = 'branch name may not be empty.';
@@ -148,9 +147,7 @@ export default class BranchDelete extends Command {
     }
 
     Log.withTick(
-      `️Deleted branch "${name}" and all of its updates on project ${chalk.bold(
-        `@${accountName}/${exp.slug}`
-      )}.`
+      `️Deleted branch "${name}" and all of its updates on project ${chalk.bold(fullName)}.`
     );
   }
 }

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -19,8 +19,12 @@ import {
 } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
-import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+import {
+  findProjectRootAsync,
+  getProjectAccountNameAsync,
+  getProjectFullNameAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
 import {
   PublishPlatform,
   buildBundlesAsync,
@@ -150,10 +154,8 @@ export default class BranchPublish extends Command {
         "Couldn't find 'runtimeVersion'. Please specify it under the 'expo' key in 'app.json'"
       );
     }
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: slug,
-    });
+    const projectId = await getProjectIdAsync(exp);
+    const fullName = await getProjectFullNameAsync(exp);
 
     if (!name) {
       const validationMessage = 'branch name may not be empty.';
@@ -161,7 +163,7 @@ export default class BranchPublish extends Command {
         throw new Error(validationMessage);
       }
 
-      const branches = await listBranchesAsync({ fullName: `@${accountName}/${slug}` });
+      const branches = await listBranchesAsync({ fullName });
       name = await selectAsync<string>(
         'which branch would you like to publish on?',
         branches.map(branch => {

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -11,10 +11,12 @@ import {
   UpdateBranch,
 } from '../../graphql/generated';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
-import { findProjectRootAsync, getProjectAccountName } from '../../project/projectUtils';
+import {
+  findProjectRootAsync,
+  getProjectFullNameAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import { ensureLoggedInAsync } from '../../user/actions';
 
 async function renameUpdateBranchOnAppAsync({
   appId,
@@ -76,12 +78,8 @@ export default class BranchRename extends Command {
       throw new Error('Please run this command inside a project directory.');
     }
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
-
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: exp.slug,
-    });
+    const fullName = await getProjectFullNameAsync(exp);
+    const projectId = await getProjectIdAsync(exp);
 
     if (!currentName) {
       const validationMessage = 'current name may not be empty.';
@@ -123,7 +121,7 @@ export default class BranchRename extends Command {
     Log.withTick(
       `️Renamed branch from ${currentName} to ${chalk.bold(
         editedBranch.name
-      )} on project ${chalk.bold(`@${accountName}/${exp.slug}`)}.`
+      )} on project ${chalk.bold(fullName)}.`
     );
   }
 }

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -16,8 +16,11 @@ import {
   ViewBranchQueryVariables,
 } from '../../graphql/generated';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
-import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+import {
+  findProjectRootAsync,
+  getProjectFullNameAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { UPDATE_COLUMNS, formatUpdate, getPlatformsForGroup } from '../../update/utils';
 
@@ -118,12 +121,8 @@ export default class BranchView extends Command {
     }
 
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    const accountName = await getProjectAccountNameAsync(exp);
-    const { slug } = exp;
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: slug,
-    });
+    const fullName = await getProjectFullNameAsync(exp);
+    const projectId = await getProjectIdAsync(exp);
 
     if (!name) {
       const validationMessage = 'Branch name may not be empty.';
@@ -171,7 +170,7 @@ export default class BranchView extends Command {
 
     Log.withTick(
       `️Branch: ${chalk.bold(UpdateBranch.name)} on project ${chalk.bold(
-        `@${accountName}/${slug}`
+        fullName
       )}. Branch ID: ${chalk.bold(UpdateBranch.id)}`
     );
     Log.log(chalk.bold('Recent update groups published on this branch:'));

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -9,11 +9,11 @@ import {
   CreateUpdateChannelOnAppMutationVariables,
 } from '../../graphql/generated';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import {
   findProjectRootAsync,
   getBranchByNameAsync,
-  getProjectAccountNameAsync,
+  getProjectFullNameAsync,
+  getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { createUpdateBranchOnAppAsync } from '../branch/create';
@@ -87,12 +87,8 @@ export default class ChannelCreate extends Command {
       throw new Error('Please run this command inside a project directory.');
     }
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    const accountName = await getProjectAccountNameAsync(exp);
-    const { slug } = exp;
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: slug,
-    });
+    const fullName = await getProjectFullNameAsync(exp);
+    const projectId = await getProjectIdAsync(exp);
 
     if (!channelName) {
       const validationMessage = 'Channel name may not be empty.';
@@ -146,7 +142,7 @@ export default class ChannelCreate extends Command {
 
     Log.withTick(
       `️Created a new channel ${chalk.bold(newChannel.name)} on project ${chalk.bold(
-        `@${accountName}/${slug}`
+        fullName
       )}. ${branchMessage} and have pointed the channel at it. You can now update your app by publishing!`
     );
   }

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -13,11 +13,10 @@ import {
   UpdateChannelBranchMappingMutationVariables,
 } from '../../graphql/generated';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import {
   findProjectRootAsync,
   getBranchByNameAsync,
-  getProjectAccountNameAsync,
+  getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 
@@ -126,12 +125,7 @@ export default class ChannelEdit extends Command {
       throw new Error('Please run this command inside a project directory.');
     }
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    const accountName = await getProjectAccountNameAsync(exp);
-    const { slug } = exp;
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: slug,
-    });
+    const projectId = await getProjectIdAsync(exp);
 
     if (!channelName) {
       const validationMessage = 'A channel name is required to edit a specific channel.';

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -9,8 +9,7 @@ import {
   GetAllChannelsForAppQueryVariables,
 } from '../../graphql/generated';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
-import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { logChannelDetails } from './view';
 
 const CHANNEL_LIMIT = 10_000;
@@ -85,12 +84,7 @@ export default class ChannelList extends Command {
       throw new Error('Please run this command inside a project directory.');
     }
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    const accountName = await getProjectAccountNameAsync(exp);
-    const { slug } = exp;
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: slug,
-    });
+    const projectId = await getProjectIdAsync(exp);
 
     const getAllUpdateChannelForAppResult = await getAllUpdateChannelForAppAsync({
       appId: projectId,

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -4,11 +4,11 @@ import chalk from 'chalk';
 
 import { GetChannelByNameForAppQuery, UpdateBranch } from '../../graphql/generated';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import {
   findProjectRootAsync,
   getBranchByNameAsync,
-  getProjectAccountNameAsync,
+  getProjectFullNameAsync,
+  getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync, selectAsync } from '../../prompts';
 import { updateChannelBranchMappingAsync } from './edit';
@@ -349,12 +349,8 @@ export default class ChannelRollout extends Command {
       throw new Error('Please run this command inside a project directory.');
     }
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    const accountName = await getProjectAccountNameAsync(exp);
-    const { slug } = exp;
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: slug,
-    });
+    const fullName = await getProjectFullNameAsync(exp);
+    const projectId = await getProjectIdAsync(exp);
 
     const getUpdateChannelByNameForAppResult = await getUpdateChannelByNameForAppAsync({
       appId: projectId,
@@ -399,7 +395,7 @@ export default class ChannelRollout extends Command {
         percent,
         jsonFlag,
         projectId,
-        fullName: `@${accountName}/${slug}`,
+        fullName,
         currentBranchMapping,
         getUpdateChannelByNameForAppResult,
       });

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -11,8 +11,11 @@ import {
   GetChannelByNameForAppQueryVariables,
 } from '../../graphql/generated';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
-import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+import {
+  findProjectRootAsync,
+  getProjectFullNameAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import {
   FormatUpdateParameter,
@@ -217,12 +220,8 @@ export default class ChannelView extends Command {
       throw new Error('Please run this command inside a project directory.');
     }
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    const accountName = await getProjectAccountNameAsync(exp);
-    const { slug } = exp;
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: slug,
-    });
+    const fullName = await getProjectFullNameAsync(exp);
+    const projectId = await getProjectIdAsync(exp);
 
     if (!channelName) {
       const validationMessage = 'A channel name is required to view a specific channel.';
@@ -252,7 +251,7 @@ export default class ChannelView extends Command {
     }
 
     Log.withTick(
-      chalk`Channel: {bold ${channel.name}} on project {bold ${accountName}/${slug}}. Channel ID: {bold ${channel.id}}`
+      chalk`Channel: {bold ${channel.name}} on project {bold ${fullName}}. Channel ID: {bold ${channel.id}}`
     );
     Log.log(
       chalk`{bold Branches, pointed at by this channel, and their most recent update group:}`

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -4,12 +4,15 @@ import chalk from 'chalk';
 
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
 import Log from '../../log';
-import { ensureProjectExistsAsync } from '../../project/ensureProjectExists';
 import {
   isEasEnabledForProjectAsync,
   warnEasUnavailable,
 } from '../../project/isEasEnabledForProject';
-import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+import {
+  findProjectRootAsync,
+  getProjectAccountNameAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { findAccountByName } from '../../user/Account';
 import { getActorDisplayName } from '../../user/User';
@@ -47,10 +50,7 @@ export default class EnvironmentSecretCreate extends Command {
     const accountName = await getProjectAccountNameAsync(exp);
 
     const { slug } = exp;
-    const projectId = await ensureProjectExistsAsync({
-      accountName,
-      projectName: slug,
-    });
+    const projectId = await getProjectIdAsync(exp);
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
       warnEasUnavailable();

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -5,7 +5,7 @@ import { asMock } from '../../../__tests__/utils';
 import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { AppPlatform, SubmissionFragment, SubmissionStatus } from '../../../graphql/generated';
 import { createTestProject } from '../../../project/__tests__/project-utils';
-import { ensureProjectExistsAsync } from '../../../project/ensureProjectExists';
+import { getProjectIdAsync } from '../../../project/projectUtils';
 import SubmissionService from '../../SubmissionService';
 import { AndroidArchiveType, AndroidSubmitCommandFlags } from '../../types';
 import { AndroidSubmissionConfig, ReleaseStatus, ReleaseTrack } from '../AndroidSubmissionConfig';
@@ -58,7 +58,7 @@ describe(AndroidSubmitCommand, () => {
   });
 
   afterEach(() => {
-    asMock(ensureProjectExistsAsync).mockClear();
+    asMock(getProjectIdAsync).mockClear();
   });
 
   describe('sending submission', () => {
@@ -88,7 +88,7 @@ describe(AndroidSubmitCommand, () => {
           };
         }
       );
-      asMock(ensureProjectExistsAsync).mockImplementationOnce(() => projectId);
+      asMock(getProjectIdAsync).mockImplementationOnce(() => projectId);
 
       const options: AndroidSubmitCommandFlags = {
         latest: false,

--- a/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
@@ -5,7 +5,7 @@ import { asMock } from '../../../__tests__/utils';
 import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { AppPlatform, SubmissionFragment, SubmissionStatus } from '../../../graphql/generated';
 import { createTestProject } from '../../../project/__tests__/project-utils';
-import { ensureProjectExistsAsync } from '../../../project/ensureProjectExists';
+import { getProjectIdAsync } from '../../../project/projectUtils';
 import SubmissionService from '../../SubmissionService';
 import { IosSubmitCommandFlags } from '../../types';
 import { IosSubmissionConfig } from '../IosSubmissionConfig';
@@ -53,7 +53,7 @@ describe(IosSubmitCommand, () => {
   });
 
   afterEach(() => {
-    asMock(ensureProjectExistsAsync).mockClear();
+    asMock(getProjectIdAsync).mockClear();
   });
 
   describe('sending submission', () => {
@@ -83,7 +83,7 @@ describe(IosSubmitCommand, () => {
           };
         }
       );
-      asMock(ensureProjectExistsAsync).mockImplementationOnce(() => projectId);
+      asMock(getProjectIdAsync).mockImplementationOnce(() => projectId);
 
       process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD = 'supersecret';
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

getProjectIdAsync is superior to ensureProjectExistsAsync as it will check to see if the ID is saved locally. This switch will reduce the number of network calls and make the CLI significantly "snappier",


# How

find/replace. Also made use of the `getFullName` util to further simplify code.

Would appreciate @FiberJW eyes on places I'm unfamiliar with usage in places like:
https://github.com/expo/eas-cli/blame/main/packages/eas-cli/src/commands/secret/create.ts#L50
in particular.

# Test Plan

tested various commands in a demo project.