### PR TITLE
mock fs-extra so tests don't produce files

### DIFF
--- a/packages/eas-cli/src/credentials/android/actions/__tests__/DownloadKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/DownloadKeystore-test.ts
@@ -5,6 +5,8 @@ import { createCtxMock } from '../../../__tests__/fixtures-context';
 import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { DownloadKeystore } from '../DownloadKeystore';
 
+jest.mock('fs-extra');
+
 const originalConsoleLog = console.log;
 const originalConsoleWarn = console.warn;
 beforeAll(() => {

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveKeystore-test.ts
@@ -4,6 +4,7 @@ import { createCtxMock } from '../../../__tests__/fixtures-context';
 import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 import { RemoveKeystore } from '../RemoveKeystore';
 
+jest.mock('fs-extra');
 jest.mock('../../../../prompts');
 (confirmAsync as jest.Mock).mockImplementation(() => true);
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

I've noticed that running `yarn test` produces some files.

# How

Mock `fs-extra` so `yarn test` doesn't produce any files.

# Test Plan

<img width="907" alt="Screenshot 2021-06-25 at 16 10 17" src="https://user-images.githubusercontent.com/5256730/123437382-e8772100-d5cf-11eb-8617-243b2558e89b.png">

