### PR TITLE
[eas-cli] support multiflavor android projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Use envs from build profile to resolve app config when auto-submitting. ([#614](https://github.com/expo/eas-cli/pull/614) by [@dsokal](https://github.com/dsokal))
+- Support multiflavor Android projects. ([#595](https://github.com/expo/eas-cli/pull/595) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -42,7 +42,7 @@
     "fs-extra": "10.0.0",
     "getenv": "1.0.0",
     "got": "11.8.2",
-    "gradle-to-js": "^2.0.0",
+    "gradle-to-js": "2.0.0",
     "graphql": "15.5.1",
     "graphql-tag": "2.12.5",
     "ignore": "5.1.8",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -42,6 +42,7 @@
     "fs-extra": "10.0.0",
     "getenv": "1.0.0",
     "got": "11.8.2",
+    "gradle-to-js": "^2.0.0",
     "graphql": "15.5.1",
     "graphql-tag": "2.12.5",
     "ignore": "5.1.8",

--- a/packages/eas-cli/src/build/android/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/android/__tests__/version-test.ts
@@ -1,9 +1,11 @@
 import { ExpoConfig } from '@expo/config';
+import { Platform } from '@expo/eas-build-job';
+import { BuildProfile } from '@expo/eas-json';
 import fs from 'fs-extra';
 import { vol } from 'memfs';
 import os from 'os';
 
-import { readVersionCodeAsync, readVersionNameAsync } from '../version';
+import { maybeResolveVersionsAsync } from '../version';
 
 jest.mock('fs');
 
@@ -20,36 +22,29 @@ beforeEach(() => {
   fs.mkdirpSync(os.tmpdir());
 });
 
-describe(readVersionCodeAsync, () => {
+describe(maybeResolveVersionsAsync, () => {
   describe('generic project', () => {
     it('reads the version code from native code', async () => {
       const exp = initGenericProject();
-      const versionCode = await readVersionCodeAsync('/repo', exp);
-      expect(versionCode).toBe(123);
+      const { appVersion, appBuildVersion } = await maybeResolveVersionsAsync(
+        '/repo',
+        exp,
+        {} as BuildProfile<Platform.ANDROID>
+      );
+      expect(appVersion).toBe('2.0');
+      expect(appBuildVersion).toBe('123');
     });
   });
   describe('managed project', () => {
     it('reads the version code from expo config', async () => {
       const exp = initManagedProject();
-      const versionCode = await readVersionCodeAsync('/repo', exp);
-      expect(versionCode).toBe(123);
-    });
-  });
-});
-
-describe(readVersionNameAsync, () => {
-  describe('generic project', () => {
-    it('reads the version name from native code', async () => {
-      const exp = initGenericProject();
-      const versionName = await readVersionNameAsync('/repo', exp);
-      expect(versionName).toBe('1.0');
-    });
-  });
-  describe('managed project', () => {
-    it('reads the version from expo config', async () => {
-      const exp = initManagedProject();
-      const versionName = await readVersionNameAsync('/repo', exp);
-      expect(versionName).toBe('1.0.0');
+      const { appVersion, appBuildVersion } = await maybeResolveVersionsAsync(
+        '/repo',
+        exp,
+        {} as BuildProfile<Platform.ANDROID>
+      );
+      expect(appVersion).toBe('5.0.0');
+      expect(appBuildVersion).toBe('126');
     });
   });
 });
@@ -69,7 +64,7 @@ function initGenericProject(): ExpoConfig {
   defaultConfig {
     applicationId "com.expo.testapp"
     versionCode 123
-    versionName "1.0"
+    versionName "2.0"
   }
 }`,
       './android/app/src/main/AndroidManifest.xml': 'fake',
@@ -80,9 +75,9 @@ function initGenericProject(): ExpoConfig {
   const fakeExp: ExpoConfig = {
     name: 'myproject',
     slug: 'myproject',
-    version: '1.0.0',
+    version: '3.0.0',
     android: {
-      versionCode: 123,
+      versionCode: 124,
     },
   };
   return fakeExp;
@@ -93,9 +88,9 @@ function initManagedProject(): ExpoConfig {
     {
       './app.json': JSON.stringify({
         expo: {
-          version: '1.0.0',
+          version: '4.0.0',
           android: {
-            versionCode: 123,
+            versionCode: 125,
           },
         },
       }),
@@ -106,9 +101,9 @@ function initManagedProject(): ExpoConfig {
   const fakeExp: ExpoConfig = {
     name: 'myproject',
     slug: 'myproject',
-    version: '1.0.0',
+    version: '5.0.0',
     android: {
-      versionCode: 123,
+      versionCode: 126,
     },
   };
   return fakeExp;

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -34,7 +34,7 @@ export async function maybeResolveVersionsAsync(
     }
   } else {
     return {
-      appBuildVersion: String(AndroidConfig.Version.getVersionCode(exp) ?? 1),
+      appBuildVersion: String(AndroidConfig.Version.getVersionCode(exp)),
       appVersion: exp.version,
     };
   }

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -1,50 +1,44 @@
 import { ExpoConfig } from '@expo/config';
 import { AndroidConfig } from '@expo/config-plugins';
 import { Platform, Workflow } from '@expo/eas-build-job';
-import fs from 'fs-extra';
+import { BuildProfile } from '@expo/eas-json';
 
 import { resolveWorkflowAsync } from '../../project/workflow';
 
-export async function readVersionCodeAsync(
+export async function maybeResolveVersionsAsync(
   projectDir: string,
-  exp: ExpoConfig
-): Promise<number | undefined> {
+  exp: ExpoConfig,
+  buildProfile: BuildProfile<Platform.ANDROID>
+): Promise<{ appVersion?: string; appBuildVersion?: string }> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
   if (workflow === Workflow.GENERIC) {
-    const buildGradle = readBuildGradle(projectDir);
-    const matchResult = buildGradle?.match(/versionCode (.*)/);
-    if (matchResult) {
-      return Number(matchResult[1]);
-    } else {
-      return undefined;
+    const buildGradle = await AndroidConfig.BuildGradle.getAppBuildGradleAsync(projectDir);
+    try {
+      const parsedGradleCommand = buildProfile.gradleCommand
+        ? AndroidConfig.BuildGradle.parseGradleCommand(buildProfile.gradleCommand, buildGradle)
+        : undefined;
+
+      return {
+        appVersion:
+          AndroidConfig.BuildGradle.resolveConfigValue(
+            buildGradle,
+            parsedGradleCommand?.flavor,
+            'versionName'
+          ) ?? '1.0.0',
+        appBuildVersion:
+          AndroidConfig.BuildGradle.resolveConfigValue(
+            buildGradle,
+            parsedGradleCommand?.flavor,
+            'versionCode'
+          ) ?? '1',
+      };
+    } catch (err: any) {
+      return {};
     }
   } else {
-    return AndroidConfig.Version.getVersionCode(exp) ?? 1;
+    return {
+      appBuildVersion: String(AndroidConfig.Version.getVersionCode(exp) ?? 1),
+      appVersion: exp.version,
+    };
   }
-}
-
-export async function readVersionNameAsync(
-  projectDir: string,
-  exp: ExpoConfig
-): Promise<string | undefined> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
-  if (workflow === Workflow.GENERIC) {
-    const buildGradle = readBuildGradle(projectDir);
-    const matchResult = buildGradle?.match(/versionName ["'](.*)["']/);
-    if (matchResult) {
-      return matchResult[1];
-    } else {
-      return undefined;
-    }
-  } else {
-    return exp.version;
-  }
-}
-
-function readBuildGradle(projectDir: string): string | undefined {
-  const buildGradlePath = AndroidConfig.Paths.getAppBuildGradleFilePath(projectDir);
-  if (!fs.pathExistsSync(buildGradlePath)) {
-    return undefined;
-  }
-  return fs.readFileSync(buildGradlePath, 'utf8');
 }

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -67,7 +67,11 @@ export async function prepareIosBuildAsync(
         buildConfiguration: applicationTarget.buildConfiguration,
       });
       const buildSettings = xcBuildConfiguration?.buildSettings ?? {};
-      return { buildSettings };
+      return {
+        buildSettings,
+        targetName: applicationTarget.targetName,
+        buildConfiguration: applicationTarget.buildConfiguration,
+      };
     },
     prepareJobAsync: async (
       ctx: BuildContext<Platform.IOS>,

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -146,8 +146,9 @@ export async function maybeResolveVersionsAsync(
       appBuildVersion: await readBuildNumberAsync(projectDir, exp, buildSettings),
       appVersion: await readShortVersionAsync(projectDir, exp, buildSettings),
     };
-  } catch {}
-  return {};
+  } catch {
+    return {};
+  }
 }
 
 async function writeVersionsToInfoPlistAsync({

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -136,6 +136,20 @@ export async function readBuildNumberAsync(
   }
 }
 
+export async function maybeResolveVersionsAsync(
+  projectDir: string,
+  exp: ExpoConfig,
+  buildSettings: XCBuildConfiguration['buildSettings']
+): Promise<{ appVersion?: string; appBuildVersion?: string }> {
+  try {
+    return {
+      appBuildVersion: await readBuildNumberAsync(projectDir, exp, buildSettings),
+      appVersion: await readShortVersionAsync(projectDir, exp, buildSettings),
+    };
+  } catch {}
+  return {};
+}
+
 async function writeVersionsToInfoPlistAsync({
   projectDir,
   exp,

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -3,6 +3,7 @@ import { IosEnterpriseProvisioning } from '@expo/eas-json';
 import type { XCBuildConfiguration } from 'xcode';
 
 import { getApplicationIdAsync } from '../project/android/applicationId';
+import { GradleBuildContext } from '../project/android/gradle';
 import { getBundleIdentifierAsync } from '../project/ios/bundleIdentifier';
 import { getUsername } from '../project/projectUtils';
 import { ensureLoggedInAsync } from '../user/actions';
@@ -11,13 +12,13 @@ import {
   readChannelSafelyAsync as readAndroidChannelSafelyAsync,
   readReleaseChannelSafelyAsync as readAndroidReleaseChannelSafelyAsync,
 } from './android/UpdatesModule';
-import { readVersionCodeAsync, readVersionNameAsync } from './android/version';
+import { maybeResolveVersionsAsync as maybeResolveAndroidVersionsAsync } from './android/version';
 import { BuildContext } from './context';
 import {
   readChannelSafelyAsync as readIosChannelSafelyAsync,
   readReleaseChannelSafelyAsync as readIosReleaseChannelSafelyAsync,
 } from './ios/UpdatesModule';
-import { readBuildNumberAsync, readShortVersionAsync } from './ios/version';
+import { maybeResolveVersionsAsync as maybeResolveIosVersionsAsync } from './ios/version';
 import { isExpoUpdatesInstalled } from './utils/updates';
 
 /**
@@ -28,16 +29,21 @@ import { isExpoUpdatesInstalled } from './utils/updates';
 const packageJSON = require('../../package.json');
 
 export type MetadataContext<T extends Platform> = T extends Platform.ANDROID
-  ? object
+  ? AndroidMetadataContext
   : IosMetadataContext;
 
+export interface AndroidMetadataContext {
+  gradleContext?: GradleBuildContext;
+}
 export interface IosMetadataContext {
   buildSettings: XCBuildConfiguration['buildSettings'];
+  targetName?: string;
+  buildConfiguration?: string;
 }
 
 export async function collectMetadata<T extends Platform>(
   ctx: BuildContext<T>,
-  platformContext?: MetadataContext<T>
+  platformContext: MetadataContext<T>
 ): Promise<Metadata> {
   const channelOrReleaseChannel = await resolveChannelOrReleaseChannelAsync(ctx);
   const distribution =
@@ -46,8 +52,7 @@ export async function collectMetadata<T extends Platform>(
       : ctx.buildProfile.distribution) ?? 'store';
   const metadata = {
     trackingContext: ctx.trackingCtx,
-    appVersion: await resolveAppVersionAsync(ctx, platformContext),
-    appBuildVersion: await resolveAppBuildVersionAsync(ctx, platformContext),
+    ...(await resolveVersionsAsync(ctx, platformContext)),
     cliVersion: packageJSON.version,
     workflow: ctx.workflow,
     credentialsSource: ctx.buildProfile.credentialsSource,
@@ -56,7 +61,7 @@ export async function collectMetadata<T extends Platform>(
     ...channelOrReleaseChannel,
     distribution,
     appName: ctx.exp.name,
-    appIdentifier: await resolveAppIdentifierAsync(ctx),
+    appIdentifier: await resolveAppIdentifierAsync(ctx, platformContext),
     buildProfile: ctx.buildProfileName,
     gitCommitHash: await vcs.getCommitHashAsync(),
     username: getUsername(ctx.exp, await ensureLoggedInAsync()),
@@ -69,38 +74,38 @@ export async function collectMetadata<T extends Platform>(
   return sanitizeMetadata(metadata);
 }
 
-async function resolveAppVersionAsync<T extends Platform>(
+async function resolveVersionsAsync<T extends Platform>(
   ctx: BuildContext<T>,
   platformContext?: MetadataContext<T>
-): Promise<string | undefined> {
+): Promise<{ appBuildVersion?: string; appVersion?: string }> {
   if (ctx.platform === Platform.IOS) {
     const iosContext = platformContext as IosMetadataContext | undefined;
-    return await readShortVersionAsync(ctx.projectDir, ctx.exp, iosContext?.buildSettings ?? {});
+    return await maybeResolveIosVersionsAsync(
+      ctx.projectDir,
+      ctx.exp,
+      iosContext?.buildSettings ?? {}
+    );
+  } else if (ctx.platform === Platform.ANDROID) {
+    const androidCtx = ctx as BuildContext<Platform.ANDROID>;
+    return await maybeResolveAndroidVersionsAsync(ctx.projectDir, ctx.exp, androidCtx.buildProfile);
   } else {
-    return await readVersionNameAsync(ctx.projectDir, ctx.exp);
-  }
-}
-
-async function resolveAppBuildVersionAsync<T extends Platform>(
-  ctx: BuildContext<T>,
-  platformContext?: MetadataContext<T>
-): Promise<string | undefined> {
-  if (ctx.platform === Platform.IOS) {
-    const iosContext = platformContext as IosMetadataContext | undefined;
-    return await readBuildNumberAsync(ctx.projectDir, ctx.exp, iosContext?.buildSettings ?? {});
-  } else {
-    const versionCode = await readVersionCodeAsync(ctx.projectDir, ctx.exp);
-    return versionCode !== undefined ? String(versionCode) : undefined;
+    throw new Error(`Unsupported platform ${ctx.platform}`);
   }
 }
 
 async function resolveAppIdentifierAsync<T extends Platform>(
-  ctx: BuildContext<T>
+  ctx: BuildContext<T>,
+  platformContext: MetadataContext<T>
 ): Promise<string> {
   if (ctx.platform === Platform.IOS) {
-    return await getBundleIdentifierAsync(ctx.projectDir, ctx.exp);
+    const iosContext = platformContext as IosMetadataContext;
+    return await getBundleIdentifierAsync(ctx.projectDir, ctx.exp, {
+      targetName: iosContext.targetName,
+      buildConfiguration: iosContext.buildConfiguration,
+    });
   } else {
-    return await getApplicationIdAsync(ctx.projectDir, ctx.exp);
+    const androidContext = platformContext as AndroidMetadataContext;
+    return await getApplicationIdAsync(ctx.projectDir, ctx.exp, androidContext.gradleContext);
   }
 }
 

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -52,7 +52,7 @@ export async function collectMetadata<T extends Platform>(
       : ctx.buildProfile.distribution) ?? 'store';
   const metadata = {
     trackingContext: ctx.trackingCtx,
-    ...(await resolveVersionsAsync(ctx, platformContext)),
+    ...(await maybeResolveVersionsAsync(ctx, platformContext)),
     cliVersion: packageJSON.version,
     workflow: ctx.workflow,
     credentialsSource: ctx.buildProfile.credentialsSource,
@@ -74,12 +74,12 @@ export async function collectMetadata<T extends Platform>(
   return sanitizeMetadata(metadata);
 }
 
-async function resolveVersionsAsync<T extends Platform>(
+async function maybeResolveVersionsAsync<T extends Platform>(
   ctx: BuildContext<T>,
-  platformContext?: MetadataContext<T>
+  platformContext: MetadataContext<T>
 ): Promise<{ appBuildVersion?: string; appVersion?: string }> {
   if (ctx.platform === Platform.IOS) {
-    const iosContext = platformContext as IosMetadataContext | undefined;
+    const iosContext = platformContext as IosMetadataContext;
     return await maybeResolveIosVersionsAsync(
       ctx.projectDir,
       ctx.exp,

--- a/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
@@ -34,7 +34,7 @@ export default class AndroidCredentialsProvider {
   }
 
   private async getRemoteAsync(): Promise<AndroidCredentials> {
-    const setupBuildCredentialsAction = await new SetupBuildCredentials({ app: this.options.app });
+    const setupBuildCredentialsAction = new SetupBuildCredentials({ app: this.options.app });
     const buildCredentials = await setupBuildCredentialsAction.runAsync(this.ctx);
     return this.toAndroidCredentials(buildCredentials);
   }

--- a/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
@@ -4,6 +4,7 @@ import ora from 'ora';
 
 import { AndroidAppBuildCredentialsFragment } from '../../../graphql/generated';
 import { getApplicationIdAsync } from '../../../project/android/applicationId';
+import { GradleBuildContext } from '../../../project/android/gradle';
 import { getProjectAccountName, getProjectConfigDescription } from '../../../project/projectUtils';
 import { promptAsync } from '../../../prompts';
 import { findAccountByName } from '../../../user/Account';
@@ -83,7 +84,10 @@ export async function promptUserAndCopyLegacyCredentialsAsync(
   spinner.succeed('Credentials copied to EAS.');
 }
 
-export async function getAppLookupParamsFromContextAsync(ctx: Context): Promise<AppLookupParams> {
+export async function getAppLookupParamsFromContextAsync(
+  ctx: Context,
+  gradleContext?: GradleBuildContext
+): Promise<AppLookupParams> {
   ctx.ensureProjectContext();
   const projectName = ctx.exp.slug;
   const accountName = getProjectAccountName(ctx.exp, ctx.user);
@@ -92,7 +96,11 @@ export async function getAppLookupParamsFromContextAsync(ctx: Context): Promise<
     throw new Error(`You do not have access to account: ${accountName}`);
   }
 
-  const androidApplicationIdentifier = await getApplicationIdAsync(ctx.projectDir, ctx.exp);
+  const androidApplicationIdentifier = await getApplicationIdAsync(
+    ctx.projectDir,
+    ctx.exp,
+    gradleContext
+  );
   if (!androidApplicationIdentifier) {
     throw new Error(
       `android.package needs to be defined in your ${getProjectConfigDescription(

--- a/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
@@ -29,14 +29,18 @@ describe(getApplicationIdAsync, () => {
       vol.fromJSON(
         {
           'android/app/build.gradle': `
-            applicationId "com.expo.notdominik"
+          android {
+            defaultConfig {
+              applicationId "com.expo.notdominik"
+            }
+          }
           `,
           'android/app/src/main/AndroidManifest.xml': 'fake',
         },
         '/app'
       );
 
-      const applicationId = await getApplicationIdAsync('/app', {} as any);
+      const applicationId = await getApplicationIdAsync('/app', {} as any, { moduleName: 'app' });
       expect(applicationId).toBe('com.expo.notdominik');
     });
 
@@ -48,7 +52,7 @@ describe(getApplicationIdAsync, () => {
         },
         '/app'
       );
-      await expect(getApplicationIdAsync('/app', {} as any)).rejects.toThrowError(
+      await expect(getApplicationIdAsync('/app', {} as any, undefined)).rejects.toThrowError(
         /Could not read application id/
       );
     });
@@ -62,29 +66,35 @@ describe(getApplicationIdAsync, () => {
         '/app'
       );
 
-      await expect(getApplicationIdAsync('/app', {} as any)).rejects.toThrowError(
-        /Could not read application id/
-      );
+      await expect(
+        getApplicationIdAsync('/app', {} as any, { moduleName: 'app' })
+      ).rejects.toThrowError(/Could not read application id/);
     });
   });
 
   describe('managed projects', () => {
     it('reads applicationId (Android package) from app config', async () => {
-      const applicationId = await getApplicationIdAsync('/app', {
-        android: { package: 'com.expo.notdominik' },
-      } as any);
+      const applicationId = await getApplicationIdAsync(
+        '/app',
+        {
+          android: { package: 'com.expo.notdominik' },
+        } as any,
+        { moduleName: 'app' }
+      );
       expect(applicationId).toBe('com.expo.notdominik');
     });
 
     it('throws an error if Android package is not defined in app config', async () => {
-      await expect(getApplicationIdAsync('/app', {} as any)).rejects.toThrowError(
-        /Specify "android.package"/
-      );
+      await expect(
+        getApplicationIdAsync('/app', {} as any, { moduleName: 'app' })
+      ).rejects.toThrowError(/Specify "android.package"/);
     });
 
     it('throws an error if Android package in app config is invalid', async () => {
       await expect(
-        getApplicationIdAsync('/app', { android: { package: '1com.expo.notdominik' } } as any)
+        getApplicationIdAsync('/app', { android: { package: '1com.expo.notdominik' } } as any, {
+          moduleName: 'app',
+        })
       ).rejects.toThrowError(/Specify "android.package"/);
     });
   });

--- a/packages/eas-cli/src/project/android/__tests__/fixtures/build.gradle
+++ b/packages/eas-cli/src/project/android/__tests__/fixtures/build.gradle
@@ -1,0 +1,221 @@
+/* Example build.gradle file from https://github.com/expo/expo/blob/6ab0274b5cb9a9c223e0d453787a522b438b4fcb/templates/expo-template-bare-minimum/android/app/build.gradle */
+
+apply plugin: "com.android.application"
+
+import com.android.build.OutputFile
+
+/**
+ * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
+ * and bundleReleaseJsAndAssets).
+ * These basically call `react-native bundle` with the correct arguments during the Android build
+ * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
+ * bundle directly from the development server. Below you can see all the possible configurations
+ * and their defaults. If you decide to add a configuration block, make sure to add it before the
+ * `apply from: "../../node_modules/react-native/react.gradle"` line.
+ *
+ * project.ext.react = [
+ *   // the name of the generated asset file containing your JS bundle
+ *   bundleAssetName: "index.android.bundle",
+ *
+ *   // the entry file for bundle generation. If none specified and
+ *   // "index.android.js" exists, it will be used. Otherwise "index.js" is
+ *   // default. Can be overridden with ENTRY_FILE environment variable.
+ *   entryFile: "index.android.js",
+ *
+ *   // https://reactnative.dev/docs/performance#enable-the-ram-format
+ *   bundleCommand: "ram-bundle",
+ *
+ *   // whether to bundle JS and assets in debug mode
+ *   bundleInDebug: false,
+ *
+ *   // whether to bundle JS and assets in release mode
+ *   bundleInRelease: true,
+ *
+ *   // whether to bundle JS and assets in another build variant (if configured).
+ *   // See http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Variants
+ *   // The configuration property can be in the following formats
+ *   //         'bundleIn${productFlavor}${buildType}'
+ *   //         'bundleIn${buildType}'
+ *   // bundleInFreeDebug: true,
+ *   // bundleInPaidRelease: true,
+ *   // bundleInBeta: true,
+ *
+ *   // whether to disable dev mode in custom build variants (by default only disabled in release)
+ *   // for example: to disable dev mode in the staging build type (if configured)
+ *   devDisabledInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'devDisabledIn${productFlavor}${buildType}'
+ *   //         'devDisabledIn${buildType}'
+ *
+ *   // the root of your project, i.e. where "package.json" lives
+ *   root: "../../",
+ *
+ *   // where to put the JS bundle asset in debug mode
+ *   jsBundleDirDebug: "$buildDir/intermediates/assets/debug",
+ *
+ *   // where to put the JS bundle asset in release mode
+ *   jsBundleDirRelease: "$buildDir/intermediates/assets/release",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in debug mode
+ *   resourcesDirDebug: "$buildDir/intermediates/res/merged/debug",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in release mode
+ *   resourcesDirRelease: "$buildDir/intermediates/res/merged/release",
+ *
+ *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
+ *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
+ *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
+ *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
+ *   // for example, you might want to remove it from here.
+ *   inputExcludes: ["android/**", "ios/**"],
+ *
+ *   // override which node gets called and with what additional arguments
+ *   nodeExecutableAndArgs: ["node"],
+ *
+ *   // supply additional arguments to the packager
+ *   extraPackagerArgs: []
+ * ]
+ */
+
+project.ext.react = [
+    enableHermes: false
+]
+
+apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
+apply from: "../../node_modules/react-native/react.gradle"
+apply from: "../../node_modules/expo-constants/scripts/get-app-config-android.gradle"
+apply from: "../../node_modules/expo-updates/scripts/create-manifest-android.gradle"
+
+/**
+ * Set this to true to create two separate APKs instead of one:
+ *   - An APK that only works on ARM devices
+ *   - An APK that only works on x86 devices
+ * The advantage is the size of the APK is reduced by about 4MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = false
+
+/**
+ * Run Proguard to shrink the Java bytecode in release builds.
+ */
+def enableProguardInReleaseBuilds = false
+
+/**
+ * The preferred build flavor of JavaScriptCore.
+ *
+ * For example, to use the international variant, you can use:
+ * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ *
+ * The international variant includes ICU i18n library and necessary data
+ * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
+ * give correct results when using with locales other than en-US.  Note that
+ * this variant is about 6MiB larger per architecture than default.
+ */
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+/**
+ * Whether to enable the Hermes VM.
+ *
+ * This should be set on project.ext.react and mirrored here.  If it is not set
+ * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
+ * and the benefits of using Hermes will therefore be sharply reduced.
+ */
+def enableHermes = project.ext.react.get("enableHermes", false);
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        applicationId "com.helloworld"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+        }
+    }
+    signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // For each separate APK per architecture, set a unique version code as described here:
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug, universal-release variants
+                output.versionCodeOverride =
+                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            }
+
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+      exclude group:'com.facebook.fbjni'
+    }
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+    addUnimodulesDependencies()
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.compile
+    into 'libs'
+}
+
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/packages/eas-cli/src/project/android/__tests__/fixtures/multiflavor-build.gradle
+++ b/packages/eas-cli/src/project/android/__tests__/fixtures/multiflavor-build.gradle
@@ -1,0 +1,231 @@
+apply plugin: "com.android.application"
+
+import com.android.build.OutputFile
+
+/**
+ * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
+ * and bundleReleaseJsAndAssets).
+ * These basically call `react-native bundle` with the correct arguments during the Android build
+ * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
+ * bundle directly from the development server. Below you can see all the possible configurations
+ * and their defaults. If you decide to add a configuration block, make sure to add it before the
+ * `apply from: "../../node_modules/react-native/react.gradle"` line.
+ *
+ * project.ext.react = [
+ *   // the name of the generated asset file containing your JS bundle
+ *   bundleAssetName: "index.android.bundle",
+ *
+ *   // the entry file for bundle generation. If none specified and
+ *   // "index.android.js" exists, it will be used. Otherwise "index.js" is
+ *   // default. Can be overridden with ENTRY_FILE environment variable.
+ *   entryFile: "index.android.js",
+ *
+ *   // https://reactnative.dev/docs/performance#enable-the-ram-format
+ *   bundleCommand: "ram-bundle",
+ *
+ *   // whether to bundle JS and assets in debug mode
+ *   bundleInDebug: false,
+ *
+ *   // whether to bundle JS and assets in release mode
+ *   bundleInRelease: true,
+ *
+ *   // whether to bundle JS and assets in another build variant (if configured).
+ *   // See http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Variants
+ *   // The configuration property can be in the following formats
+ *   //         'bundleIn${productFlavor}${buildType}'
+ *   //         'bundleIn${buildType}'
+ *   // bundleInFreeDebug: true,
+ *   // bundleInPaidRelease: true,
+ *   // bundleInBeta: true,
+ *
+ *   // whether to disable dev mode in custom build variants (by default only disabled in release)
+ *   // for example: to disable dev mode in the staging build type (if configured)
+ *   devDisabledInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'devDisabledIn${productFlavor}${buildType}'
+ *   //         'devDisabledIn${buildType}'
+ *
+ *   // the root of your project, i.e. where "package.json" lives
+ *   root: "../../",
+ *
+ *   // where to put the JS bundle asset in debug mode
+ *   jsBundleDirDebug: "$buildDir/intermediates/assets/debug",
+ *
+ *   // where to put the JS bundle asset in release mode
+ *   jsBundleDirRelease: "$buildDir/intermediates/assets/release",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in debug mode
+ *   resourcesDirDebug: "$buildDir/intermediates/res/merged/debug",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in release mode
+ *   resourcesDirRelease: "$buildDir/intermediates/res/merged/release",
+ *
+ *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
+ *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
+ *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
+ *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
+ *   // for example, you might want to remove it from here.
+ *   inputExcludes: ["android/**", "ios/**"],
+ *
+ *   // override which node gets called and with what additional arguments
+ *   nodeExecutableAndArgs: ["node"],
+ *
+ *   // supply additional arguments to the packager
+ *   extraPackagerArgs: []
+ * ]
+ */
+
+project.ext.react = [
+    enableHermes: false
+]
+
+apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
+apply from: "../../node_modules/react-native/react.gradle"
+apply from: "../../node_modules/expo-updates/scripts/create-manifest-android.gradle"
+
+/**
+ * Set this to true to create two separate APKs instead of one:
+ *   - An APK that only works on ARM devices
+ *   - An APK that only works on x86 devices
+ * The advantage is the size of the APK is reduced by about 4MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = false
+
+/**
+ * Run Proguard to shrink the Java bytecode in release builds.
+ */
+def enableProguardInReleaseBuilds = false
+
+/**
+ * The preferred build flavor of JavaScriptCore.
+ *
+ * For example, to use the international variant, you can use:
+ * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ *
+ * The international variant includes ICU i18n library and necessary data
+ * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
+ * give correct results when using with locales other than en-US.  Note that
+ * this variant is about 6MiB larger per architecture than default.
+ */
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+/**
+ * Whether to enable the Hermes VM.
+ *
+ * This should be set on project.ext.react and mirrored here.  If it is not set
+ * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
+ * and the benefits of using Hermes will therefore be sharply reduced.
+ */
+def enableHermes = project.ext.react.get("enableHermes", false);
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        applicationId "com.testapp"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+        }
+    }
+    signingConfigs {
+        debug {
+            storeFile rootProject.file('keystores/debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    productFlavors {
+        abc {
+            applicationId "wefewf.wefew.abc"
+            versionCode 123
+        }
+        efg {
+            applicationId "wefewf.wefew.efg"
+            versionCode 124
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // For each separate APK per architecture, set a unique version code as described here:
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug, universal-release variants
+                output.versionCodeOverride =
+                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            }
+
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+      exclude group:'com.facebook.fbjni'
+    }
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+    addUnimodulesDependencies()
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.compile
+    into 'libs'
+}
+
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+apply from: "./eas-build.gradle"
+

--- a/packages/eas-cli/src/project/android/__tests__/fixtures/multiflavor-with-dimensions-build.gradle
+++ b/packages/eas-cli/src/project/android/__tests__/fixtures/multiflavor-with-dimensions-build.gradle
@@ -1,0 +1,234 @@
+apply plugin: "com.android.application"
+
+import com.android.build.OutputFile
+
+/**
+ * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
+ * and bundleReleaseJsAndAssets).
+ * These basically call `react-native bundle` with the correct arguments during the Android build
+ * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
+ * bundle directly from the development server. Below you can see all the possible configurations
+ * and their defaults. If you decide to add a configuration block, make sure to add it before the
+ * `apply from: "../../node_modules/react-native/react.gradle"` line.
+ *
+ * project.ext.react = [
+ *   // the name of the generated asset file containing your JS bundle
+ *   bundleAssetName: "index.android.bundle",
+ *
+ *   // the entry file for bundle generation. If none specified and
+ *   // "index.android.js" exists, it will be used. Otherwise "index.js" is
+ *   // default. Can be overridden with ENTRY_FILE environment variable.
+ *   entryFile: "index.android.js",
+ *
+ *   // https://reactnative.dev/docs/performance#enable-the-ram-format
+ *   bundleCommand: "ram-bundle",
+ *
+ *   // whether to bundle JS and assets in debug mode
+ *   bundleInDebug: false,
+ *
+ *   // whether to bundle JS and assets in release mode
+ *   bundleInRelease: true,
+ *
+ *   // whether to bundle JS and assets in another build variant (if configured).
+ *   // See http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Variants
+ *   // The configuration property can be in the following formats
+ *   //         'bundleIn${productFlavor}${buildType}'
+ *   //         'bundleIn${buildType}'
+ *   // bundleInFreeDebug: true,
+ *   // bundleInPaidRelease: true,
+ *   // bundleInBeta: true,
+ *
+ *   // whether to disable dev mode in custom build variants (by default only disabled in release)
+ *   // for example: to disable dev mode in the staging build type (if configured)
+ *   devDisabledInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'devDisabledIn${productFlavor}${buildType}'
+ *   //         'devDisabledIn${buildType}'
+ *
+ *   // the root of your project, i.e. where "package.json" lives
+ *   root: "../../",
+ *
+ *   // where to put the JS bundle asset in debug mode
+ *   jsBundleDirDebug: "$buildDir/intermediates/assets/debug",
+ *
+ *   // where to put the JS bundle asset in release mode
+ *   jsBundleDirRelease: "$buildDir/intermediates/assets/release",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in debug mode
+ *   resourcesDirDebug: "$buildDir/intermediates/res/merged/debug",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in release mode
+ *   resourcesDirRelease: "$buildDir/intermediates/res/merged/release",
+ *
+ *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
+ *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
+ *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
+ *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
+ *   // for example, you might want to remove it from here.
+ *   inputExcludes: ["android/**", "ios/**"],
+ *
+ *   // override which node gets called and with what additional arguments
+ *   nodeExecutableAndArgs: ["node"],
+ *
+ *   // supply additional arguments to the packager
+ *   extraPackagerArgs: []
+ * ]
+ */
+
+project.ext.react = [
+    enableHermes: false
+]
+
+apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
+apply from: "../../node_modules/react-native/react.gradle"
+apply from: "../../node_modules/expo-updates/scripts/create-manifest-android.gradle"
+
+/**
+ * Set this to true to create two separate APKs instead of one:
+ *   - An APK that only works on ARM devices
+ *   - An APK that only works on x86 devices
+ * The advantage is the size of the APK is reduced by about 4MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = false
+
+/**
+ * Run Proguard to shrink the Java bytecode in release builds.
+ */
+def enableProguardInReleaseBuilds = false
+
+/**
+ * The preferred build flavor of JavaScriptCore.
+ *
+ * For example, to use the international variant, you can use:
+ * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ *
+ * The international variant includes ICU i18n library and necessary data
+ * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
+ * give correct results when using with locales other than en-US.  Note that
+ * this variant is about 6MiB larger per architecture than default.
+ */
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+/**
+ * Whether to enable the Hermes VM.
+ *
+ * This should be set on project.ext.react and mirrored here.  If it is not set
+ * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
+ * and the benefits of using Hermes will therefore be sharply reduced.
+ */
+def enableHermes = project.ext.react.get("enableHermes", false);
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        applicationId "com.testapp"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+        }
+    }
+    signingConfigs {
+        debug {
+            storeFile rootProject.file('keystores/debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    flavorDimensions "api", "mode"
+    productFlavors {
+        abc {
+            dimension "api"
+            applicationId "wefewf.wefew.abc"
+            versionCode 123
+        }
+        efg {
+            dimension "mode"
+            applicationId "wefewf.wefew.efg"
+            versionCode 124
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // For each separate APK per architecture, set a unique version code as described here:
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug, universal-release variants
+                output.versionCodeOverride =
+                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            }
+
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+      exclude group:'com.facebook.fbjni'
+    }
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+    addUnimodulesDependencies()
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.compile
+    into 'libs'
+}
+
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+apply from: "./eas-build.gradle"
+

--- a/packages/eas-cli/src/project/android/__tests__/gradle-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/gradle-test.ts
@@ -1,0 +1,110 @@
+import fs from 'fs-extra';
+import { vol } from 'memfs';
+import os from 'os';
+
+import { asMock } from '../../../__tests__/utils';
+import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
+import { promptAsync } from '../../../prompts';
+import { resolveGradleBuildContextAsync } from '../gradle';
+
+jest.mock('fs');
+jest.mock('../../../prompts');
+jest.mock('../../../user/actions', () => ({ ensureLoggedInAsync: jest.fn(() => mockJester) }));
+
+beforeEach(() => {
+  vol.reset();
+  // do not remove the following line
+  // this fixes a weird error with tempy in @expo/image-utils
+  fs.mkdirpSync(os.tmpdir());
+
+  asMock(promptAsync).mockReset();
+});
+
+describe(resolveGradleBuildContextAsync, () => {
+  describe('generic projects', () => {
+    it('resolves to default config (no flavor)', async () => {
+      vol.fromJSON(
+        {
+          'android/app/build.gradle': `
+          android {
+            defaultConfig {
+              applicationId "com.expo.notdominik"
+            }
+          }
+          `,
+          'android/app/src/main/AndroidManifest.xml': 'fake',
+        },
+        '/app'
+      );
+
+      const gradleContext = await resolveGradleBuildContextAsync('/app', {} as any);
+      expect(gradleContext).toEqual({ moduleName: 'app' });
+    });
+    it('resolves to flavor', async () => {
+      vol.fromJSON(
+        {
+          'android/app/build.gradle': `
+          android {
+            defaultConfig {
+              applicationId "com.expo.notdominik"
+            }
+            productFlavors {
+              abc {
+                applicationId "efwaf.eafawefwa.wefwf"
+              }
+            }
+          }
+          `,
+          'android/app/src/main/AndroidManifest.xml': 'fake',
+        },
+        '/app'
+      );
+
+      const gradleContext = await resolveGradleBuildContextAsync('/app', {
+        gradleCommand: ':app:buildAbcRelease',
+      } as any);
+      expect(gradleContext).toEqual({ moduleName: 'app', flavor: 'abc' });
+    });
+
+    it('returns undefined if build.gradle does not exist', async () => {
+      vol.fromJSON(
+        {
+          'android/gradle.properties': 'fake file',
+          'android/app/src/main/AndroidManifest.xml': 'fake',
+        },
+        '/app'
+      );
+      const gradleContext = await resolveGradleBuildContextAsync('/app', {
+        gradleCommand: ':app:buildAbcRelease',
+      } as any);
+      expect(gradleContext).toEqual(undefined);
+    });
+    it('returns undefined if flavor does not exist', async () => {
+      vol.fromJSON(
+        {
+          'android/app/build.gradle': `
+          android {
+            defaultConfig {
+              applicationId "com.expo.notdominik"
+            }
+          }
+          `,
+          'android/app/src/main/AndroidManifest.xml': 'fake',
+        },
+        '/app'
+      );
+
+      const gradleContext = await resolveGradleBuildContextAsync('/app', {
+        gradleCommand: ':app:buildAbcRelease',
+      } as any);
+      expect(gradleContext).toEqual(undefined);
+    });
+  });
+
+  describe('managed projects', () => {
+    it('resolves to { moduleName: app } for managed projects', async () => {
+      const gradleContext = await resolveGradleBuildContextAsync('/app', {} as any);
+      expect(gradleContext).toEqual({ moduleName: 'app' });
+    });
+  });
+});

--- a/packages/eas-cli/src/project/android/__tests__/gradleUtils-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/gradleUtils-test.ts
@@ -1,0 +1,189 @@
+import fs from 'fs';
+import { vol } from 'memfs';
+import path from 'path';
+
+import pick from '../../../utils/expodash/pick';
+import { getAppBuildGradleAsync, parseGradleCommand, resolveConfigValue } from '../gradleUtils';
+
+const fsReal = jest.requireActual('fs') as typeof fs;
+
+jest.mock('fs');
+
+describe(getAppBuildGradleAsync, () => {
+  afterEach(async () => {
+    vol.reset();
+  });
+
+  test('parsing build.gradle from managed template', async () => {
+    vol.fromJSON(
+      {
+        'android/app/build.gradle': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/build.gradle'),
+          'utf-8'
+        ),
+      },
+      '/test'
+    );
+    const buildGradle = await getAppBuildGradleAsync('/test');
+    expect(
+      pick(buildGradle?.android ?? {}, ['defaultConfig', 'flavorDimensions', 'productFlavors'])
+    ).toEqual({
+      defaultConfig: {
+        applicationId: 'com.helloworld',
+        minSdkVersion: 'rootProject.ext.minSdkVersion',
+        targetSdkVersion: 'rootProject.ext.targetSdkVersion',
+        versionCode: '1',
+        versionName: '1.0',
+      },
+    });
+  });
+
+  test('parsing multiflavor build.gradle', async () => {
+    vol.fromJSON(
+      {
+        'android/app/build.gradle': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/multiflavor-build.gradle'),
+          'utf-8'
+        ),
+      },
+      '/test'
+    );
+    const buildGradle = await getAppBuildGradleAsync('/test');
+    expect(
+      pick(buildGradle?.android ?? {}, ['defaultConfig', 'flavorDimensions', 'productFlavors'])
+    ).toEqual({
+      defaultConfig: {
+        applicationId: 'com.testapp',
+        minSdkVersion: 'rootProject.ext.minSdkVersion',
+        targetSdkVersion: 'rootProject.ext.targetSdkVersion',
+        versionCode: '1',
+        versionName: '1.0',
+      },
+      productFlavors: {
+        abc: {
+          applicationId: 'wefewf.wefew.abc',
+          versionCode: '123',
+        },
+        efg: {
+          applicationId: 'wefewf.wefew.efg',
+          versionCode: '124',
+        },
+      },
+    });
+  });
+
+  test('parsing build.gradle with flavor dimensions', async () => {
+    vol.fromJSON(
+      {
+        'android/app/build.gradle': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/multiflavor-with-dimensions-build.gradle'),
+          'utf-8'
+        ),
+      },
+      '/test'
+    );
+    const buildGradle = await getAppBuildGradleAsync('/test');
+    expect(
+      pick(buildGradle?.android ?? {}, ['defaultConfig', 'flavorDimensions', 'productFlavors'])
+    ).toEqual({
+      defaultConfig: {
+        applicationId: 'com.testapp',
+        minSdkVersion: 'rootProject.ext.minSdkVersion',
+        targetSdkVersion: 'rootProject.ext.targetSdkVersion',
+        versionCode: '1',
+        versionName: '1.0',
+      },
+      flavorDimensions: '"api", "mode"',
+      productFlavors: {
+        abc: {
+          applicationId: 'wefewf.wefew.abc',
+          versionCode: '123',
+          dimension: 'api',
+        },
+        efg: {
+          applicationId: 'wefewf.wefew.efg',
+          versionCode: '124',
+          dimension: 'mode',
+        },
+      },
+    });
+  });
+});
+
+describe(parseGradleCommand, () => {
+  test('parsing :app:bundleRelease', async () => {
+    const result = parseGradleCommand(':app:bundleRelease', {});
+    expect(result).toEqual({ moduleName: 'app', buildType: 'release' });
+  });
+  test('parsing :app:buildExampleDebug', async () => {
+    const result = parseGradleCommand(':app:buildExampleRelease', {
+      android: { productFlavors: { example: {} } },
+    });
+    expect(result).toEqual({ moduleName: 'app', flavor: 'example', buildType: 'release' });
+  });
+  test('parsing :app:buildExampleDebug when flavor is named with uper-case', async () => {
+    const result = parseGradleCommand(':app:buildExampleRelease', {
+      android: { productFlavors: { Example: {} } },
+    });
+    expect(result).toEqual({ moduleName: 'app', flavor: 'Example', buildType: 'release' });
+  });
+  test('parsing :app:buildExampleDebug when flavor does not exists', async () => {
+    const result = () => {
+      parseGradleCommand(':app:buildExampleRelease', {
+        android: { productFlavors: {} },
+      });
+    };
+    expect(result).toThrow('flavor example is not defined');
+  });
+  test('parsing with aditional cmdline options', async () => {
+    const result = parseGradleCommand(':app:bundleRelease --console verbose', {});
+    expect(result).toEqual({ moduleName: 'app', buildType: 'release' });
+  });
+  test('parsing without module name specified', async () => {
+    const result = parseGradleCommand('bundleRelease --console verbose', {});
+    expect(result).toEqual({ buildType: 'release' });
+  });
+});
+
+describe(resolveConfigValue, () => {
+  it('get versionCode for default flavor', async () => {
+    const buildGradle = {
+      android: {
+        defaultConfig: { versionCode: '123' },
+        productFlavors: { example: { versionCode: '1234' } },
+      },
+    };
+    const result = resolveConfigValue(buildGradle, 'versionCode');
+    expect(result).toEqual('123');
+  });
+  it('get versionCode for example flavor', async () => {
+    const buildGradle = {
+      android: {
+        defaultConfig: { versionCode: '123' },
+        productFlavors: { example: { versionCode: '1234' } },
+      },
+    };
+    const result = resolveConfigValue(buildGradle, 'versionCode', 'example');
+    expect(result).toEqual('1234');
+  });
+  it('get versionCode for example flavor from default config', async () => {
+    const buildGradle = {
+      android: {
+        defaultConfig: { versionCode: '123' },
+        productFlavors: { example: { versionName: '1234' } },
+      },
+    };
+    const result = resolveConfigValue(buildGradle, 'versionCode', 'example');
+    expect(result).toEqual('123');
+  });
+  it('get versionCode for example flavor from default config', async () => {
+    const buildGradle = {
+      android: {
+        defaultConfig: { versionCode: '123' },
+        productFlavors: { example: { versionName: '1234' } },
+      },
+    };
+    const result = resolveConfigValue(buildGradle, 'versionCode', 'example');
+    expect(result).toEqual('123');
+  });
+});

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -11,6 +11,7 @@ import { getProjectConfigDescription, getUsername } from '../../project/projectU
 import { promptAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';
 import { resolveWorkflowAsync } from '../workflow';
+import { GradleBuildContext } from './gradle';
 
 const INVALID_APPLICATION_ID_MESSAGE = `Invalid format of Android applicationId. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter.`;
 
@@ -22,28 +23,48 @@ export async function ensureApplicationIdIsDefinedForManagedProjectAsync(
   assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
 
   try {
-    return await getApplicationIdAsync(projectDir, exp);
+    return await getApplicationIdAsync(projectDir, exp, { moduleName: 'app' });
   } catch (err) {
     return await configureApplicationIdAsync(projectDir, exp);
   }
 }
 
-export async function getApplicationIdAsync(projectDir: string, exp: ExpoConfig): Promise<string> {
+export async function getApplicationIdAsync(
+  projectDir: string,
+  exp: ExpoConfig,
+  gradleContext: GradleBuildContext | undefined
+): Promise<string> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
   if (workflow === Workflow.GENERIC) {
     warnIfAndroidPackageDefinedInAppConfigForGenericProject(projectDir, exp);
 
     const errorMessage = 'Could not read application id from Android project.';
-    let buildGradlePath = null;
-    try {
-      buildGradlePath = AndroidConfig.Paths.getAppBuildGradleFilePath(projectDir);
-    } catch {}
-    if (!buildGradlePath || !fs.pathExistsSync(buildGradlePath)) {
-      throw new Error(errorMessage);
+    if (gradleContext) {
+      const buildGradle = await AndroidConfig.BuildGradle.getAppBuildGradleAsync(projectDir);
+      const applicationId = AndroidConfig.BuildGradle.resolveConfigValue(
+        buildGradle,
+        gradleContext.flavor,
+        'applicationId'
+      );
+      return nullthrows(applicationId, errorMessage);
+    } else {
+      // fallback to best effort approach, this logic can be dropped when we start supporting
+      // modules diffrent than 'app' and 'flavorDimensions'
+      let buildGradlePath = null;
+      try {
+        buildGradlePath = AndroidConfig.Paths.getAppBuildGradleFilePath(projectDir);
+      } catch {}
+      if (!buildGradlePath || !fs.pathExistsSync(buildGradlePath)) {
+        throw new Error(errorMessage);
+      }
+      const buildGradle = fs.readFileSync(buildGradlePath, 'utf8');
+      const matchResult = buildGradle.match(/applicationId ['"](.*)['"]/);
+      const applicationId = nullthrows(matchResult?.[1], errorMessage);
+
+      Log.warn(`Unable to detect applicationId`);
+      Log.warn(`Falling back to best effort approach, using applicationId ${applicationId}`);
+      return applicationId;
     }
-    const buildGradle = fs.readFileSync(buildGradlePath, 'utf8');
-    const matchResult = buildGradle.match(/applicationId ['"](.*)['"]/);
-    return nullthrows(matchResult?.[1], errorMessage);
   } else {
     const applicationId = AndroidConfig.Package.getPackage(exp);
     if (!applicationId || !isApplicationIdValid(applicationId)) {

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -12,6 +12,7 @@ import { promptAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';
 import { resolveWorkflowAsync } from '../workflow';
 import { GradleBuildContext } from './gradle';
+import { getAppBuildGradleAsync, resolveConfigValue } from './gradleUtils';
 
 const INVALID_APPLICATION_ID_MESSAGE = `Invalid format of Android applicationId. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter.`;
 
@@ -40,12 +41,8 @@ export async function getApplicationIdAsync(
 
     const errorMessage = 'Could not read application id from Android project.';
     if (gradleContext) {
-      const buildGradle = await AndroidConfig.BuildGradle.getAppBuildGradleAsync(projectDir);
-      const applicationId = AndroidConfig.BuildGradle.resolveConfigValue(
-        buildGradle,
-        gradleContext.flavor,
-        'applicationId'
-      );
+      const buildGradle = await getAppBuildGradleAsync(projectDir);
+      const applicationId = resolveConfigValue(buildGradle, 'applicationId', gradleContext.flavor);
       return nullthrows(applicationId, errorMessage);
     } else {
       // fallback to best effort approach, this logic can be dropped when we start supporting

--- a/packages/eas-cli/src/project/android/gradle.ts
+++ b/packages/eas-cli/src/project/android/gradle.ts
@@ -3,7 +3,7 @@ import { BuildProfile } from '@expo/eas-json';
 
 import Log from '../../log';
 import { resolveWorkflowAsync } from '../../project/workflow';
-import { getAppBuildGradleAsync, parseGradleCommand } from './gradleUtils';
+import * as gradleUtils from './gradleUtils';
 
 export interface GradleBuildContext {
   moduleName?: string;
@@ -18,25 +18,30 @@ export async function resolveGradleBuildContextAsync(
   if (workflow === Workflow.GENERIC) {
     try {
       if (buildProfile.gradleCommand) {
-        const buildGradle = await getAppBuildGradleAsync(projectDir);
+        const buildGradle = await gradleUtils.getAppBuildGradleAsync(projectDir);
         const parsedGradleCommand = buildProfile.gradleCommand
-          ? parseGradleCommand(buildProfile.gradleCommand, buildGradle)
+          ? gradleUtils.parseGradleCommand(buildProfile.gradleCommand, buildGradle)
           : undefined;
-        if (parsedGradleCommand?.moduleName && parsedGradleCommand.moduleName !== 'app') {
-          Log.warn('Building modules different than "app" migth result in unexpected behavior');
+        if (
+          parsedGradleCommand?.moduleName &&
+          parsedGradleCommand.moduleName !== gradleUtils.DEFAULT_MODULE_NAME
+        ) {
+          Log.warn(
+            `Building modules different than "${gradleUtils.DEFAULT_MODULE_NAME}" might result in unexpected behavior`
+          );
         }
         return {
-          moduleName: parsedGradleCommand?.moduleName ?? 'app',
+          moduleName: parsedGradleCommand?.moduleName ?? gradleUtils.DEFAULT_MODULE_NAME,
           flavor: parsedGradleCommand?.flavor,
         };
       } else {
-        return { moduleName: 'app' };
+        return { moduleName: gradleUtils.DEFAULT_MODULE_NAME };
       }
     } catch (err: any) {
       Log.warn(`Unable to read project config from app/build.gradle: ${err.message}`);
       return undefined;
     }
   } else {
-    return { moduleName: 'app' };
+    return { moduleName: gradleUtils.DEFAULT_MODULE_NAME };
   }
 }

--- a/packages/eas-cli/src/project/android/gradle.ts
+++ b/packages/eas-cli/src/project/android/gradle.ts
@@ -1,0 +1,42 @@
+import { AndroidConfig } from '@expo/config-plugins';
+import { Platform, Workflow } from '@expo/eas-build-job';
+import { BuildProfile } from '@expo/eas-json';
+
+import Log from '../../log';
+import { resolveWorkflowAsync } from '../../project/workflow';
+
+export interface GradleBuildContext {
+  moduleName?: string;
+  flavor?: string;
+}
+
+export async function resolveGradleBuildContextAsync(
+  projectDir: string,
+  buildProfile: BuildProfile<Platform.ANDROID>
+): Promise<GradleBuildContext | undefined> {
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
+  if (workflow === Workflow.GENERIC) {
+    try {
+      if (buildProfile.gradleCommand) {
+        const buildGradle = await AndroidConfig.BuildGradle.getAppBuildGradleAsync(projectDir);
+        const parsedGradleCommand = buildProfile.gradleCommand
+          ? AndroidConfig.BuildGradle.parseGradleCommand(buildProfile.gradleCommand, buildGradle)
+          : undefined;
+        if (parsedGradleCommand?.moduleName && parsedGradleCommand.moduleName !== 'app') {
+          Log.warn('Building modules different than "app" migth result in unexpected behavior');
+        }
+        return {
+          moduleName: parsedGradleCommand?.moduleName ?? 'app',
+          flavor: parsedGradleCommand?.flavor,
+        };
+      } else {
+        return { moduleName: 'app' };
+      }
+    } catch (err: any) {
+      Log.warn(`Unable to read project config from app/build.gradle: ${err.message}`);
+      return undefined;
+    }
+  } else {
+    return { moduleName: 'app' };
+  }
+}

--- a/packages/eas-cli/src/project/android/gradle.ts
+++ b/packages/eas-cli/src/project/android/gradle.ts
@@ -1,9 +1,9 @@
-import { AndroidConfig } from '@expo/config-plugins';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { BuildProfile } from '@expo/eas-json';
 
 import Log from '../../log';
 import { resolveWorkflowAsync } from '../../project/workflow';
+import { getAppBuildGradleAsync, parseGradleCommand } from './gradleUtils';
 
 export interface GradleBuildContext {
   moduleName?: string;
@@ -18,9 +18,9 @@ export async function resolveGradleBuildContextAsync(
   if (workflow === Workflow.GENERIC) {
     try {
       if (buildProfile.gradleCommand) {
-        const buildGradle = await AndroidConfig.BuildGradle.getAppBuildGradleAsync(projectDir);
+        const buildGradle = await getAppBuildGradleAsync(projectDir);
         const parsedGradleCommand = buildProfile.gradleCommand
-          ? AndroidConfig.BuildGradle.parseGradleCommand(buildProfile.gradleCommand, buildGradle)
+          ? parseGradleCommand(buildProfile.gradleCommand, buildGradle)
           : undefined;
         if (parsedGradleCommand?.moduleName && parsedGradleCommand.moduleName !== 'app') {
           Log.warn('Building modules different than "app" migth result in unexpected behavior');

--- a/packages/eas-cli/src/project/android/gradleUtils.ts
+++ b/packages/eas-cli/src/project/android/gradleUtils.ts
@@ -1,0 +1,101 @@
+import { AndroidConfig } from '@expo/config-plugins';
+import fs from 'fs-extra';
+import g2js from 'gradle-to-js/lib/parser';
+
+// represents gradle command
+// e.g. for `:app:buildExampleDebug` -> { moduleName: app, flavor: example, buildType: debug }
+interface GradleCommand {
+  moduleName?: string;
+  flavor?: string;
+  buildType?: string;
+}
+
+interface Config {
+  applicationId?: string;
+  versionCode?: string;
+  versionName?: string;
+}
+
+interface AppBuildGradle {
+  android?: {
+    defaultConfig?: Config;
+    flavorDimensions?: string; // e.g. '"dimension1", "dimension2"'
+    productFlavors?: Record<string, Config>;
+  };
+}
+
+export async function getAppBuildGradleAsync(projectDir: string): Promise<AppBuildGradle> {
+  const buildGradlePath = AndroidConfig.Paths.getAppBuildGradleFilePath(projectDir);
+  const rawBuildGradle = await fs.readFile(buildGradlePath, 'utf8');
+  return await g2js.parseText(rawBuildGradle);
+}
+
+export function resolveConfigValue(
+  buildGradle: AppBuildGradle,
+  field: keyof Config,
+  flavor?: string
+) {
+  return (
+    (flavor && buildGradle?.android?.productFlavors?.[flavor]?.[field]) ??
+    buildGradle?.android?.defaultConfig?.[field]
+  );
+}
+
+/**
+ * Extract module name, buildType, and flavor from the gradle command.
+ *
+ * @param cmd can be any valid string that can be added after `./gradlew` call
+ * e.g.
+ *   - :app:buildDebug
+ *   - app:buildDebug
+ *   - buildDebug
+ *   - buildDebug --console verbose
+ * @param buildGradle is used to verify correct casing of the first letter in
+ * the flavor name
+ **/
+export function parseGradleCommand(cmd: string, buildGradle: AppBuildGradle): GradleCommand {
+  const hasFlavorDimensions = (buildGradle.android?.flavorDimensions ?? '').split(',').length > 1;
+  if (hasFlavorDimensions) {
+    throw new Error('flavorDimensions in build.gradle are not supported yet');
+  }
+  const flavors = new Set(Object.keys(buildGradle?.android?.productFlavors ?? {}));
+
+  // remove any params specified after command name
+  const [withoutParams] = cmd.split(' ');
+
+  // remove leading :
+  const rawCmd = withoutParams.startsWith(':') ? withoutParams.slice(1) : withoutParams;
+
+  // separate moduleName and rest of the definition
+  const splitCmd = rawCmd.split(':');
+  const [moduleName, taskName] =
+    splitCmd.length > 1 ? [splitCmd[0], splitCmd[1]] : [undefined, splitCmd[0]];
+
+  const matchResult = taskName.match(/(build|bundle|assemble)(.*)(Release|Debug)/);
+  if (!matchResult) {
+    throw new Error('Failed to parse gradle command');
+  }
+  let flavor: string | undefined;
+  if (matchResult[2]) {
+    const [firstLetter, rest] = [matchResult[2].slice(0, 1), matchResult[2].slice(1)];
+    // first letter casing is not known based on gradle task name
+    // so we need to check both options
+    const flavorOptions = [
+      firstLetter.toLowerCase().concat(rest),
+      firstLetter.toUpperCase().concat(rest),
+    ];
+    flavorOptions.forEach(option => {
+      if (flavors.has(option)) {
+        flavor = option;
+      }
+    });
+    if (!flavor) {
+      throw new Error(`flavor ${firstLetter.toLowerCase().concat(rest)} is not defined`);
+    }
+  }
+  return {
+    moduleName,
+    flavor,
+    buildType: matchResult[3] ? matchResult[3].toLowerCase() : undefined,
+  };
+}

--- a/packages/eas-cli/src/project/android/gradleUtils.ts
+++ b/packages/eas-cli/src/project/android/gradleUtils.ts
@@ -24,6 +24,8 @@ interface AppBuildGradle {
   };
 }
 
+export const DEFAULT_MODULE_NAME = 'app';
+
 export async function getAppBuildGradleAsync(projectDir: string): Promise<AppBuildGradle> {
   const buildGradlePath = AndroidConfig.Paths.getAppBuildGradleFilePath(projectDir);
   const rawBuildGradle = await fs.readFile(buildGradlePath, 'utf8');
@@ -34,7 +36,7 @@ export function resolveConfigValue(
   buildGradle: AppBuildGradle,
   field: keyof Config,
   flavor?: string
-) {
+): string | undefined {
   return (
     (flavor && buildGradle?.android?.productFlavors?.[flavor]?.[field]) ??
     buildGradle?.android?.defaultConfig?.[field]
@@ -73,7 +75,7 @@ export function parseGradleCommand(cmd: string, buildGradle: AppBuildGradle): Gr
 
   const matchResult = taskName.match(/(build|bundle|assemble)(.*)(Release|Debug)/);
   if (!matchResult) {
-    throw new Error('Failed to parse gradle command');
+    throw new Error(`Failed to parse gradle command: ${cmd}`);
   }
   let flavor: string | undefined;
   if (matchResult[2]) {

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
@@ -9,6 +9,7 @@ import {
 } from '../../graphql/generated';
 import Log from '../../log';
 import { getApplicationIdAsync } from '../../project/android/applicationId';
+import * as gradleUtils from '../../project/android/gradleUtils';
 import capitalize from '../../utils/expodash/capitalize';
 import { ArchiveSource } from '../ArchiveSource';
 import { resolveArchiveSource } from '../commons';
@@ -60,7 +61,9 @@ export default class AndroidSubmitCommand {
 
   private async maybeGetAndroidPackageFromCurrentProjectAsync(): Promise<string | undefined> {
     try {
-      return await getApplicationIdAsync(this.ctx.projectDir, this.ctx.exp, { moduleName: 'app' });
+      return await getApplicationIdAsync(this.ctx.projectDir, this.ctx.exp, {
+        moduleName: gradleUtils.DEFAULT_MODULE_NAME,
+      });
     } catch {
       return undefined;
     }

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
@@ -60,7 +60,7 @@ export default class AndroidSubmitCommand {
 
   private async maybeGetAndroidPackageFromCurrentProjectAsync(): Promise<string | undefined> {
     try {
-      return await getApplicationIdAsync(this.ctx.projectDir, this.ctx.exp);
+      return await getApplicationIdAsync(this.ctx.projectDir, this.ctx.exp, { moduleName: 'app' });
     } catch {
       return undefined;
     }

--- a/ts-declarations/gradle-to-js/index.d.ts
+++ b/ts-declarations/gradle-to-js/index.d.ts
@@ -1,0 +1,3 @@
+declare module 'gradle-to-js/lib/parser' {
+  export function parseText(text: string): Promise<object>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5946,6 +5946,13 @@ graceful-fs@^4.2.3:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
+gradle-to-js@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gradle-to-js/-/gradle-to-js-2.0.0.tgz#b790a97376d3d713105a086590e569610f7e6bc4"
+  integrity sha512-eoYJiSoreHG0cS5aUmv7ISJhajuULlqdqG3QKVti6x1EFkBXE8rGH6ipGKWEesXpCkfNgzBrhzo5ztIH1JWZMw==
+  dependencies:
+    lodash.merge "4.6.2"
+
 graphql-config@^3.0.2, graphql-config@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-3.2.0.tgz#3ec3a7e319792086b80e54db4b37372ad4a79a32"
@@ -7670,7 +7677,7 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
-lodash.merge@^4.6.2:
+lodash.merge@4.6.2, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5946,7 +5946,7 @@ graceful-fs@^4.2.3:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-gradle-to-js@^2.0.0:
+gradle-to-js@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/gradle-to-js/-/gradle-to-js-2.0.0.tgz#b790a97376d3d713105a086590e569610f7e6bc4"
   integrity sha512-eoYJiSoreHG0cS5aUmv7ISJhajuULlqdqG3QKVti6x1EFkBXE8rGH6ipGKWEesXpCkfNgzBrhzo5ztIH1JWZMw==


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

blocked by https://github.com/expo/expo-cli/pull/3830

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

applicationId and versions are read incorrectly if there are multiple flavors defined
this PR adds support for
- build command
- credentials command

# How

- [moved gradle utils from expo-cli to eas-cli] https://github.com/expo/expo-cli/pull/3830
- if parsing fails fallback to old behavior for applicationId


# Test Plan

fixed existing tests
tested by running builds and credentials manager on a test project
