### PR TITLE
[eas submit] propagate build id to submission mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp
 node_modules
 coverage
 .history
+.DS_Store

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -313,6 +313,22 @@
             "deprecationReason": null
           },
           {
+            "name": "easBuild",
+            "description": "Top-level query object for querying EAS Build configuration.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EasBuildQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "experimentation",
             "description": "Top-level query object for querying Experimentation configuration.",
             "args": [],
@@ -1419,7 +1435,7 @@
           },
           {
             "name": "buildOrBuildJobs",
-            "description": "Coalesced Build (EAS) or BuildJob (Classic) items for this account. Use \"createdBefore\" to offset a query.",
+            "description": "Coalesced Build (EAS) or BuildJob (Classic) for all apps belonging to this account.",
             "args": [
               {
                 "name": "limit",
@@ -1437,7 +1453,7 @@
               },
               {
                 "name": "createdBefore",
-                "description": " Use a Date to offset queries ",
+                "description": " Offset the query ",
                 "type": {
                   "kind": "SCALAR",
                   "name": "DateTime",
@@ -1458,6 +1474,73 @@
                   "ofType": {
                     "kind": "INTERFACE",
                     "name": "BuildOrBuildJob",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use activityTimelineProjectActivities with filterTypes instead"
+          },
+          {
+            "name": "activityTimelineProjectActivities",
+            "description": "Coalesced project activity for all apps belonging to this account.",
+            "args": [
+              {
+                "name": "limit",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "createdBefore",
+                "description": " Offset the query ",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "filterTypes",
+                "description": " Types of objects to filter ",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ActivityTimelineProjectActivityType",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "ActivityTimelineProjectActivity",
                     "ofType": null
                   }
                 }
@@ -2822,7 +2905,7 @@
           },
           {
             "name": "buildOrBuildJobs",
-            "description": "Coalesced Build (EAS) or BuildJob (Classic) items for this app. Use \"createdBefore\" to offset a query.",
+            "description": "Coalesced Build (EAS) or BuildJob (Classic) items for this app.",
             "args": [
               {
                 "name": "limit",
@@ -2840,7 +2923,7 @@
               },
               {
                 "name": "createdBefore",
-                "description": " Use a Date to offset queries ",
+                "description": " Offset the query ",
                 "type": {
                   "kind": "SCALAR",
                   "name": "DateTime",
@@ -2866,8 +2949,8 @@
                 }
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use activityTimelineProjectActivities with filterTypes instead"
           },
           {
             "name": "submissions",
@@ -3168,7 +3251,7 @@
           },
           {
             "name": "activityTimelineProjectActivities",
-            "description": "Coalesced project activity for an app. Use \"createdBefore\" to offset a query.",
+            "description": "Coalesced project activity for an app",
             "args": [
               {
                 "name": "limit",
@@ -3186,11 +3269,29 @@
               },
               {
                 "name": "createdBefore",
-                "description": " Use a Date to offset queries ",
+                "description": " Offset the query ",
                 "type": {
                   "kind": "SCALAR",
                   "name": "DateTime",
                   "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "filterTypes",
+                "description": " Types of objects to filter ",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ActivityTimelineProjectActivityType",
+                      "ofType": null
+                    }
+                  }
                 },
                 "defaultValue": null
               }
@@ -4669,6 +4770,73 @@
             "deprecationReason": null
           },
           {
+            "name": "activityTimelineProjectActivities",
+            "description": "Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer.",
+            "args": [
+              {
+                "name": "limit",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "createdBefore",
+                "description": " Offset the query ",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "filterTypes",
+                "description": " Types of objects to filter ",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ActivityTimelineProjectActivityType",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "ActivityTimelineProjectActivity",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "featureGates",
             "description": "Server feature gate values for this actor, optionally filtering by desired gates.\nOnly resolves for the viewer.",
             "args": [
@@ -5333,6 +5501,41 @@
           },
           {
             "name": "NOT_ADMIN",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ActivityTimelineProjectActivityType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILD_JOB",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BUILD",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UPDATE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUBMISSION",
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null
@@ -11091,6 +11294,113 @@
       },
       {
         "kind": "OBJECT",
+        "name": "EasBuildQuery",
+        "description": "",
+        "fields": [
+          {
+            "name": "killSwitches",
+            "description": "Get EAS Build kill switches state",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EasBuildKillSwitch",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EasBuildKillSwitch",
+        "description": "",
+        "fields": [
+          {
+            "name": "name",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EasBuildKillSwitchName",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EasBuildKillSwitchName",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "STOP_ACCEPTING_BUILDS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STOP_SCHEDULING_BUILDS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STOP_ACCEPTING_NORMAL_PRIORITY_BUILDS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ExperimentationQuery",
         "description": "",
         "fields": [
@@ -12172,6 +12482,22 @@
               "kind": "OBJECT",
               "name": "MeMutation",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "easBuildKillSwitch",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EasBuildKillSwitchMutation",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -20548,6 +20874,86 @@
                   "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EasBuildKillSwitchMutation",
+        "description": "",
+        "fields": [
+          {
+            "name": "set",
+            "description": "Set an EAS Build kill switch to a given value",
+            "args": [
+              {
+                "name": "name",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "EasBuildKillSwitchName",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "value",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EasBuildKillSwitch",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resetAll",
+            "description": "Reset all EAS Build kill switches (set them to false)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EasBuildKillSwitch",
+                    "ofType": null
+                  }
                 }
               }
             },

--- a/packages/eas-cli/src/graphql/mutations/SubmissionMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/SubmissionMutation.ts
@@ -17,6 +17,7 @@ interface CreateSubmissionResult {
 export const SubmissionMutation = {
   async createSubmissionAsync(input: {
     appId: string;
+    submittedBuildId?: string;
     platform: AppPlatform;
     config: JSONObject;
   }): Promise<CreateSubmissionResult> {

--- a/packages/eas-cli/src/graphql/mutations/SubmissionMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/SubmissionMutation.ts
@@ -29,9 +29,17 @@ export const SubmissionMutation = {
               $appId: ID!
               $platform: AppPlatform!
               $config: JSONObject!
+              $submittedBuildId: ID
             ) {
               submission {
-                createSubmission(input: { appId: $appId, platform: $platform, config: $config }) {
+                createSubmission(
+                  input: {
+                    appId: $appId
+                    platform: $platform
+                    config: $config
+                    submittedBuildId: $submittedBuildId
+                  }
+                ) {
                   submission {
                     id
                   }

--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -22,6 +22,7 @@ abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
 
   protected async startSubmissionAsync(
     submissionConfig: SubmissionConfig,
+    submittedBuildId?: string,
     verbose: boolean = false
   ): Promise<SubmissionStatus> {
     Log.addNewLineIfNone();
@@ -31,7 +32,8 @@ abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
       submissionId = await SubmissionService.startSubmissionAsync(
         this.platform,
         submissionConfig.projectId,
-        submissionConfig
+        submissionConfig,
+        submittedBuildId
       );
       scheduleSpinner.succeed();
     } catch (err) {

--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -22,7 +22,7 @@ abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
 
   protected async startSubmissionAsync(
     submissionConfig: SubmissionConfig,
-    submittedBuildId?: string,
+    buildId?: string,
     verbose: boolean = false
   ): Promise<SubmissionStatus> {
     Log.addNewLineIfNone();
@@ -33,7 +33,7 @@ abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
         this.platform,
         submissionConfig.projectId,
         submissionConfig,
-        submittedBuildId
+        buildId
       );
       scheduleSpinner.succeed();
     } catch (err) {

--- a/packages/eas-cli/src/submissions/SubmissionService.ts
+++ b/packages/eas-cli/src/submissions/SubmissionService.ts
@@ -21,13 +21,13 @@ async function startSubmissionAsync(
   platform: AppPlatform,
   projectId: string,
   config: SubmissionConfig,
-  submittedBuildId?: string
+  buildId?: string
 ): Promise<StartSubmissionResult> {
   const { submission } = await SubmissionMutation.createSubmissionAsync({
     appId: projectId,
     platform,
     config: (config as unknown) as JSONObject,
-    submittedBuildId,
+    submittedBuildId: buildId,
   });
   return submission.id;
 }

--- a/packages/eas-cli/src/submissions/SubmissionService.ts
+++ b/packages/eas-cli/src/submissions/SubmissionService.ts
@@ -20,12 +20,14 @@ export const DEFAULT_CHECK_INTERVAL_MS = 5 * 1000; // 5 secs
 async function startSubmissionAsync(
   platform: AppPlatform,
   projectId: string,
-  config: SubmissionConfig
+  config: SubmissionConfig,
+  submittedBuildId?: string
 ): Promise<StartSubmissionResult> {
   const { submission } = await SubmissionMutation.createSubmissionAsync({
     appId: projectId,
     platform,
     config: (config as unknown) as JSONObject,
+    submittedBuildId,
   });
   return submission.id;
 }

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
@@ -92,8 +92,8 @@ class AndroidSubmitter extends BaseSubmitter<AndroidSubmissionContext, AndroidSu
       track,
       releaseStatus,
       archiveType: archive.type as AndroidArchiveType,
-      ...formatArchiveSourceSummary(archive),
       serviceAccountPath,
+      ...formatArchiveSourceSummary(archive),
     };
   }
 }
@@ -112,11 +112,11 @@ const SummaryHumanReadableKeys: Record<keyof Summary, string> = {
   archivePath: 'Archive path',
   archiveUrl: 'Download URL',
   archiveType: 'Archive type',
-  buildId: 'Build ID',
   serviceAccountPath: 'Google Service Key',
   track: 'Release track',
   releaseStatus: 'Release status',
   projectId: 'Project ID',
+  submittedBuildDetails: 'Submitted Build',
 };
 
 const SummaryHumanReadableValues: Partial<Record<keyof Summary, Function>> = {

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
@@ -43,7 +43,11 @@ class AndroidSubmitter extends BaseSubmitter<AndroidSubmissionContext, AndroidSu
       SummaryHumanReadableValues
     );
 
-    await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
+    await this.startSubmissionAsync(
+      submissionConfig,
+      resolvedSourceOptions.archive.submittedBuildDetails?.buildId,
+      this.ctx.commandFlags.verbose
+    );
   }
 
   private async resolveSourceOptions(): Promise<ResolvedSourceOptions> {

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
@@ -45,7 +45,7 @@ class AndroidSubmitter extends BaseSubmitter<AndroidSubmissionContext, AndroidSu
 
     await this.startSubmissionAsync(
       submissionConfig,
-      resolvedSourceOptions.archive.submittedBuildDetails?.buildId,
+      resolvedSourceOptions.archive.build?.id,
       this.ctx.commandFlags.verbose
     );
   }
@@ -116,7 +116,7 @@ const SummaryHumanReadableKeys: Record<keyof Summary, string> = {
   track: 'Release track',
   releaseStatus: 'Release status',
   projectId: 'Project ID',
-  submittedBuildDetails: 'Submitted Build',
+  formattedBuild: 'Build',
 };
 
 const SummaryHumanReadableValues: Partial<Record<keyof Summary, Function>> = {

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -111,7 +111,8 @@ describe(AndroidSubmitCommand, () => {
       expect(SubmissionService.startSubmissionAsync).toHaveBeenCalledWith(
         AppPlatform.Android,
         projectId,
-        androidSubmissionConfig
+        androidSubmissionConfig,
+        undefined
       );
     });
   });

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -3,12 +3,17 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { asMock } from '../../../__tests__/utils';
 import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
-import { AppPlatform, SubmissionFragment, SubmissionStatus } from '../../../graphql/generated';
+import {
+  AppPlatform,
+  BuildFragment,
+  SubmissionFragment,
+  SubmissionStatus,
+} from '../../../graphql/generated';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { getProjectIdAsync } from '../../../project/projectUtils';
 import SubmissionService from '../../SubmissionService';
 import { AndroidArchiveType, AndroidSubmitCommandFlags } from '../../types';
-import { getLatestBuildInfoAsync } from '../../utils/builds';
+import { getLatestBuildForSubmissionAsync } from '../../utils/builds';
 import { AndroidSubmissionConfig, ReleaseStatus, ReleaseTrack } from '../AndroidSubmissionConfig';
 import AndroidSubmitCommand from '../AndroidSubmitCommand';
 
@@ -37,9 +42,9 @@ describe(AndroidSubmitCommand, () => {
     '/google-service-account.json': JSON.stringify({ service: 'account' }),
   };
 
-  const fakeBuildDetails = {
-    buildId: uuidv4(),
-    artifactUrl: 'http://expo.io/fake.apk',
+  const fakeBuildFragment: Partial<BuildFragment> = {
+    id: uuidv4(),
+    artifacts: { buildUrl: 'http://expo.io/fake.apk' },
     appVersion: '1.2.3',
     platform: AppPlatform.Android,
   };
@@ -137,7 +142,7 @@ describe(AndroidSubmitCommand, () => {
         }
       );
       asMock(getProjectIdAsync).mockImplementationOnce(() => projectId);
-      asMock(getLatestBuildInfoAsync).mockResolvedValueOnce(fakeBuildDetails);
+      asMock(getLatestBuildForSubmissionAsync).mockResolvedValueOnce(fakeBuildFragment);
 
       const options: AndroidSubmitCommandFlags = {
         latest: true,
@@ -165,7 +170,7 @@ describe(AndroidSubmitCommand, () => {
         AppPlatform.Android,
         projectId,
         androidSubmissionConfig,
-        fakeBuildDetails.buildId
+        fakeBuildFragment.id
       );
     });
   });

--- a/packages/eas-cli/src/submissions/archiveSource/ArchiveFileSource.ts
+++ b/packages/eas-cli/src/submissions/archiveSource/ArchiveFileSource.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { URL, parse as parseUrl } from 'url';
 import * as uuid from 'uuid';
 
-import { AppPlatform } from '../../graphql/generated';
+import { AppPlatform, BuildFragment } from '../../graphql/generated';
 import Log from '../../log';
 import { promptAsync } from '../../prompts';
 import { getBuildArtifactUrlByIdAsync, getLatestBuildArtifactUrlAsync } from '../utils/builds';
@@ -49,6 +49,7 @@ interface ArchiveFilePromptSource extends ArchiveFileSourceBase {
 export interface ResolvedArchive {
   location: string;
   realSource: ArchiveFileSource;
+  buildDetails?: BuildFragment;
 }
 
 export type ArchiveFileSource =

--- a/packages/eas-cli/src/submissions/archiveSource/index.ts
+++ b/packages/eas-cli/src/submissions/archiveSource/index.ts
@@ -1,5 +1,6 @@
 import { AppPlatform } from '../../graphql/generated';
 import { ArchiveType } from '../types';
+import { SubmittedBuildInfo } from '../utils/builds';
 import {
   ArchiveFileSource,
   ArchiveFileSourceType,
@@ -16,18 +17,22 @@ export interface Archive {
   location: string;
   type: ArchiveType;
   realFileSource: ArchiveFileSource;
+  submittedBuildDetails?: SubmittedBuildInfo;
 }
 
 export async function getArchiveAsync(
   platform: AppPlatform,
   source: ArchiveSource
 ): Promise<Archive> {
-  const { location, realSource } = await getArchiveFileLocationAsync(source.archiveFile);
+  const { location, realSource, buildDetails } = await getArchiveFileLocationAsync(
+    source.archiveFile
+  );
   const type = await getArchiveTypeAsync(platform, source.archiveType, location);
   return {
     location,
     type,
     realFileSource: realSource,
+    submittedBuildDetails: buildDetails,
   };
 }
 

--- a/packages/eas-cli/src/submissions/archiveSource/index.ts
+++ b/packages/eas-cli/src/submissions/archiveSource/index.ts
@@ -1,6 +1,5 @@
-import { AppPlatform } from '../../graphql/generated';
+import { AppPlatform, BuildFragment } from '../../graphql/generated';
 import { ArchiveType } from '../types';
-import { SubmittedBuildInfo } from '../utils/builds';
 import {
   ArchiveFileSource,
   ArchiveFileSourceType,
@@ -17,22 +16,20 @@ export interface Archive {
   location: string;
   type: ArchiveType;
   realFileSource: ArchiveFileSource;
-  submittedBuildDetails?: SubmittedBuildInfo;
+  build?: BuildFragment;
 }
 
 export async function getArchiveAsync(
   platform: AppPlatform,
   source: ArchiveSource
 ): Promise<Archive> {
-  const { location, realSource, buildDetails } = await getArchiveFileLocationAsync(
-    source.archiveFile
-  );
+  const { location, realSource, build } = await getArchiveFileLocationAsync(source.archiveFile);
   const type = await getArchiveTypeAsync(platform, source.archiveType, location);
   return {
     location,
     type,
     realFileSource: realSource,
-    submittedBuildDetails: buildDetails,
+    build,
   };
 }
 

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -49,7 +49,12 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
       SummaryHumanReadableKeys,
       SummaryHumanReadableValues
     );
-    const result = await this.startSubmissionAsync(submissionConfig, this.ctx.commandFlags.verbose);
+
+    const result = await this.startSubmissionAsync(
+      submissionConfig,
+      resolvedSourceOptions.archive.submittedBuildDetails?.buildId,
+      this.ctx.commandFlags.verbose
+    );
 
     if (result === SubmissionStatus.Finished) {
       Log.addNewLineIfNone();

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -120,7 +120,7 @@ const SummaryHumanReadableKeys: Record<keyof SummaryData, string> = {
   projectId: 'Project ID',
   archiveUrl: 'Archive URL',
   archivePath: 'Archive Path',
-  buildId: 'Build ID',
+  submittedBuildDetails: 'Submitted Build',
 };
 
 const SummaryHumanReadableValues: Partial<Record<keyof SummaryData, Function>> = {};

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -52,7 +52,7 @@ class IosSubmitter extends BaseSubmitter<IosSubmissionContext, IosSubmissionOpti
 
     const result = await this.startSubmissionAsync(
       submissionConfig,
-      resolvedSourceOptions.archive.submittedBuildDetails?.buildId,
+      resolvedSourceOptions.archive.build?.id,
       this.ctx.commandFlags.verbose
     );
 
@@ -120,7 +120,7 @@ const SummaryHumanReadableKeys: Record<keyof SummaryData, string> = {
   projectId: 'Project ID',
   archiveUrl: 'Archive URL',
   archivePath: 'Archive Path',
-  submittedBuildDetails: 'Submitted Build',
+  formattedBuild: 'Build',
 };
 
 const SummaryHumanReadableValues: Partial<Record<keyof SummaryData, Function>> = {};

--- a/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
@@ -104,7 +104,8 @@ describe(IosSubmitCommand, () => {
       expect(SubmissionService.startSubmissionAsync).toHaveBeenCalledWith(
         AppPlatform.Ios,
         projectId,
-        iosSubmissionConfig
+        iosSubmissionConfig,
+        undefined
       );
 
       delete process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD;

--- a/packages/eas-cli/src/submissions/utils/builds.ts
+++ b/packages/eas-cli/src/submissions/utils/builds.ts
@@ -2,8 +2,8 @@ import { AppPlatform, BuildArtifacts, BuildFragment, BuildStatus } from '../../g
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 
 // `BuildFragment` with non-null `artifacts.buildUrl`
-type BuildFragmentWithArtifact = Omit<BuildFragment, 'artifacts'> & {
-  artifacts: Omit<BuildArtifacts, 'buildUrl'> & BuildArtifacts & { buildUrl: string };
+type BuildFragmentWithArtifact = BuildFragment & {
+  artifacts: BuildArtifacts & { buildUrl: string };
 };
 
 /**

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -1,34 +1,32 @@
 import chalk from 'chalk';
 
-import { AppPlatform } from '../../graphql/generated';
+import { AppPlatform, BuildFragment } from '../../graphql/generated';
 import Log from '../../log';
 import formatFields from '../../utils/formatFields';
 import { Archive, ArchiveFileSourceType } from '../archiveSource';
-import { SubmittedBuildInfo } from './builds';
-
 export interface ArchiveSourceSummaryFields {
   archiveUrl?: string;
   archivePath?: string;
-  submittedBuildDetails?: string;
+  formattedBuild?: string;
 }
 
-function formatSubmittedBuildSummary(info: SubmittedBuildInfo) {
+function formatSubmissionBuildSummary(build: BuildFragment) {
   const fields = [
     {
       label: 'Build ID',
-      value: info.buildId,
+      value: build.id,
     },
     {
       label: 'Build Date',
-      value: new Date(info.createdAt).toLocaleString(),
+      value: new Date(build.createdAt).toLocaleString(),
     },
     {
       label: 'App Version',
-      value: info.appVersion,
+      value: build.appVersion,
     },
     {
-      label: info.platform === AppPlatform.Android ? 'Version code' : 'Build number',
-      value: info.appBuildVersion,
+      label: build.platform === AppPlatform.Android ? 'Version code' : 'Build number',
+      value: build.appBuildVersion,
     },
   ];
 
@@ -47,7 +45,7 @@ function formatSubmittedBuildSummary(info: SubmittedBuildInfo) {
 
 export function formatArchiveSourceSummary({
   realFileSource,
-  submittedBuildDetails,
+  build,
 }: Archive): ArchiveSourceSummaryFields {
   const summarySlice: ArchiveSourceSummaryFields = {};
 
@@ -60,7 +58,7 @@ export function formatArchiveSourceSummary({
       break;
     case ArchiveFileSourceType.buildId:
     case ArchiveFileSourceType.latest:
-      summarySlice.submittedBuildDetails = formatSubmittedBuildSummary(submittedBuildDetails!);
+      summarySlice.formattedBuild = formatSubmissionBuildSummary(build!);
       break;
   }
   return summarySlice;

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -12,6 +12,7 @@ export interface ArchiveSourceSummaryFields {
 
 export function formatArchiveSourceSummary({
   realFileSource,
+  submittedBuildDetails,
 }: Archive): ArchiveSourceSummaryFields {
   const summarySlice: ArchiveSourceSummaryFields = {};
 
@@ -26,8 +27,7 @@ export function formatArchiveSourceSummary({
       summarySlice.buildId = realFileSource.id;
       break;
     case ArchiveFileSourceType.latest:
-      // TODO: Resolve real build ID here
-      summarySlice.buildId = '[latest]';
+      summarySlice.buildId = submittedBuildDetails?.buildId;
       break;
   }
   return summarySlice;

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -1,13 +1,48 @@
 import chalk from 'chalk';
 
+import { AppPlatform } from '../../graphql/generated';
 import Log from '../../log';
 import formatFields from '../../utils/formatFields';
 import { Archive, ArchiveFileSourceType } from '../archiveSource';
+import { SubmittedBuildInfo } from './builds';
 
 export interface ArchiveSourceSummaryFields {
   archiveUrl?: string;
   archivePath?: string;
-  buildId?: string;
+  submittedBuildDetails?: string;
+}
+
+function formatSubmittedBuildSummary(info: SubmittedBuildInfo) {
+  const fields = [
+    {
+      label: 'Build ID',
+      value: info.buildId,
+    },
+    {
+      label: 'Build Date',
+      value: new Date(info.createdAt).toLocaleString(),
+    },
+    {
+      label: 'App Version',
+      value: info.appVersion,
+    },
+    {
+      label: info.platform === AppPlatform.Android ? 'Version code' : 'Build number',
+      value: info.appBuildVersion,
+    },
+  ];
+
+  const filteredFields = fields.filter(({ value }) => value !== undefined && value !== null) as {
+    label: string;
+    value: string;
+  }[];
+
+  return (
+    '\n' +
+    formatFields(filteredFields, {
+      labelFormat: label => `    ${chalk.dim(label)}:`,
+    })
+  );
 }
 
 export function formatArchiveSourceSummary({
@@ -24,10 +59,8 @@ export function formatArchiveSourceSummary({
       summarySlice.archiveUrl = realFileSource.url;
       break;
     case ArchiveFileSourceType.buildId:
-      summarySlice.buildId = realFileSource.id;
-      break;
     case ArchiveFileSourceType.latest:
-      summarySlice.buildId = submittedBuildDetails?.buildId;
+      summarySlice.submittedBuildDetails = formatSubmittedBuildSummary(submittedBuildDetails!);
       break;
   }
   return summarySlice;


### PR DESCRIPTION
# Why

In https://github.com/expo/universe/pull/7799 we created relationship between builds and submissions. When an EAS build is submitted, we should attach its ID to the submission.

# How

- Ran graphql codegen
- When the _Latest_ or _Build ID_ option is selected during `eas submit`, besides `artifactUrl` we query for other build metadata (id, date, app version...)
- The build ID is propagated into `createSubmissionMutation`.
- Having more data, I improved the _Submission Summary_ table to display some build details
  > It only displayed `Build ID` or the `[latest]` string before.
  
<img width="590" alt="Screenshot 2021-07-20 at 09 59 18" src="https://user-images.githubusercontent.com/278340/126288778-d60f5f99-2698-44e3-b24c-66cfba5cc902.png">

> The values on this screenshot are random 😅  used some old staging builds for tests

# Test Plan

Updated unit tests, added a test case. Also tested manually.
