### PR TITLE
[eas-cli] add 'remove push key' action

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -134,6 +134,7 @@ export function getNewIosApiMock() {
     deleteDistributionCertificateAsync: jest.fn(),
     createPushKeyAsync: jest.fn(),
     getPushKeyForAppAsync: jest.fn(),
+    deletePushKeyAsync: jest.fn(),
   };
 }
 

--- a/packages/eas-cli/src/credentials/ios/actions/RemovePushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemovePushKey.ts
@@ -26,6 +26,7 @@ export class RemovePushKey {
       throw new Error(`Cannot remove push keys in non-interactive mode`);
     }
 
+    // TODO(quin): show the projects that rely on this
     const confirm = await confirmAsync({
       message: `Removing this push key will disable push notifications for projects that rely on it. Do you want to continue?`,
     });

--- a/packages/eas-cli/src/credentials/ios/actions/RemovePushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemovePushKey.ts
@@ -1,0 +1,52 @@
+import { ApplePushKeyFragment } from '../../../graphql/generated';
+import Log from '../../../log';
+import { confirmAsync } from '../../../prompts';
+import { Account } from '../../../user/Account';
+import { Context } from '../../context';
+import { selectPushKeyAsync } from './PushKeyUtils';
+
+export class SelectAndRemovePushKey {
+  constructor(private account: Account) {}
+
+  async runAsync(ctx: Context): Promise<void> {
+    const selected = await selectPushKeyAsync(ctx, this.account);
+    if (selected) {
+      await new RemovePushKey(this.account, selected).runAsync(ctx);
+      Log.succeed('Removed push key');
+      Log.newLine();
+    }
+  }
+}
+
+export class RemovePushKey {
+  constructor(private account: Account, private pushKey: ApplePushKeyFragment) {}
+
+  public async runAsync(ctx: Context): Promise<void> {
+    if (ctx.nonInteractive) {
+      throw new Error(`Cannot remove push keys in non-interactive mode`);
+    }
+
+    const confirm = await confirmAsync({
+      message: `Removing this push key will disable push notifications for projects that rely on it. Do you want to continue?`,
+    });
+
+    if (!confirm) {
+      return;
+    }
+
+    Log.log('Removing Push Key');
+    await ctx.ios.deletePushKeyAsync(this.pushKey.id);
+
+    let shouldRevoke = false;
+    if (!ctx.nonInteractive) {
+      shouldRevoke = await confirmAsync({
+        message: `Do you also want to revoke this Push Key on the Apple Developer Portal?`,
+      });
+    } else if (ctx.nonInteractive) {
+      Log.log('Skipping certificate revocation on the Apple Developer Portal.');
+    }
+    if (shouldRevoke) {
+      await ctx.appStore.revokePushKeyAsync([this.pushKey.keyIdentifier]);
+    }
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/RemovePushKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/RemovePushKey-test.ts
@@ -1,0 +1,37 @@
+import { findApplicationTarget } from '../../../../project/ios/target';
+import { confirmAsync } from '../../../../prompts';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { testPushKey, testTargets } from '../../../__tests__/fixtures-ios';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { RemovePushKey } from '../RemovePushKey';
+
+jest.mock('../../../../prompts');
+(confirmAsync as jest.Mock).mockImplementation(() => true);
+
+const originalConsoleLog = console.log;
+beforeAll(() => {
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.log = originalConsoleLog;
+});
+
+describe(RemovePushKey, () => {
+  it('deletes the push key on Expo and Apple servers in Interactive Mode', async () => {
+    const ctx = createCtxMock({ nonInteractive: false });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const removePushKeyAction = new RemovePushKey(appLookupParams.account, testPushKey);
+    await removePushKeyAction.runAsync(ctx);
+
+    // expect push key to be deleted on expo servers
+    expect((ctx.ios.deletePushKeyAsync as any).mock.calls.length).toBe(1);
+    // expect push key to be revoked on apple portal
+    expect((ctx.appStore.revokePushKeyAsync as any).mock.calls.length).toBe(1);
+  });
+  it('errors in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({ nonInteractive: true });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const removePushKeyAction = new RemovePushKey(appLookupParams.account, testPushKey);
+    await expect(removePushKeyAction.runAsync(ctx)).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -406,5 +406,9 @@ export async function getPushKeyForAppAsync(
   return maybeIosAppCredentials?.pushKey ?? null;
 }
 
+export async function deletePushKeyAsync(pushKeyId: string): Promise<void> {
+  return await ApplePushKeyMutation.deleteApplePushKey(pushKeyId);
+}
+
 const formatProjectFullName = ({ account, projectName }: AppLookupParams): string =>
   `@${account.name}/${projectName}`;

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/ApplePushKeyMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/ApplePushKeyMutation.ts
@@ -7,6 +7,7 @@ import {
   ApplePushKeyFragment,
   ApplePushKeyInput,
   CreateApplePushKeyMutation,
+  DeleteApplePushKeyMutation,
 } from '../../../../../graphql/generated';
 import { ApplePushKeyFragmentNode } from '../../../../../graphql/types/credentials/ApplePushKey';
 
@@ -44,6 +45,29 @@ const ApplePushKeyMutation = {
       'GraphQL: `createApplePushKey` not defined in server response'
     );
     return data.applePushKey.createApplePushKey;
+  },
+  async deleteApplePushKey(applePushKeyId: string): Promise<void> {
+    await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeleteApplePushKeyMutation>(
+          gql`
+            mutation DeleteApplePushKeyMutation($applePushKeyId: ID!) {
+              applePushKey {
+                deleteApplePushKey(id: $applePushKeyId) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            applePushKeyId,
+          },
+          {
+            additionalTypenames: ['ApplePushKey', 'IosAppCredentials'],
+          }
+        )
+        .toPromise()
+    );
   },
 };
 

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -23,6 +23,7 @@ import { selectValidDistributionCertificateAsync } from '../ios/actions/Distribu
 import { selectPushKeyAsync } from '../ios/actions/PushKeyUtils';
 import { SelectAndRemoveDistributionCertificate } from '../ios/actions/RemoveDistributionCertificate';
 import { RemoveProvisioningProfiles } from '../ios/actions/RemoveProvisioningProfile';
+import { SelectAndRemovePushKey } from '../ios/actions/RemovePushKey';
 import { SetupAdhocProvisioningProfile } from '../ios/actions/SetupAdhocProvisioningProfile';
 import { SetupBuildCredentials } from '../ios/actions/SetupBuildCredentials';
 import { SetupBuildCredentialsFromCredentialsJson } from '../ios/actions/SetupBuildCredentialsFromCredentialsJson';
@@ -53,6 +54,7 @@ enum ActionType {
   SetupPushKey,
   CreatePushKey,
   UseExistingPushKey,
+  RemovePushKey,
 }
 
 enum Scope {
@@ -120,6 +122,11 @@ function getPushKeyActions(ctx: Context): ActionInfo[] {
       value: ActionType.UseExistingPushKey,
       title: 'Use an existing push key',
       scope: Scope.Project,
+    },
+    {
+      value: ActionType.RemovePushKey,
+      title: 'Remove a push key from your account',
+      scope: Scope.Account,
     },
     {
       value: ActionType.GoBackToHighLevelActions,
@@ -293,6 +300,8 @@ export class ManageIos {
       await new CreateDistributionCertificate(account).runAsync(ctx);
     } else if (action === ActionType.CreatePushKey) {
       await new CreatePushKey(account).runAsync(ctx);
+    } else if (action === ActionType.RemovePushKey) {
+      await new SelectAndRemovePushKey(account).runAsync(ctx);
     }
   }
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3995,6 +3995,22 @@ export type CreateApplePushKeyMutation = (
   ) }
 );
 
+export type DeleteApplePushKeyMutationVariables = Exact<{
+  applePushKeyId: Scalars['ID'];
+}>;
+
+
+export type DeleteApplePushKeyMutation = (
+  { __typename?: 'RootMutation' }
+  & { applePushKey: (
+    { __typename?: 'ApplePushKeyMutation' }
+    & { deleteApplePushKey: (
+      { __typename?: 'deleteApplePushKeyResult' }
+      & Pick<DeleteApplePushKeyResult, 'id'>
+    ) }
+  ) }
+);
+
 export type CreateAppleTeamMutationVariables = Exact<{
   appleTeamInput: AppleTeamInput;
   accountId: Scalars['ID'];


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Add the 'remove push key' action. It works the following way:
- user chooses a push key from their account to delete
- remove push key from eas servers
- ask if they want to revoke the push key on apple servers

# Test Plan

- [ ] new tests pass
