### PR TITLE
[eas-cli] setup push key action

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -116,6 +116,7 @@ export const testAppleTeam = {
 
 export function getNewIosApiMock() {
   return {
+    getIosAppCredentialsWithCommonFieldsAsync: jest.fn(),
     createOrGetIosAppCredentialsWithCommonFieldsAsync: jest.fn(),
     updateIosAppCredentialsAsync: jest.fn(),
     createOrUpdateIosAppBuildCredentialsAsync: jest.fn(),
@@ -132,6 +133,7 @@ export function getNewIosApiMock() {
     createDistributionCertificateAsync: jest.fn(),
     deleteDistributionCertificateAsync: jest.fn(),
     createPushKeyAsync: jest.fn(),
+    getPushKeyForAppAsync: jest.fn(),
   };
 }
 

--- a/packages/eas-cli/src/credentials/ios/actions/AppleTeamUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AppleTeamUtils.ts
@@ -14,3 +14,7 @@ export async function resolveAppleTeamIfAuthenticatedAsync(
     appleTeamName: ctx.appStore.authCtx.team.name,
   });
 }
+
+export function formatAppleTeam({ appleTeamIdentifier, appleTeamName }: AppleTeamFragment): string {
+  return `Team ID: ${appleTeamIdentifier}${appleTeamName ? `, Team name: ${appleTeamName}` : ''}`;
+}

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -2,10 +2,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 import dateformat from 'dateformat';
 
-import {
-  AppleDistributionCertificateFragment,
-  AppleTeamFragment,
-} from '../../../graphql/generated';
+import { AppleDistributionCertificateFragment } from '../../../graphql/generated';
 import Log, { learnMore } from '../../../log';
 import { promptAsync } from '../../../prompts';
 import { Account } from '../../../user/Account';
