### PR TITLE
[eas-cli] Support configuring one platform at a time when running `eas build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Auto-suggest application id and bundle identifier when running `eas build:configure` for a managed project. ([#487](https://github.com/expo/eas-cli/pull/487) by [@dsokal](https://github.com/dsokal))
-- Support configuring one platform at a time when running  ([#483](https://github.com/expo/eas-cli/pull/483) by [@brentvatne](https://github.com/brentvatne))
+- Support configuring one platform at a time when running `eas build`. ([#483](https://github.com/expo/eas-cli/pull/483) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Auto-suggest application id and bundle identifier when running `eas build:configure` for a managed project. ([#487](https://github.com/expo/eas-cli/pull/487) by [@dsokal](https://github.com/dsokal))
+- Support configuring one platform at a time when running  ([#483](https://github.com/expo/eas-cli/pull/483) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -121,7 +121,7 @@ export async function ensureEasJsonExistsAsync(ctx: ConfigureContext): Promise<v
 
   const easJson = {
     builds: {
-      ...existingEasJson,
+      ...(existingEasJson?.builds ?? existingEasJson),
       ...(shouldInitAndroid
         ? {
             android: ctx.hasAndroidNativeProject ? ANDROID_GENERIC_DEFAULTS : MANAGED_DEFAULTS,

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -121,7 +121,7 @@ export async function ensureEasJsonExistsAsync(ctx: ConfigureContext): Promise<v
 
   const easJson = {
     builds: {
-      ...(existingEasJson?.builds ?? existingEasJson),
+      ...existingEasJson?.builds,
       ...(shouldInitAndroid
         ? {
             android: ctx.hasAndroidNativeProject ? ANDROID_GENERIC_DEFAULTS : MANAGED_DEFAULTS,

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -152,9 +152,15 @@ async function ensureProjectConfiguredAsync(
     return null;
   }
 
-  const confirm = await confirmAsync({
-    message: 'This app is not set up for building with EAS. Set it up now?',
-  });
+  // Ensure the prompt is consistent with the platforms we need to configure
+  let message = 'This app is not configured to build with EAS. Set it up now?';
+  if (platformsToConfigure === RequestedPlatform.Ios) {
+    message = 'Your iOS app is not configured to build with EAS. Set it up now?';
+  } else if (platformsToConfigure === RequestedPlatform.Android) {
+    message = 'Your Android app is not configured to build with EAS. Set it up now?';
+  }
+
+  const confirm = await confirmAsync({ message });
   if (confirm) {
     await configureAsync({
       projectDir,

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -153,11 +153,11 @@ async function ensureProjectConfiguredAsync(
   }
 
   // Ensure the prompt is consistent with the platforms we need to configure
-  let message = 'This app is not configured to build with EAS. Set it up now?';
+  let message = 'This project is not configured to build with EAS. Set it up now?';
   if (platformsToConfigure === RequestedPlatform.Ios) {
-    message = 'Your iOS app is not configured to build with EAS. Set it up now?';
+    message = 'Your iOS project is not configured to build with EAS. Set it up now?';
   } else if (platformsToConfigure === RequestedPlatform.Android) {
-    message = 'Your Android app is not configured to build with EAS. Set it up now?';
+    message = 'Your Android project is not configured to build with EAS. Set it up now?';
   }
 
   const confirm = await confirmAsync({ message });

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig, getConfig } from '@expo/config';
+import { EasJsonReader } from '@expo/eas-json';
 import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import fs from 'fs-extra';
@@ -87,7 +88,7 @@ export default class Build extends EasCommand {
       return;
     }
 
-    exp = (await ensureProjectConfiguredAsync(projectDir)) ?? exp;
+    exp = (await ensureProjectConfiguredAsync(projectDir, platform)) ?? exp;
 
     const commandCtx = await createCommandContextAsync({
       requestedPlatform: platform,
@@ -101,6 +102,7 @@ export default class Build extends EasCommand {
       skipProjectConfiguration: flags['skip-project-configuration'],
       waitForBuildEnd: flags.wait,
     });
+
     await buildAsync(commandCtx);
   }
 }
@@ -140,17 +142,23 @@ async function promptForPlatformAsync(): Promise<RequestedPlatform> {
   return platform;
 }
 
-async function ensureProjectConfiguredAsync(projectDir: string): Promise<ExpoConfig | null> {
-  if (await fs.pathExists(path.join(projectDir, 'eas.json'))) {
+async function ensureProjectConfiguredAsync(
+  projectDir: string,
+  platform: RequestedPlatform
+): Promise<ExpoConfig | null> {
+  const platformsToConfigure = await getPlatformsToConfigureAsync(projectDir, platform);
+
+  if (!platformsToConfigure) {
     return null;
   }
+
   const confirm = await confirmAsync({
     message: 'This app is not set up for building with EAS. Set it up now?',
   });
   if (confirm) {
     await configureAsync({
       projectDir,
-      platform: RequestedPlatform.All,
+      platform: platformsToConfigure,
     });
     if (await vcs.hasUncommittedChangesAsync()) {
       throw new Error(
@@ -166,4 +174,31 @@ async function ensureProjectConfiguredAsync(projectDir: string): Promise<ExpoCon
       )})`
     );
   }
