### PR TITLE
enable lint rule for curly braces around blocks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
       },
     ],
     'flowtype/no-types-missing-file-annotation': 'off',
+    'curly': 'warn',
   },
   settings: {
     react: {

--- a/packages/eas-cli/src/build/utils/credentials.ts
+++ b/packages/eas-cli/src/build/utils/credentials.ts
@@ -7,9 +7,10 @@ import { requestedPlatformDisplayNames } from '../constants';
 
 export function logCredentialsSource(credentialsSource: CredentialsSource, platform: Platform) {
   let message = `Using ${credentialsSource} ${requestedPlatformDisplayNames[platform]} credentials`;
-  if (credentialsSource === CredentialsSource.LOCAL)
+  if (credentialsSource === CredentialsSource.LOCAL) {
     message += ` ${chalk.dim('(credentials.json)')}`;
-  else if (credentialsSource === CredentialsSource.REMOTE)
+  } else if (credentialsSource === CredentialsSource.REMOTE) {
     message += ` ${chalk.dim('(Expo server)')}`;
+  }
   Log.succeed(message);
 }

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -97,7 +97,9 @@ export default class EnvironmentSecretCreate extends Command {
         },
       }));
 
-      if (!name) throw new Error('Secret name may not be empty.');
+      if (!name) {
+        throw new Error('Secret name may not be empty.');
+      }
     }
 
     if (!secretValue) {
@@ -110,7 +112,9 @@ export default class EnvironmentSecretCreate extends Command {
         validate: value => (value ? true : validationMessage),
       }));
 
-      if (!secretValue) throw new Error(validationMessage);
+      if (!secretValue) {
+        throw new Error(validationMessage);
+      }
     }
 
     if (scope === EnvironmentSecretScope.PROJECT) {

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -67,7 +67,9 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
 
       id = secret?.id;
 
-      if (!id) throw new Error(validationMessage);
+      if (!id) {
+        throw new Error(validationMessage);
+      }
     }
 
     Log.addNewLineIfNone();

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -63,7 +63,9 @@ export async function syncCapabilitiesForEntitlementsAsync(
   bundleId: BundleId,
   entitlements: JSONObject = {}
 ): Promise<{ enabled: string[]; disabled: string[] }> {
-  if (EXPO_NO_CAPABILITY_SYNC) return { enabled: [], disabled: [] };
+  if (EXPO_NO_CAPABILITY_SYNC) {
+    return { enabled: [], disabled: [] };
+  }
   const currentCapabilities = await bundleId.getBundleIdCapabilitiesAsync();
   if (Log.isDebug) {
     Log.log(`Current remote capabilities:\n${JSON.stringify(currentCapabilities, null, 2)}`);

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -136,10 +136,11 @@ async function manageAdHocProfilesAsync(
   if (profileId) {
     existingProfile = await findProfileByIdAsync(context, profileId, bundleId);
     // Fail if we cannot find the profile that was specifically requested
-    if (!existingProfile)
+    if (!existingProfile) {
       throw new Error(
         `Could not find profile with profile id "${profileId}" for bundle id "${bundleId}"`
       );
+    }
   } else {
     // If no profile id is passed, try to find a suitable provisioning profile for the App ID.
     const results = await findProfileByBundleIdAsync(context, bundleId, certSerialNumber);

--- a/packages/eas-cli/src/credentials/ios/utils/convertHTMLToASCII.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/convertHTMLToASCII.ts
@@ -41,7 +41,9 @@ function getService(rootUrl: string) {
     },
     replacement(content: string, node: any) {
       let href = node.getAttribute('href');
-      if (href.startsWith('/')) href = `${rootUrl}${href}`;
+      if (href.startsWith('/')) {
+        href = `${rootUrl}${href}`;
+      }
       if (terminalLink.isSupported) {
         return chalk.cyan(terminalLink(content, href));
       }

--- a/packages/eas-cli/src/help.ts
+++ b/packages/eas-cli/src/help.ts
@@ -34,12 +34,16 @@ class CustomCommandHelp extends CommandHelp {
       this.aliases(cmd.aliases),
       this.examples(cmd.examples || (cmd as any).example),
     ]).join('\n\n');
-    if (this.opts.stripAnsi) output = stripAnsi(output);
+    if (this.opts.stripAnsi) {
+      output = stripAnsi(output);
+    }
     return output;
   }
 
   protected flags(flags: Config.Command.Flag[]): string | undefined {
-    if (flags.length === 0) return;
+    if (flags.length === 0) {
+      return;
+    }
     const groupableFlags = flags.map(originalFlag => {
       const { helpLabel, ...flag } = originalFlag;
       // We re-purpose `helpLabel` to mean a "header to group the flag under".

--- a/packages/eas-cli/src/utils/timer.ts
+++ b/packages/eas-cli/src/utils/timer.ts
@@ -14,7 +14,9 @@ export function endTimer(label = LABEL, clear: boolean = true) {
   const startTime = startTimes[label];
   if (startTime) {
     const delta = endTime - startTime;
-    if (clear) delete startTimes[label];
+    if (clear) {
+      delete startTimes[label];
+    }
     return delta;
   }
   throw new Error(`Timer '${label}' has not be started yet`);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

I've noticed that we don't have this rule (`curly`) enabled. It's enabled in our other repositories, e.g. in www - https://github.com/expo/universe/blob/main/server/www/.eslintrc.js#L30

# How

I enabled the `curly` eslint rule and ran `yarn lint --fix`.

# Test Plan

CI