### PR TITLE
[submit] log submissions link at end of eas-submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add --auto flag for eas branch:publish ([#549](https://github.com/expo/eas-cli/pull/549) by [@jkhales](https://github.com/jkhales))
+- Add submissions link in output of `eas submit`([#553](https://github.com/expo/eas-cli/pull/553) by [@ajsmth](https://github.com/ajsmth))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -98,7 +98,7 @@ abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
     }
   }
 
-  private async getProjectUrl(): Promise<string> {
+  private async getProjectUrlAsync(): Promise<string> {
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const accountName = await getProjectAccountNameAsync(exp);

--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -51,7 +51,7 @@ abstract class BaseSubmitter<SubmissionContext, SubmissionOptions> {
     Log.log();
     Log.log(`Submission details: ${chalk.underline(submissionUrl)}`);
     Log.log(`Waiting for submission to finish. You can press Ctrl + C to exit`);
-    Log.log();
+    Log.newLine();
 
     let submissionCompleted = false;
     let submissionStatus: SubmissionStatus | null = null;

--- a/packages/eas-cli/src/submissions/types.ts
+++ b/packages/eas-cli/src/submissions/types.ts
@@ -1,7 +1,10 @@
-export interface SubmissionContext<T extends SubmitCommandFlags> {
+export interface SubmissionContext<T extends SubmitCommandFlags> extends BaseSubmissionContext {
+  commandFlags: T;
+}
+
+export interface BaseSubmissionContext {
   projectDir: string;
   projectId: string;
-  commandFlags: T;
 }
 
 export interface SubmitCommandFlags {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

Now that we have a submissions page on the site, we can direct users to see the status of their submissions (similar to what we do with the build command)

# How

How did you build this feature or fix this bug and why?

Logged out the url just before the submission status spinner begins - the formatting / copy was taken from the builds logs which is a very similar feature

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

Run a local submit and ensure that the link is correct:

<img width="1324" alt="Screen Shot 2021-08-10 at 2 37 14 PM" src="https://user-images.githubusercontent.com/40680668/128939272-5ff404e9-88f8-402f-a8ad-74cd7bf377a3.png">

