### PR TITLE
[docs] update 'See code' links in README

### DIFF
--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -69,7 +69,7 @@ ALIASES
   $ eas login
 ```
 
-_See code: [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/account/login.ts)_
+_See code: [src/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/account/login.ts)_
 
 ## `eas account:logout`
 
@@ -83,7 +83,7 @@ ALIASES
   $ eas logout
 ```
 
-_See code: [build/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/account/logout.ts)_
+_See code: [src/commands/account/logout.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/account/logout.ts)_
 
 ## `eas account:view`
 
@@ -97,7 +97,7 @@ ALIASES
   $ eas whoami
 ```
 
-_See code: [build/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/account/view.ts)_
+_See code: [src/commands/account/view.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/account/view.ts)_
 
 ## `eas analytics [STATUS]`
 
@@ -108,7 +108,7 @@ USAGE
   $ eas analytics [STATUS]
 ```
 
-_See code: [build/commands/analytics.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/analytics.ts)_
+_See code: [src/commands/analytics.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/analytics.ts)_
 
 ## `eas build`
 
@@ -129,7 +129,7 @@ OPTIONS
   --[no-]wait                       Wait for build(s) to complete
 ```
 
-_See code: [build/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/build/index.ts)_
+_See code: [src/commands/build/index.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/build/index.ts)_
 
 ## `eas build:cancel [BUILD_ID]`
 
@@ -140,7 +140,7 @@ USAGE
   $ eas build:cancel [BUILD_ID]
 ```
 
-_See code: [build/commands/build/cancel.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/build/cancel.ts)_
+_See code: [src/commands/build/cancel.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/build/cancel.ts)_
 
 ## `eas build:configure`
 
@@ -155,7 +155,7 @@ OPTIONS
   --allow-experimental              Enable experimental configuration steps.
 ```
 
-_See code: [build/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/build/configure.ts)_
+_See code: [src/commands/build/configure.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/build/configure.ts)_
 
 ## `eas build:list`
 
@@ -171,7 +171,7 @@ OPTIONS
   --status=(in-queue|in-progress|errored|finished|canceled)
 ```
 
-_See code: [build/commands/build/list.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/build/list.ts)_
+_See code: [src/commands/build/list.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/build/list.ts)_
 
 ## `eas build:view [BUILD_ID]`
 
@@ -182,7 +182,7 @@ USAGE
   $ eas build:view [BUILD_ID]
 ```
 
-_See code: [build/commands/build/view.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/build/view.ts)_
+_See code: [src/commands/build/view.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/build/view.ts)_
 
 ## `eas credentials`
 
@@ -193,7 +193,7 @@ USAGE
   $ eas credentials
 ```
 
-_See code: [build/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/credentials.ts)_
+_See code: [src/commands/credentials.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/credentials.ts)_
 
 ## `eas device:create`
 
@@ -204,7 +204,7 @@ USAGE
   $ eas device:create
 ```
 
-_See code: [build/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/device/create.ts)_
+_See code: [src/commands/device/create.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/device/create.ts)_
 
 ## `eas device:list`
 
@@ -218,7 +218,7 @@ OPTIONS
   --apple-team-id=apple-team-id
 ```
 
-_See code: [build/commands/device/list.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/device/list.ts)_
+_See code: [src/commands/device/list.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/device/list.ts)_
 
 ## `eas device:view [UDID]`
 
@@ -229,7 +229,7 @@ USAGE
   $ eas device:view [UDID]
 ```
 
-_See code: [build/commands/device/view.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/device/view.ts)_
+_See code: [src/commands/device/view.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/device/view.ts)_
 
 ## `eas help [COMMAND]`
 
@@ -262,7 +262,7 @@ OPTIONS
   --value=value              Value of the secret
 ```
 
-_See code: [build/commands/secret/create.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/secret/create.ts)_
+_See code: [src/commands/secret/create.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/secret/create.ts)_
 
 ## `eas secret:delete`
 
@@ -279,7 +279,7 @@ DESCRIPTION
   Unsure where to find the secret's ID? Run eas secrets:list
 ```
 
-_See code: [build/commands/secret/delete.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/secret/delete.ts)_
+_See code: [src/commands/secret/delete.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/secret/delete.ts)_
 
 ## `eas secret:list`
 
@@ -290,7 +290,7 @@ USAGE
   $ eas secret:list
 ```
 
-_See code: [build/commands/secret/list.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/secret/list.ts)_
+_See code: [src/commands/secret/list.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/secret/list.ts)_
 
 ## `eas submit --platform=(android|ios)`
 
@@ -370,7 +370,7 @@ EXAMPLES
          and provide its App ID
 ```
 
-_See code: [build/commands/submit.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/submit.ts)_
+_See code: [src/commands/submit.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/submit.ts)_
 
 ## `eas webhook:create`
 
@@ -389,7 +389,7 @@ OPTIONS
   --url=url        Webhook URL
 ```
 
