### PR TITLE
[eas-cli] refactor credential input types

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1697,6 +1697,18 @@
             "deprecationReason": null
           },
           {
+            "name": "subscription",
+            "description": "Subscription info visible to members that have VIEWER role",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SubscriptionDetails",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "appleTeams",
             "description": "iOS credentials for account",
             "args": [
@@ -14962,13 +14974,9 @@
             "name": "appleTeamName",
             "description": "",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null
           }

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
@@ -6,7 +6,6 @@ import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/cl
 import {
   AndroidKeystoreFragment,
   AndroidKeystoreInput,
-  AndroidKeystoreType,
   CreateAndroidKeystoreMutation,
 } from '../../../../../graphql/generated';
 import { AndroidKeystoreFragmentNode } from '../../../../../graphql/types/credentials/AndroidKeystore';

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
@@ -5,6 +5,7 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AndroidKeystoreFragment,
+  AndroidKeystoreInput,
   AndroidKeystoreType,
   CreateAndroidKeystoreMutation,
 } from '../../../../../graphql/generated';
@@ -12,13 +13,7 @@ import { AndroidKeystoreFragmentNode } from '../../../../../graphql/types/creden
 
 const AndroidKeystoreMutation = {
   async createAndroidKeystore(
-    androidKeystoreInput: {
-      base64EncodedKeystore: string;
-      keystorePassword: string;
-      keyAlias: string;
-      keyPassword?: string;
-      type: AndroidKeystoreType;
-    },
+    androidKeystoreInput: AndroidKeystoreInput,
     accountId: string
   ): Promise<AndroidKeystoreFragment> {
     const data = await withErrorHandlingAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
@@ -5,17 +5,14 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleAppIdentifierFragment,
+  AppleAppIdentifierInput,
   CreateAppleAppIdentifierMutation,
 } from '../../../../../graphql/generated';
 import { AppleAppIdentifierFragmentNode } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
 
 const AppleAppIdentifierMutation = {
   async createAppleAppIdentifierAsync(
-    appleAppIdentifierInput: {
-      bundleIdentifier: string;
-      appleTeamId?: string;
-      parentAppleAppId?: string;
-    },
+    appleAppIdentifierInput: AppleAppIdentifierInput,
     accountId: string
   ): Promise<AppleAppIdentifierFragment> {
     const data = await withErrorHandlingAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
@@ -3,20 +3,15 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
-  AppleDeviceClass,
   AppleDeviceFragment,
+  AppleDeviceInput,
   CreateAppleDeviceMutation,
 } from '../../../../../graphql/generated';
 import { AppleDeviceFragmentNode } from '../../../../../graphql/types/credentials/AppleDevice';
 
 const AppleDeviceMutation = {
   async createAppleDeviceAsync(
-    appleDeviceInput: {
-      appleTeamId: string;
-      identifier: string;
-      name?: string;
-      deviceClass?: AppleDeviceClass;
-    },
+    appleDeviceInput: AppleDeviceInput,
     accountId: string
   ): Promise<AppleDeviceFragment> {
     const data = await withErrorHandlingAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
@@ -5,6 +5,7 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleDistributionCertificateFragment,
+  AppleDistributionCertificateInput,
   AppleTeamFragment,
   CreateAppleDistributionCertificateMutation,
   DeleteAppleDistributionCertificateMutation,
@@ -18,13 +19,7 @@ export type AppleDistributionCertificateMutationResult = AppleDistributionCertif
 
 const AppleDistributionCertificateMutation = {
   async createAppleDistributionCertificate(
-    appleDistributionCertificateInput: {
-      certP12: string;
-      certPassword: string;
-      certPrivateSigningKey?: string;
-      developerPortalIdentifier?: string;
-      appleTeamId?: string;
-    },
+    appleDistributionCertificateInput: AppleDistributionCertificateInput,
     accountId: string
   ): Promise<AppleDistributionCertificateMutationResult> {
     const data = await withErrorHandlingAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleProvisioningProfileFragment,
+  AppleProvisioningProfileInput,
   AppleTeamFragment,
   CreateAppleProvisioningProfileMutation,
   UpdateAppleProvisioningProfileMutation,
@@ -17,10 +18,7 @@ export type AppleProvisioningProfileMutationResult = AppleProvisioningProfileFra
 
 const AppleProvisioningProfileMutation = {
   async createAppleProvisioningProfileAsync(
-    appleProvisioningProfileInput: {
-      appleProvisioningProfile: string;
-      developerPortalIdentifier?: string;
-    },
+    appleProvisioningProfileInput: AppleProvisioningProfileInput,
     accountId: string,
     appleAppIdentifierId: string
   ): Promise<AppleProvisioningProfileMutationResult> {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
@@ -2,7 +2,11 @@ import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
-import { AppleTeamFragment, CreateAppleTeamMutation } from '../../../../../graphql/generated';
+import {
+  AppleTeamFragment,
+  AppleTeamInput,
+  CreateAppleTeamMutation,
+} from '../../../../../graphql/generated';
 import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 import { Account } from '../../../../../user/Account';
 
@@ -12,10 +16,7 @@ export type AppleTeamMutationResult = AppleTeamFragment & {
 
 const AppleTeamMutation = {
   async createAppleTeamAsync(
-    appleTeamInput: {
-      appleTeamIdentifier: string;
-      appleTeamName?: string;
-    },
+    appleTeamInput: AppleTeamInput,
     accountId: string
   ): Promise<AppleTeamMutationResult> {
     const data = await withErrorHandlingAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
@@ -6,18 +6,14 @@ import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/cl
 import {
   IosAppBuildCredentials,
   IosAppBuildCredentialsFragment,
-  IosDistributionType,
+  IosAppBuildCredentialsInput,
   SetProvisioningProfileMutation,
 } from '../../../../../graphql/generated';
 import { IosAppBuildCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
 
 const IosAppBuildCredentialsMutation = {
   async createIosAppBuildCredentialsAsync(
-    iosAppBuildCredentialsInput: {
-      iosDistributionType: IosDistributionType;
-      distributionCertificateId: string;
-      provisioningProfileId: string;
-    },
+    iosAppBuildCredentialsInput: IosAppBuildCredentialsInput,
     iosAppCredentialsId: string
   ): Promise<IosAppBuildCredentials> {
     const data = await withErrorHandlingAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
@@ -6,15 +6,13 @@ import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/cl
 import {
   CreateIosAppCredentialsMutation,
   IosAppCredentialsFragment,
+  IosAppCredentialsInput,
 } from '../../../../../graphql/generated';
 import { IosAppCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppCredentials';
 
 const IosAppCredentialsMutation = {
   async createIosAppCredentialsAsync(
-    iosAppCredentialsInput: {
-      appleTeamId: string;
-      pushKeyId?: string;
-    },
+    iosAppCredentialsInput: IosAppCredentialsInput,
     appId: string,
     appleAppIdentifierId: string
   ): Promise<IosAppCredentialsFragment> {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -218,6 +218,8 @@ export type Account = {
   userInvitations: Array<UserInvitation>;
   /** Billing information */
   billing?: Maybe<Billing>;
+  /** Subscription info visible to members that have VIEWER role */
+  subscription?: Maybe<SubscriptionDetails>;
   /** iOS credentials for account */
   appleTeams: Array<AppleTeam>;
   appleAppIdentifiers: Array<AppleAppIdentifier>;
@@ -2274,7 +2276,7 @@ export type AppleTeamMutationCreateAppleTeamArgs = {
 
 export type AppleTeamInput = {
   appleTeamIdentifier: Scalars['String'];
-  appleTeamName: Scalars['String'];
+  appleTeamName?: Maybe<Scalars['String']>;
 };
 
 export type AppMutation = {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

cleanup input types to use the generated ones

# Test Plan

- [ ] everything still passes
