### PR TITLE
[ENG-755] implement auto-submits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Implement support for `--platform all` in `eas submit`. ([#598](https://github.com/expo/eas-cli/pull/598) by [@dsokal](https://github.com/dsokal))
 - Implement support for `--non-interactive` in `eas submit`. ([#600](https://github.com/expo/eas-cli/pull/600) by [@dsokal](https://github.com/dsokal))
+- Add auto-submit feature. Run `eas build --submit` to submit automatically on build complete. ([#603](https://github.com/expo/eas-cli/pull/603) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -54,7 +54,7 @@ interface RawBuildFlags {
   'clear-cache': boolean;
   json: boolean;
   submit: boolean;
-  'submit-profile'?: string;
+  'submit-with-profile'?: string;
 }
 
 interface BuildFlags {
@@ -251,7 +251,7 @@ export default class Build extends EasCommand {
 
     const requestedPlatform = await selectRequestedPlatformAsync(flags.platform);
     if (flags.local) {
-      if (flags.submit || flags['submit-profile'] !== undefined) {
+      if (flags.submit || flags['submit-with-profile'] !== undefined) {
         // TODO: implement this
         error('Auto-submits are not yet supported when building locally', { exit: 1 });
       }
@@ -282,7 +282,7 @@ export default class Build extends EasCommand {
       clearCache: flags['clear-cache'],
       json: flags['json'],
       submit: flags['submit'],
-      submitProfile: flags['submit-profile'] ?? profile,
+      submitProfile: flags['submit-with-profile'] ?? profile,
     };
   }
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -53,8 +53,8 @@ interface RawBuildFlags {
   wait: boolean;
   'clear-cache': boolean;
   json: boolean;
-  submit: boolean;
-  'submit-with-profile'?: string;
+  'auto-submit': boolean;
+  'auto-submit-with-profile'?: string;
 }
 
 interface BuildFlags {
@@ -66,7 +66,7 @@ interface BuildFlags {
   wait: boolean;
   clearCache: boolean;
   json: boolean;
-  submit: boolean;
+  autoSubmit: boolean;
   submitProfile?: string;
 }
 
@@ -112,16 +112,16 @@ export default class Build extends EasCommand {
       default: false,
       description: 'Clear cache before the build',
     }),
-    submit: flags.boolean({
+    'auto-submit': flags.boolean({
       default: false,
       description:
         'Submit on build complete using the submit profile with the same name as the build profile',
-      exclusive: ['submit-with-profile'],
+      exclusive: ['auto-submit-with-profile'],
     }),
-    'submit-with-profile': flags.string({
+    'auto-submit-with-profile': flags.string({
       description: 'Submit on build complete using the submit profile with provided name',
       helpValue: 'PROFILE_NAME',
-      exclusive: ['submit'],
+      exclusive: ['auto-submit'],
     }),
   };
 
@@ -166,7 +166,7 @@ export default class Build extends EasCommand {
     Log.newLine();
 
     const submissions: SubmissionFragment[] = [];
-    if (flags.submit) {
+    if (flags.autoSubmit) {
       for (const build of startedBuilds) {
         const submission = await this.prepareAndStartSubmissionAsync({
           projectDir,
@@ -188,7 +188,7 @@ export default class Build extends EasCommand {
     const builds = await waitForBuildEndAsync(startedBuilds.map(build => build.id));
     printBuildResults(builds, flags.json);
 
-    if (!flags.submit) {
+    if (!flags.autoSubmit) {
       this.exitWithNonZeroCodeIfSomeBuildsFailed(builds);
     } else {
       // the following function also exits with non zero code if any of the submissions failed
@@ -207,7 +207,7 @@ export default class Build extends EasCommand {
 
     const requestedPlatform = await selectRequestedPlatformAsync(flags.platform);
     if (flags.local) {
-      if (flags.submit || flags['submit-with-profile'] !== undefined) {
+      if (flags['auto-submit'] || flags['auto-submit-with-profile'] !== undefined) {
         // TODO: implement this
         error('Auto-submits are not yet supported when building locally', { exit: 1 });
       }
@@ -237,8 +237,8 @@ export default class Build extends EasCommand {
       wait: flags['wait'],
       clearCache: flags['clear-cache'],
       json: flags['json'],
-      submit: flags['submit'],
-      submitProfile: flags['submit-with-profile'] ?? profile,
+      autoSubmit: flags['auto-submit'],
+      submitProfile: flags['auto-submit-with-profile'] ?? profile,
     };
   }
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -17,8 +17,8 @@ import { prepareIosBuildAsync } from '../../build/ios/build';
 import { printBuildResults, printLogsUrls } from '../../build/utils/printBuildInfo';
 import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
 import EasCommand from '../../commandUtils/EasCommand';
-import { BuildFragment, BuildStatus } from '../../graphql/generated';
-import { toAppPlatform } from '../../graphql/types/AppPlatform';
+import { BuildFragment, BuildStatus, SubmissionFragment } from '../../graphql/generated';
+import { toAppPlatform, toPlatform } from '../../graphql/types/AppPlatform';
 import Log from '../../log';
 import {
   RequestedPlatform,
@@ -34,6 +34,12 @@ import {
 import { validateMetroConfigForManagedWorkflowAsync } from '../../project/metroConfig';
 import { findProjectRootAsync } from '../../project/projectUtils';
 import { confirmAsync } from '../../prompts';
+import { createSubmissionContext } from '../../submissions/context';
+import {
+  submitAsync,
+  waitToCompleteAsync as waitForSubmissionsToCompleteAsync,
+} from '../../submissions/submit';
+import { printSubmissionDetailsUrls } from '../../submissions/utils/urls';
 import { enableJsonOutput } from '../../utils/json';
 import vcs from '../../vcs';
 
@@ -47,6 +53,8 @@ interface RawBuildFlags {
   wait: boolean;
   'clear-cache': boolean;
   json: boolean;
+  submit: boolean;
+  'submit-profile'?: string;
 }
 
 interface BuildFlags {
@@ -58,6 +66,8 @@ interface BuildFlags {
   wait: boolean;
   clearCache: boolean;
   json: boolean;
+  submit: boolean;
+  submitProfile?: string;
 }
 
 export default class Build extends EasCommand {
@@ -102,6 +112,17 @@ export default class Build extends EasCommand {
       default: false,
       description: 'Clear cache before the build',
     }),
+    submit: flags.boolean({
+      default: false,
+      description:
+        'Submit on build complete using the submit profile with the same name as the build profile',
+      exclusive: ['submit-with-profile'],
+    }),
+    'submit-with-profile': flags.string({
+      description: 'Submit on build complete using the submit profile with provided name',
+      helpValue: 'PROFILE_NAME',
+      exclusive: ['submit'],
+    }),
   };
 
   async run(): Promise<void> {
@@ -127,7 +148,7 @@ export default class Build extends EasCommand {
     let metroConfigValidated = false;
     for (const platform of platforms) {
       const buildProfile = await easJsonReader.readBuildProfileAsync(platform, flags.profile);
-      const ctx = await createBuildContextAsync({
+      const buildCtx = await createBuildContextAsync({
         buildProfileName: flags.profile,
         clearCache: flags.clearCache,
         buildProfile,
@@ -148,16 +169,16 @@ export default class Build extends EasCommand {
         );
       }
 
-      if (ctx.workflow === Workflow.MANAGED && !metroConfigValidated) {
-        await validateMetroConfigForManagedWorkflowAsync(ctx);
+      if (buildCtx.workflow === Workflow.MANAGED && !metroConfigValidated) {
+        await validateMetroConfigForManagedWorkflowAsync(buildCtx);
         metroConfigValidated = true;
       }
 
-      if (!ctx.local && !(await isEasEnabledForProjectAsync(ctx.projectId))) {
+      if (!buildCtx.local && !(await isEasEnabledForProjectAsync(buildCtx.projectId))) {
         error(EAS_UNAVAILABLE_MESSAGE, { exit: 1 });
       }
 
-      const maybeBuild = await this.startBuildAsync(ctx);
+      const maybeBuild = await this.startBuildAsync(buildCtx);
       if (maybeBuild) {
         startedBuilds.push(maybeBuild);
       }
@@ -170,10 +191,52 @@ export default class Build extends EasCommand {
     printLogsUrls(startedBuilds);
     Log.newLine();
 
-    if (flags.wait) {
-      const builds = await waitForBuildEndAsync(startedBuilds.map(build => build.id));
-      printBuildResults(builds, flags.json);
+    const submissions: SubmissionFragment[] = [];
+    if (flags.submit) {
+      for (const build of startedBuilds) {
+        const platform = toPlatform(build.platform);
+        const submitProfile = await easJsonReader.readSubmitProfileAsync(
+          platform,
+          flags.submitProfile
+        );
+        const submissionCtx = createSubmissionContext({
+          platform,
+          projectDir,
+          projectId: build.project.id,
+          profile: submitProfile,
+          archiveFlags: { id: build.id },
+          nonInteractive: flags.nonInteractive,
+        });
+
+        if (startedBuilds.length > 1) {
+          Log.newLine();
+          Log.log(
+            `${appPlatformEmojis[build.platform]} ${chalk.bold(
+              `${appPlatformDisplayNames[build.platform]} submission`
+            )}`
+          );
+        }
+
+        const submission = await submitAsync(submissionCtx);
+        submissions.push(submission);
+      }
+
+      Log.newLine();
+      printSubmissionDetailsUrls(submissions);
+    }
+
+    if (!flags.wait) {
+      return;
+    }
+
+    const builds = await waitForBuildEndAsync(startedBuilds.map(build => build.id));
+    printBuildResults(builds, flags.json);
+
+    if (!flags.submit) {
       this.exitWithNonZeroCodeIfSomeBuildsFailed(builds);
+    } else {
+      // the following function also exits with non zero code if any of the submissions failed
+      await waitForSubmissionsToCompleteAsync(submissions);
     }
   }
 
@@ -185,9 +248,14 @@ export default class Build extends EasCommand {
     if (flags.json && !nonInteractive) {
       error('--json is allowed only when building in non-interactive mode', { exit: 1 });
     }
-    const requestedPlatform = await selectRequestedPlatformAsync(flags.platform);
 
+    const requestedPlatform = await selectRequestedPlatformAsync(flags.platform);
     if (flags.local) {
+      if (flags.submit || flags['submit-profile'] !== undefined) {
+        // TODO: implement this
+        error('Auto-submits are not yet supported when building locally', { exit: 1 });
+      }
+
       if (requestedPlatform === RequestedPlatform.All) {
         error('Builds for multiple platforms are not supported with flag --local', { exit: 1 });
       } else if (process.platform !== 'darwin' && requestedPlatform === RequestedPlatform.Ios) {
@@ -203,15 +271,18 @@ export default class Build extends EasCommand {
       Log.newLine();
     }
 
+    const profile = flags['profile'];
     return {
       requestedPlatform,
       skipProjectConfiguration: flags['skip-project-configuration'],
-      profile: flags['profile'],
+      profile,
       nonInteractive,
       local: flags['local'],
       wait: flags['wait'],
       clearCache: flags['clear-cache'],
       json: flags['json'],
+      submit: flags['submit'],
+      submitProfile: flags['submit-profile'] ?? profile,
     };
   }
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -179,6 +179,7 @@ export default class Build extends EasCommand {
 
       Log.newLine();
       printSubmissionDetailsUrls(submissions);
+      Log.newLine();
     }
 
     if (!flags.wait) {
@@ -188,7 +189,10 @@ export default class Build extends EasCommand {
     const builds = await waitForBuildEndAsync(startedBuilds.map(build => build.id));
     printBuildResults(builds, flags.json);
 
-    if (!flags.autoSubmit) {
+    const haveAllBuildsFailedOrCanceled = builds.every(
+      build => build?.status && [BuildStatus.Errored, BuildStatus.Canceled].includes(build?.status)
+    );
+    if (haveAllBuildsFailedOrCanceled || !flags.autoSubmit) {
       this.exitWithNonZeroCodeIfSomeBuildsFailed(builds);
     } else {
       // the following function also exits with non zero code if any of the submissions failed

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -1,12 +1,11 @@
 import { getConfig } from '@expo/config';
-import { Platform } from '@expo/eas-build-job';
 import { EasJsonReader } from '@expo/eas-json';
 import { flags } from '@oclif/command';
 import { error } from '@oclif/errors';
 import chalk from 'chalk';
 
 import EasCommand from '../commandUtils/EasCommand';
-import { AppPlatform, SubmissionFragment, SubmissionStatus } from '../graphql/generated';
+import { SubmissionFragment } from '../graphql/generated';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log, { learnMore } from '../log';
 import {
@@ -18,16 +17,9 @@ import {
 } from '../platform';
 import { isEasEnabledForProjectAsync, warnEasUnavailable } from '../project/isEasEnabledForProject';
 import { findProjectRootAsync, getProjectIdAsync } from '../project/projectUtils';
-import AndroidSubmitCommand from '../submissions/android/AndroidSubmitCommand';
-import {
-  SubmissionContext,
-  SubmitArchiveFlags,
-  createSubmissionContext,
-} from '../submissions/context';
-import IosSubmitCommand from '../submissions/ios/IosSubmitCommand';
-import { displayLogsAsync } from '../submissions/utils/logs';
+import { SubmitArchiveFlags, createSubmissionContext } from '../submissions/context';
+import { submitAsync, waitToCompleteAsync } from '../submissions/submit';
 import { printSubmissionDetailsUrls } from '../submissions/utils/urls';
-import { waitForSubmissionsEndAsync } from '../submissions/utils/wait';
 
 interface RawFlags {
   platform?: string;
@@ -135,7 +127,7 @@ See how to configure submits with eas.json: ${learnMore('https://docs.expo.dev/s
         );
       }
 
-      const submission = await this.submitAsync(ctx);
+      const submission = await submitAsync(ctx);
       submissions.push(submission);
     }
 
@@ -143,7 +135,7 @@ See how to configure submits with eas.json: ${learnMore('https://docs.expo.dev/s
     printSubmissionDetailsUrls(submissions);
 
     if (flags.wait) {
-      this.waitToCompleteAsync(submissions, flags);
+      await waitToCompleteAsync(submissions, { verbose: flags.verbose });
     }
   }
 
@@ -179,71 +171,5 @@ See how to configure submits with eas.json: ${learnMore('https://docs.expo.dev/s
       profile,
       nonInteractive,
     };
-  }
-
-  private async submitAsync<T extends Platform>(
-    ctx: SubmissionContext<T>
-  ): Promise<SubmissionFragment> {
-    const command =
-      ctx.platform === Platform.ANDROID
-        ? new AndroidSubmitCommand(ctx as SubmissionContext<Platform.ANDROID>)
-        : new IosSubmitCommand(ctx as SubmissionContext<Platform.IOS>);
-    return command.runAsync();
-  }
-
-  private async waitToCompleteAsync(
-    submissions: SubmissionFragment[],
-    flags: Flags
-  ): Promise<void> {
-    Log.newLine();
-    const completedSubmissions = await waitForSubmissionsEndAsync(submissions);
-    if (completedSubmissions.length > 1) {
-      Log.newLine();
-    }
-    for (const submission of completedSubmissions) {
-      if (completedSubmissions.length > 1) {
-        Log.log(
-          `${appPlatformEmojis[submission.platform]} ${chalk.bold(
-            `${appPlatformDisplayNames[submission.platform]} submission`
-          )}`
-        );
-      }
-      this.printInstructionsForIosSubmission(submission);
-      await displayLogsAsync(submission, { verbose: flags.verbose });
-      if (completedSubmissions.length > 1) {
-        Log.newLine();
-      }
-    }
-    this.exitWithNonZeroCodeIfSomeSubmissionsDidntFinish(completedSubmissions);
-  }
-
-  private printInstructionsForIosSubmission(submission: SubmissionFragment): void {
-    if (
-      submission.platform === AppPlatform.Ios &&
-      submission.status === SubmissionStatus.Finished
-    ) {
-      const logMsg = [
-        chalk.bold('Your binary has been successfully uploaded to App Store Connect!'),
-        '- It is now being processed by Apple - you will receive an e-mail when the processing finishes.',
-        '- It usually takes about 5-10 minutes depending on how busy Apple servers are.',
-        // ascAppIdentifier should be always available for ios submissions but check it anyway
-        submission.iosConfig?.ascAppIdentifier &&
-          `- When it’s done, you can see your build here: ${learnMore(
-            `https://appstoreconnect.apple.com/apps/${submission.iosConfig?.ascAppIdentifier}/appstore/ios`,
-            { learnMoreMessage: '' }
-          )}`,
-      ].join('\n');
-      Log.addNewLineIfNone();
-      Log.log(logMsg);
-    }
-  }
-
-  private exitWithNonZeroCodeIfSomeSubmissionsDidntFinish(submissions: SubmissionFragment[]): void {
-    const nonFinishedSubmissions = submissions.filter(
-      ({ status }) => status !== SubmissionStatus.Finished
-    );
-    if (nonFinishedSubmissions.length > 0) {
-      process.exit(1);
-    }
   }
 }

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -87,7 +87,7 @@ export default class IosCredentialsProvider {
     const isPushKeySetup = await setupPushKeyAction.isPushKeySetupAsync(ctx);
     if (isPushKeySetup) {
       Log.succeed(
-        `Push Notifications setup for ${app.projectName}:${applicationTarget.bundleIdentifier}`
+        `Push Notifications setup for ${app.projectName}: ${applicationTarget.bundleIdentifier}`
       );
       return null;
     }

--- a/packages/eas-cli/src/graphql/types/AppPlatform.ts
+++ b/packages/eas-cli/src/graphql/types/AppPlatform.ts
@@ -11,3 +11,11 @@ export function toAppPlatform(platform: Platform): AppPlatform {
     throw new Error(`Unsupported platform: ${platform}`);
   }
 }
+
+export function toPlatform(appPlatform: AppPlatform): Platform {
+  if (appPlatform === AppPlatform.Android) {
+    return Platform.ANDROID;
+  } else {
+    return Platform.IOS;
+  }
+}

--- a/packages/eas-cli/src/submissions/ArchiveSource.ts
+++ b/packages/eas-cli/src/submissions/ArchiveSource.ts
@@ -50,7 +50,7 @@ interface ArchivePromptSource extends ArchiveSourceBase {
 export interface Archive {
   build?: BuildFragment;
   source: ArchiveSource;
-  url: string;
+  url?: string;
 }
 
 export type ArchiveSource =
@@ -62,8 +62,9 @@ export type ArchiveSource =
 
 export async function getArchiveAsync(source: ArchiveSource): Promise<Archive> {
   switch (source.sourceType) {
-    case ArchiveSourceType.prompt:
+    case ArchiveSourceType.prompt: {
       return await handlePromptSourceAsync(source);
+    }
     case ArchiveSourceType.url: {
       return await handleUrlSourceAsync(source);
     }
@@ -115,7 +116,6 @@ async function handleLatestSourceAsync(source: ArchiveLatestSource): Promise<Arc
 
     return {
       build: latestBuild,
-      url: latestBuild.artifacts.buildUrl,
       source,
     };
   } catch (err) {
@@ -147,7 +147,6 @@ async function handleBuildIdSourceAsync(source: ArchiveBuildIdSource): Promise<A
     return {
       build,
       source,
-      url: build.artifacts.buildUrl,
     };
   } catch (err) {
     Log.error(chalk.bold(`Couldn't find build for id ${source.id}`));
@@ -166,7 +165,7 @@ async function handlePromptSourceAsync(source: ArchivePromptSource): Promise<Arc
     message: 'What would you like to submit?',
     choices: [
       {
-        title: 'Latest build from EAS',
+        title: 'Latest finished build from EAS',
         value: ArchiveSourceType.latest,
       },
       { title: 'I have a url to the app archive', value: ArchiveSourceType.url },

--- a/packages/eas-cli/src/submissions/__tests__/ArchiveSource-test.ts
+++ b/packages/eas-cli/src/submissions/__tests__/ArchiveSource-test.ts
@@ -185,5 +185,7 @@ function assertArchiveResult(
   expectedUrl: string = ARCHIVE_URL
 ) {
   expect(archive.source.sourceType).toBe(expectedSourceType);
-  expect(archive.url).toBe(expectedUrl);
+  if (archive.url) {
+    expect(archive.url).toBe(expectedUrl);
+  }
 }

--- a/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submissions/android/__tests__/AndroidSubmitCommand-test.ts
@@ -156,7 +156,6 @@ describe(AndroidSubmitCommand, () => {
       expect(SubmissionMutation.createAndroidSubmissionAsync).toHaveBeenCalledWith({
         appId: projectId,
         config: {
-          archiveUrl: 'http://expo.dev/fake.apk',
           applicationIdentifier: testProject.appJSON.expo.android?.package,
           googleServiceAccountKeyJson: fakeFiles['/google-service-account.json'],
           releaseStatus: SubmissionAndroidReleaseStatus.Draft,

--- a/packages/eas-cli/src/submissions/submit.ts
+++ b/packages/eas-cli/src/submissions/submit.ts
@@ -1,0 +1,74 @@
+import { Platform } from '@expo/eas-build-job';
+import chalk from 'chalk';
+
+import { AppPlatform, SubmissionFragment, SubmissionStatus } from '../graphql/generated';
+import Log, { learnMore } from '../log';
+import { appPlatformDisplayNames, appPlatformEmojis } from '../platform';
+import AndroidSubmitCommand from './android/AndroidSubmitCommand';
+import { SubmissionContext } from './context';
+import IosSubmitCommand from './ios/IosSubmitCommand';
+import { displayLogsAsync } from './utils/logs';
+import { waitForSubmissionsEndAsync } from './utils/wait';
+
+export async function submitAsync<T extends Platform>(
+  ctx: SubmissionContext<T>
+): Promise<SubmissionFragment> {
+  const command =
+    ctx.platform === Platform.ANDROID
+      ? new AndroidSubmitCommand(ctx as SubmissionContext<Platform.ANDROID>)
+      : new IosSubmitCommand(ctx as SubmissionContext<Platform.IOS>);
+  return command.runAsync();
+}
+
+export async function waitToCompleteAsync(
+  submissions: SubmissionFragment[],
+  { verbose = false }: { verbose?: boolean } = {}
+): Promise<void> {
+  Log.newLine();
+  const completedSubmissions = await waitForSubmissionsEndAsync(submissions);
+  if (completedSubmissions.length > 1) {
+    Log.newLine();
+  }
+  for (const submission of completedSubmissions) {
+    if (completedSubmissions.length > 1) {
+      Log.log(
+        `${appPlatformEmojis[submission.platform]} ${chalk.bold(
+          `${appPlatformDisplayNames[submission.platform]} submission`
+        )}`
+      );
+    }
+    printInstructionsForIosSubmission(submission);
+    await displayLogsAsync(submission, { verbose });
+    if (completedSubmissions.length > 1) {
+      Log.newLine();
+    }
+  }
+  exitWithNonZeroCodeIfSomeSubmissionsDidntFinish(completedSubmissions);
+}
+
+function printInstructionsForIosSubmission(submission: SubmissionFragment): void {
+  if (submission.platform === AppPlatform.Ios && submission.status === SubmissionStatus.Finished) {
+    const logMsg = [
+      chalk.bold('Your binary has been successfully uploaded to App Store Connect!'),
+      '- It is now being processed by Apple - you will receive an e-mail when the processing finishes.',
+      '- It usually takes about 5-10 minutes depending on how busy Apple servers are.',
+      // ascAppIdentifier should be always available for ios submissions but check it anyway
+      submission.iosConfig?.ascAppIdentifier &&
+        `- When it’s done, you can see your build here: ${learnMore(
+          `https://appstoreconnect.apple.com/apps/${submission.iosConfig?.ascAppIdentifier}/appstore/ios`,
+          { learnMoreMessage: '' }
+        )}`,
+    ].join('\n');
+    Log.addNewLineIfNone();
+    Log.log(logMsg);
+  }
+}
+
+function exitWithNonZeroCodeIfSomeSubmissionsDidntFinish(submissions: SubmissionFragment[]): void {
+  const nonFinishedSubmissions = submissions.filter(
+    ({ status }) => status !== SubmissionStatus.Finished
+  );
+  if (nonFinishedSubmissions.length > 0) {
+    process.exit(1);
+  }
+}

--- a/packages/eas-cli/src/submissions/submit.ts
+++ b/packages/eas-cli/src/submissions/submit.ts
@@ -37,7 +37,11 @@ export async function waitToCompleteAsync(
         )}`
       );
     }
-    printInstructionsForIosSubmission(submission);
+    if (submission.platform === AppPlatform.Android) {
+      printInstructionsForAndroidSubmission(submission);
+    } else {
+      printInstructionsForIosSubmission(submission);
+    }
     await displayLogsAsync(submission, { verbose });
     if (completedSubmissions.length > 1) {
       Log.newLine();
@@ -46,8 +50,15 @@ export async function waitToCompleteAsync(
   exitWithNonZeroCodeIfSomeSubmissionsDidntFinish(completedSubmissions);
 }
 
+function printInstructionsForAndroidSubmission(submission: SubmissionFragment): void {
+  if (submission.status === SubmissionStatus.Finished) {
+    Log.addNewLineIfNone();
+    Log.log('All done!');
+  }
+}
+
 function printInstructionsForIosSubmission(submission: SubmissionFragment): void {
-  if (submission.platform === AppPlatform.Ios && submission.status === SubmissionStatus.Finished) {
+  if (submission.status === SubmissionStatus.Finished) {
     const logMsg = [
       chalk.bold('Your binary has been successfully uploaded to App Store Connect!'),
       '- It is now being processed by Apple - you will receive an e-mail when the processing finishes.',

--- a/packages/eas-cli/src/submissions/submit.ts
+++ b/packages/eas-cli/src/submissions/submit.ts
@@ -26,11 +26,12 @@ export async function waitToCompleteAsync(
 ): Promise<void> {
   Log.newLine();
   const completedSubmissions = await waitForSubmissionsEndAsync(submissions);
-  if (completedSubmissions.length > 1) {
+  const moreSubmissions = completedSubmissions.length > 1;
+  if (moreSubmissions) {
     Log.newLine();
   }
   for (const submission of completedSubmissions) {
-    if (completedSubmissions.length > 1) {
+    if (moreSubmissions) {
       Log.log(
         `${appPlatformEmojis[submission.platform]} ${chalk.bold(
           `${appPlatformDisplayNames[submission.platform]} submission`
@@ -42,8 +43,8 @@ export async function waitToCompleteAsync(
     } else {
       printInstructionsForIosSubmission(submission);
     }
-    await displayLogsAsync(submission, { verbose });
-    if (completedSubmissions.length > 1) {
+    await displayLogsAsync(submission, { verbose, moreSubmissions });
+    if (moreSubmissions) {
       Log.newLine();
     }
   }

--- a/packages/eas-cli/src/submissions/utils/builds.ts
+++ b/packages/eas-cli/src/submissions/utils/builds.ts
@@ -1,10 +1,5 @@
-import { AppPlatform, BuildArtifacts, BuildFragment, BuildStatus } from '../../graphql/generated';
+import { AppPlatform, BuildFragment, BuildStatus } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
-
-// `BuildFragment` with non-null `artifacts.buildUrl`
-type BuildFragmentWithArtifact = BuildFragment & {
-  artifacts: BuildArtifacts & { buildUrl: string };
-};
 
 /**
  * Gets build by ID and ensures that `artifacts.buildUrl` exists
@@ -12,15 +7,11 @@ type BuildFragmentWithArtifact = BuildFragment & {
 export async function getBuildByIdForSubmissionAsync(
   platform: AppPlatform,
   buildId: string
-): Promise<BuildFragmentWithArtifact> {
+): Promise<BuildFragment> {
   const build = await BuildQuery.byIdAsync(buildId);
 
   if (build.platform !== platform) {
     throw new Error("Build platform doesn't match!");
-  }
-
-  if (!buildFragmentHasArtifact(build)) {
-    throw new Error('Build has no artifacts or build URL is not defined.');
   }
 
   return build;
@@ -29,28 +20,13 @@ export async function getBuildByIdForSubmissionAsync(
 export async function getLatestBuildForSubmissionAsync(
   platform: AppPlatform,
   appId: string
-): Promise<BuildFragmentWithArtifact | null> {
-  const builds = await BuildQuery.allForAppAsync(appId, {
+): Promise<BuildFragment | null> {
+  const [build] = await BuildQuery.allForAppAsync(appId, {
     limit: 1,
     filter: {
       platform,
       status: BuildStatus.Finished,
     },
   });
-
-  if (builds.length < 1) {
-    return null;
-  }
-
-  const build = builds[0];
-  if (!buildFragmentHasArtifact(build)) {
-    return null;
-  }
-
   return build;
-}
-
-// Utility function needed to make TypeScript happy
-function buildFragmentHasArtifact(build: BuildFragment): build is BuildFragmentWithArtifact {
-  return build.artifacts?.buildUrl != null;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This is the last part for https://linear.app/expo/issue/ENG-755/submitting-automatically-on-build-success
The PR adds `--submit` and `--submit-with-profile` params to `eas build` that allow for submitting automatically on build complete.

# How

- All parts were already almost in place. I basically copy-pasted some code from `eas submit`.
- I added two CLI params to `eas build`:
   - `--submit` - creates a submission that's waiting for the build to complete. The CLI can be killed (CTRL+C) as soon as the submission has been created. The user doesn't need to wait for the build to complete. When this flag is supplied, the submit profile with the same name as the build profile is picked up.
   - `--submit-with-profile` - works the same as `--submit` but allows for using another submit profile.
- Currently, auto-submits are not supported with the `--local` flag. I'll work on this in another PR.

# Test Plan

Tested manually.

<img width="1228" alt="Screenshot 2021-09-09 at 18 10 22" src="https://user-images.githubusercontent.com/5256730/132722602-f15edea7-0cf8-494d-aacf-d51b9c71220b.png">
