### PR TITLE
[eas-cli] Adds keystore create tracking

### DIFF
--- a/packages/eas-cli/src/build/utils/analytics.ts
+++ b/packages/eas-cli/src/build/utils/analytics.ts
@@ -18,6 +18,8 @@ export enum Event {
   CREDENTIALS_SYNC_UPDATE_LOCAL_FAIL = 'build cli credentials sync update local fail',
   CREDENTIALS_SYNC_UPDATE_REMOTE_SUCCESS = 'build cli credentials sync update remote success',
   CREDENTIALS_SYNC_UPDATE_REMOTE_FAIL = 'build cli credentials sync update remote fail',
+
+  ANDROID_KEYSTORE_CREATE = 'build cli credentials keystore create',
 }
 
 export default {

--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -1,9 +1,8 @@
-import { Command } from '@oclif/command';
-
+import EasCommand from '../commandUtils/EasCommand';
 import { createCredentialsContextAsync } from '../credentials/context';
 import { SelectPlatform } from '../credentials/manager/SelectPlatform';
 
-export default class Credentials extends Command {
+export default class Credentials extends EasCommand {
   static description = 'Manage your credentials';
 
   async run() {

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/CreateKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/CreateKeystore-test.ts
@@ -1,14 +1,15 @@
-import { confirmAsync } from '../../../../prompts';
+import { asMock } from '../../../../__tests__/utils';
+import { jester as mockJester } from '../../../../credentials/__tests__/fixtures-constants';
 import { testKeystore } from '../../../__tests__/fixtures-android';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
 import { askForUserProvidedAsync } from '../../../utils/promptForCredentials';
 import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { CreateKeystore } from '../CreateKeystore';
 
-jest.mock('../../../../prompts');
-(confirmAsync as jest.Mock).mockImplementation(() => true);
-
 jest.mock('../../../utils/promptForCredentials');
+jest.mock('../../../../project/ensureProjectExists');
+jest.mock('../../../../prompts', () => ({ confirmAsync: jest.fn(() => true) }));
+jest.mock('../../../../user/actions', () => ({ ensureLoggedInAsync: jest.fn(() => mockJester) }));
 
 describe('CreateKeystore', () => {
   it('creates a keystore in Interactive Mode', async () => {
@@ -21,7 +22,7 @@ describe('CreateKeystore', () => {
     expect(ctx.android.createKeystoreAsync as any).toHaveBeenCalledTimes(1);
   });
   it('creates a keystore by uploading', async () => {
-    (askForUserProvidedAsync as jest.Mock).mockImplementation(() => testKeystore);
+    asMock(askForUserProvidedAsync).mockImplementationOnce(() => testKeystore);
     const ctx = createCtxMock({ nonInteractive: false });
     const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const createKeystoreAction = new CreateKeystore(appLookupParams.account);

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetupBuildCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetupBuildCredentials-test.ts
@@ -1,16 +1,17 @@
-import { confirmAsync, promptAsync } from '../../../../prompts';
 import {
   getNewAndroidApiMock,
   testAndroidBuildCredentialsFragment,
   testJksAndroidKeystoreFragment,
 } from '../../../__tests__/fixtures-android';
+import { jester as mockJester } from '../../../__tests__/fixtures-constants';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
 import { MissingCredentialsNonInteractiveError } from '../../../errors';
 import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { SetupBuildCredentials } from '../SetupBuildCredentials';
 
-jest.mock('../../../../prompts');
-(confirmAsync as jest.Mock).mockImplementation(() => true);
+jest.mock('../../../../project/ensureProjectExists');
+jest.mock('../../../../user/actions', () => ({ ensureLoggedInAsync: jest.fn(() => mockJester) }));
+jest.mock('../../../../prompts', () => ({ confirmAsync: jest.fn(() => true) }));
 
 describe('SetupBuildCredentials', () => {
   it('skips setup when there are prior credentials', async () => {
@@ -31,7 +32,6 @@ describe('SetupBuildCredentials', () => {
     expect(ctx.android.createKeystoreAsync as any).toHaveBeenCalledTimes(0);
   });
   it('sets up credentials when there are no prior credentials', async () => {
-    (promptAsync as jest.Mock).mockImplementation(() => ({ providedName: 'test-provided-name' }));
     const ctx = createCtxMock({
       nonInteractive: false,
       android: {
@@ -47,7 +47,6 @@ describe('SetupBuildCredentials', () => {
     expect(ctx.android.createKeystoreAsync as any).toHaveBeenCalledTimes(1);
   });
   it('errors in Non-Interactive Mode', async () => {
-    (promptAsync as jest.Mock).mockImplementation(() => ({ providedName: 'test-provided-name' }));
     const ctx = createCtxMock({
       nonInteractive: true,
       android: {

--- a/packages/eas-cli/src/credentials/android/utils/__mocks__/keystore.ts
+++ b/packages/eas-cli/src/credentials/android/utils/__mocks__/keystore.ts
@@ -1,4 +1,2 @@
 export const keytoolCommandExistsAsync = jest.fn();
-export const exportCertificateAsync = jest.fn();
-export const logKeystoreHashesAsync = jest.fn();
 export const generateRandomKeystoreAsync = jest.fn();


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

We'd like to understand what percentage of users are blocked from creating credentials because they do not have `keytool` installed.

# How

Adds a new event, `ANDROID_KEYSTORE_CREATE`, containing a property called`step` which can be either `fail`, `success`, or `attempt`. We can construct the funnel of create attempts => falures using this schema. I also converted the `credentials` command to an `EASCommand` so that it can fire `action` events on start.

I had to mock some things out in `CreateKeystore-test` & `SetupBuildCredentials-test` to account for getting the project id inside the create keystore action.

# Test Plan

I ran this locally and confirmed events were making it to the backend.
