### PR TITLE
[eas-cli] Error message for eas build downtime

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -103,6 +103,13 @@ export async function prepareBuildRequestForPlatformAsync<
           Log.error('EAS Build API has changed, please upgrade to the latest eas-cli version.');
           throw new Error('Build request failed.');
         } else if (
+          error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_DOWN_FOR_MAINTENANCE'
+        ) {
+          Log.error(
+            'EAS Build is down for maintenance, please try again later. Check https://status.expo.dev/ for updates.'
+          );
+          throw new Error('Build request failed.');
+        } else if (
           error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_TOO_MANY_PENDING_BUILDS'
         ) {
           Log.error(


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Handle error message for eas downtime

# How



# Test Plan

run local build with kill switch enabled
