### PR TITLE
[eas-cli] Deprecate --skip-credentials-check flag for build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Deprecate `--skip-credentials-check` flag because it doesn't do anything and is no longer needed.([#442](https://github.com/expo/eas-cli/pull/442) by [@brentvatne](https://github.com/brentvatne))
+
 ## [0.17.0](https://github.com/expo/eas-cli/releases/tag/v0.17.0) - 2021-06-02
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -136,7 +136,6 @@ async function ensureAndroidCredentialsAsync(
         projectName: ctx.commandCtx.projectName,
         androidApplicationIdentifier,
       },
-      skipCredentialsCheck: ctx.commandCtx.skipCredentialsCheck,
     }
   );
   const { credentialsSource } = ctx.buildProfile;

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -21,7 +21,6 @@ export interface CommandContext {
   nonInteractive: boolean;
   local: boolean;
   clearCache: boolean;
-  skipCredentialsCheck: boolean;
   skipProjectConfiguration: boolean;
   waitForBuildEnd: boolean;
 }
@@ -35,7 +34,6 @@ export async function createCommandContextAsync({
   nonInteractive = false,
   local,
   clearCache = false,
-  skipCredentialsCheck = false,
   skipProjectConfiguration = false,
   waitForBuildEnd,
 }: {
@@ -47,7 +45,6 @@ export async function createCommandContextAsync({
   nonInteractive: boolean;
   local: boolean;
   clearCache: boolean;
-  skipCredentialsCheck: boolean;
   skipProjectConfiguration: boolean;
   waitForBuildEnd: boolean;
 }): Promise<CommandContext> {
@@ -67,7 +64,6 @@ export async function createCommandContextAsync({
     nonInteractive,
     local,
     clearCache,
-    skipCredentialsCheck,
     skipProjectConfiguration,
     waitForBuildEnd,
   };

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -25,7 +25,7 @@ export default class Build extends EasCommand {
     platform: flags.enum({ char: 'p', options: ['android', 'ios', 'all'] }),
     'skip-credentials-check': flags.boolean({
       default: false,
-      description: 'Skip validation of build credentials',
+      hidden: true,
     }),
     'skip-project-configuration': flags.boolean({
       default: false,
@@ -64,6 +64,14 @@ export default class Build extends EasCommand {
     const platform =
       (flags.platform as RequestedPlatform | undefined) ?? (await promptForPlatformAsync());
 
+    if (flags['skip-credentials-check']) {
+      Log.warnDeprecatedFlag(
+        'skip-credentials-check',
+        'Build credential validation is always skipped with the --non-interactive flag. You can also skip interactively.'
+      );
+      Log.newLine();
+    }
+
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
     let { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
@@ -89,7 +97,6 @@ export default class Build extends EasCommand {
       projectId,
       nonInteractive,
       clearCache: flags['clear-cache'],
-      skipCredentialsCheck: flags['skip-credentials-check'],
       local: flags.local,
       skipProjectConfiguration: flags['skip-project-configuration'],
       waitForBuildEnd: flags.wait,

--- a/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
@@ -15,7 +15,6 @@ export interface AndroidCredentials {
 
 interface Options {
   app: AppLookupParams;
-  skipCredentialsCheck?: boolean;
 }
 
 export default class AndroidCredentialsProvider {

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -35,6 +35,10 @@ export default class Log {
     Log.consoleLog(...Log.withTextColor(args, chalk.gray));
   }
 
+  public static warnDeprecatedFlag(flag: string, message: string) {
+    Log.warn(`› ${chalk.bold('--' + flag)} flag is deprecated. ${message}`);
+  }
+
   public static succeed(message: string) {
     ora().succeed(message);
   }


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [n/a] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Context in https://linear.app/expo/issue/ENG-1103/remove-skip-credentials-check

# How

- Delete usage of `skipCredentialsCheck`
- Add warning to when the `--skip-credentials-check` flag is passed in to `eas build`
- Create a logging helper that we can use for future flag deprecations to ensure we have a consistent format (using the same format as expo-cli, eg: run `expo start --config example.json` anywhere to see a similar warning.
- Hide the flag from `eas build --help`

# Test Plan

### Flag is hidden from help

```
╰─$ easd build --help
Start a build

USAGE
  $ eas build

OPTIONS
  --clear-cache                     Clear cache before the build
  --local                           Run build locally [experimental]
  --non-interactive                 Run command in --non-interactive mode
  -p, --platform=(android|ios|all)
  --profile=profile                 [default: release] Name of the build profile from eas.json
  --skip-project-configuration      Skip project configuration
  --[no-]wait                       Wait for build(s) to complete

COMMANDS
  build:cancel     Cancel a build.
  build:configure  Configure the project to support EAS Build.
  build:list       list all builds for your project
  build:view       view a build for your project
```

### Warning is printed when flag is used

<img width="1130" alt="Screen Shot 2021-06-10 at 8 09 34 PM" src="https://user-images.githubusercontent.com/90494/121625567-8f808800-ca28-11eb-90e4-551eab42928d.png">