### PR TITLE
[eas-cli] setup android build credentials with graphql

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -13294,13 +13294,9 @@
             "name": "fcmId",
             "description": "",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
             "defaultValue": null
           }

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -47,6 +47,7 @@
     "lodash": "4.17.20",
     "mime": "2.4.7",
     "minimatch": "3.0.4",
+    "nanoid": "3.1.23",
     "node-fetch": "2.6.1",
     "node-forge": "0.10.0",
     "nullthrows": "1.1.1",

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-android-new.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-android-new.ts
@@ -63,7 +63,15 @@ export const testAndroidAppCredentialsFragment: CommonAndroidAppCredentialsFragm
 export function getNewAndroidApiMockWithoutCredentials() {
   return {
     getAndroidAppCredentialsWithCommonFieldsAsync: jest.fn(),
+    getAndroidAppBuildCredentialsListAsync: jest.fn(() => []),
     getLegacyAndroidAppCredentialsWithCommonFieldsAsync: jest.fn(),
+    getLegacyAndroidAppBuildCredentialsAsync: jest.fn(),
+    createOrGetExistingAndroidAppCredentialsWithBuildCredentialsAsync: jest.fn(),
+    updateAndroidAppBuildCredentialsAsync: jest.fn(),
+    createAndroidAppBuildCredentialsAsync: jest.fn(),
+    getDefaultAndroidAppBuildCredentialsAsync: jest.fn(),
+    getAndroidAppBuildCredentialsByNameAsync: jest.fn(),
+    createOrUpdateAndroidAppBuildCredentialsByNameAsync: jest.fn(),
     createKeystoreAsync: jest.fn(),
   };
 }

--- a/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
@@ -66,5 +66,5 @@ export async function createOrUpdateDefaultAndroidAppBuildCredentialsAsync(
 }
 
 function generateRandomName(): string {
-  return `build-credentials-${nanoid(10)}`;
+  return `Build Credentials ${nanoid(10)}`;
 }

