### PR TITLE
[ENG-1377] auto-suggest application id and bundle identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Auto-suggest application id and bundle identifier when running `eas build:configure` for a managed project. ([#487](https://github.com/expo/eas-cli/pull/487) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
@@ -3,6 +3,7 @@ import { vol } from 'memfs';
 import os from 'os';
 
 import { asMock } from '../../../__tests__/utils';
+import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { promptAsync } from '../../../prompts';
 import {
   ensureApplicationIdIsDefinedForManagedProjectAsync,
@@ -11,10 +12,13 @@ import {
 
 jest.mock('fs');
 jest.mock('../../../prompts');
+jest.mock('../../../user/actions', () => ({ ensureLoggedInAsync: jest.fn(() => mockJester) }));
 
 const originalConsoleWarn = console.warn;
+const originalConsoleLog = console.log;
 beforeAll(() => {
   console.warn = jest.fn();
+  console.log = jest.fn();
 });
 
 beforeEach(() => {
@@ -29,6 +33,7 @@ beforeEach(() => {
 afterAll(() => {
   fs.removeSync(os.tmpdir());
   console.warn = originalConsoleWarn;
+  console.log = originalConsoleLog;
 });
 
 describe(getApplicationId, () => {

--- a/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 
 import { asMock } from '../../../__tests__/utils';
+import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { promptAsync } from '../../../prompts';
 import {
   ensureBundleIdentifierIsDefinedForManagedProjectAsync,
@@ -13,10 +14,13 @@ import {
 
 jest.mock('fs');
 jest.mock('../../../prompts');
+jest.mock('../../../user/actions', () => ({ ensureLoggedInAsync: jest.fn(() => mockJester) }));
 
 const originalConsoleWarn = console.warn;
+const originalConsoleLog = console.log;
 beforeAll(() => {
   console.warn = jest.fn();
+  console.log = jest.fn();
 });
 
 beforeEach(() => {
@@ -31,6 +35,7 @@ beforeEach(() => {
 afterAll(() => {
   fs.removeSync(os.tmpdir());
   console.warn = originalConsoleWarn;
+  console.log = originalConsoleLog;
 });
 
 const originalFs = jest.requireActual('fs');

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -1,12 +1,14 @@
 import { ExpoConfig, getConfigFilePaths } from '@expo/config';
-import { IOSConfig } from '@expo/config-plugins';
+import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import assert from 'assert';
+import chalk from 'chalk';
 import fs from 'fs-extra';
 import once from 'lodash/once';
 
-import Log from '../../log';
+import Log, { learnMore } from '../../log';
 import { promptAsync } from '../../prompts';
+import { getActorDisplayName, getUserAsync } from '../../user/User';
 import { getProjectConfigDescription, sanitizedProjectName } from '../projectUtils';
 import { resolveWorkflow } from '../workflow';
 
@@ -90,10 +92,19 @@ async function configureBundleIdentifierAsync(
 
   assert(paths.staticConfigPath, 'app.json must exist');
 
+  Log.addNewLineIfNone();
+  Log.log(
+    `${chalk.bold(`📝  iOS Bundle Identifier`)} ${chalk.dim(
+      learnMore('https://expo.fyi/bundle-identifier')
+    )}`
+  );
+
+  const recommendedBundleIdentifier = await getRecommendedBundleIdentifierAsync(exp);
   const { bundleIdentifier } = await promptAsync({
     name: 'bundleIdentifier',
     type: 'text',
     message: `What would you like your iOS bundle identifier to be?`,
+    initial: recommendedBundleIdentifier,
     validate: value => (isBundleIdentifierValid(value) ? true : INVALID_BUNDLE_IDENTIFIER_MESSAGE),
   });
 
@@ -134,4 +145,20 @@ export const warnIfBundleIdentifierDefinedInAppConfigForGenericProject = once(
 export function isWildcardBundleIdentifier(bundleIdentifier: string): boolean {
   const wildcardRegex = /^[A-Za-z0-9.-]+\*$/;
   return wildcardRegex.test(bundleIdentifier);
+}
+
+async function getRecommendedBundleIdentifierAsync(exp: ExpoConfig): Promise<string | undefined> {
+  // Attempt to use the android package name first since it's convenient to have them aligned.
+  const maybeAndroidPackage = AndroidConfig.Package.getPackage(exp);
+  if (maybeAndroidPackage && isBundleIdentifierValid(maybeAndroidPackage)) {
+    return maybeAndroidPackage;
+  } else {
+    const username = exp.owner ?? getActorDisplayName(await getUserAsync());
+    // It's common to use dashes in your node project name, strip them from the suggested package name.
+    const possibleId = `com.${username}.${exp.slug}`.split('-').join('');
+    if (isBundleIdentifierValid(possibleId)) {
+      return possibleId;
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Fixes https://linear.app/expo/issue/ENG-1377/auto-suggest-application-id-and-bundle-identifier-and-provide-context

> Currently we ask the user to provide an application id and bundle identifier without any suggested default value in eas-cli. This is a good start and much better than erroring without any options, but we can do a bit better than this and have the same behavior as in expo-cli:
>
> <img width="574" alt="Screen Shot 2021-06-17 at 10 55 21 AM" src="https://user-images.githubusercontent.com/5256730/123648055-eb208300-d828-11eb-89d6-f9199ebc7cbc.png">


# How

I implemented the logic as described in the linear task:

> The logic suggested name is approximately com.username.slug, and if we are prompting for both, one after the other, we should use the value that the user provides for the first prompt as the default for the second. You can see this behavior by running expo prebuild on a brand new managed project.

# Test Plan

Tested locally (see the GIF):
![Kapture 2021-06-28 at 15 46 33](https://user-images.githubusercontent.com/5256730/123647763-a72d7e00-d828-11eb-8296-7d628dc2c429.gif)
