### PR TITLE
[ENG-1444] improve workflow detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Improve project workflow detection (fixes the case where the `android` and/or `ios` directories are git-ignored). ([#490](https://github.com/expo/eas-cli/pull/490) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/__mocks__/fs.ts
+++ b/packages/eas-cli/__mocks__/fs.ts
@@ -1,6 +1,9 @@
 import { fs } from 'memfs';
+
+// needed because of a weird bug with tempy (dependency of @expo/config-plugins)
 fs.mkdirSync('/tmp');
 if (process.env.TMPDIR) {
   fs.mkdirSync(process.env.TMPDIR, { recursive: true });
 }
+
 module.exports = fs;

--- a/packages/eas-cli/__mocks__/fs.ts
+++ b/packages/eas-cli/__mocks__/fs.ts
@@ -1,2 +1,6 @@
 import { fs } from 'memfs';
+fs.mkdirSync('/tmp');
+if (process.env.TMPDIR) {
+  fs.mkdirSync(process.env.TMPDIR, { recursive: true });
+}
 module.exports = fs;

--- a/packages/eas-cli/global-setup.ts
+++ b/packages/eas-cli/global-setup.ts
@@ -1,3 +1,5 @@
 module.exports = async () => {
   process.env.TZ = 'UTC';
+  process.env.EAS_NO_VCS = '1';
+  process.env.EAS_PROJECT_ROOT = '/app';
 };

--- a/packages/eas-cli/src/build/android/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/android/__tests__/version-test.ts
@@ -3,14 +3,19 @@ import fs from 'fs-extra';
 import { vol } from 'memfs';
 import os from 'os';
 
-import { readVersionCode, readVersionName } from '../version';
+import { readVersionCodeAsync, readVersionNameAsync } from '../version';
 
 jest.mock('fs');
 
+const originalConsoleWarn = console.warn;
+beforeAll(() => {
+  console.warn = jest.fn();
+});
 afterAll(() => {
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
   fs.removeSync(os.tmpdir());
+  console.warn = originalConsoleWarn;
 });
 
 beforeEach(() => {
@@ -20,35 +25,35 @@ beforeEach(() => {
   fs.mkdirpSync(os.tmpdir());
 });
 
-describe(readVersionCode, () => {
+describe(readVersionCodeAsync, () => {
   describe('generic project', () => {
-    it('reads the version code from native code', () => {
+    it('reads the version code from native code', async () => {
       const exp = initGenericProject();
-      const versionCode = readVersionCode('/repo', exp);
+      const versionCode = await readVersionCodeAsync('/repo', exp);
       expect(versionCode).toBe(123);
     });
   });
   describe('managed project', () => {
-    it('reads the version code from expo config', () => {
+    it('reads the version code from expo config', async () => {
       const exp = initManagedProject();
-      const versionCode = readVersionCode('/repo', exp);
+      const versionCode = await readVersionCodeAsync('/repo', exp);
       expect(versionCode).toBe(123);
     });
   });
 });
 
-describe(readVersionName, () => {
+describe(readVersionNameAsync, () => {
   describe('generic project', () => {
-    it('reads the version name from native code', () => {
+    it('reads the version name from native code', async () => {
       const exp = initGenericProject();
-      const versionName = readVersionName('/repo', exp);
+      const versionName = await readVersionNameAsync('/repo', exp);
       expect(versionName).toBe('1.0');
     });
   });
   describe('managed project', () => {
-    it('reads the version from expo config', () => {
+    it('reads the version from expo config', async () => {
       const exp = initManagedProject();
-      const versionName = readVersionName('/repo', exp);
+      const versionName = await readVersionNameAsync('/repo', exp);
       expect(versionName).toBe('1.0.0');
     });
   });
@@ -72,6 +77,7 @@ function initGenericProject(): ExpoConfig {
     versionName "1.0"
   }
 }`,
+      './android/app/src/main/AndroidManifest.xml': 'fake',
     },
     '/repo'
   );

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -13,7 +13,7 @@ import { BuildMutation, BuildResult } from '../../graphql/mutations/BuildMutatio
 import Log from '../../log';
 import {
   ensureApplicationIdIsDefinedForManagedProjectAsync,
-  getApplicationId,
+  getApplicationIdAsync,
 } from '../../project/android/applicationId';
 import { toggleConfirmAsync } from '../../prompts';
 import { findAccountByName } from '../../user/Account';
@@ -110,7 +110,7 @@ async function ensureAndroidCredentialsAsync(
   if (!shouldProvideCredentials(ctx)) {
     return;
   }
-  const androidApplicationIdentifier = getApplicationId(
+  const androidApplicationIdentifier = await getApplicationIdAsync(
     ctx.commandCtx.projectDir,
     ctx.commandCtx.exp
   );

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -5,8 +5,11 @@ import fs from 'fs-extra';
 
 import { resolveWorkflow } from '../../project/workflow';
 
-export function readVersionCode(projectDir: string, exp: ExpoConfig): number | undefined {
-  const workflow = resolveWorkflow(projectDir, Platform.ANDROID);
+export async function readVersionCodeAsync(
+  projectDir: string,
+  exp: ExpoConfig
+): Promise<number | undefined> {
+  const workflow = await resolveWorkflow(projectDir, Platform.ANDROID);
   if (workflow === Workflow.GENERIC) {
     const buildGradle = readBuildGradle(projectDir);
     const matchResult = buildGradle?.match(/versionCode (.*)/);
@@ -20,8 +23,11 @@ export function readVersionCode(projectDir: string, exp: ExpoConfig): number | u
   }
 }
 
-export function readVersionName(projectDir: string, exp: ExpoConfig): string | undefined {
-  const workflow = resolveWorkflow(projectDir, Platform.ANDROID);
+export async function readVersionNameAsync(
+  projectDir: string,
+  exp: ExpoConfig
+): Promise<string | undefined> {
+  const workflow = await resolveWorkflow(projectDir, Platform.ANDROID);
   if (workflow === Workflow.GENERIC) {
     const buildGradle = readBuildGradle(projectDir);
     const matchResult = buildGradle?.match(/versionName ["'](.*)["']/);

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -3,13 +3,13 @@ import { AndroidConfig } from '@expo/config-plugins';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 
-import { resolveWorkflow } from '../../project/workflow';
+import { resolveWorkflowAsync } from '../../project/workflow';
 
 export async function readVersionCodeAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<number | undefined> {
-  const workflow = await resolveWorkflow(projectDir, Platform.ANDROID);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
   if (workflow === Workflow.GENERIC) {
     const buildGradle = readBuildGradle(projectDir);
     const matchResult = buildGradle?.match(/versionCode (.*)/);
@@ -27,7 +27,7 @@ export async function readVersionNameAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<string | undefined> {
-  const workflow = await resolveWorkflow(projectDir, Platform.ANDROID);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
   if (workflow === Workflow.GENERIC) {
     const buildGradle = readBuildGradle(projectDir);
     const matchResult = buildGradle?.match(/versionName ["'](.*)["']/);

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -106,7 +106,7 @@ export async function readShortVersionAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<string | undefined> {
-  const workflow = resolveWorkflow(projectDir, Platform.IOS);
+  const workflow = await resolveWorkflow(projectDir, Platform.IOS);
   if (workflow === Workflow.GENERIC) {
     const infoPlist = await readInfoPlistAsync(projectDir);
     return infoPlist.CFBundleShortVersionString;
@@ -119,7 +119,7 @@ export async function readBuildNumberAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<string | undefined> {
-  const workflow = resolveWorkflow(projectDir, Platform.IOS);
+  const workflow = await resolveWorkflow(projectDir, Platform.IOS);
   if (workflow === Workflow.GENERIC) {
     const infoPlist = await readInfoPlistAsync(projectDir);
     return infoPlist.CFBundleVersion;

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -6,7 +6,7 @@ import nullthrows from 'nullthrows';
 import semver from 'semver';
 
 import Log from '../../log';
-import { resolveWorkflow } from '../../project/workflow';
+import { resolveWorkflowAsync } from '../../project/workflow';
 import { promptAsync } from '../../prompts';
 import { updateAppJsonConfigAsync } from '../utils/appJson';
 import { readPlistAsync, writePlistAsync } from './plist';
@@ -106,7 +106,7 @@ export async function readShortVersionAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<string | undefined> {
-  const workflow = await resolveWorkflow(projectDir, Platform.IOS);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
   if (workflow === Workflow.GENERIC) {
     const infoPlist = await readInfoPlistAsync(projectDir);
     return infoPlist.CFBundleShortVersionString;
@@ -119,7 +119,7 @@ export async function readBuildNumberAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<string | undefined> {
-  const workflow = await resolveWorkflow(projectDir, Platform.IOS);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
   if (workflow === Workflow.GENERIC) {
     const infoPlist = await readInfoPlistAsync(projectDir);
     return infoPlist.CFBundleVersion;

--- a/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
@@ -3,7 +3,7 @@ import { nanoid } from 'nanoid';
 import ora from 'ora';
 
 import { AndroidAppBuildCredentialsFragment } from '../../../graphql/generated';
-import { getApplicationId } from '../../../project/android/applicationId';
+import { getApplicationIdAsync } from '../../../project/android/applicationId';
 import { getProjectAccountName, getProjectConfigDescription } from '../../../project/projectUtils';
 import { promptAsync } from '../../../prompts';
 import { findAccountByName } from '../../../user/Account';
@@ -86,7 +86,7 @@ export async function promptUserAndCopyLegacyCredentialsAsync(
   spinner.succeed('Credentials copied to EAS.');
 }
 
-export function getAppLookupParamsFromContext(ctx: Context): AppLookupParams {
+export async function getAppLookupParamsFromContextAsync(ctx: Context): Promise<AppLookupParams> {
   ctx.ensureProjectContext();
   const projectName = ctx.exp.slug;
   const accountName = getProjectAccountName(ctx.exp, ctx.user);
@@ -95,7 +95,7 @@ export function getAppLookupParamsFromContext(ctx: Context): AppLookupParams {
     throw new Error(`You do not have access to account: ${accountName}`);
   }
 
-  const androidApplicationIdentifier = getApplicationId(ctx.projectDir, ctx.exp);
+  const androidApplicationIdentifier = await getApplicationIdAsync(ctx.projectDir, ctx.exp);
   if (!androidApplicationIdentifier) {
     throw new Error(
       `android.package needs to be defined in your ${getProjectConfigDescription(

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/AssignFcm-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/AssignFcm-test.ts
@@ -1,14 +1,14 @@
 import { testLegacyAndroidFcmFragment } from '../../../__tests__/fixtures-android';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
 import { AssignFcm } from '../AssignFcm';
-import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 
 describe(AssignFcm, () => {
   it('assigns an fcm api key in Interactive Mode', async () => {
     const ctx = createCtxMock({
       nonInteractive: false,
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const assignFcmAction = new AssignFcm(appLookupParams);
     await assignFcmAction.runAsync(ctx, testLegacyAndroidFcmFragment);
 
@@ -22,7 +22,7 @@ describe(AssignFcm, () => {
     const ctx = createCtxMock({
       nonInteractive: true,
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const assignFcmAction = new AssignFcm(appLookupParams);
 
     // dont fail if users are running in non-interactive mode

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/BuildCredentialsUtils-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/BuildCredentialsUtils-test.ts
@@ -10,7 +10,7 @@ import {
 import { createCtxMock } from '../../../__tests__/fixtures-context';
 import {
   canCopyLegacyCredentialsAsync,
-  getAppLookupParamsFromContext,
+  getAppLookupParamsFromContextAsync,
   promptUserAndCopyLegacyCredentialsAsync,
 } from '../BuildCredentialsUtils';
 
@@ -41,7 +41,7 @@ describe('BuildCredentialsUtils', () => {
           ),
         },
       });
-      const appLookupParams = getAppLookupParamsFromContext(ctx);
+      const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
       const canCopyLegacyCredentials = await canCopyLegacyCredentialsAsync(ctx, appLookupParams);
       expect(canCopyLegacyCredentials).toBe(true);
     });
@@ -58,7 +58,7 @@ describe('BuildCredentialsUtils', () => {
           ),
         },
       });
-      const appLookupParams = getAppLookupParamsFromContext(ctx);
+      const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
       const canCopyLegacyCredentials = await canCopyLegacyCredentialsAsync(ctx, appLookupParams);
       expect(canCopyLegacyCredentials).toBe(false);
     });
@@ -71,7 +71,7 @@ describe('BuildCredentialsUtils', () => {
           getLegacyAndroidAppCredentialsWithCommonFieldsAsync: jest.fn(() => null),
         },
       });
-      const appLookupParams = getAppLookupParamsFromContext(ctx);
+      const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
       const canCopyLegacyCredentials = await canCopyLegacyCredentialsAsync(ctx, appLookupParams);
       expect(canCopyLegacyCredentials).toBe(false);
     });
@@ -86,7 +86,7 @@ describe('BuildCredentialsUtils', () => {
           ),
         },
       });
-      const appLookupParams = getAppLookupParamsFromContext(ctx);
+      const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
       const canCopyLegacyCredentials = await canCopyLegacyCredentialsAsync(ctx, appLookupParams);
       expect(canCopyLegacyCredentials).toBe(true);
     });
@@ -109,7 +109,7 @@ describe('BuildCredentialsUtils', () => {
           createFcmAsync: jest.fn(() => testLegacyAndroidFcmFragment),
         },
       });
-      const appLookupParams = getAppLookupParamsFromContext(ctx);
+      const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
       await promptUserAndCopyLegacyCredentialsAsync(ctx, appLookupParams);
 
       expect(
@@ -131,7 +131,7 @@ describe('BuildCredentialsUtils', () => {
           ),
         },
       });
-      const appLookupParams = getAppLookupParamsFromContext(ctx);
+      const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
       await expect(
         promptUserAndCopyLegacyCredentialsAsync(ctx, appLookupParams)
       ).rejects.toThrowError();

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/CreateFcm-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/CreateFcm-test.ts
@@ -1,6 +1,6 @@
 import { promptAsync } from '../../../../prompts';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
-import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { CreateFcm } from '../CreateFcm';
 
 jest.mock('../../../../prompts');
@@ -9,7 +9,7 @@ jest.mock('../../../../prompts');
 describe(CreateFcm, () => {
   it('creates an fcm api key in Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: false });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const createFcmAction = new CreateFcm(appLookupParams.account);
     await createFcmAction.runAsync(ctx);
 
@@ -18,7 +18,7 @@ describe(CreateFcm, () => {
   });
   it('errors in Non-Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: true });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const createFcmAction = new CreateFcm(appLookupParams.account);
 
     // fail if users are running in non-interactive mode

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/CreateKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/CreateKeystore-test.ts
@@ -1,6 +1,6 @@
 import { confirmAsync } from '../../../../prompts';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
-import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { CreateKeystore } from '../CreateKeystore';
 
 jest.mock('../../../../prompts');
@@ -9,7 +9,7 @@ jest.mock('../../../../prompts');
 describe('CreateKeystore', () => {
   it('creates a keystore in Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: false });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const createKeystoreAction = new CreateKeystore(appLookupParams.account);
     await createKeystoreAction.runAsync(ctx);
 
@@ -18,7 +18,7 @@ describe('CreateKeystore', () => {
   });
   it('errors in Non-Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: true });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const createKeystoreAction = new CreateKeystore(appLookupParams.account);
 
     // fail if users are running in non-interactive mode

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/DownloadKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/DownloadKeystore-test.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 
 import { testAndroidBuildCredentialsFragment } from '../../../__tests__/fixtures-android';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
-import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { DownloadKeystore } from '../DownloadKeystore';
 
 jest.mock('fs-extra');
@@ -23,7 +23,7 @@ describe(DownloadKeystore, () => {
     const ctx = createCtxMock({
       nonInteractive: false,
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const downloadKeystoreAction = new DownloadKeystore({ app: appLookupParams });
     await downloadKeystoreAction.runAsync(ctx, testAndroidBuildCredentialsFragment);
     expect(fsWriteFileSpy as any).toHaveBeenCalledTimes(1);
@@ -36,7 +36,7 @@ describe(DownloadKeystore, () => {
   });
   it('works in Non-Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: true });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const downloadKeystoreAction = new DownloadKeystore({ app: appLookupParams });
     await expect(
       downloadKeystoreAction.runAsync(ctx, testAndroidBuildCredentialsFragment)

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveFcm-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveFcm-test.ts
@@ -4,7 +4,7 @@ import {
   testAndroidAppCredentialsFragment,
 } from '../../../__tests__/fixtures-android';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
-import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { RemoveFcm } from '../RemoveFcm';
 
 jest.mock('../../../../prompts');
@@ -31,14 +31,14 @@ describe(RemoveFcm, () => {
         ),
       },
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const removeFcmApiKeyAction = new RemoveFcm(appLookupParams);
     await removeFcmApiKeyAction.runAsync(ctx);
     expect(ctx.android.deleteFcmAsync as any).toHaveBeenCalledTimes(1);
   });
   it('errors in Non-Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: true });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const removeFcmApiKeyAction = new RemoveFcm(appLookupParams);
     await expect(removeFcmApiKeyAction.runAsync(ctx)).rejects.toThrowError();
   });

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveKeystore-test.ts
@@ -1,7 +1,7 @@
 import { confirmAsync } from '../../../../prompts';
 import { testAndroidBuildCredentialsFragment } from '../../../__tests__/fixtures-android';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
-import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { RemoveKeystore } from '../RemoveKeystore';
 
 jest.mock('fs-extra');
@@ -23,14 +23,14 @@ describe(RemoveKeystore, () => {
     const ctx = createCtxMock({
       nonInteractive: false,
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const removeKeystoreAction = new RemoveKeystore(appLookupParams);
     await removeKeystoreAction.runAsync(ctx, testAndroidBuildCredentialsFragment);
     expect(ctx.android.deleteKeystoreAsync as any).toHaveBeenCalledTimes(1);
   });
   it('errors in Non-Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: true });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const removeKeystoreAction = new RemoveKeystore(appLookupParams);
     await expect(
       removeKeystoreAction.runAsync(ctx, testAndroidBuildCredentialsFragment)

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetupBuildCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetupBuildCredentials-test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../__tests__/fixtures-android';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
 import { MissingCredentialsNonInteractiveError } from '../../../errors';
-import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { SetupBuildCredentials } from '../SetupBuildCredentials';
 
 jest.mock('../../../../prompts');
@@ -34,7 +34,7 @@ describe('SetupBuildCredentials', () => {
         ),
       },
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const setupBuildCredentialsAction = new SetupBuildCredentials({ app: appLookupParams });
     await setupBuildCredentialsAction.runAsync(ctx);
 
@@ -50,7 +50,7 @@ describe('SetupBuildCredentials', () => {
         createKeystoreAsync: jest.fn(() => testJksAndroidKeystoreFragment),
       },
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const setupBuildCredentialsAction = new SetupBuildCredentials({ app: appLookupParams });
     await setupBuildCredentialsAction.runAsync(ctx);
 
@@ -65,7 +65,7 @@ describe('SetupBuildCredentials', () => {
         ...getNewAndroidApiMock(),
       },
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const setupBuildCredentialsAction = new SetupBuildCredentials({ app: appLookupParams });
     await expect(setupBuildCredentialsAction.runAsync(ctx)).rejects.toThrowError(
       MissingCredentialsNonInteractiveError

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetupBuildCredentialsFromCredentialsJson-test.ts
@@ -12,7 +12,7 @@ import {
   SelectAndroidBuildCredentials,
   SelectAndroidBuildCredentialsResultType,
 } from '../../../manager/SelectAndroidBuildCredentials';
-import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { SetupBuildCredentialsFromCredentialsJson } from '../SetupBuildCredentialsFromCredentialsJson';
 
 jest.mock('fs');
@@ -67,7 +67,7 @@ describe(SetupBuildCredentialsFromCredentialsJson, () => {
       }),
       'keystore.jks': 'some-binary-content',
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const setupBuildCredentialsAction = new SetupBuildCredentialsFromCredentialsJson(
       appLookupParams
     );
@@ -117,7 +117,7 @@ describe(SetupBuildCredentialsFromCredentialsJson, () => {
       }),
       'keystore.jks': 'some-binary-content',
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const setupBuildCredentialsAction = new SetupBuildCredentialsFromCredentialsJson(
       appLookupParams
     );
@@ -140,7 +140,7 @@ describe(SetupBuildCredentialsFromCredentialsJson, () => {
     const ctx = createCtxMock({
       nonInteractive: true,
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const setupBuildCredentialsAction = new SetupBuildCredentialsFromCredentialsJson(
       appLookupParams
     );

--- a/packages/eas-cli/src/credentials/android/utils/__tests__/printCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/android/utils/__tests__/printCredentials-test.ts
@@ -3,7 +3,7 @@ import mockdate from 'mockdate';
 import Log from '../../../../log';
 import { testAndroidAppCredentialsFragment } from '../../../__tests__/fixtures-android';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
-import { getAppLookupParamsFromContext } from '../../actions/BuildCredentialsUtils';
+import { getAppLookupParamsFromContextAsync } from '../../actions/BuildCredentialsUtils';
 import { displayAndroidAppCredentials } from '../printCredentials';
 
 jest.mock('../../../../log');
@@ -14,7 +14,7 @@ mockdate.set(new Date('4/20/2021'));
 describe('print credentials', () => {
   it('prints the AndroidAppCredentials fragment', async () => {
     const ctx = createCtxMock();
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     displayAndroidAppCredentials({
       appLookupParams,
       appCredentials: testAndroidAppCredentialsFragment,

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -6,7 +6,7 @@ import { ensureActorHasUsername } from '../../user/actions';
 import { AssignFcm } from '../android/actions/AssignFcm';
 import {
   canCopyLegacyCredentialsAsync,
-  getAppLookupParamsFromContext,
+  getAppLookupParamsFromContextAsync,
   promptUserAndCopyLegacyCredentialsAsync,
 } from '../android/actions/BuildCredentialsUtils';
 import { CreateFcm } from '../android/actions/CreateFcm';
@@ -147,7 +147,7 @@ export class ManageAndroid {
           throw new Error(`You do not have access to account: ${accountName}`);
         }
         if (ctx.hasProjectContext) {
-          const appLookupParams = getAppLookupParamsFromContext(ctx);
+          const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
           const appCredentials = await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(
             appLookupParams
           );
@@ -196,7 +196,7 @@ export class ManageAndroid {
             return await this.callingAction.runAsync(ctx);
           }
         }
-        const appLookupParams = getAppLookupParamsFromContext(ctx);
+        const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
         if (chosenAction === ActionType.CreateKeystore) {
           const selectBuildCredentialsResult = await new SelectAndroidBuildCredentials(
             appLookupParams

--- a/packages/eas-cli/src/credentials/manager/__tests__/SelectAndroidBuildCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/manager/__tests__/SelectAndroidBuildCredentials-test.ts
@@ -4,7 +4,7 @@ import {
   testAndroidBuildCredentialsFragment,
 } from '../../__tests__/fixtures-android';
 import { createCtxMock } from '../../__tests__/fixtures-context';
-import { getAppLookupParamsFromContext } from '../../android/actions/BuildCredentialsUtils';
+import { getAppLookupParamsFromContextAsync } from '../../android/actions/BuildCredentialsUtils';
 import {
   SelectAndroidBuildCredentials,
   SelectAndroidBuildCredentialsResultType,
@@ -28,7 +28,7 @@ describe(SelectAndroidBuildCredentials, () => {
         getAndroidAppBuildCredentialsListAsync: jest.fn(() => []),
       },
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const selectAndroidBuildCredentialsAction = new SelectAndroidBuildCredentials(appLookupParams);
     const buildCredentialsMetadataInput = await selectAndroidBuildCredentialsAction.runAsync(ctx);
     expect(buildCredentialsMetadataInput).toMatchObject({
@@ -50,7 +50,7 @@ describe(SelectAndroidBuildCredentials, () => {
         ]),
       },
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const selectAndroidBuildCredentialsAction = new SelectAndroidBuildCredentials(appLookupParams);
     const buildCredentialsMetadataInput = await selectAndroidBuildCredentialsAction.runAsync(ctx);
     expect(buildCredentialsMetadataInput).toMatchObject({
@@ -70,7 +70,7 @@ describe(SelectAndroidBuildCredentials, () => {
         getAndroidAppBuildCredentialsListAsync: jest.fn(() => []),
       },
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const selectAndroidBuildCredentialsAction = new SelectAndroidBuildCredentials(appLookupParams);
     const buildCredentialsMetadataInput = await selectAndroidBuildCredentialsAction.runAsync(ctx);
     expect(buildCredentialsMetadataInput).toMatchObject({
@@ -90,7 +90,7 @@ describe(SelectAndroidBuildCredentials, () => {
         ]),
       },
     });
-    const appLookupParams = getAppLookupParamsFromContext(ctx);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const selectAndroidBuildCredentialsAction = new SelectAndroidBuildCredentials(appLookupParams);
     const buildCredentialsMetadataInput = await selectAndroidBuildCredentialsAction.runAsync(ctx);
     expect(buildCredentialsMetadataInput).toMatchObject({

--- a/packages/eas-cli/src/project/__tests__/workflow-test.ts
+++ b/packages/eas-cli/src/project/__tests__/workflow-test.ts
@@ -1,0 +1,61 @@
+import { Platform, Workflow } from '@expo/eas-build-job';
+import { vol } from 'memfs';
+
+import { resolveWorkflow } from '../workflow';
+
+jest.mock('fs');
+
+const originalConsoleWarn = console.warn;
+beforeAll(() => {
+  console.warn = jest.fn();
+});
+afterAll(() => {
+  console.warn = originalConsoleWarn;
+});
+
+describe(resolveWorkflow, () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  const projectDir = '/app';
+
+  test('generic workflow for both platforms', async () => {
+    vol.fromJSON(
+      {
+        './ios/helloworld.xcodeproj/project.pbxproj': 'fake',
+        './android/app/src/main/AndroidManifest.xml': 'fake',
+      },
+      projectDir
+    );
+
+    await expect(resolveWorkflow(projectDir, Platform.ANDROID)).resolves.toBe(Workflow.GENERIC);
+    await expect(resolveWorkflow(projectDir, Platform.IOS)).resolves.toBe(Workflow.GENERIC);
+  });
+
+  test('generic workflow for single platform', async () => {
+    vol.fromJSON(
+      {
+        './ios/helloworld.xcodeproj/project.pbxproj': 'fake',
+      },
+      projectDir
+    );
+
+    await expect(resolveWorkflow(projectDir, Platform.ANDROID)).resolves.toBe(Workflow.MANAGED);
+    await expect(resolveWorkflow(projectDir, Platform.IOS)).resolves.toBe(Workflow.GENERIC);
+  });
+
+  test('android/ios directories are ignored', async () => {
+    vol.fromJSON(
+      {
+        './ios/helloworld.xcodeproj/project.pbxproj': 'fake',
+        './android/app/src/main/AndroidManifest.xml': 'fake',
+        './.easignore': 'android/\nios/',
+      },
+      projectDir
+    );
+
+    await expect(resolveWorkflow(projectDir, Platform.ANDROID)).resolves.toBe(Workflow.MANAGED);
+    await expect(resolveWorkflow(projectDir, Platform.IOS)).resolves.toBe(Workflow.MANAGED);
+  });
+});

--- a/packages/eas-cli/src/project/__tests__/workflow-test.ts
+++ b/packages/eas-cli/src/project/__tests__/workflow-test.ts
@@ -1,7 +1,7 @@
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { vol } from 'memfs';
 
-import { resolveWorkflow } from '../workflow';
+import { resolveWorkflowAsync } from '../workflow';
 
 jest.mock('fs');
 
@@ -13,7 +13,7 @@ afterAll(() => {
   console.warn = originalConsoleWarn;
 });
 
-describe(resolveWorkflow, () => {
+describe(resolveWorkflowAsync, () => {
   beforeEach(() => {
     vol.reset();
   });
@@ -29,8 +29,10 @@ describe(resolveWorkflow, () => {
       projectDir
     );
 
-    await expect(resolveWorkflow(projectDir, Platform.ANDROID)).resolves.toBe(Workflow.GENERIC);
-    await expect(resolveWorkflow(projectDir, Platform.IOS)).resolves.toBe(Workflow.GENERIC);
+    await expect(resolveWorkflowAsync(projectDir, Platform.ANDROID)).resolves.toBe(
+      Workflow.GENERIC
+    );
+    await expect(resolveWorkflowAsync(projectDir, Platform.IOS)).resolves.toBe(Workflow.GENERIC);
   });
 
   test('generic workflow for single platform', async () => {
@@ -41,8 +43,10 @@ describe(resolveWorkflow, () => {
       projectDir
     );
 
-    await expect(resolveWorkflow(projectDir, Platform.ANDROID)).resolves.toBe(Workflow.MANAGED);
-    await expect(resolveWorkflow(projectDir, Platform.IOS)).resolves.toBe(Workflow.GENERIC);
+    await expect(resolveWorkflowAsync(projectDir, Platform.ANDROID)).resolves.toBe(
+      Workflow.MANAGED
+    );
+    await expect(resolveWorkflowAsync(projectDir, Platform.IOS)).resolves.toBe(Workflow.GENERIC);
   });
 
   test('android/ios directories are ignored', async () => {
@@ -55,7 +59,9 @@ describe(resolveWorkflow, () => {
       projectDir
     );
 
-    await expect(resolveWorkflow(projectDir, Platform.ANDROID)).resolves.toBe(Workflow.MANAGED);
-    await expect(resolveWorkflow(projectDir, Platform.IOS)).resolves.toBe(Workflow.MANAGED);
+    await expect(resolveWorkflowAsync(projectDir, Platform.ANDROID)).resolves.toBe(
+      Workflow.MANAGED
+    );
+    await expect(resolveWorkflowAsync(projectDir, Platform.IOS)).resolves.toBe(Workflow.MANAGED);
   });
 });

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -11,7 +11,7 @@ import Log, { learnMore } from '../../log';
 import { getProjectConfigDescription, getUsername } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';
-import { resolveWorkflow } from '../workflow';
+import { resolveWorkflowAsync } from '../workflow';
 
 const INVALID_APPLICATION_ID_MESSAGE = `Invalid format of Android applicationId. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter.`;
 
@@ -19,7 +19,7 @@ export async function ensureApplicationIdIsDefinedForManagedProjectAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<string> {
-  const workflow = await resolveWorkflow(projectDir, Platform.ANDROID);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
   assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
 
   try {
@@ -30,7 +30,7 @@ export async function ensureApplicationIdIsDefinedForManagedProjectAsync(
 }
 
 export async function getApplicationIdAsync(projectDir: string, exp: ExpoConfig): Promise<string> {
-  const workflow = await resolveWorkflow(projectDir, Platform.ANDROID);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
   if (workflow === Workflow.GENERIC) {
     warnIfAndroidPackageDefinedInAppConfigForGenericProject(projectDir, exp);
 

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -19,18 +19,18 @@ export async function ensureApplicationIdIsDefinedForManagedProjectAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<string> {
-  const workflow = resolveWorkflow(projectDir, Platform.ANDROID);
+  const workflow = await resolveWorkflow(projectDir, Platform.ANDROID);
   assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
 
   try {
-    return getApplicationId(projectDir, exp);
+    return await getApplicationIdAsync(projectDir, exp);
   } catch (err) {
     return await configureApplicationIdAsync(projectDir, exp);
   }
 }
 
-export function getApplicationId(projectDir: string, exp: ExpoConfig): string {
-  const workflow = resolveWorkflow(projectDir, Platform.ANDROID);
+export async function getApplicationIdAsync(projectDir: string, exp: ExpoConfig): Promise<string> {
+  const workflow = await resolveWorkflow(projectDir, Platform.ANDROID);
   if (workflow === Workflow.GENERIC) {
     warnIfAndroidPackageDefinedInAppConfigForGenericProject(projectDir, exp);
 

--- a/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
@@ -8,7 +8,7 @@ import { jester as mockJester } from '../../../credentials/__tests__/fixtures-co
 import { promptAsync } from '../../../prompts';
 import {
   ensureBundleIdentifierIsDefinedForManagedProjectAsync,
-  getBundleIdentifier,
+  getBundleIdentifierAsync,
   isWildcardBundleIdentifier,
 } from '../bundleIdentifier';
 
@@ -40,9 +40,9 @@ afterAll(() => {
 
 const originalFs = jest.requireActual('fs');
 
-describe(getBundleIdentifier, () => {
+describe(getBundleIdentifierAsync, () => {
   describe('generic projects', () => {
-    it('reads bundle identifier from project.', () => {
+    it('reads bundle identifier from project.', async () => {
       vol.fromJSON(
         {
           'ios/myproject.xcodeproj/project.pbxproj': originalFs.readFileSync(
@@ -53,11 +53,11 @@ describe(getBundleIdentifier, () => {
         '/app'
       );
 
-      const bundleIdentifier = getBundleIdentifier('/app', {} as any);
+      const bundleIdentifier = await getBundleIdentifierAsync('/app', {} as any);
       expect(bundleIdentifier).toBe('org.name.testproject');
     });
 
-    it('throws an error if the pbxproj is not configured with bundle id', () => {
+    it('throws an error if the pbxproj is not configured with bundle id', async () => {
       vol.fromJSON(
         {
           'ios/myproject.xcodeproj/project.pbxproj': originalFs.readFileSync(
@@ -68,30 +68,30 @@ describe(getBundleIdentifier, () => {
         '/app'
       );
 
-      expect(() => {
-        getBundleIdentifier('/app', {} as any);
-      }).toThrowError(/Could not read bundle identifier/);
+      await expect(getBundleIdentifierAsync('/app', {} as any)).rejects.toThrowError(
+        /Could not read bundle identifier/
+      );
     });
   });
 
   describe('managed projects', () => {
-    it('reads bundleIdentifier from app config', () => {
-      const applicationId = getBundleIdentifier('/app', {
+    it('reads bundleIdentifier from app config', async () => {
+      const applicationId = await getBundleIdentifierAsync('/app', {
         ios: { bundleIdentifier: 'com.expo.notdominik' },
       } as any);
       expect(applicationId).toBe('com.expo.notdominik');
     });
 
-    it('throws an error if bundleIdentifier is not defined in app config', () => {
-      expect(() => {
-        getBundleIdentifier('/app', {} as any);
-      }).toThrowError(/Specify "ios.bundleIdentifier"/);
+    it('throws an error if bundleIdentifier is not defined in app config', async () => {
+      await expect(getBundleIdentifierAsync('/app', {} as any)).rejects.toThrowError(
+        /Specify "ios.bundleIdentifier"/
+      );
     });
 
-    it('throws an error if bundleIdentifier in app config is invalid', () => {
-      expect(() => {
-        getBundleIdentifier('/app', { ios: { bundleIdentifier: '' } } as any);
-      }).toThrowError(/Specify "ios.bundleIdentifier"/);
+    it('throws an error if bundleIdentifier in app config is invalid', async () => {
+      await expect(
+        getBundleIdentifierAsync('/app', { ios: { bundleIdentifier: '' } } as any)
+      ).rejects.toThrowError(/Specify "ios.bundleIdentifier"/);
     });
   });
 });

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -10,7 +10,7 @@ import Log, { learnMore } from '../../log';
 import { promptAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';
 import { getProjectConfigDescription, getUsername, sanitizedProjectName } from '../projectUtils';
-import { resolveWorkflow } from '../workflow';
+import { resolveWorkflowAsync } from '../workflow';
 
 const INVALID_BUNDLE_IDENTIFIER_MESSAGE = `Invalid format of iOS bundle identifier. Only alphanumeric characters, '.' and '-' are allowed, and each '.' must be followed by a letter.`;
 
@@ -18,7 +18,7 @@ export async function ensureBundleIdentifierIsDefinedForManagedProjectAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<string> {
-  const workflow = await resolveWorkflow(projectDir, Platform.IOS);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
   assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
 
   try {
@@ -33,7 +33,7 @@ export async function getBundleIdentifierAsync(
   exp: ExpoConfig,
   { targetName, buildConfiguration }: { targetName?: string; buildConfiguration?: string } = {}
 ): Promise<string> {
-  const workflow = await resolveWorkflow(projectDir, Platform.IOS);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
   if (workflow === Workflow.GENERIC) {
     warnIfBundleIdentifierDefinedInAppConfigForGenericProject(projectDir, exp);
 

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -18,22 +18,22 @@ export async function ensureBundleIdentifierIsDefinedForManagedProjectAsync(
   projectDir: string,
   exp: ExpoConfig
 ): Promise<string> {
-  const workflow = resolveWorkflow(projectDir, Platform.IOS);
+  const workflow = await resolveWorkflow(projectDir, Platform.IOS);
   assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
 
   try {
-    return getBundleIdentifier(projectDir, exp);
+    return await getBundleIdentifierAsync(projectDir, exp);
   } catch (err) {
     return await configureBundleIdentifierAsync(projectDir, exp);
   }
 }
 
-export function getBundleIdentifier(
+export async function getBundleIdentifierAsync(
   projectDir: string,
   exp: ExpoConfig,
   { targetName, buildConfiguration }: { targetName?: string; buildConfiguration?: string } = {}
-): string {
-  const workflow = resolveWorkflow(projectDir, Platform.IOS);
+): Promise<string> {
+  const workflow = await resolveWorkflow(projectDir, Platform.IOS);
   if (workflow === Workflow.GENERIC) {
     warnIfBundleIdentifierDefinedInAppConfigForGenericProject(projectDir, exp);
 

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -3,7 +3,7 @@ import { IOSConfig } from '@expo/config-plugins';
 import { Platform, Workflow } from '@expo/eas-build-job';
 
 import { Target } from '../../credentials/ios/types';
-import { resolveWorkflow } from '../workflow';
+import { resolveWorkflowAsync } from '../workflow';
 import { getBundleIdentifierAsync } from './bundleIdentifier';
 import { XcodeBuildContext } from './scheme';
 
@@ -43,7 +43,7 @@ async function readApplicationTargetForSchemeAsync(
   projectDir: string,
   scheme: string
 ): Promise<IOSConfig.Target.Target> {
-  const workflow = await resolveWorkflow(projectDir, Platform.IOS);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
   if (workflow === Workflow.GENERIC) {
     return await IOSConfig.Target.findApplicationTargetWithDependenciesAsync(projectDir, scheme);
   } else {

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -4,7 +4,7 @@ import { Platform, Workflow } from '@expo/eas-build-job';
 
 import { Target } from '../../credentials/ios/types';
 import { resolveWorkflow } from '../workflow';
-import { getBundleIdentifier } from './bundleIdentifier';
+import { getBundleIdentifierAsync } from './bundleIdentifier';
 import { XcodeBuildContext } from './scheme';
 
 export async function resolveTargetsAsync(
@@ -14,7 +14,7 @@ export async function resolveTargetsAsync(
   const result: Target[] = [];
 
   const applicationTarget = await readApplicationTargetForSchemeAsync(projectDir, buildScheme);
-  const bundleIdentifier = getBundleIdentifier(projectDir, exp, {
+  const bundleIdentifier = await getBundleIdentifierAsync(projectDir, exp, {
     targetName: applicationTarget.name,
     buildConfiguration,
   });
@@ -27,7 +27,7 @@ export async function resolveTargetsAsync(
     for (const dependency of applicationTarget.dependencies) {
       result.push({
         targetName: dependency.name,
-        bundleIdentifier: getBundleIdentifier(projectDir, exp, {
+        bundleIdentifier: await getBundleIdentifierAsync(projectDir, exp, {
           targetName: dependency.name,
           buildConfiguration,
         }),
@@ -43,7 +43,7 @@ async function readApplicationTargetForSchemeAsync(
   projectDir: string,
   scheme: string
 ): Promise<IOSConfig.Target.Target> {
-  const workflow = resolveWorkflow(projectDir, Platform.IOS);
+  const workflow = await resolveWorkflow(projectDir, Platform.IOS);
   if (workflow === Workflow.GENERIC) {
     return await IOSConfig.Target.findApplicationTargetWithDependenciesAsync(projectDir, scheme);
   } else {

--- a/packages/eas-cli/src/project/workflow.ts
+++ b/packages/eas-cli/src/project/workflow.ts
@@ -1,7 +1,26 @@
+import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 import path from 'path';
 
-export function resolveWorkflow(projectDir: string, platform: Platform): Workflow {
-  return fs.pathExistsSync(path.join(projectDir, platform)) ? Workflow.GENERIC : Workflow.MANAGED;
+import vcs from '../vcs';
+
+export async function resolveWorkflow(projectDir: string, platform: Platform): Promise<Workflow> {
+  let platformWorkflowMarker;
+  try {
+    platformWorkflowMarker =
+      platform === Platform.ANDROID
+        ? await AndroidConfig.Paths.getAndroidManifestAsync(projectDir)
+        : IOSConfig.Paths.getXcodeProjectPath(projectDir);
+  } catch {
+    return Workflow.MANAGED;
+  }
+
+  if (await fs.pathExists(platformWorkflowMarker)) {
+    return (await vcs.isFileIgnoredAsync(path.relative(projectDir, platformWorkflowMarker)))
+      ? Workflow.MANAGED
+      : Workflow.GENERIC;
+  } else {
+    return Workflow.MANAGED;
+  }
 }

--- a/packages/eas-cli/src/project/workflow.ts
+++ b/packages/eas-cli/src/project/workflow.ts
@@ -5,7 +5,10 @@ import path from 'path';
 
 import vcs from '../vcs';
 
-export async function resolveWorkflow(projectDir: string, platform: Platform): Promise<Workflow> {
+export async function resolveWorkflowAsync(
+  projectDir: string,
+  platform: Platform
+): Promise<Workflow> {
   let platformWorkflowMarker;
   try {
     platformWorkflowMarker =

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -8,7 +8,7 @@ import {
   ensureBundleIdExistsWithNameAsync,
 } from '../../credentials/ios/appstore/ensureAppExists';
 import Log from '../../log';
-import { getBundleIdentifier } from '../../project/ios/bundleIdentifier';
+import { getBundleIdentifierAsync } from '../../project/ios/bundleIdentifier';
 import { promptAsync } from '../../prompts';
 import { IosSubmissionContext } from '../types';
 import { sanitizeLanguage } from './utils/language';
@@ -41,7 +41,8 @@ export async function ensureAppStoreConnectAppExistsAsync(
   // - for builds from the database, read bundled identifier from metadata
   // - for builds uploaded from file system, prompt for the bundle identifier
   // this is necessary to make submit work outside the project directory
-  const resolvedBundleId = bundleIdentifier ?? getBundleIdentifier(ctx.projectDir, exp);
+  const resolvedBundleId =
+    bundleIdentifier ?? (await getBundleIdentifierAsync(ctx.projectDir, exp));
 
   const options = {
     ...ctx.commandFlags,

--- a/packages/eas-cli/src/vcs/git.ts
+++ b/packages/eas-cli/src/vcs/git.ts
@@ -130,8 +130,8 @@ export default class GitClient extends Client {
 
   public async isFileIgnoredAsync(filePath: string): Promise<boolean> {
     try {
-      const { status } = await spawnAsync('git', ['check-ignore', '-q', filePath]);
-      return status === 0;
+      await spawnAsync('git', ['check-ignore', '-q', filePath]);
+      return true;
     } catch (e) {
       return false;
     }

--- a/packages/eas-cli/src/vcs/git.ts
+++ b/packages/eas-cli/src/vcs/git.ts
@@ -127,6 +127,15 @@ export default class GitClient extends Client {
       !trackedFiles.includes(pathWithoutLeadingDot)
     );
   }
+
+  public async isFileIgnoredAsync(filePath: string): Promise<boolean> {
+    try {
+      const { status } = await spawnAsync('git', ['check-ignore', '-q', filePath]);
+      return status === 0;
+    } catch (e) {
+      return false;
+    }
+  }
 }
 
 async function isGitInstalledAsync(): Promise<boolean> {

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import ignore from 'ignore';
+import ignore, { Ignore } from 'ignore';
 import path from 'path';
 
 import { Client } from './vcs';
@@ -10,34 +10,46 @@ node_modules
 
 export default class LocalClient extends Client {
   public async getRootPathAsync(): Promise<string> {
-    const rootPath = process.env.EAS_PROJECT_ROOT ?? process.cwd();
-    if (!path.isAbsolute(rootPath)) {
-      return path.resolve(process.cwd(), rootPath);
-    }
-    return rootPath;
+    return getRootPath();
   }
 
   public async makeShallowCopyAsync(destinationPath: string): Promise<void> {
-    const srcPath = await this.getRootPathAsync();
-    const easIgnorePath = path.join(srcPath, '.easignore');
-    const gitIgnorePath = path.join(srcPath, '.gitignore');
-
-    let ignoreFile = DEFAULT_IGNORE;
-    if (await fs.pathExists(easIgnorePath)) {
-      ignoreFile = await fs.readFile(easIgnorePath, 'utf8');
-    } else if (await fs.pathExists(gitIgnorePath)) {
-      ignoreFile = await fs.readFile(gitIgnorePath, 'utf8');
-    }
-
-    const match = ignore().add(ignoreFile);
-
+    const srcPath = getRootPath();
+    const ignore = initIgnore();
     await fs.copy(srcPath, destinationPath, {
       filter: (srcFilePath: string) => {
         if (srcFilePath === srcPath) {
           return true;
         }
-        return !match.ignores(path.relative(srcPath, srcFilePath));
+        return !ignore.ignores(path.relative(srcPath, srcFilePath));
       },
     });
   }
+
+  public async isFileIgnoredAsync(filePath: string): Promise<boolean> {
+    return initIgnore().ignores(filePath);
+  }
+}
+
+function getRootPath(): string {
+  const rootPath = process.env.EAS_PROJECT_ROOT ?? process.cwd();
+  if (!path.isAbsolute(rootPath)) {
+    return path.resolve(process.cwd(), rootPath);
+  }
+  return rootPath;
+}
+
+function initIgnore(): Ignore {
+  const srcPath = getRootPath();
+  const easIgnorePath = path.join(srcPath, '.easignore');
+  const gitIgnorePath = path.join(srcPath, '.gitignore');
+
+  let ignoreFile = DEFAULT_IGNORE;
+  if (fs.pathExistsSync(easIgnorePath)) {
+    ignoreFile = fs.readFileSync(easIgnorePath, 'utf8');
+  } else if (fs.pathExistsSync(gitIgnorePath)) {
+    ignoreFile = fs.readFileSync(gitIgnorePath, 'utf8');
+  }
+
+  return ignore().add(ignoreFile);
 }

--- a/packages/eas-cli/src/vcs/vcs.ts
+++ b/packages/eas-cli/src/vcs/vcs.ts
@@ -2,7 +2,7 @@ export abstract class Client {
   // makeShallowCopyAsync should copy current project (result of getRootPathAsync()) to the specified
   // destination, folder created this way will be uploaded "as is", so implementation should skip
   // anything that is not commited to the repository. Most optimal solution is to create shallow clone
-  // using tooling provided by specific VCS, that respect all ignore rules
+  // using tooling provided by specific VCS, that respects all ignore rules
   public abstract makeShallowCopyAsync(destinationPath: string): Promise<void>;
 
   // Find root of the repository.
@@ -57,5 +57,12 @@ export abstract class Client {
   // used for EAS Update - implementation can be safely skipped
   public async getLastCommitMessageAsync(): Promise<string | null> {
     return null;
+  }
+
+  // (optional) checks if the file is ignored
+  // - returns true if the file is included in the project tarball
+  // - returns false otherwise
+  public async isFileIgnoredAsync(filePath: string): Promise<boolean> {
+    return false;
   }
 }

--- a/packages/eas-cli/src/vcs/vcs.ts
+++ b/packages/eas-cli/src/vcs/vcs.ts
@@ -59,9 +59,9 @@ export abstract class Client {
     return null;
   }
 
-  // (optional) checks if the file is ignored
-  // - returns true if the file is included in the project tarball
-  // - returns false otherwise
+  // (optional) checks if the file is ignored, an implementation should ensure
+  // that if file exists and `isFileIgnoredAsync` returns true, then that file
+  // should not be included in the project tarball.
   public async isFileIgnoredAsync(filePath: string): Promise<boolean> {
     return false;
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Fixes https://linear.app/expo/issue/ENG-1444/check-if-androidios-directory-is-gitignored-when-detecting-type-of-the
Context: https://exponent-internal.slack.com/archives/C02123T524U/p1624830319179000
If `android`/`ios` directory exists but is git-ignored, we don't include it in the project tarball (so the project is a managed one). However, the function which resolves the workflow thinks the project is generic.

# How

Change the `resolveWorkflow` function so it respects git-ignored files.

# Test Plan

- Added unit tests.
- Tested manually: fresh managed project + `android/app/src/main/AndroidManifest.xml` git-ignored file -> EAS CLI properly detected that the project is managed.