### PR TITLE
Fix capability syncing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix iOS capability syncing on build. ([#521](https://github.com/expo/eas-cli/pull/521) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix unhandled error when amplitude domains are blocked. ([#512](https://github.com/expo/eas-cli/pull/512) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -107,7 +107,7 @@ function getCapabilitiesToEnable(
       continue;
     }
 
-    const existingIndex = currentCapabilities.findIndex(existing =>
+    const existingIndex = remainingCapabilities.findIndex(existing =>
       existing.isType(staticCapabilityInfo.capability)
     );
     const existing = existingIndex > -1 ? remainingCapabilities[existingIndex] : null;
@@ -120,6 +120,10 @@ function getCapabilitiesToEnable(
       remainingCapabilities.splice(existingIndex, 1);
       if (Log.isDebug) {
         Log.log(`Skipping existing capability: ${key} (${staticCapabilityInfo.name})`);
+        Log.log(
+          `Remaining to remove: `,
+          remainingCapabilities.map(({ id }) => id)
+        );
       }
       continue;
     }
@@ -145,6 +149,12 @@ function getCapabilitiesToDisable(
   currentCapabilities: BundleIdCapability[],
   request: { capabilityType: CapabilityType; option: any }[]
 ) {
+  if (Log.isDebug) {
+    Log.log(
+      `Existing to disable: `,
+      currentCapabilities.map(({ id }) => id)
+    );
+  }
   const disabledCapabilityNames: string[] = [];
 
   // Disable any extras that aren't present, this functionality is kinda unreliable because managed apps


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

- Fixes https://github.com/expo/eas-cli/issues/452
- Was finally able to repro by adding a comprehensive entitlements object:
```plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <key>aps-environment</key>
    <string>development</string>
    <key>com.apple.developer.applesignin</key>
    <array>
      <string>Default</string>
    </array>
    <key>com.apple.developer.healthkit</key>
    <true/>
    <key>com.apple.developer.healthkit.access</key>
    <array/>
    <key>com.apple.developer.networking.wifi-info</key>
    <true/>
    <key>com.apple.developer.nfc.readersession.formats</key>
    <array>
      <string>NDEF</string>
      <string>TAG</string>
    </array>
  </dict>
</plist>
```

The issue was that the wrong array was being used to find an index.

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Test Plan


Ran `eas build -p ios` and ensured that the capabilities were being updated as expected.