### PR TITLE
[eas-cli] Add force option to overwrite existing secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `secret:create --force` command to overwrite existing secrets. ([#513](https://github.com/expo/eas-cli/pull/513) by [@bycedric](https://github.com/bycedric))
+
 ### 🐛 Bug fixes
 
 - Fix unhandled error when amplitude domains are blocked. ([#512](https://github.com/expo/eas-cli/pull/512) by [@wkozyra95](https://github.com/wkozyra95))

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
 import {
+  EnvironmentSecretScope,
   EnvironmentSecretWithScope,
   EnvironmentSecretsQuery,
 } from '../../graphql/queries/EnvironmentSecretsQuery';
@@ -19,7 +20,6 @@ import {
 } from '../../project/projectUtils';
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';
-import { EnvironmentSecretScope } from './create';
 
 export default class EnvironmentSecretDelete extends Command {
   static description = `Delete an environment secret by ID.

--- a/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
@@ -1,7 +1,6 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { EnvironmentSecretScope } from '../../commands/secret/create';
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import {
   EnvironmentSecretFragment,
@@ -9,6 +8,11 @@ import {
   EnvironmentSecretsByAppIdQuery,
 } from '../generated';
 import { EnvironmentSecretFragmentNode } from '../types/EnvironmentSecret';
+
+export enum EnvironmentSecretScope {
+  ACCOUNT = 'account',
+  PROJECT = 'project',
+}
 
 export type EnvironmentSecretWithScope = EnvironmentSecretFragment & {
   scope: EnvironmentSecretScope;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This is a proposal to help users tie their app properties better into their git workflow. Someone in discord mentioned they want to use the pipeline ID as version code. In the most ideal scenario, people would be able to specify additional environment variables when they start a build. But this seems like a quick alternative.

### Example

```bash
$ eas secret:create --name=PIPELINE_ID --value=$GITHUB_RUN_ID --force
$ eas build ...
```

**Pros**

- Keep environment variables up to date, programmatically
- Allows for tighter integration with existing workflows

**Cons**

- Running multiple builds at once will not inherit the right env var

# How

Added force option to `secret:create` instead of a new `secret:update` command. This reflects better what it actually would do, delete and create.

# Test Plan

```bash
$ eas secret:create --name=PIPELINE_ID --value=1337

# Would fail, because secret already exists
$ eas secret:create --name=PIPELINE_ID --value=1337

# Would succeed, if it exists it gets deleted before creating again
$ eas secret:create --force --name=PIPELINE_ID --value=2337
$ eas secret:create --force --name=NON_EXISTING --value=2337
```