+}
+
+async function getPlatformsToConfigureAsync(
+  projectDir: string,
+  platform: RequestedPlatform
+): Promise<RequestedPlatform | null> {
+  if (!(await fs.pathExists(path.join(projectDir, 'eas.json')))) {
+    return platform;
+  }
+
+  const easConfig = await new EasJsonReader(projectDir, platform).readRawAsync();
+  if (platform === RequestedPlatform.All) {
+    if (easConfig.builds?.android && easConfig.builds?.ios) {
+      return null;
+    } else if (easConfig.builds?.ios) {
+      return RequestedPlatform.Android;
+    } else if (easConfig.builds?.android) {
+      return RequestedPlatform.Ios;
+    }
+  } else if (
+    (platform === RequestedPlatform.Android || platform === RequestedPlatform.Ios) &&
+    easConfig.builds?.[platform]
+  ) {
+    return null;
+  }
+
+  return platform;
 }


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

- If you run `eas build -p ios` and you have not configured EAS yet, you are prompted to set an Android application id and configure Android in eas.json if it's not configured already.
- If you run `eas build -p ios` and Android is already configured but iOS is not, we currently bail out rather than configuring iOS:

```
✔ Linked to project @notbrent/brandnew
    Error: There is no profile named release for platform android
```

- This is undesirable because you should be able to run `eas build -p ios` and configure only iOS stuff and then run `eas build -p android` and configure only Android stuff.

# How

I made the function that checks if we need to configure the project aware of the current configuration state. I also had to fix a small bug in `build/configure.ts` where we'd spread the existing eas.json under the `builds` key, which would result in `builds.builds.ios` if we already had the iOS configured and then configured the Android project, for example. Lastly, I updated the prompt to indicate what needs to be configured.

# Test Plan

Try various states of configuration, ensure the prompt and config works as expected.

- Init an empty project, run `eas build -p all` - should configure iOS and Android
- Reset that project, run `eas build -p android` and then `eas build -p ios`, it should configure one at a time.
- Reset that project, run `eas build -p android` and then `eas build -p all`, it should prompt to configure iOS on the `all`

The flow looks something like this when configuring one platform during the build command:

```
╭─~/code/brandnew ‹main›
╰─$ easd build -p android                                                                                                                                                   130 ↵
✔ Linked to project @notbrent/brandnew
✔ Your Android app is not configured to build with EAS. Set it up now? … yes

✔ Validated eas.json
✔ Updated eas.json
✔ What would you like your Android application id to be? … com.notbrent.brandnew

✔ Can we commit these changes to git for you? › Yes
✔ Commit message: … Configure EAS Build for Android
✔ Committed changes
✔ Using remote Android credentials (Expo server)
```