### PR TITLE
drop support for node < 12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16'
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn build
       - name: Build tarballs
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16'
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn build
       - name: Build tarballs
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16'
       - run: yarn install --frozen-lockfile --check-files
       - run: sudo apt-get install nsis
       - run: yarn build

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16'
       - uses: preactjs/compressed-size-action@v2
         with:
           build-script: 'build:tarballs:linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12', '14']
+        node: ['12', '14', '16']
         include:
-          - node: '14'
+          - node: '16'
             coverage: true
     name: Test with Node ${{ matrix.node }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Drop support for node < 12. ([#581](https://github.com/expo/eas-cli/pull/581) by [@dsokal](https://github.com/dsokal))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -104,7 +104,7 @@
     "typescript": "4.3.5"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "files": [
     "/bin",
@@ -184,7 +184,5 @@
     "test": "jest",
     "version": "yarn oclif-dev readme && node patch-readme && git add README.md",
     "generate-graphql-code": "graphql-codegen --config graphql-codegen.yml"
-  },
-  "types": "build/index.d.ts",
-  "gitHead": "161808bc37c255fdea6801d69d23dbc725c056c3"
+  }
 }

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -23,7 +23,7 @@
     "typescript": "4.3.5"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://github.com/expo/eas-cli",
   "license": "MIT",
@@ -38,6 +38,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "161808bc37c255fdea6801d69d23dbc725c056c3"
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

- Node versions < 12 are not supported anymore - https://nodejs.org/en/about/releases/ 
- Expo CLI doesn't support Node < 12 -  https://github.com/expo/expo-cli/blob/master/packages/expo-cli/package.json#L42
- Needed for https://github.com/expo/eas-cli/issues/516

# How

- I updated `engines.node` in `package.json`.
- I made the `test` workflow run on Node 16. I made the other workflows also run on Node 16.

# Test Plan

CI