### PR TITLE
[eas-cli] fix bug when publishing without platform flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix failure when publishing without the platform flag.  ([#415](https://github.com/expo/eas-cli/pull/415) by [@jkhales](https://github.com/jkhales))
 - Pin versions in package.json. ([#399](https://github.com/expo/eas-cli/pull/399) by [@dsokal](https://github.com/dsokal))
 - Revert [0ac2f](https://github.com/expo/eas-cli/commit/0ac2fb77a118df609381c4e350aa68609340c3cd) as the root cause of the issue has been fixed in [#399](https://github.com/expo/eas-cli/pull/399).
 - Include development-client in valid buildType for internal distribution. ([#410](https://github.com/expo/eas-cli/pull/410) by [@brentvatne](https://github.com/brentvatne))

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -237,9 +237,7 @@ export default class BranchPublish extends Command {
 
       const assetSpinner = ora('Uploading assets...').start();
       try {
-        const platforms = platformFlag
-          ? [platformFlag as PublishPlatform]
-          : defaultPublishPlatforms;
+        const platforms = platformFlag === 'all' ? defaultPublishPlatforms : [platformFlag];
         const assets = collectAssets({ inputDir: inputDir!, platforms });
         await uploadAssetsAsync(assets);
         updateInfoGroup = await buildUpdateInfoGroupAsync(assets);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

publishing without platform flag fails

# How

substitute `defaultPlatforms` for `all` appropriately.

When this command was made initially, we didn't default to 'all' so this check was looking for an `undefined`.

# Test Plan

Tested in demo repo, no flag and each different possible flag.

```
eas branch:publish main
eas branch:publish main --platform all
eas branch:publish main --platform android
eas branch:publish main --platform ios
```