### PR TITLE
use custom ora instance

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,11 @@ module.exports = {
     ],
     'flowtype/no-types-missing-file-annotation': 'off',
     curly: 'warn',
+    'import/no-cycle': 'error',
+    'import/no-extraneous-dependencies': [
+      'error',
+      { devDependencies: ['**/__tests__/**/*', '**/__mocks__/**/*'] },
+    ],
     'import/no-relative-packages': 'error',
     'no-restricted-imports': [
       'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Prevent ora spinners breaking when debug logs are enabled ([#575](https://github.com/expo/eas-cli/pull/575) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `--sku` flag being ignored when running `eas submit -p ios`. ([#559](https://github.com/expo/eas-cli/pull/559) by [@barthap](https://github.com/barthap))
 - Set correct distribution for simulator builds. ([#556](https://github.com/expo/eas-cli/pull/556) by [@wkozyra95](https://github.com/wkozyra95))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Prevent ora spinners breaking when debug logs are enabled. ([#575](https://github.com/expo/eas-cli/pull/575) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🧹 Chores
 
 ## [0.28.0](https://github.com/expo/eas-cli/releases/tag/v0.28.0) - 2021-09-10
@@ -112,7 +114,6 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Prevent ora spinners breaking when debug logs are enabled. ([#575](https://github.com/expo/eas-cli/pull/575) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `--sku` flag being ignored when running `eas submit -p ios`. ([#559](https://github.com/expo/eas-cli/pull/559) by [@barthap](https://github.com/barthap))
 - Set correct distribution for simulator builds. ([#556](https://github.com/expo/eas-cli/pull/556) by [@wkozyra95](https://github.com/wkozyra95))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Prevent ora spinners breaking when debug logs are enabled ([#575](https://github.com/expo/eas-cli/pull/575) by [@EvanBacon](https://github.com/EvanBacon))
+- Prevent ora spinners breaking when debug logs are enabled. ([#575](https://github.com/expo/eas-cli/pull/575) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `--sku` flag being ignored when running `eas submit -p ios`. ([#559](https://github.com/expo/eas-cli/pull/559) by [@barthap](https://github.com/barthap))
 - Set correct distribution for simulator builds. ([#556](https://github.com/expo/eas-cli/pull/556) by [@wkozyra95](https://github.com/wkozyra95))
 

--- a/packages/eas-cli/.eslintrc.js
+++ b/packages/eas-cli/.eslintrc.js
@@ -1,9 +1,18 @@
+const rootEslintrc = require('../../.eslintrc.js');
+
 module.exports = {
   rules: {
-    'import/no-cycle': 'error',
-    'import/no-extraneous-dependencies': [
+    'no-restricted-imports': [
       'error',
-      { devDependencies: ['**/__tests__/**/*', '**/__mocks__/**/*'] },
+      {
+        paths: [
+          ...rootEslintrc.rules['no-restricted-imports'][1].paths,
+          {
+            name: 'ora',
+            message: 'Import ora from src/ora.ts instead.',
+          },
+        ],
+      },
     ],
     'graphql/template-strings': [
       'error',

--- a/packages/eas-cli/__mocks__/ora.ts
+++ b/packages/eas-cli/__mocks__/ora.ts
@@ -3,5 +3,7 @@ export default jest.fn().mockReturnValue({
     fail: jest.fn(),
     succeed: jest.fn(),
   }),
+  stop: jest.fn(),
+  stopAndPersist: jest.fn(),
   succeed: jest.fn(),
 });

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -3,12 +3,12 @@ import { CredentialsSource } from '@expo/eas-json';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import nullthrows from 'nullthrows';
-import ora from 'ora';
 
 import { BuildFragment, BuildStatus, UploadSessionType } from '../graphql/generated';
 import { BuildResult } from '../graphql/mutations/BuildMutation';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
 import Log, { learnMore } from '../log';
+import { ora } from '../ora';
 import { requestedPlatformDisplayNames } from '../platform';
 import { uploadAsync } from '../uploads';
 import { formatBytes } from '../utils/files';

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import ora from 'ora';
 import path from 'path';
 import tar from 'tar';
 import { v4 as uuidv4 } from 'uuid';
 
 import Log from '../../log';
+import { ora } from '../../ora';
 import { confirmAsync, promptAsync } from '../../prompts';
 import { formatBytes } from '../../utils/files';
 import { getTmpDirectory } from '../../utils/paths';

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -5,7 +5,6 @@ import assert from 'assert';
 import chalk from 'chalk';
 import dateFormat from 'dateformat';
 import gql from 'graphql-tag';
-import ora from 'ora';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
@@ -20,6 +19,7 @@ import {
 } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import Log from '../../log';
+import { ora } from '../../ora';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import {
   PublishPlatform,

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -1,7 +1,6 @@
 import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
-import ora from 'ora';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
@@ -13,6 +12,7 @@ import {
 } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
+import { ora } from '../../ora';
 import { appPlatformEmojis } from '../../platform';
 import {
   findProjectRootAsync,

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -1,7 +1,6 @@
 import { getConfig } from '@expo/config';
 import { flags } from '@oclif/command';
 import chalk from 'chalk';
-import ora from 'ora';
 
 import { BuildDistributionType, BuildStatus } from '../../build/types';
 import { formatGraphQLBuild } from '../../build/utils/formatBuild';
@@ -13,6 +12,7 @@ import {
 } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
+import { ora } from '../../ora';
 import { RequestedPlatform } from '../../platform';
 import {
   findProjectRootAsync,

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -1,12 +1,12 @@
 import { getConfig } from '@expo/config';
 import { flags } from '@oclif/command';
-import ora from 'ora';
 
 import { formatGraphQLBuild } from '../../build/utils/formatBuild';
 import EasCommand from '../../commandUtils/EasCommand';
 import { BuildFragment } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
+import { ora } from '../../ora';
 import {
   findProjectRootAsync,
   getProjectFullNameAsync,

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -2,13 +2,14 @@ import { getConfig } from '@expo/config';
 import { flags } from '@oclif/command';
 import assert from 'assert';
 import chalk from 'chalk';
-import ora from 'ora';
+import { Ora } from 'ora';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import { AppleTeamQuery } from '../../credentials/ios/api/graphql/queries/AppleTeamQuery';
 import formatDevice from '../../devices/utils/formatDevice';
 import Log from '../../log';
+import { ora } from '../../ora';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 
@@ -26,7 +27,7 @@ export default class BuildList extends EasCommand {
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const accountName = await getProjectAccountNameAsync(exp);
 
-    let spinner: ora.Ora;
+    let spinner: Ora;
 
     if (!appleTeamIdentifier) {
       spinner = ora().start('Fetching the list of teams for the project…');

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -2,14 +2,13 @@ import { getConfig } from '@expo/config';
 import { flags } from '@oclif/command';
 import assert from 'assert';
 import chalk from 'chalk';
-import { Ora } from 'ora';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import { AppleTeamQuery } from '../../credentials/ios/api/graphql/queries/AppleTeamQuery';
 import formatDevice from '../../devices/utils/formatDevice';
 import Log from '../../log';
-import { ora } from '../../ora';
+import { Ora, ora } from '../../ora';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -1,10 +1,10 @@
 import { getConfig } from '@expo/config';
-import ora from 'ora';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import formatDevice from '../../devices/utils/formatDevice';
 import Log from '../../log';
+import { ora } from '../../ora';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 
 export default class DeviceView extends EasCommand {

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -1,10 +1,10 @@
 import { getConfig } from '@expo/config';
 import { flags } from '@oclif/command';
-import ora from 'ora';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
+import { ora } from '../../ora';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { prepareInputParamsAsync } from '../../webhooks/input';
 

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -2,13 +2,13 @@ import { getConfig } from '@expo/config';
 import assert from 'assert';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
-import ora from 'ora';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { WebhookFragment } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import Log from '../../log';
+import { ora } from '../../ora';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
 import { formatWebhook } from '../../webhooks/formatWebhook';

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -1,12 +1,12 @@
 import { getConfig } from '@expo/config';
 import { flags } from '@oclif/command';
 import chalk from 'chalk';
-import ora from 'ora';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import Log from '../../log';
+import { ora } from '../../ora';
 import {
   findProjectRootAsync,
   getProjectFullNameAsync,

--- a/packages/eas-cli/src/commands/webhook/update.ts
+++ b/packages/eas-cli/src/commands/webhook/update.ts
@@ -1,10 +1,10 @@
 import { flags } from '@oclif/command';
-import ora from 'ora';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
+import { ora } from '../../ora';
 import pick from '../../utils/expodash/pick';
 import { prepareInputParamsAsync } from '../../webhooks/input';
 

--- a/packages/eas-cli/src/commands/webhook/view.ts
+++ b/packages/eas-cli/src/commands/webhook/view.ts
@@ -1,8 +1,7 @@
-import ora from 'ora';
-
 import EasCommand from '../../commandUtils/EasCommand';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import Log from '../../log';
+import { ora } from '../../ora';
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
 export default class WebhookView extends EasCommand {

--- a/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import { nanoid } from 'nanoid';
-import ora from 'ora';
 
 import { AndroidAppBuildCredentialsFragment } from '../../../graphql/generated';
+import { ora } from '../../../ora';
 import { getApplicationIdAsync } from '../../../project/android/applicationId';
 import { GradleBuildContext } from '../../../project/android/gradle';
 import { getProjectAccountName, getProjectConfigDescription } from '../../../project/projectUtils';

--- a/packages/eas-cli/src/credentials/android/actions/SetupBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/actions/SetupBuildCredentials.ts
@@ -1,11 +1,11 @@
 import nullthrows from 'nullthrows';
-import ora from 'ora';
 
 import {
   AndroidAppBuildCredentialsFragment,
   AndroidKeystoreFragment,
 } from '../../../graphql/generated';
 import Log from '../../../log';
+import { ora } from '../../../ora';
 import { Context } from '../../context';
 import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -1,12 +1,12 @@
 import assert from 'assert';
 import chalk from 'chalk';
-import ora from 'ora';
 
 import {
   AppleDistributionCertificateFragment,
   AppleProvisioningProfileFragment,
 } from '../../../graphql/generated';
 import Log from '../../../log';
+import { ora } from '../../../ora';
 import { Context } from '../../context';
 import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';

--- a/packages/eas-cli/src/credentials/ios/appstore/contractMessages.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/contractMessages.ts
@@ -1,6 +1,6 @@
 import { ITCAgreements, RequestContext } from '@expo/apple-utils';
 import chalk from 'chalk';
-import { Ora } from 'ora';
+import type { Ora } from 'ora';
 
 import Log from '../../../log';
 import { convertHTMLToASCII } from '../utils/convertHTMLToASCII';

--- a/packages/eas-cli/src/credentials/ios/appstore/contractMessages.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/contractMessages.ts
@@ -1,8 +1,8 @@
 import { ITCAgreements, RequestContext } from '@expo/apple-utils';
 import chalk from 'chalk';
-import type { Ora } from 'ora';
 
 import Log from '../../../log';
+import type { Ora } from '../../../ora';
 import { convertHTMLToASCII } from '../utils/convertHTMLToASCII';
 
 async function getContractStatusAsync(

--- a/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
@@ -4,8 +4,8 @@ import {
   RequestContext,
   createCertificateAndP12Async,
 } from '@expo/apple-utils';
-import ora from 'ora';
 
+import { ora } from '../../../ora';
 import { DistributionCertificate, DistributionCertificateStoreInfo } from './Credentials.types';
 import { AuthCtx, getRequestContext } from './authenticate';
 

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -1,9 +1,9 @@
 import { App, BundleId } from '@expo/apple-utils';
 import { JSONObject } from '@expo/json-file';
 import chalk from 'chalk';
-import ora from 'ora';
 
 import Log from '../../../log';
+import { ora } from '../../../ora';
 import { AuthCtx, getRequestContext } from './authenticate';
 import { syncCapabilitiesForEntitlementsAsync } from './bundleIdCapabilities';
 import { syncCapabilityIdentifiersForEntitlementsAsync } from './capabilityIdentifiers';

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
@@ -1,6 +1,6 @@
 import { Profile, ProfileType, RequestContext } from '@expo/apple-utils';
-import ora from 'ora';
 
+import { ora } from '../../../ora';
 import { findP12CertSerialNumber } from '../utils/p12Certificate';
 import {
   DistributionCertificate,

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -1,6 +1,6 @@
 import { Device, Profile, ProfileState, ProfileType, RequestContext } from '@expo/apple-utils';
-import ora from 'ora';
 
+import { ora } from '../../../ora';
 import { ProvisioningProfile } from './Credentials.types';
 import { AuthCtx, getRequestContext } from './authenticate';
 import { getBundleIdForIdentifierAsync, getProfilesForBundleIdAsync } from './bundleId';

--- a/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
@@ -1,9 +1,9 @@
 import { Keys } from '@expo/apple-utils';
 import chalk from 'chalk';
 import dateformat from 'dateformat';
-import ora from 'ora';
 
 import Log from '../../../log';
+import { ora } from '../../../ora';
 import { PushKey, PushKeyStoreInfo } from './Credentials.types';
 import { AuthCtx, getRequestContext } from './authenticate';
 

--- a/packages/eas-cli/src/devices/actions/create/inputMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/inputMethod.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import Table from 'cli-table3';
-import ora from 'ora';
 
 import { AppleDeviceMutation } from '../../../credentials/ios/api/graphql/mutations/AppleDeviceMutation';
 import { AppleDeviceClass, AppleTeam } from '../../../graphql/generated';
 import Log from '../../../log';
+import { ora } from '../../../ora';
 import { confirmAsync, promptAsync } from '../../../prompts';
 import { isValidUDID, normalizeUDID } from '../../udids';
 

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -1,8 +1,6 @@
-/* eslint-disable no-console */
 import chalk from 'chalk';
 import figures from 'figures';
 import { boolish } from 'getenv';
-import ora from 'ora';
 import terminalLink from 'terminal-link';
 
 type Color = (...text: string[]) => string;
@@ -47,7 +45,7 @@ export default class Log {
   }
 
   public static succeed(message: string): void {
-    ora().succeed(message);
+    Log.log(`${chalk.green('√')} ${message}`);
   }
 
   public static withTick(...args: any[]): void {
@@ -56,16 +54,19 @@ export default class Log {
 
   private static consoleLog(...args: any[]): void {
     Log.updateIsLastLineNewLine(args);
+    // eslint-disable-next-line no-console
     console.log(...args);
   }
 
   private static consoleWarn(...args: any[]): void {
     Log.updateIsLastLineNewLine(args);
+    // eslint-disable-next-line no-console
     console.warn(...args);
   }
 
   private static consoleError(...args: any[]): void {
     Log.updateIsLastLineNewLine(args);
+    // eslint-disable-next-line no-console
     console.error(...args);
   }
 

--- a/packages/eas-cli/src/ora.ts
+++ b/packages/eas-cli/src/ora.ts
@@ -1,0 +1,74 @@
+import oraReal from 'ora';
+
+import Log from './log';
+
+/**
+ * A custom ora spinner that sends the stream to stdout in CI, or non-TTY, instead of stderr (the default).
+ *
+ * @param options
+ * @returns
+ */
+export function ora(options?: oraReal.Options | string): oraReal.Ora {
+  const inputOptions = typeof options === 'string' ? { text: options } : options || {};
+  const disabled = Log.isDebug || !process.stdin.isTTY;
+  const ora = oraReal({
+    // Ensure our non-interactive mode emulates CI mode.
+    isEnabled: !disabled,
+    // In non-interactive mode, send the stream to stdout so it prevents looking like an error.
+    stream: disabled ? process.stdout : process.stderr,
+    ...inputOptions,
+  });
+
+  // eslint-disable-next-line no-console
+  const logReal = console.log;
+  // eslint-disable-next-line no-console
+  const infoReal = console.info;
+  // eslint-disable-next-line no-console
+  const warnReal = console.warn;
+  // eslint-disable-next-line no-console
+  const errorReal = console.error;
+
+  const oraStop = ora.stop.bind(ora);
+
+  const origStopAndPersist = ora.stopAndPersist.bind(ora);
+
+  const logWrap = (method: any, args: any[]) => {
+    oraStop();
+    method(...args);
+    ora!.start();
+  };
+
+  // eslint-disable-next-line no-console
+  console.log = (...args: any) => logWrap(logReal, args);
+  // eslint-disable-next-line no-console
+  console.info = (...args: any) => logWrap(infoReal, args);
+  // eslint-disable-next-line no-console
+  console.warn = (...args: any) => logWrap(warnReal, args);
+  // eslint-disable-next-line no-console
+  console.error = (...args: any) => logWrap(errorReal, args);
+
+  const resetNativeLogs = () => {
+    // eslint-disable-next-line no-console
+    console.log = logReal;
+    // eslint-disable-next-line no-console
+    console.info = logReal;
+    // eslint-disable-next-line no-console
+    console.warn = warnReal;
+    // eslint-disable-next-line no-console
+    console.error = errorReal;
+  };
+
+  ora.stopAndPersist = (): oraReal.Ora => {
+    origStopAndPersist();
+    resetNativeLogs();
+    return ora!;
+  };
+
+  ora.stop = (): oraReal.Ora => {
+    oraStop();
+    resetNativeLogs();
+    return ora!;
+  };
+
+  return ora;
+}

--- a/packages/eas-cli/src/ora.ts
+++ b/packages/eas-cli/src/ora.ts
@@ -1,4 +1,4 @@
-import oraReal from 'ora';
+import oraReal, { Options, Ora } from 'ora';
 
 import Log from './log';
 
@@ -8,10 +8,10 @@ import Log from './log';
  * @param options
  * @returns
  */
-export function ora(options?: oraReal.Options | string): oraReal.Ora {
-  const inputOptions = typeof options === 'string' ? { text: options } : options || {};
+export function ora(options?: Options | string): Ora {
+  const inputOptions = typeof options === 'string' ? { text: options } : options ?? {};
   const disabled = Log.isDebug || !process.stdin.isTTY;
-  const ora = oraReal({
+  const spinner = oraReal({
     // Ensure our non-interactive mode emulates CI mode.
     isEnabled: !disabled,
     // In non-interactive mode, send the stream to stdout so it prevents looking like an error.
@@ -28,14 +28,14 @@ export function ora(options?: oraReal.Options | string): oraReal.Ora {
   // eslint-disable-next-line no-console
   const errorReal = console.error;
 
-  const oraStop = ora.stop.bind(ora);
+  const oraStop = spinner.stop.bind(spinner);
 
-  const origStopAndPersist = ora.stopAndPersist.bind(ora);
+  const oraStopAndPersist = spinner.stopAndPersist.bind(spinner);
 
   const logWrap = (method: any, args: any[]) => {
     oraStop();
     method(...args);
-    ora!.start();
+    spinner.start();
   };
 
   // eslint-disable-next-line no-console
@@ -58,17 +58,19 @@ export function ora(options?: oraReal.Options | string): oraReal.Ora {
     console.error = errorReal;
   };
 
-  ora.stopAndPersist = (): oraReal.Ora => {
-    origStopAndPersist();
+  spinner.stopAndPersist = (): Ora => {
+    oraStopAndPersist();
     resetNativeLogs();
-    return ora!;
+    return spinner;
   };
 
-  ora.stop = (): oraReal.Ora => {
+  spinner.stop = (): Ora => {
     oraStop();
     resetNativeLogs();
-    return ora!;
+    return spinner;
   };
 
-  return ora;
+  return spinner;
 }
+
+export { Ora, Options };

--- a/packages/eas-cli/src/ora.ts
+++ b/packages/eas-cli/src/ora.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line
 import oraReal, { Options, Ora } from 'ora';
 
 import Log from './log';

--- a/packages/eas-cli/src/ora.ts
+++ b/packages/eas-cli/src/ora.ts
@@ -2,6 +2,17 @@ import oraReal, { Options, Ora } from 'ora';
 
 import Log from './log';
 
+export { Ora, Options };
+
+// eslint-disable-next-line no-console
+const logReal = console.log;
+// eslint-disable-next-line no-console
+const infoReal = console.info;
+// eslint-disable-next-line no-console
+const warnReal = console.warn;
+// eslint-disable-next-line no-console
+const errorReal = console.error;
+
 /**
  * A custom ora spinner that sends the stream to stdout in CI, or non-TTY, instead of stderr (the default).
  *
@@ -19,35 +30,28 @@ export function ora(options?: Options | string): Ora {
     ...inputOptions,
   });
 
-  // eslint-disable-next-line no-console
-  const logReal = console.log;
-  // eslint-disable-next-line no-console
-  const infoReal = console.info;
-  // eslint-disable-next-line no-console
-  const warnReal = console.warn;
-  // eslint-disable-next-line no-console
-  const errorReal = console.error;
-
+  const oraStart = spinner.start.bind(spinner);
   const oraStop = spinner.stop.bind(spinner);
-
   const oraStopAndPersist = spinner.stopAndPersist.bind(spinner);
 
-  const logWrap = (method: any, args: any[]) => {
+  const logWrap = (method: any, args: any[]): void => {
     oraStop();
     method(...args);
     spinner.start();
   };
 
-  // eslint-disable-next-line no-console
-  console.log = (...args: any) => logWrap(logReal, args);
-  // eslint-disable-next-line no-console
-  console.info = (...args: any) => logWrap(infoReal, args);
-  // eslint-disable-next-line no-console
-  console.warn = (...args: any) => logWrap(warnReal, args);
-  // eslint-disable-next-line no-console
-  console.error = (...args: any) => logWrap(errorReal, args);
+  const wrapNativeLogs = (): void => {
+    // eslint-disable-next-line no-console
+    console.log = (...args: any) => logWrap(logReal, args);
+    // eslint-disable-next-line no-console
+    console.info = (...args: any) => logWrap(infoReal, args);
+    // eslint-disable-next-line no-console
+    console.warn = (...args: any) => logWrap(warnReal, args);
+    // eslint-disable-next-line no-console
+    console.error = (...args: any) => logWrap(errorReal, args);
+  };
 
-  const resetNativeLogs = () => {
+  const resetNativeLogs = (): void => {
     // eslint-disable-next-line no-console
     console.log = logReal;
     // eslint-disable-next-line no-console
@@ -58,19 +62,22 @@ export function ora(options?: Options | string): Ora {
     console.error = errorReal;
   };
 
+  spinner.start = (): Ora => {
+    wrapNativeLogs();
+    return oraStart();
+  };
+
   spinner.stopAndPersist = (): Ora => {
-    oraStopAndPersist();
+    const result = oraStopAndPersist();
     resetNativeLogs();
-    return spinner;
+    return result;
   };
 
   spinner.stop = (): Ora => {
-    oraStop();
+    const result = oraStop();
     resetNativeLogs();
-    return spinner;
+    return result;
   };
 
   return spinner;
 }
-
-export { Ora, Options };

--- a/packages/eas-cli/src/project/ensureProjectExists.ts
+++ b/packages/eas-cli/src/project/ensureProjectExists.ts
@@ -1,12 +1,12 @@
 import assert from 'assert';
 import chalk from 'chalk';
-import ora from 'ora';
 import terminalLink from 'terminal-link';
 
 import { getProjectDashboardUrl } from '../build/utils/url';
 import { AppPrivacy } from '../graphql/generated';
 import { AppMutation } from '../graphql/mutations/AppMutation';
 import { ProjectQuery } from '../graphql/queries/ProjectQuery';
+import { ora } from '../ora';
 import { findAccountByName } from '../user/Account';
 import { ensureLoggedInAsync } from '../user/actions';
 

--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -1,5 +1,4 @@
 import { Platform } from '@expo/eas-build-job';
-import ora from 'ora';
 
 import {
   AndroidSubmissionConfigInput,
@@ -8,6 +7,7 @@ import {
 } from '../graphql/generated';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log from '../log';
+import { ora } from '../ora';
 import { appPlatformDisplayNames } from '../platform';
 import { SubmissionContext } from './context';
 

--- a/packages/eas-cli/src/submissions/utils/wait.ts
+++ b/packages/eas-cli/src/submissions/utils/wait.ts
@@ -1,8 +1,7 @@
-import ora from 'ora';
-
 import { AppPlatform, SubmissionFragment, SubmissionStatus } from '../../graphql/generated';
 import { SubmissionQuery } from '../../graphql/queries/SubmissionQuery';
 import Log from '../../log';
+import { ora } from '../../ora';
 import { sleepAsync } from '../../utils/promise';
 
 const APP_STORE_NAMES: Record<AppPlatform, string> = {

--- a/packages/eas-cli/src/utils/progress.ts
+++ b/packages/eas-cli/src/utils/progress.ts
@@ -1,7 +1,8 @@
 import chalk from 'chalk';
 import { Progress } from 'got';
-import ora from 'ora';
+import { Ora } from 'ora';
 
+import { ora } from '../ora';
 import { endTimer, formatMilliseconds, startTimer } from './timer';
 
 type ProgressHandler = (props: {
@@ -19,7 +20,7 @@ function createProgressTracker({
   message: string | ((ratio: number) => string);
   completedMessage: string | ((duration: string) => string);
 }): ProgressHandler {
-  let bar: ora.Ora | null = null;
+  let bar: Ora | null = null;
   let calcTotal: number = total ?? 0;
   let transferredSoFar = 0;
   let current = 0;

--- a/packages/eas-cli/src/utils/progress.ts
+++ b/packages/eas-cli/src/utils/progress.ts
@@ -1,8 +1,7 @@
 import chalk from 'chalk';
 import { Progress } from 'got';
-import { Ora } from 'ora';
 
-import { ora } from '../ora';
+import { Ora, ora } from '../ora';
 import { endTimer, formatMilliseconds, startTimer } from './timer';
 
 type ProgressHandler = (props: {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Prevent debug logs from breaking spinners

## Before

<img width="1073" alt="Screen Shot 2021-08-24 at 2 00 12 PM" src="https://user-images.githubusercontent.com/9664363/130682209-ef7f839f-22c0-4f48-8e61-432511a451ed.png">

## After

<img width="1089" alt="Screen Shot 2021-08-24 at 1 59 59 PM" src="https://user-images.githubusercontent.com/9664363/130682228-f888020f-8db0-4dc8-ae7b-fcd95d70a5f8.png">

# How

override logs and pause ora before logging to the console, also disable ora when EXPO_DEBUG is enabled.

# Test Plan

- `EXPO_DEBUG=1 eas build` -- static spinners
- `EXPO_APP_STORE_DEBUG=1 eas build` -- no broken logs