### PR TITLE
Move updating the release on Github to after the release is completed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 1. Run `yarn release` in the repository root folder. This will create a new tag like `v1.0.0`.
 1. **Wait until the `release` GitHub workflow has finished.**
    ![Wait for all three jobs to complete](./.gh-assets/release-workflow.png)
-1. Once the release is ready to go, you can go to https://github.com/expo/eas-cli/releases and mark it as not draft.
-   - Remember to copy the changelog entries from `CHANGELOG.md`.
-   - Before hitting the submit button, make sure there are 5 assets available under the release entry.
-     ![There are 5 assets for each release](./.gh-assets/draft-release.png)
 1. Run `yarn lerna publish from-git` in the repository root folder. This will publish the packages to npm.
 
    - This command works only if `HEAD` is on the release commit, e.g. when `git log -1` prints:
@@ -31,6 +27,10 @@
 1. Update `CHANGELOG.md`.
    - Add the new section with the release version in the title.
    - Leave the `main` section empty (without any changelog entries).
+1. Once the release is ready to go, you can go to https://github.com/expo/eas-cli/releases and mark it as not draft.
+   - Remember to copy the changelog entries from `CHANGELOG.md`.
+   - Before hitting the submit button, make sure there are 5 assets available under the release entry.
+     ![There are 5 assets for each release](./.gh-assets/draft-release.png)
 1. If any of the changelog entries have been tagged with `[EAS BUILD API]`
    - Open `package.json` and note the version of `@expo/eas-build-job` used in the eas-cli.
    - Find the `Publish` commit in [expo/eas-build](https://github.com/expo/eas-build/commit/) for that version. In most cases, it will be the latest `Publish` commit.


### PR DESCRIPTION
# Why

Currently the contributing guide reads a bit strangely because we recommend copying the changelog over to the release on Github and marking it as released before updating the changelog in the repo or publishing.

# How

I moved the Github release update to after the "Update `CHANGELOG.md` step

# Test Plan

I followed these steps for 0.15.0