### PR TITLE
[eas-cli] more manager dx improvements

### DIFF
--- a/packages/eas-cli/src/credentials/manager/HelperActions.ts
+++ b/packages/eas-cli/src/credentials/manager/HelperActions.ts
@@ -1,10 +1,8 @@
 import Log from '../../log';
 import { pressAnyKeyToContinueAsync } from '../../prompts';
-import { Action, CredentialsManager } from '../CredentialsManager';
-import { Context } from '../context';
 
-export class PressAnyKeyToContinue implements Action {
-  public async runAsync(manager: CredentialsManager, context: Context): Promise<void> {
+export class PressAnyKeyToContinue {
+  public async runAsync(): Promise<void> {
     Log.log('Press any key to continue...');
     await pressAnyKeyToContinueAsync();
     Log.newLine();

--- a/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
@@ -17,7 +17,7 @@ export class SelectPlatform implements Action {
     });
 
     if (platform === 'ios') {
-      return await new ManageIos().runAsync(ctx);
+      return await new ManageIos(new SelectPlatform()).runAsync(ctx);
     }
     return await manager.runActionAsync(new SelectAndroidApp());
   }

--- a/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
@@ -15,7 +15,10 @@ export class SelectPlatform implements Action {
         { value: 'ios', title: 'iOS' },
       ],
     });
-    const action = platform === 'ios' ? new ManageIos() : new SelectAndroidApp();
-    await manager.runActionAsync(action);
+
+    if (platform === 'ios') {
+      return await new ManageIos().runAsync(ctx);
+    }
+    return await manager.runActionAsync(new SelectAndroidApp());
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

previously, the user has to choose their build profile each time they navigate anywhere through the UI. 
![Screen Shot 2021-06-09 at 2 00 03 PM](https://user-images.githubusercontent.com/6380927/121428880-29faa180-c92b-11eb-81a2-ba145ddc6fa7.png)

- changed this so the user only needs to choose their build profile once when the manager is run. If they want a different build profile, they can choose 'Go Back' from the main menu and run the ios manager again 

# Test Plan

- [x] current tests still pass
