### PR TITLE
display short build artifact URL if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Auto-suggest application id and bundle identifier when running `eas build:configure` for a managed project. ([#487](https://github.com/expo/eas-cli/pull/487) by [@dsokal](https://github.com/dsokal))
+- Display short build artifact URL if available. ([#486](https://github.com/expo/eas-cli/pull/486) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -5490,6 +5490,18 @@
             "deprecationReason": null
           },
           {
+            "name": "shortBuildUrl",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "xcodeBuildLogsUrl",
             "description": "",
             "args": [],

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -59,7 +59,7 @@ export function formatGraphQLBuild(build: BuildFragment) {
           case GraphQLBuildStatus.Errored:
             return '---------';
           case GraphQLBuildStatus.Finished: {
-            const url = build.artifacts?.buildUrl;
+            const url = build.artifacts?.shortBuildUrl ?? build.artifacts?.buildUrl;
             return url ? url : chalk.red('not found');
           }
           default:

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -95,7 +95,7 @@ function printBuildResult(accountName: string, build: BuildFragment): void {
   } else {
     // TODO: it looks like buildUrl could possibly be undefined, based on the code below.
     // we should account for this case better if it is possible
-    const url = build.artifacts?.buildUrl ?? '';
+    const url = build.artifacts?.shortBuildUrl ?? build.artifacts?.buildUrl ?? '';
     Log.log(`${appPlatformEmojis[build.platform]} ${appPlatformDisplayNames[build.platform]} app:`);
     Log.log(`${chalk.underline(url)}`);
   }

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -24,7 +24,8 @@ export function getInternalDistributionInstallUrl(build: BuildFragment): string 
     }/builds/${build.id}/manifest.plist`;
   }
 
-  assert(build.artifacts?.buildUrl, 'buildUrl is missing');
+  const buildUrl = build.artifacts?.shortBuildUrl ?? build.artifacts?.buildUrl;
+  assert(buildUrl, 'buildUrl is missing');
 
-  return build.artifacts.buildUrl;
+  return buildUrl;
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -803,6 +803,7 @@ export enum Role {
 export type BuildArtifacts = {
   __typename?: 'BuildArtifacts';
   buildUrl?: Maybe<Scalars['String']>;
+  shortBuildUrl?: Maybe<Scalars['String']>;
   xcodeBuildLogsUrl?: Maybe<Scalars['String']>;
 };
 
@@ -5018,7 +5019,7 @@ export type BuildFragment = (
     & Pick<BuildError, 'errorCode' | 'message' | 'docsUrl'>
   )>, artifacts?: Maybe<(
     { __typename?: 'BuildArtifacts' }
-    & Pick<BuildArtifacts, 'buildUrl' | 'xcodeBuildLogsUrl'>
+    & Pick<BuildArtifacts, 'buildUrl' | 'shortBuildUrl' | 'xcodeBuildLogsUrl'>
   )>, initiatingActor?: Maybe<(
     { __typename: 'User' }
     & Pick<User, 'username' | 'id'>

--- a/packages/eas-cli/src/graphql/types/Build.ts
+++ b/packages/eas-cli/src/graphql/types/Build.ts
@@ -12,6 +12,7 @@ export const BuildFragmentNode = gql`
     }
     artifacts {
       buildUrl
+      shortBuildUrl
       xcodeBuildLogsUrl
     }
     initiatingActor {

--- a/packages/eas-cli/src/submissions/utils/builds.ts
+++ b/packages/eas-cli/src/submissions/utils/builds.ts
@@ -14,7 +14,7 @@ export async function getBuildArtifactUrlByIdAsync(
   if (!artifacts) {
     throw new Error('Build has no artifacts.');
   }
-  const buildUrl = artifacts.buildUrl;
+  const buildUrl = artifacts.shortBuildUrl ?? artifacts.buildUrl;
   if (!buildUrl) {
     throw new Error('Build URL is not defined.');
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://github.com/expo/universe/pull/7779 exposes short build artifact URL via GraphQL. This PR makes use of the new field.

# How

I updated the generated GraphQL code and updated all places using `artifacts.buildUrl` with `artifacts.shortBuildUrl ?? artifacts.buildUrl`

# Test Plan

<img width="966" alt="Screenshot 2021-06-28 at 14 20 51" src="https://user-images.githubusercontent.com/5256730/123636534-464c7880-d81d-11eb-9de3-c3cc500f3a83.png">

