### PR TITLE
[eas-cli] warn if NODE_ENV or googleServicesFile is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add warnings around common issues(`NODE_ENV=production`, gitignored `googleServicesFile`). ([#569](https://github.com/expo/eas-cli/pull/569) by [@wkozyra95](https://github.com/wkozyra95))
+
 ## [0.23.0](https://github.com/expo/eas-cli/releases/tag/v0.23.0) - 2021-08-05
 
 ### 🛠 Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Add warnings around common issues(`NODE_ENV=production`, gitignored `googleServicesFile`). ([#569](https://github.com/expo/eas-cli/pull/569) by [@wkozyra95](https://github.com/wkozyra95))
+- Add warnings around common issues (`NODE_ENV=production`, git ignored `googleServicesFile`). ([#569](https://github.com/expo/eas-cli/pull/569) by [@wkozyra95](https://github.com/wkozyra95))
 
 ## [0.23.0](https://github.com/expo/eas-cli/releases/tag/v0.23.0) - 2021-08-05
 

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -23,6 +23,7 @@ import { BuildContext } from '../context';
 import { transformMetadata } from '../graphql';
 import { Platform } from '../types';
 import { logCredentialsSource } from '../utils/credentials';
+import { checkGoogleServicesFileAsync, checkNodeEnvVariable } from '../validate';
 import { validateAndSyncProjectConfigurationAsync } from './configure';
 import { transformJob } from './graphql';
 import { prepareJobAsync } from './prepareJob';
@@ -47,6 +48,9 @@ This means that it will most likely produce an AAB and you will not be able to i
       process.exit(1);
     }
   }
+
+  checkNodeEnvVariable(ctx);
+  await checkGoogleServicesFileAsync(ctx);
 
   if (ctx.workflow === Workflow.MANAGED) {
     await ensureApplicationIdIsDefinedForManagedProjectAsync(ctx.projectDir, ctx.exp);

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -11,6 +11,7 @@ import { BuildContext } from '../context';
 import { transformMetadata } from '../graphql';
 import { IosMetadataContext } from '../metadata';
 import { Platform } from '../types';
+import { checkGoogleServicesFileAsync, checkNodeEnvVariable } from '../validate';
 import { validateAndSyncProjectConfigurationAsync } from './configure';
 import { ensureIosCredentialsAsync } from './credentials';
 import { transformJob } from './graphql';
@@ -24,6 +25,9 @@ export async function prepareIosBuildAsync(
   if (ctx.workflow === Workflow.MANAGED) {
     await ensureBundleIdentifierIsDefinedForManagedProjectAsync(ctx.projectDir, ctx.exp);
   }
+
+  checkNodeEnvVariable(ctx);
+  await checkGoogleServicesFileAsync(ctx);
 
   const xcodeBuildContext = await resolveXcodeBuildContextAsync(
     {

--- a/packages/eas-cli/src/build/validate.ts
+++ b/packages/eas-cli/src/build/validate.ts
@@ -1,0 +1,60 @@
+import { Workflow } from '@expo/eas-build-job';
+import fs from 'fs-extra';
+import path from 'path';
+
+import Log, { learnMore } from '../log';
+import vcs from '../vcs';
+import { BuildContext } from './context';
+import { Platform } from './types';
+
+export function checkNodeEnvVariable(ctx: BuildContext<Platform>) {
+  if (ctx.buildProfile.env?.NODE_ENV === 'production') {
+    Log.warn(
+      'You are setting environment variable NODE_ENV=production, remember that it will be available during entire build process and will affect among other things what yarn/npm packages will be installed.'
+    );
+    Log.newLine();
+  }
+}
+
+export async function checkGoogleServicesFileAsync<T extends Platform>(
+  ctx: BuildContext<T>
+): Promise<void> {
+  if (ctx.workflow === Workflow.GENERIC || ctx.buildProfile?.env?.GOOGLE_SERVICES_FILE) {
+    return;
+  }
+  const googleServicesFilePath = ctx.exp[ctx.platform]?.googleServicesFile;
+  if (!googleServicesFilePath) {
+    return;
+  }
+  const rootDir = await vcs.getRootPathAsync();
+  const absGoogleServicesFilePath = path.resolve(ctx.projectDir, googleServicesFilePath);
+  if (
+    (await fs.pathExists(googleServicesFilePath)) &&
+    ((await vcs.isFileIgnoredAsync(googleServicesFilePath)) ||
+      !isInsideDirectory(absGoogleServicesFilePath, rootDir))
+  ) {
+    Log.warn(
+      `File specified via "${ctx.platform}.googleServicesFile" field in your app.json is not commited into your repository and won't be uploaded to the builder.`
+    );
+    Log.warn(
+      `Use EAS Secret to pass all values that you don't want to include in your version control. ${learnMore(
+        'https://docs.expo.dev/build-reference/variables/#using-secrets-in-environment-variables'
+      )}`
+    );
+    Log.warn(
+      'If you are using that file for compatibility with classic build service you can silence this warning by setting GOOGLE_SERVICES_FILE in your build profile in eas.json to any non falsy value.'
+    );
+    Log.newLine();
+  }
+}
+
+function isInsideDirectory(file: string, directory: string): boolean {
+  let lastPath = file;
+  while (path.dirname(lastPath) !== lastPath) {
+    if (lastPath === directory) {
+      return true;
+    }
+    lastPath = path.dirname(lastPath);
+  }
+  return false;
+}

--- a/packages/eas-cli/src/build/validate.ts
+++ b/packages/eas-cli/src/build/validate.ts
@@ -7,10 +7,10 @@ import vcs from '../vcs';
 import { BuildContext } from './context';
 import { Platform } from './types';
 
-export function checkNodeEnvVariable(ctx: BuildContext<Platform>) {
+export function checkNodeEnvVariable(ctx: BuildContext<Platform>): void {
   if (ctx.buildProfile.env?.NODE_ENV === 'production') {
     Log.warn(
-      'You are setting environment variable NODE_ENV=production, remember that it will be available during entire build process and will affect among other things what yarn/npm packages will be installed.'
+      'You set NODE_ENV=production in the build profile. Remember that it will be available during the entire build process. In particular, it will make yarn/npm install only production packages.'
     );
     Log.newLine();
   }
@@ -34,7 +34,7 @@ export async function checkGoogleServicesFileAsync<T extends Platform>(
       !isInsideDirectory(absGoogleServicesFilePath, rootDir))
   ) {
     Log.warn(
-      `File specified via "${ctx.platform}.googleServicesFile" field in your app.json is not commited into your repository and won't be uploaded to the builder.`
+      `File specified via "${ctx.platform}.googleServicesFile" field in your app.json is not checked in to your repository and won't be uploaded to the builder.`
     );
     Log.warn(
       `Use EAS Secret to pass all values that you don't want to include in your version control. ${learnMore(
@@ -42,19 +42,12 @@ export async function checkGoogleServicesFileAsync<T extends Platform>(
       )}`
     );
     Log.warn(
-      'If you are using that file for compatibility with classic build service you can silence this warning by setting GOOGLE_SERVICES_FILE in your build profile in eas.json to any non falsy value.'
+      'If you are using that file for compatibility with the classic build service (expo build) you can silence this warning by setting GOOGLE_SERVICES_FILE in your build profile in eas.json to any non-falsy value.'
     );
     Log.newLine();
   }
 }
 
 function isInsideDirectory(file: string, directory: string): boolean {
-  let lastPath = file;
-  while (path.dirname(lastPath) !== lastPath) {
-    if (lastPath === directory) {
-      return true;
-    }
-    lastPath = path.dirname(lastPath);
-  }
-  return false;
+  return file.startsWith(directory);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

add warnings around common issues

# How

- warn if NODE_ENV=production is set
- warn if `googleServicesFile does exist but it's gitingored or not part of the repository
- provide a way to silence warning for googleServicesFile

# Test Plan

run builds that trigger those warnings
