### PR TITLE
clean up legacy stuff 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Drop support for `experimental.npmToken` in credentials.json, EAS Secrets can be used instead. ([#444](https://github.com/expo/eas-cli/pull/444) by [@dsokal](https://github.com/dsokal))
+- Remove `--allow-experimental` flag from `eas build:configure` as it has no effect now. ([#444](https://github.com/expo/eas-cli/pull/444) by [@dsokal](https://github.com/dsokal))
+
 ### 🎉 New features
 
 - Make credentials manager work with multi-target iOS projects. ([#441](https://github.com/expo/eas-cli/pull/441) by [@dsokal](https://github.com/dsokal))

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -3,7 +3,6 @@ import { AndroidGenericBuildProfile, AndroidManagedBuildProfile } from '@expo/ea
 import path from 'path';
 
 import { AndroidCredentials } from '../../credentials/android/AndroidCredentialsProvider';
-import { readEnvironmentSecretsAsync } from '../../credentials/credentialsJson/read';
 import { getUsername } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
 import { gitRootDirectoryAsync } from '../../utils/git';
@@ -39,7 +38,6 @@ interface CommonJobProperties {
     buildCredentials?: {
       keystore: Android.Keystore;
     };
-    environmentSecrets?: Record<string, string>;
   };
 }
 
@@ -47,8 +45,7 @@ async function prepareJobCommonAsync(
   ctx: BuildContext<Platform.ANDROID>,
   jobData: JobData
 ): Promise<Partial<CommonJobProperties>> {
-  const environmentSecrets = await readEnvironmentSecretsAsync(ctx.commandCtx.projectDir);
-  const credentials = jobData.credentials;
+  const { credentials } = jobData;
   const buildCredentials = credentials
     ? {
         buildCredentials: {
@@ -78,7 +75,6 @@ async function prepareJobCommonAsync(
       clear: ctx.commandCtx.clearCache,
     },
     secrets: {
-      ...(environmentSecrets ? { environmentSecrets } : {}),
       ...buildCredentials,
     },
   };

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -28,7 +28,6 @@ const configureCommitMessage = {
 export async function configureAsync(options: {
   platform: RequestedPlatform;
   projectDir: string;
-  allowExperimental: boolean;
 }): Promise<void> {
   await ensureGitRepoExistsAsync();
   await maybeBailOnGitStatusAsync();
@@ -39,7 +38,6 @@ export async function configureAsync(options: {
     user: await ensureLoggedInAsync(),
     projectDir: options.projectDir,
     exp,
-    allowExperimental: options.allowExperimental,
     requestedPlatform: options.platform,
     shouldConfigureAndroid: [RequestedPlatform.All, RequestedPlatform.Android].includes(
       options.platform

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -77,7 +77,6 @@ export interface ConfigureContext {
   user: Actor;
   projectDir: string;
   exp: ExpoConfig;
-  allowExperimental: boolean;
   requestedPlatform: RequestedPlatform;
   shouldConfigureAndroid: boolean;
   shouldConfigureIos: boolean;

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -2,7 +2,6 @@ import { ArchiveSource, Cache, Ios, Job, Workflow, sanitizeJob } from '@expo/eas
 import { IosGenericBuildProfile, IosManagedBuildProfile } from '@expo/eas-json';
 import path from 'path';
 
-import { readEnvironmentSecretsAsync } from '../../credentials/credentialsJson/read';
 import { IosCredentials, TargetCredentials } from '../../credentials/ios/types';
 import { getUsername } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
@@ -48,8 +47,6 @@ async function prepareJobCommonAsync(
   ctx: BuildContext<Platform.IOS>,
   { credentials, projectArchive }: { credentials?: IosCredentials; projectArchive: ArchiveSource }
 ): Promise<Partial<CommonJobProperties>> {
-  const environmentSecrets = await readEnvironmentSecretsAsync(ctx.commandCtx.projectDir);
-
   const buildCredentials: CommonJobProperties['secrets']['buildCredentials'] = {};
   if (credentials) {
     const targetNames = Object.keys(credentials);
@@ -77,7 +74,6 @@ async function prepareJobCommonAsync(
       clear: ctx.commandCtx.clearCache,
     },
     secrets: {
-      ...(environmentSecrets ? { environmentSecrets } : {}),
       buildCredentials,
     },
   };

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -17,10 +17,6 @@ export default class BuildConfigure extends Command {
       char: 'p',
       options: ['android', 'ios', 'all'],
     }),
-    'allow-experimental': flags.boolean({
-      description: 'Enable experimental configuration steps.',
-      default: false,
-    }),
   };
 
   async run() {
@@ -32,20 +28,10 @@ export default class BuildConfigure extends Command {
 
     const platform =
       (flags.platform as RequestedPlatform | undefined) ?? (await promptForPlatformAsync());
-    const allowExperimental = flags['allow-experimental'];
-
-    if (allowExperimental) {
-      Log.warn(
-        `Project configuration will execute some additional steps that might fail if structure of your native project is significantly different from ${chalk.bold(
-          'expo eject'
-        )} or ${chalk.bold('expo init')}`
-      );
-    }
 
     await ensureLoggedInAsync();
     await configureAsync({
       platform,
-      allowExperimental,
       projectDir: (await findProjectRootAsync()) ?? process.cwd(),
     });
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -144,7 +144,6 @@ async function ensureProjectConfiguredAsync(projectDir: string): Promise<ExpoCon
     await configureAsync({
       projectDir,
       platform: RequestedPlatform.All,
-      allowExperimental: false,
     });
     if (!(await isGitStatusCleanAsync())) {
       throw new Error(

--- a/packages/eas-cli/src/credentials/credentialsJson/__tests__/read-test.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/__tests__/read-test.ts
@@ -247,29 +247,4 @@ describe('credentialsJson', () => {
       });
     });
   });
-
-  describe('readEnvironmentSecretsAsync', () => {
-    it('should read environmentSecrets field correctly', async () => {
-      vol.fromJSON({
-        './credentials.json': JSON.stringify({
-          ios: {
-            provisioningProfilePath: 'pprofile',
-            distributionCertificate: {
-              path: 'cert.p12',
-              password: 'certPass',
-            },
-          },
-          experimental: {
-            npmToken: 'VALUE',
-          },
-        }),
-        './pprofile': 'somebinarycontent',
-        './cert.p12': 'somebinarycontent2',
-      });
-      const result = await credentialsJsonReader.readEnvironmentSecretsAsync('.');
-      expect(result).toEqual({
-        NPM_TOKEN: 'VALUE',
-      });
-    });
-  });
 });

--- a/packages/eas-cli/src/credentials/credentialsJson/read.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/read.ts
@@ -84,17 +84,6 @@ async function readCredentialsForTargetAsync(
   };
 }
 
-export async function readEnvironmentSecretsAsync(
-  projectDir: string
-): Promise<Record<string, string> | undefined> {
-  if (!(await fs.pathExists(getCredentialsJsonPath(projectDir)))) {
-    return undefined;
-  }
-  const credentialsJson = await readAsync(projectDir);
-  const npmToken = credentialsJson?.experimental?.npmToken;
-  return npmToken ? { NPM_TOKEN: npmToken } : undefined;
-}
-
 async function readAsync(projectDir: string): Promise<CredentialsJson> {
   const credentialsJSONRaw = await readRawAsync(projectDir);
 

--- a/packages/eas-cli/src/credentials/credentialsJson/types.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/types.ts
@@ -5,9 +5,6 @@ import { Keystore } from '../android/credentials';
 export interface CredentialsJson {
   android?: CredentialsJsonAndroidCredentials;
   ios?: CredentialsJsonIosTargetCredentials | CredentialsJsonIosCredentials;
-  experimental?: {
-    npmToken?: string;
-  };
 }
 
 export interface CredentialsJsonAndroidCredentials {
@@ -65,7 +62,4 @@ export const CredentialsJsonSchema = Joi.object({
       CredentialsJsonIosTargetCredentialsSchema.required()
     ),
   ],
-  experimental: Joi.object({
-    npmToken: Joi.string(),
-  }),
 });


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

- `experimental.npmToken` in credentials.json is a legacy way of providing the token to EAS Build. EAS Secrets should be used instead. This is what our docs are suggesting to do - https://docs.expo.io/build-reference/how-tos/#how-to-use-private-package-repositories
- `--allow-experimental` flag for `eas build:configure` has no effect now (it's not related to the previous point).

# How

- I updated the credentials.json schema and removed the `experimental.npmToken` field.
- I removed `--allow-experimental` flag from `eas build:configure`.

# Test Plan

None