### PR TITLE
fall back to APK when building for internal distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add `secret:create --force` command to overwrite existing secrets. ([#513](https://github.com/expo/eas-cli/pull/513) by [@bycedric](https://github.com/bycedric))
+- Fall back to APK when building for internal distribution. ([#527](https://github.com/expo/eas-cli/pull/527) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -1,4 +1,4 @@
-import { ArchiveSource, Job, sanitizeJob } from '@expo/eas-build-job';
+import { Android, ArchiveSource, Job, sanitizeJob } from '@expo/eas-build-job';
 import path from 'path';
 
 import { AndroidCredentials } from '../../credentials/android/AndroidCredentialsProvider';
@@ -34,6 +34,11 @@ export async function prepareJobAsync(
       }
     : {};
 
+  let buildType: Android.BuildType | undefined = ctx.buildProfile.buildType;
+  if (!buildType && ctx.buildProfile.distribution === 'internal') {
+    buildType = Android.BuildType.APK;
+  }
+
   const job = {
     type: ctx.workflow,
     platform: Platform.ANDROID,
@@ -61,7 +66,7 @@ export async function prepareJobAsync(
     artifactPath: ctx.buildProfile.artifactPath,
 
     username,
-    buildType: ctx.buildProfile.buildType,
+    buildType,
   };
 
   return sanitizeJob(job);

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -34,8 +34,9 @@ export async function prepareJobAsync(
       }
     : {};
 
+  const { gradleCommand } = ctx.buildProfile;
   let buildType: Android.BuildType | undefined = ctx.buildProfile.buildType;
-  if (!buildType && ctx.buildProfile.distribution === 'internal') {
+  if (!buildType && !gradleCommand && ctx.buildProfile.distribution === 'internal') {
     buildType = Android.BuildType.APK;
   }
 
@@ -62,7 +63,7 @@ export async function prepareJobAsync(
     releaseChannel: ctx.buildProfile.releaseChannel,
     updates: { channel: ctx.buildProfile.channel },
 
-    gradleCommand: ctx.buildProfile.gradleCommand,
+    gradleCommand,
     artifactPath: ctx.buildProfile.artifactPath,
 
     username,


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

When building Android for internal distribution and neither `gradleCommand` nor `buildType` is defined, we should build an APK.

# How

I added a conditional in `prepareJob` for Android.

# Test Plan

I ran a build with the following build profile:
```
{
  "builds": {
    "android": {
      "release": {
        "workflow": "managed",
        "distribution": "internal"
      }
    }
  }
}
```
The build produced an APK.