### PR TITLE
bump typescript target to ES2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Replace `@hapi/joi` with `joi`. Upgrade typescript to 4.4.2. Upgrade dependencies. ([#582](https://github.com/expo/eas-cli/pull/582) by [@dsokal](https://github.com/dsokal))
+- Change typescript target from `ES2017` to `ES2019`. ([#584](https://github.com/expo/eas-cli/pull/584) by [@dsokal](https://github.com/dsokal))
 
 ## [0.24.1](https://github.com/expo/eas-cli/releases/tag/v0.24.1) - 2021-08-25
 

--- a/packages/eas-cli/src/analytics.ts
+++ b/packages/eas-cli/src/analytics.ts
@@ -2,6 +2,7 @@ import { Identify } from '@amplitude/identify';
 import * as Amplitude from '@amplitude/node';
 import RudderAnalytics from '@expo/rudder-sdk-node';
 import os from 'os';
+import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 
 import UserSettings from './user/UserSettings';

--- a/packages/eas-cli/tsconfig.json
+++ b/packages/eas-cli/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "noImplicitReturns": true,
     "strict": true,
-    "target": "es2017",
+    "target": "ES2019",
     "outDir": "build",
     "rootDir": "src",
     "typeRoots": [


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

We've dropped support for Node < 12. We can now change the typescript target to newer.

# How

I changed the target from `ES2017` to `ES2019`.

# Test Plan

CI