@@ -21,6 +18,7 @@ import {
 import { filterRevokedDistributionCertsFromEasServers } from '../appstore/CredentialsUtils';
 import { distributionCertificateSchema } from '../credentials';
 import { validateDistributionCertificateAsync } from '../validators/validateDistributionCertificate';
+import { formatAppleTeam } from './AppleTeamUtils';
 
 export function formatDistributionCertificate(
   distributionCertificate: AppleDistributionCertificateFragment,
@@ -61,10 +59,6 @@ export function formatDistributionCertificate(
     line += '';
   }
   return line;
-}
-
-function formatAppleTeam({ appleTeamIdentifier, appleTeamName }: AppleTeamFragment): string {
-  return `Team ID: ${appleTeamIdentifier}${appleTeamName ? `, Team name: ${appleTeamName}` : ''}`;
 }
 
 async function _selectDistributionCertificateAsync(

--- a/packages/eas-cli/src/credentials/ios/actions/SetupPushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupPushKey.ts
@@ -1,0 +1,93 @@
+import assert from 'assert';
+import nullthrows from 'nullthrows';
+
+import { ApplePushKeyFragment, CommonIosAppCredentialsFragment } from '../../../graphql/generated';
+import Log from '../../../log';
+import { confirmAsync, promptAsync } from '../../../prompts';
+import { Context } from '../../context';
+import { AppLookupParams } from '../api/GraphqlClient';
+import { AssignPushKey } from './AssignPushKey';
+import { CreatePushKey } from './CreatePushKey';
+import {
+  formatPushKey,
+  getValidAndTrackedPushKeysOnEasServersAsync,
+  selectPushKeyAsync,
+} from './PushKeyUtils';
+
+export class SetupPushKey {
+  constructor(private app: AppLookupParams) {}
+
+  async isPushKeySetupAsync(ctx: Context): Promise<boolean> {
+    const pushKey = await ctx.ios.getPushKeyForAppAsync(this.app);
+    return !!pushKey;
+  }
+
+  public async runAsync(ctx: Context): Promise<CommonIosAppCredentialsFragment | null> {
+    if (ctx.nonInteractive) {
+      throw new Error(`Push keys cannot be setup in non-interactive mode.`);
+    }
+
+    const isPushKeySetup = await this.isPushKeySetupAsync(ctx);
+    if (isPushKeySetup) {
+      return await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(this.app);
+    }
+
+    const pushKeysForAccount = await ctx.ios.getPushKeysForAccountAsync(this.app.account);
+    let pushKey: ApplePushKeyFragment;
+    if (pushKeysForAccount.length === 0) {
+      pushKey = await new CreatePushKey(this.app.account).runAsync(ctx);
+    } else {
+      pushKey = await this.createOrReusePushKey(ctx);
+    }
+    return await new AssignPushKey(this.app).runAsync(ctx, pushKey);
+  }
+
+  private async createOrReusePushKey(ctx: Context): Promise<ApplePushKeyFragment> {
+    const pushKeysForAccount = await ctx.ios.getPushKeysForAccountAsync(this.app.account);
+    assert(
+      pushKeysForAccount.length > 0,
+      'createOrReusePushKey: There are no Push Keys available in your EAS account.'
+    );
+
+    if (ctx.appStore.authCtx) {
+      // only provide autoselect if we can find a push key that is certainly valid
+      const validPushKeys = ctx.appStore.authCtx
+        ? await getValidAndTrackedPushKeysOnEasServersAsync(ctx, pushKeysForAccount)
+        : [];
+      if (validPushKeys.length > 0) {
+        const autoselectedPushKey = validPushKeys[0];
+
+        const useAutoselected = await confirmAsync({
+          message: `Reuse this Push Key?\n${formatPushKey(
+            autoselectedPushKey,
+            validPushKeys.map(pushKey => pushKey.keyIdentifier)
+          )}`,
+        });
+
+        if (useAutoselected) {
+          Log.log(`Using push key with ID ${autoselectedPushKey.keyIdentifier}`);
+          return autoselectedPushKey;
+        }
+      }
+    }
+
+    const { action } = await promptAsync({
+      type: 'select',
+      name: 'action',
+      message: 'Select the Apple Push Key to use for your project:',
+      choices: [
+        {
+          title: '[Choose another existing push key] (Recommended)',
+          value: 'CHOOSE_EXISTING',
+        },
+        { title: '[Add a new push key]', value: 'GENERATE' },
+      ],
+    });
+
+    if (action === 'GENERATE') {
+      return await new CreatePushKey(this.app.account).runAsync(ctx);
+    } else {
+      return nullthrows(await selectPushKeyAsync(ctx, this.app.account));
+    }
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupPushKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetupPushKey-test.ts
@@ -1,0 +1,88 @@
+import { findApplicationTarget } from '../../../../project/ios/target';
+import { confirmAsync } from '../../../../prompts';
+import { getAppstoreMock, testAuthCtx } from '../../../__tests__/fixtures-appstore';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { getNewIosApiMock, testPushKey, testTargets } from '../../../__tests__/fixtures-ios';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { SetupPushKey } from '../SetupPushKey';
+
+jest.mock('../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+
+const originalConsoleLog = console.log;
+beforeAll(() => {
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+});
+
+describe(SetupPushKey, () => {
+  it('skips setting up a Push Key if it is already configured', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      ios: {
+        ...getNewIosApiMock(),
+        getPushKeyForAppAsync: jest.fn(() => testPushKey),
+      },
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const setupPushKeyAction = new SetupPushKey(appLookupParams);
+    await setupPushKeyAction.runAsync(ctx);
+
+    // expect not to create a new push key on expo servers
+    expect((ctx.ios.createPushKeyAsync as any).mock.calls.length).toBe(0);
+    // expect configuration not to be updated with a new push key
+    expect((ctx.ios.updateIosAppCredentialsAsync as any).mock.calls.length).toBe(0);
+  });
+  it('sets up a Push Key, creating a new one if there are no existing push keys', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      ios: {
+        ...getNewIosApiMock(),
+        createPushKeyAsync: jest.fn(() => testPushKey),
+        getPushKeysForAccountAsync: jest.fn(() => []),
+      },
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const setupPushKeyAction = new SetupPushKey(appLookupParams);
+    await setupPushKeyAction.runAsync(ctx);
+
+    // expect to create a new push key on expo servers
+    expect((ctx.ios.createPushKeyAsync as any).mock.calls.length).toBe(1);
+    // expect configuration to be updated with a new push key
+    expect((ctx.ios.updateIosAppCredentialsAsync as any).mock.calls.length).toBe(1);
+  });
+  it('sets up a Push Key, use autoselected push key when there are existing keys', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+        authCtx: testAuthCtx,
+        listPushKeysAsync: jest.fn(() => [{ id: testPushKey.keyIdentifier }]),
+      },
+      ios: {
+        ...getNewIosApiMock(),
+        createPushKeyAsync: jest.fn(() => testPushKey),
+        getPushKeysForAccountAsync: jest.fn(() => [testPushKey]),
+      },
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const setupPushKeyAction = new SetupPushKey(appLookupParams);
+    await setupPushKeyAction.runAsync(ctx);
+
+    // expect not to create a new push key on expo servers, we are using the existing one
+    expect((ctx.ios.createPushKeyAsync as any).mock.calls.length).toBe(0);
+    // expect configuration not to be updated with a new push key
+    expect((ctx.ios.updateIosAppCredentialsAsync as any).mock.calls.length).toBe(1);
+  });
+  it('errors in Non Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const createPushKeyAction = new SetupPushKey(appLookupParams);
+    await expect(createPushKeyAction.runAsync(ctx)).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -35,6 +35,7 @@ import {
   AppleProvisioningProfileQuery,
   AppleProvisioningProfileQueryResult,
 } from './graphql/queries/AppleProvisioningProfileQuery';
+import { ApplePushKeyQuery } from './graphql/queries/ApplePushKeyQuery';
 import { AppleTeamQuery } from './graphql/queries/AppleTeamQuery';
 import { IosAppCredentialsQuery } from './graphql/queries/IosAppCredentialsQuery';
 
@@ -140,10 +141,7 @@ export async function createOrGetIosAppCredentialsWithCommonFieldsAsync(
     appleTeam: AppleTeamFragment;
   }
 ): Promise<CommonIosAppCredentialsFragment> {
-  const maybeIosAppCredentials = await getIosAppCredentialsWithBuildCredentialsAsync(
-    appLookupParams,
-    {}
-  );
+  const maybeIosAppCredentials = await getIosAppCredentialsWithCommonFieldsAsync(appLookupParams);
   if (maybeIosAppCredentials) {
     return maybeIosAppCredentials;
   }
@@ -393,6 +391,19 @@ export async function createPushKeyAsync(
     },
     account.id
   );
+}
+
+export async function getPushKeysForAccountAsync(
+  account: Account
+): Promise<ApplePushKeyFragment[]> {
+  return await ApplePushKeyQuery.getAllForAccount(account.name);
+}
+
+export async function getPushKeyForAppAsync(
+  appLookupParams: AppLookupParams
+): Promise<ApplePushKeyFragment | null> {
+  const maybeIosAppCredentials = await getIosAppCredentialsWithCommonFieldsAsync(appLookupParams);
+  return maybeIosAppCredentials?.pushKey ?? null;
 }
 
 const formatProjectFullName = ({ account, projectName }: AppLookupParams): string =>

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/ApplePushKeyQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/ApplePushKeyQuery.ts
@@ -1,0 +1,37 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ApplePushKeyByAccountQuery, ApplePushKeyFragment } from '../../../../../graphql/generated';
+import { ApplePushKeyFragmentNode } from '../../../../../graphql/types/credentials/ApplePushKey';
+
+const ApplePushKeyQuery = {
+  async getAllForAccount(accountName: string): Promise<ApplePushKeyFragment[]> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<ApplePushKeyByAccountQuery>(
+          gql`
+            query ApplePushKeyByAccountQuery($accountName: String!) {
+              account {
+                byName(accountName: $accountName) {
+                  id
+                  applePushKeys {
+                    id
+                    ...ApplePushKeyFragment
+                  }
+                }
+              }
+            }
+            ${print(ApplePushKeyFragmentNode)}
+          `,
+          {
+            accountName,
+          }
+        )
+        .toPromise()
+    );
+    return data.account.byName.applePushKeys;
+  },
+};
+
+export { ApplePushKeyQuery };

