### PR TITLE
[eas-cli] add error message when free tier is disabled

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -110,6 +110,13 @@ export async function prepareBuildRequestForPlatformAsync<
           );
           throw new Error('Build request failed.');
         } else if (
+          error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED'
+        ) {
+          Log.error(
+            'EAS Build for free tier is temporarily disabled, please try again later. Check https://status.expo.dev/ for updates.'
+          );
+          throw new Error('Build request failed.');
+        } else if (
           error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_TOO_MANY_PENDING_BUILDS'
         ) {
           Log.error(

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -113,7 +113,7 @@ export async function prepareBuildRequestForPlatformAsync<
           error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED'
         ) {
           Log.error(
-            'EAS Build for free tier is temporarily disabled, please try again later. Check https://status.expo.dev/ for updates.'
+            'EAS Build free tier is temporarily disabled, please try again later. Check https://status.expo.dev/ for updates.'
           );
           throw new Error('Build request failed.');
         } else if (


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Better error message

# How

based on error code

# Test Plan


