### PR TITLE
[eas-cli] Recommend bundle id and application id in the same way as Expo CLI

### DIFF
--- a/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
@@ -11,6 +11,15 @@ import {
 
 jest.mock('fs');
 jest.mock('../../../prompts');
+jest.mock('../../../user/actions', () => ({
+  ensureLoggedInAsync: jest.fn(() => ({
+    __typename: 'User',
+    id: 'jester-id',
+    username: 'jester',
+    accounts: [{ id: 'jester-account-id', name: 'jester' }],
+    isExpoAdmin: false,
+  })),
+}));
 
 const originalConsoleWarn = console.warn;
 beforeAll(() => {

--- a/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
@@ -13,6 +13,15 @@ import {
 
 jest.mock('fs');
 jest.mock('../../../prompts');
+jest.mock('../../../user/actions', () => ({
+  ensureLoggedInAsync: jest.fn(() => ({
+    __typename: 'User',
+    id: 'jester-id',
+    username: 'jester',
+    accounts: [{ id: 'jester-account-id', name: 'jester' }],
+    isExpoAdmin: false,
+  })),
+}));
 
 const originalConsoleWarn = console.warn;
 beforeAll(() => {


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This is a nice experience and consistent with Expo CLI.

https://user-images.githubusercontent.com/90494/123492409-40ad2380-d5ce-11eb-881c-38b439b8e07d.mov

# How

Mirrored the implementation from Expo CLI, using the utility methods available within EAS CLI.

# Test Plan

```
eas build:configure -p ios # suggests a value
eas build:configure -p android # suggests a value based on the ios config
# -- reset state in project

eas build:configure -p all # suggests a value for android based on username/slug, if you change it then the changed value will be used for ios suggestion

# etc..
```