--- a/packages/eas-cli/src/credentials/ios/validators/validatePushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validatePushKey.ts
@@ -1,9 +1,9 @@
 import { Context } from '../../context';
 import { PushKey } from '../appstore/Credentials.types';
-import { filterRevokedPushKeys } from '../appstore/CredentialsUtils';
+import { filterRevokedAndUntrackedPushKeys } from '../appstore/CredentialsUtils';
 
-export async function validatePushKeyAsync(ctx: Context, pushKey: PushKey) {
+export async function isPushKeyValidAndTrackedAsync(ctx: Context, pushKey: PushKey) {
   const pushInfoFromApple = await ctx.appStore.listPushKeysAsync();
-  const validPushKeys = await filterRevokedPushKeys([pushKey], pushInfoFromApple);
+  const validPushKeys = await filterRevokedAndUntrackedPushKeys([pushKey], pushInfoFromApple);
   return validPushKeys.length > 0;
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4326,6 +4326,27 @@ export type AppleProvisioningProfilesByAppQuery = (
   )> }
 );
 
+export type ApplePushKeyByAccountQueryVariables = Exact<{
+  accountName: Scalars['String'];
+}>;
+
+
+export type ApplePushKeyByAccountQuery = (
+  { __typename?: 'RootQuery' }
+  & { account: (
+    { __typename?: 'AccountQuery' }
+    & { byName: (
+      { __typename?: 'Account' }
+      & Pick<Account, 'id'>
+      & { applePushKeys: Array<(
+        { __typename?: 'ApplePushKey' }
+        & Pick<ApplePushKey, 'id'>
+        & ApplePushKeyFragment
+      )> }
+    ) }
+  ) }
+);
+
 export type AppleTeamsByAccountNameQueryVariables = Exact<{
   accountName: Scalars['String'];
 }>;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Add the action to setup a new push key. It works the following way :
- If a push key is already configured, return
-  If the user has no push keys in their account, create a new one for them
- If the user has a valid push key in their account, ask if they want to use that one (autoselection)
- Else, give the option to use an existing push key or to create a new one

# Test Plan

- [ ] new tests pass