### PR TITLE
[eas-json][eas-cli] add simulator key to build profile json validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Fix build profile schema validation when `simulator` key is present for iOS ([#542](https://github.com/expo/eas-cli/pull/546) by [@sallar](https://github.com/sallar))
+- Fix build profile schema validation when `simulator` key is present for iOS ([#546](https://github.com/expo/eas-cli/pull/546) by [@sallar](https://github.com/sallar))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix build profile schema validation when `simulator` key is present for iOS ([#542](https://github.com/expo/eas-cli/pull/546) by [@sallar](https://github.com/sallar))
+
 ### 🧹 Chores
 
 ## [0.22.2](https://github.com/expo/eas-cli/releases/tag/v0.22.2) - 2021-08-02

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -51,6 +51,7 @@ const IosBuildProfileSchema = CommonBuildProfileSchema.concat(
       Joi.boolean(),
       Joi.string().valid('version', 'buildNumber')
     ),
+    simulator: Joi.boolean(),
 
     image: Joi.string().valid(...Ios.builderBaseImages),
     bundler: Joi.string().empty(null).custom(semverSchemaCheck),
@@ -59,7 +60,6 @@ const IosBuildProfileSchema = CommonBuildProfileSchema.concat(
 
     artifactPath: Joi.string(),
     scheme: Joi.string(),
-    simulator: Joi.boolean(),
     buildConfiguration: Joi.string(),
   })
 );

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -59,6 +59,7 @@ const IosBuildProfileSchema = CommonBuildProfileSchema.concat(
 
     artifactPath: Joi.string(),
     scheme: Joi.string(),
+    simulator: Joi.boolean(),
     buildConfiguration: Joi.string(),
   })
 );


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] ~I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).~ (not applicable)

# Why

The new build profile format is missing the `simulator` key in JSON schema validation. Fixes #545

# How

Ran the new format in development, realized it's broken, and fixed it.

# Test Plan

`eas build --profile development` should not throw an error when `simulator: true` is present in the build profile.
