### PR TITLE
fix: git config --get core.ignorecase exits with code 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix `eas build` from throwing an exception when detecting git core.ignorecase ([#592](https://github.com/expo/eas-cli/pull/592) by [@mwillbanks](https://github.com/mwillbanks))
+
 ### 🧹 Chores
 
 ## [0.25.0](https://github.com/expo/eas-cli/releases/tag/v0.25.0) - 2021-09-01

--- a/packages/eas-cli/src/vcs/git.ts
+++ b/packages/eas-cli/src/vcs/git.ts
@@ -207,14 +207,19 @@ async function isGitCaseSensitiveAsync(): Promise<boolean | undefined> {
   if (process.platform !== 'darwin') {
     return undefined;
   }
-  const result = await spawnAsync('git', ['config', '--get', 'core.ignorecase']);
-  const isIgnoreCaseEnabled = result.stdout.trim();
-  if (isIgnoreCaseEnabled === '') {
+
+  try {
+    const result = await spawnAsync('git', ['config', '--get', 'core.ignorecase']);
+    const isIgnoreCaseEnabled = result.stdout.trim();
+    if (isIgnoreCaseEnabled === '') {
+      return undefined;
+    } else if (isIgnoreCaseEnabled === 'true') {
+      return false;
+    } else {
+      return true;
+    }
+  } catch (e) {
     return undefined;
-  } else if (isIgnoreCaseEnabled === 'true') {
-    return false;
-  } else {
-    return true;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

When `git config --get core.ignorecase` is run and the variable is not currently set, it will return with an exit code of 1 thus causing the `eas build` command to fail.

This also appears to have happened in the wild for others [1](https://forums.expo.dev/t/eas-build-platform-ios-issue-git-exited-with-non-zero-code-128/53612/5).

# How

To solve this, we try/catch and then return undefined to allow for the default behavior.

# Test Plan

Prior to finding this, I added the variable and ensure that `eas build` ran normally.  I then removed the variable and `eas build` failed.  After adding this change and running my patched version `eas build` operated properly.