### PR TITLE
[eas-cli] add support for big sur image for ios builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Make credentials manager work with multi-target iOS projects. ([#441](https://github.com/expo/eas-cli/pull/441) by [@dsokal](https://github.com/dsokal))
 - Copy over credentials from Expo Classic to EAS ([#445](https://github.com/expo/eas-cli/pull/445) by [@quinlanj](https://github.com/quinlanj))
+- Add Big Sur image for iOS builds. ([#457](https://github.com/expo/eas-cli/pull/457) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/apple-utils": "0.0.0-alpha.20",
     "@expo/config": "3.3.42",
     "@expo/config-plugins": "2.0.2",
-    "@expo/eas-build-job": "0.2.35",
+    "@expo/eas-build-job": "0.2.37",
     "@expo/eas-json": "^0.17.0",
     "@expo/json-file": "8.2.25",
     "@expo/pkcs12": "0.0.4",

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.35",
+    "@expo/eas-build-job": "0.2.37",
     "@hapi/joi": "17.1.1",
     "fs-extra": "9.0.1",
     "tslib": "1.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,10 +1917,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.35":
-  version "0.2.35"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.35.tgz#4e64ebe1314d0af0f33d3922b15d9e3fe415378e"
-  integrity sha512-+R24ZbZSgC1rLm83pOIUJ8pk2e9e/V6nJBrdl/jLWaCE1YPp1N/Elh8R6x1QuqYyXGOm2AG6r++MGItg9KmggA==
+"@expo/eas-build-job@0.2.37":
+  version "0.2.37"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.37.tgz#fd6cb911e33774239d1ab7662c0ccc8efa22f7a2"
+  integrity sha512-B9gahwTTYs0pWQP2HnfYWcbsqmUIAdnr+iwounVqpcxHhERxGJby2JEw+Vxtl2+VMARM4w9RLgNduP5Vk/zeQw==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

add big sure image

# How

update eas-build-job

# Test Plan

