### PR TITLE
[eas-cli] prompt to create project if not exists, more credentials guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Improve project workflow detection (fixes the case where the `android` and/or `ios` directories are git-ignored). ([#490](https://github.com/expo/eas-cli/pull/490) by [@dsokal](https://github.com/dsokal))
+- Improve credentials workflow with project creation and current working directories ([#491](https://github.com/expo/eas-cli/pull/491) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -155,7 +155,7 @@ export class ManageAndroid {
           const maybeProjectId = await promptToCreateProjectIfNotExistsAsync(ctx.exp);
           if (!maybeProjectId) {
             throw new Error(
-              'Your project must be registered with Expo in order to use the credentials manager.'
+              'Your project must be registered with EAS in order to use the credentials manager.'
             );
           }
           const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -276,7 +276,7 @@ export class ManageIos {
     const maybeProjectId = await promptToCreateProjectIfNotExistsAsync(ctx.exp);
     if (!maybeProjectId) {
       throw new Error(
-        'Your project must be registered with Expo in order to use the credentials manager.'
+        'Your project must be registered with EAS in order to use the credentials manager.'
       );
     }
 

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -10,7 +10,10 @@ import {
 import Log from '../../log';
 import { resolveXcodeBuildContextAsync } from '../../project/ios/scheme';
 import { resolveTargetsAsync } from '../../project/ios/target';
-import { getProjectAccountName } from '../../project/projectUtils';
+import {
+  getProjectAccountName,
+  promptToCreateProjectIfNotExistsAsync,
+} from '../../project/projectUtils';
 import { confirmAsync, promptAsync, selectAsync } from '../../prompts';
 import { Account, findAccountByName } from '../../user/Account';
 import { ensureActorHasUsername } from '../../user/actions';
@@ -235,11 +238,15 @@ export class ManageIos {
             return await this.callingAction.runAsync(ctx);
           }
         } else if (actionInfo.scope === Scope.Project) {
+          assert(
+            ctx.hasProjectContext,
+            'You must be in your project directory in order to perform this action'
+          );
           await this.runProjectSpecificActionAsync(
             ctx,
-            nullthrows(app),
-            nullthrows(targets),
-            nullthrows(buildProfile),
+            nullthrows(app, 'app must be defined in project context'),
+            nullthrows(targets, 'targets must be defined in project context'),
+            nullthrows(buildProfile, 'buildProfile must be defined in project context'),
             chosenAction
           );
         } else if (actionInfo.scope === Scope.Account) {
@@ -264,6 +271,13 @@ export class ManageIos {
         targets: null,
         buildProfile: null,
       };
+    }
+
+    const maybeProjectId = await promptToCreateProjectIfNotExistsAsync(ctx.exp);
+    if (!maybeProjectId) {
+      throw new Error(
+        'Your project must be registered with Expo in order to use the credentials manager.'
+      );
     }
 
     const app = { account, projectName: ctx.exp.slug };

--- a/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
@@ -1,17 +1,24 @@
 import { vol } from 'memfs';
 
 import { asMock } from '../../__tests__/utils';
+import { confirmAsync } from '../../prompts';
 import { Actor, getUserAsync } from '../../user/User';
+import {
+  ensureProjectExistsAsync,
+  findProjectIdByAccountNameAndSlugNullableAsync,
+} from '../ensureProjectExists';
 import {
   findProjectRootAsync,
   getProjectAccountName,
   getProjectAccountNameAsync,
+  promptToCreateProjectIfNotExistsAsync,
 } from '../projectUtils';
 
 jest.mock('@expo/config');
 jest.mock('fs');
 
 jest.mock('../../user/User');
+jest.mock('../ensureProjectExists');
 
 const originalConsoleLog = console.log;
 const originalConsoleWarn = console.warn;
@@ -166,5 +173,64 @@ describe(getProjectAccountNameAsync, () => {
     await expect(getProjectAccountNameAsync(expWithoutOwner)).rejects.toThrow(
       'manifest property is required'
     );
+  });
+});
+
+describe(promptToCreateProjectIfNotExistsAsync, () => {
+  beforeEach(() => {
+    asMock(getUserAsync).mockReset();
+    asMock(findProjectIdByAccountNameAndSlugNullableAsync).mockReset();
+  });
+
+  it('returns the existing project', async () => {
+    asMock(getUserAsync).mockImplementation((): Actor | undefined => ({
+      __typename: 'User',
+      id: 'user_id',
+      username: 'quin',
+      accounts: [{ id: 'account_id_1', name: 'quin' }],
+      isExpoAdmin: false,
+    }));
+    asMock(findProjectIdByAccountNameAndSlugNullableAsync).mockImplementation(
+      () => 'already-existing-project-id'
+    );
+    const exp: any = {};
+    const projectId = await promptToCreateProjectIfNotExistsAsync(exp);
+    expect(projectId).toBe('already-existing-project-id');
+  });
+  it('makes a new project if none exists', async () => {
+    jest.mock('../../prompts');
+    asMock(getUserAsync).mockImplementation((): Actor | undefined => ({
+      __typename: 'User',
+      id: 'user_id',
+      username: 'quin',
+      accounts: [{ id: 'account_id_1', name: 'quin' }],
+      isExpoAdmin: false,
+    }));
+    asMock(findProjectIdByAccountNameAndSlugNullableAsync).mockImplementation(() => null);
+    asMock(ensureProjectExistsAsync).mockImplementation(() => 'new-project-id');
+
+    // user agrees to make new project
+    (confirmAsync as jest.Mock).mockImplementation(() => true);
+    const exp: any = {};
+    const projectId = await promptToCreateProjectIfNotExistsAsync(exp);
+    expect(projectId).toBe('new-project-id');
+  });
+  it('aborts making a new project if the user declines', async () => {
+    jest.mock('../../prompts');
+    asMock(getUserAsync).mockImplementation((): Actor | undefined => ({
+      __typename: 'User',
+      id: 'user_id',
+      username: 'quin',
+      accounts: [{ id: 'account_id_1', name: 'quin' }],
+      isExpoAdmin: false,
+    }));
+    asMock(findProjectIdByAccountNameAndSlugNullableAsync).mockImplementation(() => null);
+    asMock(ensureProjectExistsAsync).mockImplementation(() => 'new-project-id');
+
+    // user doesnt agree to make new project
+    (confirmAsync as jest.Mock).mockImplementation(() => false);
+    const exp: any = {};
+    const projectId = await promptToCreateProjectIfNotExistsAsync(exp);
+    expect(projectId).toBe(null);
   });
 });

--- a/packages/eas-cli/src/project/ensureProjectExists.ts
+++ b/packages/eas-cli/src/project/ensureProjectExists.ts
@@ -54,15 +54,14 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
  * Finds project by `@accountName/slug` and returns its ID, return null if the project does not exist
  * @param accountName account name
  * @param slug project slug
- * @returns A promise resolving to Project ID
+ * @returns A promise resolving to Project ID, null if it doesn't exist
  */
 export async function findProjectIdByAccountNameAndSlugNullableAsync(
   accountName: string,
   slug: string
 ): Promise<string | null> {
   try {
-    const id = await findProjectIdByAccountNameAndSlugAsync(accountName, slug);
-    return id;
+    return await findProjectIdByAccountNameAndSlugAsync(accountName, slug);
   } catch (err) {
     if (err.graphQLErrors?.some((it: any) => it.extensions?.errorCode !== 'EXPERIENCE_NOT_FOUND')) {
       throw err;

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -244,7 +244,7 @@ export async function promptToCreateProjectIfNotExistsAsync(
   }
   const fullName = await getProjectFullNameAsync(exp);
   const shouldCreateProject = await confirmAsync({
-    message: `Looks like ${fullName} is new. Register it with Expo?`,
+    message: `Looks like ${fullName} is new. Register it with EAS?`,
   });
   if (!shouldCreateProject) {
     return null;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

- Add a way to prompt user to create a project if it doesn't exist  -- `findProjectIdByAccountNameAndSlugNullableAsync`
- Add more guardrails to the credentials manager (ie) tell people if they aren't in a project directory, prompt to create project if it doesnt exist on eas servers yet

# Test Plan

- [ ] new tests pass
