### PR TITLE
[eas-cli] add ability to double publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Allow publishing of multiple update groups ([#566](https://github.com/expo/eas-cli/pull/566) by [@jkhales](https://github.com/jkhales))
+
 ### 🎉 New features
 
 - Add --auto flag for eas branch:publish ([#549](https://github.com/expo/eas-cli/pull/549) by [@jkhales](https://github.com/jkhales))

--- a/packages/eas-cli/graphql-codegen.yml
+++ b/packages/eas-cli/graphql-codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://staging.exp.host/--/graphql'
+schema: 'http://localhost:3000/--/graphql'
 documents:
   - 'src/graphql/**/!(*.d).{ts,tsx}'
   - 'src/credentials/ios/api/graphql/**/!(*.d).{ts,tsx}'

--- a/packages/eas-cli/graphql-codegen.yml
+++ b/packages/eas-cli/graphql-codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'http://localhost:3000/--/graphql'
+schema: 'https://staging.exp.host/--/graphql'
 documents:
   - 'src/graphql/**/!(*.d).{ts,tsx}'
   - 'src/credentials/ios/api/graphql/**/!(*.d).{ts,tsx}'

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -3048,25 +3048,21 @@
                 "defaultValue": null
               },
               {
-                "name": "buildListMaxSize",
-                "description": "Max number of associated builds to return",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
                 "name": "mostRecentlyUpdatedAt",
                 "description": "Offset the query",
                 "type": {
                   "kind": "SCALAR",
                   "name": "DateTime",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "options",
+                "description": "",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DeploymentOptions",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -3088,6 +3084,57 @@
                   }
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deployment",
+            "description": "",
+            "args": [
+              {
+                "name": "channel",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "runtimeVersion",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "options",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DeploymentOptions",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Deployment",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6983,6 +7030,27 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "DeploymentOptions",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "buildListMaxSize",
+            "description": "Max number of associated builds to return",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "Deployment",
         "description": "Represents a Deployment - a set of Builds with the same Runtime Version and Channel",
@@ -8810,6 +8878,18 @@
             "deprecationReason": null
           },
           {
+            "name": "googleServiceAccountKeyForSubmissions",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GoogleServiceAccountKey",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "androidAppBuildCredentialsList",
             "description": "",
             "args": [],
@@ -9158,6 +9238,145 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GoogleServiceAccountKey",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "account",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "privateKeyIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientEmail",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -18919,6 +19138,37 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "createAndroidSubmission",
+            "description": "Create an Android EAS Submit submission",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreateAndroidSubmissionInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateSubmissionResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -19044,7 +19294,7 @@
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
-                "name": "NewIosSubmissionConfig",
+                "name": "IosSubmissionConfigInput",
                 "ofType": null
               }
             },
@@ -19067,7 +19317,7 @@
       },
       {
         "kind": "INPUT_OBJECT",
-        "name": "NewIosSubmissionConfig",
+        "name": "IosSubmissionConfigInput",
         "description": "",
         "fields": null,
         "inputFields": [
@@ -19130,6 +19380,152 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CreateAndroidSubmissionInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "config",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "AndroidSubmissionConfigInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "submittedBuildId",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AndroidSubmissionConfigInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "googleServiceAccountKeyId",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "googleServiceAccountKeyJson",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "archiveUrl",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "archiveType",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SubmissionAndroidArchiveType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "applicationIdentifier",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "track",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SubmissionAndroidTrack",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "releaseStatus",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "SubmissionAndroidReleaseStatus",
+              "ofType": null
             },
             "defaultValue": null
           }
@@ -19477,16 +19873,28 @@
             "deprecationReason": null
           },
           {
-            "name": "publishUpdateGroup",
+            "name": "publishUpdateGroups",
             "description": "Publish an update group to a branch",
             "args": [
               {
-                "name": "publishUpdateGroupInput",
+                "name": "publishUpdateGroupsInput",
                 "description": null,
                 "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "PublishUpdateGroupInput",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "PublishUpdateGroupInput",
+                        "ofType": null
+                      }
+                    }
+                  }
                 },
                 "defaultValue": null
               }

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -181,7 +181,7 @@ export default class BranchPublish extends Command {
       runtimeVersion = getRuntimeVersionForSDKVersion(sdkVersion);
     }
 
-    let runtimeVersions: { [keyof: string]: string };
+    let runtimeVersions: Record<string, string>;
     const iOSRuntimeVersion = (exp as any).ios?.runtimeVersion; // TODO-JJ remove cast to any
     const androidRuntimeVersion = (exp as any).android?.runtimeVersion; // TODO-JJ remove cast to any
     switch (platformFlag) {
@@ -365,7 +365,7 @@ export default class BranchPublish extends Command {
       }));
     }
 
