### PR TITLE
[eas-cli] stop sending deprecated storageBucket field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Stop including deprecated storageBucket field when publishing ([547](https://github.com/expo/eas-cli/pull/547)) by [@jkhales](https://github.com/jkhales)
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -6992,9 +6992,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7004,9 +7008,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7016,9 +7024,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7028,19 +7040,27 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "Build",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Build",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "branchToReceive",
+            "name": "branchMapping",
             "description": "",
             "args": [],
             "type": {
@@ -7185,30 +7205,6 @@
                 "defaultValue": null
               }
             ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Update",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "mostRecentUpdateForEachPlatform",
-            "description": "",
-            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -19809,16 +19805,12 @@
             "defaultValue": null
           },
           {
-            "name": "storageBucket",
+            "name": "fileExtension",
             "description": "",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null
           },

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1013,11 +1013,11 @@ export type SubmissionFilter = {
 /** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
 export type Deployment = {
   __typename?: 'Deployment';
-  id?: Maybe<Scalars['String']>;
-  runtimeVersion?: Maybe<Scalars['String']>;
-  channel?: Maybe<Scalars['String']>;
-  recentBuilds?: Maybe<Array<Maybe<Build>>>;
-  branchToReceive?: Maybe<UpdateBranch>;
+  id: Scalars['ID'];
+  runtimeVersion: Scalars['String'];
+  channel: Scalars['String'];
+  recentBuilds: Array<Build>;
+  branchMapping?: Maybe<UpdateBranch>;
 };
 
 export type UpdateBranch = {
@@ -1028,7 +1028,6 @@ export type UpdateBranch = {
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
   updates: Array<Update>;
-  mostRecentUpdateForEachPlatform: Array<Update>;
 };
 
 
@@ -3052,7 +3051,7 @@ export type PartialManifestAsset = {
   fileSHA256: Scalars['String'];
   bundleKey: Scalars['String'];
   contentType: Scalars['String'];
-  storageBucket: Scalars['String'];
+  fileExtension?: Maybe<Scalars['String']>;
   storageKey: Scalars['String'];
 };
 

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -141,7 +141,6 @@ describe(convertAssetToUpdateInfoGroupFormatAsync, () => {
       bundleKey: 'c939e759656f577c058f445bfb19182e',
       contentType: 'image/jpeg',
       fileSHA256: 'tzD6J-OQZaHCKnL3GHWV9RbnrpyojnagiOE7r3mSkU4',
-      storageBucket: 'update-assets-production',
       storageKey: 'fo8Y08LktVk6qLtGbn8GRWpOUyD13ABMUnbtRCN1L7Y',
     });
   });
@@ -184,7 +183,6 @@ describe(buildUpdateInfoGroupAsync, () => {
             bundleKey: 'c939e759656f577c058f445bfb19182e',
             contentType: 'image/jpeg',
             fileSHA256: 'tzD6J-OQZaHCKnL3GHWV9RbnrpyojnagiOE7r3mSkU4',
-            storageBucket: 'update-assets-production',
             storageKey: 'fo8Y08LktVk6qLtGbn8GRWpOUyD13ABMUnbtRCN1L7Y',
           },
         ],
@@ -192,7 +190,6 @@ describe(buildUpdateInfoGroupAsync, () => {
           bundleKey: 'ec0dd14670aae108f99a810df9c1482c',
           contentType: 'bundle/javascript',
           fileSHA256: 'KEw79FnKTLOyVbRT1SlohSTjPe5e8FpULy2ST-I5BUg',
-          storageBucket: 'update-assets-production',
           storageKey: 'aC9N6RZlcHoIYjIsoJd2KUcigBKy98RHvZacDyPNjCQ',
         },
         extra: {

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -16,15 +16,6 @@ import Log from '../log';
 import { uploadWithPresignedPostAsync } from '../uploads';
 
 export const TIMEOUT_LIMIT = 60_000; // 1 minute
-const STORAGE_BUCKET = getStorageBucket();
-
-function getStorageBucket(): string {
-  if (process.env.EXPO_STAGING || process.env.EXPO_LOCAL) {
-    return 'update-assets-staging';
-  } else {
-    return 'update-assets-production';
-  }
-}
 
 export type PublishPlatform = Extract<'android' | 'ios', Platform>;
 type Metadata = {
@@ -124,7 +115,6 @@ export async function convertAssetToUpdateInfoGroupFormatAsync(
   return {
     fileSHA256,
     contentType,
-    storageBucket: STORAGE_BUCKET,
     storageKey,
     bundleKey,
   };


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

storageBucket is determined server side, and has been for a while.
 
Note: Landing/publishing should happen after this PR: https://github.com/expo/universe/pull/7970
# How

removed storageBucket, updated tests and types.

# Test Plan

yarn test
tested publish in demo repo.