### PR TITLE
[eas-cli] add --auto flag to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add --auto flag for eas branch:publish ([549](https://github.com/expo/eas-cli/pull/549) by [@jkhales](https://github.com/jkhales)
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -72,12 +72,13 @@ async function ensureBranchExists({
 }: {
   appId: string;
   name: string;
-}): Promise<
-  Exclude<
+}): Promise<{
+  id: string;
+  updates: Exclude<
     Exclude<ViewBranchQuery['app'], null | undefined>['byId']['updateBranchByName'],
     null | undefined
-  >
-> {
+  >['updates'];
+}> {
   const { app } = await viewUpdateBranchAsync({
     appId,
     name: branchName,
@@ -85,17 +86,16 @@ async function ensureBranchExists({
   const updateBranch = app?.byId.updateBranchByName;
   if (updateBranch) {
     const { id, updates } = updateBranch;
-    return { id, name: branchName, updates };
+    return { id, updates };
   }
 
   const newUpdateBranch = await createUpdateBranchOnAppAsync({ appId, name: branchName });
-  return { id: newUpdateBranch.id, name: branchName, updates: [] };
+  return { id: newUpdateBranch.id, updates: [] };
 }
 
 export default class BranchPublish extends Command {
   static hidden = true;
   static description = 'Publish an update group to a branch.';
-  static aliases = ['publish', 'p'];
 
   static args = [
     {
@@ -106,7 +106,7 @@ export default class BranchPublish extends Command {
 
   static flags = {
     message: flags.string({
-      description: 'Short message describing the updates.',
+      description: 'short message describing the updates.',
       required: false,
     }),
     republish: flags.boolean({
@@ -128,7 +128,7 @@ export default class BranchPublish extends Command {
     }),
     platform: flags.enum({
       char: 'p',
-      description: `Only publish to a single platform`,
+      description: `only publish to a single platform`,
       options: [...defaultPublishPlatforms, 'all'],
       default: 'all',
       required: false,
@@ -139,7 +139,7 @@ export default class BranchPublish extends Command {
     }),
     auto: flags.boolean({
       description:
-        'Publish to an EAS branch with the same name as the current git branch and publish message equal to the last git commit message.',
+        'use the current git branch and commit message for the EAS branch and update message',
       default: false,
     }),
   };

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -10,11 +10,13 @@ import ora from 'ora';
 
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
-  Actor,
   GetUpdateGroupAsyncQuery,
+  Robot,
   RootQueryUpdatesByGroupArgs,
   Update,
   UpdateInfoGroup,
+  User,
+  ViewBranchQuery,
 } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import Log from '../../log';
@@ -30,6 +32,7 @@ import { promptAsync, selectAsync } from '../../prompts';
 import { formatUpdate } from '../../update/utils';
 import formatFields from '../../utils/formatFields';
 import vcs from '../../vcs';
+import { createUpdateBranchOnAppAsync } from './create';
 import { listBranchesAsync } from './list';
 import { viewUpdateBranchAsync } from './view';
 
@@ -63,9 +66,36 @@ async function getUpdateGroupAsync({
   return updatesByGroup;
 }
 
+async function ensureBranchExists({
+  appId,
+  name: branchName,
+}: {
+  appId: string;
+  name: string;
+}): Promise<
+  Exclude<
+    Exclude<ViewBranchQuery['app'], null | undefined>['byId']['updateBranchByName'],
+    null | undefined
+  >
+> {
+  const { app } = await viewUpdateBranchAsync({
+    appId,
+    name: branchName,
+  });
+  const updateBranch = app?.byId.updateBranchByName;
+  if (updateBranch) {
+    const { id, updates } = updateBranch;
+    return { id, name: branchName, updates };
+  }
+
+  const newUpdateBranch = await createUpdateBranchOnAppAsync({ appId, name: branchName });
+  return { id: newUpdateBranch.id, name: branchName, updates: [] };
+}
+
 export default class BranchPublish extends Command {
   static hidden = true;
   static description = 'Publish an update group to a branch.';
+  static aliases = ['publish', 'p'];
 
   static args = [
     {
@@ -107,13 +137,19 @@ export default class BranchPublish extends Command {
       description: `return a json with the new update group.`,
       default: false,
     }),
+    auto: flags.boolean({
+      description:
+        'Publish to an EAS branch with the same name as the current git branch and publish message equal to the last git commit message.',
+      default: false,
+    }),
   };
 
   async run() {
     let {
-      args: { name },
+      args: { name: branchName },
       flags: {
         json: jsonFlag,
+        auto: autoFlag,
         message,
         republish,
         group,
@@ -152,14 +188,19 @@ export default class BranchPublish extends Command {
     }
     const projectId = await getProjectIdAsync(exp);
 
-    if (!name) {
+    if (!branchName && autoFlag) {
+      branchName =
+        (await vcs.getBranchNameAsync()) || `branch-${Math.random().toString(36).substr(2, 4)}`;
+    }
+
+    if (!branchName) {
       const validationMessage = 'branch name may not be empty.';
       if (jsonFlag) {
         throw new Error(validationMessage);
       }
 
       const branches = await listBranchesAsync({ projectId });
-      name = await selectAsync<string>(
+      branchName = await selectAsync<string>(
         'which branch would you like to publish on?',
         branches.map(branch => {
           return {
@@ -171,11 +212,10 @@ export default class BranchPublish extends Command {
         })
       );
     }
-    assert(name, 'branch name must be specified.');
-
-    const { id: branchId, updates } = await viewUpdateBranchAsync({
+    assert(branchName, 'branch name must be specified.');
+    const { id: branchId, updates } = await ensureBranchExists({
       appId: projectId,
-      name,
+      name: branchName,
     });
 
     let updateInfoGroup: UpdateInfoGroup = {};
@@ -206,7 +246,7 @@ export default class BranchPublish extends Command {
           }));
         if (updateGroups.length === 0) {
           throw new Error(
-            `There are no updates on branch "${name}" published on the platform(s) ${platformFlag}. Did you mean to publish a new update instead?`
+            `There are no updates on branch "${branchName}" published on the platform(s) ${platformFlag}. Did you mean to publish a new update instead?`
           );
         }
 
@@ -222,7 +262,7 @@ export default class BranchPublish extends Command {
       );
       if (updatesToRepublishFilteredByPlatform.length === 0) {
         throw new Error(
-          `There are no updates on branch "${name}" published on the platform(s) "${platformFlag}" with group ID "${
+          `There are no updates on branch "${branchName}" published on the platform(s) "${platformFlag}" with group ID "${
             group ? group : updatesToRepublish[0].group
           }". Did you mean to publish a new update instead?`
         );
@@ -271,6 +311,10 @@ export default class BranchPublish extends Command {
       }
     }
 
+    if (!message && autoFlag) {
+      message = (await vcs.getLastCommitMessageAsync())?.trim();
+    }
+
     if (!message) {
       const validationMessage = 'publish message may not be empty.';
       if (jsonFlag) {
@@ -307,7 +351,7 @@ export default class BranchPublish extends Command {
     } else {
       Log.log(
         formatFields([
-          { label: 'branch', value: name },
+          { label: 'branch', value: branchName },
           { label: 'runtime version', value: runtimeVersion },
           { label: 'update group ID', value: newUpdateGroup.group },
           { label: 'message', value: message },
@@ -318,12 +362,29 @@ export default class BranchPublish extends Command {
 }
 
 function formatUpdateTitle(
-  update: Pick<Update, 'message' | 'createdAt' | 'runtimeVersion'> & {
-    actor?: Pick<Actor, 'firstName'> | null;
-  }
+  update: Exclude<
+    Exclude<ViewBranchQuery['app'], null | undefined>['byId']['updateBranchByName'],
+    null | undefined
+  >['updates'][number]
 ): string {
   const { message, createdAt, actor, runtimeVersion } = update;
-  return `[${dateFormat(createdAt, 'mmm dd HH:MM')} by ${
-    actor?.firstName ?? 'unknown'
-  }, runtimeVersion: ${runtimeVersion}] ${message}`;
+
+  let actorName: string;
+  switch (actor?.__typename) {
+    case 'User': {
+      actorName = (actor as Pick<User, 'username' | 'id'>).username;
+      break;
+    }
+    case 'Robot': {
+      const { firstName, id } = actor as Pick<Robot, 'firstName' | 'id'>;
+      actorName = firstName ?? `robot: ${id.slice(0, 4)}...`;
+      break;
+    }
+    default:
+      actorName = 'unknown';
+  }
+  return `[${dateFormat(
+    createdAt,
+    'mmm dd HH:MM'
+  )} by ${actorName}, runtimeVersion: ${runtimeVersion}] ${message}`;
 }

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -211,8 +211,9 @@ export default class BranchPublish extends Command {
           };
         })
       );
+      assert(branchName, 'branch name must be specified.');
     }
-    assert(branchName, 'branch name must be specified.');
+
     const { id: branchId, updates } = await ensureBranchExists({
       appId: projectId,
       name: branchName,

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -110,7 +110,6 @@ export default class BranchView extends Command {
       }));
     }
 
-    // return data.app?.byId.updateBranchByName;
     const { app } = await viewUpdateBranchAsync({
       appId: projectId,
       name,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

We want a flag to automatically set the branch name and update message to the git branch and commit message.

Also made command create a branch if it doesn't already exist.

# Test Plan

Tested in demo repo.
