### PR TITLE
[ENG-1460] add runtime version to build metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Added support for iOS 15 capabilities: Communication Notifications, Time Sensitive Notifications, Group Activities, and Family Controls. ([#499](https://github.com/expo/eas-cli/pull/499) by [@EvanBacon](https://github.com/EvanBacon))
 - Show more build metadata in `build:view` and `build:list`. ([#504](https://github.com/expo/eas-cli/pull/504) by [@dsokal](https://github.com/dsokal))
+- Add runtime version to build metadata. ([#493](https://github.com/expo/eas-cli/pull/493) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/apple-utils": "0.0.0-alpha.23",
     "@expo/config": "3.3.42",
     "@expo/config-plugins": "3.0.3",
-    "@expo/eas-build-job": "0.2.41",
+    "@expo/eas-build-job": "0.2.43",
     "@expo/eas-json": "^0.20.0",
     "@expo/json-file": "8.2.25",
     "@expo/pkcs12": "0.0.4",

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -44,6 +44,7 @@ export async function collectMetadata<T extends Platform>(
     workflow: ctx.workflow,
     credentialsSource,
     sdkVersion: ctx.commandCtx.exp.sdkVersion,
+    runtimeVersion: ctx.commandCtx.exp.runtimeVersion,
     ...channelOrReleaseChannel,
     distribution: ctx.buildProfile.distribution ?? 'store',
     appName: ctx.commandCtx.exp.name,

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.41",
+    "@expo/eas-build-job": "0.2.43",
     "@hapi/joi": "17.1.1",
     "fs-extra": "9.0.1",
     "tslib": "1.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,10 +1918,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.41":
-  version "0.2.41"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.41.tgz#d44ce7f5e7a1f08caa415913fed43f875fce4d52"
-  integrity sha512-tp3i7EZRMGvlJ3NyhpBpLdIxg6+CI6z6P3JgZVh57s2skN5zjzHcfjXPcw0gVH9fCouUnvhSSye8O+g2Zo1oaA==
+"@expo/eas-build-job@0.2.43":
+  version "0.2.43"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.43.tgz#23d4683f3fb23c55fd02f8507d8935c91427dafb"
+  integrity sha512-us9RY9kD5sd8Q7sxzYkx2LCYZQmNnC9kpG2ieUPw+mdXdtF+HpdZtNQWD0Tttvu+T2HWYIot8PMrxu3a6JdFlA==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://linear.app/expo/issue/ENG-1460/add-runtimeversion-to-build-job-metadata
We want to display the runtime version on the website.

# How

I added the runtime version to build metadata. 

# Test Plan

I had `runtimeVersion` defined in the app config, I ran a build and checked it was sent to www.

# Note

Merge after https://github.com/expo/universe/pull/7821 is merged and deployed.