### PR TITLE
[eas-cli] un-hide project:*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `project:*` commands. ([#500](https://github.com/expo/eas-cli/pull/500) by [@jkhales](https://github.com/jkhales)) 
 - Added support for iOS 15 capabilities: Communication Notifications, Time Sensitive Notifications, Group Activities, and Family Controls. ([#499](https://github.com/expo/eas-cli/pull/499) by [@EvanBacon](https://github.com/EvanBacon))
 - Show more build metadata in `build:view` and `build:list`. ([#504](https://github.com/expo/eas-cli/pull/504) and [#508](https://github.com/expo/eas-cli/pull/508) by [@dsokal](https://github.com/dsokal))
 - Add runtime version to build metadata. ([#493](https://github.com/expo/eas-cli/pull/493) by [@dsokal](https://github.com/dsokal))
@@ -25,9 +26,6 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 - Unifify generic and managed workflow, deprecate `workflow` field. ([#497](https://github.com/expo/eas-cli/pull/497) by [@wkozyra95](https://github.com/wkozyra95))
-
-### 🐛 Bug fixes
-
 - Fix runtime version checks. ([#495](https://github.com/expo/eas-cli/pull/495) by [@dsokal](https://github.com/dsokal))
 - Resolve `--android-package` correctly in `eas submit` command. ([#494](https://github.com/expo/eas-cli/pull/494) by [@wkozyra95](https://github.com/wkozyra95))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 - Unifify generic and managed workflow, deprecate `workflow` field. ([#497](https://github.com/expo/eas-cli/pull/497) by [@wkozyra95](https://github.com/wkozyra95))
+
+### 🐛 Bug fixes
+
 - Fix runtime version checks. ([#495](https://github.com/expo/eas-cli/pull/495) by [@dsokal](https://github.com/dsokal))
 - Resolve `--android-package` correctly in `eas submit` command. ([#494](https://github.com/expo/eas-cli/pull/494) by [@wkozyra95](https://github.com/wkozyra95))
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -141,7 +141,7 @@
         "description": "manage update channels"
       },
       "device": {
-        "description": "manage your Apple devices"
+        "description": "manage your Apple devices for internal distribution"
       },
       "project": {
         "description": "manage your project"

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -131,14 +131,26 @@
     ],
     "helpClass": "./build/help",
     "topics": {
+      "account": {
+        "description": "manage your account"
+      },
       "build": {
         "description": "build app binaries"
       },
       "channel": {
         "description": "manage update channels"
       },
+      "device": {
+        "description": "manage your Apple devices"
+      },
+      "project": {
+        "description": "manage your project"
+      },
       "release": {
         "description": "manage update releases"
+      },
+      "secret": {
+        "description": "manage project and account secrets"
       },
       "update": {
         "description": "manage individual updates"

--- a/packages/eas-cli/src/commands/project/info.ts
+++ b/packages/eas-cli/src/commands/project/info.ts
@@ -31,7 +31,6 @@ async function projectInfoByIdAsync(appId: string): Promise<AppInfoQuery> {
 }
 
 export default class ProjectInfo extends Command {
-  static hidden = true;
   static description = 'information about the current project';
 
   async run() {
@@ -49,8 +48,8 @@ export default class ProjectInfo extends Command {
     Log.addNewLineIfNone();
     Log.log(
       formatFields([
-        { label: 'ID', value: projectId },
         { label: 'fullName', value: app.byId.fullName },
+        { label: 'ID', value: projectId },
       ])
     );
   }

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -6,7 +6,6 @@ import Log from '../../log';
 import { findProjectRootAsync, setProjectIdAsync } from '../../project/projectUtils';
 
 export default class ProjectInit extends Command {
-  static hidden = true;
   static description = 'create or link an EAS project';
   static aliases = ['init'];
 

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -15,7 +15,6 @@ import {
 import {
   findProjectRootAsync,
   getProjectAccountNameAsync,
-  getProjectFullNameAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
@@ -38,7 +37,6 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
-    const projectFullName = await getProjectFullNameAsync(exp);
     const projectAccountName = await getProjectAccountNameAsync(exp);
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
@@ -55,7 +53,7 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
     if (!id) {
       const validationMessage = 'You must select which secret to delete.';
 
-      const secrets = await EnvironmentSecretsQuery.allAsync(projectAccountName, projectFullName);
+      const secrets = await EnvironmentSecretsQuery.allAsync(projectAccountName, projectId);
 
       ({ secret } = await promptAsync({
         type: 'autocomplete',

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -13,7 +13,6 @@ import {
 import {
   findProjectRootAsync,
   getProjectAccountNameAsync,
-  getProjectFullNameAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
@@ -27,7 +26,6 @@ export default class EnvironmentSecretList extends Command {
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
-    const projectFullName = await getProjectFullNameAsync(exp);
     const projectAccountName = await getProjectAccountNameAsync(exp);
 
     if (!(await isEasEnabledForProjectAsync(projectId))) {
@@ -40,7 +38,7 @@ export default class EnvironmentSecretList extends Command {
       throw new Error("Please run this command inside your project's directory");
     }
 
-    const secrets = await EnvironmentSecretsQuery.allAsync(projectAccountName, projectFullName);
+    const secrets = await EnvironmentSecretsQuery.allAsync(projectAccountName, projectId);
 
     const table = new Table({
       head: ['Name', 'Scope', 'ID', 'Updated at'],

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4815,16 +4815,16 @@ export type EnvironmentSecretsByAccountNameQuery = (
   ) }
 );
 
-export type EnvironmentSecretsByAppFullNameQueryVariables = Exact<{
-  fullName: Scalars['String'];
+export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
+  appId: Scalars['String'];
 }>;
 
 
-export type EnvironmentSecretsByAppFullNameQuery = (
+export type EnvironmentSecretsByAppIdQuery = (
   { __typename?: 'RootQuery' }
   & { app?: Maybe<(
     { __typename?: 'AppQuery' }
-    & { byFullName: (
+    & { byId: (
       { __typename?: 'App' }
       & Pick<App, 'id'>
       & { environmentSecrets: Array<(

--- a/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
@@ -6,7 +6,7 @@ import { graphqlClient, withErrorHandlingAsync } from '../client';
 import {
   EnvironmentSecretFragment,
   EnvironmentSecretsByAccountNameQuery,
-  EnvironmentSecretsByAppFullNameQuery,
+  EnvironmentSecretsByAppIdQuery,
 } from '../generated';
 import { EnvironmentSecretFragmentNode } from '../types/EnvironmentSecret';
 
@@ -40,14 +40,14 @@ export const EnvironmentSecretsQuery = {
 
     return data.account.byName.environmentSecrets;
   },
-  async byAppFullNameAsync(fullName: string): Promise<EnvironmentSecretFragment[]> {
+  async byAppIdAsync(appId: string): Promise<EnvironmentSecretFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<EnvironmentSecretsByAppFullNameQuery>(
+        .query<EnvironmentSecretsByAppIdQuery>(
           gql`
-            query EnvironmentSecretsByAppFullName($fullName: String!) {
+            query EnvironmentSecretsByAppId($appId: String!) {
               app {
-                byFullName(fullName: $fullName) {
+                byId(appId: $appId) {
                   id
                   environmentSecrets {
                     id
@@ -58,12 +58,12 @@ export const EnvironmentSecretsQuery = {
             }
             ${print(EnvironmentSecretFragmentNode)}
           `,
-          { fullName }
+          { appId }
         )
         .toPromise()
     );
 
-    return data.app?.byFullName.environmentSecrets ?? [];
+    return data.app?.byId.environmentSecrets ?? [];
   },
   async allAsync(
     projectAccountName: string,
@@ -71,7 +71,7 @@ export const EnvironmentSecretsQuery = {
   ): Promise<EnvironmentSecretWithScope[]> {
     const [accountSecrets, appSecrets] = await Promise.all([
       this.byAcccountNameAsync(projectAccountName),
-      this.byAppFullNameAsync(projectFullName),
+      this.byAppIdAsync(projectFullName),
     ]);
 
     return [


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This removes `fullName` from the log messages as well as the graphQL calls in everything *but* the credentials commands.

The credentials are somewhat involved and will be done in a separate PR to keep things easily reviewable.

# How

* remove fullName in message logs
* replace graphQL calls that use fullName with their `byId` analog.
* remove `hidden` from `project:*` commands.

Also cleaned up the `topic` display:

Before:
<img width="935" alt="Screen Shot 2021-07-07 at 2 10 04 PM" src="https://user-images.githubusercontent.com/1220444/124829121-08420980-df2d-11eb-95b8-c237beaee660.png">
After:
<img width="635" alt="Screen Shot 2021-07-07 at 2 10 26 PM" src="https://user-images.githubusercontent.com/1220444/124829158-155ef880-df2d-11eb-8dd7-29e0f0dc0de8.png">
(another option is to just remove the descriptions of these topics as they are pretty redundant)

Q: Are there any other blockers to removing the `EAS_ENABLE_PROJECT_ID` gating?

# Test Plan

Tested commands in demo repo.
* branch:*
* channel:*
* build:*
* secrets:*
