### PR TITLE
[eas-cli] fix keystore upload bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix workflow detection when xcodeproj is an empty directory. ([#531](https://github.com/expo/eas-cli/pull/531) by [@wkozyra95](https://github.com/wkozyra95))
+- Fix Android Keystore upload. ([#538](https://github.com/expo/eas-cli/pull/538) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/credentials/android/actions/CreateKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/CreateKeystore.ts
@@ -25,6 +25,7 @@ export class CreateKeystore {
     if (providedKeystore) {
       const providedKeystoreWithType = getKeystoreWithType(providedKeystore);
       validateKeystore(providedKeystoreWithType);
+      return providedKeystoreWithType;
     }
     return await generateRandomKeystoreAsync();
   }

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/CreateKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/CreateKeystore-test.ts
@@ -1,10 +1,14 @@
 import { confirmAsync } from '../../../../prompts';
+import { testKeystore } from '../../../__tests__/fixtures-android';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { askForUserProvidedAsync } from '../../../utils/promptForCredentials';
 import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { CreateKeystore } from '../CreateKeystore';
 
 jest.mock('../../../../prompts');
 (confirmAsync as jest.Mock).mockImplementation(() => true);
+
+jest.mock('../../../utils/promptForCredentials');
 
 describe('CreateKeystore', () => {
   it('creates a keystore in Interactive Mode', async () => {
@@ -15,6 +19,20 @@ describe('CreateKeystore', () => {
 
     // expect keystore to be created on expo servers
     expect(ctx.android.createKeystoreAsync as any).toHaveBeenCalledTimes(1);
+  });
+  it('creates a keystore by uploading', async () => {
+    (askForUserProvidedAsync as jest.Mock).mockImplementation(() => testKeystore);
+    const ctx = createCtxMock({ nonInteractive: false });
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
+    const createKeystoreAction = new CreateKeystore(appLookupParams.account);
+    await createKeystoreAction.runAsync(ctx);
+
+    // expect keystore to be created on expo servers
+    expect(ctx.android.createKeystoreAsync as any).toHaveBeenCalledTimes(1);
+    expect(ctx.android.createKeystoreAsync as any).toHaveBeenCalledWith(
+      appLookupParams.account,
+      expect.objectContaining(testKeystore)
+    );
   });
   it('errors in Non-Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: true });


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Users who wanted to upload their keystores found that a new one was generated instead

# How

return the uploaded keystore

# Test Plan

- [ ] added regression test to make sure this issue will be detected in the future
