### PR TITLE
support new build status: `new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,21 +12,21 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Make credentials manager work with multi-target iOS projects. ([#441](https://github.com/expo/eas-cli/pull/441) by [@dsokal](https://github.com/dsokal))
-- Copy over credentials from Expo Classic to EAS ([#445](https://github.com/expo/eas-cli/pull/445) by [@quinlanj](https://github.com/quinlanj))
+- Copy over credentials from Expo Classic to EAS. ([#445](https://github.com/expo/eas-cli/pull/445) by [@quinlanj](https://github.com/quinlanj))
 - Add Big Sur image for iOS builds. ([#457](https://github.com/expo/eas-cli/pull/457) by [@wkozyra95](https://github.com/wkozyra95))
-- New version of Android credentials manager ([#460](https://github.com/expo/eas-cli/pull/460) by [@quinlanj](https://github.com/quinlanj))
+- New version of Android credentials manager. ([#460](https://github.com/expo/eas-cli/pull/460) by [@quinlanj](https://github.com/quinlanj))
 - Add an internal distribution with dev client to `build:configure` defaults. ([#465](https://github.com/expo/eas-cli/pull/465) by [@fson](https://github.com/fson))
 - Add `updates.channel` to build metadata. ([#461](https://github.com/expo/eas-cli/pull/461) by [@jkhales](https://github.com/jkhales))
-- iOS push key setup and management now available in `eas-cli credentials` ([#469](https://github.com/expo/eas-cli/pull/469) [#470](https://github.com/expo/eas-cli/pull/470) by [@quinlanj](https://github.com/quinlanj))
-
+- iOS push key setup and management now available in `eas-cli credentials`. ([#469](https://github.com/expo/eas-cli/pull/469) [#470](https://github.com/expo/eas-cli/pull/470) by [@quinlanj](https://github.com/quinlanj))
+- Support new build status: `new`. ([#475](https://github.com/expo/eas-cli/pull/475) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 
 ### 🧹 Chores
 
-- Deprecate `--skip-credentials-check` flag because it doesn't do anything and is no longer needed.([#442](https://github.com/expo/eas-cli/pull/442) by [@brentvatne](https://github.com/brentvatne))
-- Move android credentials code to new Graphql API ([#439](https://github.com/expo/eas-cli/pull/439) [#440](https://github.com/expo/eas-cli/pull/440) [#438](https://github.com/expo/eas-cli/pull/438) [#443](https://github.com/expo/eas-cli/pull/443) [#447](https://github.com/expo/eas-cli/pull/447) [#451](https://github.com/expo/eas-cli/pull/451) [#455](https://github.com/expo/eas-cli/pull/455) by [@quinlanj](https://github.com/quinlanj))
-- Prepare Graphql infra to support iOS push keys ([#456](https://github.com/expo/eas-cli/pull/456) by [@quinlanj](https://github.com/quinlanj))
+- Deprecate `--skip-credentials-check` flag because it doesn't do anything and is no longer needed. ([#442](https://github.com/expo/eas-cli/pull/442) by [@brentvatne](https://github.com/brentvatne))
+- Move android credentials code to new Graphql API. ([#439](https://github.com/expo/eas-cli/pull/439) [#440](https://github.com/expo/eas-cli/pull/440) [#438](https://github.com/expo/eas-cli/pull/438) [#443](https://github.com/expo/eas-cli/pull/443) [#447](https://github.com/expo/eas-cli/pull/447) [#451](https://github.com/expo/eas-cli/pull/451) [#455](https://github.com/expo/eas-cli/pull/455) by [@quinlanj](https://github.com/quinlanj))
+- Prepare Graphql infra to support iOS push keys. ([#456](https://github.com/expo/eas-cli/pull/456) by [@quinlanj](https://github.com/quinlanj))
 - Improve credentials DX ([#448](https://github.com/expo/eas-cli/pull/448) [#449](https://github.com/expo/eas-cli/pull/449) by [@quinlanj](https://github.com/quinlanj))
 - Add analytics on dev client builds. ([#454](https://github.com/expo/eas-cli/pull/454) by [@fson](https://github.com/fson))
 - Support non-git projects. ([#462](https://github.com/expo/eas-cli/pull/462) by [@wkozyra95](https://github.com/wkozyra95))

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -3876,6 +3876,12 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "NEW",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "IN_QUEUE",
             "description": "",
             "isDeprecated": false,
@@ -7930,6 +7936,30 @@
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "iosAppCredentialsList",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "IosAppCredentials",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -17397,13 +17427,9 @@
             "name": "appleTeamId",
             "description": "",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
             "defaultValue": null
           },
@@ -20246,6 +20272,12 @@
         "enumValues": [
           {
             "name": "EAS_MASTER_LIST",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DEV_CLIENT_USERS",
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/build/create.ts
+++ b/packages/eas-cli/src/build/create.ts
@@ -94,6 +94,9 @@ async function waitForBuildEndAsync(
         case BuildStatus.Finished:
           spinner.succeed('Build finished');
           return builds;
+        case BuildStatus.New:
+          spinner.text = 'Build created';
+          break;
         case BuildStatus.InQueue:
           spinner.text = 'Build queued...';
           break;
@@ -131,6 +134,7 @@ async function waitForBuildEndAsync(
         spinner.fail('Some of the builds were canceled or failed.');
         return builds;
       } else {
+        const newBuilds = builds.filter(build => build?.status === BuildStatus.New).length;
         const inQueue = builds.filter(build => build?.status === BuildStatus.InQueue).length;
         const inProgress = builds.filter(build => build?.status === BuildStatus.InProgress).length;
         const errored = builds.filter(build => build?.status === BuildStatus.Errored).length;
@@ -138,6 +142,7 @@ async function waitForBuildEndAsync(
         const canceled = builds.filter(build => build?.status === BuildStatus.Canceled).length;
         const unknownState = builds.length - inQueue - inProgress - errored - finished;
         spinner.text = [
+          newBuilds && `Builds created: ${newBuilds}`,
           inQueue && `Builds in queue: ${inQueue}`,
           inProgress && `Builds in progress: ${inProgress}`,
           canceled && `Builds canceled: ${canceled}`,

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -7,6 +7,7 @@ export enum RequestedPlatform {
 }
 
 export enum BuildStatus {
+  NEW = 'new',
   IN_QUEUE = 'in-queue',
   IN_PROGRESS = 'in-progress',
   ERRORED = 'errored',

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -18,6 +18,8 @@ export function formatGraphQLBuild(build: BuildFragment) {
       label: 'Status',
       get value() {
         switch (build.status) {
+          case GraphQLBuildStatus.New:
+            return chalk.blue('new');
           case GraphQLBuildStatus.InQueue:
             return chalk.blue('in queue');
           case GraphQLBuildStatus.InProgress:
@@ -48,12 +50,8 @@ export function formatGraphQLBuild(build: BuildFragment) {
     {
       label: 'Artifact',
       get value() {
-        if (
-          build.status === GraphQLBuildStatus.InQueue ||
-          build.status === GraphQLBuildStatus.InProgress
-        ) {
-        }
         switch (build.status) {
+          case GraphQLBuildStatus.New:
           case GraphQLBuildStatus.InQueue:
           case GraphQLBuildStatus.InProgress:
             return '<in progress>';
@@ -72,11 +70,13 @@ export function formatGraphQLBuild(build: BuildFragment) {
     { label: 'Started at', value: new Date(build.createdAt).toLocaleString() },
     {
       label: 'Finished at',
-      value:
-        build.status === GraphQLBuildStatus.InQueue ||
-        build.status === GraphQLBuildStatus.InProgress
-          ? '<in progress>'
-          : new Date(build.updatedAt).toLocaleString(),
+      value: [
+        GraphQLBuildStatus.New,
+        GraphQLBuildStatus.InQueue,
+        GraphQLBuildStatus.InProgress,
+      ].includes(build.status)
+        ? '<in progress>'
+        : new Date(build.updatedAt).toLocaleString(),
     },
     { label: 'Started by', value: actor ?? 'unknown' },
   ];

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -23,6 +23,7 @@ export default class BuildList extends Command {
     }),
     status: flags.enum({
       options: [
+        BuildStatus.NEW,
         BuildStatus.IN_QUEUE,
         BuildStatus.IN_PROGRESS,
         BuildStatus.ERRORED,
@@ -92,6 +93,8 @@ const toAppPlatform = (requestedPlatform?: RequestedPlatform): AppPlatform | und
 const toGraphQLBuildStatus = (buildStatus: BuildStatus): GraphQLBuildStatus | undefined => {
   if (!buildStatus) {
     return undefined;
+  } else if (buildStatus === BuildStatus.NEW) {
+    return GraphQLBuildStatus.New;
   } else if (buildStatus === BuildStatus.IN_QUEUE) {
     return GraphQLBuildStatus.InQueue;
   } else if (buildStatus === BuildStatus.IN_PROGRESS) {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -604,6 +604,7 @@ export enum AppPrivacy {
 }
 
 export enum BuildStatus {
+  New = 'NEW',
   InQueue = 'IN_QUEUE',
   InProgress = 'IN_PROGRESS',
   Errored = 'ERRORED',
@@ -1092,6 +1093,7 @@ export type ApplePushKey = {
   keyP8: Scalars['String'];
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
+  iosAppCredentialsList: Array<IosAppCredentials>;
 };
 
 export type IosAppBuildCredentialsFilter = {
@@ -2650,7 +2652,7 @@ export type IosAppCredentialsMutationSetAppSpecificPasswordArgs = {
 };
 
 export type IosAppCredentialsInput = {
-  appleTeamId: Scalars['ID'];
+  appleTeamId?: Maybe<Scalars['ID']>;
   pushKeyId?: Maybe<Scalars['ID']>;
   appSpecificPasswordId?: Maybe<Scalars['ID']>;
 };
@@ -3182,7 +3184,8 @@ export type AddUserInput = {
 };
 
 export enum MailchimpTag {
-  EasMasterList = 'EAS_MASTER_LIST'
+  EasMasterList = 'EAS_MASTER_LIST',
+  DevClientUsers = 'DEV_CLIENT_USERS'
 }
 
 export enum MailchimpAudience {
@@ -4800,30 +4803,6 @@ export type GetAllBuildsForAppQuery = (
       )> }
     ) }
   )> }
-);
-
-export type PendingBuildsForAccountAndPlatformQueryVariables = Exact<{
-  accountName: Scalars['String'];
-  platform: AppPlatform;
-}>;
-
-
-export type PendingBuildsForAccountAndPlatformQuery = (
-  { __typename?: 'RootQuery' }
-  & { account: (
-    { __typename?: 'AccountQuery' }
-    & { byName: (
-      { __typename?: 'Account' }
-      & Pick<Account, 'id'>
-      & { inQueueBuilds: Array<(
-        { __typename?: 'Build' }
-        & Pick<Build, 'id' | 'platform'>
-      )>, inProgressBuilds: Array<(
-        { __typename?: 'Build' }
-        & Pick<Build, 'id' | 'platform'>
-      )> }
-    ) }
-  ) }
 );
 
 export type EnvironmentSecretsByAccountNameQueryVariables = Exact<{

--- a/packages/eas-cli/src/graphql/queries/BuildQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BuildQuery.ts
@@ -11,8 +11,6 @@ import {
   BuildsByIdQueryVariables,
   GetAllBuildsForAppQuery,
   GetAllBuildsForAppQueryVariables,
-  PendingBuildsForAccountAndPlatformQuery,
-  PendingBuildsForAccountAndPlatformQueryVariables,
 } from '../generated';
 import { BuildFragmentNode } from '../types/Build';
 
@@ -89,56 +87,5 @@ export const BuildQuery = {
     );
 
     return data.app?.byId.builds ?? [];
-  },
-
-  async getPendingBuildIdAsync(
-    accountName: string,
-    platform: AppPlatform
-  ): Promise<PendingBuildQueryResult | null> {
-    const data = await withErrorHandlingAsync(
-      graphqlClient
-        .query<
-          PendingBuildsForAccountAndPlatformQuery,
-          PendingBuildsForAccountAndPlatformQueryVariables
-        >(
-          gql`
-            query PendingBuildsForAccountAndPlatform(
-              $accountName: String!
-              $platform: AppPlatform!
-            ) {
-              account {
-                byName(accountName: $accountName) {
-                  id
-                  inQueueBuilds: builds(
-                    offset: 0
-                    limit: 1
-                    platform: $platform
-                    status: IN_QUEUE
-                  ) {
-                    id
-                    platform
-                  }
-                  inProgressBuilds: builds(
-                    offset: 0
-                    limit: 1
-                    platform: $platform
-                    status: IN_PROGRESS
-                  ) {
-                    id
-                    platform
-                  }
-                }
-              }
-            }
-          `,
-          { accountName, platform }
-        )
-        .toPromise()
-    );
-    const pendingBuilds = [
-      ...data.account.byName.inProgressBuilds,
-      ...data.account.byName.inQueueBuilds,
-    ];
-    return pendingBuilds.length > 0 ? pendingBuilds[0] : null;
   },
 };


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

`new` is now the initial build status. A build is in this state when it's not yet enqueued. This can happen when the account reaches the concurrency limit.

Part of https://linear.app/expo/issue/ENG-1395/add-status-to-reflect-prequeue-state-to-www
www PR: https://github.com/expo/universe/pull/7756

# How

- I grepped the repo for `BuildStatus` and added support for the new status.
- Deleted `getPendingBuildIdAsync` as it hasn't been used anywhere.

# Test Plan

I ran a build in staging and the CLI didn't break.