### PR TITLE
[eas-cli] Upload exp config as client config when publishing or republishing

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -313,6 +313,22 @@
             "deprecationReason": null
           },
           {
+            "name": "easBuild",
+            "description": "Top-level query object for querying EAS Build configuration.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EasBuildQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "experimentation",
             "description": "Top-level query object for querying Experimentation configuration.",
             "args": [],
@@ -1419,7 +1435,7 @@
           },
           {
             "name": "buildOrBuildJobs",
-            "description": "Coalesced Build (EAS) or BuildJob (Classic) items for this account. Use \"createdBefore\" to offset a query.",
+            "description": "Coalesced Build (EAS) or BuildJob (Classic) for all apps belonging to this account.",
             "args": [
               {
                 "name": "limit",
@@ -1437,7 +1453,7 @@
               },
               {
                 "name": "createdBefore",
-                "description": " Use a Date to offset queries ",
+                "description": " Offset the query ",
                 "type": {
                   "kind": "SCALAR",
                   "name": "DateTime",
@@ -1458,6 +1474,73 @@
                   "ofType": {
                     "kind": "INTERFACE",
                     "name": "BuildOrBuildJob",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use activityTimelineProjectActivities with filterTypes instead"
+          },
+          {
+            "name": "activityTimelineProjectActivities",
+            "description": "Coalesced project activity for all apps belonging to this account.",
+            "args": [
+              {
+                "name": "limit",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "createdBefore",
+                "description": " Offset the query ",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "filterTypes",
+                "description": " Types of objects to filter ",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ActivityTimelineProjectActivityType",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "ActivityTimelineProjectActivity",
                     "ofType": null
                   }
                 }
@@ -2822,7 +2905,7 @@
           },
           {
             "name": "buildOrBuildJobs",
-            "description": "Coalesced Build (EAS) or BuildJob (Classic) items for this app. Use \"createdBefore\" to offset a query.",
+            "description": "Coalesced Build (EAS) or BuildJob (Classic) items for this app.",
             "args": [
               {
                 "name": "limit",
@@ -2840,7 +2923,7 @@
               },
               {
                 "name": "createdBefore",
-                "description": " Use a Date to offset queries ",
+                "description": " Offset the query ",
                 "type": {
                   "kind": "SCALAR",
                   "name": "DateTime",
@@ -2866,8 +2949,8 @@
                 }
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use activityTimelineProjectActivities with filterTypes instead"
           },
           {
             "name": "submissions",
@@ -3168,7 +3251,7 @@
           },
           {
             "name": "activityTimelineProjectActivities",
-            "description": "Coalesced project activity for an app. Use \"createdBefore\" to offset a query.",
+            "description": "Coalesced project activity for an app",
             "args": [
               {
                 "name": "limit",
@@ -3186,11 +3269,29 @@
               },
               {
                 "name": "createdBefore",
-                "description": " Use a Date to offset queries ",
+                "description": " Offset the query ",
                 "type": {
                   "kind": "SCALAR",
                   "name": "DateTime",
                   "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "filterTypes",
+                "description": " Types of objects to filter ",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ActivityTimelineProjectActivityType",
+                      "ofType": null
+                    }
+                  }
                 },
                 "defaultValue": null
               }
@@ -4069,6 +4170,18 @@
             "deprecationReason": null
           },
           {
+            "name": "iosEnterpriseProvisioning",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildIosEnterpriseProvisioning",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildProfile",
             "description": "",
             "args": [],
@@ -4660,6 +4773,73 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "UserInvitation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activityTimelineProjectActivities",
+            "description": "Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer.",
+            "args": [
+              {
+                "name": "limit",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "createdBefore",
+                "description": " Offset the query ",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "filterTypes",
+                "description": " Types of objects to filter ",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ActivityTimelineProjectActivityType",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "ActivityTimelineProjectActivity",
                     "ofType": null
                   }
                 }
@@ -5341,6 +5521,41 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "ActivityTimelineProjectActivityType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILD_JOB",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BUILD",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UPDATE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUBMISSION",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "JSONObject",
         "description": "The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
@@ -5442,6 +5657,29 @@
           },
           {
             "name": "SIMULATOR",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BuildIosEnterpriseProvisioning",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ADHOC",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNIVERSAL",
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null
@@ -11091,6 +11329,113 @@
       },
       {
         "kind": "OBJECT",
+        "name": "EasBuildQuery",
+        "description": "",
+        "fields": [
+          {
+            "name": "killSwitches",
+            "description": "Get EAS Build kill switches state",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EasBuildKillSwitch",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EasBuildKillSwitch",
+        "description": "",
+        "fields": [
+          {
+            "name": "name",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EasBuildKillSwitchName",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EasBuildKillSwitchName",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "STOP_ACCEPTING_BUILDS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STOP_SCHEDULING_BUILDS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STOP_ACCEPTING_NORMAL_PRIORITY_BUILDS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ExperimentationQuery",
         "description": "",
         "fields": [
@@ -12172,6 +12517,22 @@
               "kind": "OBJECT",
               "name": "MeMutation",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "easBuildKillSwitch",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EasBuildKillSwitchMutation",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -16200,6 +16561,16 @@
             "defaultValue": null
           },
           {
+            "name": "iosEnterpriseProvisioning",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildIosEnterpriseProvisioning",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "appName",
             "description": "",
             "type": {
@@ -18826,9 +19197,13 @@
                 "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Update",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Update",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -19062,6 +19437,16 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "extra",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
             },
             "defaultValue": null
           }
@@ -20548,6 +20933,86 @@
                   "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EasBuildKillSwitchMutation",
+        "description": "",
+        "fields": [
+          {
+            "name": "set",
+            "description": "Set an EAS Build kill switch to a given value",
+            "args": [
+              {
+                "name": "name",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "EasBuildKillSwitchName",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "value",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EasBuildKillSwitch",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resetAll",
+            "description": "Reset all EAS Build kill switches (set them to false)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EasBuildKillSwitch",
+                    "ofType": null
+                  }
                 }
               }
             },

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -130,7 +130,10 @@ export default class BranchPublish extends Command {
       throw new Error('Please run this command inside a project directory.');
     }
 
-    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const { exp } = getConfig(projectDir, {
+      skipSDKVersionRequirement: true,
+      isPublicConfig: true,
+    });
     let { runtimeVersion, sdkVersion } = exp;
 
     // When a SDK version is supplied instead of a runtime version and we're in the managed workflow
@@ -260,7 +263,7 @@ export default class BranchPublish extends Command {
         const platforms = platformFlag === 'all' ? defaultPublishPlatforms : [platformFlag];
         const assets = collectAssets({ inputDir: inputDir!, platforms });
         await uploadAssetsAsync(assets);
-        updateInfoGroup = await buildUpdateInfoGroupAsync(assets);
+        updateInfoGroup = await buildUpdateInfoGroupAsync(assets, exp);
         assetSpinner.succeed('Uploaded assets!');
       } catch (e) {
         assetSpinner.fail('Failed to upload assets');

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -23,8 +23,6 @@ import formatFields from '../../utils/formatFields';
 
 const PAGE_LIMIT = 10_000;
 
-type TruncatedUpdate = Pick<Update, 'group' | 'message' | 'createdAt' | 'actor'>;
-
 export async function viewUpdateBranchAsync({
   appId,
   name,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -58,6 +58,8 @@ export type RootQuery = {
   buildJobs: BuildJobQuery;
   builds: BuildQuery;
   clientBuilds: ClientBuildQuery;
+  /** Top-level query object for querying EAS Build configuration. */
+  easBuild: EasBuildQuery;
   /** Top-level query object for querying Experimentation configuration. */
   experimentation: ExperimentationQuery;
   project: ProjectQuery;
@@ -188,8 +190,13 @@ export type Account = {
   buildJobs: Array<BuildJob>;
   /** (EAS Build) Builds associated with this account */
   builds: Array<Build>;
-  /** Coalesced Build (EAS) or BuildJob (Classic) items for this account. Use "createdBefore" to offset a query. */
+  /**
+   * Coalesced Build (EAS) or BuildJob (Classic) for all apps belonging to this account.
+   * @deprecated Use activityTimelineProjectActivities with filterTypes instead
+   */
   buildOrBuildJobs: Array<BuildOrBuildJob>;
+  /** Coalesced project activity for all apps belonging to this account. */
+  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   /** Owning User of this account if personal account */
   owner?: Maybe<User>;
   /** Actors associated with this account and permissions they hold */
@@ -276,6 +283,17 @@ export type AccountBuildsArgs = {
 export type AccountBuildOrBuildJobsArgs = {
   limit: Scalars['Int'];
   createdBefore?: Maybe<Scalars['DateTime']>;
+};
+
+
+/**
+ * An account is a container owning projects, credentials, billing and other organization
+ * data and settings. Actors may own and be members of accounts.
+ */
+export type AccountActivityTimelineProjectActivitiesArgs = {
+  limit: Scalars['Int'];
+  createdBefore?: Maybe<Scalars['DateTime']>;
+  filterTypes?: Maybe<Array<ActivityTimelineProjectActivityType>>;
 };
 
 
@@ -411,7 +429,10 @@ export type App = Project & {
   /** (EAS Build) Builds associated with this app */
   builds: Array<Build>;
   buildJobs: Array<BuildJob>;
-  /** Coalesced Build (EAS) or BuildJob (Classic) items for this app. Use "createdBefore" to offset a query. */
+  /**
+   * Coalesced Build (EAS) or BuildJob (Classic) items for this app.
+   * @deprecated Use activityTimelineProjectActivities with filterTypes instead
+   */
   buildOrBuildJobs: Array<BuildOrBuildJob>;
   /** EAS Submissions associated with this app */
   submissions: Array<Submission>;
@@ -427,7 +448,7 @@ export type App = Project & {
   updateBranches: Array<UpdateBranch>;
   /** get an EAS branch owned by the app by name */
   updateBranchByName?: Maybe<UpdateBranch>;
-  /** Coalesced project activity for an app. Use "createdBefore" to offset a query. */
+  /** Coalesced project activity for an app */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   /** Environment secrets for an app */
   environmentSecrets: Array<EnvironmentSecret>;
@@ -538,6 +559,7 @@ export type AppUpdateBranchByNameArgs = {
 export type AppActivityTimelineProjectActivitiesArgs = {
   limit: Scalars['Int'];
   createdBefore?: Maybe<Scalars['DateTime']>;
+  filterTypes?: Maybe<Array<ActivityTimelineProjectActivityType>>;
 };
 
 
@@ -622,6 +644,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   channel?: Maybe<Scalars['String']>;
   metrics?: Maybe<BuildMetrics>;
   distribution?: Maybe<DistributionType>;
+  iosEnterpriseProvisioning?: Maybe<BuildIosEnterpriseProvisioning>;
   buildProfile?: Maybe<Scalars['String']>;
   gitCommitHash?: Maybe<Scalars['String']>;
   error?: Maybe<BuildError>;
@@ -667,6 +690,8 @@ export type User = Actor & {
   hasPendingUserInvitations: Scalars['Boolean'];
   /** Pending UserInvitations for this user. Only resolves for the viewer. */
   pendingUserInvitations: Array<UserInvitation>;
+  /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
+  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   /**
    * Server feature gate values for this actor, optionally filtering by desired gates.
    * Only resolves for the viewer.
@@ -701,6 +726,14 @@ export type UserAppsArgs = {
   offset: Scalars['Int'];
   limit: Scalars['Int'];
   includeUnpublished?: Maybe<Scalars['Boolean']>;
+};
+
+
+/** Represents a human (not robot) actor. */
+export type UserActivityTimelineProjectActivitiesArgs = {
+  limit: Scalars['Int'];
+  createdBefore?: Maybe<Scalars['DateTime']>;
+  filterTypes?: Maybe<Array<ActivityTimelineProjectActivityType>>;
 };
 
 
@@ -781,6 +814,13 @@ export enum Role {
   NotAdmin = 'NOT_ADMIN'
 }
 
+export enum ActivityTimelineProjectActivityType {
+  BuildJob = 'BUILD_JOB',
+  Build = 'BUILD',
+  Update = 'UPDATE',
+  Submission = 'SUBMISSION'
+}
+
 
 export type BuildArtifacts = {
   __typename?: 'BuildArtifacts';
@@ -798,6 +838,11 @@ export enum DistributionType {
   Store = 'STORE',
   Internal = 'INTERNAL',
   Simulator = 'SIMULATOR'
+}
+
+export enum BuildIosEnterpriseProvisioning {
+  Adhoc = 'ADHOC',
+  Universal = 'UNIVERSAL'
 }
 
 export type BuildError = {
@@ -1552,6 +1597,24 @@ export type ClientBuild = {
   userId?: Maybe<Scalars['String']>;
 };
 
+export type EasBuildQuery = {
+  __typename?: 'EasBuildQuery';
+  /** Get EAS Build kill switches state */
+  killSwitches: Array<EasBuildKillSwitch>;
+};
+
+export type EasBuildKillSwitch = {
+  __typename?: 'EasBuildKillSwitch';
+  name: EasBuildKillSwitchName;
+  value: Scalars['Boolean'];
+};
+
+export enum EasBuildKillSwitchName {
+  StopAcceptingBuilds = 'STOP_ACCEPTING_BUILDS',
+  StopSchedulingBuilds = 'STOP_SCHEDULING_BUILDS',
+  StopAcceptingNormalPriorityBuilds = 'STOP_ACCEPTING_NORMAL_PRIORITY_BUILDS'
+}
+
 export type ExperimentationQuery = {
   __typename?: 'ExperimentationQuery';
   /** Get user experimentation config */
@@ -1731,6 +1794,7 @@ export type RootMutation = {
   userInvitation: UserInvitationMutation;
   /** Mutations that modify the currently authenticated User */
   me?: Maybe<MeMutation>;
+  easBuildKillSwitch: EasBuildKillSwitchMutation;
   /** Mutations that modify an EmailSubscription */
   emailSubscription: EmailSubscriptionMutation;
   /** Mutations that create and delete EnvironmentSecrets */
@@ -2485,6 +2549,7 @@ export type BuildMetadataInput = {
   releaseChannel?: Maybe<Scalars['String']>;
   channel?: Maybe<Scalars['String']>;
   distribution?: Maybe<DistributionType>;
+  iosEnterpriseProvisioning?: Maybe<BuildIosEnterpriseProvisioning>;
   appName?: Maybe<Scalars['String']>;
   appIdentifier?: Maybe<Scalars['String']>;
   buildProfile?: Maybe<Scalars['String']>;
@@ -2891,7 +2956,7 @@ export type UpdateBranchMutation = {
   /** Delete an EAS branch and all of its updates as long as the branch is not being used by any channels */
   deleteUpdateBranch: DeleteUpdateBranchResult;
   /** Publish an update group to a branch */
-  publishUpdateGroup: Array<Maybe<Update>>;
+  publishUpdateGroup: Array<Update>;
 };
 
 
@@ -2943,6 +3008,7 @@ export type UpdateInfoGroup = {
 export type PartialManifest = {
   launchAsset: PartialManifestAsset;
   assets: Array<Maybe<PartialManifestAsset>>;
+  extra?: Maybe<Scalars['JSONObject']>;
 };
 
 export type PartialManifestAsset = {
@@ -3224,6 +3290,20 @@ export type SecondFactorBooleanResult = {
 export type SecondFactorRegenerateBackupCodesResult = {
   __typename?: 'SecondFactorRegenerateBackupCodesResult';
   plaintextBackupCodes: Array<Maybe<Scalars['String']>>;
+};
+
+export type EasBuildKillSwitchMutation = {
+  __typename?: 'EasBuildKillSwitchMutation';
+  /** Set an EAS Build kill switch to a given value */
+  set: EasBuildKillSwitch;
+  /** Reset all EAS Build kill switches (set them to false) */
+  resetAll: Array<EasBuildKillSwitch>;
+};
+
+
+export type EasBuildKillSwitchMutationSetArgs = {
+  name: EasBuildKillSwitchName;
+  value: Scalars['Boolean'];
 };
 
 export type EmailSubscriptionMutation = {
@@ -4659,10 +4739,10 @@ export type UpdatePublishMutation = (
   { __typename?: 'RootMutation' }
   & { updateBranch: (
     { __typename?: 'UpdateBranchMutation' }
-    & { publishUpdateGroup: Array<Maybe<(
+    & { publishUpdateGroup: Array<(
       { __typename?: 'Update' }
       & Pick<Update, 'id' | 'group'>
-    )>> }
+    )> }
   ) }
 );
 

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -155,22 +155,28 @@ describe(buildUpdateInfoGroupAsync, () => {
 
   it('returns the correct value', async () => {
     await expect(
-      buildUpdateInfoGroupAsync({
-        android: {
-          launchAsset: {
-            type: 'bundle',
-            contentType: 'bundle/javascript',
-            path: androidBundlePath,
-          },
-          assets: [
-            {
-              type: 'jpg',
-              contentType: 'image/jpeg',
-              path: assetPath,
+      buildUpdateInfoGroupAsync(
+        {
+          android: {
+            launchAsset: {
+              type: 'bundle',
+              contentType: 'bundle/javascript',
+              path: androidBundlePath,
             },
-          ],
+            assets: [
+              {
+                type: 'jpg',
+                contentType: 'image/jpeg',
+                path: assetPath,
+              },
+            ],
+          },
         },
-      })
+        {
+          slug: 'hello',
+          name: 'hello',
+        }
+      )
     ).resolves.toEqual({
       android: {
         assets: [
@@ -182,13 +188,18 @@ describe(buildUpdateInfoGroupAsync, () => {
             storageKey: 'fo8Y08LktVk6qLtGbn8GRWpOUyD13ABMUnbtRCN1L7Y',
           },
         ],
-
         launchAsset: {
           bundleKey: 'ec0dd14670aae108f99a810df9c1482c',
           contentType: 'bundle/javascript',
           fileSHA256: 'KEw79FnKTLOyVbRT1SlohSTjPe5e8FpULy2ST-I5BUg',
           storageBucket: 'update-assets-production',
           storageKey: 'aC9N6RZlcHoIYjIsoJd2KUcigBKy98RHvZacDyPNjCQ',
+        },
+        extra: {
+          expoClient: {
+            slug: 'hello',
+            name: 'hello',
+          },
         },
       },
     });

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -1,4 +1,4 @@
-import { Platform } from '@expo/config';
+import { ExpoConfig, Platform } from '@expo/config';
 import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
 import Joi from '@hapi/joi';
@@ -46,9 +46,14 @@ type CollectedAssets = {
   };
 };
 
+type ManifestExtra = {
+  expoClient?: { [key: string]: any };
+  [key: string]: any;
+};
 type ManifestFragment = {
   launchAsset: PartialManifestAsset;
   assets: PartialManifestAsset[];
+  extra?: ManifestExtra;
 };
 type UpdateInfoGroup = {
   [key in PublishPlatform]: ManifestFragment;
@@ -125,7 +130,10 @@ export async function convertAssetToUpdateInfoGroupFormatAsync(
   };
 }
 
-export async function buildUpdateInfoGroupAsync(assets: CollectedAssets): Promise<UpdateInfoGroup> {
+export async function buildUpdateInfoGroupAsync(
+  assets: CollectedAssets,
+  exp: ExpoConfig
+): Promise<UpdateInfoGroup> {
   let platform: PublishPlatform;
   const updateInfoGroup: Partial<UpdateInfoGroup> = {};
   for (platform in assets) {
@@ -134,6 +142,9 @@ export async function buildUpdateInfoGroupAsync(assets: CollectedAssets): Promis
       assets: await Promise.all(
         (assets[platform]?.assets ?? []).map(convertAssetToUpdateInfoGroupFormatAsync)
       ),
+      extra: {
+        expoClient: exp,
+      },
     };
   }
   return updateInfoGroup as UpdateInfoGroup;


### PR DESCRIPTION
# Why

As of https://github.com/expo/universe/pull/7893, the server will support storing and serving the `extra.expoClient` field in the eas update manifest. As part of that, we need to upload it during the update group publish process.

# How

Include the public `exp` project config in the `updateInfo` fields. This is the same thing that is uploaded in the `expo-cli` publish process as the "manifest" (https://github.com/expo/expo-cli/blob/master/packages/xdl/src/project/getPublishExpConfigAsync.ts#L35), which is what we want to put in the `extra.expoClient` field.

The format of the `extra.expoClient` field is defined in https://github.com/expo/expo-cli/pull/3606.

# Test Plan

Waiting on the dependent www PR to go to staging/prod, but after it does the test plan will be:
- `eas branch:publish` and then get a manifest for the update, ensure it contains the `extra.expoClient` field.
