### PR TITLE
[eas submit][android] Autodetect google-services JSON key path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add `secret:create --force` command to overwrite existing secrets. ([#513](https://github.com/expo/eas-cli/pull/513) by [@bycedric](https://github.com/bycedric))
 - Fall back to APK when building for internal distribution. ([#527](https://github.com/expo/eas-cli/pull/527) by [@dsokal](https://github.com/dsokal))
 - Add `iosEnterpriseProvisioning` to build metadata. ([#522](https://github.com/expo/eas-cli/pull/522) by [@dsokal](https://github.com/dsokal))
+- Autodetect Google Services JSON key path in `eas submit -p android`. ([#520](https://github.com/expo/eas-cli/pull/297) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
@@ -155,7 +155,7 @@ class AndroidSubmitCommand {
       });
     } else {
       return result({
-        sourceType: ServiceAccountSourceType.prompt,
+        sourceType: ServiceAccountSourceType.detect,
       });
     }
   }

--- a/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
@@ -144,7 +144,7 @@ async function displayPathChooserAsync(
   const { selectedPath } = await promptAsync({
     name: 'selectedPath',
     type: 'select',
-    message: 'Choose the key you want to use for this submission',
+    message: 'Choose the key you want to use for this submission:',
     choices,
   });
 
@@ -153,7 +153,7 @@ async function displayPathChooserAsync(
 }
 
 async function confirmDetectedPathAsync(path: string): Promise<boolean> {
-  Log.log(`A Google Service Account JSON key has been found at \n   ${chalk.underline(path)}`);
+  Log.log(`A Google Service Account JSON key has been found at\n  ${chalk.underline(path)}`);
   const { confirmed } = await promptAsync({
     name: 'confirmed',
     type: 'confirm',

--- a/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
@@ -77,7 +77,7 @@ async function handleDetectSourceAsync(_source: ServiceAccountDetectSource): Pro
       return selectedPath;
     }
   } else if (googleServiceFiles.length === 1) {
-    const detectedPath = googleServiceFiles[0];
+    const [detectedPath] = googleServiceFiles;
 
     if (await confirmDetectedPathAsync(detectedPath)) {
       return detectedPath;
@@ -153,7 +153,7 @@ async function displayPathChooserAsync(
 }
 
 async function confirmDetectedPathAsync(path: string): Promise<boolean> {
-  Log.log(`A Google Service Account JSON key has been found in \n   ${chalk.underline(path)}`);
+  Log.log(`A Google Service Account JSON key has been found at \n   ${chalk.underline(path)}`);
   const { confirmed } = await promptAsync({
     name: 'confirmed',
     type: 'confirm',

--- a/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
@@ -61,7 +61,7 @@ async function handleDetectSourceAsync(_source: ServiceAccountDetectSoruce): Pro
   const projectDir = (await findProjectRootAsync()) ?? process.cwd();
   const foundFilenames = await glob('**/*.json', {
     cwd: projectDir,
-    ignore: ['app.json', 'package*.json', 'tsconfig.json'],
+    ignore: ['app.json', 'package*.json', 'tsconfig.json', 'node_modules'],
   });
 
   const googleServiceFiles = await filterAsync(

--- a/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import Log, { learnMore } from '../../log';
 import { findProjectRootAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
+import { filterAsync } from '../../utils/filterAsync';
 import { isExistingFile } from '../utils/files';
 
 export enum ServiceAccountSourceType {
@@ -29,14 +30,14 @@ interface ServiceAccountPromptSource extends ServiceAccountSourceBase {
   sourceType: ServiceAccountSourceType.prompt;
 }
 
-interface ServiceAccountDetectSoruce extends ServiceAccountSourceBase {
+interface ServiceAccountDetectSource extends ServiceAccountSourceBase {
   sourceType: ServiceAccountSourceType.detect;
 }
 
 export type ServiceAccountSource =
   | ServiceAccountPathSource
   | ServiceAccountPromptSource
-  | ServiceAccountDetectSoruce;
+  | ServiceAccountDetectSource;
 
 export async function getServiceAccountAsync(source: ServiceAccountSource): Promise<string> {
   switch (source.sourceType) {
@@ -57,7 +58,7 @@ async function handlePathSourceAsync(source: ServiceAccountPathSource): Promise<
   return source.path;
 }
 
-async function handleDetectSourceAsync(_source: ServiceAccountDetectSoruce): Promise<string> {
+async function handleDetectSourceAsync(_source: ServiceAccountDetectSource): Promise<string> {
   const projectDir = (await findProjectRootAsync()) ?? process.cwd();
   const foundFilePaths = await glob('**/*.json', {
     cwd: projectDir,
@@ -172,14 +173,3 @@ async function fileIsGoogleServicesAsync(path: string): Promise<boolean> {
     return false;
   }
 }
-
-/**
- * asynchronous array filter
- * @param arr array to filter
- * @param predicate a predicate function to run asynchronously
- * @returns a promise resolving to a filtered array
- */
-const filterAsync = async <T>(
-  arr: T[],
-  predicate: (arg: T, index?: number, array?: T[]) => Promise<boolean>
-) => Promise.all(arr.map(predicate)).then(results => arr.filter((_v, index) => results[index]));

--- a/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
@@ -8,6 +8,7 @@ import { isExistingFile } from '../utils/files';
 export enum ServiceAccountSourceType {
   path,
   prompt,
+  detect,
   // credentialsService,
   // ...
 }
@@ -25,7 +26,14 @@ interface ServiceAccountPromptSource extends ServiceAccountSourceBase {
   sourceType: ServiceAccountSourceType.prompt;
 }
 
-export type ServiceAccountSource = ServiceAccountPathSource | ServiceAccountPromptSource;
+interface ServiceAccountDetectSoruce extends ServiceAccountSourceBase {
+  sourceType: ServiceAccountSourceType.detect;
+}
+
+export type ServiceAccountSource =
+  | ServiceAccountPathSource
+  | ServiceAccountPromptSource
+  | ServiceAccountDetectSoruce;
 
 export async function getServiceAccountAsync(source: ServiceAccountSource): Promise<string> {
   switch (source.sourceType) {
@@ -33,6 +41,8 @@ export async function getServiceAccountAsync(source: ServiceAccountSource): Prom
       return await handlePathSourceAsync(source);
     case ServiceAccountSourceType.prompt:
       return await handlePromptSourceAsync(source);
+    case ServiceAccountSourceType.detect:
+      return await handleDetectSourceAsync(source);
   }
 }
 
@@ -42,6 +52,14 @@ async function handlePathSourceAsync(source: ServiceAccountPathSource): Promise<
     return await getServiceAccountAsync({ sourceType: ServiceAccountSourceType.prompt });
   }
   return source.path;
+}
+
+async function handleDetectSourceAsync(source: ServiceAccountDetectSoruce): Promise<string> {
+  // some detection logic
+  // if detected, return path source
+
+  // prompt if not found
+  return await getServiceAccountAsync({ sourceType: ServiceAccountSourceType.prompt });
 }
 
 async function handlePromptSourceAsync(_source: ServiceAccountPromptSource): Promise<string> {

--- a/packages/eas-cli/src/submissions/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/ServiceAccountSource-test.ts
@@ -1,6 +1,7 @@
 import { vol } from 'memfs';
 
 import { asMock } from '../../../__tests__/utils';
+import { findProjectRootAsync } from '../../../project/projectUtils';
 import { promptAsync } from '../../../prompts';
 import {
   ServiceAccountSource,
@@ -10,11 +11,14 @@ import {
 
 jest.mock('fs');
 jest.mock('../../../prompts');
+jest.mock('../../../project/projectUtils');
 
 describe(getServiceAccountAsync, () => {
   beforeAll(() => {
     vol.fromJSON({
       '/google-service-account.json': JSON.stringify({ service: 'account' }),
+      '/valid-service-account.json': JSON.stringify({ type: 'service_account' }),
+      '/other_dir/invalid_file.txt': 'this is not even a JSON',
     });
   });
   afterAll(() => {
@@ -87,6 +91,57 @@ describe(getServiceAccountAsync, () => {
       };
       const serviceAccountPath = await getServiceAccountAsync(source);
       expect(promptAsync).toHaveBeenCalledTimes(3);
+      expect(serviceAccountPath).toBe('/google-service-account.json');
+    });
+  });
+
+  describe('when source is ServiceAccountSourceType.detect', () => {
+    it('detects a valid google-services file', async () => {
+      asMock(findProjectRootAsync).mockResolvedValueOnce('/');
+      asMock(promptAsync).mockResolvedValueOnce({
+        confirmed: true,
+      });
+      const source: ServiceAccountSource = {
+        sourceType: ServiceAccountSourceType.detect,
+      };
+
+      const serviceAccountPath = await getServiceAccountAsync(source);
+
+      expect(promptAsync).toHaveBeenCalledTimes(1);
+      expect(serviceAccountPath).toBe('/valid-service-account.json');
+    });
+
+    it('falls back to prompt, when no valid files are found in the dir', async () => {
+      asMock(findProjectRootAsync).mockResolvedValueOnce('/other_dir');
+      asMock(promptAsync).mockResolvedValueOnce({
+        filePath: '/google-service-account.json',
+      });
+      const source: ServiceAccountSource = {
+        sourceType: ServiceAccountSourceType.detect,
+      };
+
+      const serviceAccountPath = await getServiceAccountAsync(source);
+
+      expect(promptAsync).toHaveBeenCalledTimes(1);
+      expect(serviceAccountPath).toBe('/google-service-account.json');
+    });
+
+    it('falls back to prompt, when user rejects to use detected file', async () => {
+      asMock(findProjectRootAsync).mockResolvedValueOnce('/');
+      asMock(promptAsync)
+        .mockResolvedValueOnce({
+          confirmed: false,
+        })
+        .mockResolvedValueOnce({
+          filePath: '/google-service-account.json',
+        });
+      const source: ServiceAccountSource = {
+        sourceType: ServiceAccountSourceType.detect,
+      };
+
+      const serviceAccountPath = await getServiceAccountAsync(source);
+
+      expect(promptAsync).toHaveBeenCalledTimes(2);
       expect(serviceAccountPath).toBe('/google-service-account.json');
     });
   });

--- a/packages/eas-cli/src/submissions/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/ServiceAccountSource-test.ts
@@ -15,9 +15,14 @@ jest.mock('../../../project/projectUtils');
 
 describe(getServiceAccountAsync, () => {
   beforeAll(() => {
+    const mockDetectableServiceAccountJson = JSON.stringify({
+      type: 'service_account',
+    });
+
     vol.fromJSON({
       '/google-service-account.json': JSON.stringify({ service: 'account' }),
-      '/valid-service-account.json': JSON.stringify({ type: 'service_account' }),
+      '/project_dir/subdir/service-account.json': mockDetectableServiceAccountJson,
+      '/project_dir/another-service-account.json': mockDetectableServiceAccountJson,
       '/other_dir/invalid_file.txt': 'this is not even a JSON',
     });
   });
@@ -96,38 +101,36 @@ describe(getServiceAccountAsync, () => {
   });
 
   describe('when source is ServiceAccountSourceType.detect', () => {
-    it('detects a valid google-services file', async () => {
-      asMock(findProjectRootAsync).mockResolvedValueOnce('/');
+    it('detects a single google-services file and prompts for confirmation', async () => {
+      asMock(findProjectRootAsync).mockResolvedValueOnce('/project_dir/subdir'); // should find 1 file
       asMock(promptAsync).mockResolvedValueOnce({
         confirmed: true,
       });
-      const source: ServiceAccountSource = {
+
+      const serviceAccountPath = await getServiceAccountAsync({
         sourceType: ServiceAccountSourceType.detect,
-      };
+      });
 
-      const serviceAccountPath = await getServiceAccountAsync(source);
-
-      expect(promptAsync).toHaveBeenCalledTimes(1);
-      expect(serviceAccountPath).toBe('/valid-service-account.json');
+      expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'confirm' }));
+      expect(serviceAccountPath).toBe('/project_dir/subdir/service-account.json');
     });
 
     it('falls back to prompt, when no valid files are found in the dir', async () => {
-      asMock(findProjectRootAsync).mockResolvedValueOnce('/other_dir');
+      asMock(findProjectRootAsync).mockResolvedValueOnce('/other_dir'); // no valid files in that dir
       asMock(promptAsync).mockResolvedValueOnce({
         filePath: '/google-service-account.json',
       });
-      const source: ServiceAccountSource = {
+
+      const serviceAccountPath = await getServiceAccountAsync({
         sourceType: ServiceAccountSourceType.detect,
-      };
+      });
 
-      const serviceAccountPath = await getServiceAccountAsync(source);
-
-      expect(promptAsync).toHaveBeenCalledTimes(1);
+      expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'text' }));
       expect(serviceAccountPath).toBe('/google-service-account.json');
     });
 
     it('falls back to prompt, when user rejects to use detected file', async () => {
-      asMock(findProjectRootAsync).mockResolvedValueOnce('/');
+      asMock(findProjectRootAsync).mockResolvedValueOnce('/project_dir/subdir'); // should find 1 file
       asMock(promptAsync)
         .mockResolvedValueOnce({
           confirmed: false,
@@ -142,6 +145,53 @@ describe(getServiceAccountAsync, () => {
       const serviceAccountPath = await getServiceAccountAsync(source);
 
       expect(promptAsync).toHaveBeenCalledTimes(2);
+      expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'confirm' }));
+      expect(promptAsync).toHaveBeenLastCalledWith(expect.objectContaining({ type: 'text' }));
+      expect(serviceAccountPath).toBe('/google-service-account.json');
+    });
+
+    it('displays a chooser, when multiple files are found', async () => {
+      asMock(findProjectRootAsync).mockResolvedValueOnce('/project_dir'); // should find 2 files here
+      asMock(promptAsync).mockResolvedValueOnce({
+        selectedPath: '/project_dir/another-service-account.json',
+      });
+
+      const serviceAccountPath = await getServiceAccountAsync({
+        sourceType: ServiceAccountSourceType.detect,
+      });
+
+      const expectedChoices = expect.arrayContaining([
+        expect.objectContaining({ value: '/project_dir/another-service-account.json' }),
+        expect.objectContaining({ value: '/project_dir/subdir/service-account.json' }),
+        expect.objectContaining({ value: false }),
+      ]);
+
+      expect(promptAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'select',
+          choices: expectedChoices,
+        })
+      );
+      expect(serviceAccountPath).toBe('/project_dir/another-service-account.json');
+    });
+
+    it('falls back to prompt, when user selects the "None of above"', async () => {
+      asMock(findProjectRootAsync).mockResolvedValueOnce('/project_dir'); // should find 2 files here
+      asMock(promptAsync)
+        .mockResolvedValueOnce({
+          selectedPath: false,
+        })
+        .mockResolvedValueOnce({
+          filePath: '/google-service-account.json',
+        });
+
+      const serviceAccountPath = await getServiceAccountAsync({
+        sourceType: ServiceAccountSourceType.detect,
+      });
+
+      expect(promptAsync).toHaveBeenCalledTimes(2);
+      expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'select' }));
+      expect(promptAsync).toHaveBeenLastCalledWith(expect.objectContaining({ type: 'text' }));
       expect(serviceAccountPath).toBe('/google-service-account.json');
     });
   });

--- a/packages/eas-cli/src/utils/filterAsync.ts
+++ b/packages/eas-cli/src/utils/filterAsync.ts
@@ -1,0 +1,10 @@
+/**
+ * asynchronous array filter
+ * @param arr array to filter
+ * @param predicate a predicate function to run asynchronously
+ * @returns a promise resolving to a filtered array
+ */
+export const filterAsync = async <T>(
+  arr: T[],
+  predicate: (value: T, index: number, array: T[]) => Promise<boolean>
+) => Promise.all(arr.map(predicate)).then(results => arr.filter((_v, index) => results[index]));


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Resolves #511

In future, we may prepend this with proposing stored credentials

# How

If the `--key` param is not specified, `eas submit -p android` tries to find a valid JSON key in the project directory.
- If a single file is found, asks user for confirmation to use this key.
- If multiple files are found, a chooser is displayerd with additional option "None of the above".
- Falls back to old prompt for path if not found or user rejected the detected file[s]. 

A valid key is found by:
1. glob `**/*.json` in project dir.
2. read json and check if it contains
```json
{
   "type": "service_account"
}
```
3. based on number of files found:
   - `> 1` - display a chooser
   - `= 1` - ask for confirmation
   - `< 1` - fallback to prompt

<img width="612" alt="Screenshot 2021-07-21 at 08 56 17" src="https://user-images.githubusercontent.com/278340/126445879-533c9890-2f0d-4da2-b9c5-edda6302a8d5.png">

<img width="612" alt="Screenshot 2021-07-27 at 09 18 24" src="https://user-images.githubusercontent.com/278340/127112586-c2fc0664-3eb3-4ab5-8260-57e4d5d20bc6.png">


# Test Plan

Unit tests, manual tests.
