### PR TITLE
[eas-json] Include development-client in valid buildType for internal distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Pin versions in package.json. ([#399](https://github.com/expo/eas-cli/pull/399) by [@dsokal](https://github.com/dsokal))
 - Revert [0ac2f](https://github.com/expo/eas-cli/commit/0ac2fb77a118df609381c4e350aa68609340c3cd) as the root cause of the issue has been fixed in [#399](https://github.com/expo/eas-cli/pull/399).
+- Include development-client in valid buildType for internal distribution. ([#410](https://github.com/expo/eas-cli/pull/410) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -61,7 +61,7 @@ const AndroidManagedSchema = Joi.object({
   releaseChannel: Joi.string(),
   buildType: Joi.alternatives().conditional('distribution', {
     is: 'internal',
-    then: Joi.string().valid('apk').default('apk'),
+    then: Joi.string().valid('apk', 'development-client').default('apk'),
     otherwise: Joi.string().valid('apk', 'app-bundle', 'development-client').default('app-bundle'),
   }),
   distribution: Joi.string().valid('store', 'internal').default('store'),

--- a/packages/eas-json/src/__tests__/EasJsonReader-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-test.ts
@@ -248,7 +248,7 @@ test('invalid managed profile for internal distribution on Android', async () =>
   const reader = new EasJsonReader('/project', 'android');
   const promise = reader.readAsync('internal');
   await expect(promise).rejects.toThrowError(
-    'Object "android.internal" in eas.json is not valid [ValidationError: "buildType" must be [apk]]'
+    'Object "android.internal" in eas.json is not valid [ValidationError: "buildType" must be one of [apk, development-client]]'
   );
 });
 


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

It is intended to be possible to do ` development-client` build when using `distribution: internal`

# How

Update the eas.json validation to allow this.

# Test Plan

Run a build using local eas-cli with these changes using this config:

```json
"development": {
  "workflow": "managed",
  "distribution": "internal",
  "buildType": "development-client"
}
```