### PR TITLE
[eas-cli] support --json flag for build commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add --auto flag for eas branch:publish ([#549](https://github.com/expo/eas-cli/pull/549) by [@jkhales](https://github.com/jkhales))
 - Add submissions link in output of `eas submit`([#553](https://github.com/expo/eas-cli/pull/553) by [@ajsmth](https://github.com/ajsmth))
 - Add submit profiles. ([#555](https://github.com/expo/eas-cli/pull/555) by [@wkozyra95](https://github.com/wkozyra95))
+- Support `--json` flag in build commands ([#567](https://github.com/expo/eas-cli/pull/567) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -12,6 +12,7 @@ import {
   EasBuildDeprecationInfoType,
 } from '../../graphql/generated';
 import Log, { learnMore } from '../../log';
+import { printJsonOnlyOutput } from '../../utils/json';
 import { appPlatformDisplayNames, appPlatformEmojis } from '../constants';
 import { getBuildLogsUrl, getInternalDistributionInstallUrl } from './url';
 
@@ -28,14 +29,18 @@ export function printLogsUrls(builds: BuildFragment[]): void {
   }
 }
 
-export function printBuildResults(builds: (BuildFragment | null)[]): void {
-  Log.newLine();
-  if (builds.length === 1) {
-    const [build] = builds;
-    assert(build, 'Build should be defined');
-    printBuildResult(build);
+export function printBuildResults(builds: (BuildFragment | null)[], json: boolean): void {
+  if (json) {
+    printJsonOnlyOutput(builds);
   } else {
-    (builds.filter(i => i) as BuildFragment[]).forEach(build => printBuildResult(build));
+    Log.newLine();
+    if (builds.length === 1) {
+      const [build] = builds;
+      assert(build, 'Build should be defined');
+      printBuildResult(build);
+    } else {
+      (builds.filter(i => i) as BuildFragment[]).forEach(build => printBuildResult(build));
+    }
   }
 }
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -62,7 +62,7 @@ export default class Build extends EasCommand {
       hidden: true,
     }),
     json: flags.boolean({
-      description: 'Enable json output, non-json messages will printed to stderr',
+      description: 'Enable JSON output, non-JSON messages will be printed to stderr',
       default: false,
     }),
     'skip-project-configuration': flags.boolean({

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -27,7 +27,7 @@ export default class BuildList extends Command {
       options: [RequestedPlatform.All, RequestedPlatform.Android, RequestedPlatform.Ios],
     }),
     json: flags.boolean({
-      description: 'Enable json output, non-json messages will printed to stderr',
+      description: 'Enable JSON output, non-JSON messages will be printed to stderr',
     }),
     status: flags.enum({
       options: [

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -20,7 +20,7 @@ export default class BuildView extends Command {
 
   static flags = {
     json: flags.boolean({
-      description: 'Enable json output, non json messages will printed to stderr',
+      description: 'Enable JSON output, non-JSON messages will be printed to stderr',
     }),
   };
 

--- a/packages/eas-cli/src/utils/json.ts
+++ b/packages/eas-cli/src/utils/json.ts
@@ -1,0 +1,27 @@
+import assert from 'assert';
+
+import Log from '../log';
+
+let stdoutWrite: NodeJS.WriteStream['write'] | undefined;
+
+export function enableJsonOutput() {
+  if (stdoutWrite) {
+    return;
+  }
+  stdoutWrite = process.stdout.write;
+  process.stdout.write = (...args: any) => {
+    return process.stderr.write.call(null, args);
+  };
+}
+
+export function printJsonOnlyOutput(value: object): void {
+  assert(stdoutWrite, 'this should only be called with --json flag');
+  try {
+    process.stdout.write = stdoutWrite;
+    Log.log(JSON.stringify(value, null, 2));
+  } finally {
+    process.stdout.write = (...args: any) => {
+      return process.stderr.write.call(null, args);
+    };
+  }
+}

--- a/packages/eas-cli/src/utils/json.ts
+++ b/packages/eas-cli/src/utils/json.ts
@@ -18,10 +18,26 @@ export function printJsonOnlyOutput(value: object): void {
   assert(stdoutWrite, 'this should only be called with --json flag');
   try {
     process.stdout.write = stdoutWrite;
-    Log.log(JSON.stringify(value, null, 2));
+    Log.log(JSON.stringify(sanitizeValue(value), null, 2));
   } finally {
     process.stdout.write = (...args: any) => {
       return process.stderr.write.call(null, args);
     };
+  }
+}
+
+function sanitizeValue(value: any): unknown {
+  if (Array.isArray(value)) {
+    return value.map(val => sanitizeValue(val));
+  } else if (value && typeof value === 'object') {
+    const result: Record<string, any> = {};
+    Object.keys(value).forEach(key => {
+      if (key !== '__typename' && value[key] !== null) {
+        result[key] = sanitizeValue(value[key]);
+      }
+    });
+    return result;
+  } else {
+    return value;
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://linear.app/expo/issue/ENG-1602/add-json-flag-to-some-eas-cli-commands-to-output-results-as-json

# How

- if json flag is specified override `process.stdout.write` with `process.stderr.write`
- when printing actual json result use original stdou write function
- for build require non-interactive flag because this approach does not work when prompts are showing up
- for now we print directly graphql objects, it still an open question whether we want to do that or display only curated list of values. cc @brentvatne 

# Test Plan

run build build:list and build view with and without json flag
