### PR TITLE
fix sending `appBuildVersion` to api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix sending `appBuildVersion` as part of the build metadata. ([#423](https://github.com/expo/eas-cli/pull/423) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [0.15.0](https://github.com/expo/eas-cli/releases/tag/v0.15.0) - 2021-05-20

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1885,6 +1885,30 @@
             "deprecationReason": null
           },
           {
+            "name": "appleAppSpecificPasswords",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppleAppSpecificPassword",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "environmentSecrets",
             "description": "Environment secrets for an account",
             "args": [
@@ -4090,6 +4114,18 @@
           },
           {
             "name": "appVersion",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appBuildVersion",
             "description": "",
             "args": [],
             "type": {
@@ -6704,6 +6740,18 @@
             "deprecationReason": null
           },
           {
+            "name": "appSpecificPassword",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AppleAppSpecificPassword",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "iosAppBuildCredentialsArray",
             "description": "",
             "args": [
@@ -7875,6 +7923,109 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppleAppSpecificPassword",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "account",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appleIdUsername",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "passwordLabel",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -11712,6 +11863,22 @@
             "deprecationReason": null
           },
           {
+            "name": "appleAppSpecificPassword",
+            "description": "Mutations that modify an App Specific Password for an Apple User Account",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppleAppSpecificPasswordMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "appleDevice",
             "description": "Mutations that modify an Apple Device",
             "args": [],
@@ -13744,6 +13911,111 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppleAppSpecificPasswordMutation",
+        "description": "",
+        "fields": [
+          {
+            "name": "createAppleAppSpecificPassword",
+            "description": "Create an App Specific Password for an Apple User Account",
+            "args": [
+              {
+                "name": "appleAppSpecificPasswordInput",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppleAppSpecificPasswordInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "accountId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppleAppSpecificPassword",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppleAppSpecificPasswordInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appleIdUsername",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "passwordLabel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "appSpecificPassword",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppleDeviceMutation",
         "description": "",
         "fields": [
@@ -15704,6 +15976,16 @@
           },
           {
             "name": "appVersion",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "appBuildVersion",
             "description": "",
             "type": {
               "kind": "SCALAR",

--- a/packages/eas-cli/src/build/graphql.ts
+++ b/packages/eas-cli/src/build/graphql.ts
@@ -27,18 +27,10 @@ export function transformProjectArchive(archiveSource: ArchiveSource): ProjectAr
 
 export function transformMetadata(metadata: Metadata): BuildMetadataInput {
   return {
-    appIdentifier: metadata.appIdentifier,
-    appName: metadata.appName,
-    appVersion: metadata.appVersion,
-    buildProfile: metadata.buildProfile,
-    cliVersion: metadata.cliVersion,
+    ...metadata,
     credentialsSource:
       metadata.credentialsSource && transformCredentialsSource(metadata.credentialsSource),
     distribution: metadata.distribution && transformDistribution(metadata.distribution),
-    gitCommitHash: metadata.gitCommitHash,
-    releaseChannel: metadata.releaseChannel,
-    sdkVersion: metadata.sdkVersion,
-    trackingContext: metadata.trackingContext,
     workflow: metadata.workflow && transformWorkflow(metadata.workflow),
   };
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -225,6 +225,7 @@ export type Account = {
   applePushKeys: Array<ApplePushKey>;
   appleProvisioningProfiles: Array<AppleProvisioningProfile>;
   appleDevices: Array<AppleDevice>;
+  appleAppSpecificPasswords: Array<AppleAppSpecificPassword>;
   /** Environment secrets for an account */
   environmentSecrets: Array<EnvironmentSecret>;
   /** @deprecated Legacy access tokens are deprecated */
@@ -631,6 +632,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   expirationDate?: Maybe<Scalars['DateTime']>;
   platform: AppPlatform;
   appVersion?: Maybe<Scalars['String']>;
+  appBuildVersion?: Maybe<Scalars['String']>;
   sdkVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
   metrics?: Maybe<BuildMetrics>;
@@ -961,6 +963,7 @@ export type IosAppCredentials = {
   appleAppIdentifier: AppleAppIdentifier;
   iosAppBuildCredentialsList: Array<IosAppBuildCredentials>;
   pushKey?: Maybe<ApplePushKey>;
+  appSpecificPassword?: Maybe<AppleAppSpecificPassword>;
   /** @deprecated use iosAppBuildCredentialsList instead */
   iosAppBuildCredentialsArray: Array<IosAppBuildCredentials>;
 };
@@ -1089,6 +1092,16 @@ export type ApplePushKey = {
 
 export type IosAppBuildCredentialsFilter = {
   iosDistributionType?: Maybe<IosDistributionType>;
+};
+
+export type AppleAppSpecificPassword = {
+  __typename?: 'AppleAppSpecificPassword';
+  id: Scalars['ID'];
+  account: Account;
+  appleIdUsername: Scalars['String'];
+  passwordLabel?: Maybe<Scalars['String']>;
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
 };
 
 export type AndroidAppCredentialsFilter = {
@@ -1686,6 +1699,8 @@ export type RootMutation = {
   androidKeystore: AndroidKeystoreMutation;
   /** Mutations that modify an Identifier for an iOS App */
   appleAppIdentifier: AppleAppIdentifierMutation;
+  /** Mutations that modify an App Specific Password for an Apple User Account */
+  appleAppSpecificPassword: AppleAppSpecificPasswordMutation;
   /** Mutations that modify an Apple Device */
   appleDevice: AppleDeviceMutation;
   /** Mutations that modify an Apple Device registration request */
@@ -2073,6 +2088,24 @@ export type AppleAppIdentifierInput = {
   parentAppleAppId?: Maybe<Scalars['ID']>;
 };
 
+export type AppleAppSpecificPasswordMutation = {
+  __typename?: 'AppleAppSpecificPasswordMutation';
+  /** Create an App Specific Password for an Apple User Account */
+  createAppleAppSpecificPassword: AppleAppSpecificPassword;
+};
+
+
+export type AppleAppSpecificPasswordMutationCreateAppleAppSpecificPasswordArgs = {
+  appleAppSpecificPasswordInput: AppleAppSpecificPasswordInput;
+  accountId: Scalars['ID'];
+};
+
+export type AppleAppSpecificPasswordInput = {
+  appleIdUsername: Scalars['String'];
+  passwordLabel?: Maybe<Scalars['String']>;
+  appSpecificPassword: Scalars['String'];
+};
+
 export type AppleDeviceMutation = {
   __typename?: 'AppleDeviceMutation';
   /** Create an Apple Device */
@@ -2412,6 +2445,7 @@ export type BuildCacheInput = {
 export type BuildMetadataInput = {
   trackingContext?: Maybe<Scalars['JSONObject']>;
   appVersion?: Maybe<Scalars['String']>;
+  appBuildVersion?: Maybe<Scalars['String']>;
   cliVersion?: Maybe<Scalars['String']>;
   workflow?: Maybe<BuildWorkflow>;
   credentialsSource?: Maybe<BuildCredentialsSource>;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

I've found out that even though that https://github.com/expo/eas-cli/pull/413 has been released, the `appBuildVersion` is not being sent to api. 

This is because I forgot to do two things:
- Regenerate graphql code
- Update the metadata transformer 

# How

- I regenerated GraphQL code.
- I updated the metadata transformer so now it passes the `appBuildVersion` to the build mutation. 

# Test Plan

This time I double-checked that the `appBuildVersion` is sent with other metadata to the API (checked the records in db).