### PR TITLE
[eas cli] Fix SKU not being applied to App Store Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Fixed `--sku` flag being ignored when running `eas submit -p ios`. ([#559](https://github.com/expo/eas-cli/pull/559) by [@barthap](https://github.com/barthap))
+- Fix `--sku` flag being ignored when running `eas submit -p ios`. ([#559](https://github.com/expo/eas-cli/pull/559) by [@barthap](https://github.com/barthap))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fixed `--sku` flag being ignored when running `eas submit -p ios`. ([#559](https://github.com/expo/eas-cli/pull/559) by [@barthap](https://github.com/barthap))
+
 ### 🧹 Chores
 
 ## [0.23.0](https://github.com/expo/eas-cli/releases/tag/v0.23.0) - 2021-08-05

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -152,7 +152,14 @@ export async function ensureAppExistsAsync(
     language,
     companyName,
     bundleIdentifier,
-  }: { name: string; language?: string; companyName?: string; bundleIdentifier: string }
+    sku,
+  }: {
+    name: string;
+    language?: string;
+    companyName?: string;
+    bundleIdentifier: string;
+    sku?: string;
+  }
 ) {
   const context = getRequestContext(authCtx);
   const spinner = ora(`Linking to App Store ${chalk.dim(bundleIdentifier)}`).start();
@@ -170,6 +177,7 @@ export async function ensureAppExistsAsync(
         name,
         primaryLocale: language,
         companyName,
+        sku,
       });
     } catch (error) {
       if (error.message.match(/An App ID with Identifier '(.*)' is not available/)) {

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -70,6 +70,7 @@ async function createAppStoreConnectAppAsync(options: CreateAppOptions): Promise
     appName,
     language,
     companyName,
+    sku,
   } = options;
 
   const authCtx = await authenticateAsync({
@@ -99,6 +100,7 @@ async function createAppStoreConnectAppAsync(options: CreateAppOptions): Promise
       language,
       companyName,
       bundleIdentifier: bundleId,
+      sku,
     });
   } catch (error) {
     if (


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

When reviewing #555 I realised that `sku` is not being propagated to App Store Connect API when running `eas submit -p ios --sku=My_SKU_Here`

# How

It was a matter of propagating the `--sku` command flag value down to `App.createAsync()`.

# Test Plan

`console.log` based debugging 😉 
