### PR TITLE
[eas-cli] fix detecting  `googleServicesFile` with `EAS_NO_VCS=1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix detecting `googleServicesFile` with `EAS_NO_VCS=1`. ([#583](https://github.com/expo/eas-cli/pull/583) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [0.24.1](https://github.com/expo/eas-cli/releases/tag/v0.24.1) - 2021-08-25

--- a/packages/eas-cli/src/build/validate.ts
+++ b/packages/eas-cli/src/build/validate.ts
@@ -29,9 +29,9 @@ export async function checkGoogleServicesFileAsync<T extends Platform>(
   const rootDir = await vcs.getRootPathAsync();
   const absGoogleServicesFilePath = path.resolve(ctx.projectDir, googleServicesFilePath);
   if (
-    (await fs.pathExists(googleServicesFilePath)) &&
-    ((await vcs.isFileIgnoredAsync(googleServicesFilePath)) ||
-      !isInsideDirectory(absGoogleServicesFilePath, rootDir))
+    (await fs.pathExists(absGoogleServicesFilePath)) &&
+    (!isInsideDirectory(absGoogleServicesFilePath, rootDir) ||
+      (await vcs.isFileIgnoredAsync(path.relative(rootDir, absGoogleServicesFilePath))))
   ) {
     Log.warn(
       `File specified via "${ctx.platform}.googleServicesFile" field in your app.json is not checked in to your repository and won't be uploaded to the builder.`

--- a/packages/eas-cli/src/vcs/vcs.ts
+++ b/packages/eas-cli/src/vcs/vcs.ts
@@ -64,7 +64,7 @@ export abstract class Client {
   // should not be included in the project tarball.
   //
   // @param filePath has to be a relative normalized path pointing to a file
-  // located under root of the repository
+  // located under the root of the repository
   public async isFileIgnoredAsync(filePath: string): Promise<boolean> {
     return false;
   }

--- a/packages/eas-cli/src/vcs/vcs.ts
+++ b/packages/eas-cli/src/vcs/vcs.ts
@@ -62,6 +62,9 @@ export abstract class Client {
   // (optional) checks if the file is ignored, an implementation should ensure
   // that if file exists and `isFileIgnoredAsync` returns true, then that file
   // should not be included in the project tarball.
+  //
+  // @param filePath has to be a relative normalized path pointing to a file
+  // located under root of the repository
   public async isFileIgnoredAsync(filePath: string): Promise<boolean> {
     return false;
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Closes #577 

# How

- check if path points inside directory first
- pass normalized path (remove leading `./` with path.relative)

# Test Plan

run builds with and without EAS_NO_VCS and with services  file gitignored and outside of the repo