-_See code: [build/commands/webhook/create.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/webhook/create.ts)_
+_See code: [src/commands/webhook/create.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/webhook/create.ts)_
 
 ## `eas webhook:delete [ID]`
 
@@ -403,7 +403,7 @@ ARGUMENTS
   ID  ID of the webhook to delete
 ```
 
-_See code: [build/commands/webhook/delete.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/webhook/delete.ts)_
+_See code: [src/commands/webhook/delete.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/webhook/delete.ts)_
 
 ## `eas webhook:list`
 
@@ -417,7 +417,7 @@ OPTIONS
   --event=(BUILD)  Event type that triggers the webhook
 ```
 
-_See code: [build/commands/webhook/list.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/webhook/list.ts)_
+_See code: [src/commands/webhook/list.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/webhook/list.ts)_
 
 ## `eas webhook:update`
 
@@ -437,7 +437,7 @@ OPTIONS
   --url=url        Webhook URL
 ```
 
-_See code: [build/commands/webhook/update.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/webhook/update.ts)_
+_See code: [src/commands/webhook/update.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/webhook/update.ts)_
 
 ## `eas webhook:view ID`
 
@@ -451,5 +451,5 @@ ARGUMENTS
   ID  ID of the webhook to view
 ```
 
-_See code: [build/commands/webhook/view.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/webhook/view.ts)_
+_See code: [src/commands/webhook/view.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/webhook/view.ts)_
 <!-- commandsstop -->

--- a/packages/eas-cli/clean-readme.py
+++ b/packages/eas-cli/clean-readme.py
@@ -1,7 +1,0 @@
-s = open('README.md').read()
-s = s.replace('[build/', '[src/')
-s = s.replace('build/commands', 'packages/eas-cli/src/commands')
-f = open('README.md', 'w')
-f.write(s)
-f.close()
-quit()

--- a/packages/eas-cli/clean-readme.py
+++ b/packages/eas-cli/clean-readme.py
@@ -1,0 +1,7 @@
+s = open('README.md').read()
+s = s.replace('[build/', '[src/')
+s = s.replace('build/commands', 'packages/eas-cli/src/commands')
+f = open('README.md', 'w')
+f.write(s)
+f.close()
+quit()

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -166,12 +166,12 @@
   "repository": "expo/eas-cli",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
-    "prepack": "rm -rf build && yarn build && yarn oclif-dev manifest && yarn oclif-dev readme",
+    "prepack": "rm -rf build && yarn build && yarn oclif-dev manifest && yarn oclif-dev readme && node patch-readme",
     "build": "tsc --project tsconfig.build.json",
     "watch": "yarn build --watch --preserveWatchOutput",
     "typecheck": "tsc",
     "test": "jest",
-    "version": "yarn oclif-dev readme && git add README.md",
+    "version": "yarn oclif-dev readme && node patch-readme && git add README.md",
     "generate-graphql-code": "graphql-codegen --config graphql-codegen.yml"
   },
   "types": "build/index.d.ts",

--- a/packages/eas-cli/patch-readme.js
+++ b/packages/eas-cli/patch-readme.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+
+// Patch `oclif-dev readme` path and link generation
+let readmeContent = fs.readFileSync('README.md', 'utf8');
+readmeContent = readmeContent.replaceAll('[build/', '[src/');
+readmeContent = readmeContent.replaceAll('build/commands', 'packages/eas-cli/src/commands');
+fs.writeFileSync('README.md', readmeContent);

--- a/packages/eas-cli/patch-readme.js
+++ b/packages/eas-cli/patch-readme.js
@@ -5,3 +5,5 @@ let readmeContent = fs.readFileSync('README.md', 'utf8');
 readmeContent = readmeContent.replaceAll('[build/', '[src/');
 readmeContent = readmeContent.replaceAll('build/commands', 'packages/eas-cli/src/commands');
 fs.writeFileSync('README.md', readmeContent);
+
+console.log('Patched README path generation');

--- a/packages/eas-cli/patch-readme.js
+++ b/packages/eas-cli/patch-readme.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 
 // Patch `oclif-dev readme` path and link generation
 let readmeContent = fs.readFileSync('README.md', 'utf8');
-readmeContent = readmeContent.replaceAll('[build/', '[src/');
-readmeContent = readmeContent.replaceAll('build/commands', 'packages/eas-cli/src/commands');
+readmeContent = readmeContent.replace(/\[build\//g, '[src/');
+readmeContent = readmeContent.replace(/build\/commands/g, 'packages/eas-cli/src/commands');
 fs.writeFileSync('README.md', readmeContent);
 
 console.log('Patched README path generation');


### PR DESCRIPTION
# Checklist

Not applicable

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Majority of the `See code` links in the README resolve to nonexistent paths causing 404s. For example, [build/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.17.0/build/commands/account/login.ts) should resolve to [src/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v0.17.0/packages/eas-cli/src/commands/account/login.ts).

Closes #350.

# How

Simple find and replace with the links and updating relevant text using `patch-readme.js` script added to `package.json`.

# Test Plan

Clicked through the links to make sure they all resolve to right locations.