### PR TITLE
[eas-cli] use new build mutation

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -15455,8 +15455,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use createAndroidBuild instead"
           },
           {
             "name": "createAndroidManagedBuild",
@@ -15485,6 +15485,61 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "AndroidManagedJobInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildMetadataInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateBuildResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use createAndroidBuild instead"
+          },
+          {
+            "name": "createAndroidBuild",
+            "description": "Create an Android build",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "job",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AndroidJobInput",
                     "ofType": null
                   }
                 },
@@ -15595,6 +15650,61 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "IosManagedJobInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildMetadataInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateBuildResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createIosBuild",
+            "description": "Create an iOS build",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "job",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "IosJobInput",
                     "ofType": null
                   }
                 },
@@ -16534,6 +16644,178 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "AndroidJobInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "type",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BuildWorkflow",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectArchive",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectArchiveSourceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "updates",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildUpdatesInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secrets",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "builderEnvironment",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AndroidBuilderEnvironmentInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cache",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "gradleCommand",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "artifactPath",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "buildType",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "AndroidBuildType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "username",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AndroidBuildType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "APK",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "APP_BUNDLE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DEVELOPMENT_CLIENT",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "IosGenericJobInput",
         "description": "",
         "fields": null,
@@ -17038,6 +17320,192 @@
       {
         "kind": "ENUM",
         "name": "IosManagedBuildType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "RELEASE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DEVELOPMENT_CLIENT",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "IosJobInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "type",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BuildWorkflow",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectArchive",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ProjectArchiveSourceInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "updates",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildUpdatesInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "distribution",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "DistributionType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "secrets",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IosJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "builderEnvironment",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IosBuilderEnvironmentInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cache",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "scheme",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "buildConfiguration",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "artifactPath",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "buildType",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "IosBuildType",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "username",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "IosBuildType",
         "description": "",
         "fields": null,
         "inputFields": null,

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/apple-utils": "0.0.0-alpha.20",
     "@expo/config": "3.3.42",
     "@expo/config-plugins": "2.0.2",
-    "@expo/eas-build-job": "0.2.37",
+    "@expo/eas-build-job": "0.2.41",
     "@expo/eas-json": "^0.18.2",
     "@expo/json-file": "8.2.25",
     "@expo/pkcs12": "0.0.4",

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -23,7 +23,7 @@ import { transformMetadata } from '../graphql';
 import { Platform } from '../types';
 import { logCredentialsSource } from '../utils/credentials';
 import { validateAndSyncProjectConfigurationAsync } from './configure';
-import { transformGenericJob, transformManagedJob } from './graphql';
+import { transformJob } from './graphql';
 import { prepareJobAsync } from './prepareJob';
 
 export async function prepareAndroidBuildAsync(
@@ -87,21 +87,12 @@ This means that it will most likely produce an AAB and you will not be able to i
       metadata: Metadata
     ): Promise<BuildResult> => {
       const graphqlMetadata = transformMetadata(metadata);
-      if (job.type === Workflow.GENERIC) {
-        const graphqlJob = transformGenericJob(job);
-        return await BuildMutation.createAndroidGenericBuildAsync({
-          appId,
-          job: graphqlJob,
-          metadata: graphqlMetadata,
-        });
-      } else {
-        const graphqlJob = transformManagedJob(job);
-        return await BuildMutation.createAndroidManagedBuildAsync({
-          appId,
-          job: graphqlJob,
-          metadata: graphqlMetadata,
-        });
-      }
+      const graphqlJob = transformJob(job);
+      return await BuildMutation.createAndroidBuildAsync({
+        appId,
+        job: graphqlJob,
+        metadata: graphqlMetadata,
+      });
     },
   });
 }

--- a/packages/eas-cli/src/build/android/graphql.ts
+++ b/packages/eas-cli/src/build/android/graphql.ts
@@ -1,14 +1,11 @@
 import { Android } from '@expo/eas-build-job';
 
