### PR TITLE
clean up repo deps + use volta

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
       },
     ],
     'flowtype/no-types-missing-file-annotation': 'off',
-    'curly': 'warn',
+    curly: 'warn',
     'import/no-relative-packages': 'error',
   },
   settings: {

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
     "prettier": "2.3.2",
     "ts-jest": "27.0.5",
     "typescript": "4.4.2"
+  },
+  "volta": {
+    "node": "16.8.0",
+    "yarn": "1.22.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@types/jest": "27.0.1",
     "eslint": "7.32.0",
     "eslint-config-universe": "7.0.1",
-    "eslint-plugin-graphql": "4.0.0",
     "jest": "27.1.0",
     "jest-watch-typeahead": "0.6.4",
     "lerna": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@babel/core": "7.15.0",
     "@expo/oclif-dev-cli": "1.24.0-expo",
     "@types/jest": "27.0.1",
     "eslint": "7.32.0",
@@ -23,6 +24,7 @@
     "jest-watch-typeahead": "0.6.4",
     "lerna": "4.0.0",
     "prettier": "2.3.2",
-    "ts-jest": "27.0.5"
+    "ts-jest": "27.0.5",
+    "typescript": "4.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/core": "7.15.0",
     "@expo/oclif-dev-cli": "1.24.0-expo",
     "@types/jest": "27.0.1",
+    "@types/node": "^12",
     "eslint": "7.32.0",
     "eslint-config-universe": "7.0.1",
     "jest": "27.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "lerna run watch --parallel",
     "watch": "yarn start",
     "eas": "packages/eas-cli/bin/run",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint . --ext .ts --ext .js",
     "release": "lerna version",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/core": "7.15.0",
     "@expo/oclif-dev-cli": "1.24.0-expo",
     "@types/jest": "27.0.1",
-    "@types/node": "^12",
+    "@types/node": "16.7.8",
     "eslint": "7.32.0",
     "eslint-config-universe": "7.0.1",
     "jest": "27.1.0",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -81,7 +81,6 @@
     "@types/getenv": "^1.0.0",
     "@types/lodash": "4.14.172",
     "@types/mime": "2.0.3",
-    "@types/node": "^12",
     "@types/node-fetch": "^2.5.7",
     "@types/node-forge": "^0.9.5",
     "@types/prompts": "^2.0.9",
@@ -94,8 +93,7 @@
     "eslint-plugin-graphql": "4.0.0",
     "memfs": "3.2.2",
     "mockdate": "^3.0.2",
-    "nock": "^13.0.5",
-    "typescript": "4.4.2"
+    "nock": "^13.0.5"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -91,6 +91,7 @@
     "@types/uuid": "8.3.1",
     "@types/wrap-ansi": "3.0.0",
     "axios": "0.21.1",
+    "eslint-plugin-graphql": "4.0.0",
     "memfs": "3.2.2",
     "mockdate": "^3.0.2",
     "nock": "^13.0.5",

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -12,9 +12,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "9.0.12",
-    "@types/node": "^12",
-    "memfs": "3.2.2",
-    "typescript": "4.4.2"
+    "memfs": "3.2.2"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/eas-json/tsconfig.json
+++ b/packages/eas-json/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "noImplicitReturns": true,
     "strict": true,
-    "target": "es2017",
+    "target": "ES2019",
     "outDir": "build",
     "rootDir": "src",
     "typeRoots": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,6 +79,27 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.15.0.tgz#2dbaf8b85334796cafbb0f5793a90a2fc010b176"
   integrity sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==
 
+"@babel/core@7.15.0", "@babel/core@^7.7.2":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.0.tgz#749e57c68778b73ad8082775561f67f5196aafa8"
+  integrity sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.0"
+    "@babel/helper-compilation-targets" "^7.15.0"
+    "@babel/helper-module-transforms" "^7.15.0"
+    "@babel/helpers" "^7.14.8"
+    "@babel/parser" "^7.15.0"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.15.0"
+    "@babel/types" "^7.15.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
 "@babel/core@7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
@@ -121,27 +142,6 @@
     lodash "^4.17.19"
     resolve "^1.3.2"
     semver "^5.4.1"
-    source-map "^0.5.0"
-
-"@babel/core@^7.7.2":
-  version "7.15.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.0.tgz#749e57c68778b73ad8082775561f67f5196aafa8"
-  integrity sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==
-  dependencies:
-    "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.15.0"
-    "@babel/helper-compilation-targets" "^7.15.0"
-    "@babel/helper-module-transforms" "^7.15.0"
-    "@babel/helpers" "^7.14.8"
-    "@babel/parser" "^7.15.0"
-    "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.15.0"
-    "@babel/types" "^7.15.0"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.1.2"
-    semver "^6.3.0"
     source-map "^0.5.0"
 
 "@babel/eslint-parser@^7.11.5":

--- a/yarn.lock
+++ b/yarn.lock
@@ -4038,10 +4038,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
   integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
 
-"@types/node@^12":
-  version "12.20.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.21.tgz#575e91f59c2e79318c2d39a48286c6954e484fd5"
-  integrity sha512-Qk7rOvV2A4vNgXNS88vEvbJE1NDFPCQ8AU+pNElrU2bA4yrRDef3fg3SUe+xkwyin3Bpg/Xh5JkNWTlsOcS2tA==
+"@types/node@16.7.8":
+  version "16.7.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.8.tgz#2448be5f24fe6b77114632b6350fcd219334651e"
+  integrity sha512-8upnoQU0OPzbIkm+ZMM0zCeFCkw2s3mS0IWdx0+AAaWqm4fkBb0UJp8Edl7FVKRamYbpJC/aVsHpKWBIbiC7Zg==
 
 "@types/node@^12.7.1":
   version "12.19.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4038,7 +4038,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
   integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
 
-"@types/node@^12", "@types/node@^12.7.1":
+"@types/node@^12":
+  version "12.20.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.21.tgz#575e91f59c2e79318c2d39a48286c6954e484fd5"
+  integrity sha512-Qk7rOvV2A4vNgXNS88vEvbJE1NDFPCQ8AU+pNElrU2bA4yrRDef3fg3SUe+xkwyin3Bpg/Xh5JkNWTlsOcS2tA==
+
+"@types/node@^12.7.1":
   version "12.19.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.2.tgz#9565ed5c72ba96038fc3add643edd5e7820598e7"
   integrity sha512-SRH6QM0IMOBBFmDiJ75vlhcbUEYEquvSuhsVW9ijG20JvdFTfOrB1p6ddZxz5y/JNnbf+9HoHhjhOVSX2hsJyA==


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

- `yarn install` produces a lot of warnings
- Developers can use different node/yarn versions when working on the CLI. This could lead to hard to debug issues.

# How

- I moved `eslint-plugin-graphql` from the root package.json to the eas-cli specific one.
- I installed `@babel/core` and `typescript` as dev deps.
- I configured volta to use `node@16.8.0` and `yarn@1.22.11`.
- I fixed one minor lint warning and configured `yarn lint` to lint .js files as well.
- I bumped typescript target in `eas-json` to `es2019` as I forgot to do that in https://github.com/expo/eas-cli/commit/4cb726f3740c95b2db3e6115528ac895060ff93d

# Test Plan

`yarn install`

Before:

<details>

```
yarn install v1.22.10
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "eslint-config-universe > @babel/eslint-parser@7.14.7" has unmet peer dependency "@babel/core@>=7.11.0".
warning "eslint-config-universe > @typescript-eslint/eslint-plugin > tsutils@3.21.0" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
warning " > eslint-plugin-graphql@4.0.0" has unmet peer dependency "graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config@3.2.0" has unmet peer dependency "graphql@^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/graphql-file-loader@6.2.5" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/json-file-loader@6.2.5" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/load@6.2.5" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/merge@6.2.5" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/url-loader@6.4.0" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/utils@6.2.4" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @endemolshinegroup/cosmiconfig-typescript-loader > ts-node@9.0.0" has unmet peer dependency "typescript@>=2.7".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/graphql-file-loader > @graphql-tools/import@6.2.4" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/graphql-file-loader > @graphql-tools/utils@7.0.2" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/merge > @graphql-tools/schema@7.0.0" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/url-loader > @graphql-tools/delegate@7.0.5" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/url-loader > @graphql-tools/wrap@7.0.1" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/url-loader > subscriptions-transport-ws@0.9.18" has unmet peer dependency "graphql@>=0.10.0".
warning "eslint-plugin-graphql > graphql-config > @graphql-tools/url-loader > @graphql-tools/delegate > @graphql-tools/batch-execute@7.0.0" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning " > ts-jest@27.0.5" has unmet peer dependency "typescript@>=3.8 <5.0".
[4/4] 🔨  Building fresh packages...
✨  Done in 16.28s.
```

</details>

After:

<details>

```
yarn install v1.22.11
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
✨  Done in 14.63s.
```

</details>
