### PR TITLE
[eas-cli] Stop using project name in build details URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Validate metadata client side to print better errors. ([#542](https://github.com/expo/eas-cli/pull/542) by [@wkozyra95](https://github.com/wkozyra95))
 - Fix `new` build status when building both paltforms. ([#543](https://github.com/expo/eas-cli/pull/543) by [@wkozyra95](https://github.com/wkozyra95))
+- Fix link to build details page where previously we used `project.name` instead of `project.slug` - leave out project segment entirely and depend on redirect. ([#554](https://github.com/expo/eas-cli/pull/554) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -6,9 +6,7 @@ import { AppPlatform, BuildFragment } from '../../graphql/generated';
 export function getBuildLogsUrl(build: BuildFragment): string {
   const { project } = build;
   if (project.__typename === 'App') {
-    return `${getExpoWebsiteBaseUrl()}/accounts/${project.ownerAccount.name}/projects/${
-      project.name
-    }/builds/${build.id}`;
+    return `${getExpoWebsiteBaseUrl()}/accounts/${project.ownerAccount.name}/builds/${build.id}`;
   } else {
     return `${getExpoWebsiteBaseUrl()}/builds/${build.id}`;
   }


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

A user reported this issue:

<img width="1281" alt="Screen_Shot_2021-08-10_at_3 41 57_PM" src="https://user-images.githubusercontent.com/90494/128948891-95194f71-7887-435a-98c7-abc6fd35c398.png">

Notice that where the slug should be, there is a string that would be a valid slug -- this is actually the project name.

# How

We don't actually have `project.slug` available on `BuildFragment` so I shortened the URL and just linked to `/accounts/${owner}/builds/${build.id}` -- without including the project segment. This will redirect to the appropriate place. That said, we likely want to properly fix this as I'm unsure what the downsides are of using this specific path, cc @jonsamp.

# Test Plan

Run a build and use a `name` that is different from `slug`, notice that it is used in the build details URL and  the link will be invalid. Run again with this PR, notice that the URL will work but won't include the project `name` or `slug`.