### PR TITLE
[eas-cli] make republish work smoothly with different platforms

### DIFF
--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -208,7 +208,7 @@ export default class BranchPublish extends Command {
           }));
         if (updateGroups.length === 0) {
           throw new Error(
-            `There are no updates on branch "${name}" published on the platform(s) ${platformFlag}. Did you mean to do a regular publish?`
+            `There are no updates on branch "${name}" published on the platform(s) ${platformFlag}. Did you mean to publish a new update instead?`
           );
         }
 
@@ -226,7 +226,7 @@ export default class BranchPublish extends Command {
         throw new Error(
           `There are no updates on branch "${name}" published on the platform(s) "${platformFlag}" with group ID "${
             group ? group : updatesToRepublish[0].group
-          }". Did you mean to do a regular publish?`
+          }". Did you mean to publish a new update instead?`
         );
       }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

There are complexities when republishing an update group to a different set of platforms that is was originally published to.

# How

* republishing to a super set: log a warning that the original updateGroup was not published for all platforms
* republishing to a platform that does not exist on the original: throw an error
* add a Log.withTick describing the platforms to which we are republishing.

# Test Plan

On a demo repo:

select an update that was only published to one platform:

<img width="1204" alt="Screen Shot 2021-05-20 at 9 00 10 AM" src="https://user-images.githubusercontent.com/1220444/119011309-c98acc80-b949-11eb-8184-a6ace505d04d.png">

attempt to republish a group that was published to a disjoint set of platforms:

<img width="1444" alt="Screen Shot 2021-05-20 at 9 01 34 AM" src="https://user-images.githubusercontent.com/1220444/119011505-fc34c500-b949-11eb-92ad-e053684b47a3.png">

publish to a group with an equal set of platforms:

<img width="1204" alt="Screen Shot 2021-05-20 at 9 02 15 AM" src="https://user-images.githubusercontent.com/1220444/119011603-1373b280-b94a-11eb-9c25-060e4a017deb.png">

interactive prompt filters by platform correctly:
<img width="716" alt="Screen Shot 2021-05-20 at 9 03 30 AM" src="https://user-images.githubusercontent.com/1220444/119011801-40c06080-b94a-11eb-8abe-4cfd10d682d5.png">
<img width="637" alt="Screen Shot 2021-05-20 at 9 03 49 AM" src="https://user-images.githubusercontent.com/1220444/119011849-4b7af580-b94a-11eb-9b80-5b03de74ee7d.png">

