### PR TITLE
Added iOS 15 capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Added support for iOS 15 capabilities: Communication Notifications, Time Sensitive Notifications, Group Activities, and Family Controls. ([#499](https://github.com/expo/eas-cli/pull/499) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 - Fix runtime version checks. ([#495](https://github.com/expo/eas-cli/pull/495) by [@dsokal](https://github.com/dsokal))

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@amplitude/identify": "1.5.0",
     "@amplitude/node": "1.5.0",
-    "@expo/apple-utils": "0.0.0-alpha.20",
+    "@expo/apple-utils": "0.0.0-alpha.23",
     "@expo/config": "3.3.42",
     "@expo/config-plugins": "3.0.3",
     "@expo/eas-build-job": "0.2.41",

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts
@@ -33,6 +33,10 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       'com.apple.developer.applesignin': ['Default'],
       'com.apple.developer.siri': true,
       'com.apple.developer.networking.wifi-info': true,
+      'com.apple.developer.usernotifications.communication': true,
+      'com.apple.developer.usernotifications.time-sensitive': true,
+      'com.apple.developer.group-session': true,
+      'com.apple.developer.family-controls': true,
       'com.apple.developer.authentication-services.autofill-credential-provider': true,
       //   'com.apple.developer.game-center': true,
       'com.apple.security.application-groups': [
@@ -61,6 +65,22 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       { capabilityType: 'APPLE_ID_AUTH', option: 'ON' },
       { capabilityType: 'SIRIKIT', option: 'ON' },
       { capabilityType: 'ACCESS_WIFI_INFORMATION', option: 'ON' },
+      {
+        capabilityType: 'USERNOTIFICATIONS_COMMUNICATION',
+        option: 'ON',
+      },
+      {
+        capabilityType: 'USERNOTIFICATIONS_TIMESENSITIVE',
+        option: 'ON',
+      },
+      {
+        capabilityType: 'GROUP_ACTIVITIES',
+        option: 'ON',
+      },
+      {
+        capabilityType: 'FAMILY_CONTROLS',
+        option: 'ON',
+      },
       { capabilityType: 'AUTOFILL_CREDENTIAL_PROVIDER', option: 'ON' },
       { capabilityType: 'APP_GROUPS', option: 'ON' },
     ]);
@@ -86,6 +106,10 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       'Sign In with Apple',
       'SiriKit',
       'Access WiFi Information',
+      'Communication Notifications',
+      'Time Sensitive Notifications',
+      'Group Activities',
+      'Family Controls',
       'AutoFill Credential Provider',
       'App Groups',
     ]);

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -314,6 +314,34 @@ export const CapabilityMapping: {
     getOptions: getDefinedOptions,
   },
   {
+    name: 'Communication Notifications',
+    entitlement: 'com.apple.developer.usernotifications.communication',
+    capability: CapabilityType.USER_NOTIFICATIONS_COMMUNICATION,
+    validateOptions: validateBooleanOptions,
+    getOptions: getBooleanOptions,
+  },
+  {
+    name: 'Time Sensitive Notifications',
+    entitlement: 'com.apple.developer.usernotifications.time-sensitive',
+    capability: CapabilityType.USER_NOTIFICATIONS_TIME_SENSITIVE,
+    validateOptions: validateBooleanOptions,
+    getOptions: getBooleanOptions,
+  },
+  {
+    name: 'Group Activities',
+    entitlement: 'com.apple.developer.group-session',
+    capability: CapabilityType.GROUP_ACTIVITIES,
+    validateOptions: validateBooleanOptions,
+    getOptions: getBooleanOptions,
+  },
+  {
+    name: 'Family Controls',
+    entitlement: 'com.apple.developer.family-controls',
+    capability: CapabilityType.FAMILY_CONTROLS,
+    validateOptions: validateBooleanOptions,
+    getOptions: getBooleanOptions,
+  },
+  {
     // https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_default-data-protection
     name: 'Data Protection',
     entitlement: 'com.apple.developer.default-data-protection',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,10 +1818,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/apple-utils@0.0.0-alpha.20":
-  version "0.0.0-alpha.20"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.20.tgz#cbc92e4c7e8754b051b7293af60a55a550fb6583"
-  integrity sha512-L/M9NPNlT1e38whA3M4QdnIDCClj6Y2GPXFOxBxuwzlmh847RHwZ/ojJpVP8sLVC+is54DS1hU9vtDkiPHGPRw==
+"@expo/apple-utils@0.0.0-alpha.23":
+  version "0.0.0-alpha.23"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.23.tgz#88c19bc8f02e6be2d88d3defe34311deb401e481"
+  integrity sha512-sp2kH5zoQ0kWhnVIlkN+x+GqeznueukdS80z9uhYpe6b8UXNzWgvQxV0y28V5k5stuut1G/IQjbKjVYdo93WKg==
 
 "@expo/babel-preset-cli@^0.2.17":
   version "0.2.18"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

- iOS 15 added new capabilities, this PR adds support for those new capabilities.
- https://github.com/expo/third-party/pull/58
- Downloaded the Xcode beta to get the entitlement keys

# Test Plan

- Updated the unit tests
- Tested the API directly
- Ran local EAS on a project with the following app.json:
```
{
  "expo": {
    "ios": {
      "entitlements": {
        "com.apple.developer.family-controls": true,
        "com.apple.developer.group-session": true,
        "com.apple.developer.usernotifications.communication": true,
        "com.apple.developer.usernotifications.time-sensitive": true
      }
    }
  }
}
``` 
- Got the following message: 
```
✔ Synced capabilities: Enabled: Family Controls, Group Activities, Communication Notifications, Time Sensitive Notifications
```
- Checked https://developer.apple.com/account/resources/identifiers/bundleId to ensure the updates applied