### PR TITLE
[eas-cli] detect case inconsistencies on macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Support `--no-wait` in `eas submit`. ([#578](https://github.com/expo/eas-cli/pull/578) by [@dsokal](https://github.com/dsokal))
+- Detect changes when `core.ignorecase` is set to true. ([#570](https://github.com/expo/eas-cli/pull/570) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/vcs/git.ts
+++ b/packages/eas-cli/src/vcs/git.ts
@@ -192,6 +192,12 @@ async function gitDiffAsync({ withPager = false }: { withPager?: boolean } = {})
   await spawnAsync('git', [...options, 'diff'], { stdio: ['ignore', 'inherit', 'inherit'] });
 }
 
+/**
+ * Checks if git is configured to be case sensitive
+ * @returns {boolean | undefined}
+ *    - boolean - is git case senstive
+ *    - undefined - case sensitivity is not configured and git is using default behaviour
+ */
 async function isGitCaseSensitiveAsync(): Promise<boolean | undefined> {
   if (process.platform !== 'darwin') {
     return undefined;

--- a/packages/eas-cli/src/vcs/git.ts
+++ b/packages/eas-cli/src/vcs/git.ts
@@ -66,8 +66,8 @@ export default class GitClient extends Client {
   public async makeShallowCopyAsync(destinationPath: string): Promise<void> {
     if (await this.hasUncommittedChangesAsync()) {
       // it should not happen, we need that to make sure that check before clone
-      // is always caused by case sensitvity
-      throw new Error('You have some uncommited changes in you repository.');
+      // is always caused by case sensitivity
+      throw new Error('You have some uncommitted changes in your repository.');
     }
     let gitRepoUri;
     if (process.platform === 'win32') {
@@ -85,9 +85,9 @@ export default class GitClient extends Client {
       if (await this.hasUncommittedChangesAsync()) {
         await spawnAsync('git', ['status'], { stdio: 'inherit' });
         Log.error(
-          'Case of some of your filenames is inconsitent between value stored in the git and in the filesystem. Run "git config core.ignorecase false" to show those differences.'
+          'Case of some of your filenames is inconsistent between values stored in the git and in the filesystem. Run "git config core.ignorecase false" to show those differences.'
         );
-        throw new Error('You have some uncommited changes in you repository.');
+        throw new Error('You have some uncommitted changes in your repository.');
       }
       await spawnAsync('git', [
         'clone',


### PR DESCRIPTION

<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

detect if there are filename differences when `core.ignorecase` is enabled.
Not sure if this should be a warning or an error cc @brentvatne 

# How

- set core.ignorecase' false
- check status
- restore old state
- above changes are only applied on macos, I assume that someone using Linux or windows had to set this value explicitly and if they did then they should know what they are doing

![20210830_16h12m24s_grim](https://user-images.githubusercontent.com/9753141/131352931-5125fb9e-32fc-4e25-84a1-ada030fdecdd.png)


- affected files are displayed using `git status --short`

# Test Plan

run build with file renamed
