### PR TITLE
[ENG-1396] change default ios image for sdk <= 41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Change default iOS image for projects with Expo SDK <= 41 (SDK 41 won't build with Xcode 12.5). ([#479](https://github.com/expo/eas-cli/pull/479) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -35,7 +35,7 @@ export interface AndroidGenericBuildProfile extends Android.BuilderEnvironment {
   cache: Cache;
 }
 
-export interface IosManagedBuildProfile extends Ios.BuilderEnvironment {
+export interface IosManagedBuildProfile extends Omit<Ios.BuilderEnvironment, 'image'> {
   workflow: Workflow.MANAGED;
   credentialsSource: CredentialsSource;
   buildType?: Ios.ManagedBuildType;
@@ -45,9 +45,10 @@ export interface IosManagedBuildProfile extends Ios.BuilderEnvironment {
   enterpriseProvisioning?: IosEnterpriseProvisioning;
   autoIncrement: VersionAutoIncrement;
   cache: Cache;
+  image?: Ios.BuilderEnvironment['image'];
 }
 
-export interface IosGenericBuildProfile extends Ios.BuilderEnvironment {
+export interface IosGenericBuildProfile extends Omit<Ios.BuilderEnvironment, 'image'> {
   workflow: Workflow.GENERIC;
   credentialsSource: CredentialsSource;
   scheme?: string;
@@ -59,6 +60,7 @@ export interface IosGenericBuildProfile extends Ios.BuilderEnvironment {
   enterpriseProvisioning?: IosEnterpriseProvisioning;
   autoIncrement: VersionAutoIncrement;
   cache: Cache;
+  image?: Ios.BuilderEnvironment['image'];
 }
 
 export type AndroidBuildProfile = AndroidManagedBuildProfile | AndroidGenericBuildProfile;

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -21,9 +21,7 @@ const AndroidBuilderEnvironmentSchema = Joi.object({
 });
 
 const IosBuilderEnvironmentSchema = Joi.object({
-  image: Joi.string()
-    .valid(...Ios.builderBaseImages)
-    .default('default'),
+  image: Joi.string().valid(...Ios.builderBaseImages),
   node: Joi.string().empty(null).custom(semverSchemaCheck),
   yarn: Joi.string().empty(null).custom(semverSchemaCheck),
   bundler: Joi.string().empty(null).custom(semverSchemaCheck),
@@ -100,7 +98,7 @@ const IosManagedSchema = Joi.object({
   cache: CacheSchema.default(),
 }).concat(IosBuilderEnvironmentSchema);
 
-const schemaBuildProfileMap: Record<string, Record<string, Joi.Schema>> = {
+export const schemaBuildProfileMap: Record<string, Record<string, Joi.Schema>> = {
   android: {
     generic: AndroidGenericSchema,
     managed: AndroidManagedSchema,
@@ -111,7 +109,7 @@ const schemaBuildProfileMap: Record<string, Record<string, Joi.Schema>> = {
   },
 };
 
-const EasJsonSchema = Joi.object({
+export const EasJsonSchema = Joi.object({
   builds: Joi.object({
     android: Joi.object().pattern(
       Joi.string(),
@@ -127,5 +125,3 @@ const EasJsonSchema = Joi.object({
     ),
   }),
 });
-
-export { EasJsonSchema, schemaBuildProfileMap };

--- a/packages/eas-json/src/__tests__/EasJsonReader-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-test.ts
@@ -56,7 +56,6 @@ test('minimal valid ios eas.json', async () => {
         autoIncrement: false,
         env: {},
         cache: { disabled: false, cacheDefaultPaths: true, customPaths: [] },
-        image: 'default',
       },
     },
   }).toEqual(easJson);
@@ -94,7 +93,6 @@ test('minimal valid eas.json for both platforms', async () => {
         autoIncrement: false,
         env: {},
         cache: { disabled: false, cacheDefaultPaths: true, customPaths: [] },
-        image: 'default',
       },
     },
   }).toEqual(easJson);
@@ -165,7 +163,6 @@ test('valid eas.json for development client builds', async () => {
         distribution: 'store',
         autoIncrement: false,
         env: {},
-        image: 'default',
         cache: { disabled: false, cacheDefaultPaths: true, customPaths: [] },
         buildType: 'development-client',
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,13 +1924,6 @@
   dependencies:
     "@hapi/joi" "^17.1.1"
 
-"@expo/eas-build-job@0.2.37":
-  version "0.2.37"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.37.tgz#fd6cb911e33774239d1ab7662c0ccc8efa22f7a2"
-  integrity sha512-B9gahwTTYs0pWQP2HnfYWcbsqmUIAdnr+iwounVqpcxHhERxGJby2JEw+Vxtl2+VMARM4w9RLgNduP5Vk/zeQw==
-  dependencies:
-    "@hapi/joi" "^17.1.1"
-
 "@expo/image-utils@0.3.14":
   version "0.3.14"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.14.tgz#eea0d59c5845e8b19504011c20afd837c5d044c5"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://linear.app/expo/issue/ENG-1396/make-default-image-dependent-on-sdk-version
Expo SDK 41 (and lower) projects won't build with Xcode 12.5.

# How

If we detect that a project uses SDK <= 41 we use image `macos-catalina-10.15-xcode-12.4`. 

# Test Plan

- I ran a build for an SDK 41 project without `image` in `eas.json`. I saw that `macos-catalina-10.15-xcode-12.4` was used for the build.
- I ran another build for the same project but with `image` set in `eas.json`. The image was propagated to the job object.
