### PR TITLE
[ENG-755] eas submit - implement --platform all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Implement support for `--platform all` in `eas submit`. ([#598](https://github.com/expo/eas-cli/pull/598) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -9,13 +9,13 @@ import { BuildFragment, BuildStatus, UploadSessionType } from '../graphql/genera
 import { BuildResult } from '../graphql/mutations/BuildMutation';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
 import Log, { learnMore } from '../log';
+import { requestedPlatformDisplayNames } from '../platform';
 import { promptAsync } from '../prompts';
 import { uploadAsync } from '../uploads';
 import { formatBytes } from '../utils/files';
 import { createProgressTracker } from '../utils/progress';
 import { sleep } from '../utils/promise';
 import vcs from '../vcs';
-import { requestedPlatformDisplayNames } from './constants';
 import { BuildContext } from './context';
 import { runLocalBuildAsync } from './local';
 import { MetadataContext, collectMetadata } from './metadata';

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 
 import Log, { learnMore } from '../log';
+import { RequestedPlatform } from '../platform';
 import { resolveWorkflowAsync } from '../project/workflow';
 import { confirmAsync, promptAsync } from '../prompts';
 import { ensureLoggedInAsync } from '../user/actions';
@@ -13,7 +14,6 @@ import vcs from '../vcs';
 import { configureAndroidAsync } from './android/configure';
 import { ConfigureContext } from './context';
 import { configureIosAsync } from './ios/configure';
-import { RequestedPlatform } from './types';
 import { commitPromptAsync, maybeBailOnRepoStatusAsync } from './utils/repository';
 
 const configureCommitMessage = {

--- a/packages/eas-cli/src/build/constants.ts
+++ b/packages/eas-cli/src/build/constants.ts
@@ -1,7 +1,0 @@
-import { RequestedPlatform } from './types';
-
-export const requestedPlatformDisplayNames: Record<RequestedPlatform, string> = {
-  [RequestedPlatform.Ios]: 'iOS',
-  [RequestedPlatform.Android]: 'Android',
-  [RequestedPlatform.All]: 'Android and iOS',
-};

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -5,13 +5,14 @@ import JsonFile from '@expo/json-file';
 import resolveFrom from 'resolve-from';
 import { v4 as uuidv4 } from 'uuid';
 
+import { RequestedPlatform } from '../platform';
 import { getExpoConfig } from '../project/expoConfig';
 import { getProjectAccountName, getProjectIdAsync } from '../project/projectUtils';
 import { resolveWorkflowAsync } from '../project/workflow';
 import { findAccountByName } from '../user/Account';
 import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
-import { RequestedPlatform, TrackingContext } from './types';
+import { TrackingContext } from './types';
 import Analytics, { Event } from './utils/analytics';
 
 export interface ConfigureContext {

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -1,9 +1,3 @@
-export enum RequestedPlatform {
-  Android = 'android',
-  Ios = 'ios',
-  All = 'all',
-}
-
 export enum BuildStatus {
   NEW = 'new',
   IN_QUEUE = 'in-queue',

--- a/packages/eas-cli/src/build/utils/credentials.ts
+++ b/packages/eas-cli/src/build/utils/credentials.ts
@@ -3,7 +3,7 @@ import { CredentialsSource } from '@expo/eas-json';
 import chalk from 'chalk';
 
 import Log from '../../log';
-import { requestedPlatformDisplayNames } from '../constants';
+import { requestedPlatformDisplayNames } from '../../platform';
 
 export function logCredentialsSource(credentialsSource: CredentialsSource, platform: Platform) {
   let message = `Using ${credentialsSource} ${requestedPlatformDisplayNames[platform]} credentials`;

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -2,8 +2,8 @@ import { Command, flags } from '@oclif/command';
 import chalk from 'chalk';
 
 import { configureAsync } from '../../build/configure';
-import { RequestedPlatform } from '../../build/types';
 import Log, { learnMore } from '../../log';
+import { RequestedPlatform } from '../../platform';
 import { findProjectRootAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -6,7 +6,7 @@ import {
   migrateAsync,
 } from '@expo/eas-json';
 import { flags } from '@oclif/command';
-import { error, exit } from '@oclif/errors';
+import { error } from '@oclif/errors';
 
 import { prepareAndroidBuildAsync } from '../../build/android/build';
 import { BuildRequestSender, waitForBuildEndAsync } from '../../build/build';
@@ -117,10 +117,11 @@ export default class Build extends EasCommand {
     const startedBuilds: BuildFragment[] = [];
     let metroConfigValidated = false;
     for (const platform of platformsToBuild) {
+      const buildProfile = await easJsonReader.readBuildProfileAsync(platform, flags.profile);
       const ctx = await createBuildContextAsync({
         buildProfileName: flags.profile,
         clearCache: flags.clearCache,
-        buildProfile: await easJsonReader.readBuildProfileAsync(platform, flags.profile),
+        buildProfile,
         local: flags.local,
         nonInteractive: flags.nonInteractive,
         platform,
@@ -210,7 +211,7 @@ export default class Build extends EasCommand {
       i => i.status === BuildStatus.Errored
     );
     if (failedBuilds.length > 0) {
-      exit(1);
+      process.exit(1);
     }
   }
 }

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -13,12 +13,12 @@ import { BuildRequestSender, waitForBuildEndAsync } from '../../build/build';
 import { ensureProjectConfiguredAsync } from '../../build/configure';
 import { BuildContext, createBuildContextAsync } from '../../build/context';
 import { prepareIosBuildAsync } from '../../build/ios/build';
-import { RequestedPlatform } from '../../build/types';
 import { printBuildResults, printLogsUrls } from '../../build/utils/printBuildInfo';
 import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
 import EasCommand from '../../commandUtils/EasCommand';
 import { BuildFragment, BuildStatus } from '../../graphql/generated';
 import Log from '../../log';
+import { RequestedPlatform } from '../../platform';
 import {
   EAS_UNAVAILABLE_MESSAGE,
   isEasEnabledForProjectAsync,
@@ -56,7 +56,10 @@ export default class Build extends EasCommand {
   static description = 'start a build';
 
   static flags = {
-    platform: flags.enum({ char: 'p', options: ['android', 'ios', 'all'] }),
+    platform: flags.enum({
+      char: 'p',
+      options: ['android', 'ios', 'all'],
+    }),
     'skip-credentials-check': flags.boolean({
       default: false,
       hidden: true,

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -200,8 +200,8 @@ export default class Build extends EasCommand {
       name: 'platform',
       choices: [
         { title: 'All', value: RequestedPlatform.All },
-        { title: 'iOS', value: RequestedPlatform.Ios },
         { title: 'Android', value: RequestedPlatform.Android },
+        { title: 'iOS', value: RequestedPlatform.Ios },
       ],
     });
     return platform;

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -3,7 +3,7 @@ import { Command, flags } from '@oclif/command';
 import chalk from 'chalk';
 import ora from 'ora';
 
-import { BuildDistributionType, BuildStatus, RequestedPlatform } from '../../build/types';
+import { BuildDistributionType, BuildStatus } from '../../build/types';
 import { formatGraphQLBuild } from '../../build/utils/formatBuild';
 import {
   AppPlatform,
@@ -12,6 +12,7 @@ import {
 } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
+import { RequestedPlatform } from '../../platform';
 import {
   findProjectRootAsync,
   getProjectFullNameAsync,

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -178,12 +178,12 @@ See how to configure submits with eas.json: ${learnMore('https://docs.expo.dev/s
       name: 'platform',
       choices: [
         {
-          title: 'iOS',
-          value: AppPlatform.Ios,
-        },
-        {
           title: 'Android',
           value: AppPlatform.Android,
+        },
+        {
+          title: 'iOS',
+          value: AppPlatform.Ios,
         },
       ],
     });

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -1,12 +1,13 @@
 import { getConfig } from '@expo/config';
 import { Platform } from '@expo/eas-build-job';
-import { EasJsonReader, IosSubmitProfile } from '@expo/eas-json';
+import { EasJsonReader } from '@expo/eas-json';
 import { flags } from '@oclif/command';
-import { error, exit } from '@oclif/errors';
+import { error } from '@oclif/errors';
 import chalk from 'chalk';
 
 import EasCommand from '../commandUtils/EasCommand';
 import { AppPlatform, SubmissionFragment, SubmissionStatus } from '../graphql/generated';
+import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log, { learnMore } from '../log';
 import {
   RequestedPlatform,
@@ -18,7 +19,11 @@ import {
 import { isEasEnabledForProjectAsync, warnEasUnavailable } from '../project/isEasEnabledForProject';
 import { findProjectRootAsync, getProjectIdAsync } from '../project/projectUtils';
 import AndroidSubmitCommand from '../submissions/android/AndroidSubmitCommand';
-import { SubmitArchiveFlags, createSubmissionContext } from '../submissions/context';
+import {
+  SubmissionContext,
+  SubmitArchiveFlags,
+  createSubmissionContext,
+} from '../submissions/context';
 import IosSubmitCommand from '../submissions/ios/IosSubmitCommand';
 import { displayLogsAsync } from '../submissions/utils/logs';
 import { printSubmissionDetailsUrls } from '../submissions/utils/urls';
@@ -33,7 +38,6 @@ interface RawFlags {
   url?: string;
   verbose: boolean;
   wait: boolean;
-  'non-interactive': boolean;
 }
 
 interface Flags {
@@ -42,7 +46,6 @@ interface Flags {
   archiveFlags: SubmitArchiveFlags;
   verbose: boolean;
   wait: boolean;
-  nonInteractive: boolean;
 }
 
 export default class Submit extends EasCommand {
@@ -64,7 +67,6 @@ See how to configure submits with eas.json: ${learnMore('https://docs.expo.dev/s
     latest: flags.boolean({
       description: 'Submit the latest build for specified platform',
       exclusive: ['id', 'path', 'url'],
-      default: false,
     }),
     id: flags.string({
       description: 'ID of the build to submit',
@@ -87,10 +89,6 @@ See how to configure submits with eas.json: ${learnMore('https://docs.expo.dev/s
       default: true,
       allowNo: true,
     }),
-    'non-interactive': flags.boolean({
-      default: false,
-      description: 'Run command in non-interactive mode',
-    }),
   };
 
   async run(): Promise<void> {
@@ -108,95 +106,56 @@ See how to configure submits with eas.json: ${learnMore('https://docs.expo.dev/s
     }
 
     const easJsonReader = new EasJsonReader(projectDir);
-
-    // TODO: change this
-    const [platform] = toPlatforms(flags.requestedPlatform);
+    const platforms = toPlatforms(flags.requestedPlatform);
     const submissions: SubmissionFragment[] = [];
-    let iosSubmitProfile: IosSubmitProfile | null = null;
-    if (platform === Platform.ANDROID) {
-      const submitProfile = await easJsonReader.readSubmitProfileAsync(
-        Platform.ANDROID,
-        flags.profile
-      );
+    for (const platform of platforms) {
+      const profile = await easJsonReader.readSubmitProfileAsync(platform, flags.profile);
       const ctx = createSubmissionContext({
         platform,
         projectDir,
         projectId,
-        profile: submitProfile,
+        profile,
         archiveFlags: flags.archiveFlags,
       });
-      const command = new AndroidSubmitCommand(ctx);
-      submissions.push(await command.runAsync());
-    } else {
-      iosSubmitProfile = await easJsonReader.readSubmitProfileAsync(Platform.IOS, flags.profile);
-      const ctx = createSubmissionContext({
-        platform,
-        projectDir,
-        projectId,
-        profile: iosSubmitProfile,
-        archiveFlags: flags.archiveFlags,
-      });
-      const command = new IosSubmitCommand(ctx);
-      submissions.push(await command.runAsync());
+
+      if (platforms.length > 1) {
+        Log.newLine();
+        const appPlatform = toAppPlatform(platform);
+        Log.log(
+          `${appPlatformEmojis[appPlatform]} ${chalk.bold(
+            `${appPlatformDisplayNames[appPlatform]} submission`
+          )}`
+        );
+      }
+
+      const submission = await this.submitAsync(ctx);
+      submissions.push(submission);
     }
 
     Log.newLine();
     printSubmissionDetailsUrls(submissions);
 
     if (flags.wait) {
-      Log.newLine();
-      const completedSubmissions = await waitForSubmissionsEndAsync(submissions);
-      for (const submission of completedSubmissions) {
-        if (completedSubmissions.length > 1) {
-          Log.log(
-            `${appPlatformEmojis[submission.platform]}${chalk.bold(
-              `${appPlatformDisplayNames[submission.platform]} submission`
-            )}`
-          );
-        }
-        if (
-          submission.platform === AppPlatform.Ios &&
-          submission.status === SubmissionStatus.Finished
-        ) {
-          const logMsg = [
-            chalk.bold('Your binary has been successfully uploaded to App Store Connect!'),
-            '- It is now being processed by Apple - you will receive an e-mail when the processing finishes.',
-            '- It usually takes about 5-10 minutes depending on how busy Apple servers are.',
-            // ascAppIdentifier should be always available for ios submissions but check it anyway
-            submission.iosConfig?.ascAppIdentifier &&
-              `- When it’s done, you can see your build here: ${learnMore(
-                `https://appstoreconnect.apple.com/apps/${submission.iosConfig?.ascAppIdentifier}/appstore/ios`,
-                { learnMoreMessage: '' }
-              )}`,
-          ].join('\n');
-          Log.addNewLineIfNone();
-          Log.log(logMsg);
-        }
-        await displayLogsAsync(submission, { verbose: flags.verbose });
-        if (completedSubmissions.length > 1) {
-          Log.newLine();
-        }
-      }
-      this.exitWithNonZeroCodeIfSomeSubmissionsDidntFinish(completedSubmissions);
+      this.waitToCompleteAsync(submissions, flags);
     }
   }
 
   private async sanitizeFlagsAsync(flags: RawFlags): Promise<Flags> {
-    const {
-      'non-interactive': nonInteractive,
-      platform,
-      verbose,
-      wait,
-      profile,
-      ...archiveFlags
-    } = flags;
-    if (!platform && nonInteractive) {
-      error('--platform is required when building in non-interactive mode', { exit: 1 });
-    }
+    const { platform, verbose, wait, profile, ...archiveFlags } = flags;
+
     const requestedPlatform = await selectRequestedPlatformAsync(flags.platform);
+
+    if (requestedPlatform === RequestedPlatform.All) {
+      if (archiveFlags.id || archiveFlags.path || archiveFlags.url) {
+        error(
+          '--id, --path, and --url params are only supported when performing a single-platform submit',
+          { exit: 1 }
+        );
+      }
+    }
+
     return {
       archiveFlags,
-      nonInteractive,
       requestedPlatform,
       verbose,
       wait,
@@ -204,12 +163,69 @@ See how to configure submits with eas.json: ${learnMore('https://docs.expo.dev/s
     };
   }
 
+  private async submitAsync<T extends Platform>(
+    ctx: SubmissionContext<T>
+  ): Promise<SubmissionFragment> {
+    const command =
+      ctx.platform === Platform.ANDROID
+        ? new AndroidSubmitCommand(ctx as SubmissionContext<Platform.ANDROID>)
+        : new IosSubmitCommand(ctx as SubmissionContext<Platform.IOS>);
+    return command.runAsync();
+  }
+
+  private async waitToCompleteAsync(
+    submissions: SubmissionFragment[],
+    flags: Flags
+  ): Promise<void> {
+    Log.newLine();
+    const completedSubmissions = await waitForSubmissionsEndAsync(submissions);
+    if (completedSubmissions.length > 1) {
+      Log.newLine();
+    }
+    for (const submission of completedSubmissions) {
+      if (completedSubmissions.length > 1) {
+        Log.log(
+          `${appPlatformEmojis[submission.platform]} ${chalk.bold(
+            `${appPlatformDisplayNames[submission.platform]} submission`
+          )}`
+        );
+      }
+      this.printInstructionsForIosSubmission(submission);
+      await displayLogsAsync(submission, { verbose: flags.verbose });
+      if (completedSubmissions.length > 1) {
+        Log.newLine();
+      }
+    }
+    this.exitWithNonZeroCodeIfSomeSubmissionsDidntFinish(completedSubmissions);
+  }
+
+  private printInstructionsForIosSubmission(submission: SubmissionFragment): void {
+    if (
+      submission.platform === AppPlatform.Ios &&
+      submission.status === SubmissionStatus.Finished
+    ) {
+      const logMsg = [
+        chalk.bold('Your binary has been successfully uploaded to App Store Connect!'),
+        '- It is now being processed by Apple - you will receive an e-mail when the processing finishes.',
+        '- It usually takes about 5-10 minutes depending on how busy Apple servers are.',
+        // ascAppIdentifier should be always available for ios submissions but check it anyway
+        submission.iosConfig?.ascAppIdentifier &&
+          `- When it’s done, you can see your build here: ${learnMore(
+            `https://appstoreconnect.apple.com/apps/${submission.iosConfig?.ascAppIdentifier}/appstore/ios`,
+            { learnMoreMessage: '' }
+          )}`,
+      ].join('\n');
+      Log.addNewLineIfNone();
+      Log.log(logMsg);
+    }
+  }
+
   private exitWithNonZeroCodeIfSomeSubmissionsDidntFinish(submissions: SubmissionFragment[]): void {
     const nonFinishedSubmissions = submissions.filter(
       ({ status }) => status !== SubmissionStatus.Finished
     );
     if (nonFinishedSubmissions.length > 0) {
-      exit(1);
+      process.exit(1);
     }
   }
 }

--- a/packages/eas-cli/src/platform.ts
+++ b/packages/eas-cli/src/platform.ts
@@ -1,4 +1,7 @@
+import { Platform } from '@expo/eas-build-job';
+
 import { AppPlatform } from './graphql/generated';
+import { promptAsync } from './prompts';
 
 export const appPlatformDisplayNames: Record<AppPlatform, string> = {
   [AppPlatform.Android]: 'Android',
@@ -22,3 +25,31 @@ export const requestedPlatformDisplayNames: Record<RequestedPlatform, string> = 
   [RequestedPlatform.Ios]: 'iOS',
   [RequestedPlatform.All]: 'Android and iOS',
 };
+
+export async function selectRequestedPlatformAsync(platform?: string): Promise<RequestedPlatform> {
+  if (platform && platform in RequestedPlatform) {
+    return platform as RequestedPlatform;
+  }
+
+  const { requestedPlatform } = await promptAsync({
+    type: 'select',
+    message: 'Select platform',
+    name: 'requestedPlatform',
+    choices: [
+      { title: 'All', value: RequestedPlatform.All },
+      { title: 'Android', value: RequestedPlatform.Android },
+      { title: 'iOS', value: RequestedPlatform.Ios },
+    ],
+  });
+  return requestedPlatform;
+}
+
+export function toPlatforms(requestedPlatform: RequestedPlatform): Platform[] {
+  if (requestedPlatform === RequestedPlatform.All) {
+    return [Platform.ANDROID, Platform.IOS];
+  } else if (requestedPlatform === RequestedPlatform.Android) {
+    return [Platform.ANDROID];
+  } else {
+    return [Platform.IOS];
+  }
+}

--- a/packages/eas-cli/src/platform.ts
+++ b/packages/eas-cli/src/platform.ts
@@ -27,8 +27,11 @@ export const requestedPlatformDisplayNames: Record<RequestedPlatform, string> = 
 };
 
 export async function selectRequestedPlatformAsync(platform?: string): Promise<RequestedPlatform> {
-  if (platform && platform in RequestedPlatform) {
-    return platform as RequestedPlatform;
+  if (
+    platform &&
+    Object.values(RequestedPlatform).includes(platform.toLowerCase() as RequestedPlatform)
+  ) {
+    return platform.toLowerCase() as RequestedPlatform;
   }
 
   const { requestedPlatform } = await promptAsync({

--- a/packages/eas-cli/src/platform.ts
+++ b/packages/eas-cli/src/platform.ts
@@ -9,3 +9,16 @@ export const appPlatformEmojis = {
   [AppPlatform.Ios]: '🍎',
   [AppPlatform.Android]: '🤖',
 };
+
+// for `eas build` and `eas submit`
+export enum RequestedPlatform {
+  Android = 'android',
+  Ios = 'ios',
+  All = 'all',
+}
+
+export const requestedPlatformDisplayNames: Record<RequestedPlatform, string> = {
+  [RequestedPlatform.Android]: 'Android',
+  [RequestedPlatform.Ios]: 'iOS',
+  [RequestedPlatform.All]: 'Android and iOS',
+};

--- a/packages/eas-cli/src/project/metroConfig.ts
+++ b/packages/eas-cli/src/project/metroConfig.ts
@@ -1,5 +1,4 @@
 import { Platform } from '@expo/eas-build-job';
-import { exit } from '@oclif/errors';
 import chalk from 'chalk';
 import type MetroConfig from 'metro-config';
 import resolveFrom from 'resolve-from';
@@ -38,7 +37,7 @@ export async function validateMetroConfigForManagedWorkflowAsync(ctx: BuildConte
     });
     if (shouldAbort) {
       Log.log('Aborting...');
-      exit();
+      process.exit(1);
     }
   }
 }

--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -6,7 +6,9 @@ import {
   IosSubmissionConfigInput,
   SubmissionFragment,
 } from '../graphql/generated';
+import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log from '../log';
+import { appPlatformDisplayNames } from '../platform';
 import { SubmissionContext } from './context';
 
 export interface SubmissionInput<P extends Platform> {
@@ -25,13 +27,14 @@ export default abstract class BaseSubmitter<P extends Platform, SubmissionOption
     submissionInput: SubmissionInput<P>
   ): Promise<SubmissionFragment> {
     Log.addNewLineIfNone();
-    const scheduleSpinner = ora('Scheduling submission').start();
+    const platformDisplayName = appPlatformDisplayNames[toAppPlatform(this.ctx.platform)];
+    const scheduleSpinner = ora(`Scheduling ${platformDisplayName} submission`).start();
     try {
       const submission = this.createPlatformSubmissionAsync(submissionInput);
-      scheduleSpinner.succeed();
+      scheduleSpinner.succeed(`Scheduled ${platformDisplayName} submission`);
       return submission;
     } catch (err) {
-      scheduleSpinner.fail('Failed to schedule submission');
+      scheduleSpinner.fail(`Failed to schedule ${platformDisplayName} submission`);
       throw err;
     }
   }

--- a/packages/eas-cli/src/submissions/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submissions/BaseSubmitter.ts
@@ -7,7 +7,7 @@ import {
   SubmissionFragment,
 } from '../graphql/generated';
 import Log from '../log';
-import { SubmissionContext } from './types';
+import { SubmissionContext } from './context';
 
 export interface SubmissionInput<P extends Platform> {
   projectId: string;

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
@@ -1,6 +1,6 @@
 import { getConfig } from '@expo/config';
 import { Platform } from '@expo/eas-build-job';
-import { AndroidReleaseStatus, AndroidReleaseTrack, AndroidSubmitProfile } from '@expo/eas-json';
+import { AndroidReleaseStatus, AndroidReleaseTrack } from '@expo/eas-json';
 import { Result, result } from '@expo/results';
 import capitalize from 'lodash/capitalize';
 
@@ -13,32 +13,12 @@ import Log from '../../log';
 import { getApplicationIdAsync } from '../../project/android/applicationId';
 import { ArchiveSource } from '../ArchiveSource';
 import { resolveArchiveSource } from '../commons';
-import { SubmissionContext, SubmitArchiveFlags } from '../types';
+import { SubmissionContext } from '../context';
 import { AndroidPackageSource, AndroidPackageSourceType } from './AndroidPackageSource';
 import AndroidSubmitter, { AndroidSubmissionOptions } from './AndroidSubmitter';
 import { ServiceAccountSource, ServiceAccountSourceType } from './ServiceAccountSource';
 
 export default class AndroidSubmitCommand {
-  static createContext({
-    archiveFlags,
-    profile,
-    projectDir,
-    projectId,
-  }: {
-    archiveFlags: SubmitArchiveFlags;
-    profile: AndroidSubmitProfile;
-    projectDir: string;
-    projectId: string;
-  }): SubmissionContext<Platform.ANDROID> {
-    return {
-      archiveFlags,
-      platform: Platform.ANDROID,
-      profile,
-      projectDir,
-      projectId,
-    };
-  }
-
   constructor(private ctx: SubmissionContext<Platform.ANDROID>) {}
 
   async runAsync(): Promise<SubmissionFragment> {

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -1,3 +1,4 @@
+import { Platform } from '@expo/eas-build-job';
 import { AndroidReleaseStatus, AndroidReleaseTrack } from '@expo/eas-json';
 import { vol } from 'memfs';
 import { v4 as uuidv4 } from 'uuid';
@@ -13,6 +14,7 @@ import {
 import { SubmissionMutation } from '../../../graphql/mutations/SubmissionMutation';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { getProjectIdAsync } from '../../../project/projectUtils';
+import { createSubmissionContext } from '../../context';
 import { getLatestBuildForSubmissionAsync } from '../../utils/builds';
 import AndroidSubmitCommand from '../AndroidSubmitCommand';
 
@@ -75,7 +77,8 @@ describe(AndroidSubmitCommand, () => {
     it('sends a request to Submission Service', async () => {
       const projectId = uuidv4();
 
-      const ctx = AndroidSubmitCommand.createContext({
+      const ctx = createSubmissionContext({
+        platform: Platform.ANDROID,
         projectDir: testProject.projectRoot,
         projectId,
         archiveFlags: {
@@ -108,7 +111,8 @@ describe(AndroidSubmitCommand, () => {
       const projectId = uuidv4();
       asMock(getLatestBuildForSubmissionAsync).mockResolvedValueOnce(fakeBuildFragment);
 
-      const ctx = AndroidSubmitCommand.createContext({
+      const ctx = createSubmissionContext({
+        platform: Platform.ANDROID,
         projectDir: testProject.projectRoot,
         projectId,
         archiveFlags: {

--- a/packages/eas-cli/src/submissions/commons.ts
+++ b/packages/eas-cli/src/submissions/commons.ts
@@ -2,7 +2,7 @@ import { Platform } from '@expo/eas-build-job';
 import * as uuid from 'uuid';
 
 import { ArchiveSource, ArchiveSourceType } from './ArchiveSource';
-import { SubmissionContext } from './types';
+import { SubmissionContext } from './context';
 
 export function resolveArchiveSource<T extends Platform>(
   ctx: SubmissionContext<T>,

--- a/packages/eas-cli/src/submissions/context.ts
+++ b/packages/eas-cli/src/submissions/context.ts
@@ -15,3 +15,13 @@ export interface SubmitArchiveFlags {
   path?: string;
   url?: string;
 }
+
+export function createSubmissionContext<T extends Platform>(params: {
+  platform: T;
+  archiveFlags: SubmitArchiveFlags;
+  profile: SubmitProfile<T>;
+  projectDir: string;
+  projectId: string;
+}): SubmissionContext<T> {
+  return params;
+}

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -11,7 +11,7 @@ import {
 import Log from '../../log';
 import { getBundleIdentifierAsync } from '../../project/ios/bundleIdentifier';
 import { promptAsync } from '../../prompts';
-import { SubmissionContext } from '../types';
+import { SubmissionContext } from '../context';
 import { sanitizeLanguage } from './utils/language';
 
 interface CreateAppOptions {

--- a/packages/eas-cli/src/submissions/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitCommand.ts
@@ -1,5 +1,4 @@
 import { Platform } from '@expo/eas-build-job';
-import { IosSubmitProfile } from '@expo/eas-json';
 import { Result, result } from '@expo/results';
 import chalk from 'chalk';
 import getenv from 'getenv';
@@ -11,7 +10,7 @@ import { promptAsync } from '../../prompts';
 import UserSettings from '../../user/UserSettings';
 import { ArchiveSource } from '../ArchiveSource';
 import { resolveArchiveSource } from '../commons';
-import { SubmissionContext, SubmitArchiveFlags } from '../types';
+import { SubmissionContext } from '../context';
 import { ensureAppStoreConnectAppExistsAsync } from './AppProduce';
 import {
   AppSpecificPasswordSource,
@@ -20,26 +19,6 @@ import {
 import IosSubmitter, { IosSubmissionOptions } from './IosSubmitter';
 
 export default class IosSubmitCommand {
-  static createContext({
-    archiveFlags,
-    profile,
-    projectDir,
-    projectId,
-  }: {
-    archiveFlags: SubmitArchiveFlags;
-    profile: IosSubmitProfile;
-    projectDir: string;
-    projectId: string;
-  }): SubmissionContext<Platform.IOS> {
-    return {
-      archiveFlags,
-      platform: Platform.IOS,
-      profile,
-      projectDir,
-      projectId,
-    };
-  }
-
   constructor(private ctx: SubmissionContext<Platform.IOS>) {}
 
   async runAsync(): Promise<SubmissionFragment> {

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -63,7 +63,6 @@ export default class IosSubmitter extends BaseSubmitter<Platform.IOS, IosSubmiss
     const appSpecificPassword = await getAppSpecificPasswordAsync(
       this.options.appSpecificPasswordSource
     );
-
     return {
       archive,
       appSpecificPassword,

--- a/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
@@ -1,3 +1,4 @@
+import { Platform } from '@expo/eas-build-job';
 import { vol } from 'memfs';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -6,6 +7,7 @@ import { jester as mockJester } from '../../../credentials/__tests__/fixtures-co
 import { SubmissionMutation } from '../../../graphql/mutations/SubmissionMutation';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { getProjectIdAsync } from '../../../project/projectUtils';
+import { createSubmissionContext } from '../../context';
 import IosSubmitCommand from '../IosSubmitCommand';
 
 jest.mock('fs');
@@ -57,7 +59,8 @@ describe(IosSubmitCommand, () => {
 
       process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD = 'supersecret';
 
-      const ctx = IosSubmitCommand.createContext({
+      const ctx = createSubmissionContext({
+        platform: Platform.IOS,
         projectDir: testProject.projectRoot,
         projectId,
         archiveFlags: {

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -68,7 +68,7 @@ export function printSummary<T>(summary: T, keyMap: Record<keyof T, string>): vo
     fields.push({ label, value });
   }
 
-  Log.newLine();
+  Log.addNewLineIfNone();
   Log.log(formatFields(fields, { labelFormat: chalk.bold.cyan }));
   Log.addNewLineIfNone();
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Another part of https://linear.app/expo/issue/ENG-755/submitting-automatically-on-build-success. It's probably the last part before we can start working on the actual feature in the CLI. (Maybe I'll implement the `--non-interactive` flag first.)

It's currently possible to submit to only one platform at a time. This PR implements the support for `--platform all` - similarly to what we have for `eas build`.

# How

I implemented the support for the `--platform all` parameter. 

# Test Plan

<img width="925" alt="Screenshot 2021-09-08 at 16 16 40" src="https://user-images.githubusercontent.com/5256730/132526336-41e2a26c-5eee-4a2e-95a7-4d1a587f72be.png">
