### PR TITLE
[ENG-1570] evaluate interpolated iOS version strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add more filter params to `build:list`. ([#540](https://github.com/expo/eas-cli/pull/540) by [@dsokal](https://github.com/dsokal))
+- Evaluate interpolated iOS version strings for metadata. ([#541](https://github.com/expo/eas-cli/pull/541) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -60,6 +60,7 @@ This means that it will most likely produce an AAB and you will not be able to i
         await validateAndSyncProjectConfigurationAsync(ctx.projectDir, ctx.exp);
       }
     },
+    getMetadataContext: () => ({}),
     prepareJobAsync,
     sendBuildRequestAsync: async (
       appId: string,

--- a/packages/eas-cli/src/build/ios/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/ios/__tests__/version-test.ts
@@ -149,7 +149,7 @@ describe(readBuildNumberAsync, () => {
   describe('generic project', () => {
     it('reads the build number from native code', async () => {
       const exp = initGenericProject();
-      const buildNumber = await readBuildNumberAsync('/repo', exp);
+      const buildNumber = await readBuildNumberAsync('/repo', exp, {});
       expect(buildNumber).toBe('1');
     });
   });
@@ -157,7 +157,7 @@ describe(readBuildNumberAsync, () => {
   describe('managed project', () => {
     it('reads the build number from expo config', async () => {
       const exp = initManagedProject();
-      const buildNumber = await readBuildNumberAsync('/repo', exp);
+      const buildNumber = await readBuildNumberAsync('/repo', exp, {});
       expect(buildNumber).toBe('1');
     });
   });
@@ -167,21 +167,33 @@ describe(readShortVersionAsync, () => {
   describe('generic project', () => {
     it('reads the short version from native code', async () => {
       const exp = initGenericProject();
-      const shortVersion = await readShortVersionAsync('/repo', exp);
+      const shortVersion = await readShortVersionAsync('/repo', exp, {});
       expect(shortVersion).toBe('1.0.0');
+    });
+    it('evaluates interpolated build number', async () => {
+      const exp = initGenericProject({
+        shortVersion: '$(CURRENT_PROJECT_VERSION)',
+      });
+      const buildNumber = await readShortVersionAsync('/repo', exp, {
+        CURRENT_PROJECT_VERSION: '1.0.0',
+      });
+      expect(buildNumber).toBe('1.0.0');
     });
   });
 
   describe('managed project', () => {
     it('reads the version from app config', async () => {
       const exp = initGenericProject();
-      const shortVersion = await readShortVersionAsync('/repo', exp);
+      const shortVersion = await readShortVersionAsync('/repo', exp, {});
       expect(shortVersion).toBe('1.0.0');
     });
   });
 });
 
-function initGenericProject(): ExpoConfig {
+function initGenericProject({
+  shortVersion = '1.0.0',
+  version = '1',
+}: { shortVersion?: string; version?: string } = {}): ExpoConfig {
   vol.fromJSON(
     {
       './app.json': JSON.stringify({
@@ -197,9 +209,9 @@ function initGenericProject(): ExpoConfig {
 <plist version="1.0">
 <dict>
   <key>CFBundleShortVersionString</key>
-  <string>1.0.0</string>
+  <string>${shortVersion}</string>
   <key>CFBundleVersion</key>
-  <string>1</string>
+  <string>${version}</string>
 </dict>
 </plist>`,
     },

--- a/packages/eas-cli/src/build/utils/template.ts
+++ b/packages/eas-cli/src/build/utils/template.ts
@@ -1,0 +1,5 @@
+import template from 'lodash/template';
+
+export function evaluateString(s: string, vars: Record<string, any>): string {
+  return template(s, { interpolate: /\$\(([\s\S]+?)\)/g })(vars);
+}

--- a/packages/eas-cli/src/credentials/ios/types.ts
+++ b/packages/eas-cli/src/credentials/ios/types.ts
@@ -11,6 +11,7 @@ export interface App {
 
 export interface Target {
   targetName: string;
+  buildConfiguration?: string;
   bundleIdentifier: string;
   parentBundleIdentifier?: string;
 }

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -21,12 +21,14 @@ export async function resolveTargetsAsync(
   result.push({
     targetName: applicationTarget.name,
     bundleIdentifier,
+    buildConfiguration,
   });
 
   if (applicationTarget.dependencies && applicationTarget.dependencies.length > 0) {
     for (const dependency of applicationTarget.dependencies) {
       result.push({
         targetName: dependency.name,
+        buildConfiguration,
         bundleIdentifier: await getBundleIdentifierAsync(projectDir, exp, {
           targetName: dependency.name,
           buildConfiguration,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://linear.app/expo/issue/ENG-1570/evaluate-interpolated-version-strings-for-metadata

It's common to have versions refer to $(SOME_VALUE) on iOS. We should evaluate these when populating metadata.

# How

- I read build settings from pbxproj - these are the vars used to evaluate the templates.
- I made evaluated version strings in `readShortVersionAsync` and `readBuildNumberAsync`.

# Test Plan

- Tested manually with a project with 
```
        <key>CFBundleVersion</key>
	<string>$(CURRENT_PROJECT_VERSION)</string>
```
in Info.plist. The version has been resolved properly.
- Added unit test.