### PR TITLE
[eas-cli] remove nullthrows on keystore keyPassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix android builds for PKCS12 keystores. ([#484](https://github.com/expo/eas-cli/pull/484) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🧹 Chores
 
 ## [0.18.2](https://github.com/expo/eas-cli/releases/tag/v0.18.2) - 2021-06-25

--- a/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
@@ -47,7 +47,7 @@ export default class AndroidCredentialsProvider {
         keystore: nullthrows(androidBuildCredentials.androidKeystore?.keystore),
         keystorePassword: nullthrows(androidBuildCredentials.androidKeystore?.keystorePassword),
         keyAlias: nullthrows(androidBuildCredentials.androidKeystore?.keyAlias),
-        keyPassword: nullthrows(androidBuildCredentials.androidKeystore?.keyPassword),
+        keyPassword: androidBuildCredentials.androidKeystore?.keyPassword ?? undefined,
       },
     };
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Remove restriction on `keyPassword` for keystores -- this is only required for JKS keystores and pkcs12 ones don't have them

# Test Plan

- [x] manually tested with pkcs12 keystore
- [x] current tests still pass
