### PR TITLE
[eas-cli] Fix inverted conditional so we actually only prompt about commit when index is dirty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix inverted conditional so we actually only prompt about commit when index is dirty. ([#481](https://github.com/expo/eas-cli/pull/481) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🧹 Chores
 
 ## [0.18.1](https://github.com/expo/eas-cli/releases/tag/v0.18.1) - 2021-06-24

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -13,7 +13,7 @@ import { endTimer, formatMilliseconds, startTimer } from '../../utils/timer';
 import vcs from '../../vcs';
 
 export async function maybeBailOnRepoStatusAsync(): Promise<void> {
-  if (await vcs.hasUncommittedChangesAsync()) {
+  if (!(await vcs.hasUncommittedChangesAsync())) {
     return;
   }
   Log.addNewLineIfNone();

--- a/packages/eas-cli/src/vcs/git.ts
+++ b/packages/eas-cli/src/vcs/git.ts
@@ -56,7 +56,7 @@ export default class GitClient extends Client {
 
   public async hasUncommittedChangesAsync(): Promise<boolean> {
     const changes = await gitStatusAsync({ showUntracked: true });
-    return changes.length !== 0;
+    return changes.length > 0;
   }
 
   public async getRootPathAsync(): Promise<string> {


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

I noticed that I was being prompted to commit my changes even when I had a clean git index:

```
╭─~/code/abcd ‹main›
╰─$ gs                                                                                                                                                                                                                                                  130 ↵
On branch main
nothing to commit, working tree clean
╭─~/code/abcd ‹main›
╰─$ easd build:configure
💡 The following process will configure your iOS and/or Android project to be compatible with EAS Build. These changes only apply to your local project files and you can safely revert them at any time.

✔ Which platforms would you like to configure for EAS Build? › All
Warning! Your repository working tree is dirty.
It's recommended to commit all your changes before proceeding, so you can revert the changes made by this command if necessary.
? Would you like to proceed? › (Y/n)
```

It looks like in the refactor to a VCS client interface we accidentally regressed this check.

# How

Add a strategic `!`

# Test Plan

Initialize a new project, and with a clean git index run `eas build:configure` - you should not be told that your git working tree is dirty.
