### PR TITLE
merge channel and release channel in build metadata

### DIFF
--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -47,12 +47,8 @@ export function formatGraphQLBuild(build: BuildFragment) {
       value: build.iosEnterpriseProvisioning?.toLowerCase(),
     },
     {
-      label: 'Release Channel',
-      value: build.releaseChannel,
-    },
-    {
       label: 'Channel',
-      value: build.channel,
+      value: build.releaseChannel ?? build.channel,
     },
     {
       label: 'SDK Version',


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

I've noticed that we unnecessarily make distinction between `channel` and `releaseChannel` in build metadata.
Build metadata is mostly only used for displaying them on the website.

# How

This PR merges those two into `channel`.

# Test Plan

None.