### PR TITLE
Bump apple-utils to v25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- Retry status code 500-600 server errors from Apple servers with cookies auth ([#574](https://github.com/expo/eas-cli/pull/574) by [@EvanBacon](https://github.com/EvanBacon))
-- Throw internal server errors when Apple servers fail to authenticate ([#574](https://github.com/expo/eas-cli/pull/574) by [@EvanBacon](https://github.com/EvanBacon))
+- Retry status code 500-600 server errors from Apple servers with cookies auth. ([#574](https://github.com/expo/eas-cli/pull/574) by [@EvanBacon](https://github.com/EvanBacon))
+- Throw internal server errors when Apple servers fail to authenticate. ([#574](https://github.com/expo/eas-cli/pull/574) by [@EvanBacon](https://github.com/EvanBacon))
 - Add --auto flag for eas branch:publish ([#549](https://github.com/expo/eas-cli/pull/549) by [@jkhales](https://github.com/jkhales))
 - Add submissions link in output of `eas submit`([#553](https://github.com/expo/eas-cli/pull/553) by [@ajsmth](https://github.com/ajsmth))
 - Add submit profiles. ([#555](https://github.com/expo/eas-cli/pull/555) by [@wkozyra95](https://github.com/wkozyra95))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Retry status code 500-600 server errors from Apple servers with cookies auth ([#574](https://github.com/expo/eas-cli/pull/574) by [@EvanBacon](https://github.com/EvanBacon))
+- Throw internal server errors when Apple servers fail to authenticate ([#574](https://github.com/expo/eas-cli/pull/574) by [@EvanBacon](https://github.com/EvanBacon))
 - Add --auto flag for eas branch:publish ([#549](https://github.com/expo/eas-cli/pull/549) by [@jkhales](https://github.com/jkhales))
 - Add submissions link in output of `eas submit`([#553](https://github.com/expo/eas-cli/pull/553) by [@ajsmth](https://github.com/ajsmth))
 - Add submit profiles. ([#555](https://github.com/expo/eas-cli/pull/555) by [@wkozyra95](https://github.com/wkozyra95))

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@amplitude/identify": "1.7.0",
     "@amplitude/node": "1.7.0",
-    "@expo/apple-utils": "0.0.0-alpha.24",
+    "@expo/apple-utils": "0.0.0-alpha.25",
     "@expo/config": "3.3.42",
     "@expo/config-plugins": "3.0.3",
     "@expo/eas-build-job": "0.2.45",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,10 +1865,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/apple-utils@0.0.0-alpha.24":
-  version "0.0.0-alpha.24"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.24.tgz#4208204d3763a4770ce9e63f36c14476adc635bd"
-  integrity sha512-96MGsGcRIjzJ3Stqw9fiXAgOfMn4UlmlBp2EZkmpad7945ke9Gguceafb6rpbKJHEkQd2qcBcfcumU73QisP2w==
+"@expo/apple-utils@0.0.0-alpha.25":
+  version "0.0.0-alpha.25"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.25.tgz#fea4f5a409cc1bf79a0d2acec3eca52dbd8443c1"
+  integrity sha512-meyCJ/5jHJsgZNBMwlAugqD5Z0bcazCLgAyYQCw8O1/sXh4gWf0IiWJGnkevdxnA3g1R9nmJFmjkFuLoGOt+Bw==
 
 "@expo/babel-preset-cli@^0.2.17":
   version "0.2.18"


### PR DESCRIPTION
- Related https://github.com/expo/expo-cli/pull/3798
- This should only change what happens when users encounter server errors (status 500-600) -- I couldn't repro so all of my testing was done via mock axios tests.