### PR TITLE
Record dev client builds created and downloaded to analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Move android credentials code to new Graphql API ([#439](https://github.com/expo/eas-cli/pull/439) [#440](https://github.com/expo/eas-cli/pull/440) [#438](https://github.com/expo/eas-cli/pull/438) [#443](https://github.com/expo/eas-cli/pull/443) [#447](https://github.com/expo/eas-cli/pull/447) [#451](https://github.com/expo/eas-cli/pull/451) [#455](https://github.com/expo/eas-cli/pull/455) by [@quinlanj](https://github.com/quinlanj))
 - Prepare Graphql infra to support iOS push keys ([#456](https://github.com/expo/eas-cli/pull/456) by [@quinlanj](https://github.com/quinlanj))
 - Improve credentials DX ([#448](https://github.com/expo/eas-cli/pull/448) [#449](https://github.com/expo/eas-cli/pull/449) by [@quinlanj](https://github.com/quinlanj))
+- Add analytics on dev client builds. ([#454](https://github.com/expo/eas-cli/pull/454) by [@fson](https://github.com/fson))
 
 ## [0.17.0](https://github.com/expo/eas-cli/releases/tag/v0.17.0) - 2021-06-02
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -56,6 +56,7 @@
     "progress": "2.0.3",
     "prompts": "2.3.2",
     "qrcode-terminal": "0.12.0",
+    "resolve-from": "5.0.0",
     "semver": "7.3.4",
     "strip-ansi": "6.0.0",
     "tar": "6.0.5",

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -115,6 +115,7 @@ export function createBuildContext<T extends Platform>({
   }
 
   const accountId = findAccountByName(commandCtx.user.accounts, commandCtx.accountName)?.id;
+  const devClienProperties = getDevClientEventProperties(platform, commandCtx, buildProfile);
   const trackingCtx = {
     tracking_id: uuidv4(),
     platform,
@@ -122,7 +123,10 @@ export function createBuildContext<T extends Platform>({
     account_name: commandCtx.accountName,
     project_id: commandCtx.projectId,
     project_type: buildProfile.workflow,
-    ...getDevClientEventProperties(platform, commandCtx, buildProfile),
+    dev_client: devClienProperties.dev_client,
+    ...(devClienProperties.dev_client_version
+      ? { dev_client_version: devClienProperties.dev_client_version }
+      : {}),
   };
   Analytics.logEvent(Event.BUILD_COMMAND, trackingCtx);
   return {

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -126,7 +126,9 @@ export function createBuildContext<T extends Platform>({
   };
 }
 
-function getDevClientEventProperties(projectDir: string) {
+function getDevClientEventProperties(
+  projectDir: string
+): { dev_client: boolean; dev_client_version?: string } {
   try {
     const pkg = JsonFile.read(resolveFrom(projectDir, 'expo-dev-client/package.json'));
     return { dev_client: true, dev_client_version: pkg.version?.toString() };

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -129,7 +129,7 @@ export function createBuildContext<T extends Platform>({
 function getDevClientEventProperties(projectDir: string) {
   try {
     const pkg = JsonFile.read(resolveFrom(projectDir, 'expo-dev-client/package.json'));
-    return { dev_client: true, dev_client_version: pkg.version };
+    return { dev_client: true, dev_client_version: pkg.version?.toString() };
   } catch {
     return { dev_client: false };
   }

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -1,6 +1,7 @@
 import { ExpoConfig } from '@expo/config';
 import { AndroidBuildProfile, EasConfig, IosBuildProfile } from '@expo/eas-json';
 import JsonFile from '@expo/json-file';
+import resolveFrom from 'resolve-from';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getProjectAccountName } from '../project/projectUtils';
@@ -9,7 +10,6 @@ import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import { Platform, RequestedPlatform, TrackingContext } from './types';
 import Analytics, { Event } from './utils/analytics';
-import resolveFrom from 'resolve-from';
 
 export interface CommandContext {
   requestedPlatform: RequestedPlatform;

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -1,12 +1,6 @@
 import { ExpoConfig } from '@expo/config';
-import { Android, Ios, Workflow } from '@expo/eas-build-job';
-import {
-  AndroidBuildProfile,
-  AndroidGenericBuildProfile,
-  EasConfig,
-  IosBuildProfile,
-  IosGenericBuildProfile,
-} from '@expo/eas-json';
+import { Workflow } from '@expo/eas-build-job';
+import { AndroidBuildProfile, EasConfig, IosBuildProfile } from '@expo/eas-json';
 import JsonFile from '@expo/json-file';
 import resolveFrom from 'resolve-from';
 import { v4 as uuidv4 } from 'uuid';

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -30,6 +30,9 @@ export async function collectMetadata<T extends Platform>(
   }
 ): Promise<Metadata> {
   return {
+    // TODO: type error fixed in https://github.com/expo/eas-build/pull/34
+    // remove @ts-expect-error after upgrading @expo/eas-build-job
+    // @ts-expect-error error TS2322: not assignable to type 'Record<string, string | number>'
     trackingContext: ctx.trackingCtx,
     appVersion: await resolveAppVersionAsync(ctx),
     appBuildVersion: await resolveAppBuildVersionAsync(ctx),

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -14,4 +14,4 @@ export enum BuildStatus {
   CANCELED = 'canceled',
 }
 
-export type TrackingContext = Record<string, string | number | boolean | undefined>;
+export type TrackingContext = Record<string, string | number | boolean>;

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -14,4 +14,4 @@ export enum BuildStatus {
   CANCELED = 'canceled',
 }
 
-export type TrackingContext = Record<string, string | number | boolean>;
+export type TrackingContext = Record<string, string | number | boolean | undefined>;

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -14,4 +14,4 @@ export enum BuildStatus {
   CANCELED = 'canceled',
 }
 
-export type TrackingContext = Record<string, string | number>;
+export type TrackingContext = Record<string, string | number | boolean>;


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

We track usage of dev client in order to to understand how it's used and to improve the experience.

# How

Added properties to `BuildContext.trackingCtx`.

# Test Plan

Because these properties get added to all build events, only did a spot check of a couple of events.
- Added logging to `analytics.ts`
- In a managed project with `expo-dev-client` installed, ran `eas build`
- Observed that the properties were included.
<img width="461" alt="Screen Shot 2021-06-14 at 18 03 02" src="https://user-images.githubusercontent.com/497214/121914686-2b690700-cd3b-11eb-879c-97a49a83f1f7.png">

Tested `dev_client: false` case:
- Ran `yarn remove expo-dev-client`.
- Ran `eas build`.
- Checked that `dev_client` property was `false` and `dev_client_version` property was not defined.
