### PR TITLE
[eas-cli] unify generic and manged workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Unifify generic and managed workflow, deprecate `workflow` field. ([#497](https://github.com/expo/eas-cli/pull/497) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -6,6 +6,7 @@ import resolveFrom from 'resolve-from';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getProjectAccountName } from '../project/projectUtils';
+import { resolveWorkflowAsync } from '../project/workflow';
 import { findAccountByName } from '../user/Account';
 import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
@@ -92,9 +93,10 @@ export interface BuildContext<T extends Platform> {
   trackingCtx: TrackingContext;
   platform: T;
   buildProfile: PlatformBuildProfile<T>;
+  workflow: Workflow;
 }
 
-export function createBuildContext<T extends Platform>({
+export async function createBuildContextAsync<T extends Platform>({
   platform,
   easConfig,
   commandCtx,
@@ -102,45 +104,58 @@ export function createBuildContext<T extends Platform>({
   platform: T;
   easConfig: EasConfig;
   commandCtx: CommandContext;
-}): BuildContext<T> {
+}): Promise<BuildContext<T>> {
   const buildProfile = easConfig.builds[platform] as PlatformBuildProfile<T> | undefined;
   if (!buildProfile) {
     throw new Error(`${platform} build profile does not exist`);
   }
 
+  const workflow = await resolveWorkflowAsync(commandCtx.projectDir, platform);
   const accountId = findAccountByName(commandCtx.user.accounts, commandCtx.accountName)?.id;
-  const devClientProperties = getDevClientEventProperties(platform, commandCtx, buildProfile);
+  const devClientProperties = getDevClientEventProperties({
+    platform,
+    projectDir: commandCtx.projectDir,
+    buildProfile,
+    workflow,
+  });
   const trackingCtx = {
     tracking_id: uuidv4(),
     platform,
     ...(accountId && { account_id: accountId }),
     account_name: commandCtx.accountName,
     project_id: commandCtx.projectId,
-    project_type: buildProfile.workflow,
+    project_type: workflow,
     ...devClientProperties,
   };
   Analytics.logEvent(Event.BUILD_COMMAND, trackingCtx);
   return {
     commandCtx,
+    workflow,
     trackingCtx,
     platform,
     buildProfile,
   };
 }
 
-function getDevClientEventProperties(
-  platform: Platform,
-  commandCtx: CommandContext,
-  buildProfile: AndroidBuildProfile | IosBuildProfile
-): Partial<TrackingContext> {
+function getDevClientEventProperties({
+  platform,
+  projectDir,
+  buildProfile,
+  workflow,
+}: {
+  platform: Platform;
+  projectDir: string;
+  buildProfile: AndroidBuildProfile | IosBuildProfile;
+  workflow: Workflow;
+}): Partial<TrackingContext> {
   let includesDevClient;
-  const version = tryGetDevClientVersion(commandCtx.projectDir);
-  if (buildProfile.workflow === Workflow.MANAGED) {
-    includesDevClient = buildProfile.buildType === 'development-client';
-  } else if (platform === Platform.ANDROID && 'gradleCommand' in buildProfile) {
+  const version = tryGetDevClientVersion(projectDir);
+  if (platform === Platform.ANDROID && 'gradleCommand' in buildProfile) {
     includesDevClient = Boolean(version && buildProfile.gradleCommand?.includes('Debug'));
   } else if (platform === Platform.IOS && 'schemeBuildConfiguration' in buildProfile) {
     includesDevClient = Boolean(version && buildProfile.schemeBuildConfiguration === 'Debug');
+  } else if ('buildType' in buildProfile) {
+    includesDevClient = buildProfile.buildType === 'development-client';
   } else {
     includesDevClient = false;
   }

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config';
-import { Workflow } from '@expo/eas-build-job';
+import { Platform, Workflow } from '@expo/eas-build-job';
 import { IosBuildProfile, VersionAutoIncrement } from '@expo/eas-json';
 
 import Log from '../../log';
@@ -7,6 +7,7 @@ import {
   ensureBundleIdentifierIsDefinedForManagedProjectAsync,
   warnIfBundleIdentifierDefinedInAppConfigForGenericProject,
 } from '../../project/ios/bundleIdentifier';
+import { resolveWorkflowAsync } from '../../project/workflow';
 import { ConfigureContext } from '../context';
 import { isExpoUpdatesInstalled } from '../utils/updates';
 import { configureUpdatesAsync, syncUpdatesConfigurationAsync } from './UpdatesModule';
@@ -35,7 +36,8 @@ export async function validateAndSyncProjectConfigurationAsync({
   exp: ExpoConfig;
   buildProfile: IosBuildProfile;
 }): Promise<void> {
-  const { workflow, autoIncrement } = buildProfile;
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
+  const { autoIncrement } = buildProfile;
   const versionBumpStrategy = resolveVersionBumpStrategy(autoIncrement);
 
   if (workflow === Workflow.GENERIC) {

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -28,7 +28,7 @@ export async function ensureIosCredentialsAsync(
     iosCapabilitiesOptions: {
       entitlements: await resolveEntitlementsJsonAsync(
         buildCtx.commandCtx.projectDir,
-        buildCtx.buildProfile.workflow
+        buildCtx.workflow
       ),
     },
     distribution: buildCtx.buildProfile.distribution ?? 'store',

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -1,5 +1,4 @@
-import { ArchiveSource, Cache, Ios, Job, Workflow, sanitizeJob } from '@expo/eas-build-job';
-import { IosGenericBuildProfile, IosManagedBuildProfile } from '@expo/eas-json';
+import { ArchiveSource, Ios, Job, sanitizeJob } from '@expo/eas-build-job';
 import path from 'path';
 import semver from 'semver';
 
@@ -20,44 +19,22 @@ export async function prepareJobAsync(
   ctx: BuildContext<Platform.IOS>,
   jobData: JobData
 ): Promise<Job> {
-  if (ctx.buildProfile.workflow === Workflow.GENERIC) {
-    const partialJob = await prepareGenericJobAsync(ctx, jobData, ctx.buildProfile);
-    return sanitizeJob(partialJob);
-  } else if (ctx.buildProfile.workflow === Workflow.MANAGED) {
-    const partialJob = await prepareManagedJobAsync(ctx, jobData, ctx.buildProfile);
-    return sanitizeJob(partialJob);
-  } else {
-    throw new Error("Unknown workflow. Shouldn't happen");
-  }
-}
-
-interface CommonJobProperties {
-  platform: Platform.IOS;
-  projectArchive: ArchiveSource;
-  builderEnvironment: Ios.BuilderEnvironment;
-  distribution?: Ios.DistributionType;
-  cache: Cache;
-  secrets: {
-    buildCredentials: Ios.BuildCredentials;
-    environmentSecrets?: Record<string, string>;
-  };
-}
-
-async function prepareJobCommonAsync(
-  ctx: BuildContext<Platform.IOS>,
-  { credentials, projectArchive }: { credentials?: IosCredentials; projectArchive: ArchiveSource }
-): Promise<Partial<CommonJobProperties>> {
-  const buildCredentials: CommonJobProperties['secrets']['buildCredentials'] = {};
-  if (credentials) {
-    const targetNames = Object.keys(credentials);
+  const projectRootDirectory =
+    path.relative(await vcs.getRootPathAsync(), ctx.commandCtx.projectDir) || '.';
+  const username = getUsername(ctx.commandCtx.exp, await ensureLoggedInAsync());
+  const buildCredentials: Ios.Job['secrets']['buildCredentials'] = {};
+  if (jobData.credentials) {
+    const targetNames = Object.keys(jobData.credentials);
     for (const targetName of targetNames) {
-      buildCredentials[targetName] = prepareTargetCredentials(credentials[targetName]);
+      buildCredentials[targetName] = prepareTargetCredentials(jobData.credentials[targetName]);
     }
   }
 
-  return {
+  const job = {
+    type: ctx.workflow,
     platform: Platform.IOS,
-    projectArchive,
+    projectArchive: jobData.projectArchive,
+    projectRootDirectory,
     distribution: ctx.buildProfile.distribution,
     builderEnvironment: {
       image: resolveImage(ctx),
@@ -76,7 +53,18 @@ async function prepareJobCommonAsync(
     secrets: {
       buildCredentials,
     },
+    releaseChannel: ctx.buildProfile.releaseChannel,
+    updates: { channel: ctx.buildProfile.channel },
+
+    scheme: jobData.buildScheme,
+    buildConfiguration: ctx.buildProfile.schemeBuildConfiguration,
+    artifactPath: ctx.buildProfile.artifactPath,
+
+    buildType: ctx.buildProfile.buildType,
+    username,
   };
+
+  return sanitizeJob(job);
 }
 
 function resolveImage(ctx: BuildContext<Platform.IOS>): Ios.BuilderEnvironment['image'] {
@@ -97,49 +85,5 @@ function prepareTargetCredentials(targetCredentials: TargetCredentials): Ios.Tar
       dataBase64: targetCredentials.distributionCertificate.certificateP12,
       password: targetCredentials.distributionCertificate.certificatePassword,
     },
-  };
-}
-
-async function prepareGenericJobAsync(
-  ctx: BuildContext<Platform.IOS>,
-  jobData: JobData,
-  buildProfile: IosGenericBuildProfile
-): Promise<Partial<Ios.Job>> {
-  const projectRootDirectory =
-    path.relative(await vcs.getRootPathAsync(), ctx.commandCtx.projectDir) || '.';
-  return {
-    ...(await prepareJobCommonAsync(ctx, {
-      credentials: jobData.credentials,
-      projectArchive: jobData.projectArchive,
-    })),
-    type: Workflow.GENERIC,
-    scheme: jobData.buildScheme,
-    buildConfiguration: buildProfile.schemeBuildConfiguration,
-    artifactPath: buildProfile.artifactPath,
-    releaseChannel: buildProfile.releaseChannel,
-    updates: { channel: buildProfile.channel },
-    projectRootDirectory,
-  };
-}
-
-async function prepareManagedJobAsync(
-  ctx: BuildContext<Platform.IOS>,
-  jobData: JobData,
-  buildProfile: IosManagedBuildProfile
-): Promise<Partial<Ios.Job>> {
-  const projectRootDirectory =
-    path.relative(await vcs.getRootPathAsync(), ctx.commandCtx.projectDir) || '.';
-  const username = getUsername(ctx.commandCtx.exp, await ensureLoggedInAsync());
-  return {
-    ...(await prepareJobCommonAsync(ctx, {
-      credentials: jobData.credentials,
-      projectArchive: jobData.projectArchive,
-    })),
-    type: Workflow.MANAGED,
-    buildType: buildProfile.buildType,
-    username,
-    releaseChannel: buildProfile.releaseChannel,
-    updates: { channel: buildProfile.channel },
-    projectRootDirectory,
   };
 }

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -41,7 +41,7 @@ export async function collectMetadata<T extends Platform>(
     appVersion: await resolveAppVersionAsync(ctx),
     appBuildVersion: await resolveAppBuildVersionAsync(ctx),
     cliVersion: packageJSON.version,
-    workflow: ctx.buildProfile.workflow,
+    workflow: ctx.workflow,
     credentialsSource,
     sdkVersion: ctx.commandCtx.exp.sdkVersion,
     ...channelOrReleaseChannel,

--- a/packages/eas-cli/src/project/ios/scheme.ts
+++ b/packages/eas-cli/src/project/ios/scheme.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
-import { Workflow } from '@expo/eas-build-job';
+import { Platform, Workflow } from '@expo/eas-build-job';
 import { IosBuildProfile } from '@expo/eas-json';
 import chalk from 'chalk';
 import sortBy from 'lodash/sortBy';
@@ -8,6 +8,7 @@ import sortBy from 'lodash/sortBy';
 import Log from '../../log';
 import { promptAsync } from '../../prompts';
 import { sanitizedProjectName } from '../projectUtils';
+import { resolveWorkflowAsync } from '../workflow';
 
 export interface XcodeBuildContext {
   buildScheme: string;
@@ -22,7 +23,8 @@ export async function resolveXcodeBuildContextAsync(
   }: { exp: ExpoConfig; projectDir: string; nonInteractive: boolean },
   buildProfile: IosBuildProfile
 ): Promise<XcodeBuildContext> {
-  if (buildProfile.workflow === Workflow.GENERIC) {
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
+  if (workflow === Workflow.GENERIC) {
     const buildScheme =
       buildProfile.scheme ??
       (await selectSchemeAsync({

--- a/packages/eas-json/src/Config.types.ts
+++ b/packages/eas-json/src/Config.types.ts
@@ -1,4 +1,4 @@
-import { Android, Cache, Ios, Workflow } from '@expo/eas-build-job';
+import { Android, Cache, Ios } from '@expo/eas-build-job';
 
 export enum CredentialsSource {
   LOCAL = 'local',
@@ -13,64 +13,46 @@ export type IosEnterpriseProvisioning = 'adhoc' | 'universal';
 
 export type VersionAutoIncrement = boolean | 'version' | 'buildNumber';
 
-export interface AndroidManagedBuildProfile extends Android.BuilderEnvironment {
-  workflow: Workflow.MANAGED;
+interface IosBuilderEnvironment extends Omit<Ios.BuilderEnvironment, 'image'> {
+  image?: Ios.BuilderEnvironment['image'];
+}
+
+export interface AndroidBuildProfile extends Android.BuilderEnvironment {
   credentialsSource: CredentialsSource;
-  buildType?: Android.BuildType;
   releaseChannel?: string;
   channel?: string;
   distribution: AndroidDistributionType;
   cache: Cache;
-}
-
-export interface AndroidGenericBuildProfile extends Android.BuilderEnvironment {
-  workflow: Workflow.GENERIC;
-  credentialsSource: CredentialsSource;
-  gradleCommand?: string;
-  releaseChannel?: string;
-  channel?: string;
-  artifactPath?: string;
   withoutCredentials?: boolean;
-  distribution: AndroidDistributionType;
-  cache: Cache;
+
+  buildType?: Android.BuildType;
+
+  gradleCommand?: string;
+  artifactPath?: string;
 }
 
-export interface IosManagedBuildProfile extends Omit<Ios.BuilderEnvironment, 'image'> {
-  workflow: Workflow.MANAGED;
+export interface IosBuildProfile extends IosBuilderEnvironment {
   credentialsSource: CredentialsSource;
-  buildType?: Ios.BuildType;
   releaseChannel?: string;
   channel?: string;
   distribution: IosDistributionType;
   enterpriseProvisioning?: IosEnterpriseProvisioning;
   autoIncrement: VersionAutoIncrement;
   cache: Cache;
-  image?: Ios.BuilderEnvironment['image'];
-}
 
-export interface IosGenericBuildProfile extends Omit<Ios.BuilderEnvironment, 'image'> {
-  workflow: Workflow.GENERIC;
-  credentialsSource: CredentialsSource;
+  artifactPath?: string;
   scheme?: string;
   schemeBuildConfiguration?: string;
-  releaseChannel?: string;
-  channel?: string;
-  artifactPath?: string;
-  distribution: IosDistributionType;
-  enterpriseProvisioning?: IosEnterpriseProvisioning;
-  autoIncrement: VersionAutoIncrement;
-  cache: Cache;
-  image?: Ios.BuilderEnvironment['image'];
+
+  buildType?: Ios.BuildType;
 }
 
-export type AndroidBuildProfile = AndroidManagedBuildProfile | AndroidGenericBuildProfile;
-export type IosBuildProfile = IosManagedBuildProfile | IosGenericBuildProfile;
 export type BuildProfile = AndroidBuildProfile | IosBuildProfile;
 
 // EasConfig represents eas.json with one specific profile
 export interface EasConfig {
   builds: {
-    android?: AndroidManagedBuildProfile | AndroidGenericBuildProfile;
-    ios?: IosManagedBuildProfile | IosGenericBuildProfile;
+    android?: AndroidBuildProfile;
+    ios?: IosBuildProfile;
   };
 }

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -76,9 +76,7 @@ export class EasJsonReader {
     const androidProfiles = easJson.builds?.android ?? {};
     for (const name of Object.keys(androidProfiles)) {
       try {
-        if (this.isWorkflowKeySpecified(Platform.ANDROID, name, androidProfiles)) {
-          this.validateBuildProfile(Platform.ANDROID, name, androidProfiles);
-        }
+        this.validateBuildProfile(Platform.ANDROID, name, androidProfiles);
       } catch (err) {
         err.msg = `Failed to validate Android build profile "${name}"\n${err.msg}`;
         throw err;
@@ -87,9 +85,7 @@ export class EasJsonReader {
     const iosProfiles = easJson.builds?.ios ?? {};
     for (const name of Object.keys(iosProfiles)) {
       try {
-        if (this.isWorkflowKeySpecified(Platform.IOS, name, iosProfiles)) {
-          this.validateBuildProfile(Platform.IOS, name, iosProfiles);
-        }
+        this.validateBuildProfile(Platform.IOS, name, iosProfiles);
       } catch (err) {
         err.msg = `Failed to validate iOS build profile "${name}"\n${err.msg}`;
         throw err;
@@ -117,15 +113,7 @@ export class EasJsonReader {
     buildProfiles: Record<string, BuildProfilePreValidation>
   ): T {
     const buildProfile = this.resolveBuildProfile(platform, buildProfileName, buildProfiles);
-    if (![Workflow.GENERIC, Workflow.MANAGED].includes(buildProfile.workflow)) {
-      throw new Error(
-        '"workflow" key is required in a build profile and has to be one of ["generic", "managed"].'
-      );
-    }
-    const schema = schemaBuildProfileMap[platform][buildProfile.workflow];
-    if (!schema) {
-      throw new Error('invalid workflow'); // this should be validated earlier
-    }
+    const schema = schemaBuildProfileMap[platform];
     const { value, error } = schema.validate(buildProfile, {
       stripUnknown: true,
       convert: true,
@@ -138,15 +126,6 @@ export class EasJsonReader {
       );
     }
     return value;
-  }
-
-  private isWorkflowKeySpecified(
-    platform: Platform,
-    buildProfileName: string,
-    buildProfiles: Record<string, BuildProfilePreValidation>
-  ): boolean {
-    const buildProfile = this.resolveBuildProfile(platform, buildProfileName, buildProfiles);
-    return !!buildProfile.workflow;
   }
 
   private resolveBuildProfile(

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -38,90 +38,58 @@ const CacheSchema = Joi.object({
   customPaths: Joi.array().items(Joi.string()).default([]),
 });
 
-const AndroidGenericSchema = Joi.object({
-  workflow: Joi.string().valid('generic').required(),
+const AndroidSchema = Joi.object({
+  workflow: Joi.string(),
   credentialsSource: Joi.string().valid('local', 'remote').default('remote'),
-  gradleCommand: Joi.alternatives().conditional('distribution', {
-    is: 'internal',
-    then: Joi.string().default(':app:assembleRelease'),
-    otherwise: Joi.string(),
-  }),
   releaseChannel: Joi.string(),
   channel: Joi.string(),
-  artifactPath: Joi.string(),
-  withoutCredentials: Joi.boolean().default(false),
   distribution: Joi.string().valid('store', 'internal').default('store'),
   cache: CacheSchema.default(),
-}).concat(AndroidBuilderEnvironmentSchema);
+  withoutCredentials: Joi.boolean().default(false),
 
-const AndroidManagedSchema = Joi.object({
-  workflow: Joi.string().valid('managed').required(),
-  credentialsSource: Joi.string().valid('local', 'remote').default('remote'),
-  releaseChannel: Joi.string(),
-  channel: Joi.string(),
+  artifactPath: Joi.string(),
+  gradleCommand: Joi.string(),
+
   buildType: Joi.alternatives().conditional('distribution', {
     is: 'internal',
-    then: Joi.string().valid('apk', 'development-client').default('apk'),
-    otherwise: Joi.string().valid('apk', 'app-bundle', 'development-client').default('app-bundle'),
+    then: Joi.string().valid('apk', 'development-client'),
+    otherwise: Joi.string().valid('apk', 'app-bundle', 'development-client'),
   }),
-  distribution: Joi.string().valid('store', 'internal').default('store'),
-  cache: CacheSchema.default(),
 }).concat(AndroidBuilderEnvironmentSchema);
 
-const IosGenericSchema = Joi.object({
-  workflow: Joi.string().valid('generic').required(),
+const IosSchema = Joi.object({
+  workflow: Joi.string(),
   credentialsSource: Joi.string().valid('local', 'remote').default('remote'),
+  releaseChannel: Joi.string(),
+  channel: Joi.string(),
+  distribution: Joi.string().valid('store', 'internal', 'simulator').default('store'),
+  enterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
+  autoIncrement: Joi.alternatives()
+    .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
+    .default(false),
+  cache: CacheSchema.default(),
+
+  artifactPath: Joi.string(),
   scheme: Joi.string(),
   schemeBuildConfiguration: Joi.string(),
-  releaseChannel: Joi.string(),
-  channel: Joi.string(),
-  artifactPath: Joi.string(),
-  distribution: Joi.string().valid('store', 'internal', 'simulator').default('store'),
-  enterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
-  autoIncrement: Joi.alternatives()
-    .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
-    .default(false),
-  cache: CacheSchema.default(),
+
+  buildType: Joi.string().valid('release', 'development-client'),
 }).concat(IosBuilderEnvironmentSchema);
 
-const IosManagedSchema = Joi.object({
-  workflow: Joi.string().valid('managed').required(),
-  credentialsSource: Joi.string().valid('local', 'remote').default('remote'),
-  buildType: Joi.string().valid('release', 'development-client').default('release'),
-  releaseChannel: Joi.string(),
-  channel: Joi.string(),
-  distribution: Joi.string().valid('store', 'internal', 'simulator').default('store'),
-  enterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
-  autoIncrement: Joi.alternatives()
-    .try(Joi.boolean(), Joi.string().valid('version', 'buildNumber'))
-    .default(false),
-  cache: CacheSchema.default(),
-}).concat(IosBuilderEnvironmentSchema);
-
-export const schemaBuildProfileMap: Record<string, Record<string, Joi.Schema>> = {
-  android: {
-    generic: AndroidGenericSchema,
-    managed: AndroidManagedSchema,
-  },
-  ios: {
-    managed: IosManagedSchema,
-    generic: IosGenericSchema,
-  },
+export const schemaBuildProfileMap: Record<string, Joi.Schema> = {
+  android: AndroidSchema,
+  ios: IosSchema,
 };
 
 export const EasJsonSchema = Joi.object({
   builds: Joi.object({
     android: Joi.object().pattern(
       Joi.string(),
-      Joi.object({
-        workflow: Joi.string().valid('generic', 'managed'),
-      }).unknown(true) // profile is validated further only if build is for that platform
+      Joi.object({}).unknown(true) // profile is validated further only if build is for that platform
     ),
     ios: Joi.object().pattern(
       Joi.string(),
-      Joi.object({
-        workflow: Joi.string().valid('generic', 'managed'),
-      }).unknown(true) // profile is validated further only if build is for that platform
+      Joi.object({}).unknown(true) // profile is validated further only if build is for that platform
     ),
   }),
 });

--- a/packages/eas-json/src/__tests__/EasJsonReader-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-test.ts
@@ -14,7 +14,7 @@ test('minimal valid android eas.json', async () => {
   await fs.writeJson('/project/eas.json', {
     builds: {
       android: {
-        release: { workflow: 'generic' },
+        release: {},
       },
     },
   });
@@ -24,7 +24,6 @@ test('minimal valid android eas.json', async () => {
   expect({
     builds: {
       android: {
-        workflow: 'generic',
         distribution: 'store',
         credentialsSource: 'remote',
         env: {},
@@ -40,7 +39,7 @@ test('minimal valid ios eas.json', async () => {
   await fs.writeJson('/project/eas.json', {
     builds: {
       ios: {
-        release: { workflow: 'generic' },
+        release: {},
       },
     },
   });
@@ -52,7 +51,6 @@ test('minimal valid ios eas.json', async () => {
       ios: {
         credentialsSource: 'remote',
         distribution: 'store',
-        workflow: 'generic',
         autoIncrement: false,
         env: {},
         cache: { disabled: false, cacheDefaultPaths: true, customPaths: [] },
@@ -65,10 +63,10 @@ test('minimal valid eas.json for both platforms', async () => {
   await fs.writeJson('/project/eas.json', {
     builds: {
       android: {
-        release: { workflow: 'generic' },
+        release: {},
       },
       ios: {
-        release: { workflow: 'generic' },
+        release: {},
       },
     },
   });
@@ -78,7 +76,6 @@ test('minimal valid eas.json for both platforms', async () => {
   expect({
     builds: {
       android: {
-        workflow: 'generic',
         distribution: 'store',
         credentialsSource: 'remote',
         env: {},
@@ -87,7 +84,6 @@ test('minimal valid eas.json for both platforms', async () => {
         image: 'default',
       },
       ios: {
-        workflow: 'generic',
         distribution: 'store',
         credentialsSource: 'remote',
         autoIncrement: false,
@@ -102,10 +98,10 @@ test('valid eas.json with both platform, but reading only android', async () => 
   await fs.writeJson('/project/eas.json', {
     builds: {
       ios: {
-        release: { workflow: 'generic' },
+        release: {},
       },
       android: {
-        release: { workflow: 'generic' },
+        release: {},
       },
     },
   });
@@ -115,7 +111,6 @@ test('valid eas.json with both platform, but reading only android', async () => 
   expect({
     builds: {
       android: {
-        workflow: 'generic',
         distribution: 'store',
         credentialsSource: 'remote',
         env: {},
@@ -131,13 +126,13 @@ test('valid eas.json for development client builds', async () => {
   await fs.writeJson('/project/eas.json', {
     builds: {
       ios: {
-        release: { workflow: 'managed' },
-        debug: { workflow: 'managed', buildType: 'development-client' },
+        release: {},
+        debug: { buildType: 'development-client' },
       },
       android: {
-        release: { workflow: 'managed' },
+        release: {},
         debug: {
-          workflow: 'managed',
+          withoutCredentials: false,
           buildType: 'development-client',
         },
       },
@@ -150,16 +145,15 @@ test('valid eas.json for development client builds', async () => {
     builds: {
       android: {
         credentialsSource: 'remote',
-        workflow: 'managed',
         distribution: 'store',
         env: {},
         image: 'default',
+        withoutCredentials: false,
         cache: { disabled: false, cacheDefaultPaths: true, customPaths: [] },
         buildType: 'development-client',
       },
       ios: {
         credentialsSource: 'remote',
-        workflow: 'managed',
         distribution: 'store',
         autoIncrement: false,
         env: {},
@@ -175,7 +169,6 @@ test('valid generic profile for internal distribution on Android', async () => {
     builds: {
       android: {
         internal: {
-          workflow: 'generic',
           distribution: 'internal',
         },
       },
@@ -187,10 +180,8 @@ test('valid generic profile for internal distribution on Android', async () => {
   expect({
     builds: {
       android: {
-        workflow: 'generic',
         distribution: 'internal',
         credentialsSource: 'remote',
-        gradleCommand: ':app:assembleRelease',
         env: {},
         withoutCredentials: false,
         cache: { disabled: false, cacheDefaultPaths: true, customPaths: [] },
@@ -205,7 +196,6 @@ test('valid managed profile for internal distribution on Android', async () => {
     builds: {
       android: {
         internal: {
-          workflow: 'managed',
           distribution: 'internal',
         },
       },
@@ -217,10 +207,9 @@ test('valid managed profile for internal distribution on Android', async () => {
   expect({
     builds: {
       android: {
-        workflow: 'managed',
-        buildType: 'apk',
         distribution: 'internal',
         credentialsSource: 'remote',
+        withoutCredentials: false,
         env: {},
         cache: { disabled: false, cacheDefaultPaths: true, customPaths: [] },
         image: 'default',
@@ -234,7 +223,6 @@ test('invalid managed profile for internal distribution on Android', async () =>
     builds: {
       android: {
         internal: {
-          workflow: 'managed',
           buildType: 'aab',
           distribution: 'internal',
         },
@@ -253,9 +241,7 @@ test('invalid eas.json with missing preset', async () => {
   await fs.writeJson('/project/eas.json', {
     builds: {
       android: {
-        release: {
-          workflow: 'generic',
-        },
+        release: {},
       },
     },
   });
@@ -271,7 +257,7 @@ test('invalid eas.json when using buildType for wrong platform', async () => {
   await fs.writeJson('/project/eas.json', {
     builds: {
       android: {
-        release: { workflow: 'managed', buildType: 'archive' },
+        release: { buildType: 'archive' },
       },
     },
   });
@@ -280,22 +266,6 @@ test('invalid eas.json when using buildType for wrong platform', async () => {
   const promise = reader.readAsync('release');
   await expect(promise).rejects.toThrowError(
     'Object "android.release" in eas.json is not valid [ValidationError: "buildType" must be one of [apk, app-bundle, development-client]]'
-  );
-});
-
-test('invalid eas.json when missing workflow', async () => {
-  await fs.writeJson('/project/eas.json', {
-    builds: {
-      android: {
-        release: { buildType: 'apk' },
-      },
-    },
-  });
-
-  const reader = new EasJsonReader('/project', 'android');
-  const promise = reader.readAsync('release');
-  await expect(promise).rejects.toThrowError(
-    '"workflow" key is required in a build profile and has to be one of ["generic", "managed"].'
   );
 });
 
@@ -313,7 +283,7 @@ test('invalid semver value', async () => {
   await fs.writeJson('/project/eas.json', {
     builds: {
       android: {
-        release: { workflow: 'generic', node: '12.0.0-alpha' },
+        release: { node: '12.0.0-alpha' },
       },
     },
   });
@@ -329,12 +299,12 @@ test('get profile names', async () => {
   await fs.writeJson('/project/eas.json', {
     builds: {
       android: {
-        release: { workflow: 'generic', node: '12.0.0-alpha' },
-        blah: { workflow: 'generic', node: '12.0.0-alpha' },
+        release: { node: '12.0.0-alpha' },
+        blah: { node: '12.0.0-alpha' },
       },
       ios: {
-        test: { workflow: 'generic', node: '12.0.0-alpha' },
-        blah: { workflow: 'generic', node: '12.0.0-alpha' },
+        test: { node: '12.0.0-alpha' },
+        blah: { node: '12.0.0-alpha' },
       },
     },
   });

--- a/packages/eas-json/src/index.ts
+++ b/packages/eas-json/src/index.ts
@@ -1,13 +1,9 @@
 export {
   CredentialsSource,
   AndroidDistributionType,
-  AndroidManagedBuildProfile,
-  AndroidGenericBuildProfile,
   AndroidBuildProfile,
   BuildProfile,
   IosDistributionType,
-  IosManagedBuildProfile,
-  IosGenericBuildProfile,
   IosBuildProfile,
   IosEnterpriseProvisioning,
   DistributionType,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

unify generic and managed workflow

# How

support the same set of option for both workflows

# Test Plan

Run builds with few different combinations of options in eas.json against production