--- a/packages/eas-cli/src/credentials/android/actions/new/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/SetupBuildCredentials.ts
@@ -1,3 +1,5 @@
+import nullthrows from 'nullthrows';
+
 import {
   AndroidAppBuildCredentialsFragment,
   AndroidKeystoreFragment,
@@ -80,7 +82,9 @@ export class SetupBuildCredentials {
     );
     const defaultKeystore = defaultBuildCredentials?.androidKeystore ?? null;
     if (defaultKeystore) {
-      Log.log(`Using Keystore from configuration: ${defaultBuildCredentials?.name} (default)`);
+      Log.log(
+        `Using Keystore from configuration: ${nullthrows(defaultBuildCredentials).name} (default)`
+      );
       return defaultBuildCredentials;
     }
 
@@ -105,22 +109,23 @@ export class SetupBuildCredentials {
     app: AppLookupParams;
     name: string;
   }): Promise<AndroidAppBuildCredentialsFragment | null> {
-    const buildCredentials = await ctx.newAndroid.getAndroidAppBuildCredentialsByNameAsync(
+    const maybeBuildCredentials = await ctx.newAndroid.getAndroidAppBuildCredentialsByNameAsync(
       app,
       name
     );
-    const keystore = buildCredentials?.androidKeystore ?? null;
+    const keystore = maybeBuildCredentials?.androidKeystore ?? null;
     if (keystore) {
+      const buildCredentials = nullthrows(maybeBuildCredentials);
       Log.log(
-        `Using Keystore from configuration: ${buildCredentials?.name}${
-          buildCredentials?.isDefault ? ' (default)' : ''
+        `Using Keystore from configuration: ${buildCredentials.name}${
+          buildCredentials.isDefault ? ' (default)' : ''
         }`
       );
       return buildCredentials;
     }
     Log.log(
-      `No Keystore found for configuration: ${buildCredentials?.name}${
-        buildCredentials?.isDefault ? ' (default)' : ''
+      `No Keystore found for configuration: ${name}${
+        maybeBuildCredentials?.isDefault ? ' (default)' : ''
       }`
     );
     return null;

--- a/packages/eas-cli/src/credentials/android/actions/new/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/SetupBuildCredentials.ts
@@ -1,0 +1,128 @@
+import {
+  AndroidAppBuildCredentialsFragment,
+  AndroidKeystoreFragment,
+} from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { Context } from '../../../context';
+import { MissingCredentialsNonInteractiveError } from '../../../errors';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { createOrUpdateDefaultAndroidAppBuildCredentialsAsync } from '../BuildCredentialsUtils';
+import { CreateKeystore } from './CreateKeystore';
+
+interface Options {
+  app: AppLookupParams;
+  name?: string;
+}
+
+/**
+ * Sets up Build Credentials for Android
+ * @name: sets up build credentials for the specified configuration. If no name is specified, the default configuration is setup
+ */
+export class SetupBuildCredentials {
+  constructor(private options: Options) {}
+
+  async runAsync(ctx: Context): Promise<AndroidAppBuildCredentialsFragment> {
+    const { app, name: maybeName } = this.options;
+    const alreadySetupBuildCredentials = await this.getFullySetupBuildCredentialsAsync({
+      ctx,
+      app,
+      name: maybeName,
+    });
+    if (alreadySetupBuildCredentials) {
+      return alreadySetupBuildCredentials;
+    }
+    if (ctx.nonInteractive) {
+      throw new MissingCredentialsNonInteractiveError(
+        'Generating a new Keystore is not supported in --non-interactive mode'
+      );
+    }
+
+    const keystore = await new CreateKeystore(app.account).runAsync(ctx);
+    return await this.assignBuildCredentialsAsync({ ctx, app, name: maybeName, keystore });
+  }
+
+  async assignBuildCredentialsAsync({
+    ctx,
+    app,
+    name,
+    keystore,
+  }: {
+    ctx: Context;
+    app: AppLookupParams;
+    name?: string;
+    keystore: AndroidKeystoreFragment;
+  }): Promise<AndroidAppBuildCredentialsFragment> {
+    if (name) {
+      return await ctx.newAndroid.createOrUpdateAndroidAppBuildCredentialsByNameAsync(app, name, {
+        androidKeystoreId: keystore.id,
+      });
+    }
+    return await createOrUpdateDefaultAndroidAppBuildCredentialsAsync(ctx, app, {
+      androidKeystoreId: keystore.id,
+    });
+  }
+
+  async getFullySetupBuildCredentialsAsync({
+    ctx,
+    app,
+    name,
+  }: {
+    ctx: Context;
+    app: AppLookupParams;
+    name?: string;
+  }): Promise<AndroidAppBuildCredentialsFragment | null> {
+    if (name) {
+      return await this.getFullySetupBuildCredentialsByNameAsync({ ctx, app, name });
+    }
+
+    const defaultBuildCredentials = await ctx.newAndroid.getDefaultAndroidAppBuildCredentialsAsync(
+      app
+    );
+    const defaultKeystore = defaultBuildCredentials?.androidKeystore ?? null;
+    if (defaultKeystore) {
+      Log.log(`Using Keystore from configuration: ${defaultBuildCredentials?.name} (default)`);
+      return defaultBuildCredentials;
+    }
+
+    // fall back to legacy credentials if we cant find a default keystore
+    const legacyBuildCredentials = await ctx.newAndroid.getLegacyAndroidAppBuildCredentialsAsync(
+      app
+    );
+    const legacyKeystore = legacyBuildCredentials?.androidKeystore ?? null;
+    if (legacyKeystore) {
+      Log.log('Using Keystore ported from Expo Classic (expo-cli)');
+      return legacyBuildCredentials;
+    }
+    return null;
+  }
+
+  async getFullySetupBuildCredentialsByNameAsync({
+    ctx,
+    app,
+    name,
+  }: {
+    ctx: Context;
+    app: AppLookupParams;
+    name: string;
+  }): Promise<AndroidAppBuildCredentialsFragment | null> {
+    const buildCredentials = await ctx.newAndroid.getAndroidAppBuildCredentialsByNameAsync(
+      app,
+      name
+    );
+    const keystore = buildCredentials?.androidKeystore ?? null;
+    if (keystore) {
+      Log.log(
+        `Using Keystore from configuration: ${buildCredentials?.name}${
+          buildCredentials?.isDefault ? ' (default)' : ''
+        }`
+      );
+      return buildCredentials;
+    }
+    Log.log(
+      `No Keystore found for configuration: ${buildCredentials?.name}${
+        buildCredentials?.isDefault ? ' (default)' : ''
+      }`
+    );
+    return null;
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/new/__tests__/SetupBuildCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/__tests__/SetupBuildCredentials-test.ts
@@ -1,0 +1,92 @@
+import { confirmAsync, promptAsync } from '../../../../../prompts';
+import {
+  getNewAndroidApiMockWithoutCredentials,
+  testAndroidBuildCredentialsFragment,
+  testJksAndroidKeystoreFragment,
+  testLegacyAndroidBuildCredentialsFragment,
+} from '../../../../__tests__/fixtures-android-new';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
+import { MissingCredentialsNonInteractiveError } from '../../../../errors';
+import { getAppLookupParamsFromContext } from '../../BuildCredentialsUtils';
+import { SetupBuildCredentials } from '../SetupBuildCredentials';
+
+jest.mock('../../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+
+const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+beforeAll(() => {
+  console.log = jest.fn();
+  console.warn = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+  console.warn = originalConsoleWarn;
+});
+
+describe('SetupBuildCredentials', () => {
+  it('skips setup when there are prior legacy credentials', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      newAndroid: {
+        ...getNewAndroidApiMockWithoutCredentials(),
+        getLegacyAndroidAppBuildCredentialsAsync: jest.fn(
+          () => testLegacyAndroidBuildCredentialsFragment
+        ),
+      },
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsAction = new SetupBuildCredentials({ app: appLookupParams });
+    await setupBuildCredentialsAction.runAsync(ctx);
+
+    // expect keystore not to be created
+    expect(ctx.newAndroid.createKeystoreAsync as any).toHaveBeenCalledTimes(0);
+  });
+  it('skips setup when there are prior credentials', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      newAndroid: {
+        ...getNewAndroidApiMockWithoutCredentials(),
+        getDefaultAndroidAppBuildCredentialsAsync: jest.fn(
+          () => testAndroidBuildCredentialsFragment
+        ),
+      },
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsAction = new SetupBuildCredentials({ app: appLookupParams });
+    await setupBuildCredentialsAction.runAsync(ctx);
+
+    // expect keystore not to be created
+    expect(ctx.newAndroid.createKeystoreAsync as any).toHaveBeenCalledTimes(0);
+  });
+  it('sets up credentials when there are no prior credentials', async () => {
+    (promptAsync as jest.Mock).mockImplementation(() => ({ providedName: 'test-provided-name' }));
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      newAndroid: {
+        ...getNewAndroidApiMockWithoutCredentials(),
+        createKeystoreAsync: jest.fn(() => testJksAndroidKeystoreFragment),
+      },
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsAction = new SetupBuildCredentials({ app: appLookupParams });
+    await setupBuildCredentialsAction.runAsync(ctx);
+
+    // expect keystore to be created
+    expect(ctx.newAndroid.createKeystoreAsync as any).toHaveBeenCalledTimes(1);
+  });
+  it('errors in Non-Interactive Mode', async () => {
+    (promptAsync as jest.Mock).mockImplementation(() => ({ providedName: 'test-provided-name' }));
+    const ctx = createCtxMock({
+      nonInteractive: true,
+      newAndroid: {
+        ...getNewAndroidApiMockWithoutCredentials(),
+      },
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsAction = new SetupBuildCredentials({ app: appLookupParams });
+    await expect(setupBuildCredentialsAction.runAsync(ctx)).rejects.toThrowError(
+      MissingCredentialsNonInteractiveError
+    );
+  });
+});

--- a/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
@@ -114,7 +114,7 @@ export async function createAndroidAppBuildCredentialsAsync(
   const buildCredentialsList = androidAppCredentials.androidAppBuildCredentialsList;
   const existingDefaultBuildCredentials =
     buildCredentialsList.find(buildCredentials => buildCredentials.isDefault) ?? null;
-  if (existingDefaultBuildCredentials) {
+  if (existingDefaultBuildCredentials && isDefault) {
     throw new Error(
       'Cannot create new default Android Build Credentials. A set of default credentials exists already.'
     );

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppBuildCredentialsMutation.ts
@@ -4,8 +4,8 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
-  AndroidAppBuildCredentials,
   AndroidAppBuildCredentialsFragment,
+  CreateAndroidAppBuildCredentialsMutation,
   SetKeystoreMutation,
 } from '../../../../../graphql/generated';
 import { AndroidAppBuildCredentialsFragmentNode } from '../../../../../graphql/types/credentials/AndroidAppBuildCredentials';
@@ -18,14 +18,10 @@ const AndroidAppBuildCredentialsMutation = {
       keystoreId: string;
     },
     androidAppCredentialsId: string
-  ): Promise<AndroidAppBuildCredentials> {
+  ): Promise<AndroidAppBuildCredentialsFragment> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .mutation<{
-          androidAppBuildCredentials: {
-            createAndroidAppBuildCredentials: AndroidAppBuildCredentials;
-          };
-        }>(
+        .mutation<CreateAndroidAppBuildCredentialsMutation>(
           gql`
             mutation CreateAndroidAppBuildCredentialsMutation(
               $androidAppBuildCredentialsInput: AndroidAppBuildCredentialsInput!
@@ -49,6 +45,10 @@ const AndroidAppBuildCredentialsMutation = {
           }
         )
         .toPromise()
+    );
+    assert(
+      data.androidAppBuildCredentials.createAndroidAppBuildCredentials,
+      'GraphQL: `createAndroidAppBuildCredentials` not defined in server response'
     );
     return data.androidAppBuildCredentials.createAndroidAppBuildCredentials;
   },

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppBuildCredentialsMutation.ts
@@ -1,0 +1,88 @@
+import assert from 'assert';
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import {
+  AndroidAppBuildCredentials,
+  AndroidAppBuildCredentialsFragment,
+  SetKeystoreMutation,
+} from '../../../../../graphql/generated';
+import { AndroidAppBuildCredentialsFragmentNode } from '../../../../../graphql/types/credentials/AndroidAppBuildCredentials';
+
+const AndroidAppBuildCredentialsMutation = {
+  async createAndroidAppBuildCredentialsAsync(
+    androidAppBuildCredentialsInput: {
+      isDefault: boolean;
+      name: string;
+      keystoreId: string;
+    },
+    androidAppCredentialsId: string
+  ): Promise<AndroidAppBuildCredentials> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<{
+          androidAppBuildCredentials: {
+            createAndroidAppBuildCredentials: AndroidAppBuildCredentials;
+          };
+        }>(
+          gql`
+            mutation CreateAndroidAppBuildCredentialsMutation(
+              $androidAppBuildCredentialsInput: AndroidAppBuildCredentialsInput!
+              $androidAppCredentialsId: ID!
+            ) {
+              androidAppBuildCredentials {
+                createAndroidAppBuildCredentials(
+                  androidAppBuildCredentialsInput: $androidAppBuildCredentialsInput
+                  androidAppCredentialsId: $androidAppCredentialsId
+                ) {
+                  id
+                  ...AndroidAppBuildCredentialsFragment
+                }
+              }
+            }
+            ${print(AndroidAppBuildCredentialsFragmentNode)}
+          `,
+          {
+            androidAppBuildCredentialsInput,
+            androidAppCredentialsId,
+          }
+        )
+        .toPromise()
+    );
+    return data.androidAppBuildCredentials.createAndroidAppBuildCredentials;
+  },
+  async setKeystoreAsync(
+    androidAppBuildCredentialsId: string,
+    keystoreId: string
+  ): Promise<AndroidAppBuildCredentialsFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<SetKeystoreMutation>(
+          gql`
+            mutation SetKeystoreMutation($androidAppBuildCredentialsId: ID!, $keystoreId: ID!) {
+              androidAppBuildCredentials {
+                setKeystore(id: $androidAppBuildCredentialsId, keystoreId: $keystoreId) {
+                  id
+                  ...AndroidAppBuildCredentialsFragment
+                }
+              }
+            }
+            ${print(AndroidAppBuildCredentialsFragmentNode)}
+          `,
+          {
+            androidAppBuildCredentialsId,
+            keystoreId,
+          }
+        )
+        .toPromise()
+    );
+    assert(
+      data.androidAppBuildCredentials.setKeystore,
+      'GraphQL: `setKeystore` not defined in server response'
+    );
+    return data.androidAppBuildCredentials.setKeystore;
+  },
+};
+
+export { AndroidAppBuildCredentialsMutation };

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppCredentialsMutation.ts
@@ -1,0 +1,58 @@
+import assert from 'assert';
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import {
+  CommonAndroidAppCredentialsFragment,
+  CreateAndroidAppCredentialsMutation,
+} from '../../../../../graphql/generated';
+import { CommonAndroidAppCredentialsFragmentNode } from '../../../../../graphql/types/credentials/AndroidAppCredentials';
+
+const AndroidAppCredentialsMutation = {
+  async createAndroidAppCredentialsAsync(
+    androidAppCredentialsInput: {
+      fcmId?: string;
+    },
+    appId: string,
+    applicationIdentifier: string
+  ): Promise<CommonAndroidAppCredentialsFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateAndroidAppCredentialsMutation>(
+          gql`
+            mutation CreateAndroidAppCredentialsMutation(
+              $androidAppCredentialsInput: AndroidAppCredentialsInput!
+              $appId: ID!
+              $applicationIdentifier: String!
+            ) {
+              androidAppCredentials {
+                createAndroidAppCredentials(
+                  androidAppCredentialsInput: $androidAppCredentialsInput
+                  appId: $appId
+                  applicationIdentifier: $applicationIdentifier
+                ) {
+                  id
+                  ...CommonAndroidAppCredentialsFragment
+                }
+              }
+            }
+            ${print(CommonAndroidAppCredentialsFragmentNode)}
+          `,
+          {
+            androidAppCredentialsInput,
+            appId,
+            applicationIdentifier,
+          }
+        )
+        .toPromise()
+    );
+    assert(
+      data.androidAppCredentials.createAndroidAppCredentials,
+      'GraphQL: `createAndroidAppCredentials` not defined in server response'
+    );
+    return data.androidAppCredentials.createAndroidAppCredentials;
+  },
+};
+
+export { AndroidAppCredentialsMutation };

--- a/packages/eas-cli/src/credentials/errors.ts
+++ b/packages/eas-cli/src/credentials/errors.ts
@@ -1,0 +1,7 @@
+export class MissingCredentialsNonInteractiveError extends Error {
+  constructor(message?: string) {
+    super(
+      message ?? 'Credentials are not set up. Please run this command again in interactive mode.'
+    );
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -8,11 +8,11 @@ import {
 } from '../../../graphql/generated';
 import Log from '../../../log';
 import { Context } from '../../context';
+import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
 import { AppleProvisioningProfileMutationResult } from '../api/graphql/mutations/AppleProvisioningProfileMutation';
 import { ProvisioningProfileStoreInfo } from '../appstore/Credentials.types';
 import { AuthCtx } from '../appstore/authenticate';
-import { MissingCredentialsNonInteractiveError } from '../errors';
 
 export class ConfigureProvisioningProfile {
   constructor(

--- a/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
@@ -4,13 +4,13 @@ import nullthrows from 'nullthrows';
 import { AppleDistributionCertificateFragment } from '../../../graphql/generated';
 import Log from '../../../log';
 import { Context } from '../../context';
+import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { askForUserProvidedAsync } from '../../utils/promptForCredentials';
 import { AppLookupParams } from '../api/GraphqlClient';
 import { AppleProvisioningProfileMutationResult } from '../api/graphql/mutations/AppleProvisioningProfileMutation';
 import { ProvisioningProfile } from '../appstore/Credentials.types';
 import { AuthCtx } from '../appstore/authenticate';
 import { provisioningProfileSchema } from '../credentials';
-import { MissingCredentialsNonInteractiveError } from '../errors';
 import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
 import { generateProvisioningProfileAsync } from './ProvisioningProfileUtils';
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupAdhocProvisioningProfile.ts
@@ -16,8 +16,8 @@ import {
 import Log from '../../../log';
 import { confirmAsync, pressAnyKeyToContinueAsync } from '../../../prompts';
 import { Context } from '../../context';
+import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
-import { MissingCredentialsNonInteractiveError } from '../errors';
 import { validateProvisioningProfileAsync } from '../validators/validateProvisioningProfile';
 import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
 import { assignBuildCredentialsAsync, getBuildCredentialsAsync } from './BuildCredentialsUtils';

--- a/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
@@ -9,10 +9,11 @@ import {
 import Log from '../../../log';
 import { confirmAsync, promptAsync } from '../../../prompts';
 import { Context } from '../../context';
+import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
 import { AppleDistributionCertificateMutationResult } from '../api/graphql/mutations/AppleDistributionCertificateMutation';
 import { getValidCertSerialNumbers } from '../appstore/CredentialsUtils';
-import { AppleTeamMissingError, MissingCredentialsNonInteractiveError } from '../errors';
+import { AppleTeamMissingError } from '../errors';
 import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
 import { CreateDistributionCertificate } from './CreateDistributionCertificate';
 import { formatDistributionCertificate } from './DistributionCertificateUtils';

--- a/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupProvisioningProfile.ts
@@ -8,9 +8,9 @@ import {
 } from '../../../graphql/generated';
 import { confirmAsync } from '../../../prompts';
 import { Context } from '../../context';
+import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
 import { ProvisioningProfileStoreInfo } from '../appstore/Credentials.types';
-import { MissingCredentialsNonInteractiveError } from '../errors';
 import { validateProvisioningProfileAsync } from '../validators/validateProvisioningProfile';
 import {
   assignBuildCredentialsAsync,

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/ConfigureProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/ConfigureProvisioningProfile-test.ts
@@ -6,7 +6,7 @@ import {
   testProvisioningProfile,
   testProvisioningProfileFragment,
 } from '../../../__tests__/fixtures-ios';
-import { MissingCredentialsNonInteractiveError } from '../../errors';
+import { MissingCredentialsNonInteractiveError } from '../../../errors';
 import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { ConfigureProvisioningProfile } from '../ConfigureProvisioningProfile';
 jest.mock('../../../../prompts');

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateProvisioningProfile-test.ts
@@ -5,7 +5,7 @@ import {
   testDistCertFragmentNoDependencies,
   testProvisioningProfile,
 } from '../../../__tests__/fixtures-ios';
-import { MissingCredentialsNonInteractiveError } from '../../errors';
+import { MissingCredentialsNonInteractiveError } from '../../../errors';
 import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { CreateProvisioningProfile } from '../CreateProvisioningProfile';
 jest.mock('../../../../prompts');

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupProvisioningProfile-test.ts
@@ -10,7 +10,7 @@ import {
   testIosAppBuildCredentialsFragment,
   testIosAppCredentialsWithBuildCredentialsQueryResult,
 } from '../../../__tests__/fixtures-ios';
-import { MissingCredentialsNonInteractiveError } from '../../errors';
+import { MissingCredentialsNonInteractiveError } from '../../../errors';
 import { validateProvisioningProfileAsync } from '../../validators/validateProvisioningProfile';
 import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { SetupProvisioningProfile } from '../SetupProvisioningProfile';

--- a/packages/eas-cli/src/credentials/ios/errors.ts
+++ b/packages/eas-cli/src/credentials/ios/errors.ts
@@ -3,11 +3,3 @@ export class AppleTeamMissingError extends Error {
     super(message ?? 'Apple Team is necessary to create Apple App Identifier');
   }
 }
-
-export class MissingCredentialsNonInteractiveError extends Error {
-  constructor(message?: string) {
-    super(
-      message ?? 'Credentials are not set up. Please run this command again in interactive mode.'
-    );
-  }
-}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3574,6 +3574,61 @@ export type UpdatesByGroupQuery = (
   )> }
 );
 
+export type CreateAndroidAppBuildCredentialsMutationVariables = Exact<{
+  androidAppBuildCredentialsInput: AndroidAppBuildCredentialsInput;
+  androidAppCredentialsId: Scalars['ID'];
+}>;
+
+
+export type CreateAndroidAppBuildCredentialsMutation = (
+  { __typename?: 'RootMutation' }
+  & { androidAppBuildCredentials: (
+    { __typename?: 'AndroidAppBuildCredentialsMutation' }
+    & { createAndroidAppBuildCredentials?: Maybe<(
+      { __typename?: 'AndroidAppBuildCredentials' }
+      & Pick<AndroidAppBuildCredentials, 'id'>
+      & AndroidAppBuildCredentialsFragment
+    )> }
+  ) }
+);
+
+export type SetKeystoreMutationVariables = Exact<{
+  androidAppBuildCredentialsId: Scalars['ID'];
+  keystoreId: Scalars['ID'];
+}>;
+
+
+export type SetKeystoreMutation = (
+  { __typename?: 'RootMutation' }
+  & { androidAppBuildCredentials: (
+    { __typename?: 'AndroidAppBuildCredentialsMutation' }
+    & { setKeystore?: Maybe<(
+      { __typename?: 'AndroidAppBuildCredentials' }
+      & Pick<AndroidAppBuildCredentials, 'id'>
+      & AndroidAppBuildCredentialsFragment
+    )> }
+  ) }
+);
+
+export type CreateAndroidAppCredentialsMutationVariables = Exact<{
+  androidAppCredentialsInput: AndroidAppCredentialsInput;
+  appId: Scalars['ID'];
+  applicationIdentifier: Scalars['String'];
+}>;
+
+
+export type CreateAndroidAppCredentialsMutation = (
+  { __typename?: 'RootMutation' }
+  & { androidAppCredentials: (
+    { __typename?: 'AndroidAppCredentialsMutation' }
+    & { createAndroidAppCredentials?: Maybe<(
+      { __typename?: 'AndroidAppCredentials' }
+      & Pick<AndroidAppCredentials, 'id'>
+      & CommonAndroidAppCredentialsFragment
+    )> }
+  ) }
+);
+
 export type CreateAndroidKeystoreMutationVariables = Exact<{
   androidKeystoreInput: AndroidKeystoreInput;
   accountId: Scalars['ID'];

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1991,7 +1991,7 @@ export type AndroidAppCredentialsMutationSetFcmArgs = {
 };
 
 export type AndroidAppCredentialsInput = {
-  fcmId: Scalars['ID'];
+  fcmId?: Maybe<Scalars['ID']>;
 };
 
 export type AndroidFcmMutation = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9055,6 +9055,11 @@ mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
+nanoid@^3.1.23:
+  version "3.1.23"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
+  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9055,7 +9055,7 @@ mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^3.1.23:
+nanoid@3.1.23:
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
   integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to create a new keystore using the new Graphql Api. This is what will eventually replace the old `SetupBuildCredentials` here:  https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/android/actions/SetupBuildCredentials.ts

# How
### Default behaviour: 
1. If user has legacy or modern default credentials, return that
2. If user has no credentials setup, set up some modern default credentials

### Specified name behaviour: 
If user specifies a named configuration to setup, we do the following: 
1. If user has credentials setup under the named configuration, return that
2. Else set up some credentials under the named configuration

### concept of named configuration
![Screen Shot 2021-05-12 at 6 31 08 PM](https://user-images.githubusercontent.com/6380927/118064808-98f6d180-b350-11eb-9597-19d3c8b9b55b.png)

In the modern android credentials setup, we have the concept of unique 'configuration names'. For example, if someone wanted to submit their app to the Google Play store and the Huawei App Store, they would generate a keystore for each Android Store. Eventually, we'd like to allow the user to specify which configuration name they want to use for their build

# Test Plan

- [x] new tests pass
- [ ] do manual testing
