### PR TITLE
Add ESLint rule to prevent relative package imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
     jasmine: false,
   },
   rules: {
-    'no-console':'warn',
+    'no-console': 'warn',
     'no-constant-condition': ['warn', { checkLoops: false }],
     'sort-imports': [
       'warn',
@@ -20,6 +20,7 @@ module.exports = {
     ],
     'flowtype/no-types-missing-file-annotation': 'off',
     'curly': 'warn',
+    'import/no-relative-packages': 'error',
   },
   settings: {
     react: {


### PR DESCRIPTION
# Why

Prevents runtime errors on released `eas-cli` caused by relative imports between packages, like https://github.com/expo/eas-cli/commit/951eea2396591bd612aa7cb3038da35e45c33bb8 

# How

Added [`import/no-relative-packages`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-relative-packages.md) to `.eslintrc.js`

# Test Plan

- Ran VSCode command: `ESLint: Restart ESLint Server` to make VS Code apply this rule.
- Locally reverted https://github.com/expo/eas-cli/commit/951eea2396591bd612aa7cb3038da35e45c33bb8 to see if it's working:
 
![Screenshot 2021-08-25 at 12 16 16](https://user-images.githubusercontent.com/278340/130774601-c41bef53-213b-4d41-aee2-6ca24d88d36d.png)
![Screenshot 2021-08-25 at 12 16 56](https://user-images.githubusercontent.com/278340/130774607-d269d4fd-1fd6-41bf-bcc0-898f6050fc0d.png)

