### PR TITLE
Add env var to disable capability sync and extra logs when EXPO_DEBUG is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Opt out of capability syncing with `EXPO_NO_CAPABILITY_SYNC=1`. ([#426](https://github.com/expo/eas-cli/pull/426) by [@brentvatne](https://github.com/brentvatne))
+- Add more verbose logging around capability syncing to help debug reported issues. ([#426](https://github.com/expo/eas-cli/pull/426) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -7,8 +7,11 @@ import {
   CapabilityTypeOption,
 } from '@expo/apple-utils';
 import { JSONObject, JSONValue } from '@expo/json-file';
+import getenv from 'getenv';
 
 import Log from '../../../log';
+
+const EXPO_NO_CAPABILITY_SYNC = getenv.boolish('EXPO_NO_CAPABILITY_SYNC', false);
 
 type GetOptionsMethod<T extends CapabilityType = any> = (
   entitlement: JSONValue,
@@ -59,7 +62,8 @@ const getDefinedOptions: GetOptionsMethod = entitlement => {
 export async function syncCapabilitiesForEntitlementsAsync(
   bundleId: BundleId,
   entitlements: JSONObject = {}
-) {
+): Promise<{ enabled: string[]; disabled: string[] }> {
+  if (EXPO_NO_CAPABILITY_SYNC) return { enabled: [], disabled: [] };
   const currentCapabilities = await bundleId.getBundleIdCapabilitiesAsync();
 
   const { enabledCapabilityNames, request, remainingCapabilities } = getCapabilitiesToEnable(

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -65,6 +65,10 @@ export async function syncCapabilitiesForEntitlementsAsync(
 ): Promise<{ enabled: string[]; disabled: string[] }> {
   if (EXPO_NO_CAPABILITY_SYNC) return { enabled: [], disabled: [] };
   const currentCapabilities = await bundleId.getBundleIdCapabilitiesAsync();
+  if (Log.isDebug) {
+    Log.log(`Current remote capabilities:\n${JSON.stringify(currentCapabilities, null, 2)}`);
+    Log.log(`\nCurrent local entitlements:\n${JSON.stringify(entitlements, null, 2)}`);
+  }
 
   const { enabledCapabilityNames, request, remainingCapabilities } = getCapabilitiesToEnable(
     currentCapabilities,


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Help debug [this forums post](https://forums.expo.io/t/eas-build-managed-workflow-for-ios-disables-sign-in-with-apple-and-associated-domains/) and give the ability to opt out of capability syncing without needing to downgrade eas-cli.

# How

Talked to @EvanBacon and he shared this code snippet mostly.

# Test Plan

Ran these commands

```
EXPO_DEBUG=1 ENVIRONMENT=STAGING easd build --platform ios --profile staging
EXPO_NO_CAPABILITY_SYNC=1 EXPO_DEBUG=1 ENVIRONMENT=STAGING easd build --platform ios --profile staging
```
