### PR TITLE
[eas-cli] fix metadata for simulator builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Set correct distribution for simulator builds. ([#556](https://github.com/expo/eas-cli/pull/556) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [0.23.0](https://github.com/expo/eas-cli/releases/tag/v0.23.0) - 2021-08-05

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -41,6 +41,10 @@ export async function collectMetadata<T extends Platform>(
   platformContext?: MetadataContext<T>
 ): Promise<Metadata> {
   const channelOrReleaseChannel = await resolveChannelOrReleaseChannelAsync(ctx);
+  const distribution =
+    ('simulator' in ctx.buildProfile && ctx.buildProfile.simulator
+      ? 'simulator'
+      : ctx.buildProfile.distribution) ?? 'store';
   const metadata = {
     trackingContext: ctx.trackingCtx,
     appVersion: await resolveAppVersionAsync(ctx, platformContext),
@@ -51,7 +55,7 @@ export async function collectMetadata<T extends Platform>(
     sdkVersion: ctx.exp.sdkVersion,
     runtimeVersion: ctx.exp.runtimeVersion,
     ...channelOrReleaseChannel,
-    distribution: ctx.buildProfile.distribution ?? 'store',
+    distribution,
     appName: ctx.exp.name,
     appIdentifier: await resolveAppIdentifierAsync(ctx),
     buildProfile: ctx.buildProfileName,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

simulator builds are marked as app store ones

# How



# Test Plan

run build
