### PR TITLE
[ENG-755] add --non-interactive flag for `eas submit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Implement support for `--platform all` in `eas submit`. ([#598](https://github.com/expo/eas-cli/pull/598) by [@dsokal](https://github.com/dsokal))
+- Implement support for `--non-interactive` in `eas submit`. ([#600](https://github.com/expo/eas-cli/pull/600) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetupBuildCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetupBuildCredentials-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../../../__tests__/utils';
 import {
   getNewAndroidApiMock,
   testAndroidBuildCredentialsFragment,
@@ -16,6 +17,10 @@ jest.mock('../../../../prompts', () => ({ confirmAsync: jest.fn(() => true) }));
 jest.mock('../../utils/keystore', () => ({ generateRandomKeystoreAsync: jest.fn() }));
 
 describe('SetupBuildCredentials', () => {
+  beforeEach(() => {
+    asMock(generateRandomKeystoreAsync).mockReset();
+  });
+
   it('skips setup when there are prior credentials', async () => {
     const ctx = createCtxMock({
       nonInteractive: false,

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
@@ -45,7 +45,7 @@ export default class AndroidSubmitCommand {
     if (errored.length > 0) {
       const message = errored.map(err => err.reason?.message).join('\n');
       Log.error(message);
-      throw new Error('Failed to submit the app');
+      throw new Error('Submission failed');
     }
 
     return {
@@ -75,6 +75,8 @@ export default class AndroidSubmitCommand {
         sourceType: AndroidPackageSourceType.userDefined,
         androidPackage,
       });
+    } else if (this.ctx.nonInteractive) {
+      return result(new Error("Couldn't resolve the Android package."));
     } else {
       return result({
         sourceType: AndroidPackageSourceType.prompt,
@@ -127,7 +129,11 @@ export default class AndroidSubmitCommand {
   }
 
   private resolveArchiveSource(): Result<ArchiveSource> {
-    return result(resolveArchiveSource(this.ctx, Platform.ANDROID));
+    try {
+      return result(resolveArchiveSource(this.ctx, Platform.ANDROID));
+    } catch (err: any) {
+      return result(err);
+    }
   }
 
   private resolveServiceAccountSource(): Result<ServiceAccountSource> {
@@ -137,6 +143,8 @@ export default class AndroidSubmitCommand {
         sourceType: ServiceAccountSourceType.path,
         path: serviceAccountKeyPath,
       });
+    } else if (this.ctx.nonInteractive) {
+      return result(new Error('Set serviceAccountKeyPath in the submit profile (eas.json).'));
     } else {
       return result({
         sourceType: ServiceAccountSourceType.detect,

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -73,6 +73,29 @@ describe(AndroidSubmitCommand, () => {
     asMock(getProjectIdAsync).mockClear();
   });
 
+  describe('non-interactive mode', () => {
+    it("throws error if didn't provide serviceAccountKeyPath in the submit profile", async () => {
+      const projectId = uuidv4();
+
+      const ctx = createSubmissionContext({
+        platform: Platform.ANDROID,
+        projectDir: testProject.projectRoot,
+        projectId,
+        archiveFlags: {
+          url: 'http://expo.dev/fake.apk',
+        },
+        profile: {
+          track: AndroidReleaseTrack.internal,
+          releaseStatus: AndroidReleaseStatus.draft,
+          changesNotSentForReview: false,
+        },
+        nonInteractive: true,
+      });
+      const command = new AndroidSubmitCommand(ctx);
+      await expect(command.runAsync()).rejects.toThrowError();
+    });
+  });
+
   describe('sending submission', () => {
     it('sends a request to Submission Service', async () => {
       const projectId = uuidv4();
@@ -90,7 +113,7 @@ describe(AndroidSubmitCommand, () => {
           releaseStatus: AndroidReleaseStatus.draft,
           changesNotSentForReview: false,
         },
-        nonInteractive: true,
+        nonInteractive: false,
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
@@ -125,7 +148,7 @@ describe(AndroidSubmitCommand, () => {
           releaseStatus: AndroidReleaseStatus.draft,
           changesNotSentForReview: false,
         },
-        nonInteractive: true,
+        nonInteractive: false,
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -90,6 +90,7 @@ describe(AndroidSubmitCommand, () => {
           releaseStatus: AndroidReleaseStatus.draft,
           changesNotSentForReview: false,
         },
+        nonInteractive: true,
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
@@ -124,6 +125,7 @@ describe(AndroidSubmitCommand, () => {
           releaseStatus: AndroidReleaseStatus.draft,
           changesNotSentForReview: false,
         },
+        nonInteractive: true,
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();

--- a/packages/eas-cli/src/submissions/commons.ts
+++ b/packages/eas-cli/src/submissions/commons.ts
@@ -44,6 +44,8 @@ export function resolveArchiveSource<T extends Platform>(
       platform,
       projectId: ctx.projectId,
     };
+  } else if (ctx.nonInteractive) {
+    throw new Error('You need to specify the archive source when running in non-interactive mode ');
   } else {
     return {
       sourceType: ArchiveSourceType.prompt,

--- a/packages/eas-cli/src/submissions/context.ts
+++ b/packages/eas-cli/src/submissions/context.ts
@@ -7,6 +7,7 @@ export interface SubmissionContext<T extends Platform> {
   profile: SubmitProfile<T>;
   projectDir: string;
   projectId: string;
+  nonInteractive: boolean;
 }
 
 export interface SubmitArchiveFlags {
@@ -22,6 +23,7 @@ export function createSubmissionContext<T extends Platform>(params: {
   profile: SubmitProfile<T>;
   projectDir: string;
   projectId: string;
+  nonInteractive: boolean;
 }): SubmissionContext<T> {
   return params;
 }

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -32,11 +32,8 @@ type AppStoreResult = {
 export async function ensureAppStoreConnectAppExistsAsync(
   ctx: SubmissionContext<Platform.IOS>
 ): Promise<AppStoreResult> {
-  const projectConfig = getConfig(ctx.projectDir, { skipSDKVersionRequirement: true });
-  const { exp } = projectConfig;
-
+  const { exp } = getConfig(ctx.projectDir, { skipSDKVersionRequirement: true });
   const { appName, language } = ctx.profile;
-
   const options = {
     ...ctx.profile,
     bundleIdentifier: await getBundleIdentifierAsync(ctx.projectDir, exp),

--- a/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
@@ -71,6 +71,7 @@ describe(IosSubmitCommand, () => {
           appleId: 'test@example.com',
           ascAppId: '12345678',
         },
+        nonInteractive: true,
       });
       const command = new IosSubmitCommand(ctx);
       await command.runAsync();

--- a/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/ios/__tests__/IosSubmitCommand-test.ts
@@ -53,6 +53,27 @@ describe(IosSubmitCommand, () => {
     asMock(getProjectIdAsync).mockClear();
   });
 
+  describe('non-interactive mode', () => {
+    it("throws error if didn't provide appleId and ascAppId in the submit profile", async () => {
+      const projectId = uuidv4();
+
+      const ctx = createSubmissionContext({
+        platform: Platform.IOS,
+        projectDir: testProject.projectRoot,
+        projectId,
+        archiveFlags: {
+          url: 'http://expo.dev/fake.ipa',
+        },
+        profile: {
+          language: 'en-US',
+        },
+        nonInteractive: true,
+      });
+      const command = new IosSubmitCommand(ctx);
+      await expect(command.runAsync()).rejects.toThrowError();
+    });
+  });
+
   describe('sending submission', () => {
     it('sends a request to Submission Service', async () => {
       const projectId = uuidv4();
@@ -71,7 +92,7 @@ describe(IosSubmitCommand, () => {
           appleId: 'test@example.com',
           ascAppId: '12345678',
         },
-        nonInteractive: true,
+        nonInteractive: false,
       });
       const command = new IosSubmitCommand(ctx);
       await command.runAsync();


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

`eas submit` should fail with an error if it has been run with the `--non-interactive` flag but a user interaction is required (prompt).

# How

- I made `eas sumit` fail if the user didn't provide all necessary data with eas.json and env vars, and ran the submit with `--non-interactive`. 
- I refactored resolving iOS asc app identifier and apple id.

# Test Plan

- Added basic unit tests.
- Tested manually.
