### PR TITLE
[eas-cli] add project:info command

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -345,164 +345,6 @@
             "deprecationReason": null
           },
           {
-            "name": "search",
-            "description": "Search for Snacks",
-            "args": [
-              {
-                "name": "type",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "SearchType",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "query",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "offset",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INTERFACE",
-                    "name": "SearchResult",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "searchUsersAndApps",
-            "description": "",
-            "args": [
-              {
-                "name": "type",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "SearchType",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "query",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "offset",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "INTERFACE",
-                  "name": "SearchResult",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Use 'search' root field."
-          },
-          {
             "name": "snack",
             "description": "",
             "args": [],
@@ -991,12 +833,12 @@
           },
           {
             "kind": "OBJECT",
-            "name": "BuildJob",
+            "name": "Submission",
             "ofType": null
           },
           {
             "kind": "OBJECT",
-            "name": "Submission",
+            "name": "BuildJob",
             "ofType": null
           }
         ]
@@ -4167,6 +4009,18 @@
             "deprecationReason": null
           },
           {
+            "name": "runtimeVersion",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "releaseChannel",
             "description": "",
             "args": [],
@@ -4246,6 +4100,30 @@
               "kind": "OBJECT",
               "name": "BuildError",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "submissions",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Submission",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5628,6 +5506,504 @@
       },
       {
         "kind": "OBJECT",
+        "name": "Submission",
+        "description": "Represents an EAS Submission",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "actor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activityTimestamp",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiatingActor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "submittedBuild",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Build",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SubmissionStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "androidConfig",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AndroidSubmissionConfig",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "iosConfig",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "IosSubmissionConfig",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "logsUrl",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SubmissionError",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ActivityTimelineProjectActivity",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SubmissionStatus",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "IN_QUEUE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IN_PROGRESS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FINISHED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ERRORED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AndroidSubmissionConfig",
+        "description": "",
+        "fields": [
+          {
+            "name": "applicationIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archiveType",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SubmissionAndroidArchiveType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "track",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SubmissionAndroidTrack",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "releaseStatus",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "SubmissionAndroidReleaseStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SubmissionAndroidArchiveType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "APK",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "AAB",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SubmissionAndroidTrack",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "PRODUCTION",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INTERNAL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ALPHA",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BETA",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SubmissionAndroidReleaseStatus",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DRAFT",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IN_PROGRESS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HALTED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COMPLETED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "IosSubmissionConfig",
+        "description": "",
+        "fields": [
+          {
+            "name": "ascAppIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appleIdUsername",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appleAppSpecificPasswordId",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SubmissionError",
+        "description": "",
+        "fields": [
+          {
+            "name": "errorCode",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "BuildJob",
         "description": "Represents an Standalone App build job",
         "fields": [
@@ -6159,492 +6535,6 @@
           }
         ],
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "SubmissionStatus",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "IN_QUEUE",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "IN_PROGRESS",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "FINISHED",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ERRORED",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "Submission",
-        "description": "Represents an EAS Submission",
-        "fields": [
-          {
-            "name": "id",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "actor",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "INTERFACE",
-              "name": "Actor",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "activityTimestamp",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "app",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "App",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "initiatingActor",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "INTERFACE",
-              "name": "Actor",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "platform",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "AppPlatform",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "status",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "SubmissionStatus",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "androidConfig",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "AndroidSubmissionConfig",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "iosConfig",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "IosSubmissionConfig",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "logsUrl",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "error",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "SubmissionError",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "ActivityTimelineProjectActivity",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AndroidSubmissionConfig",
-        "description": "",
-        "fields": [
-          {
-            "name": "applicationIdentifier",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "archiveType",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "SubmissionAndroidArchiveType",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "track",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "SubmissionAndroidTrack",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "releaseStatus",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "SubmissionAndroidReleaseStatus",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "SubmissionAndroidArchiveType",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "APK",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "AAB",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "SubmissionAndroidTrack",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "PRODUCTION",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "INTERNAL",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ALPHA",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "BETA",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "SubmissionAndroidReleaseStatus",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "DRAFT",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "IN_PROGRESS",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "HALTED",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "COMPLETED",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "IosSubmissionConfig",
-        "description": "",
-        "fields": [
-          {
-            "name": "ascAppIdentifier",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "appleIdUsername",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "appleAppSpecificPasswordId",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "SubmissionError",
-        "description": "",
-        "fields": [
-          {
-            "name": "errorCode",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -11345,101 +11235,6 @@
         "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "SearchType",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "ALL",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "USERS",
-            "description": "",
-            "isDeprecated": true,
-            "deprecationReason": "User search has been removed."
-          },
-          {
-            "name": "APPS",
-            "description": "",
-            "isDeprecated": true,
-            "deprecationReason": "App search has been removed."
-          },
-          {
-            "name": "SNACKS",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "INTERFACE",
-        "name": "SearchResult",
-        "description": "Represents a search result for an app",
-        "fields": [
-          {
-            "name": "id",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "rank",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": [
-          {
-            "kind": "OBJECT",
-            "name": "BaseSearchResult",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "AppSearchResult",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "UserSearchResult",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "SnackSearchResult",
-            "ofType": null
-          }
-        ]
       },
       {
         "kind": "OBJECT",
@@ -16269,6 +16064,16 @@
             "defaultValue": null
           },
           {
+            "name": "runtimeVersion",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "releaseChannel",
             "description": "",
             "type": {
@@ -18400,6 +18205,16 @@
               }
             },
             "defaultValue": null
+          },
+          {
+            "name": "submittedBuildId",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
           }
         ],
         "interfaces": null,
@@ -18464,6 +18279,16 @@
                 "name": "NewIosSubmissionConfig",
                 "ofType": null
               }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "submittedBuildId",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
             "defaultValue": null
           }
@@ -21303,234 +21128,6 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "BaseSearchResult",
-        "description": "",
-        "fields": [
-          {
-            "name": "id",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Use SearchResult instead"
-          },
-          {
-            "name": "rank",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Use SearchResult instead"
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "SearchResult",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AppSearchResult",
-        "description": "Represents a search result for an app",
-        "fields": [
-          {
-            "name": "id",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
-            "name": "rank",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
-            "name": "app",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "App",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "SearchResult",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "UserSearchResult",
-        "description": "Represents a search result for a user",
-        "fields": [
-          {
-            "name": "id",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
-            "name": "rank",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
-            "name": "user",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "User",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "SearchResult",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "SnackSearchResult",
-        "description": "Represents a search result for a snack",
-        "fields": [
-          {
-            "name": "id",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "rank",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "snack",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Snack",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "SearchResult",
-            "ofType": null
-          }
-        ],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/eas-cli/src/commands/project/info.ts
+++ b/packages/eas-cli/src/commands/project/info.ts
@@ -1,0 +1,57 @@
+import { getConfig } from '@expo/config';
+import { Command } from '@oclif/command';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
+import { AppInfoQuery, AppInfoQueryVariables } from '../../graphql/generated';
+import Log from '../../log';
+import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
+import formatFields from '../../utils/formatFields';
+
+async function projectInfoByIdAsync(appId: string): Promise<AppInfoQuery> {
+  const data = await withErrorHandlingAsync(
+    graphqlClient
+      .query<AppInfoQuery, AppInfoQueryVariables>(
+        gql`
+          query AppInfo($appId: String!) {
+            app {
+              byId(appId: $appId) {
+                id
+                fullName
+              }
+            }
+          }
+        `,
+        { appId }
+      )
+      .toPromise()
+  );
+
+  return data;
+}
+
+export default class ProjectInfo extends Command {
+  static hidden = true;
+  static description = 'information about the current project';
+
+  async run() {
+    const projectDir = await findProjectRootAsync(process.cwd());
+    if (!projectDir) {
+      throw new Error('Please run this command inside a project directory.');
+    }
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const projectId = await getProjectIdAsync(exp);
+    const { app } = await projectInfoByIdAsync(projectId);
+    if (!app) {
+      throw new Error(`Could not find project with ID: ${projectId}`);
+    }
+
+    Log.addNewLineIfNone();
+    Log.log(
+      formatFields([
+        { label: 'ID', value: projectId },
+        { label: 'fullName', value: app.byId.fullName },
+      ])
+    );
+  }
+}

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -2,12 +2,13 @@ import { getConfig } from '@expo/config';
 import { Command } from '@oclif/command';
 import chalk from 'chalk';
 
-import Log from '../log';
-import { findProjectRootAsync, setProjectIdAsync } from '../project/projectUtils';
+import Log from '../../log';
+import { findProjectRootAsync, setProjectIdAsync } from '../../project/projectUtils';
 
-export default class InitView extends Command {
+export default class ProjectInit extends Command {
   static hidden = true;
-  static description = 'Create or link an EAS project';
+  static description = 'create or link an EAS project';
+  static aliases = ['init'];
 
   async run() {
     const projectDir = await findProjectRootAsync(process.cwd());

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -61,10 +61,6 @@ export type RootQuery = {
   /** Top-level query object for querying Experimentation configuration. */
   experimentation: ExperimentationQuery;
   project: ProjectQuery;
-  /** Search for Snacks */
-  search: Array<SearchResult>;
-  /** @deprecated Use 'search' root field. */
-  searchUsersAndApps: Array<Maybe<SearchResult>>;
   snack: SnackQuery;
   submissions: SubmissionQuery;
   /** Top-level query object for querying UserInvitationPublicData publicly. */
@@ -110,22 +106,6 @@ export type RootQueryAllPublicAppsArgs = {
   sort: AppSort;
   offset?: Maybe<Scalars['Int']>;
   limit?: Maybe<Scalars['Int']>;
-};
-
-
-export type RootQuerySearchArgs = {
-  type: SearchType;
-  query: Scalars['String'];
-  offset: Scalars['Int'];
-  limit: Scalars['Int'];
-};
-
-
-export type RootQuerySearchUsersAndAppsArgs = {
-  type: SearchType;
-  query: Scalars['String'];
-  offset: Scalars['Int'];
-  limit: Scalars['Int'];
 };
 
 
@@ -637,6 +617,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   appVersion?: Maybe<Scalars['String']>;
   appBuildVersion?: Maybe<Scalars['String']>;
   sdkVersion?: Maybe<Scalars['String']>;
+  runtimeVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
   channel?: Maybe<Scalars['String']>;
   metrics?: Maybe<BuildMetrics>;
@@ -644,6 +625,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   buildProfile?: Maybe<Scalars['String']>;
   gitCommitHash?: Maybe<Scalars['String']>;
   error?: Maybe<BuildError>;
+  submissions: Array<Submission>;
 };
 
 export type BuildOrBuildJob = {
@@ -825,6 +807,72 @@ export type BuildError = {
   docsUrl?: Maybe<Scalars['String']>;
 };
 
+/** Represents an EAS Submission */
+export type Submission = ActivityTimelineProjectActivity & {
+  __typename?: 'Submission';
+  id: Scalars['ID'];
+  actor?: Maybe<Actor>;
+  activityTimestamp: Scalars['DateTime'];
+  app?: Maybe<App>;
+  initiatingActor?: Maybe<Actor>;
+  submittedBuild?: Maybe<Build>;
+  platform: AppPlatform;
+  status: SubmissionStatus;
+  androidConfig?: Maybe<AndroidSubmissionConfig>;
+  iosConfig?: Maybe<IosSubmissionConfig>;
+  logsUrl?: Maybe<Scalars['String']>;
+  error?: Maybe<SubmissionError>;
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+};
+
+export enum SubmissionStatus {
+  InQueue = 'IN_QUEUE',
+  InProgress = 'IN_PROGRESS',
+  Finished = 'FINISHED',
+  Errored = 'ERRORED'
+}
+
+export type AndroidSubmissionConfig = {
+  __typename?: 'AndroidSubmissionConfig';
+  applicationIdentifier: Scalars['String'];
+  archiveType: SubmissionAndroidArchiveType;
+  track: SubmissionAndroidTrack;
+  releaseStatus?: Maybe<SubmissionAndroidReleaseStatus>;
+};
+
+export enum SubmissionAndroidArchiveType {
+  Apk = 'APK',
+  Aab = 'AAB'
+}
+
+export enum SubmissionAndroidTrack {
+  Production = 'PRODUCTION',
+  Internal = 'INTERNAL',
+  Alpha = 'ALPHA',
+  Beta = 'BETA'
+}
+
+export enum SubmissionAndroidReleaseStatus {
+  Draft = 'DRAFT',
+  InProgress = 'IN_PROGRESS',
+  Halted = 'HALTED',
+  Completed = 'COMPLETED'
+}
+
+export type IosSubmissionConfig = {
+  __typename?: 'IosSubmissionConfig';
+  ascAppIdentifier: Scalars['String'];
+  appleIdUsername: Scalars['String'];
+  appleAppSpecificPasswordId?: Maybe<Scalars['String']>;
+};
+
+export type SubmissionError = {
+  __typename?: 'SubmissionError';
+  errorCode?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
+};
+
 /** Represents an Standalone App build job */
 export type BuildJob = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   __typename?: 'BuildJob';
@@ -889,71 +937,6 @@ export enum BuildJobStatus {
 export type SubmissionFilter = {
   platform?: Maybe<AppPlatform>;
   status?: Maybe<SubmissionStatus>;
-};
-
-export enum SubmissionStatus {
-  InQueue = 'IN_QUEUE',
-  InProgress = 'IN_PROGRESS',
-  Finished = 'FINISHED',
-  Errored = 'ERRORED'
-}
-
-/** Represents an EAS Submission */
-export type Submission = ActivityTimelineProjectActivity & {
-  __typename?: 'Submission';
-  id: Scalars['ID'];
-  actor?: Maybe<Actor>;
-  activityTimestamp: Scalars['DateTime'];
-  app?: Maybe<App>;
-  initiatingActor?: Maybe<Actor>;
-  platform: AppPlatform;
-  status: SubmissionStatus;
-  androidConfig?: Maybe<AndroidSubmissionConfig>;
-  iosConfig?: Maybe<IosSubmissionConfig>;
-  logsUrl?: Maybe<Scalars['String']>;
-  error?: Maybe<SubmissionError>;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-};
-
-export type AndroidSubmissionConfig = {
-  __typename?: 'AndroidSubmissionConfig';
-  applicationIdentifier: Scalars['String'];
-  archiveType: SubmissionAndroidArchiveType;
-  track: SubmissionAndroidTrack;
-  releaseStatus?: Maybe<SubmissionAndroidReleaseStatus>;
-};
-
-export enum SubmissionAndroidArchiveType {
-  Apk = 'APK',
-  Aab = 'AAB'
-}
-
-export enum SubmissionAndroidTrack {
-  Production = 'PRODUCTION',
-  Internal = 'INTERNAL',
-  Alpha = 'ALPHA',
-  Beta = 'BETA'
-}
-
-export enum SubmissionAndroidReleaseStatus {
-  Draft = 'DRAFT',
-  InProgress = 'IN_PROGRESS',
-  Halted = 'HALTED',
-  Completed = 'COMPLETED'
-}
-
-export type IosSubmissionConfig = {
-  __typename?: 'IosSubmissionConfig';
-  ascAppIdentifier: Scalars['String'];
-  appleIdUsername: Scalars['String'];
-  appleAppSpecificPasswordId?: Maybe<Scalars['String']>;
-};
-
-export type SubmissionError = {
-  __typename?: 'SubmissionError';
-  errorCode?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
 };
 
 export type IosAppCredentialsFilter = {
@@ -1588,19 +1571,6 @@ export type ProjectQueryByUsernameAndSlugArgs = {
 
 export type ProjectQueryByPathsArgs = {
   paths?: Maybe<Array<Maybe<Scalars['String']>>>;
-};
-
-export enum SearchType {
-  All = 'ALL',
-  Users = 'USERS',
-  Apps = 'APPS',
-  Snacks = 'SNACKS'
-}
-
-/** Represents a search result for an app */
-export type SearchResult = {
-  id: Scalars['ID'];
-  rank?: Maybe<Scalars['Int']>;
 };
 
 export type SnackQuery = {
@@ -2492,6 +2462,7 @@ export type BuildMetadataInput = {
   workflow?: Maybe<BuildWorkflow>;
   credentialsSource?: Maybe<BuildCredentialsSource>;
   sdkVersion?: Maybe<Scalars['String']>;
+  runtimeVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
   channel?: Maybe<Scalars['String']>;
   distribution?: Maybe<DistributionType>;
@@ -2807,6 +2778,7 @@ export type CreateSubmissionInput = {
   appId: Scalars['ID'];
   platform: AppPlatform;
   config: Scalars['JSONObject'];
+  submittedBuildId?: Maybe<Scalars['ID']>;
 };
 
 export type CreateSubmissionResult = {
@@ -2818,6 +2790,7 @@ export type CreateSubmissionResult = {
 export type CreateIosSubmissionInput = {
   appId: Scalars['ID'];
   config: NewIosSubmissionConfig;
+  submittedBuildId?: Maybe<Scalars['ID']>;
 };
 
 export type NewIosSubmissionConfig = {
@@ -3350,44 +3323,6 @@ export type DeleteWebhookResult = {
   id: Scalars['ID'];
 };
 
-export type BaseSearchResult = SearchResult & {
-  __typename?: 'BaseSearchResult';
-  /** @deprecated Use SearchResult instead */
-  id: Scalars['ID'];
-  /** @deprecated Use SearchResult instead */
-  rank?: Maybe<Scalars['Int']>;
-};
-
-/** Represents a search result for an app */
-export type AppSearchResult = SearchResult & {
-  __typename?: 'AppSearchResult';
-  /** @deprecated Field no longer supported */
-  id: Scalars['ID'];
-  /** @deprecated Field no longer supported */
-  rank?: Maybe<Scalars['Int']>;
-  /** @deprecated Field no longer supported */
-  app: App;
-};
-
-/** Represents a search result for a user */
-export type UserSearchResult = SearchResult & {
-  __typename?: 'UserSearchResult';
-  /** @deprecated Field no longer supported */
-  id: Scalars['ID'];
-  /** @deprecated Field no longer supported */
-  rank?: Maybe<Scalars['Int']>;
-  /** @deprecated Field no longer supported */
-  user: User;
-};
-
-/** Represents a search result for a snack */
-export type SnackSearchResult = SearchResult & {
-  __typename?: 'SnackSearchResult';
-  id: Scalars['ID'];
-  rank?: Maybe<Scalars['Int']>;
-  snack: Snack;
-};
-
 export enum CacheControlScope {
   Public = 'PUBLIC',
   Private = 'PRIVATE'
@@ -3687,6 +3622,22 @@ export type GetChannelByNameForAppQuery = (
           )> }
         )> }
       )> }
+    ) }
+  )> }
+);
+
+export type AppInfoQueryVariables = Exact<{
+  appId: Scalars['String'];
+}>;
+
+
+export type AppInfoQuery = (
+  { __typename?: 'RootQuery' }
+  & { app?: Maybe<(
+    { __typename?: 'AppQuery' }
+    & { byId: (
+      { __typename?: 'App' }
+      & Pick<App, 'id' | 'fullName'>
     ) }
   )> }
 );


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

We want to transition the eas-cli to relying on the project ID instead of the `fullName`.

This command displays the project ID as well as the current `fullName`. Since `project:info` gives the user a way to see the current `FullName`, we are set up up to deprecate the current custom of the printing out of the fullName each time the user runs a command.

`project:*` commands are hidden so am not updating the changelog.

# How

Added command and a graphQL query.

# Test Plan

Tested in demo repo

<img width="544" alt="Screen Shot 2021-07-06 at 1 16 43 PM" src="https://user-images.githubusercontent.com/1220444/124661508-6c48cd00-de5c-11eb-8d72-36a44c72e4a6.png">
