### PR TITLE
[eas-cli] use .pbxproj file to check if native Xcode project is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix workflow detection when xcodeproj is an empty directory. ([#531](https://github.com/expo/eas-cli/pull/531) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [0.22.0](https://github.com/expo/eas-cli/releases/tag/v0.22.0) - 2021-07-23

--- a/packages/eas-cli/src/project/ios/scheme.ts
+++ b/packages/eas-cli/src/project/ios/scheme.ts
@@ -63,6 +63,11 @@ export async function selectSchemeAsync({
   nonInteractive?: boolean;
 }): Promise<string> {
   const schemes = IOSConfig.BuildScheme.getSchemesFromXcodeproj(projectDir);
+  if (schemes.length === 0) {
+    throw new Error(
+      'We did not found any schemes in the Xcode project, make sure that scheme is marked as "shared" in Xcode and listed in the output of "xcodebuild -list" command'
+    );
+  }
   if (schemes.length === 1) {
     return schemes[0];
   }

--- a/packages/eas-cli/src/project/ios/scheme.ts
+++ b/packages/eas-cli/src/project/ios/scheme.ts
@@ -65,7 +65,7 @@ export async function selectSchemeAsync({
   const schemes = IOSConfig.BuildScheme.getSchemesFromXcodeproj(projectDir);
   if (schemes.length === 0) {
     throw new Error(
-      'We did not found any schemes in the Xcode project, make sure that scheme is marked as "shared" in Xcode and listed in the output of "xcodebuild -list" command'
+      `We did not find any schemes in the Xcode project, make sure that at least one scheme is marked as "shared" in Xcode, and that it's listed in the output of "xcodebuild -list" command`
     );
   }
   if (schemes.length === 1) {

--- a/packages/eas-cli/src/project/workflow.ts
+++ b/packages/eas-cli/src/project/workflow.ts
@@ -14,7 +14,7 @@ export async function resolveWorkflowAsync(
     platformWorkflowMarker =
       platform === Platform.ANDROID
         ? await AndroidConfig.Paths.getAndroidManifestAsync(projectDir)
-        : IOSConfig.Paths.getXcodeProjectPath(projectDir);
+        : IOSConfig.Paths.getPBXProjectPath(projectDir);
   } catch {
     return Workflow.MANAGED;
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Closes #529

# How

- check if pbxproj exists(xcodeproj directory might exist locally for some users if project was ejected in the past, because git does not track directories)
- handle case where there is no shared scheme in the project

# Test Plan

try to start builds with
- missing pbxproj
- missing .xcscheme files
