### PR TITLE
Create and link capability identifiers automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Added support for automatically creating and linking iOS capability identifiers (Apple Pay, iCloud Containers, App Groups). ([#524](https://github.com/expo/eas-cli/pull/524) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `secret:create --force` command to overwrite existing secrets. ([#513](https://github.com/expo/eas-cli/pull/513) by [@bycedric](https://github.com/bycedric))
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@amplitude/identify": "1.7.0",
     "@amplitude/node": "1.7.0",
-    "@expo/apple-utils": "0.0.0-alpha.23",
+    "@expo/apple-utils": "0.0.0-alpha.24",
     "@expo/config": "3.3.42",
     "@expo/config-plugins": "3.0.3",
     "@expo/eas-build-job": "0.2.43",

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts
@@ -1,6 +1,21 @@
 import { BundleIdCapability, CapabilityType } from '@expo/apple-utils';
 
-import { syncCapabilitiesForEntitlementsAsync } from '../bundleIdCapabilities';
+import {
+  CapabilityMapping,
+  assertValidOptions,
+  syncCapabilitiesForEntitlementsAsync,
+} from '../bundleIdCapabilities';
+
+describe(assertValidOptions, () => {
+  it(`adds a reason for asserting capability identifiers`, () => {
+    const classifier = CapabilityMapping.find(
+      ({ capabilityIdPrefix }) => capabilityIdPrefix === 'merchant.'
+    )!;
+    expect(() => assertValidOptions(classifier, ['foobar'])).toThrowError(
+      /Expected an array of strings, where each string is prefixed with "merchant."/
+    );
+  });
+});
 
 describe(syncCapabilitiesForEntitlementsAsync, () => {
   it('enables all capabilities', async () => {

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/capabilityIdentifiers-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/capabilityIdentifiers-test.ts
@@ -1,0 +1,170 @@
+import { syncCapabilityIdentifiersForEntitlementsAsync } from '../capabilityIdentifiers';
+
+function mockCapabilities(Apple: any) {
+  Apple.MerchantId.getAsync = jest.fn(() => [
+    {
+      id: 'XXX-merch-1',
+      attributes: {
+        identifier: 'merchant.expo',
+      },
+    },
+  ]);
+
+  Apple.MerchantId.createAsync = jest.fn((ctx, { identifier }) => ({
+    id: 'XXX-merch-2',
+    attributes: {
+      identifier,
+    },
+  }));
+
+  Apple.AppGroup.getAsync = jest.fn(() => [
+    {
+      id: 'XXX-group-1',
+      attributes: {
+        identifier: 'group.expo',
+      },
+    },
+  ]);
+  Apple.AppGroup.createAsync = jest.fn((ctx, { identifier }) => ({
+    id: 'XXX-group-2',
+    attributes: {
+      identifier,
+    },
+  }));
+
+  Apple.CloudContainer.getAsync = jest.fn(() => [
+    {
+      id: 'XXX-icloud-1',
+      attributes: {
+        identifier: 'iCloud.expo',
+      },
+    },
+  ]);
+
+  Apple.CloudContainer.createAsync = jest.fn((ctx, { identifier }) => ({
+    id: 'XXX-icloud-2',
+    attributes: {
+      identifier,
+    },
+  }));
+}
+
+describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {
+  it(`creates missing capability identifiers`, async () => {
+    const Apple = require('@expo/apple-utils');
+    mockCapabilities(Apple);
+
+    const bundleId = {
+      context: {},
+      updateBundleIdCapabilityAsync: jest.fn(),
+      id: 'XXX',
+    } as any;
+
+    await syncCapabilityIdentifiersForEntitlementsAsync(bundleId, {
+      'com.apple.developer.in-app-payments': ['merchant.bacon'],
+      'com.apple.security.application-groups': ['group.bacon'],
+      'com.apple.developer.icloud-container-identifiers': ['iCloud.bacon'],
+    });
+
+    // Ensure we create missing ids
+    expect(Apple.MerchantId.createAsync).toHaveBeenLastCalledWith(
+      // auth context
+      {},
+      // props
+      { identifier: 'merchant.bacon' }
+    );
+    // Ensure we create missing ids
+    expect(Apple.AppGroup.createAsync).toHaveBeenLastCalledWith(
+      // auth context
+      {},
+      // props
+      { identifier: 'group.bacon' }
+    );
+    // Ensure we create missing ids
+    expect(Apple.CloudContainer.createAsync).toHaveBeenLastCalledWith(
+      // auth context
+      {},
+      // props
+      { identifier: 'iCloud.bacon' }
+    );
+
+    expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
+      {
+        capabilityType: 'APP_GROUPS',
+        option: 'ON',
+        relationships: {
+          appGroups: ['XXX-group-2'],
+        },
+      },
+      {
+        capabilityType: 'APPLE_PAY',
+        option: 'ON',
+        relationships: {
+          merchantIds: ['XXX-merch-2'],
+        },
+      },
+      {
+        capabilityType: 'ICLOUD',
+        option: 'ON',
+        relationships: {
+          cloudContainers: ['XXX-icloud-2'],
+        },
+      },
+    ]);
+  });
+
+  it(`removes local duplicates`, async () => {
+    const Apple = require('@expo/apple-utils');
+    mockCapabilities(Apple);
+    const bundleId = {
+      context: {},
+      updateBundleIdCapabilityAsync: jest.fn(),
+      id: 'XXX',
+    } as any;
+
+    await syncCapabilityIdentifiersForEntitlementsAsync(bundleId, {
+      'com.apple.developer.in-app-payments': ['merchant.expo', 'merchant.expo'],
+    });
+
+    // Only called once because we remove local duplicates to minimize network requests.
+    expect(Apple.MerchantId.getAsync).toBeCalledTimes(1);
+  });
+
+  it(`creates missing capability identifiers`, async () => {
+    const Apple = require('@expo/apple-utils');
+    mockCapabilities(Apple);
+    const bundleId = {
+      context: {},
+      updateBundleIdCapabilityAsync: jest.fn(),
+      id: 'XXX',
+    } as any;
+
+    await syncCapabilityIdentifiersForEntitlementsAsync(bundleId, {
+      'com.apple.developer.in-app-payments': ['merchant.expo'],
+    });
+
+    expect(Apple.MerchantId.createAsync).not.toBeCalled();
+  });
+
+  it(`throws when creating a missing capability that is reserved`, async () => {
+    const Apple = require('@expo/apple-utils');
+    mockCapabilities(Apple);
+    Apple.MerchantId.createAsync = jest.fn((ctx: any, { identifier }: { identifier: string }) => {
+      // e2e test with: merchant.expodemo
+      throw new Error(
+        `There is a problem with the request entity - A Merchant ID with Identifier '${identifier}' is not available. Please enter a different string.`
+      );
+    });
+    const bundleId = {
+      context: {},
+      updateBundleIdCapabilityAsync: jest.fn(),
+      id: 'XXX',
+    } as any;
+
+    await expect(
+      syncCapabilityIdentifiersForEntitlementsAsync(bundleId, {
+        'com.apple.developer.in-app-payments': ['merchant.bacon'],
+      })
+    ).rejects.toThrow(/is not available. Please enter a different string/);
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -5,13 +5,17 @@ import {
   CapabilityType,
   CapabilityTypeDataProtectionOption,
   CapabilityTypeOption,
+  ConnectModel,
+  AppGroup,
+  CloudContainer,
+  MerchantId,
 } from '@expo/apple-utils';
 import { JSONObject, JSONValue } from '@expo/json-file';
 import getenv from 'getenv';
 
 import Log from '../../../log';
 
-const EXPO_NO_CAPABILITY_SYNC = getenv.boolish('EXPO_NO_CAPABILITY_SYNC', false);
+export const EXPO_NO_CAPABILITY_SYNC = getenv.boolish('EXPO_NO_CAPABILITY_SYNC', false);
 
 type GetOptionsMethod<T extends CapabilityType = any> = (
   entitlement: JSONValue,
@@ -20,6 +24,13 @@ type GetOptionsMethod<T extends CapabilityType = any> = (
 
 const validateBooleanOptions = (options: any): boolean => {
   return typeof options === 'boolean';
+};
+
+const validatePrefixedStringArrayOptions = (prefix: string) => (options: any): boolean => {
+  return (
+    Array.isArray(options) &&
+    options.every(option => typeof option === 'string' && option.startsWith(prefix))
+  );
 };
 
 const validateStringArrayOptions = (options: any): boolean => {
@@ -211,6 +222,7 @@ export const CapabilityMapping: {
   capability: CapabilityType;
   validateOptions: (options: any) => boolean;
   getOptions: GetOptionsMethod;
+  capabilityIdModel?: typeof MerchantId;
   options?: undefined;
 }[] = [
   {
@@ -297,24 +309,27 @@ export const CapabilityMapping: {
     entitlement: 'com.apple.security.application-groups',
     capability: CapabilityType.APP_GROUP,
     // Ex: ['group.CY-A5149AC2-49FC-11E7-B3F3-0335A16FFB8D.com.cydia.Extender']
-    validateOptions: validateStringArrayOptions,
+    validateOptions: validatePrefixedStringArrayOptions('group.'),
     getOptions: getDefinedOptions,
+    capabilityIdModel: AppGroup,
   },
   {
     name: 'Apple Pay Payment Processing',
     entitlement: 'com.apple.developer.in-app-payments',
     capability: CapabilityType.APPLE_PAY,
     // Ex: ['merchant.com.example.development']
-    validateOptions: validateStringArrayOptions,
+    validateOptions: validatePrefixedStringArrayOptions('merchant.'),
     getOptions: getDefinedOptions,
+    capabilityIdModel: MerchantId,
   },
   {
     name: 'iCloud',
     entitlement: 'com.apple.developer.icloud-container-identifiers',
     capability: CapabilityType.ICLOUD,
-    validateOptions: validateStringArrayOptions,
+    validateOptions: validatePrefixedStringArrayOptions('iCloud.'),
     // Only supports Xcode +6, 5 could be added if needed.
     getOptions: getDefinedOptions,
+    capabilityIdModel: CloudContainer,
   },
   {
     name: 'ClassKit',

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -1,12 +1,11 @@
 import {
+  AppGroup,
   BundleId,
   BundleIdCapability,
   CapabilityOptionMap,
   CapabilityType,
   CapabilityTypeDataProtectionOption,
   CapabilityTypeOption,
-  ConnectModel,
-  AppGroup,
   CloudContainer,
   MerchantId,
 } from '@expo/apple-utils';

--- a/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
@@ -1,0 +1,103 @@
+import { BundleId, CapabilityTypeOption } from '@expo/apple-utils';
+import { JSONObject } from '@expo/json-file';
+
+import Log from '../../../log';
+import { CapabilityMapping, EXPO_NO_CAPABILITY_SYNC } from './bundleIdCapabilities';
+
+type UpdateCapabilityRequest = Parameters<BundleId['updateBundleIdCapabilityAsync']>[0];
+
+/**
+ * Sync the capability identifiers with the bundle identifier capabilities.
+ * If a capability identifier is missing, then attempt to create it.
+ * Link all of the capability identifiers at the same time after parsing the entitlements file.
+ *
+ * @param bundleId Bundle identifier object.
+ * @param entitlements JSON representation of the iOS entitlements plist
+ * @returns
+ */
+export async function syncCapabilityIdentifiersForEntitlementsAsync(
+  bundleId: BundleId,
+  entitlements: JSONObject = {}
+): Promise<{ created: string[]; linked: string[] }> {
+  if (EXPO_NO_CAPABILITY_SYNC) {
+    return { created: [], linked: [] };
+  }
+
+  const createdIds: string[] = [];
+  const linkedIds: string[] = [];
+  const CapabilityIdMapping = CapabilityMapping.filter(capability => capability.capabilityIdModel);
+
+  const updateRequest: UpdateCapabilityRequest = [];
+
+  // Iterate through the supported capabilities to build the request.
+  for (const classifier of CapabilityIdMapping) {
+    const CapabilityModel = classifier.capabilityIdModel;
+    // Skip capabilities that don't support capability IDs.
+    if (!CapabilityModel) continue;
+
+    // Skip capabilities that aren't defined in the entitlements file.
+    let capabilityIds = entitlements[classifier.entitlement] as string[];
+    if (!capabilityIds) continue;
+
+    // Assert string array matching prefix. ASC will throw if the IDs are invalid, this just saves some time.
+    if (!classifier.validateOptions(capabilityIds)) {
+      throw new Error(
+        `iOS entitlement "${classifier.entitlement}" has invalid incorrectly formatted identifier list: "${capabilityIds}".`
+      );
+    }
+
+    // Remove any duplicates to cut down on network requests
+    capabilityIds = [...new Set(capabilityIds)];
+
+    // Get a list of all of the capability IDs that are already created on the server.
+    const existingIds = await CapabilityModel.getAsync(bundleId.context);
+
+    // A list of server IDs for linking.
+    const capabilityIdOpaqueIds = [];
+
+    // Iterate through all the local IDs and see if they exist on the server.
+    for (const localId of capabilityIds) {
+      let remoteIdModel = existingIds.find(model => model.attributes.identifier === localId);
+
+      // If a remote ID exists, then create it.
+      if (!remoteIdModel) {
+        if (Log.isDebug) Log.log(`Creating capability ID: ${localId} (${CapabilityModel.type})`);
+        try {
+          remoteIdModel = await CapabilityModel.createAsync(bundleId.context, {
+            identifier: localId,
+          });
+        } catch (error) {
+          // Add a more helpful error message.
+          error.message += `\n\nRemove the value '${localId}' from the array '${classifier.entitlement}' in the iOS project entitlements.\nIf you know that the ID is registered to one of your apps, try again with a different Apple account.`;
+          throw error;
+        }
+        // Create a list of newly created IDs for displaying in the CLI.
+        createdIds.push(localId);
+        if (Log.isDebug) Log.log(`Created capability ID: ${remoteIdModel.id}`);
+      }
+      if (Log.isDebug)
+        Log.log(`Linking ID to ${CapabilityModel.type}: ${localId} (${remoteIdModel.id})`);
+      // Create a list of linked IDs for displaying in the CLI.
+      linkedIds.push(remoteIdModel.attributes.identifier);
+      capabilityIdOpaqueIds.push(remoteIdModel.id);
+    }
+
+    updateRequest.push({
+      capabilityType: classifier.capability,
+      option: CapabilityTypeOption.ON,
+      relationships: {
+        // One of: `merchantIds`, `appGroups`, `cloudContainers`.
+        [CapabilityModel.type]: capabilityIdOpaqueIds,
+      },
+    });
+  }
+
+  if (updateRequest.length) {
+    if (Log.isDebug)
+      Log.log(`Updating bundle identifier with capability identifiers:`, updateRequest);
+    await bundleId.updateBundleIdCapabilityAsync(updateRequest);
+  } else if (Log.isDebug) {
+    Log.log(`No capability identifiers need to be updated`);
+  }
+  return { created: createdIds, linked: linkedIds };
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
@@ -34,7 +34,9 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
   for (const classifier of CapabilityIdMapping) {
     const CapabilityModel = classifier.capabilityIdModel;
     // Skip capabilities that don't support capability IDs.
-    if (!CapabilityModel) continue;
+    if (!CapabilityModel) {
+      continue;
+    }
 
     const validate = (value: any): value is string[] => {
       if (!value) {
@@ -52,7 +54,9 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
     // Skip capabilities that aren't defined in the entitlements file.
     const entitlementValue = entitlements[classifier.entitlement];
 
-    if (!validate(entitlementValue)) continue;
+    if (!validate(entitlementValue)) {
+      continue;
+    }
 
     // Remove any duplicates to cut down on network requests
     const capabilityIds: string[] = [...new Set(entitlementValue)];
@@ -69,7 +73,9 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
 
       // If a remote ID exists, then create it.
       if (!remoteIdModel) {
-        if (Log.isDebug) Log.log(`Creating capability ID: ${localId} (${CapabilityModel.type})`);
+        if (Log.isDebug) {
+          Log.log(`Creating capability ID: ${localId} (${CapabilityModel.type})`);
+        }
         try {
           remoteIdModel = await CapabilityModel.createAsync(bundleId.context, {
             identifier: localId,
@@ -81,10 +87,13 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
         }
         // Create a list of newly created IDs for displaying in the CLI.
         createdIds.push(localId);
-        if (Log.isDebug) Log.log(`Created capability ID: ${remoteIdModel.id}`);
+        if (Log.isDebug) {
+          Log.log(`Created capability ID: ${remoteIdModel.id}`);
+        }
       }
-      if (Log.isDebug)
+      if (Log.isDebug) {
         Log.log(`Linking ID to ${CapabilityModel.type}: ${localId} (${remoteIdModel.id})`);
+      }
       // Create a list of linked IDs for displaying in the CLI.
       linkedIds.push(remoteIdModel.attributes.identifier);
       capabilityIdOpaqueIds.push(remoteIdModel.id);
@@ -101,8 +110,9 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
   }
 
   if (updateRequest.length) {
-    if (Log.isDebug)
+    if (Log.isDebug) {
       Log.log(`Updating bundle identifier with capability identifiers:`, updateRequest);
+    }
     await bundleId.updateBundleIdCapabilityAsync(updateRequest);
   } else if (Log.isDebug) {
     Log.log(`No capability identifiers need to be updated`);

--- a/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
@@ -2,7 +2,11 @@ import { BundleId, CapabilityTypeOption } from '@expo/apple-utils';
 import { JSONObject } from '@expo/json-file';
 
 import Log from '../../../log';
-import { CapabilityMapping, EXPO_NO_CAPABILITY_SYNC } from './bundleIdCapabilities';
+import {
+  CapabilityMapping,
+  EXPO_NO_CAPABILITY_SYNC,
+  assertValidOptions,
+} from './bundleIdCapabilities';
 
 type UpdateCapabilityRequest = Parameters<BundleId['updateBundleIdCapabilityAsync']>[0];
 
@@ -42,12 +46,7 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
       if (!value) {
         return false;
       }
-      // Assert string array matching prefix. ASC will throw if the IDs are invalid, this just saves some time.
-      if (!classifier.validateOptions(value)) {
-        throw new Error(
-          `iOS entitlement "${classifier.entitlement}" has invalid incorrectly formatted identifier list: "${value}".`
-        );
-      }
+      assertValidOptions(classifier, value);
       return true;
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,10 +1818,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/apple-utils@0.0.0-alpha.23":
-  version "0.0.0-alpha.23"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.23.tgz#88c19bc8f02e6be2d88d3defe34311deb401e481"
-  integrity sha512-sp2kH5zoQ0kWhnVIlkN+x+GqeznueukdS80z9uhYpe6b8UXNzWgvQxV0y28V5k5stuut1G/IQjbKjVYdo93WKg==
+"@expo/apple-utils@0.0.0-alpha.24":
+  version "0.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.24.tgz#4208204d3763a4770ce9e63f36c14476adc635bd"
+  integrity sha512-96MGsGcRIjzJ3Stqw9fiXAgOfMn4UlmlBp2EZkmpad7945ke9Gguceafb6rpbKJHEkQd2qcBcfcumU73QisP2w==
 
 "@expo/babel-preset-cli@^0.2.17":
   version "0.2.18"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

It's a bit peculiar that we don't manage more aspects of iOS capabilities automatically. This PR adds support for creating and linking capability identifiers to the application automatically. Based on the project entitlements, we'll link IDs for Apple Pay, iCloud containers, and shared App Groups. Capability IDs need to be unique, so we provide enhanced error handling for cases where you accidentally register a reserved value.

- Resolve https://github.com/expo/eas-cli/issues/523

# How

Sync capability identifiers with the bundle identifier, remove local duplicates, print when new IDs are created.
This functionality can be skipped using `EXPO_NO_CAPABILITY_SYNC=1`.

# Test Plan

- Added unit tests
- E2E tested that a project with the following entitlements in the app.json, syncs as expected:
```json
{
  "expo": {
    "ios": {
      "entitlements": {
        "com.apple.developer.in-app-payments": ["merchant.bacon"],
        "com.apple.security.application-groups": ["group.bacon"],
        "com.apple.developer.icloud-container-identifiers": ["iCloud.bacon"]
      }
    }
  }
}
```
<img width="586" alt="Screen Shot 2021-07-21 at 4 38 40 PM" src="https://user-images.githubusercontent.com/9664363/126568871-704c467d-abc4-4875-957d-dfcd9aaf0b7a.png">

- Tested that using `com.apple.developer.in-app-payments: ['merchant.expodemo']` fails because it is registered to @brentvatne:

<img width="1235" alt="Screen Shot 2021-07-21 at 4 19 33 PM" src="https://user-images.githubusercontent.com/9664363/126568721-6df85c7f-9166-41a8-88d5-1b6c443cc523.png">

