### PR TITLE
[eas-cli] put projectId caching behind EAS_ENABLE_PROJECT_ID flag

### DIFF
--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -111,6 +111,14 @@ export async function setProjectIdAsync(projectDir: string): Promise<ExpoConfig 
 }
 
 export async function getProjectIdAsync(exp: ExpoConfig): Promise<string> {
+  if (!process.env.EAS_ENABLE_PROJECT_ID) {
+    const privacy = toAppPrivacy(exp.privacy);
+    return await ensureProjectExistsAsync({
+      accountName: getProjectAccountName(exp, await ensureLoggedInAsync()),
+      projectName: exp.slug,
+      privacy,
+    });
+  }
   const localProjectId = exp.extra?.eas?.projectId;
   if (localProjectId) {
     return localProjectId;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

Put the projectId caching to app.json (introduced in https://github.com/expo/eas-cli/commit/09682754f89fc675b8262100eca05b1b8bf09fa4) behind a flag until we roll out a better user UX for dealing the the projectId.


# Test Plan

In demo project confirmed that `eas branch:publish` queries graphql for the projectId each time instead of attempting to read it from app.json. Both when there is an `eas.projectId` key and when there is not.

confirmed it saves and queries the projectId when the flag is set.