### PR TITLE
[eas-cli] remove android fcm/keystore actions

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-android-new.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-android-new.ts
@@ -91,5 +91,7 @@ export function getNewAndroidApiMockWithoutCredentials() {
     createOrUpdateAndroidAppBuildCredentialsByNameAsync: jest.fn(),
     createKeystoreAsync: jest.fn(),
     createFcmAsync: jest.fn(),
+    deleteKeystoreAsync: jest.fn(),
+    deleteFcmAsync: jest.fn(),
   };
 }

--- a/packages/eas-cli/src/credentials/android/actions/new/RemoveFcm.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/RemoveFcm.ts
@@ -1,0 +1,39 @@
+import Log from '../../../../log';
+import { confirmAsync } from '../../../../prompts';
+import { Context } from '../../../context';
+import { AppLookupParams, formatProjectFullName } from '../../api/GraphqlClient';
+
+export class RemoveFcm {
+  constructor(private app: AppLookupParams) {}
+
+  async runAsync(ctx: Context): Promise<void> {
+    if (ctx.nonInteractive) {
+      throw new Error(
+        "Deleting an FCM Api Key is a destructive operation. Start the CLI without the '--non-interactive' flag to delete the credentials."
+      );
+    }
+    const appCredentials = await ctx.newAndroid.getAndroidAppCredentialsWithCommonFieldsAsync(
+      this.app
+    );
+    const fcm = appCredentials?.androidFcm;
+    if (!fcm) {
+      Log.warn(
+        `There is no valid FCM Api Key defined for ${formatProjectFullName(this.app)}, ${
+          this.app.androidApplicationIdentifier
+        }`
+      );
+      return;
+    }
+
+    const confirm = await confirmAsync({
+      message: 'Permanently delete the FCM Api Key from Expo servers?',
+      initial: false,
+    });
+    if (!confirm) {
+      return;
+    }
+
+    await ctx.newAndroid.deleteFcmAsync(fcm);
+    Log.succeed('FCM Api Key removed');
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/new/RemoveKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/RemoveKeystore.ts
@@ -1,0 +1,65 @@
+import chalk from 'chalk';
+
+import { AndroidAppBuildCredentialsFragment } from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { confirmAsync } from '../../../../prompts';
+import { Context } from '../../../context';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { BackupKeystore } from './DownloadKeystore';
+
+export class RemoveKeystore {
+  constructor(private app: AppLookupParams) {}
+
+  async runAsync(
+    ctx: Context,
+    buildCredentials: AndroidAppBuildCredentialsFragment
+  ): Promise<void> {
+    if (ctx.nonInteractive) {
+      throw new Error(
+        "Deleting a keystore is a destructive operation. Start the CLI without the '--non-interactive' flag to delete the credentials."
+      );
+    }
+    const keystore = buildCredentials.androidKeystore;
+    if (!keystore) {
+      Log.warn(
+        `There is no valid Keystore defined for build credentials: ${buildCredentials.name}`
+      );
+      return;
+    }
+
+    this.displayWarning();
+    const confirm = await confirmAsync({
+      message: 'Permanently delete the Android Keystore?',
+      initial: false,
+    });
+    if (!confirm) {
+      return;
+    }
+    await new BackupKeystore(this.app).runAsync(ctx, buildCredentials);
+
+    await ctx.newAndroid.deleteKeystoreAsync(keystore);
+    Log.succeed('Keystore removed');
+  }
+
+  displayWarning() {
+    Log.newLine();
+    Log.warn(
+      `Clearing your Android build credentials from our build servers is a ${chalk.bold(
+        'PERMANENT and IRREVERSIBLE action.'
+      )}`
+    );
+    Log.warn(
+      chalk.bold(
+        'Android Keystore must be identical to the one previously used to submit your app to the Google Play Store.'
+      )
+    );
+    Log.warn(
+      'Please read https://docs.expo.io/distribution/building-standalone-apps/#if-you-choose-to-build-for-android for more info before proceeding.'
+    );
+    Log.newLine();
+    Log.warn(
+      chalk.bold('Your Keystore will be backed up to your current directory if you continue.')
+    );
+    Log.newLine();
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/new/__tests__/RemoveFcm-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/__tests__/RemoveFcm-test.ts
@@ -1,0 +1,45 @@
+import { confirmAsync } from '../../../../../prompts';
+import {
+  getNewAndroidApiMockWithoutCredentials,
+  testAndroidAppCredentialsFragment,
+} from '../../../../__tests__/fixtures-android-new';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
+import { getAppLookupParamsFromContext } from '../../BuildCredentialsUtils';
+import { RemoveFcm } from '../RemoveFcm';
+
+jest.mock('../../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+
+const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+beforeAll(() => {
+  console.log = jest.fn();
+  console.warn = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+  console.warn = originalConsoleWarn;
+});
+describe(RemoveFcm, () => {
+  it('removes an FCM Api Key', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      newAndroid: {
+        ...getNewAndroidApiMockWithoutCredentials(),
+        getAndroidAppCredentialsWithCommonFieldsAsync: jest.fn(
+          () => testAndroidAppCredentialsFragment
+        ),
+      },
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const removeFcmApiKeyAction = new RemoveFcm(appLookupParams);
+    await removeFcmApiKeyAction.runAsync(ctx);
+    expect(ctx.newAndroid.deleteFcmAsync as any).toHaveBeenCalledTimes(1);
+  });
+  it('errors in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({ nonInteractive: true });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const removeFcmApiKeyAction = new RemoveFcm(appLookupParams);
+    await expect(removeFcmApiKeyAction.runAsync(ctx)).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/android/actions/new/__tests__/RemoveKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/__tests__/RemoveKeystore-test.ts
@@ -1,0 +1,38 @@
+import { confirmAsync } from '../../../../../prompts';
+import { testAndroidBuildCredentialsFragment } from '../../../../__tests__/fixtures-android-new';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
+import { getAppLookupParamsFromContext } from '../../BuildCredentialsUtils';
+import { RemoveKeystore } from '../RemoveKeystore';
+
+jest.mock('../../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+
+const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+beforeAll(() => {
+  console.log = jest.fn();
+  console.warn = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+  console.warn = originalConsoleWarn;
+});
+describe(RemoveKeystore, () => {
+  it('removes a keystore', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const removeKeystoreAction = new RemoveKeystore(appLookupParams);
+    await removeKeystoreAction.runAsync(ctx, testAndroidBuildCredentialsFragment);
+    expect(ctx.newAndroid.deleteKeystoreAsync as any).toHaveBeenCalledTimes(1);
+  });
+  it('errors in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({ nonInteractive: true });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const removeKeystoreAction = new RemoveKeystore(appLookupParams);
+    await expect(
+      removeKeystoreAction.runAsync(ctx, testAndroidBuildCredentialsFragment)
+    ).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
@@ -205,12 +205,20 @@ export async function createKeystoreAsync(
   );
 }
 
+export async function deleteKeystoreAsync(keystore: AndroidKeystoreFragment): Promise<void> {
+  return await AndroidKeystoreMutation.deleteAndroidKeystore(keystore.id);
+}
+
 export async function createFcmAsync(
   account: Account,
   fcmApiKey: string,
   version: AndroidFcmVersion
 ): Promise<AndroidFcmFragment> {
   return await AndroidFcmMutation.createAndroidFcm({ credential: fcmApiKey, version }, account.id);
+}
+
+export async function deleteFcmAsync(fcm: AndroidFcmFragment): Promise<void> {
+  return await AndroidFcmMutation.deleteAndroidFcm(fcm.id);
 }
 
 async function getAppAsync(appLookupParams: AppLookupParams): Promise<AppFragment> {

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidFcmMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidFcmMutation.ts
@@ -7,6 +7,7 @@ import {
   AndroidFcmFragment,
   AndroidFcmInput,
   CreateAndroidFcmMutation,
+  DeleteAndroidFcmMutation,
 } from '../../../../../graphql/generated';
 import { AndroidFcmFragmentNode } from '../../../../../graphql/types/credentials/AndroidFcm';
 
@@ -41,6 +42,29 @@ const AndroidFcmMutation = {
       'GraphQL: `createAndroidFcm` not defined in server response'
     );
     return data.androidFcm.createAndroidFcm;
+  },
+  async deleteAndroidFcm(androidFcmId: string): Promise<void> {
+    await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeleteAndroidFcmMutation>(
+          gql`
+            mutation DeleteAndroidFcmMutation($androidFcmId: ID!) {
+              androidFcm {
+                deleteAndroidFcm(id: $androidFcmId) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            androidFcmId,
+          },
+          {
+            additionalTypenames: ['AndroidFcm', 'AndroidAppCredentials'],
+          }
+        )
+        .toPromise()
+    );
   },
 };
 

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
@@ -7,6 +7,7 @@ import {
   AndroidKeystoreFragment,
   AndroidKeystoreInput,
   CreateAndroidKeystoreMutation,
+  DeleteAndroidKeystoreMutation,
 } from '../../../../../graphql/generated';
 import { AndroidKeystoreFragmentNode } from '../../../../../graphql/types/credentials/AndroidKeystore';
 
@@ -47,6 +48,29 @@ const AndroidKeystoreMutation = {
       'GraphQL: `createAndroidKeystore` not defined in server response'
     );
     return data.androidKeystore.createAndroidKeystore;
+  },
+  async deleteAndroidKeystore(androidKeystoreId: string): Promise<void> {
+    await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeleteAndroidKeystoreMutation>(
+          gql`
+            mutation DeleteAndroidKeystoreMutation($androidKeystoreId: ID!) {
+              androidKeystore {
+                deleteAndroidKeystore(id: $androidKeystoreId) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            androidKeystoreId,
+          },
+          {
+            additionalTypenames: ['AndroidKeystore', 'AndroidAppBuildCredentials'],
+          }
+        )
+        .toPromise()
+    );
   },
 };
 

--- a/packages/eas-cli/src/credentials/manager/ManageAndroidBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroidBeta.ts
@@ -9,8 +9,12 @@ import {
   getAppLookupParamsFromContext,
   promptUserAndCopyLegacyCredentialsAsync,
 } from '../android/actions/BuildCredentialsUtils';
+import { AssignFcm } from '../android/actions/new/AssignFcm';
+import { CreateFcm } from '../android/actions/new/CreateFcm';
 import { CreateKeystore } from '../android/actions/new/CreateKeystore';
 import { DownloadKeystore } from '../android/actions/new/DownloadKeystore';
+import { RemoveFcm } from '../android/actions/new/RemoveFcm';
+import { RemoveKeystore } from '../android/actions/new/RemoveKeystore';
 import {
   displayAndroidAppCredentials,
   displayEmptyAndroidCredentials,
@@ -26,6 +30,9 @@ import {
 enum ActionType {
   CreateKeystore,
   DownloadKeystore,
+  RemoveKeystore,
+  CreateFcm,
+  RemoveFcm,
 }
 
 enum Scope {
@@ -83,6 +90,18 @@ export class ManageAndroid implements Action {
             value: ActionType.DownloadKeystore,
             title: 'Download existing keystore',
           },
+          {
+            value: ActionType.RemoveKeystore,
+            title: 'Delete your keystore',
+          },
+          {
+            value: ActionType.CreateFcm,
+            title: 'Upload an FCM Api Key',
+          },
+          {
+            value: ActionType.RemoveFcm,
+            title: 'Delete your FCM Api Key',
+          },
         ];
         const { action: chosenAction } = await promptAsync({
           type: 'select',
@@ -120,6 +139,21 @@ export class ManageAndroid implements Action {
           if (buildCredentials) {
             await new DownloadKeystore({ app: appLookupParams }).runAsync(ctx, buildCredentials);
           }
+        } else if (chosenAction === ActionType.RemoveKeystore) {
+          const appLookupParams = getAppLookupParamsFromContext(ctx);
+          const buildCredentials = await new SelectExistingAndroidBuildCredentials(
+            appLookupParams
+          ).runAsync(ctx);
+          if (buildCredentials) {
+            await new RemoveKeystore(appLookupParams).runAsync(ctx, buildCredentials);
+          }
+        } else if (chosenAction === ActionType.CreateFcm) {
+          const appLookupParams = getAppLookupParamsFromContext(ctx);
+          const fcm = await new CreateFcm(appLookupParams.account).runAsync(ctx);
+          await new AssignFcm(appLookupParams).runAsync(ctx, fcm);
+        } else if (chosenAction === ActionType.RemoveFcm) {
+          const appLookupParams = getAppLookupParamsFromContext(ctx);
+          await new RemoveFcm(appLookupParams).runAsync(ctx);
         }
       } catch (err) {
         Log.error(err);

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3731,6 +3731,22 @@ export type CreateAndroidFcmMutation = (
   ) }
 );
 
+export type DeleteAndroidFcmMutationVariables = Exact<{
+  androidFcmId: Scalars['ID'];
+}>;
+
+
+export type DeleteAndroidFcmMutation = (
+  { __typename?: 'RootMutation' }
+  & { androidFcm: (
+    { __typename?: 'AndroidFcmMutation' }
+    & { deleteAndroidFcm: (
+      { __typename?: 'deleteAndroidFcmResult' }
+      & Pick<DeleteAndroidFcmResult, 'id'>
+    ) }
+  ) }
+);
+
 export type CreateAndroidKeystoreMutationVariables = Exact<{
   androidKeystoreInput: AndroidKeystoreInput;
   accountId: Scalars['ID'];
@@ -3746,6 +3762,22 @@ export type CreateAndroidKeystoreMutation = (
       & Pick<AndroidKeystore, 'id'>
       & AndroidKeystoreFragment
     )> }
+  ) }
+);
+
+export type DeleteAndroidKeystoreMutationVariables = Exact<{
+  androidKeystoreId: Scalars['ID'];
+}>;
+
+
+export type DeleteAndroidKeystoreMutation = (
+  { __typename?: 'RootMutation' }
+  & { androidKeystore: (
+    { __typename?: 'AndroidKeystoreMutation' }
+    & { deleteAndroidKeystore: (
+      { __typename?: 'DeleteAndroidKeystoreResult' }
+      & Pick<DeleteAndroidKeystoreResult, 'id'>
+    ) }
   ) }
 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to remove a keystore and fcm api key using the new Graphql Api. This is what will eventually replace the old `RemoveKeystore` and add the option for the user to delete their FCM Api Key here:  https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/android/actions/RemoveKeystore.ts

# Test Plan

- [x] new tests pass
