### PR TITLE
Bump @expo/apple-utils@0.0.0-alpha.20 to support Apple server errors

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@amplitude/identify": "1.5.0",
     "@amplitude/node": "1.5.0",
-    "@expo/apple-utils": "0.0.0-alpha.19",
+    "@expo/apple-utils": "0.0.0-alpha.20",
     "@expo/config": "3.3.19",
     "@expo/config-plugins": "1.0.31",
     "@expo/eas-build-job": "0.2.33",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,10 +1107,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/apple-utils@0.0.0-alpha.19":
-  version "0.0.0-alpha.19"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.19.tgz#9cbdef847f194e30f5289b7621dc1d3ab3015998"
-  integrity sha512-j+VNmrOn0LKlzzMrtU0HhIrw1WBZyY7bXCu7iq7sYhHsDUX2zB91uyTbY7x2rvYgOIZqHDpDpvDaZaU92Kd/kQ==
+"@expo/apple-utils@0.0.0-alpha.20":
+  version "0.0.0-alpha.20"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.20.tgz#cbc92e4c7e8754b051b7293af60a55a550fb6583"
+  integrity sha512-L/M9NPNlT1e38whA3M4QdnIDCClj6Y2GPXFOxBxuwzlmh847RHwZ/ojJpVP8sLVC+is54DS1hU9vtDkiPHGPRw==
 
 "@expo/babel-preset-cli@0.2.18", "@expo/babel-preset-cli@^0.2.17":
   version "0.2.18"


### PR DESCRIPTION
- Supports a new apple server error, prevents throwing an invalid credential error when Apple servers are down.
- https://github.com/expo/expo-cli/pull/3496