### PR TITLE
[eas-cli] use new android build credentials provider

### DIFF
--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -12,7 +12,6 @@ import { createCredentialsContextAsync } from '../../credentials/context';
 import { BuildMutation, BuildResult } from '../../graphql/mutations/BuildMutation';
 import Log from '../../log';
 import { ensureApplicationIdIsDefinedForManagedProjectAsync } from '../../project/android/applicationId';
-import { getProjectConfigDescription } from '../../project/projectUtils';
 import { toggleConfirmAsync } from '../../prompts';
 import { findAccountByName } from '../../user/Account';
 import { CredentialsResult, prepareBuildRequestForPlatformAsync } from '../build';

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -117,6 +117,10 @@ async function ensureAndroidCredentialsAsync(
   if (!shouldProvideCredentials(ctx)) {
     return;
   }
+  const androidApplicationIdentifier = await getOrConfigureApplicationIdAsync(
+    ctx.commandCtx.projectDir,
+    ctx.commandCtx.exp
+  );
   const provider = new AndroidCredentialsProvider(
     await createCredentialsContextAsync(ctx.commandCtx.projectDir, {
       nonInteractive: ctx.commandCtx.nonInteractive,
@@ -128,12 +132,7 @@ async function ensureAndroidCredentialsAsync(
           `You do not have access to account: ${ctx.commandCtx.accountName}`
         ),
         projectName: ctx.commandCtx.projectName,
-        androidApplicationIdentifier: nullthrows(
-          ctx.commandCtx.exp.android?.package,
-          `android.package needs to be defined in your ${getProjectConfigDescription(
-            ctx.commandCtx.projectDir
-          )} file`
-        ),
+        androidApplicationIdentifier,
       },
       skipCredentialsCheck: ctx.commandCtx.skipCredentialsCheck,
     }

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -11,7 +11,10 @@ import AndroidCredentialsProvider, {
 import { createCredentialsContextAsync } from '../../credentials/context';
 import { BuildMutation, BuildResult } from '../../graphql/mutations/BuildMutation';
 import Log from '../../log';
-import { ensureApplicationIdIsDefinedForManagedProjectAsync } from '../../project/android/applicationId';
+import {
+  ensureApplicationIdIsDefinedForManagedProjectAsync,
+  getApplicationId,
+} from '../../project/android/applicationId';
 import { toggleConfirmAsync } from '../../prompts';
 import { findAccountByName } from '../../user/Account';
 import { CredentialsResult, prepareBuildRequestForPlatformAsync } from '../build';
@@ -116,7 +119,7 @@ async function ensureAndroidCredentialsAsync(
   if (!shouldProvideCredentials(ctx)) {
     return;
   }
-  const androidApplicationIdentifier = await getOrConfigureApplicationIdAsync(
+  const androidApplicationIdentifier = getApplicationId(
     ctx.commandCtx.projectDir,
     ctx.commandCtx.exp
   );


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Replace the old Android SetupBuildCredentials with the new one

# Test Plan

- [ ] current tests still pass 