### PR TITLE
[eas-cli] download and backup keystore action

### DIFF
--- a/packages/eas-cli/src/credentials/android/actions/new/DownloadKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/DownloadKeystore.ts
@@ -46,9 +46,9 @@ export class DownloadKeystore {
 
     // non-sensitive information
     displayAndroidKeystore(keystore);
-    Log.newLine();
 
     if (displaySensitiveInformation) {
+      Log.newLine();
       Log.log(`Sensitive Keystore information:
     Keystore password: ${chalk.bold(keystore.keystorePassword)}
     Key alias:         ${chalk.bold(keystore.keyAlias)}
@@ -57,6 +57,7 @@ export class DownloadKeystore {
     Path to Keystore:  ${keystorePath}
       `);
     }
+    Log.newLine();
   }
 }
 

--- a/packages/eas-cli/src/credentials/android/actions/new/DownloadKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/DownloadKeystore.ts
@@ -1,0 +1,81 @@
+import chalk from 'chalk';
+import fs from 'fs-extra';
+
+import { AndroidAppBuildCredentialsFragment } from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { confirmAsync } from '../../../../prompts';
+import { maybeRenameExistingFileAsync } from '../../../../utils/files';
+import { Context } from '../../../context';
+import { AppLookupParams, formatProjectFullName } from '../../api/GraphqlClient';
+import { displayAndroidKeystore } from '../../utils/printCredentialsBeta';
+
+interface DownloadKeystoreOptions {
+  app: AppLookupParams;
+  displaySensitiveInformation?: boolean;
+  outputPath?: string;
+}
+
+export class DownloadKeystore {
+  constructor(private options: DownloadKeystoreOptions) {}
+
+  public async runAsync(
+    ctx: Context,
+    buildCredentials: AndroidAppBuildCredentialsFragment
+  ): Promise<void> {
+    const keystore = buildCredentials.androidKeystore;
+    if (!keystore) {
+      Log.warn(
+        `There is no valid Keystore defined for build credentials: ${buildCredentials.name}`
+      );
+      return;
+    }
+
+    let displaySensitiveInformation = this.options?.displaySensitiveInformation;
+    if (displaySensitiveInformation === undefined && !ctx.nonInteractive) {
+      displaySensitiveInformation = await confirmAsync({
+        message: 'Do you want to display the sensitive information of the Android Keystore?',
+      });
+    }
+    const projectFullName = formatProjectFullName(this.options.app);
+    const keystorePath = this.options?.outputPath ?? `${projectFullName.replace('/', '__')}.jks`;
+
+    await maybeRenameExistingFileAsync(ctx.projectDir, keystorePath);
+
+    Log.log(`Saving Keystore to ${keystorePath}`);
+    await fs.writeFile(keystorePath, keystore.keystore, 'base64');
+
+    // non-sensitive information
+    displayAndroidKeystore(keystore);
+    Log.newLine();
+
+    if (displaySensitiveInformation) {
+      Log.log(`Sensitive Keystore information:
+    Keystore password: ${chalk.bold(keystore.keystorePassword)}
+    Key alias:         ${chalk.bold(keystore.keyAlias)}
+    Key password:      ${chalk.bold(keystore.keyPassword)}
+
+    Path to Keystore:  ${keystorePath}
+      `);
+    }
+  }
+}
+
+export class BackupKeystore {
+  constructor(private app: AppLookupParams) {}
+
+  public async runAsync(
+    ctx: Context,
+    buildCredentials: AndroidAppBuildCredentialsFragment
+  ): Promise<void> {
+    if (!buildCredentials.androidKeystore) {
+      return;
+    }
+    const projectFullName = formatProjectFullName(this.app);
+    Log.warn('Backing up your old Android Keystore now...');
+    await new DownloadKeystore({
+      app: this.app,
+      outputPath: `${projectFullName}.bak.jks`.replace('/', '__'),
+      displaySensitiveInformation: true,
+    }).runAsync(ctx, buildCredentials);
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/new/__tests__/DownloadKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/__tests__/DownloadKeystore-test.ts
@@ -1,0 +1,43 @@
+import fs from 'fs-extra';
+
+import { testAndroidBuildCredentialsFragment } from '../../../../__tests__/fixtures-android-new';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
+import { getAppLookupParamsFromContext } from '../../BuildCredentialsUtils';
+import { DownloadKeystore } from '../DownloadKeystore';
+
+const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+beforeAll(() => {
+  console.log = jest.fn();
+  console.warn = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+  console.warn = originalConsoleWarn;
+});
+describe(DownloadKeystore, () => {
+  it('downloads a keystore', async () => {
+    const fsWriteFileSpy = jest.spyOn(fs, 'writeFile');
+    const ctx = createCtxMock({
+      nonInteractive: false,
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const downloadKeystoreAction = new DownloadKeystore({ app: appLookupParams });
+    await downloadKeystoreAction.runAsync(ctx, testAndroidBuildCredentialsFragment);
+    expect(fsWriteFileSpy as any).toHaveBeenCalledTimes(1);
+    expect(fsWriteFileSpy as any).toHaveBeenCalledWith(
+      `@${appLookupParams.account.name}__${appLookupParams.projectName}.jks`,
+      testAndroidBuildCredentialsFragment.androidKeystore?.keystore,
+      'base64'
+    );
+    fsWriteFileSpy.mockRestore();
+  });
+  it('works in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({ nonInteractive: true });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const downloadKeystoreAction = new DownloadKeystore({ app: appLookupParams });
+    await expect(
+      downloadKeystoreAction.runAsync(ctx, testAndroidBuildCredentialsFragment)
+    ).resolves.not.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
@@ -218,5 +218,5 @@ async function getAppAsync(appLookupParams: AppLookupParams): Promise<AppFragmen
   return await AppQuery.byFullNameAsync(projectFullName);
 }
 
-const formatProjectFullName = ({ account, projectName }: AppLookupParams): string =>
+export const formatProjectFullName = ({ account, projectName }: AppLookupParams): string =>
   `@${account.name}/${projectName}`;

--- a/packages/eas-cli/src/credentials/android/utils/printCredentialsBeta.ts
+++ b/packages/eas-cli/src/credentials/android/utils/printCredentialsBeta.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import {
   AndroidAppBuildCredentialsFragment,
   AndroidFcmVersion,
+  AndroidKeystoreFragment,
   CommonAndroidAppCredentialsFragment,
   FcmSnippetLegacy,
   FcmSnippetV1,
@@ -109,25 +110,29 @@ function displayAndroidBuildCredentials(
   const maybeKeystore = buildCredentials.androidKeystore;
   Log.log(`  Keystore:`);
   if (maybeKeystore) {
-    const {
-      keyAlias,
-      type,
-      md5CertificateFingerprint,
-      sha1CertificateFingerprint,
-      sha256CertificateFingerprint,
-      updatedAt,
-    } = maybeKeystore;
-    Log.log(`    Type: ${type}`);
-    Log.log(`    Key Alias: ${keyAlias}`);
-
-    Log.log(`    MD5 Fingerprint: ${formatFingerprint(md5CertificateFingerprint ?? null)}`);
-    Log.log(`    SHA1 Fingerprint: ${formatFingerprint(sha1CertificateFingerprint ?? null)}`);
-    Log.log(`    SHA256 Fingerprint: ${formatFingerprint(sha256CertificateFingerprint ?? null)}`);
-    Log.log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
+    displayAndroidKeystore(maybeKeystore);
   } else {
     Log.log(`    None assigned yet`);
   }
   Log.newLine();
+}
+
+export function displayAndroidKeystore(keystore: AndroidKeystoreFragment) {
+  const {
+    keyAlias,
+    type,
+    md5CertificateFingerprint,
+    sha1CertificateFingerprint,
+    sha256CertificateFingerprint,
+    updatedAt,
+  } = keystore;
+  Log.log(`    Type: ${type}`);
+  Log.log(`    Key Alias: ${keyAlias}`);
+
+  Log.log(`    MD5 Fingerprint: ${formatFingerprint(md5CertificateFingerprint ?? null)}`);
+  Log.log(`    SHA1 Fingerprint: ${formatFingerprint(sha1CertificateFingerprint ?? null)}`);
+  Log.log(`    SHA256 Fingerprint: ${formatFingerprint(sha256CertificateFingerprint ?? null)}`);
+  Log.log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
 }
 
 export function displayAndroidAppCredentials({

--- a/packages/eas-cli/src/credentials/manager/SelectAndroidBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectAndroidBuildCredentials.ts
@@ -1,4 +1,5 @@
 import { AndroidAppBuildCredentialsFragment } from '../../graphql/generated';
+import Log from '../../log';
 import { promptAsync } from '../../prompts';
 import { promptForNameAsync, sortBuildCredentials } from '../android/actions/BuildCredentialsUtils';
 import { AppLookupParams } from '../android/api/GraphqlClient';
@@ -27,9 +28,6 @@ export class SelectAndroidBuildCredentials {
         result: AndroidAppBuildCredentialsFragment;
       }
   > {
-    await ctx.newAndroid.createOrGetExistingAndroidAppCredentialsWithBuildCredentialsAsync(
-      this.app
-    );
     const buildCredentialsList = await ctx.newAndroid.getAndroidAppBuildCredentialsListAsync(
       this.app
     );
@@ -86,5 +84,38 @@ export class SelectAndroidBuildCredentials {
         name: await promptForNameAsync(),
       },
     };
+  }
+}
+
+export class SelectExistingAndroidBuildCredentials {
+  constructor(private app: AppLookupParams) {}
+
+  async runAsync(ctx: Context): Promise<AndroidAppBuildCredentialsFragment | null> {
+    const buildCredentialsList = await ctx.newAndroid.getAndroidAppBuildCredentialsListAsync(
+      this.app
+    );
+    if (buildCredentialsList.length === 0) {
+      Log.log(`You don't have any Android Build Credentials`);
+      return null;
+    } else if (buildCredentialsList.length === 1) {
+      return buildCredentialsList[0];
+    }
+
+    const sortedBuildCredentialsList = sortBuildCredentials(buildCredentialsList);
+    const sortedBuildCredentialsChoices = sortedBuildCredentialsList.map(buildCredentials => ({
+      title: buildCredentials.isDefault
+        ? `${buildCredentials.name} (Default)`
+        : buildCredentials.name,
+      value: buildCredentials,
+    }));
+
+    return (
+      await promptAsync({
+        type: 'select',
+        name: 'buildCredentials',
+        message: 'Select build credentials',
+        choices: [...sortedBuildCredentialsChoices],
+      })
+    ).buildCredentials;
   }
 }

--- a/packages/eas-cli/src/credentials/manager/SelectAndroidBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectAndroidBuildCredentials.ts
@@ -114,7 +114,7 @@ export class SelectExistingAndroidBuildCredentials {
         type: 'select',
         name: 'buildCredentials',
         message: 'Select build credentials',
-        choices: [...sortedBuildCredentialsChoices],
+        choices: sortedBuildCredentialsChoices,
       })
     ).buildCredentials;
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to download a new keystore using the new Graphql Api. This is what will eventually replace the old `DownloadKeystore` here:  https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/android/actions/DownloadKeystore.ts


# Test Plan

- [ ] new tests pass
