### PR TITLE
[eas-cli] Fix git repo root path on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix bundle identifier resolution when native target is not provided. ([#434](https://github.com/expo/eas-cli/pull/434) by [@dsokal](https://github.com/dsokal))
+- Fix git repo root path getter on Windows. ([#429](https://github.com/expo/eas-cli/pull/429) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 
-- Android credentials setup now on Graphql API ([#434](https://github.com/expo/eas-cli/pull/427) by [@quinlanj](https://github.com/quinlanj))
+- Android credentials setup now on Graphql API. ([#434](https://github.com/expo/eas-cli/pull/427) by [@quinlanj](https://github.com/quinlanj))
 
 ## [0.16.0](https://github.com/expo/eas-cli/releases/tag/v0.16.0) - 2021-05-26
 

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -123,7 +123,7 @@ async function makeProjectTarballAsync(): Promise<{ path: string; size: number }
       '--no-hardlinks',
       '--depth',
       '1',
-      `file://${await gitRootDirectoryAsync()}`,
+      await getGitRootFullPathAsync(),
       shallowClonePath,
     ]);
     await tar.create({ cwd: shallowClonePath, file: tarPath, prefix: 'project', gzip: true }, [
@@ -150,6 +150,18 @@ async function makeProjectTarballAsync(): Promise<{ path: string; size: number }
   }
 
   return { size, path: tarPath };
+}
+
+async function getGitRootFullPathAsync() {
+  if (process.platform === 'win32') {
+    // getRootDirectoryAsync() will return C:/path/to/repo on Windows and path
+    // prefix should be file:///
+    return `file:///${await gitRootDirectoryAsync()}`;
+  } else {
+    // getRootDirectoryAsync() will /path/to/repo, and path prefix should be
+    // file:/// so only file:// needs to be prepended
+    return `file://${await gitRootDirectoryAsync()}`;
+  }
 }
 
 async function showDiffAsync() {


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

A developer trying out `eas build` on their project on Windows using git-lfs was unable to start their build:

```
✔ Using remote Android credentials (Expo server)
✖ Compressing project files
    Error: git exited with non-zero code: 128
```

We looked into this a bit and found that `git clone --depth ...` was only working for them if they added an added an additional `/` in `file://C:/...` to make `file:///C:/...`

```
PS C:\Git\app> git clone --no-hardlinks --depth 1 file:///C:\Git\app ./deleteme
fatal: destination path './deleteme' already exists and is not an empty directory.
Cloning into './deleteme'...
remote: Enumerating objects: 1134, done.
remote: Counting objects: 100% (1134/1134), done.
remote: Compressing objects: 100% (1096/1096), done.
remote: Total 1134 (delta 22), reused 598 (delta 1), pack-reused 0
Receiving objects: 100% (1134/1134), 746.89 KiB | 1.41 MiB/s, done.
Resolving deltas: 100% (22/22), done.
Downloading assets/background-phone.jpg (74 KB)
Error downloading object: assets/background-phone.jpg (0277518): Smudge error: Error downloading assets/background-phone.jpg (02775183cf03e71c2ac378d8c4af96f9f88d6da9003d69a3d455e4050b00e57b): EOF
```

```
git clone --no-hardlinks --depth 1 file://C:/Git/app ./tmp # no
git clone --no-hardlinks --depth 1 file:///C:/Git/app ./tmp # yes
```

# How

Change `file://C:/...` to `file:///C:/...`for git root path when cloning on Windows

# Test Plan

Published alpha and had the developer test it, it resolved their issue.