-    const runtimeToPlatformMapping: { [keyof: string]: string[] } = {};
+    const runtimeToPlatformMapping: Record<string, string[]> = {};
     for (const runtime of new Set(Object.values(runtimeVersions))) {
       runtimeToPlatformMapping[runtime] = Object.entries(runtimeVersions)
         .filter(pair => pair[1] === runtime)

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -30,27 +30,28 @@ const PublishMutation = {
   },
 
   async publishUpdateGroupAsync(
-    publishUpdateGroupInput: PublishUpdateGroupInput
-  ): Promise<Pick<Update, 'group'>> {
+    publishUpdateGroupsInput: PublishUpdateGroupInput[]
+  ): Promise<UpdatePublishMutation['updateBranch']['publishUpdateGroups']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<UpdatePublishMutation>(
           gql`
-            mutation UpdatePublishMutation($publishUpdateGroupInput: PublishUpdateGroupInput) {
+            mutation UpdatePublishMutation($publishUpdateGroupsInput: [PublishUpdateGroupInput!]!) {
               updateBranch {
-                publishUpdateGroup(publishUpdateGroupInput: $publishUpdateGroupInput) {
+                publishUpdateGroups(publishUpdateGroupsInput: $publishUpdateGroupsInput) {
                   id
                   group
+                  runtimeVersion
+                  platform
                 }
               }
             }
           `,
-          { publishUpdateGroupInput }
+          { publishUpdateGroupsInput }
         )
         .toPromise()
     );
-    const { group } = data.updateBranch.publishUpdateGroup[0]!;
-    return { group };
+    return data.updateBranch.publishUpdateGroups;
   },
 };
 

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
-import { PublishUpdateGroupInput, Update, UpdatePublishMutation } from '../generated';
+import { PublishUpdateGroupInput, UpdatePublishMutation } from '../generated';
 
 const PublishMutation = {
   async getUploadURLsAsync(contentTypes: string[]): Promise<{ specifications: string[] }> {

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -10,7 +10,7 @@ import { PublishQuery } from '../../graphql/queries/PublishQuery';
 import {
   MetadataJoi,
   TIMEOUT_LIMIT,
-  buildUpdateInfoGroupAsync,
+  buildUnsortedUpdateInfoGroupAsync,
   collectAssets,
   convertAssetToUpdateInfoGroupFormatAsync,
   filterOutAssetsThatAlreadyExistAsync,
@@ -147,7 +147,7 @@ describe(convertAssetToUpdateInfoGroupFormatAsync, () => {
   });
 });
 
-describe(buildUpdateInfoGroupAsync, () => {
+describe(buildUnsortedUpdateInfoGroupAsync, () => {
   const androidBundlePath = uuidv4();
   const assetPath = uuidv4();
   fs.writeFileSync(androidBundlePath, 'I am a js bundle');
@@ -155,7 +155,7 @@ describe(buildUpdateInfoGroupAsync, () => {
 
   it('returns the correct value', async () => {
     await expect(
-      buildUpdateInfoGroupAsync(
+      buildUnsortedUpdateInfoGroupAsync(
         {
           android: {
             launchAsset: {

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -122,7 +122,10 @@ export async function convertAssetToUpdateInfoGroupFormatAsync(
   };
 }
 
-export async function buildUpdateInfoGroupAsync(
+/**
+ * This will be sorted later based on the platform's runtime versions.
+ */
+export async function buildUnsortedUpdateInfoGroupAsync(
   assets: CollectedAssets,
   exp: ExpoConfig
 ): Promise<UpdateInfoGroup> {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

If a user specifies platform specific runtimes, we want to automatically publish multiple groups, one for each runtime.

# How

Updated graphQL to take an array here: https://github.com/expo/universe/pull/8036

The graphQL call is slightly more general than needed, for now we automatically create updateGroups based on the rtv's specified in the app.json.

# Test Plan

Tested in a demo repo pointed at the a local server running: https://github.com/expo/universe/pull/8036

Double publish output (Note added a message emphasizing that two groups are created as in discussions we agreed that this maybe a bit surprising if we were not clear about it):

<img width="1071" alt="Screen Shot 2021-08-18 at 8 43 32 AM" src="https://user-images.githubusercontent.com/1220444/129929825-4b4a8ac9-67c1-48db-a8a9-e6703ee05eb4.png">

Confirmed that two update groups are created:

<img width="1472" alt="Screen Shot 2021-08-18 at 8 43 45 AM" src="https://user-images.githubusercontent.com/1220444/129929765-099346f2-a9b4-4b5d-b051-188c430b46d2.png">


Single publish still works 
<img width="643" alt="Screen Shot 2021-08-18 at 8 44 20 AM" src="https://user-images.githubusercontent.com/1220444/129929902-f259a1e6-0391-4387-a87d-7eea7bcfbb30.png">
(added a `platforms` this PR as well):

Confirmed only 1 group created by single publish:

<img width="1511" alt="Screen Shot 2021-08-18 at 8 44 41 AM" src="https://user-images.githubusercontent.com/1220444/129929979-af1ae069-4f7d-4067-b0c1-b9dcddaf0b85.png">
