### PR TITLE
[eas-cli] create and assign push key actions

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -15327,6 +15327,37 @@
             "deprecationReason": null
           },
           {
+            "name": "deleteBuild",
+            "description": "Delete an EAS Build build",
+            "args": [
+              {
+                "name": "buildId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Build",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cancel",
             "description": "Cancel an EAS Build build",
             "args": [],
@@ -16995,9 +17026,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "IosAppBuildCredentials",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IosAppBuildCredentials",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -17036,9 +17071,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "IosAppBuildCredentials",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IosAppBuildCredentials",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -17077,9 +17116,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "IosAppBuildCredentials",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IosAppBuildCredentials",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -17196,9 +17239,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "IosAppCredentials",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IosAppCredentials",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -17237,9 +17284,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "IosAppCredentials",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IosAppCredentials",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -17278,9 +17329,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "IosAppCredentials",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IosAppCredentials",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
@@ -4,11 +4,11 @@ import { Context } from '../context';
 import { getNewAndroidApiMock } from './fixtures-android';
 import { getAppstoreMock } from './fixtures-appstore';
 import { testAppJson, testUsername } from './fixtures-constants';
-import { getNewIosApiMockWithoutCredentials } from './fixtures-ios';
+import { getNewIosApiMock } from './fixtures-ios';
 
 export function createCtxMock(mockOverride: Record<string, any> = {}): Context {
   const defaultMock = {
-    ios: getNewIosApiMockWithoutCredentials(),
+    ios: getNewIosApiMock(),
     android: getNewAndroidApiMock(),
     appStore: getAppstoreMock(),
     bestEffortAppStoreAuthenticateAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -9,7 +9,6 @@ import {
   IosAppBuildCredentialsFragment,
   IosDistributionType,
 } from '../../graphql/generated';
-import { IosAppCredentialsWithBuildCredentialsQueryResult } from '../ios/api/graphql/queries/IosAppCredentialsQuery';
 import { DistributionCertificate, ProvisioningProfile } from '../ios/appstore/Credentials.types';
 import { Target } from '../ios/types';
 import { testProvisioningProfileBase64 } from './fixtures-base64-data';
@@ -111,20 +110,16 @@ export const testCommonIosAppCredentialsFragment: CommonIosAppCredentialsFragmen
   iosAppBuildCredentialsList: [testIosAppBuildCredentialsFragment],
 };
 
-export const testIosAppCredentialsWithBuildCredentialsQueryResult: IosAppCredentialsWithBuildCredentialsQueryResult = {
-  id: 'test-app-credential-id',
-  iosAppBuildCredentialsList: [testIosAppBuildCredentialsFragment],
-};
-
 export const testAppleTeam = {
   id: 'test-team-id',
 };
 
-export function getNewIosApiMockWithoutCredentials() {
+export function getNewIosApiMock() {
   return {
+    createOrGetIosAppCredentialsWithCommonFieldsAsync: jest.fn(),
+    updateIosAppCredentialsAsync: jest.fn(),
     createOrUpdateIosAppBuildCredentialsAsync: jest.fn(),
     getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(),
-    createOrGetExistingIosAppCredentialsWithBuildCredentialsAsync: jest.fn(),
     createOrGetExistingAppleTeamAsync: () => testAppleTeam,
     createOrGetExistingAppleAppIdentifierAsync: jest.fn(),
     getDevicesForAppleTeamAsync: jest.fn(),
@@ -136,25 +131,7 @@ export function getNewIosApiMockWithoutCredentials() {
     getDistributionCertificatesForAccountAsync: jest.fn(),
     createDistributionCertificateAsync: jest.fn(),
     deleteDistributionCertificateAsync: jest.fn(),
-  };
-}
-
-export function getNewIosApiMockWithCredentials() {
-  return {
-    createOrUpdateIosAppBuildCredentialsAsync: jest.fn(),
-    getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(),
-    createOrGetExistingIosAppCredentialsWithBuildCredentialsAsync: jest.fn(),
-    createOrGetExistingAppleTeamAsync: jest.fn(),
-    createOrGetExistingAppleAppIdentifierAsync: jest.fn(),
-    getDevicesForAppleTeamAsync: jest.fn(),
-    createProvisioningProfileAsync: jest.fn(),
-    getProvisioningProfileAsync: jest.fn(),
-    updateProvisioningProfileAsync: jest.fn(),
-    deleteProvisioningProfilesAsync: jest.fn(),
-    getDistributionCertificateForAppAsync: jest.fn(),
-    getDistributionCertificatesForAccountAsync: jest.fn(),
-    createDistributionCertificateAsync: jest.fn(),
-    deleteDistributionCertificateAsync: jest.fn(),
+    createPushKeyAsync: jest.fn(),
   };
 }
 

--- a/packages/eas-cli/src/credentials/credentialsJson/__tests__/update-test.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/__tests__/update-test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../__tests__/fixtures-android';
 import { createCtxMock } from '../../__tests__/fixtures-context';
 import {
-  getNewIosApiMockWithoutCredentials,
+  getNewIosApiMock,
   testCommonIosAppCredentialsFragment,
   testDistCertFragmentNoDependencies,
   testProvisioningProfileFragment,
@@ -198,7 +198,7 @@ describe('update credentials.json', () => {
     it('should update ios credentials in credentials.json if www returns valid credentials', async () => {
       const ctx = createCtxMock({
         ios: {
-          ...getNewIosApiMockWithoutCredentials(),
+          ...getNewIosApiMock(),
           getIosAppCredentialsWithCommonFieldsAsync: jest.fn(
             () => testCommonIosAppCredentialsFragment
           ),
@@ -244,7 +244,7 @@ describe('update credentials.json', () => {
     it('should create credentials.json provisioning profile and distribution certificate if credentials.json does not exist', async () => {
       const ctx = createCtxMock({
         ios: {
-          ...getNewIosApiMockWithoutCredentials(),
+          ...getNewIosApiMock(),
           getIosAppCredentialsWithCommonFieldsAsync: jest.fn(
             () => testCommonIosAppCredentialsFragment
           ),
@@ -272,7 +272,7 @@ describe('update credentials.json', () => {
     it('should not do anything if no credentials are returned from www', async () => {
       const ctx = createCtxMock({
         ios: {
-          ...getNewIosApiMockWithoutCredentials(),
+          ...getNewIosApiMock(),
           getIosAppCredentialsWithCommonFieldsAsync: jest.fn(() => null),
         },
       });

--- a/packages/eas-cli/src/credentials/ios/__tests__/IosCredentialsProvider-test.ts
+++ b/packages/eas-cli/src/credentials/ios/__tests__/IosCredentialsProvider-test.ts
@@ -6,8 +6,8 @@ import { findApplicationTarget } from '../../../project/ios/target';
 import { getAppstoreMock } from '../../__tests__/fixtures-appstore';
 import { createCtxMock } from '../../__tests__/fixtures-context';
 import {
-  getNewIosApiMockWithoutCredentials,
-  testIosAppCredentialsWithBuildCredentialsQueryResult,
+  getNewIosApiMock,
+  testCommonIosAppCredentialsFragment,
   testTargets,
 } from '../../__tests__/fixtures-ios';
 import IosCredentialsProvider from '../IosCredentialsProvider';
@@ -56,7 +56,7 @@ describe(IosCredentialsProvider, () => {
           appStore: getAppstoreMock(),
           projectDir: '/app',
           ios: {
-            ...getNewIosApiMockWithoutCredentials(),
+            ...getNewIosApiMock(),
             getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(() => null),
           },
         });
@@ -86,13 +86,13 @@ describe(IosCredentialsProvider, () => {
           appStore: getAppstoreMock(),
           projectDir: '/app',
           ios: {
-            ...getNewIosApiMockWithoutCredentials(),
+            ...getNewIosApiMock(),
             getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(
-              () => testIosAppCredentialsWithBuildCredentialsQueryResult
+              () => testCommonIosAppCredentialsFragment
             ),
             getDistributionCertificateForAppAsync: jest.fn(
               () =>
-                testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsList[0]
+                testCommonIosAppCredentialsFragment.iosAppBuildCredentialsList[0]
                   .distributionCertificate
             ),
           },
@@ -113,8 +113,7 @@ describe(IosCredentialsProvider, () => {
           distribution: 'store',
         });
 
-        const buildCredentials =
-          testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsList[0];
+        const buildCredentials = testCommonIosAppCredentialsFragment.iosAppBuildCredentialsList[0];
         await expect(provider.getCredentialsAsync(CredentialsSource.REMOTE)).resolves.toMatchObject(
           {
             testapp: {

--- a/packages/eas-cli/src/credentials/ios/actions/AssignPushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AssignPushKey.ts
@@ -1,0 +1,33 @@
+import { ApplePushKeyFragment, CommonIosAppCredentialsFragment } from '../../../graphql/generated';
+import Log from '../../../log';
+import { Context } from '../../context';
+import { AppLookupParams } from '../api/GraphqlClient';
+import { AppleTeamMissingError } from '../errors';
+import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
+
+export class AssignPushKey {
+  constructor(private app: AppLookupParams) {}
+
+  public async runAsync(
+    ctx: Context,
+    pushKey: ApplePushKeyFragment
+  ): Promise<CommonIosAppCredentialsFragment> {
+    const appleTeam =
+      (await resolveAppleTeamIfAuthenticatedAsync(ctx, this.app)) ?? pushKey.appleTeam ?? null;
+    if (!appleTeam) {
+      // TODO(quin): make this optional
+      throw new AppleTeamMissingError(
+        'An Apple Team is required to proceed. You must be authenticated to your Apple account'
+      );
+    }
+    const appCredentials = await ctx.ios.createOrGetIosAppCredentialsWithCommonFieldsAsync(
+      this.app,
+      { appleTeam }
+    );
+    const updatedAppCredentials = await ctx.ios.updateIosAppCredentialsAsync(appCredentials, {
+      applePushKeyId: pushKey.id,
+    });
+    Log.succeed(`Push Key assigned to ${this.app.projectName}: ${this.app.bundleIdentifier}`);
+    return updatedAppCredentials;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/CreatePushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreatePushKey.ts
@@ -1,0 +1,20 @@
+import { ApplePushKeyFragment } from '../../../graphql/generated';
+import Log from '../../../log';
+import { Account } from '../../../user/Account';
+import { Context } from '../../context';
+import { provideOrGeneratePushKeyAsync } from './PushKeyUtils';
+
+export class CreatePushKey {
+  constructor(private account: Account) {}
+
+  public async runAsync(ctx: Context): Promise<ApplePushKeyFragment> {
+    if (ctx.nonInteractive) {
+      throw new Error(`A new push key cannot be created in non-interactive mode.`);
+    }
+
+    const pushKey = await provideOrGeneratePushKeyAsync(ctx, this.account.name);
+    const result = await ctx.ios.createPushKeyAsync(this.account, pushKey);
+    Log.succeed('Created push key');
+    return result;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
@@ -1,0 +1,108 @@
+import chalk from 'chalk';
+
+import Log, { learnMore } from '../../../log';
+import { confirmAsync, promptAsync } from '../../../prompts';
+import { Context } from '../../context';
+import { askForUserProvidedAsync } from '../../utils/promptForCredentials';
+import { PushKey, PushKeyStoreInfo } from '../appstore/Credentials.types';
+import { APPLE_KEYS_TOO_MANY_GENERATED_ERROR } from '../appstore/pushKey';
+import { pushKeySchema } from '../credentials';
+import { validatePushKeyAsync } from '../validators/validatePushKey';
+
+export async function provideOrGeneratePushKeyAsync(
+  ctx: Context,
+  accountName: string
+): Promise<PushKey> {
+  if (!ctx.nonInteractive) {
+    const userProvided = await promptForPushKeyAsync(ctx);
+    if (userProvided) {
+      if (!ctx.appStore.authCtx) {
+        Log.warn('Unable to validate push key due to insufficient Apple Credentials');
+        return userProvided;
+      } else {
+        const isValid = await validatePushKeyAsync(ctx, userProvided);
+        if (isValid) {
+          return userProvided;
+        }
+        // user could've just input the id wrong, and the p8 could still be valid
+        const useUserProvided = await confirmAsync({
+          message: `Push Key with ID ${userProvided.apnsKeyId} could not be found on Apple's servers. Proceed anyway?`,
+        });
+        if (useUserProvided) {
+          return userProvided;
+        }
+        return await provideOrGeneratePushKeyAsync(ctx, accountName);
+      }
+    }
+  }
+  return await generatePushKeyAsync(ctx, accountName);
+}
+
+async function promptForPushKeyAsync(ctx: Context): Promise<PushKey | null> {
+  let initialValues: { teamId?: string } = {};
+  if (ctx.appStore.authCtx) {
+    initialValues = {
+      teamId: ctx.appStore.authCtx.team.id,
+    };
+  }
+  const userProvided = await askForUserProvidedAsync(pushKeySchema, initialValues);
+  if (!userProvided) {
+    return null;
+  }
+  if (ctx.appStore.authCtx && userProvided.teamId === initialValues.teamId) {
+    return {
+      ...userProvided,
+      teamName: ctx.appStore.authCtx.team.name,
+    };
+  }
+  return userProvided;
+}
+
+async function generatePushKeyAsync(ctx: Context, accountName: string): Promise<PushKey> {
+  await ctx.appStore.ensureAuthenticatedAsync();
+  try {
+    return await ctx.appStore.createPushKeyAsync();
+  } catch (e) {
+    if (e.message === APPLE_KEYS_TOO_MANY_GENERATED_ERROR) {
+      const pushKeys = await ctx.appStore.listPushKeysAsync();
+      Log.warn('Maximum number of Push Notifications Keys generated on Apple Developer Portal.');
+      Log.warn(APPLE_KEYS_TOO_MANY_GENERATED_ERROR);
+
+      if (ctx.nonInteractive) {
+        throw new Error(
+          "Start the CLI without the '--non-interactive' flag to revoke existing push notification keys."
+        );
+      }
+
+      Log.log(chalk.grey(`⚠️  Revoking a Push Key will affect other apps that rely on it`));
+      Log.log(learnMore('https://docs.expo.io/distribution/app-signing/#push-notification-keys'));
+      Log.log();
+
+      const { pushKeysToRevoke } = await promptAsync({
+        type: 'multiselect',
+        name: 'pushKeysToRevoke',
+        message: 'Select Push Notifications Key to revoke.',
+        // @ts-expect-error property missing from `@types/prompts`
+        optionsPerPage: 20,
+        choices: pushKeys.map(pushKey => ({
+          value: pushKey,
+          title: formatPushKeyFromApple(pushKey),
+        })),
+      });
+
+      if (pushKeysToRevoke.length > 0) {
+        const ids = pushKeysToRevoke.map(({ id }: PushKeyStoreInfo) => id);
+        await ctx.appStore.revokePushKeyAsync(ids);
+      }
+    } else {
+      throw e;
+    }
+  }
+  return await generatePushKeyAsync(ctx, accountName);
+}
+
+function formatPushKeyFromApple(pushKey: PushKeyStoreInfo): string {
+  const { name, id } = pushKey;
+  const keyIdText = id ? ` - Key ID: ${id}` : ``;
+  return `${name}${keyIdText}`;
+}

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/AssignPushKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/AssignPushKey-test.ts
@@ -1,0 +1,33 @@
+import { findApplicationTarget } from '../../../../project/ios/target';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { testPushKey, testTargets } from '../../../__tests__/fixtures-ios';
+import { AssignPushKey } from '../AssignPushKey';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+
+describe(AssignPushKey, () => {
+  it('assigns a push key in Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const assignPushKeyAction = new AssignPushKey(appLookupParams);
+    await assignPushKeyAction.runAsync(ctx, testPushKey);
+
+    // expect app credentials to be fetched/created, then updated
+    expect(ctx.ios.createOrGetIosAppCredentialsWithCommonFieldsAsync as any).toHaveBeenCalledTimes(
+      1
+    );
+    expect(ctx.ios.updateIosAppCredentialsAsync as any).toHaveBeenCalledTimes(1);
+  });
+  it('works in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const assignPushKeyAction = new AssignPushKey(appLookupParams);
+    await assignPushKeyAction.runAsync(ctx, testPushKey);
+
+    // dont fail if users are running in non-interactive mode
+    await expect(assignPushKeyAction.runAsync(ctx, testPushKey)).resolves.not.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/CreatePushKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/CreatePushKey-test.ts
@@ -1,0 +1,38 @@
+import { findApplicationTarget } from '../../../../project/ios/target';
+import { confirmAsync } from '../../../../prompts';
+import { getAppstoreMock, testAuthCtx } from '../../../__tests__/fixtures-appstore';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { testTargets } from '../../../__tests__/fixtures-ios';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { CreatePushKey } from '../CreatePushKey';
+jest.mock('../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+
+describe(CreatePushKey, () => {
+  it('creates a Push Key in Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+        authCtx: testAuthCtx,
+      },
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const createPushKeyAction = new CreatePushKey(appLookupParams.account);
+    await createPushKeyAction.runAsync(ctx);
+
+    // expect push key to be created on expo servers
+    expect((ctx.ios.createPushKeyAsync as any).mock.calls.length).toBe(1);
+    // expect push key to be created on apple portal
+    expect((ctx.appStore.createPushKeyAsync as any).mock.calls.length).toBe(1);
+  });
+  it('errors in Non Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const createPushKeyAction = new CreatePushKey(appLookupParams.account);
+    await expect(createPushKeyAction.runAsync(ctx)).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupProvisioningProfile-test.ts
@@ -6,10 +6,10 @@ import { confirmAsync } from '../../../../prompts';
 import { getAppstoreMock, testAuthCtx } from '../../../__tests__/fixtures-appstore';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
 import {
-  getNewIosApiMockWithoutCredentials,
+  getNewIosApiMock,
   testAppleAppIdentifierFragment,
+  testCommonIosAppCredentialsFragment,
   testIosAppBuildCredentialsFragment,
-  testIosAppCredentialsWithBuildCredentialsQueryResult,
   testTargets,
 } from '../../../__tests__/fixtures-ios';
 import { MissingCredentialsNonInteractiveError } from '../../../errors';
@@ -35,16 +35,15 @@ describe('SetupProvisioningProfile', () => {
         listProvisioningProfilesAsync: jest.fn(() => [
           {
             provisioningProfileId: nullthrows(
-              testIosAppCredentialsWithBuildCredentialsQueryResult.iosAppBuildCredentialsList[0]
-                .provisioningProfile
+              testCommonIosAppCredentialsFragment.iosAppBuildCredentialsList[0].provisioningProfile
             ).developerPortalIdentifier,
           },
         ]),
       },
       ios: {
-        ...getNewIosApiMockWithoutCredentials(),
+        ...getNewIosApiMock(),
         getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(
-          () => testIosAppCredentialsWithBuildCredentialsQueryResult
+          () => testCommonIosAppCredentialsFragment
         ),
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
         createOrUpdateIosAppBuildCredentialsAsync: jest.fn(
@@ -75,9 +74,9 @@ describe('SetupProvisioningProfile', () => {
         listProvisioningProfilesAsync: jest.fn(() => []),
       },
       ios: {
-        ...getNewIosApiMockWithoutCredentials(),
+        ...getNewIosApiMock(),
         getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(
-          () => testIosAppCredentialsWithBuildCredentialsQueryResult
+          () => testCommonIosAppCredentialsFragment
         ),
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
       },
@@ -105,9 +104,9 @@ describe('SetupProvisioningProfile', () => {
         //listProvisioningProfilesAsync: jest.fn(() => []),
       },
       ios: {
-        ...getNewIosApiMockWithoutCredentials(),
+        ...getNewIosApiMock(),
         getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(
-          () => testIosAppCredentialsWithBuildCredentialsQueryResult
+          () => testCommonIosAppCredentialsFragment
         ),
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
       },
@@ -134,7 +133,7 @@ describe('SetupProvisioningProfile', () => {
         authCtx: testAuthCtx,
       },
       ios: {
-        ...getNewIosApiMockWithoutCredentials(),
+        ...getNewIosApiMock(),
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
       },
     });

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupTargetBuildCredentialsFromCredentialsJson-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupTargetBuildCredentialsFromCredentialsJson-test.ts
@@ -4,11 +4,11 @@ import { findApplicationTarget } from '../../../../project/ios/target';
 import { confirmAsync } from '../../../../prompts';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
 import {
-  getNewIosApiMockWithoutCredentials,
+  getNewIosApiMock,
   testAppleAppIdentifierFragment,
+  testCommonIosAppCredentialsFragment,
   testDistCert,
   testDistCertFragmentNoDependencies,
-  testIosAppCredentialsWithBuildCredentialsQueryResult,
   testProvisioningProfile,
   testProvisioningProfileFragment,
   testTargets,
@@ -47,16 +47,14 @@ describe('SetupTargetBuildCredentialsFromCredentialsJson', () => {
 
   it('sets up build credentials with same prior configuration in Interactive Mode', async () => {
     // create deep clone the quick and dirty way
-    const testBuildCreds = JSON.parse(
-      JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
-    );
+    const testBuildCreds = JSON.parse(JSON.stringify(testCommonIosAppCredentialsFragment));
     testBuildCreds.iosAppBuildCredentialsList[0].distributionCertificate.certificateP12 =
       testDistCert.certP12;
     testBuildCreds.iosAppBuildCredentialsList[0].provisioningProfile.provisioningProfile =
       testProvisioningProfile.provisioningProfile;
     const ctx = createCtxMock({
       ios: {
-        ...getNewIosApiMockWithoutCredentials(),
+        ...getNewIosApiMock(),
         getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(() => testBuildCreds),
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
         createDistributionCertificateAsync: jest.fn(() => ({ testDistCertFragmentNoDependencies })),
@@ -82,13 +80,13 @@ describe('SetupTargetBuildCredentialsFromCredentialsJson', () => {
   it('sets up build credentials with no prior configuration in Interactive Mode', async () => {
     const ctx = createCtxMock({
       ios: {
-        ...getNewIosApiMockWithoutCredentials(),
+        ...getNewIosApiMock(),
         getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(() => null),
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
         createDistributionCertificateAsync: jest.fn(() => ({ testDistCertFragmentNoDependencies })),
         createProvisioningProfileAsync: jest.fn(() => testProvisioningProfileFragment),
         createOrUpdateIosAppBuildCredentialsAsync: jest.fn(
-          () => testIosAppCredentialsWithBuildCredentialsQueryResult
+          () => testCommonIosAppCredentialsFragment
         ),
       },
     });
@@ -109,16 +107,14 @@ describe('SetupTargetBuildCredentialsFromCredentialsJson', () => {
   });
   it('sets up build credentials with different prior configuration in Interactive Mode', async () => {
     // create deep clone the quick and dirty way
-    const testBuildCreds = JSON.parse(
-      JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
-    );
+    const testBuildCreds = JSON.parse(JSON.stringify(testCommonIosAppCredentialsFragment));
     testBuildCreds.iosAppBuildCredentialsList[0].distributionCertificate.certificateP12 =
       'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
     testBuildCreds.iosAppBuildCredentialsList[0].provisioningProfile.provisioningProfile =
       'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
     const ctx = createCtxMock({
       ios: {
-        ...getNewIosApiMockWithoutCredentials(),
+        ...getNewIosApiMock(),
         getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(() => testBuildCreds),
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
         createDistributionCertificateAsync: jest.fn(() => ({ testDistCertFragmentNoDependencies })),
@@ -143,9 +139,7 @@ describe('SetupTargetBuildCredentialsFromCredentialsJson', () => {
   });
   it('works in Non Interactive Mode - sets up build credentials with different prior configuration', async () => {
     // create deep clone the quick and dirty way
-    const testBuildCreds = JSON.parse(
-      JSON.stringify(testIosAppCredentialsWithBuildCredentialsQueryResult)
-    );
+    const testBuildCreds = JSON.parse(JSON.stringify(testCommonIosAppCredentialsFragment));
     testBuildCreds.iosAppBuildCredentialsList[0].distributionCertificate.certificateP12 =
       'something different so SetupBuildCredentialsFromCredentialsJson doesnt think we want to exact the same cert and skip upload to expo servers';
     testBuildCreds.iosAppBuildCredentialsList[0].provisioningProfile.provisioningProfile =
@@ -153,7 +147,7 @@ describe('SetupTargetBuildCredentialsFromCredentialsJson', () => {
     const ctx = createCtxMock({
       nonInteractive: true,
       ios: {
-        ...getNewIosApiMockWithoutCredentials(),
+        ...getNewIosApiMock(),
         getIosAppCredentialsWithBuildCredentialsAsync: jest.fn(() => testBuildCreds),
         createOrGetExistingAppleAppIdentifierAsync: jest.fn(() => testAppleAppIdentifierFragment),
         createDistributionCertificateAsync: jest.fn(() => ({ testDistCertFragmentNoDependencies })),

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/ApplePushKeyMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/ApplePushKeyMutation.ts
@@ -1,0 +1,50 @@
+import assert from 'assert';
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import {
+  ApplePushKeyFragment,
+  ApplePushKeyInput,
+  CreateApplePushKeyMutation,
+} from '../../../../../graphql/generated';
+import { ApplePushKeyFragmentNode } from '../../../../../graphql/types/credentials/ApplePushKey';
+
+const ApplePushKeyMutation = {
+  async createApplePushKey(
+    applePushKeyInput: ApplePushKeyInput,
+    accountId: string
+  ): Promise<ApplePushKeyFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateApplePushKeyMutation>(
+          gql`
+            mutation CreateApplePushKeyMutation(
+              $applePushKeyInput: ApplePushKeyInput!
+              $accountId: ID!
+            ) {
+              applePushKey {
+                createApplePushKey(applePushKeyInput: $applePushKeyInput, accountId: $accountId) {
+                  id
+                  ...ApplePushKeyFragment
+                }
+              }
+            }
+            ${print(ApplePushKeyFragmentNode)}
+          `,
+          {
+            applePushKeyInput,
+            accountId,
+          }
+        )
+        .toPromise()
+    );
+    assert(
+      data.applePushKey.createApplePushKey,
+      'GraphQL: `createApplePushKey` not defined in server response'
+    );
+    return data.applePushKey.createApplePushKey;
+  },
+};
+
+export { ApplePushKeyMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
@@ -4,18 +4,19 @@ import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
+  CommonIosAppCredentialsFragment,
   CreateIosAppCredentialsMutation,
-  IosAppCredentialsFragment,
   IosAppCredentialsInput,
+  SetPushKeyMutation,
 } from '../../../../../graphql/generated';
-import { IosAppCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppCredentials';
+import { CommonIosAppCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppCredentials';
 
 const IosAppCredentialsMutation = {
   async createIosAppCredentialsAsync(
     iosAppCredentialsInput: IosAppCredentialsInput,
     appId: string,
     appleAppIdentifierId: string
-  ): Promise<IosAppCredentialsFragment> {
+  ): Promise<CommonIosAppCredentialsFragment> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<CreateIosAppCredentialsMutation>(
@@ -32,11 +33,11 @@ const IosAppCredentialsMutation = {
                   appleAppIdentifierId: $appleAppIdentifierId
                 ) {
                   id
-                  ...IosAppCredentialsFragment
+                  ...CommonIosAppCredentialsFragment
                 }
               }
             }
-            ${print(IosAppCredentialsFragmentNode)}
+            ${print(CommonIosAppCredentialsFragmentNode)}
           `,
           {
             iosAppCredentialsInput,
@@ -51,6 +52,33 @@ const IosAppCredentialsMutation = {
       'GraphQL: `createIosAppCredentials` not defined in server response'
     );
     return data.iosAppCredentials.createIosAppCredentials;
+  },
+  async setPushKeyAsync(
+    iosAppCredentialsId: string,
+    pushKeyId: string
+  ): Promise<CommonIosAppCredentialsFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<SetPushKeyMutation>(
+          gql`
+            mutation SetPushKeyMutation($iosAppCredentialsId: ID!, $pushKeyId: ID!) {
+              iosAppCredentials {
+                setPushKey(id: $iosAppCredentialsId, pushKeyId: $pushKeyId) {
+                  id
+                  ...CommonIosAppCredentialsFragment
+                }
+              }
+            }
+            ${print(CommonIosAppCredentialsFragmentNode)}
+          `,
+          {
+            iosAppCredentialsId,
+            pushKeyId,
+          }
+        )
+        .toPromise()
+    );
+    return data.iosAppCredentials.setPushKey;
   },
 };
 

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
@@ -6,59 +6,16 @@ import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/cl
 import {
   CommonIosAppCredentialsFragment,
   CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery,
-  IosAppBuildCredentialsFragment,
-  IosAppCredentialsByAppIdentifierIdQuery,
-  IosAppCredentialsFragment,
   IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery,
   IosDistributionType,
 } from '../../../../../graphql/generated';
 import { IosAppBuildCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
 import {
   CommonIosAppCredentialsFragmentNode,
-  IosAppCredentialsFragmentNode,
+  CommonIosAppCredentialsWithoutBuildCredentialsFragmentNode,
 } from '../../../../../graphql/types/credentials/IosAppCredentials';
 
-export type IosAppCredentialsWithBuildCredentialsQueryResult = IosAppCredentialsFragment & {
-  iosAppBuildCredentialsList: IosAppBuildCredentialsFragment[];
-};
 const IosAppCredentialsQuery = {
-  async byAppIdentifierIdAsync(
-    projectFullName: string,
-    appleAppIdentifierId: string
-  ): Promise<IosAppCredentialsFragment | null> {
-    const data = await withErrorHandlingAsync(
-      graphqlClient
-        .query<IosAppCredentialsByAppIdentifierIdQuery>(
-          gql`
-            query IosAppCredentialsByAppIdentifierIdQuery(
-              $projectFullName: String!
-              $appleAppIdentifierId: String!
-            ) {
-              app {
-                byFullName(fullName: $projectFullName) {
-                  id
-                  iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
-                    id
-                    ...IosAppCredentialsFragment
-                  }
-                }
-              }
-            }
-            ${print(IosAppCredentialsFragmentNode)}
-          `,
-          {
-            projectFullName,
-            appleAppIdentifierId,
-          },
-          {
-            additionalTypenames: ['IosAppCredentials'],
-          }
-        )
-        .toPromise()
-    );
-    assert(data.app, 'GraphQL: `app` not defined in server response');
-    return data.app.byFullName.iosAppCredentials[0] ?? null;
-  },
   async withBuildCredentialsByAppIdentifierIdAsync(
     projectFullName: string,
     {
@@ -68,7 +25,7 @@ const IosAppCredentialsQuery = {
       appleAppIdentifierId: string;
       iosDistributionType?: IosDistributionType;
     }
-  ): Promise<IosAppCredentialsWithBuildCredentialsQueryResult | null> {
+  ): Promise<CommonIosAppCredentialsFragment | null> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery>(
@@ -83,7 +40,7 @@ const IosAppCredentialsQuery = {
                   id
                   iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
                     id
-                    ...IosAppCredentialsFragment
+                    ...CommonIosAppCredentialsWithoutBuildCredentialsFragment
                     iosAppBuildCredentialsList(
                       filter: { iosDistributionType: $iosDistributionType }
                     ) {
@@ -94,7 +51,7 @@ const IosAppCredentialsQuery = {
                 }
               }
             }
-            ${print(IosAppCredentialsFragmentNode)}
+            ${print(CommonIosAppCredentialsWithoutBuildCredentialsFragmentNode)}
             ${print(IosAppBuildCredentialsFragmentNode)}
           `,
           {

--- a/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtils.ts
@@ -1,5 +1,21 @@
 import { AppleDistributionCertificateFragment } from '../../../graphql/generated';
-import { DistributionCertificate, DistributionCertificateStoreInfo } from './Credentials.types';
+import {
+  DistributionCertificate,
+  DistributionCertificateStoreInfo,
+  PushKey,
+  PushKeyStoreInfo,
+} from './Credentials.types';
+
+export async function filterRevokedPushKeys<T extends PushKey>(
+  pushKeys: T[],
+  pushInfoFromApple: PushKeyStoreInfo[]
+): Promise<T[]> {
+  // if the credentials are valid, check it against apple to make sure it hasnt been revoked
+  const validKeyIdsOnAppleServer = pushInfoFromApple.map(pushKey => pushKey.id);
+  return pushKeys.filter(pushKey => {
+    return validKeyIdsOnAppleServer.includes(pushKey.apnsKeyId);
+  });
+}
 
 export function filterRevokedDistributionCertsFromEasServers(
   distributionCerts: AppleDistributionCertificateFragment[],

--- a/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
@@ -9,7 +9,7 @@ import { AuthCtx, getRequestContext } from './authenticate';
 
 const { MaxKeysCreatedError } = Keys;
 
-const APPLE_KEYS_TOO_MANY_GENERATED_ERROR = `
+export const APPLE_KEYS_TOO_MANY_GENERATED_ERROR = `
 You can have only ${chalk.underline('two')} Apple Keys generated on your Apple Developer account.
 Please revoke the old ones or reuse existing from your other apps.
 Please remember that Apple Keys are not application specific!

--- a/packages/eas-cli/src/credentials/ios/validators/validatePushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validatePushKey.ts
@@ -1,0 +1,9 @@
+import { Context } from '../../context';
+import { PushKey } from '../appstore/Credentials.types';
+import { filterRevokedPushKeys } from '../appstore/CredentialsUtils';
+
+export async function validatePushKeyAsync(ctx: Context, pushKey: PushKey) {
+  const pushInfoFromApple = await ctx.appStore.listPushKeysAsync();
+  const validPushKeys = await filterRevokedPushKeys([pushKey], pushInfoFromApple);
+  return validPushKeys.length > 0;
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2343,6 +2343,8 @@ export type BuildMutation = {
   __typename?: 'BuildMutation';
   /** Cancel an EAS Build build */
   cancelBuild: Build;
+  /** Delete an EAS Build build */
+  deleteBuild: Build;
   /**
    * Cancel an EAS Build build
    * @deprecated Use cancelBuild instead
@@ -2360,6 +2362,11 @@ export type BuildMutation = {
 
 
 export type BuildMutationCancelBuildArgs = {
+  buildId: Scalars['ID'];
+};
+
+
+export type BuildMutationDeleteBuildArgs = {
   buildId: Scalars['ID'];
 };
 
@@ -2576,11 +2583,11 @@ export enum IosManagedBuildType {
 export type IosAppBuildCredentialsMutation = {
   __typename?: 'IosAppBuildCredentialsMutation';
   /** Create a set of build credentials for an iOS app */
-  createIosAppBuildCredentials?: Maybe<IosAppBuildCredentials>;
+  createIosAppBuildCredentials: IosAppBuildCredentials;
   /** Set the distribution certificate to be used for an iOS app */
-  setDistributionCertificate?: Maybe<IosAppBuildCredentials>;
+  setDistributionCertificate: IosAppBuildCredentials;
   /** Set the provisioning profile to be used for an iOS app */
-  setProvisioningProfile?: Maybe<IosAppBuildCredentials>;
+  setProvisioningProfile: IosAppBuildCredentials;
 };
 
 
@@ -2610,11 +2617,11 @@ export type IosAppBuildCredentialsInput = {
 export type IosAppCredentialsMutation = {
   __typename?: 'IosAppCredentialsMutation';
   /** Create a set of credentials for an iOS app */
-  createIosAppCredentials?: Maybe<IosAppCredentials>;
+  createIosAppCredentials: IosAppCredentials;
   /** Set the push key to be used in an iOS app */
-  setPushKey?: Maybe<IosAppCredentials>;
+  setPushKey: IosAppCredentials;
   /** Set the app-specific password to be used for an iOS app */
-  setAppSpecificPassword?: Maybe<IosAppCredentials>;
+  setAppSpecificPassword: IosAppCredentials;
 };
 
 
@@ -3964,6 +3971,24 @@ export type DeleteAppleProvisioningProfilesMutation = (
   ) }
 );
 
+export type CreateApplePushKeyMutationVariables = Exact<{
+  applePushKeyInput: ApplePushKeyInput;
+  accountId: Scalars['ID'];
+}>;
+
+
+export type CreateApplePushKeyMutation = (
+  { __typename?: 'RootMutation' }
+  & { applePushKey: (
+    { __typename?: 'ApplePushKeyMutation' }
+    & { createApplePushKey: (
+      { __typename?: 'ApplePushKey' }
+      & Pick<ApplePushKey, 'id'>
+      & ApplePushKeyFragment
+    ) }
+  ) }
+);
+
 export type CreateAppleTeamMutationVariables = Exact<{
   appleTeamInput: AppleTeamInput;
   accountId: Scalars['ID'];
@@ -3996,11 +4021,11 @@ export type CreateIosAppBuildCredentialsMutation = (
   { __typename?: 'RootMutation' }
   & { iosAppBuildCredentials: (
     { __typename?: 'IosAppBuildCredentialsMutation' }
-    & { createIosAppBuildCredentials?: Maybe<(
+    & { createIosAppBuildCredentials: (
       { __typename?: 'IosAppBuildCredentials' }
       & Pick<IosAppBuildCredentials, 'id'>
       & IosAppBuildCredentialsFragment
-    )> }
+    ) }
   ) }
 );
 
@@ -4014,11 +4039,11 @@ export type SetDistributionCertificateMutation = (
   { __typename?: 'RootMutation' }
   & { iosAppBuildCredentials: (
     { __typename?: 'IosAppBuildCredentialsMutation' }
-    & { setDistributionCertificate?: Maybe<(
+    & { setDistributionCertificate: (
       { __typename?: 'IosAppBuildCredentials' }
       & Pick<IosAppBuildCredentials, 'id'>
       & IosAppBuildCredentialsFragment
-    )> }
+    ) }
   ) }
 );
 
@@ -4032,11 +4057,11 @@ export type SetProvisioningProfileMutation = (
   { __typename?: 'RootMutation' }
   & { iosAppBuildCredentials: (
     { __typename?: 'IosAppBuildCredentialsMutation' }
-    & { setProvisioningProfile?: Maybe<(
+    & { setProvisioningProfile: (
       { __typename?: 'IosAppBuildCredentials' }
       & Pick<IosAppBuildCredentials, 'id'>
       & IosAppBuildCredentialsFragment
-    )> }
+    ) }
   ) }
 );
 
@@ -4051,11 +4076,29 @@ export type CreateIosAppCredentialsMutation = (
   { __typename?: 'RootMutation' }
   & { iosAppCredentials: (
     { __typename?: 'IosAppCredentialsMutation' }
-    & { createIosAppCredentials?: Maybe<(
+    & { createIosAppCredentials: (
       { __typename?: 'IosAppCredentials' }
       & Pick<IosAppCredentials, 'id'>
-      & IosAppCredentialsFragment
-    )> }
+      & CommonIosAppCredentialsFragment
+    ) }
+  ) }
+);
+
+export type SetPushKeyMutationVariables = Exact<{
+  iosAppCredentialsId: Scalars['ID'];
+  pushKeyId: Scalars['ID'];
+}>;
+
+
+export type SetPushKeyMutation = (
+  { __typename?: 'RootMutation' }
+  & { iosAppCredentials: (
+    { __typename?: 'IosAppCredentialsMutation' }
+    & { setPushKey: (
+      { __typename?: 'IosAppCredentials' }
+      & Pick<IosAppCredentials, 'id'>
+      & CommonIosAppCredentialsFragment
+    ) }
   ) }
 );
 
@@ -4342,28 +4385,6 @@ export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQuery = (
   )> }
 );
 
-export type IosAppCredentialsByAppIdentifierIdQueryVariables = Exact<{
-  projectFullName: Scalars['String'];
-  appleAppIdentifierId: Scalars['String'];
-}>;
-
-
-export type IosAppCredentialsByAppIdentifierIdQuery = (
-  { __typename?: 'RootQuery' }
-  & { app?: Maybe<(
-    { __typename?: 'AppQuery' }
-    & { byFullName: (
-      { __typename?: 'App' }
-      & Pick<App, 'id'>
-      & { iosAppCredentials: Array<(
-        { __typename?: 'IosAppCredentials' }
-        & Pick<IosAppCredentials, 'id'>
-        & IosAppCredentialsFragment
-      )> }
-    ) }
-  )> }
-);
-
 export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQueryVariables = Exact<{
   projectFullName: Scalars['String'];
   appleAppIdentifierId: Scalars['String'];
@@ -4386,7 +4407,7 @@ export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = (
           & Pick<IosAppBuildCredentials, 'id'>
           & IosAppBuildCredentialsFragment
         )> }
-        & IosAppCredentialsFragment
+        & CommonIosAppCredentialsWithoutBuildCredentialsFragment
       )> }
     ) }
   )> }
@@ -5133,12 +5154,7 @@ export type IosAppBuildCredentialsFragment = (
   )> }
 );
 
-export type IosAppCredentialsFragment = (
-  { __typename?: 'IosAppCredentials' }
-  & Pick<IosAppCredentials, 'id'>
-);
-
-export type CommonIosAppCredentialsFragment = (
+export type CommonIosAppCredentialsWithoutBuildCredentialsFragment = (
   { __typename?: 'IosAppCredentials' }
   & Pick<IosAppCredentials, 'id'>
   & { app: (
@@ -5157,9 +5173,16 @@ export type CommonIosAppCredentialsFragment = (
     { __typename?: 'ApplePushKey' }
     & Pick<ApplePushKey, 'id'>
     & ApplePushKeyFragment
-  )>, iosAppBuildCredentialsList: Array<(
+  )> }
+);
+
+export type CommonIosAppCredentialsFragment = (
+  { __typename?: 'IosAppCredentials' }
+  & Pick<IosAppCredentials, 'id'>
+  & { iosAppBuildCredentialsList: Array<(
     { __typename?: 'IosAppBuildCredentials' }
     & Pick<IosAppBuildCredentials, 'id'>
     & IosAppBuildCredentialsFragment
   )> }
+  & CommonIosAppCredentialsWithoutBuildCredentialsFragment
 );

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
@@ -6,14 +6,8 @@ import { ApplePushKeyFragmentNode } from './ApplePushKey';
 import { AppleTeamFragmentNode } from './AppleTeam';
 import { IosAppBuildCredentialsFragmentNode } from './IosAppBuildCredentials';
 
-export const IosAppCredentialsFragmentNode = gql`
-  fragment IosAppCredentialsFragment on IosAppCredentials {
-    id
-  }
-`;
-
-export const CommonIosAppCredentialsFragmentNode = gql`
-  fragment CommonIosAppCredentialsFragment on IosAppCredentials {
+export const CommonIosAppCredentialsWithoutBuildCredentialsFragmentNode = gql`
+  fragment CommonIosAppCredentialsWithoutBuildCredentialsFragment on IosAppCredentials {
     id
     app {
       id
@@ -31,14 +25,22 @@ export const CommonIosAppCredentialsFragmentNode = gql`
       id
       ...ApplePushKeyFragment
     }
-    iosAppBuildCredentialsList {
-      id
-      ...IosAppBuildCredentialsFragment
-    }
   }
   ${AppFragmentNode}
   ${AppleTeamFragmentNode}
   ${AppleAppIdentifierFragmentNode}
   ${ApplePushKeyFragmentNode}
+`;
+
+export const CommonIosAppCredentialsFragmentNode = gql`
+  fragment CommonIosAppCredentialsFragment on IosAppCredentials {
+    id
+    ...CommonIosAppCredentialsWithoutBuildCredentialsFragment
+    iosAppBuildCredentialsList {
+      id
+      ...IosAppBuildCredentialsFragment
+    }
+  }
+  ${CommonIosAppCredentialsWithoutBuildCredentialsFragmentNode}
   ${IosAppBuildCredentialsFragmentNode}
 `;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

CreatePushKey and AssignPushKey actions along with some refactors. Sorry it's a bit messy - I can split this up if its too hard to review.

Refactors include:
- Removing unused mocks and renaming others to be simpler (getNewIosApiMockWithCredentials, getNewIosApiMockWithoutCredentials)
- Removed unused Graphql queries (IosAppCredentialsQuery.byAppIdentifierIdAsync)
- Removed `IosAppCredentialsFragment` and replaced it with `CommonIosAppCredentialsFragment`. We only really use it in 1-2 places, and it's easier to reason about the code when there is the same fragment being passed around (`CommonIosAppCredentialsFragment`)
- Replaced `IosAppCredentialsWithBuildCredentialsQueryResult` with `CommonIosAppCredentialsFragment`

# Test Plan

- [x] new and amended tests pass
