### PR TITLE
[eas-cli] Improve build command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add submit profiles. ([#555](https://github.com/expo/eas-cli/pull/555) by [@wkozyra95](https://github.com/wkozyra95))
 - Add `changesNotSentForReview` option to android submissions. ([#560](https://github.com/expo/eas-cli/pull/560) by [@wkozyra95](https://github.com/wkozyra95))
 - Support `--json` flag in build commands ([#567](https://github.com/expo/eas-cli/pull/567) by [@wkozyra95](https://github.com/wkozyra95))
+- Add link to https://expo.fyi/eas-build-archive in `eas build` output to make it easier to understand what is going on in the archive/upload phase of the build. ([#562](https://github.com/expo/eas-cli/pull/562) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -8,7 +8,7 @@ import ora from 'ora';
 import { BuildFragment, BuildStatus, UploadSessionType } from '../graphql/generated';
 import { BuildResult } from '../graphql/mutations/BuildMutation';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
-import Log from '../log';
+import Log, { learnMore } from '../log';
 import { promptAsync } from '../prompts';
 import { uploadAsync } from '../uploads';
 import { formatBytes } from '../utils/files';
@@ -159,7 +159,10 @@ async function uploadProjectAsync<TPlatform extends Platform>(
               `Uploading to EAS Build (${formatBytes(projectTarball.size * ratio)} / ${formatBytes(
                 projectTarball.size
               )})`,
-            completedMessage: `Uploaded to EAS`,
+            completedMessage: (duration: string) =>
+              `Uploaded to EAS ${chalk.dim(duration)} ${learnMore(
+                'https://expo.fyi/eas-build-archive'
+              )}`,
           })
         );
         return bucketKey;

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -3,6 +3,10 @@ import assert from 'assert';
 import { getExpoApiBaseUrl, getExpoWebsiteBaseUrl } from '../../api';
 import { AppPlatform, BuildFragment } from '../../graphql/generated';
 
+export function getProjectDashboardUrl(accountName: string, projectName: string): string {
+  return `${getExpoWebsiteBaseUrl()}/accounts/${accountName}/projects/${projectName}`;
+}
+
 export function getBuildLogsUrl(build: BuildFragment): string {
   const { project } = build;
   if (project.__typename === 'App') {

--- a/packages/eas-cli/src/project/ensureProjectExists.ts
+++ b/packages/eas-cli/src/project/ensureProjectExists.ts
@@ -1,7 +1,9 @@
 import assert from 'assert';
 import chalk from 'chalk';
 import ora from 'ora';
+import terminalLink from 'terminal-link';
 
+import { getProjectDashboardUrl } from '../build/utils/url';
 import { AppPrivacy } from '../graphql/generated';
 import { AppMutation } from '../graphql/mutations/AppMutation';
 import { ProjectQuery } from '../graphql/queries/ProjectQuery';
@@ -26,12 +28,14 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
   assert(account, `You must have access to the ${accountName} account to run this command`);
 
   const projectFullName = `@${accountName}/${projectName}`;
+  const projectDashboardUrl = getProjectDashboardUrl(accountName, projectName);
+  const projectLink = terminalLink(projectFullName, projectDashboardUrl);
 
   const spinner = ora(`Linking to project ${chalk.bold(projectFullName)}`).start();
 
   const maybeId = await findProjectIdByAccountNameAndSlugNullableAsync(accountName, projectName);
   if (maybeId) {
-    spinner.succeed(`Linked to project ${chalk.bold(projectFullName)}`);
+    spinner.succeed(`Linked to project ${chalk.bold(projectLink)}`);
     return maybeId;
   }
 
@@ -42,7 +46,7 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
       projectName,
       privacy: projectInfo.privacy,
     });
-    spinner.succeed(`Created ${chalk.bold(projectFullName)} on Expo`);
+    spinner.succeed(`Created ${chalk.bold(projectLink)} on Expo`);
     return id;
   } catch (err) {
     spinner.fail();

--- a/packages/eas-cli/src/utils/progress.ts
+++ b/packages/eas-cli/src/utils/progress.ts
@@ -17,7 +17,7 @@ function createProgressTracker({
 }: {
   total?: number;
   message: string | ((ratio: number) => string);
-  completedMessage: string;
+  completedMessage: string | ((duration: string) => string);
 }): ProgressHandler {
   let bar: ora.Ora | null = null;
   let calcTotal: number = total ?? 0;
@@ -66,7 +66,11 @@ function createProgressTracker({
       if (error) {
         bar.fail();
       } else if (isComplete) {
-        bar.succeed(`${completedMessage} ${chalk.dim(prettyTime)}`);
+        if (typeof completedMessage === 'string') {
+          bar.succeed(`${completedMessage} ${chalk.dim(prettyTime)}`);
+        } else {
+          bar.succeed(completedMessage(prettyTime));
+        }
       }
     }
   };


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

The main motivation here was to provide an FYI link in the "Upload" phase, so that users can learn more about what exactly is being uploaded. I was hesitant to add another log message specifically for archiving the project -- it's an additional line of output and I'm not sure it's needed. That said, if we start supporting alternative version control systems we may want to do this in order to be very explicit about what tool we're using to archive the project.

# How

I extended `createProgressTracker` to support a `completedMessage` function (alternative to the string), which allowed me include a "Learn more" link. I played with three styles for this, as you can see below.

![Screen Shot 2021-08-13 at 4 24 13 PM](https://user-images.githubusercontent.com/90494/129427176-00cfcb7b-378b-4500-af07-6eefab2352b4.png)

I opted for the last style because it adds least noise, and I think is relatively easy to read, while still maintaining consistency with the other usage of this progress tracker in `submit`. My second favorite is the middle option. I'd happily change this to other suggestions, though.

I also noticed while doing this that iTerm 2 lets you cmd+click on `@username/slug`, but it doesn't open the browser anywhere useful. So, I added a `terminalLink` there.

# Test Plan

Run `eas build` from this branch
