### PR TITLE
[ENG-1474] build:list / build:view: print more metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Added support for iOS 15 capabilities: Communication Notifications, Time Sensitive Notifications, Group Activities, and Family Controls. ([#499](https://github.com/expo/eas-cli/pull/499) by [@EvanBacon](https://github.com/EvanBacon))
+- Show more build metadata in `build:view` and `build:list`. ([#504](https://github.com/expo/eas-cli/pull/504) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -10857,11 +10857,107 @@
             },
             "isDeprecated": true,
             "deprecationReason": "Use App.builds instead"
+          },
+          {
+            "name": "all",
+            "description": "Get all builds.\nBy default, they are sorted from latest to oldest.\nAvailable only for admin users.",
+            "args": [
+              {
+                "name": "statuses",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "BuildStatus",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "order",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "Order",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Build",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "Order",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DESC",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ASC",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/src/build/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/android/UpdatesModule.ts
@@ -94,7 +94,7 @@ export async function readChannelSafelyAsync(projectDir: string): Promise<string
     const androidManifest = await getAndroidManifestAsync(projectDir);
     const stringifiedRequestHeaders = AndroidConfig.Manifest.getMainApplicationMetaDataValue(
       androidManifest,
-      'expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY' //TODO-JJ AndroidConfig.Updates.Config.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY once https://github.com/expo/expo-cli/pull/3571 is published
+      AndroidConfig.Updates.Config.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
     );
     if (!stringifiedRequestHeaders) {
       return null;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1496,6 +1496,12 @@ export type BuildQuery = {
    * @deprecated Use App.builds instead
    */
   allForApp: Array<Maybe<Build>>;
+  /**
+   * Get all builds.
+   * By default, they are sorted from latest to oldest.
+   * Available only for admin users.
+   */
+  all: Array<Build>;
 };
 
 
@@ -1511,6 +1517,19 @@ export type BuildQueryAllForAppArgs = {
   offset?: Maybe<Scalars['Int']>;
   limit?: Maybe<Scalars['Int']>;
 };
+
+
+export type BuildQueryAllArgs = {
+  statuses?: Maybe<Array<BuildStatus>>;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+  order?: Maybe<Order>;
+};
+
+export enum Order {
+  Desc = 'DESC',
+  Asc = 'ASC'
+}
 
 export type ClientBuildQuery = {
   __typename?: 'ClientBuildQuery';
@@ -4963,7 +4982,7 @@ export type AppFragment = (
 
 export type BuildFragment = (
   { __typename?: 'Build' }
-  & Pick<Build, 'id' | 'status' | 'platform' | 'releaseChannel' | 'distribution' | 'createdAt' | 'updatedAt'>
+  & Pick<Build, 'id' | 'status' | 'platform' | 'channel' | 'releaseChannel' | 'distribution' | 'buildProfile' | 'sdkVersion' | 'appVersion' | 'appBuildVersion' | 'gitCommitHash' | 'createdAt' | 'updatedAt'>
   & { error?: Maybe<(
     { __typename?: 'BuildError' }
     & Pick<BuildError, 'errorCode' | 'message' | 'docsUrl'>

--- a/packages/eas-cli/src/graphql/types/Build.ts
+++ b/packages/eas-cli/src/graphql/types/Build.ts
@@ -34,8 +34,14 @@ export const BuildFragmentNode = gql`
         }
       }
     }
+    channel
     releaseChannel
     distribution
+    buildProfile
+    sdkVersion
+    appVersion
+    appBuildVersion
+    gitCommitHash
     createdAt
     updatedAt
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://linear.app/expo/issue/ENG-1474/update-eas-buildlist-and-buildshow-to-include-new-metadata

> We show version info, git commit sha, and more in the web ui now. We should dump all build metadata in build:list and build:show.

# How

- I added more build metadata to the table:
  - Channel - for new expo-updates backend
  - SDK Version
  - Version - `expo.version` (from app config) or value defined in the native project
  - Version code / Build number
  - Git commit hash
- I also added filtering for values that are null / undefined (e.g. we don't show `release` if the user has `releaseChannel` configured).  

# Test Plan

<img width="854" alt="Screenshot 2021-07-09 at 11 52 40" src="https://user-images.githubusercontent.com/5256730/125062252-78c46400-e0ae-11eb-8c55-f19499ea8335.png">