### PR TITLE
Add an internal distribution with dev client to `build:configure` defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Make credentials manager work with multi-target iOS projects. ([#441](https://github.com/expo/eas-cli/pull/441) by [@dsokal](https://github.com/dsokal))
 - Copy over credentials from Expo Classic to EAS ([#445](https://github.com/expo/eas-cli/pull/445) by [@quinlanj](https://github.com/quinlanj))
 - Add Big Sur image for iOS builds. ([#457](https://github.com/expo/eas-cli/pull/457) by [@wkozyra95](https://github.com/wkozyra95))
+- Add an internal distribution with dev client to `build:configure` defaults. ([#463](https://github.com/expo/eas-cli/pull/463) by [@fson](https://github.com/fson))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -65,6 +65,37 @@ export async function configureAsync(options: {
   }
 }
 
+const MANAGED_DEFAULTS = {
+  release: {
+    workflow: 'managed',
+  },
+  development: {
+    workflow: 'managed',
+    buildType: 'development-client',
+    distribution: 'internal',
+  },
+};
+const ANDROID_GENERIC_DEFAULTS = {
+  release: {
+    workflow: 'generic',
+  },
+  development: {
+    workflow: 'generic',
+    gradleCommand: ':app:assembleDebug',
+    distribution: 'internal',
+  },
+};
+const IOS_GENERIC_DEFAULTS = {
+  release: {
+    workflow: 'generic',
+  },
+  development: {
+    workflow: 'generic',
+    schemeBuildConfiguration: 'Debug',
+    distribution: 'internal',
+  },
+};
+
 export async function ensureEasJsonExistsAsync(ctx: ConfigureContext): Promise<void> {
   const easJsonPath = path.join(ctx.projectDir, 'eas.json');
   let existingEasJson;
@@ -99,20 +130,12 @@ export async function ensureEasJsonExistsAsync(ctx: ConfigureContext): Promise<v
       ...existingEasJson,
       ...(shouldInitAndroid
         ? {
-            android: {
-              release: {
-                workflow: ctx.hasAndroidNativeProject ? 'generic' : 'managed',
-              },
-            },
+            android: ctx.hasAndroidNativeProject ? ANDROID_GENERIC_DEFAULTS : MANAGED_DEFAULTS,
           }
         : null),
       ...(shouldInitIOS
         ? {
-            ios: {
-              release: {
-                workflow: ctx.hasIosNativeProject ? 'generic' : 'managed',
-              },
-            },
+            ios: ctx.hasIosNativeProject ? IOS_GENERIC_DEFAULTS : MANAGED_DEFAULTS,
           }
         : null),
     },


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

It should be easy to make a build for internal distribution with dev client included.

# How

Automatically configure a build profile for internal distribution in `eas.json` when `eas build:configure` is run.

I did this by modifying the default values added to `eas.json`.

# Test Plan

Ran `eas build:configure -p all` in a managed app. Contents of `eas.json`:
```json
{
  "builds": {
    "android": {
      "release": {
        "workflow": "managed"
      },
      "development": {
        "workflow": "managed",
        "buildType": "development-client",
        "distribution": "internal"
      }
    },
    "ios": {
      "release": {
        "workflow": "managed"
      },
      "development": {
        "workflow": "managed",
        "buildType": "development-client",
        "distribution": "internal"
      }
    }
  }
}
```

Ran `eas build:configure -p all` in a bare app. Contents of `eas.json`:
```json
{
  "builds": {
    "android": {
      "release": {
        "workflow": "generic"
      },
      "development": {
        "workflow": "generic",
        "gradleCommand": ":app:assembleDebug",
        "distribution": "internal"
      }
    },
    "ios": {
      "release": {
        "workflow": "generic"
      },
      "development": {
        "workflow": "generic",
        "schemeBuildConfiguration": "Debug",
        "distribution": "internal"
      }
    }
  }
}
```