### PR TITLE
add `changesNotSentForReview` option to android submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add --auto flag for eas branch:publish ([#549](https://github.com/expo/eas-cli/pull/549) by [@jkhales](https://github.com/jkhales))
 - Add submissions link in output of `eas submit`([#553](https://github.com/expo/eas-cli/pull/553) by [@ajsmth](https://github.com/ajsmth))
 - Add submit profiles. ([#555](https://github.com/expo/eas-cli/pull/555) by [@wkozyra95](https://github.com/wkozyra95))
+- Add `changesNotSentForReview` option to android submissions. ([#560](https://github.com/expo/eas-cli/pull/560) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -107,6 +107,11 @@ export default class BuildSubmit extends EasCommand {
       options: ['completed', 'draft', 'halted', 'inProgress'],
       helpLabel: ANDROID_FLAGS,
     }),
+    'changes-not-send-for-review': flags.boolean({
+      description:
+        '[default: false] Indicates that the changes in this edit will not be reviewed until they are explicitly sent for review from the Google Play Console UI',
+      helpLabel: ANDROID_FLAGS,
+    }),
 
     /* iOS specific flags */
     'apple-id': flags.string({
@@ -179,6 +184,7 @@ export default class BuildSubmit extends EasCommand {
         releaseStatus: 'completed',
         track: 'internal',
         verbose: false,
+        changesNotSentForReview: false,
         ...submitProfile,
         ...flags.androidOptions,
       };
@@ -214,6 +220,7 @@ export default class BuildSubmit extends EasCommand {
         // android
         'android-package': androidPackage,
         'release-status': releaseStatus,
+        'changes-not-send-for-review': changesNotSentForReview,
         track,
         type,
         key: serviceAccountKeyPath,
@@ -237,6 +244,7 @@ export default class BuildSubmit extends EasCommand {
         ...(androidPackage && { androidPackage }),
         ...(releaseStatus && { releaseStatus }),
         ...(track && { track }),
+        ...(changesNotSentForReview && { changesNotSentForReview }),
         ...(serviceAccountKeyPath && { serviceAccountKeyPath }),
         ...flags,
       },

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -102,14 +102,14 @@ export default class BuildSubmit extends EasCommand {
       options: ['production', 'beta', 'alpha', 'internal', 'rollout'],
       helpLabel: ANDROID_FLAGS,
     }),
+    'changes-not-sent-for-review': flags.boolean({
+      description:
+        '[default: false] Indicates that the changes sent with this submission will not be reviewed until they are explicitly sent for review from the Google Play Console UI',
+      helpLabel: ANDROID_FLAGS,
+    }),
     'release-status': flags.enum({
       description: '[default: completed] Release status (used when uploading new APKs/AABs)',
       options: ['completed', 'draft', 'halted', 'inProgress'],
-      helpLabel: ANDROID_FLAGS,
-    }),
-    'changes-not-send-for-review': flags.boolean({
-      description:
-        '[default: false] Indicates that the changes in this edit will not be reviewed until they are explicitly sent for review from the Google Play Console UI',
       helpLabel: ANDROID_FLAGS,
     }),
 
@@ -220,7 +220,7 @@ export default class BuildSubmit extends EasCommand {
         // android
         'android-package': androidPackage,
         'release-status': releaseStatus,
-        'changes-not-send-for-review': changesNotSentForReview,
+        'changes-not-sent-for-review': changesNotSentForReview,
         track,
         type,
         key: serviceAccountKeyPath,

--- a/packages/eas-cli/src/submissions/android/AndroidSubmissionConfig.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmissionConfig.ts
@@ -8,6 +8,7 @@ export interface AndroidSubmissionConfig {
   track: ReleaseTrack;
   serviceAccount: string;
   releaseStatus?: ReleaseStatus;
+  changesNotSentForReview: boolean;
 }
 
 export enum ReleaseStatus {

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
@@ -61,6 +61,7 @@ class AndroidSubmitCommand {
       releaseStatus: releaseStatus.enforceValue(),
       archiveSource: archiveSource.enforceValue(),
       serviceAccountSource: serviceAccountSource.enforceValue(),
+      changesNotSentForReview: this.ctx.commandFlags.changesNotSentForReview,
     };
   }
 

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
@@ -71,16 +71,15 @@ class AndroidSubmitter extends BaseSubmitter<AndroidSubmissionContext, AndroidSu
     const serviceAccount = await fs.readFile(serviceAccountPath, 'utf-8');
     const { track, releaseStatus, projectId, changesNotSentForReview } = options;
 
-    // structuring order affects table rows order
     return {
       androidPackage,
       archiveUrl: archive.location,
       archiveType: archive.type as AndroidArchiveType,
       track,
+      changesNotSentForReview,
       releaseStatus,
       projectId,
       serviceAccount,
-      changesNotSentForReview,
     };
   }
 
@@ -88,12 +87,14 @@ class AndroidSubmitter extends BaseSubmitter<AndroidSubmissionContext, AndroidSu
     options: AndroidSubmissionOptions,
     { archive, androidPackage, serviceAccountPath }: ResolvedSourceOptions
   ): Summary {
-    const { projectId, track, releaseStatus } = options;
+    const { projectId, track, releaseStatus, changesNotSentForReview } = options;
 
+    // structuring order affects table rows order
     return {
       projectId,
       androidPackage,
       track,
+      changesNotSentForReview,
       releaseStatus,
       archiveType: archive.type as AndroidArchiveType,
       serviceAccountPath,
@@ -109,6 +110,7 @@ type Summary = {
   track: ReleaseTrack;
   releaseStatus?: ReleaseStatus;
   projectId?: string;
+  changesNotSentForReview?: boolean;
 } & ArchiveSourceSummaryFields;
 
 const SummaryHumanReadableKeys: Record<keyof Summary, string> = {
@@ -117,6 +119,7 @@ const SummaryHumanReadableKeys: Record<keyof Summary, string> = {
   archiveUrl: 'Download URL',
   archiveType: 'Archive type',
   serviceAccountPath: 'Google Service Key',
+  changesNotSentForReview: 'Changes not sent for a review',
   track: 'Release track',
   releaseStatus: 'Release status',
   projectId: 'Project ID',

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
@@ -14,7 +14,10 @@ import { AndroidSubmissionConfig, ReleaseStatus, ReleaseTrack } from './AndroidS
 import { ServiceAccountSource, getServiceAccountAsync } from './ServiceAccountSource';
 
 export interface AndroidSubmissionOptions
-  extends Pick<AndroidSubmissionConfig, 'track' | 'releaseStatus' | 'projectId'> {
+  extends Pick<
+    AndroidSubmissionConfig,
+    'track' | 'releaseStatus' | 'projectId' | 'changesNotSentForReview'
+  > {
   androidPackageSource: AndroidPackageSource;
   archiveSource: ArchiveSource;
   serviceAccountSource: ServiceAccountSource;
@@ -66,7 +69,7 @@ class AndroidSubmitter extends BaseSubmitter<AndroidSubmissionContext, AndroidSu
     { archive, androidPackage, serviceAccountPath }: ResolvedSourceOptions
   ): Promise<AndroidSubmissionConfig> {
     const serviceAccount = await fs.readFile(serviceAccountPath, 'utf-8');
-    const { track, releaseStatus, projectId } = options;
+    const { track, releaseStatus, projectId, changesNotSentForReview } = options;
 
     // structuring order affects table rows order
     return {
@@ -77,6 +80,7 @@ class AndroidSubmitter extends BaseSubmitter<AndroidSubmissionContext, AndroidSu
       releaseStatus,
       projectId,
       serviceAccount,
+      changesNotSentForReview,
     };
   }
 

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -107,6 +107,7 @@ describe(AndroidSubmitCommand, () => {
         track: 'internal',
         releaseStatus: 'draft',
         verbose: false,
+        changesNotSentForReview: false,
       };
       const ctx = AndroidSubmitCommand.createContext(testProject.projectRoot, projectId, options);
       const command = new AndroidSubmitCommand(ctx);
@@ -119,6 +120,7 @@ describe(AndroidSubmitCommand, () => {
         serviceAccount: fakeFiles['/google-service-account.json'],
         releaseStatus: ReleaseStatus.draft,
         track: ReleaseTrack.internal,
+        changesNotSentForReview: false,
         projectId,
       };
 
@@ -151,6 +153,7 @@ describe(AndroidSubmitCommand, () => {
         track: 'internal',
         releaseStatus: 'draft',
         verbose: false,
+        changesNotSentForReview: false,
       };
       const ctx = AndroidSubmitCommand.createContext(testProject.projectRoot, projectId, options);
       const command = new AndroidSubmitCommand(ctx);
@@ -164,6 +167,7 @@ describe(AndroidSubmitCommand, () => {
         releaseStatus: ReleaseStatus.draft,
         track: ReleaseTrack.internal,
         projectId,
+        changesNotSentForReview: false,
       };
 
       expect(SubmissionService.startSubmissionAsync).toHaveBeenCalledWith(

--- a/packages/eas-cli/src/submissions/types.ts
+++ b/packages/eas-cli/src/submissions/types.ts
@@ -33,6 +33,7 @@ export interface AndroidSubmitCommandFlags extends SubmitCommandFlags {
   androidPackage?: string;
   track: string;
   releaseStatus: string;
+  changesNotSentForReview: boolean;
 }
 
 export type AndroidSubmissionContext = SubmissionContext<AndroidSubmitCommandFlags>;

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -78,6 +78,7 @@ const AndroidSubmitProfileSchema = Joi.object({
   serviceAccountKeyPath: Joi.string(),
   track: Joi.string().valid(...Object.values(ReleaseTrack)),
   releaseStatus: Joi.string().valid(...Object.values(ReleaseStatus)),
+  changesNotSentForReview: Joi.boolean(),
   verbose: Joi.boolean(),
 });
 

--- a/packages/eas-json/src/EasSubmit.types.ts
+++ b/packages/eas-json/src/EasSubmit.types.ts
@@ -18,6 +18,7 @@ export interface AndroidSubmitProfile {
   serviceAccountKeyPath?: string;
   track?: ReleaseTrack;
   releaseStatus?: ReleaseStatus;
+  changesNotSentForReview?: boolean;
   verbose?: boolean;
 }
 


### PR DESCRIPTION

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Closes #489

# How

add an option to the cli and submit profile

# Test Plan

run submit and console log www request
