### PR TITLE
[eas-cli] update QR code url for Android internal distribution build and generate smaller QR code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add `changesNotSentForReview` option to android submissions. ([#560](https://github.com/expo/eas-cli/pull/560) by [@wkozyra95](https://github.com/wkozyra95))
 - Support `--json` flag in build commands ([#567](https://github.com/expo/eas-cli/pull/567) by [@wkozyra95](https://github.com/wkozyra95))
 - Add link to https://expo.fyi/eas-build-archive in `eas build` output to make it easier to understand what is going on in the archive/upload phase of the build. ([#562](https://github.com/expo/eas-cli/pull/562) by [@brentvatne](https://github.com/brentvatne))
+- Update QR code url for Android internal distribution build and generate smaller QR code ([#573](https://github.com/expo/eas-cli/pull/573) by [@axeldelafosse](https://github.com/axeldelafosse))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add submissions link in output of `eas submit`([#553](https://github.com/expo/eas-cli/pull/553) by [@ajsmth](https://github.com/ajsmth))
 - Add submit profiles. ([#555](https://github.com/expo/eas-cli/pull/555) by [@wkozyra95](https://github.com/wkozyra95))
 - Add `changesNotSentForReview` option to android submissions. ([#560](https://github.com/expo/eas-cli/pull/560) by [@wkozyra95](https://github.com/wkozyra95))
-- Support `--json` flag in build commands ([#567](https://github.com/expo/eas-cli/pull/567) by [@wkozyra95](https://github.com/wkozyra95))
+- Support `--json` flag in build commands. ([#567](https://github.com/expo/eas-cli/pull/567) by [@wkozyra95](https://github.com/wkozyra95))
 - Add link to https://expo.fyi/eas-build-archive in `eas build` output to make it easier to understand what is going on in the archive/upload phase of the build. ([#562](https://github.com/expo/eas-cli/pull/562) by [@brentvatne](https://github.com/brentvatne))
 - Update QR code url for Android internal distribution build and generate smaller QR code ([#573](https://github.com/expo/eas-cli/pull/573) by [@axeldelafosse](https://github.com/axeldelafosse))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add `changesNotSentForReview` option to android submissions. ([#560](https://github.com/expo/eas-cli/pull/560) by [@wkozyra95](https://github.com/wkozyra95))
 - Support `--json` flag in build commands. ([#567](https://github.com/expo/eas-cli/pull/567) by [@wkozyra95](https://github.com/wkozyra95))
 - Add link to https://expo.fyi/eas-build-archive in `eas build` output to make it easier to understand what is going on in the archive/upload phase of the build. ([#562](https://github.com/expo/eas-cli/pull/562) by [@brentvatne](https://github.com/brentvatne))
-- Update QR code url for Android internal distribution build and generate smaller QR code ([#573](https://github.com/expo/eas-cli/pull/573) by [@axeldelafosse](https://github.com/axeldelafosse))
+- Update QR code url for Android internal distribution build and generate smaller QR code. ([#573](https://github.com/expo/eas-cli/pull/573) by [@axeldelafosse](https://github.com/axeldelafosse))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -4,6 +4,7 @@ import indentString from 'indent-string';
 import qrcodeTerminal from 'qrcode-terminal';
 
 import {
+  AppPlatform,
   BuildError,
   BuildFragment,
   BuildStatus,
@@ -70,7 +71,12 @@ function printBuildResult(build: BuildFragment): void {
   if (build.distribution === DistributionType.Internal) {
     const logsUrl = getBuildLogsUrl(build);
     const installUrl = getInternalDistributionInstallUrl(build);
-    qrcodeTerminal.generate(installUrl, code => Log.log(`${indentString(code, 2)}\n`));
+    // It's tricky to install the .apk file directly on Android so let's fallback
+    // to the build details page and let people press the button to download there
+    const qrcodeUrl = build.platform === AppPlatform.Ios ? installUrl : logsUrl;
+    qrcodeTerminal.generate(qrcodeUrl, { small: true }, code =>
+      Log.log(`${indentString(code, 2)}\n`)
+    );
     Log.log(
       `${appPlatformEmojis[build.platform]} Open this link on your ${
         appPlatformDisplayNames[build.platform]

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -70,10 +70,10 @@ function printBuildResult(build: BuildFragment): void {
 
   if (build.distribution === DistributionType.Internal) {
     const logsUrl = getBuildLogsUrl(build);
-    const installUrl = getInternalDistributionInstallUrl(build);
     // It's tricky to install the .apk file directly on Android so let's fallback
     // to the build details page and let people press the button to download there
-    const qrcodeUrl = build.platform === AppPlatform.Ios ? installUrl : logsUrl;
+    const qrcodeUrl =
+      build.platform === AppPlatform.Ios ? getInternalDistributionInstallUrl(build) : logsUrl;
     qrcodeTerminal.generate(qrcodeUrl, { small: true }, code =>
       Log.log(`${indentString(code, 2)}\n`)
     );

--- a/packages/eas-cli/src/devices/actions/create/registrationUrlMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/registrationUrlMethod.ts
@@ -28,10 +28,11 @@ async function generateDeviceRegistrationURLAsync(
   accountId: string,
   appleTeam: Pick<AppleTeam, 'id'>
 ) {
-  const appleDeviceRegistrationRequest = await AppleDeviceRegistrationRequestMutation.createAppleDeviceRegistrationRequestAsync(
-    appleTeam.id,
-    accountId
-  );
+  const appleDeviceRegistrationRequest =
+    await AppleDeviceRegistrationRequestMutation.createAppleDeviceRegistrationRequestAsync(
+      appleTeam.id,
+      accountId
+    );
   return formatRegistrationURL(appleDeviceRegistrationRequest.id);
 }
 

--- a/packages/eas-cli/src/devices/actions/create/registrationUrlMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/registrationUrlMethod.ts
@@ -14,7 +14,9 @@ export async function runRegistrationUrlMethodAsync(
 ): Promise<void> {
   const registrationURL = await generateDeviceRegistrationURLAsync(accountId, appleTeam);
   Log.newLine();
-  qrcodeTerminal.generate(registrationURL, code => Log.log(`${indentString(code, 2)}\n`));
+  qrcodeTerminal.generate(registrationURL, { small: true }, code =>
+    Log.log(`${indentString(code, 2)}\n`)
+  );
   Log.log(
     'Open the following link on your iOS devices (or scan the QR code) and follow the instructions to install the development profile:'
   );
@@ -26,11 +28,10 @@ async function generateDeviceRegistrationURLAsync(
   accountId: string,
   appleTeam: Pick<AppleTeam, 'id'>
 ) {
-  const appleDeviceRegistrationRequest =
-    await AppleDeviceRegistrationRequestMutation.createAppleDeviceRegistrationRequestAsync(
-      appleTeam.id,
-      accountId
-    );
+  const appleDeviceRegistrationRequest = await AppleDeviceRegistrationRequestMutation.createAppleDeviceRegistrationRequestAsync(
+    appleTeam.id,
+    accountId
+  );
   return formatRegistrationURL(appleDeviceRegistrationRequest.id);
 }
 

--- a/ts-declarations/qrcode-terminal/index.d.ts
+++ b/ts-declarations/qrcode-terminal/index.d.ts
@@ -1,3 +1,3 @@
 declare module 'qrcode-terminal' {
-  function generate(text: string, cb: (code: string) => void): void;
+  function generate(text: string, opts: { small: boolean }, cb: (code: string) => void): void;
 }


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

We introduced a QR code to install internal distribution builds here: https://github.com/expo/eas-cli/pull/371

During standup yesterday, @ccheever raised an issue where the QR code is too big to fit in the terminal and also mentioned some difficulties to install the .apk directly: https://docs.google.com/presentation/d/1pKmuhzBjXiWatTwqrPTa2Dw0mqklNAkvoC7zIxVp47E/edit#slide=id.ge85bd431ff_1_37

This PR solves these two issues. Closes https://linear.app/expo/issue/ENG-1845/update-android-internal-distribution-qr-code and https://linear.app/expo/issue/ENG-1846/smaller-qr-codes

# How

- Used `logsUrl` instead of `installUrl` for Android internal build to redirect to the build details page instead of S3
- Used `qrcode-terminal` small option: https://github.com/gtanner/qrcode-terminal/commit/c6327e52ca7681631c898ea94c519fc77db8b59c

# Test Plan

- Run `eas build --profile preview --platform android` and compare with `eas_dev build --profile preview --platform android` (here is a before / after):
<img width="932" alt="Screenshot 2021-08-24 at 15 10 49" src="https://user-images.githubusercontent.com/10477267/130632988-a5f1996b-b58e-45f6-aff0-9ecc14c6308a.png">

- Also works for iOS (which has a pretty big deep link to install the app) `eas build --profile preview --platform ios`:
<img width="787" alt="Screenshot 2021-08-24 at 16 13 02" src="https://user-images.githubusercontent.com/10477267/130633156-10b7f41a-a46c-4f6d-a7c7-d6af1af30f03.png">

- Also updated for `eas device:create`
<img width="1060" alt="Screenshot 2021-08-24 at 15 14 28" src="https://user-images.githubusercontent.com/10477267/130633172-58d3ba8a-466b-4d0c-a401-9456eddadbc4.png">
