### PR TITLE
[eas-cli] validate metadata in build request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Validate metadata client side to print better errors. ([#542](https://github.com/expo/eas-cli/pull/542) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [0.22.1](https://github.com/expo/eas-cli/releases/tag/v0.22.1) - 2021-07-28

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/apple-utils": "0.0.0-alpha.24",
     "@expo/config": "3.3.42",
     "@expo/config-plugins": "3.0.3",
-    "@expo/eas-build-job": "0.2.44",
+    "@expo/eas-build-job": "0.2.45",
     "@expo/eas-json": "^0.22.1",
     "@expo/json-file": "8.2.25",
     "@expo/pkcs12": "0.0.4",

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,4 +1,4 @@
-import { Metadata } from '@expo/eas-build-job';
+import { Metadata, sanitizeMetadata } from '@expo/eas-build-job';
 import { CredentialsSource, IosEnterpriseProvisioning } from '@expo/eas-json';
 
 import { getApplicationIdAsync } from '../project/android/applicationId';
@@ -36,7 +36,7 @@ export async function collectMetadata<T extends Platform>(
   }
 ): Promise<Metadata> {
   const channelOrReleaseChannel = await resolveChannelOrReleaseChannelAsync(ctx);
-  return {
+  const metadata = {
     trackingContext: ctx.trackingCtx,
     appVersion: await resolveAppVersionAsync(ctx),
     appBuildVersion: await resolveAppBuildVersionAsync(ctx),
@@ -58,6 +58,7 @@ export async function collectMetadata<T extends Platform>(
       ),
     }),
   };
+  return sanitizeMetadata(metadata);
 }
 
 async function resolveAppVersionAsync<T extends Platform>(

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.io>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.44",
+    "@expo/eas-build-job": "0.2.45",
     "@hapi/joi": "17.1.1",
     "fs-extra": "9.0.1",
     "tslib": "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,10 +1956,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@0.2.44":
-  version "0.2.44"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.44.tgz#11f442cf9c1ac8402afbb06742bc99d4c1c6b6d9"
-  integrity sha512-4/wtOyAFLa0aILfco0a/slL96CBUppSeXfPdLzcHkBIc+AUB/pUSGf/M+Z3Pn7QoA3BHCnSIW8DosqqBBOppRg==
+"@expo/eas-build-job@0.2.45":
+  version "0.2.45"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.45.tgz#1404767e815b08ebdce8af073dd0f0e6911af1a5"
+  integrity sha512-ysidetne3cqg6H1zsFUCJhfHwDZEGbUhZKQk12a2NtC3P8QYALkOzwc+JbqhPX6oQd9zm9WqF1w7rc7tPK6plA==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

validate metadata before sending build request

# How

How did you build this feature or fix this bug and why?

# Test Plan

run build with buildNumber set to a number(it failed with an `ValidationError: "appBuildVersion" must be a string` error)
run correct build (it succeeded)
