### PR TITLE
add `iosEnterpriseProvisioning` to build metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Added support for automatically creating and linking iOS capability identifiers (Apple Pay, iCloud Containers, App Groups). ([#524](https://github.com/expo/eas-cli/pull/524) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `secret:create --force` command to overwrite existing secrets. ([#513](https://github.com/expo/eas-cli/pull/513) by [@bycedric](https://github.com/bycedric))
 - Fall back to APK when building for internal distribution. ([#527](https://github.com/expo/eas-cli/pull/527) by [@dsokal](https://github.com/dsokal))
+- Add `iosEnterpriseProvisioning` to build metadata. ([#522](https://github.com/expo/eas-cli/pull/522) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/apple-utils": "0.0.0-alpha.24",
     "@expo/config": "3.3.42",
     "@expo/config-plugins": "3.0.3",
-    "@expo/eas-build-job": "0.2.43",
+    "@expo/eas-build-job": "0.2.44",
     "@expo/eas-json": "^0.21.0",
     "@expo/json-file": "8.2.25",
     "@expo/pkcs12": "0.0.4",

--- a/packages/eas-cli/src/build/graphql.ts
+++ b/packages/eas-cli/src/build/graphql.ts
@@ -2,6 +2,7 @@ import { ArchiveSource, ArchiveSourceType, Metadata, Workflow } from '@expo/eas-
 
 import {
   BuildCredentialsSource,
+  BuildIosEnterpriseProvisioning,
   BuildMetadataInput,
   BuildWorkflow,
   DistributionType,
@@ -32,6 +33,9 @@ export function transformMetadata(metadata: Metadata): BuildMetadataInput {
       metadata.credentialsSource && transformCredentialsSource(metadata.credentialsSource),
     distribution: metadata.distribution && transformDistribution(metadata.distribution),
     workflow: metadata.workflow && transformWorkflow(metadata.workflow),
+    iosEnterpriseProvisioning:
+      metadata.iosEnterpriseProvisioning &&
+      transformIosEnterpriseProvisioning(metadata.iosEnterpriseProvisioning),
   };
 }
 
@@ -60,5 +64,15 @@ export function transformWorkflow(workflow: Workflow): BuildWorkflow {
     return BuildWorkflow.Generic;
   } else {
     return BuildWorkflow.Managed;
+  }
+}
+
+export function transformIosEnterpriseProvisioning(
+  enterpriseProvisioning: Metadata['iosEnterpriseProvisioning']
+): BuildIosEnterpriseProvisioning {
+  if (enterpriseProvisioning === 'adhoc') {
+    return BuildIosEnterpriseProvisioning.Adhoc;
+  } else {
+    return BuildIosEnterpriseProvisioning.Universal;
   }
 }

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,5 +1,5 @@
 import { Metadata } from '@expo/eas-build-job';
-import { CredentialsSource } from '@expo/eas-json';
+import { CredentialsSource, IosEnterpriseProvisioning } from '@expo/eas-json';
 
 import { getApplicationIdAsync } from '../project/android/applicationId';
 import { getBundleIdentifierAsync } from '../project/ios/bundleIdentifier';
@@ -52,6 +52,11 @@ export async function collectMetadata<T extends Platform>(
     buildProfile: ctx.commandCtx.profile,
     gitCommitHash: await vcs.getCommitHashAsync(),
     username: getUsername(ctx.commandCtx.exp, await ensureLoggedInAsync()),
+    ...(ctx.platform === Platform.IOS && {
+      iosEnterpriseProvisioning: resolveIosEnterpriseProvisioning(
+        ctx as BuildContext<Platform.IOS>
+      ),
+    }),
   };
 }
 
@@ -134,4 +139,10 @@ async function getNativeChannelAsync<T extends Platform>(
   }
 
   return undefined;
+}
+
+function resolveIosEnterpriseProvisioning(
+  ctx: BuildContext<Platform.IOS>
+): IosEnterpriseProvisioning | undefined {
+  return ctx.buildProfile.enterpriseProvisioning;
 }

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -44,6 +44,10 @@ export function formatGraphQLBuild(build: BuildFragment) {
       value: build.distribution?.toLowerCase(),
     },
     {
+      label: 'Enterprise Provisioning',
+      value: build.iosEnterpriseProvisioning?.toLowerCase(),
+    },
+    {
       label: 'Release Channel',
       value: build.releaseChannel,
     },

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5063,7 +5063,7 @@ export type AppFragment = (
 
 export type BuildFragment = (
   { __typename?: 'Build' }
-  & Pick<Build, 'id' | 'status' | 'platform' | 'channel' | 'releaseChannel' | 'distribution' | 'buildProfile' | 'sdkVersion' | 'appVersion' | 'appBuildVersion' | 'runtimeVersion' | 'gitCommitHash' | 'createdAt' | 'updatedAt'>
+  & Pick<Build, 'id' | 'status' | 'platform' | 'channel' | 'releaseChannel' | 'distribution' | 'iosEnterpriseProvisioning' | 'buildProfile' | 'sdkVersion' | 'appVersion' | 'appBuildVersion' | 'runtimeVersion' | 'gitCommitHash' | 'createdAt' | 'updatedAt'>
   & { error?: Maybe<(
     { __typename?: 'BuildError' }
     & Pick<BuildError, 'errorCode' | 'message' | 'docsUrl'>

--- a/packages/eas-cli/src/graphql/types/Build.ts
+++ b/packages/eas-cli/src/graphql/types/Build.ts
@@ -37,6 +37,7 @@ export const BuildFragmentNode = gql`
     channel
     releaseChannel
     distribution
+    iosEnterpriseProvisioning
     buildProfile
     sdkVersion
     appVersion

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.43",
+    "@expo/eas-build-job": "0.2.44",
     "@hapi/joi": "17.1.1",
     "fs-extra": "9.0.1",
     "tslib": "1.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,10 +1918,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.43":
-  version "0.2.43"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.43.tgz#23d4683f3fb23c55fd02f8507d8935c91427dafb"
-  integrity sha512-us9RY9kD5sd8Q7sxzYkx2LCYZQmNnC9kpG2ieUPw+mdXdtF+HpdZtNQWD0Tttvu+T2HWYIot8PMrxu3a6JdFlA==
+"@expo/eas-build-job@0.2.44":
+  version "0.2.44"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.44.tgz#11f442cf9c1ac8402afbb06742bc99d4c1c6b6d9"
+  integrity sha512-4/wtOyAFLa0aILfco0a/slL96CBUppSeXfPdLzcHkBIc+AUB/pUSGf/M+Z3Pn7QoA3BHCnSIW8DosqqBBOppRg==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://linear.app/expo/issue/ENG-1292/account-for-universal-enterprise-distribution-in-install-modal

# How

I added `iosEnterpriseProvisioning` to build metadata.

# Test Plan

Tested by running a local build and fetching `iosEnterpriseProvisioning` from GraphQL.