### PR TITLE
use default version code when it's not defined for managed project in app.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Fix iOS capability syncing on build. ([#521](https://github.com/expo/eas-cli/pull/521) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix unhandled error when amplitude domains are blocked. ([#512](https://github.com/expo/eas-cli/pull/512) by [@wkozyra95](https://github.com/wkozyra95))
+- Use default value for `appBuildVersion` in build metadata when building an Android managed project. ([#526](https://github.com/expo/eas-cli/pull/526) by [@dsokal](https://github.com/dsokal))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -19,7 +19,7 @@ export async function readVersionCodeAsync(
       return undefined;
     }
   } else {
-    return AndroidConfig.Version.getVersionCode(exp) ?? undefined;
+    return AndroidConfig.Version.getVersionCode(exp) ?? 1;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

When building a managed project that doesn't have `android.versionCode` and/or `ios.buildNumber` we record the `appBuildVersion` differently for Android and iOS:
- iOS: `IOSConfig.Version.getBuildNumber()` returns `"1.0.0"`
- Android: `AndroidConfig.Version.getVersionCode` returns `null`

This PR makes those values consistent. Which is, when the `android.versionCode` is not defined, we default to `1`.
This is a temporary fix until https://github.com/expo/expo-cli/pull/3713 is merged.

# How

How did you build this feature or fix this bug and why?

# Test Plan

I ran Android and iOS builds for a fresh managed project and they had the default values recorded for `appBuildVersion`.