### PR TITLE
[eas-cli] action to upload/download credentials.json to www

### DIFF
--- a/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts
@@ -16,7 +16,7 @@ export class UpdateCredentialsJson implements Action {
     );
     const legacyBuildCredentials = legacyAppCredentials?.androidAppBuildCredentialsList[0] ?? null;
     if (!legacyBuildCredentials) {
-      Log.log('You dont have any Expo Classic Android credentials configured at this time');
+      Log.log(`You don't have any Expo Classic Android credentials configured at this time`);
       return;
     }
     Log.log('Updating Android credentials in credentials.json');

--- a/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts
@@ -2,13 +2,26 @@ import Log from '../../../log';
 import { Action, CredentialsManager } from '../../CredentialsManager';
 import { Context } from '../../context';
 import { updateAndroidCredentialsAsync } from '../../credentialsJson/update';
+import { AndroidAppCredentialsQuery } from '../api/graphql/queries/AndroidAppCredentialsQuery';
 
 export class UpdateCredentialsJson implements Action {
   constructor(private projectFullName: string) {}
 
   async runAsync(manager: CredentialsManager, ctx: Context): Promise<void> {
+    const legacyAppCredentials = await AndroidAppCredentialsQuery.withCommonFieldsByApplicationIdentifierAsync(
+      this.projectFullName,
+      {
+        legacyOnly: true,
+      }
+    );
+    const legacyBuildCredentials = legacyAppCredentials?.androidAppBuildCredentialsList[0] ?? null;
+    if (!legacyBuildCredentials) {
+      Log.log('You dont have any Expo Classic Android credentials configured at this time');
+      return;
+    }
     Log.log('Updating Android credentials in credentials.json');
-    await updateAndroidCredentialsAsync(ctx);
+
+    await updateAndroidCredentialsAsync(ctx, legacyBuildCredentials);
     Log.succeed(
       'Android part of your local credentials.json is synced with values stored on EAS servers.'
     );

--- a/packages/eas-cli/src/credentials/android/actions/new/SetupBuildCredentialsFromCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/SetupBuildCredentialsFromCredentialsJson.ts
@@ -55,7 +55,7 @@ export class SetupBuildCredentialsFromCredentialsJson {
     const providedKeystoreWithType = getKeystoreWithType(localCredentials.keystore);
     if (providedKeystoreWithType.type === AndroidKeystoreType.Unknown) {
       const confirmKeystoreIsSketchy = await confirmAsync({
-        message: `The keystore you provided could not be parsed and may be corrupt. Proceed anyways?`,
+        message: `The keystore you provided could not be parsed and may be corrupt. Proceed anyway?`,
       });
       if (!confirmKeystoreIsSketchy) {
         return null;

--- a/packages/eas-cli/src/credentials/android/actions/new/SetupBuildCredentialsFromCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/SetupBuildCredentialsFromCredentialsJson.ts
@@ -1,0 +1,88 @@
+import {
+  AndroidAppBuildCredentialsFragment,
+  AndroidKeystoreType,
+} from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { confirmAsync } from '../../../../prompts';
+import { Context } from '../../../context';
+import { readAndroidCredentialsAsync } from '../../../credentialsJson/read';
+import {
+  SelectAndroidBuildCredentials,
+  SelectAndroidBuildCredentialsResultType,
+} from '../../../manager/SelectAndroidBuildCredentials';
+import { AppLookupParams } from '../../api/GraphqlClient';
+import { getKeystoreWithType } from '../../utils/keystoreNew';
+import { BackupKeystore } from './DownloadKeystore';
+
+export class SetupBuildCredentialsFromCredentialsJson {
+  constructor(private app: AppLookupParams) {}
+
+  async runAsync(ctx: Context): Promise<AndroidAppBuildCredentialsFragment | null> {
+    if (ctx.nonInteractive) {
+      throw new Error(
+        'Setting up build credentials from credentials.json is only available in interactive mode'
+      );
+    }
+
+    let localCredentials;
+    try {
+      localCredentials = await readAndroidCredentialsAsync(ctx.projectDir);
+    } catch (error) {
+      Log.error(
+        'Reading credentials from credentials.json failed. Make sure this file is correct and all credentials are present there.'
+      );
+      throw error;
+    }
+
+    const selectBuildCredentialsResult = await new SelectAndroidBuildCredentials(this.app).runAsync(
+      ctx
+    );
+    if (
+      selectBuildCredentialsResult.resultType ===
+        SelectAndroidBuildCredentialsResultType.EXISTING_CREDENTIALS &&
+      selectBuildCredentialsResult.result.androidKeystore
+    ) {
+      const buildCredentials = selectBuildCredentialsResult.result;
+      const confirmOverwrite = await confirmAsync({
+        message: `The build configuration ${buildCredentials.name} already has a keystore configured. Overwrite?`,
+      });
+      if (!confirmOverwrite) {
+        return null;
+      }
+      await new BackupKeystore(this.app).runAsync(ctx, buildCredentials);
+    }
+
+    const providedKeystoreWithType = getKeystoreWithType(localCredentials.keystore);
+    if (providedKeystoreWithType.type === AndroidKeystoreType.Unknown) {
+      const confirmKeystoreIsSketchy = await confirmAsync({
+        message: `The keystore you provided could not be parsed and may be corrupt. Proceed anyways?`,
+      });
+      if (!confirmKeystoreIsSketchy) {
+        return null;
+      }
+    }
+    const keystoreFragment = await ctx.newAndroid.createKeystoreAsync(
+      this.app.account,
+      providedKeystoreWithType
+    );
+    let buildCredentials: AndroidAppBuildCredentialsFragment;
+    if (
+      selectBuildCredentialsResult.resultType ===
+      SelectAndroidBuildCredentialsResultType.CREATE_REQUEST
+    ) {
+      buildCredentials = await ctx.newAndroid.createAndroidAppBuildCredentialsAsync(this.app, {
+        ...selectBuildCredentialsResult.result,
+        androidKeystoreId: keystoreFragment.id,
+      });
+    } else {
+      buildCredentials = await ctx.newAndroid.updateAndroidAppBuildCredentialsAsync(
+        selectBuildCredentialsResult.result,
+        {
+          androidKeystoreId: keystoreFragment.id,
+        }
+      );
+    }
+    Log.succeed('Keystore updated');
+    return buildCredentials;
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/new/UpdateCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/UpdateCredentialsJson.ts
@@ -1,0 +1,17 @@
+import { AndroidAppBuildCredentialsFragment } from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { Context } from '../../../context';
+import { updateAndroidCredentialsAsync } from '../../../credentialsJson/update';
+
+export class UpdateCredentialsJson {
+  async runAsync(
+    ctx: Context,
+    buildCredentials: AndroidAppBuildCredentialsFragment
+  ): Promise<void> {
+    Log.log('Updating Android credentials in credentials.json');
+    await updateAndroidCredentialsAsync(ctx, buildCredentials);
+    Log.succeed(
+      'Android part of your local credentials.json is synced with values stored on EAS servers.'
+    );
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/new/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/new/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
@@ -1,0 +1,149 @@
+import { vol } from 'memfs';
+
+import { AndroidKeystoreType } from '../../../../../graphql/generated';
+import { confirmAsync } from '../../../../../prompts';
+import {
+  getNewAndroidApiMockWithoutCredentials,
+  testAndroidBuildCredentialsFragment,
+  testJksAndroidKeystoreFragment,
+} from '../../../../__tests__/fixtures-android-new';
+import { createCtxMock } from '../../../../__tests__/fixtures-context';
+import {
+  SelectAndroidBuildCredentials,
+  SelectAndroidBuildCredentialsResultType,
+} from '../../../../manager/SelectAndroidBuildCredentials';
+import { getAppLookupParamsFromContext } from '../../BuildCredentialsUtils';
+import { SetupBuildCredentialsFromCredentialsJson } from '../SetupBuildCredentialsFromCredentialsJson';
+
+jest.mock('fs');
+
+jest.mock('../../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+jest.mock('../../../../manager/SelectAndroidBuildCredentials');
+
+const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+beforeAll(() => {
+  console.log = jest.fn();
+  console.warn = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+  console.warn = originalConsoleWarn;
+});
+beforeEach(() => {
+  vol.reset();
+});
+
+describe(SetupBuildCredentialsFromCredentialsJson, () => {
+  it('sets up a new build configuration from credentials.json upon user request', async () => {
+    (SelectAndroidBuildCredentials as any).mockImplementation(() => {
+      return {
+        runAsync: () => {
+          return {
+            resultType: SelectAndroidBuildCredentialsResultType.CREATE_REQUEST,
+            result: { isDefault: true, name: 'test configuration' },
+          };
+        },
+      };
+    });
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      newAndroid: {
+        ...getNewAndroidApiMockWithoutCredentials(),
+        createKeystoreAsync: jest.fn(() => testJksAndroidKeystoreFragment),
+      },
+    });
+    vol.fromJSON({
+      './credentials.json': JSON.stringify({
+        android: {
+          keystore: {
+            keystorePath: 'keystore.jks',
+            keystorePassword: testJksAndroidKeystoreFragment.keystorePassword,
+            keyAlias: testJksAndroidKeystoreFragment.keyAlias,
+            keyPassword: testJksAndroidKeystoreFragment.keyPassword,
+          },
+        },
+      }),
+      'keystore.jks': 'some-binary-content',
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsAction = new SetupBuildCredentialsFromCredentialsJson(
+      appLookupParams
+    );
+    await setupBuildCredentialsAction.runAsync(ctx);
+
+    // expect keystore to be created with credentials.json content
+    expect(ctx.newAndroid.createKeystoreAsync as any).toHaveBeenCalledTimes(1);
+    expect(ctx.newAndroid.createKeystoreAsync as any).toBeCalledWith(appLookupParams.account, {
+      keystorePassword: testJksAndroidKeystoreFragment.keystorePassword,
+      keyAlias: testJksAndroidKeystoreFragment.keyAlias,
+      keyPassword: testJksAndroidKeystoreFragment.keyPassword,
+      keystore: Buffer.from('some-binary-content').toString('base64'),
+      type: AndroidKeystoreType.Unknown,
+    });
+
+    // expect new build credentials to be created
+    expect(ctx.newAndroid.createAndroidAppBuildCredentialsAsync as any).toHaveBeenCalledTimes(1);
+  });
+  it('uses an existing build configuration upon user request', async () => {
+    (SelectAndroidBuildCredentials as any).mockImplementation(() => {
+      return {
+        runAsync: () => {
+          return {
+            resultType: SelectAndroidBuildCredentialsResultType.EXISTING_CREDENTIALS,
+            result: testAndroidBuildCredentialsFragment,
+          };
+        },
+      };
+    });
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      newAndroid: {
+        ...getNewAndroidApiMockWithoutCredentials(),
+        createKeystoreAsync: jest.fn(() => testJksAndroidKeystoreFragment),
+      },
+    });
+    vol.fromJSON({
+      './credentials.json': JSON.stringify({
+        android: {
+          keystore: {
+            keystorePath: 'keystore.jks',
+            keystorePassword: testJksAndroidKeystoreFragment.keystorePassword,
+            keyAlias: testJksAndroidKeystoreFragment.keyAlias,
+            keyPassword: testJksAndroidKeystoreFragment.keyPassword,
+          },
+        },
+      }),
+      'keystore.jks': 'some-binary-content',
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsAction = new SetupBuildCredentialsFromCredentialsJson(
+      appLookupParams
+    );
+    await setupBuildCredentialsAction.runAsync(ctx);
+
+    // expect keystore to be created with credentials.json content
+    expect(ctx.newAndroid.createKeystoreAsync as any).toHaveBeenCalledTimes(1);
+    expect(ctx.newAndroid.createKeystoreAsync as any).toBeCalledWith(appLookupParams.account, {
+      keystorePassword: testJksAndroidKeystoreFragment.keystorePassword,
+      keyAlias: testJksAndroidKeystoreFragment.keyAlias,
+      keyPassword: testJksAndroidKeystoreFragment.keyPassword,
+      keystore: Buffer.from('some-binary-content').toString('base64'),
+      type: AndroidKeystoreType.Unknown,
+    });
+
+    // expect existing build credentials to be updated
+    expect(ctx.newAndroid.updateAndroidAppBuildCredentialsAsync as any).toHaveBeenCalledTimes(1);
+  });
+  it('errors in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const setupBuildCredentialsAction = new SetupBuildCredentialsFromCredentialsJson(
+      appLookupParams
+    );
+    await expect(setupBuildCredentialsAction.runAsync(ctx)).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/manager/ManageAndroidBeta.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroidBeta.ts
@@ -15,6 +15,8 @@ import { CreateKeystore } from '../android/actions/new/CreateKeystore';
 import { DownloadKeystore } from '../android/actions/new/DownloadKeystore';
 import { RemoveFcm } from '../android/actions/new/RemoveFcm';
 import { RemoveKeystore } from '../android/actions/new/RemoveKeystore';
+import { SetupBuildCredentialsFromCredentialsJson } from '../android/actions/new/SetupBuildCredentialsFromCredentialsJson';
+import { UpdateCredentialsJson } from '../android/actions/new/UpdateCredentialsJson';
 import {
   displayAndroidAppCredentials,
   displayEmptyAndroidCredentials,
@@ -33,6 +35,8 @@ enum ActionType {
   RemoveKeystore,
   CreateFcm,
   RemoveFcm,
+  UpdateCredentialsJson,
+  SetupBuildCredentialsFromCredentialsJson,
 }
 
 enum Scope {
@@ -102,6 +106,14 @@ export class ManageAndroid implements Action {
             value: ActionType.RemoveFcm,
             title: 'Delete your FCM Api Key',
           },
+          {
+            value: ActionType.UpdateCredentialsJson,
+            title: 'Update credentials.json with values from EAS servers',
+          },
+          {
+            value: ActionType.SetupBuildCredentialsFromCredentialsJson,
+            title: 'Update credentials on EAS servers with values from credentials.json',
+          },
         ];
         const { action: chosenAction } = await promptAsync({
           type: 'select',
@@ -154,6 +166,17 @@ export class ManageAndroid implements Action {
         } else if (chosenAction === ActionType.RemoveFcm) {
           const appLookupParams = getAppLookupParamsFromContext(ctx);
           await new RemoveFcm(appLookupParams).runAsync(ctx);
+        } else if (chosenAction === ActionType.UpdateCredentialsJson) {
+          const appLookupParams = getAppLookupParamsFromContext(ctx);
+          const buildCredentials = await new SelectExistingAndroidBuildCredentials(
+            appLookupParams
+          ).runAsync(ctx);
+          if (buildCredentials) {
+            await new UpdateCredentialsJson().runAsync(ctx, buildCredentials);
+          }
+        } else if (chosenAction === ActionType.SetupBuildCredentialsFromCredentialsJson) {
+          const appLookupParams = getAppLookupParamsFromContext(ctx);
+          await new SetupBuildCredentialsFromCredentialsJson(appLookupParams).runAsync(ctx);
         }
       } catch (err) {
         Log.error(err);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This is part of the effort to move all credentials apiv2 calls to our graphql api. This PR allows you to update/download build credentials between your local credentials.json and the EAS servers using the new Graphql Api. This is what will eventually replace the old `SetupBuildCredentialsFromCredentialsJson` and `UpdateCredentialsJson` here:  https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/android/actions/SetupBuildCredentials.ts and https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/credentials/android/actions/UpdateCredentialsJson.ts

# Test Plan

- [ ] amended and new tests pass
- [ ] manual sanity testing
