### PR TITLE
[eas-cli] Pass through build settings metadata context to app version resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Pass through metadata contexct to app version resolver
+
 ### 🧹 Chores
 
 ## [0.22.4](https://github.com/expo/eas-cli/releases/tag/v0.22.4) - 2021-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Pass through metadata contexct to app version resolver
+- Pass through metadata context to app version resolver. ([#550](https://github.com/expo/eas-cli/pull/550) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -43,7 +43,7 @@ export async function collectMetadata<T extends Platform>(
   const channelOrReleaseChannel = await resolveChannelOrReleaseChannelAsync(ctx);
   const metadata = {
     trackingContext: ctx.trackingCtx,
-    appVersion: await resolveAppVersionAsync(ctx),
+    appVersion: await resolveAppVersionAsync(ctx, platformContext),
     appBuildVersion: await resolveAppBuildVersionAsync(ctx, platformContext),
     cliVersion: packageJSON.version,
     workflow: ctx.workflow,


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Fixes https://forums.expo.dev/t/eas-build-fails-after-upload-ios/55210

# How

I noticed that we were properly extracting the build settings in the metadata context, but that we weren't passing it into the version resolver as expected, so I fixed that.

# Test Plan

I made a new project, went to Info.plist and changed the "Bundle version string (short)" to `$(MARKETING_VERSION)`:
<img width="731" alt="Screen Shot 2021-08-05 at 3 03 55 PM" src="https://user-images.githubusercontent.com/90494/128427150-85dfacbf-a0c4-4dbe-b476-71f7ea49e500.png">

Next, I set the version in the general tab for the target (this sets the `MARKETING_VERSION` build setting):
<img width="562" alt="Screen Shot 2021-08-05 at 3 04 21 PM" src="https://user-images.githubusercontent.com/90494/128427185-723f34ac-e406-4ca4-a41a-05abd297d012.png">

`eas build -p ios` will fail after uploading the project with this error: `ReferenceError: MARKETING_VERSION is not defined`

If you apply this patch, it will not fail and the version will be properly set on the build job (eg: https://expo.dev/accounts/notbrent/projects/attempt-repro/builds/02d01ceb-88ba-4b0e-9e63-59ca026732ea)