-import {
-  AndroidGenericJobInput,
-  AndroidManagedBuildType,
-  AndroidManagedJobInput,
-} from '../../graphql/generated';
-import { transformProjectArchive } from '../graphql';
+import { AndroidBuildType, AndroidJobInput } from '../../graphql/generated';
+import { transformProjectArchive, transformWorkflow } from '../graphql';
 
-export function transformGenericJob(job: Android.GenericJob): AndroidGenericJobInput {
+export function transformJob(job: Android.Job): AndroidJobInput {
   return {
+    type: transformWorkflow(job.type),
     projectArchive: transformProjectArchive(job.projectArchive),
     projectRootDirectory: job.projectRootDirectory,
     releaseChannel: job.releaseChannel,
@@ -18,29 +15,17 @@ export function transformGenericJob(job: Android.GenericJob): AndroidGenericJobI
     cache: job.cache,
     gradleCommand: job.gradleCommand,
     artifactPath: job.artifactPath,
-  };
-}
-
-export function transformManagedJob(job: Android.ManagedJob): AndroidManagedJobInput {
-  return {
-    projectArchive: transformProjectArchive(job.projectArchive),
-    projectRootDirectory: job.projectRootDirectory,
-    releaseChannel: job.releaseChannel,
-    updates: job.updates,
-    secrets: job.secrets,
-    builderEnvironment: job.builderEnvironment,
-    cache: job.cache,
     username: job.username,
-    buildType: transformBuildType(job.buildType),
+    buildType: job.buildType && transformBuildType(job.buildType),
   };
 }
 
-function transformBuildType(buildType: Android.ManagedBuildType): AndroidManagedBuildType {
-  if (buildType === Android.ManagedBuildType.APK) {
-    return AndroidManagedBuildType.Apk;
-  } else if (buildType === Android.ManagedBuildType.APP_BUNDLE) {
-    return AndroidManagedBuildType.AppBundle;
+function transformBuildType(buildType: Android.BuildType): AndroidBuildType {
+  if (buildType === Android.BuildType.APK) {
+    return AndroidBuildType.Apk;
+  } else if (buildType === Android.BuildType.APP_BUNDLE) {
+    return AndroidBuildType.AppBundle;
   } else {
-    return AndroidManagedBuildType.DevelopmentClient;
+    return AndroidBuildType.DevelopmentClient;
   }
 }

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -84,7 +84,7 @@ async function prepareGenericJobAsync(
   ctx: BuildContext<Platform.ANDROID>,
   jobData: JobData,
   buildProfile: AndroidGenericBuildProfile
-): Promise<Partial<Android.GenericJob>> {
+): Promise<Partial<Android.Job>> {
   const projectRootDirectory =
     path.relative(await vcs.getRootPathAsync(), ctx.commandCtx.projectDir) || '.';
   return {
@@ -102,7 +102,7 @@ async function prepareManagedJobAsync(
   ctx: BuildContext<Platform.ANDROID>,
   jobData: JobData,
   buildProfile: AndroidManagedBuildProfile
-): Promise<Partial<Android.ManagedJob>> {
+): Promise<Partial<Android.Job>> {
   const projectRootDirectory =
     path.relative(await vcs.getRootPathAsync(), ctx.commandCtx.projectDir) || '.';
   const username = getUsername(ctx.commandCtx.exp, await ensureLoggedInAsync());

--- a/packages/eas-cli/src/build/graphql.ts
+++ b/packages/eas-cli/src/build/graphql.ts
@@ -55,7 +55,7 @@ function transformDistribution(distribution: Metadata['distribution']): Distribu
   }
 }
 
-function transformWorkflow(workflow: Metadata['workflow']): BuildWorkflow {
+export function transformWorkflow(workflow: Workflow): BuildWorkflow {
   if (workflow === Workflow.GENERIC) {
     return BuildWorkflow.Generic;
   } else {

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -15,7 +15,7 @@ import { transformMetadata } from '../graphql';
 import { Platform } from '../types';
 import { validateAndSyncProjectConfigurationAsync } from './configure';
 import { ensureIosCredentialsAsync } from './credentials';
-import { transformGenericJob, transformManagedJob } from './graphql';
+import { transformJob } from './graphql';
 import { prepareJobAsync } from './prepareJob';
 
 export async function prepareIosBuildAsync(
@@ -87,21 +87,12 @@ export async function prepareIosBuildAsync(
       metadata: Metadata
     ): Promise<BuildResult> => {
       const graphqlMetadata = transformMetadata(metadata);
-      if (job.type === Workflow.GENERIC) {
-        const graphqlJob = transformGenericJob(job);
-        return await BuildMutation.createIosGenericBuildAsync({
-          appId,
-          job: graphqlJob,
-          metadata: graphqlMetadata,
-        });
-      } else {
-        const graphqlJob = transformManagedJob(job);
-        return await BuildMutation.createIosManagedBuildAsync({
-          appId,
-          job: graphqlJob,
-          metadata: graphqlMetadata,
-        });
-      }
+      const graphqlJob = transformJob(job);
+      return await BuildMutation.createIosBuildAsync({
+        appId,
+        job: graphqlJob,
+        metadata: graphqlMetadata,
+      });
     },
   });
 }

--- a/packages/eas-cli/src/build/ios/graphql.ts
+++ b/packages/eas-cli/src/build/ios/graphql.ts
@@ -3,15 +3,15 @@ import nullthrows from 'nullthrows';
 
 import {
   DistributionType,
-  IosGenericJobInput,
+  IosBuildType,
+  IosJobInput,
   IosJobSecretsInput,
-  IosManagedBuildType,
-  IosManagedJobInput,
 } from '../../graphql/generated';
-import { transformProjectArchive } from '../graphql';
+import { transformProjectArchive, transformWorkflow } from '../graphql';
 
-export function transformGenericJob(job: Ios.GenericJob): IosGenericJobInput {
+export function transformJob(job: Ios.Job): IosJobInput {
   return {
+    type: transformWorkflow(job.type),
     projectArchive: transformProjectArchive(job.projectArchive),
     projectRootDirectory: job.projectRootDirectory,
     releaseChannel: job.releaseChannel,
@@ -20,22 +20,11 @@ export function transformGenericJob(job: Ios.GenericJob): IosGenericJobInput {
     secrets: transformIosSecrets(job.secrets),
     builderEnvironment: job.builderEnvironment,
     cache: job.cache,
+
     scheme: job.scheme,
     buildConfiguration: job.buildConfiguration,
     artifactPath: job.artifactPath,
-  };
-}
 
-export function transformManagedJob(job: Ios.ManagedJob): IosManagedJobInput {
-  return {
-    projectArchive: transformProjectArchive(job.projectArchive),
-    projectRootDirectory: job.projectRootDirectory,
-    releaseChannel: job.releaseChannel,
-    updates: job.updates,
-    distribution: job.distribution && transformDistributionType(job.distribution),
-    secrets: transformIosSecrets(job.secrets),
-    builderEnvironment: job.builderEnvironment,
-    cache: job.cache,
     buildType: job.buildType && transformBuildType(job.buildType),
     username: job.username,
   };
@@ -73,10 +62,10 @@ function transformIosSecrets(secrets: {
   };
 }
 
-function transformBuildType(buildType: Ios.ManagedBuildType): IosManagedBuildType {
-  if (buildType === Ios.ManagedBuildType.DEVELOPMENT_CLIENT) {
-    return IosManagedBuildType.DevelopmentClient;
+function transformBuildType(buildType: Ios.BuildType): IosBuildType {
+  if (buildType === Ios.BuildType.DEVELOPMENT_CLIENT) {
+    return IosBuildType.DevelopmentClient;
   } else {
-    return IosManagedBuildType.Release;
+    return IosBuildType.Release;
   }
 }

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -104,7 +104,7 @@ async function prepareGenericJobAsync(
   ctx: BuildContext<Platform.IOS>,
   jobData: JobData,
   buildProfile: IosGenericBuildProfile
-): Promise<Partial<Ios.GenericJob>> {
+): Promise<Partial<Ios.Job>> {
   const projectRootDirectory =
     path.relative(await vcs.getRootPathAsync(), ctx.commandCtx.projectDir) || '.';
   return {
@@ -126,7 +126,7 @@ async function prepareManagedJobAsync(
   ctx: BuildContext<Platform.IOS>,
   jobData: JobData,
   buildProfile: IosManagedBuildProfile
-): Promise<Partial<Ios.ManagedJob>> {
+): Promise<Partial<Ios.Job>> {
   const projectRootDirectory =
     path.relative(await vcs.getRootPathAsync(), ctx.commandCtx.projectDir) || '.';
   const username = getUsername(ctx.commandCtx.exp, await ensureLoggedInAsync());

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -37,9 +37,6 @@ export async function collectMetadata<T extends Platform>(
 ): Promise<Metadata> {
   const channelOrReleaseChannel = await resolveChannelOrReleaseChannelAsync(ctx);
   return {
-    // TODO: type error fixed in https://github.com/expo/eas-build/pull/34
-    // remove @ts-expect-error after upgrading @expo/eas-build-job
-    // @ts-expect-error error TS2322: not assignable to type 'Record<string, string | number>'
     trackingContext: ctx.trackingCtx,
     appVersion: await resolveAppVersionAsync(ctx),
     appBuildVersion: await resolveAppBuildVersionAsync(ctx),

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2352,14 +2352,24 @@ export type BuildMutation = {
    * @deprecated Use cancelBuild instead
    */
   cancel: Build;
-  /** Create an Android generic build */
+  /**
+   * Create an Android generic build
+   * @deprecated Use createAndroidBuild instead
+   */
   createAndroidGenericBuild: CreateBuildResult;
-  /** Create an Android managed build */
+  /**
+   * Create an Android managed build
+   * @deprecated Use createAndroidBuild instead
+   */
   createAndroidManagedBuild: CreateBuildResult;
+  /** Create an Android build */
+  createAndroidBuild: CreateBuildResult;
   /** Create an iOS generic build */
   createIosGenericBuild: CreateBuildResult;
   /** Create an iOS managed build */
   createIosManagedBuild: CreateBuildResult;
+  /** Create an iOS build */
+  createIosBuild: CreateBuildResult;
 };
 
 
@@ -2387,6 +2397,13 @@ export type BuildMutationCreateAndroidManagedBuildArgs = {
 };
 
 
+export type BuildMutationCreateAndroidBuildArgs = {
+  appId: Scalars['ID'];
+  job: AndroidJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+};
+
+
 export type BuildMutationCreateIosGenericBuildArgs = {
   appId: Scalars['ID'];
   job: IosGenericJobInput;
@@ -2397,6 +2414,13 @@ export type BuildMutationCreateIosGenericBuildArgs = {
 export type BuildMutationCreateIosManagedBuildArgs = {
   appId: Scalars['ID'];
   job: IosManagedJobInput;
+  metadata?: Maybe<BuildMetadataInput>;
+};
+
+
+export type BuildMutationCreateIosBuildArgs = {
+  appId: Scalars['ID'];
+  job: IosJobInput;
   metadata?: Maybe<BuildMetadataInput>;
 };
 
@@ -2523,6 +2547,27 @@ export enum AndroidManagedBuildType {
   DevelopmentClient = 'DEVELOPMENT_CLIENT'
 }
 
+export type AndroidJobInput = {
+  type: BuildWorkflow;
+  projectArchive: ProjectArchiveSourceInput;
+  projectRootDirectory: Scalars['String'];
+  releaseChannel?: Maybe<Scalars['String']>;
+  updates?: Maybe<BuildUpdatesInput>;
+  secrets?: Maybe<AndroidJobSecretsInput>;
+  builderEnvironment?: Maybe<AndroidBuilderEnvironmentInput>;
+  cache?: Maybe<BuildCacheInput>;
+  gradleCommand?: Maybe<Scalars['String']>;
+  artifactPath?: Maybe<Scalars['String']>;
+  buildType?: Maybe<AndroidBuildType>;
+  username?: Maybe<Scalars['String']>;
+};
+
+export enum AndroidBuildType {
+  Apk = 'APK',
+  AppBundle = 'APP_BUNDLE',
+  DevelopmentClient = 'DEVELOPMENT_CLIENT'
+}
+
 export type IosGenericJobInput = {
   projectArchive: ProjectArchiveSourceInput;
   projectRootDirectory: Scalars['String'];
@@ -2584,6 +2629,28 @@ export type IosManagedJobInput = {
 };
 
 export enum IosManagedBuildType {
+  Release = 'RELEASE',
+  DevelopmentClient = 'DEVELOPMENT_CLIENT'
+}
+
+export type IosJobInput = {
+  type: BuildWorkflow;
+  projectArchive: ProjectArchiveSourceInput;
+  projectRootDirectory: Scalars['String'];
+  releaseChannel?: Maybe<Scalars['String']>;
+  updates?: Maybe<BuildUpdatesInput>;
+  distribution?: Maybe<DistributionType>;
+  secrets?: Maybe<IosJobSecretsInput>;
+  builderEnvironment?: Maybe<IosBuilderEnvironmentInput>;
+  cache?: Maybe<BuildCacheInput>;
+  scheme?: Maybe<Scalars['String']>;
+  buildConfiguration?: Maybe<Scalars['String']>;
+  artifactPath?: Maybe<Scalars['String']>;
+  buildType?: Maybe<IosBuildType>;
+  username?: Maybe<Scalars['String']>;
+};
+
+export enum IosBuildType {
   Release = 'RELEASE',
   DevelopmentClient = 'DEVELOPMENT_CLIENT'
 }
@@ -4497,18 +4564,18 @@ export type CreateAppMutation = (
   )> }
 );
 
-export type CreateAndroidGenericBuildMutationVariables = Exact<{
+export type CreateAndroidBuildMutationVariables = Exact<{
   appId: Scalars['ID'];
-  job: AndroidGenericJobInput;
+  job: AndroidJobInput;
   metadata?: Maybe<BuildMetadataInput>;
 }>;
 
 
-export type CreateAndroidGenericBuildMutation = (
+export type CreateAndroidBuildMutation = (
   { __typename?: 'RootMutation' }
   & { build?: Maybe<(
     { __typename?: 'BuildMutation' }
-    & { createAndroidGenericBuild: (
+    & { createAndroidBuild: (
       { __typename?: 'CreateBuildResult' }
       & { build: (
         { __typename?: 'Build' }
@@ -4521,66 +4588,18 @@ export type CreateAndroidGenericBuildMutation = (
   )> }
 );
 
-export type CreateAndroidManagedBuildMutationVariables = Exact<{
+export type CreateIosBuildMutationVariables = Exact<{
   appId: Scalars['ID'];
-  job: AndroidManagedJobInput;
+  job: IosJobInput;
   metadata?: Maybe<BuildMetadataInput>;
 }>;
 
 
-export type CreateAndroidManagedBuildMutation = (
+export type CreateIosBuildMutation = (
   { __typename?: 'RootMutation' }
   & { build?: Maybe<(
     { __typename?: 'BuildMutation' }
-    & { createAndroidManagedBuild: (
-      { __typename?: 'CreateBuildResult' }
-      & { build: (
-        { __typename?: 'Build' }
-        & Pick<Build, 'id'>
-      ), deprecationInfo?: Maybe<(
-        { __typename?: 'EASBuildDeprecationInfo' }
-        & Pick<EasBuildDeprecationInfo, 'type' | 'message'>
-      )> }
-    ) }
-  )> }
-);
-
-export type CreateIosGenericBuildMutationVariables = Exact<{
-  appId: Scalars['ID'];
-  job: IosGenericJobInput;
-  metadata?: Maybe<BuildMetadataInput>;
-}>;
-
-
-export type CreateIosGenericBuildMutation = (
-  { __typename?: 'RootMutation' }
-  & { build?: Maybe<(
-    { __typename?: 'BuildMutation' }
-    & { createIosGenericBuild: (
-      { __typename?: 'CreateBuildResult' }
-      & { build: (
-        { __typename?: 'Build' }
-        & Pick<Build, 'id'>
-      ), deprecationInfo?: Maybe<(
-        { __typename?: 'EASBuildDeprecationInfo' }
-        & Pick<EasBuildDeprecationInfo, 'type' | 'message'>
-      )> }
-    ) }
-  )> }
-);
-
-export type CreateIosManagedBuildMutationVariables = Exact<{
-  appId: Scalars['ID'];
-  job: IosManagedJobInput;
-  metadata?: Maybe<BuildMetadataInput>;
-}>;
-
-
-export type CreateIosManagedBuildMutation = (
-  { __typename?: 'RootMutation' }
-  & { build?: Maybe<(
-    { __typename?: 'BuildMutation' }
-    & { createIosManagedBuild: (
+    & { createIosBuild: (
       { __typename?: 'CreateBuildResult' }
       & { build: (
         { __typename?: 'Build' }

--- a/packages/eas-cli/src/graphql/mutations/BuildMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/BuildMutation.ts
@@ -3,20 +3,14 @@ import nullthrows from 'nullthrows';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import {
-  AndroidGenericJobInput,
-  AndroidManagedJobInput,
+  AndroidJobInput,
   BuildMetadataInput,
-  CreateAndroidGenericBuildMutation,
-  CreateAndroidGenericBuildMutationVariables,
-  CreateAndroidManagedBuildMutation,
-  CreateAndroidManagedBuildMutationVariables,
-  CreateIosGenericBuildMutation,
-  CreateIosGenericBuildMutationVariables,
-  CreateIosManagedBuildMutation,
-  CreateIosManagedBuildMutationVariables,
+  CreateAndroidBuildMutation,
+  CreateAndroidBuildMutationVariables,
+  CreateIosBuildMutation,
+  CreateIosBuildMutationVariables,
   EasBuildDeprecationInfo,
-  IosGenericJobInput,
-  IosManagedJobInput,
+  IosJobInput,
 } from '../generated';
 
 export interface BuildResult {
@@ -25,22 +19,22 @@ export interface BuildResult {
 }
 
 const BuildMutation = {
-  async createAndroidGenericBuildAsync(input: {
+  async createAndroidBuildAsync(input: {
     appId: string;
-    job: AndroidGenericJobInput;
+    job: AndroidJobInput;
     metadata: BuildMetadataInput;
   }): Promise<BuildResult> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .mutation<CreateAndroidGenericBuildMutation, CreateAndroidGenericBuildMutationVariables>(
+        .mutation<CreateAndroidBuildMutation, CreateAndroidBuildMutationVariables>(
           gql`
-            mutation CreateAndroidGenericBuildMutation(
+            mutation CreateAndroidBuildMutation(
               $appId: ID!
-              $job: AndroidGenericJobInput!
+              $job: AndroidJobInput!
               $metadata: BuildMetadataInput
             ) {
               build {
-                createAndroidGenericBuild(appId: $appId, job: $job, metadata: $metadata) {
+                createAndroidBuild(appId: $appId, job: $job, metadata: $metadata) {
                   build {
                     id
                   }
@@ -56,24 +50,24 @@ const BuildMutation = {
         )
         .toPromise()
     );
-    return nullthrows(data.build?.createAndroidGenericBuild);
+    return nullthrows(data.build?.createAndroidBuild);
   },
-  async createAndroidManagedBuildAsync(input: {
+  async createIosBuildAsync(input: {
     appId: string;
-    job: AndroidManagedJobInput;
+    job: IosJobInput;
     metadata: BuildMetadataInput;
   }): Promise<BuildResult> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .mutation<CreateAndroidManagedBuildMutation, CreateAndroidManagedBuildMutationVariables>(
+        .mutation<CreateIosBuildMutation, CreateIosBuildMutationVariables>(
           gql`
-            mutation CreateAndroidManagedBuildMutation(
+            mutation CreateIosBuildMutation(
               $appId: ID!
-              $job: AndroidManagedJobInput!
+              $job: IosJobInput!
               $metadata: BuildMetadataInput
             ) {
               build {
-                createAndroidManagedBuild(appId: $appId, job: $job, metadata: $metadata) {
+                createIosBuild(appId: $appId, job: $job, metadata: $metadata) {
                   build {
                     id
                   }
@@ -89,73 +83,7 @@ const BuildMutation = {
         )
         .toPromise()
     );
-    return nullthrows(data.build?.createAndroidManagedBuild);
-  },
-  async createIosGenericBuildAsync(input: {
-    appId: string;
-    job: IosGenericJobInput;
-    metadata: BuildMetadataInput;
-  }): Promise<BuildResult> {
-    const data = await withErrorHandlingAsync(
-      graphqlClient
-        .mutation<CreateIosGenericBuildMutation, CreateIosGenericBuildMutationVariables>(
-          gql`
-            mutation CreateIosGenericBuildMutation(
-              $appId: ID!
-              $job: IosGenericJobInput!
-              $metadata: BuildMetadataInput
-            ) {
-              build {
-                createIosGenericBuild(appId: $appId, job: $job, metadata: $metadata) {
-                  build {
-                    id
-                  }
-                  deprecationInfo {
-                    type
-                    message
-                  }
-                }
-              }
-            }
-          `,
-          input
-        )
-        .toPromise()
-    );
-    return nullthrows(data.build?.createIosGenericBuild);
-  },
-  async createIosManagedBuildAsync(input: {
-    appId: string;
-    job: IosManagedJobInput;
-    metadata: BuildMetadataInput;
-  }): Promise<BuildResult> {
-    const data = await withErrorHandlingAsync(
-      graphqlClient
-        .mutation<CreateIosManagedBuildMutation, CreateIosManagedBuildMutationVariables>(
-          gql`
-            mutation CreateIosManagedBuildMutation(
-              $appId: ID!
-              $job: IosManagedJobInput!
-              $metadata: BuildMetadataInput
-            ) {
-              build {
-                createIosManagedBuild(appId: $appId, job: $job, metadata: $metadata) {
-                  build {
-                    id
-                  }
-                  deprecationInfo {
-                    type
-                    message
-                  }
-                }
-              }
-            }
-          `,
-          input
-        )
-        .toPromise()
-    );
-    return nullthrows(data.build?.createIosManagedBuild);
+    return nullthrows(data.build?.createIosBuild);
   },
 };
 

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.37",
+    "@expo/eas-build-job": "0.2.41",
     "@hapi/joi": "17.1.1",
     "fs-extra": "9.0.1",
     "tslib": "1.14.1"

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -16,7 +16,7 @@ export type VersionAutoIncrement = boolean | 'version' | 'buildNumber';
 export interface AndroidManagedBuildProfile extends Android.BuilderEnvironment {
   workflow: Workflow.MANAGED;
   credentialsSource: CredentialsSource;
-  buildType?: Android.ManagedBuildType;
+  buildType?: Android.BuildType;
   releaseChannel?: string;
   channel?: string;
   distribution: AndroidDistributionType;
@@ -38,7 +38,7 @@ export interface AndroidGenericBuildProfile extends Android.BuilderEnvironment {
 export interface IosManagedBuildProfile extends Omit<Ios.BuilderEnvironment, 'image'> {
   workflow: Workflow.MANAGED;
   credentialsSource: CredentialsSource;
-  buildType?: Ios.ManagedBuildType;
+  buildType?: Ios.BuildType;
   releaseChannel?: string;
   channel?: string;
   distribution: IosDistributionType;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,10 +1917,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.37":
-  version "0.2.37"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.37.tgz#fd6cb911e33774239d1ab7662c0ccc8efa22f7a2"
-  integrity sha512-B9gahwTTYs0pWQP2HnfYWcbsqmUIAdnr+iwounVqpcxHhERxGJby2JEw+Vxtl2+VMARM4w9RLgNduP5Vk/zeQw==
+"@expo/eas-build-job@0.2.41":
+  version "0.2.41"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.41.tgz#d44ce7f5e7a1f08caa415913fed43f875fce4d52"
+  integrity sha512-tp3i7EZRMGvlJ3NyhpBpLdIxg6+CI6z6P3JgZVh57s2skN5zjzHcfjXPcw0gVH9fCouUnvhSSye8O+g2Zo1oaA==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

use new BuildMutation with unified API for generic and managed workflow

# How

switch to new API, should not contain any user-facing changes

# Test Plan

run builds on staging
