### PR TITLE
[eas-cli] refactor application id configuration

### DIFF
--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -10,7 +10,7 @@ import AndroidCredentialsProvider, {
 import { createCredentialsContextAsync } from '../../credentials/context';
 import { BuildMutation, BuildResult } from '../../graphql/mutations/BuildMutation';
 import Log from '../../log';
-import { getOrConfigureApplicationIdAsync } from '../../project/android/applicationId';
+import { ensureApplicationIdIsDefinedForManagedProjectAsync } from '../../project/android/applicationId';
 import { toggleConfirmAsync } from '../../prompts';
 import { CredentialsResult, prepareBuildRequestForPlatformAsync } from '../build';
 import { BuildContext, CommandContext, createBuildContext } from '../context';
@@ -63,8 +63,9 @@ This means that it will most likely produce an AAB and you will not be able to i
     }
   }
 
-  // this function throws if application id is invalid
-  await getOrConfigureApplicationIdAsync(commandCtx.projectDir, commandCtx.exp);
+  if (buildCtx.buildProfile.workflow === Workflow.MANAGED) {
+    await ensureApplicationIdIsDefinedForManagedProjectAsync(commandCtx.projectDir, commandCtx.exp);
+  }
 
   return await prepareBuildRequestForPlatformAsync({
     ctx: buildCtx,

--- a/packages/eas-cli/src/build/android/configure.ts
+++ b/packages/eas-cli/src/build/android/configure.ts
@@ -3,7 +3,7 @@ import { AndroidConfig } from '@expo/config-plugins';
 
 import Log from '../../log';
 import {
-  getOrConfigureApplicationIdAsync,
+  ensureApplicationIdIsDefinedForManagedProjectAsync,
   warnIfAndroidPackageDefinedInAppConfigForGenericProject,
 } from '../../project/android/applicationId';
 import { gitAddAsync } from '../../utils/git';
@@ -13,7 +13,7 @@ import { configureUpdatesAsync, syncUpdatesConfigurationAsync } from './UpdatesM
 
 export async function configureAndroidAsync(ctx: ConfigureContext): Promise<void> {
   if (!ctx.hasAndroidNativeProject) {
-    await getOrConfigureApplicationIdAsync(ctx.projectDir, ctx.exp);
+    await ensureApplicationIdIsDefinedForManagedProjectAsync(ctx.projectDir, ctx.exp);
     return;
   }
 

--- a/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
@@ -4,7 +4,10 @@ import os from 'os';
 
 import { asMock } from '../../../__tests__/utils';
 import { promptAsync } from '../../../prompts';
-import { getApplicationId, getOrConfigureApplicationIdAsync } from '../applicationId';
+import {
+  ensureApplicationIdIsDefinedForManagedProjectAsync,
+  getApplicationId,
+} from '../applicationId';
 
 jest.mock('fs');
 jest.mock('../../../prompts');
@@ -92,7 +95,7 @@ describe(getApplicationId, () => {
   });
 });
 
-describe(getOrConfigureApplicationIdAsync, () => {
+describe(ensureApplicationIdIsDefinedForManagedProjectAsync, () => {
   describe('managed project + android.package missing in app config', () => {
     it('throws an error if using app.config.js', async () => {
       vol.fromJSON(
@@ -101,9 +104,9 @@ describe(getOrConfigureApplicationIdAsync, () => {
         },
         '/app'
       );
-      await expect(getOrConfigureApplicationIdAsync('/app', {} as any)).rejects.toThrowError(
-        /we can't update this file programatically/
-      );
+      await expect(
+        ensureApplicationIdIsDefinedForManagedProjectAsync('/app', {} as any)
+      ).rejects.toThrowError(/we can't update this file programatically/);
     });
     it('prompts for the Android package if using app.json', async () => {
       vol.fromJSON(
@@ -117,9 +120,9 @@ describe(getOrConfigureApplicationIdAsync, () => {
         packageName: 'com.expo.notdominik',
       }));
 
-      await expect(getOrConfigureApplicationIdAsync('/app', {} as any)).resolves.toBe(
-        'com.expo.notdominik'
-      );
+      await expect(
+        ensureApplicationIdIsDefinedForManagedProjectAsync('/app', {} as any)
+      ).resolves.toBe('com.expo.notdominik');
       expect(promptAsync).toHaveBeenCalled();
     });
     it('puts the Android package in app.json', async () => {
@@ -134,9 +137,9 @@ describe(getOrConfigureApplicationIdAsync, () => {
         packageName: 'com.expo.notdominik',
       }));
 
-      await expect(getOrConfigureApplicationIdAsync('/app', {} as any)).resolves.toBe(
-        'com.expo.notdominik'
-      );
+      await expect(
+        ensureApplicationIdIsDefinedForManagedProjectAsync('/app', {} as any)
+      ).resolves.toBe('com.expo.notdominik');
       expect(JSON.parse(fs.readFileSync('/app/app.json', 'utf-8'))).toMatchObject({
         expo: { android: { package: 'com.expo.notdominik' } },
       });

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -13,19 +13,17 @@ import { resolveWorkflow } from '../workflow';
 
 const INVALID_APPLICATION_ID_MESSAGE = `Invalid format of Android applicationId. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter.`;
 
-export async function getOrConfigureApplicationIdAsync(
+export async function ensureApplicationIdIsDefinedForManagedProjectAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<string> {
+  const workflow = resolveWorkflow(projectDir, Platform.ANDROID);
+  assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
+
   try {
     return getApplicationId(projectDir, exp);
   } catch (err) {
-    const workflow = resolveWorkflow(projectDir, Platform.ANDROID);
-    if (workflow === Workflow.MANAGED) {
-      return await configureApplicationIdAsync(projectDir, exp);
-    } else {
-      throw err;
-    }
+    return await configureApplicationIdAsync(projectDir, exp);
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Refactor Android Application Identifier configuration so it behaves the same way as iOS. In the managed workflow, we will help the user configure their application identifier if it is not present. In the generic workflow, we skip this and we return an appropriate error message if the application identifier is not configured properly by the time we call `getApplicationId`

More details: https://github.com/expo/eas-cli/pull/431#discussion_r641394021

# Test Plan

- [ ] amended tests pass
