### PR TITLE
[eas-json] allow env vars in android.serviceAccountKeyPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Implement support for `--platform all` in `eas submit`. ([#598](https://github.com/expo/eas-cli/pull/598) by [@dsokal](https://github.com/dsokal))
 - Implement support for `--non-interactive` in `eas submit`. ([#600](https://github.com/expo/eas-cli/pull/600) by [@dsokal](https://github.com/dsokal))
 - Add auto-submit feature. Run `eas build --submit` to submit automatically on build complete. ([#603](https://github.com/expo/eas-cli/pull/603) by [@dsokal](https://github.com/dsokal))
+- Allow using env var for `android.serviceAccountKeyPath` in submit profiles. ([#604](https://github.com/expo/eas-cli/pull/604) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
     "@expo/eas-build-job": "0.2.46",
+    "env-string": "1.0.1",
     "fs-extra": "10.0.0",
     "joi": "17.4.2",
     "tslib": "2.3.1"

--- a/packages/eas-json/src/EasSubmit.types.ts
+++ b/packages/eas-json/src/EasSubmit.types.ts
@@ -21,6 +21,10 @@ export interface AndroidSubmitProfile {
   changesNotSentForReview: boolean;
 }
 
+export const AndroidSubmitProfileFieldsToEvaluate: (keyof AndroidSubmitProfile)[] = [
+  'serviceAccountKeyPath',
+];
+
 export interface IosSubmitProfile {
   appleId?: string;
   ascAppId?: string;
@@ -30,6 +34,8 @@ export interface IosSubmitProfile {
   companyName?: string;
   appName?: string;
 }
+
+export const IosSubmitProfileFieldsToEvaluate: (keyof IosSubmitProfile)[] = [];
 
 export type SubmitProfile<TPlatform extends Platform = Platform> =
   TPlatform extends Platform.ANDROID

--- a/packages/eas-json/src/__tests__/EasJsonReader-submit-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-submit-test.ts
@@ -59,6 +59,35 @@ test('android config with all required values', async () => {
   });
 });
 
+test('android config with serviceAccountKeyPath set to env var', async () => {
+  await fs.writeJson('/project/eas.json', {
+    submit: {
+      release: {
+        android: {
+          serviceAccountKeyPath: '$GOOGLE_SERVICE_ACCOUNT',
+          track: 'beta',
+          releaseStatus: 'completed',
+        },
+      },
+    },
+  });
+
+  try {
+    process.env.GOOGLE_SERVICE_ACCOUNT = './path.json';
+    const reader = new EasJsonReader('/project');
+    const androidProfile = await reader.readSubmitProfileAsync(Platform.ANDROID, 'release');
+
+    expect(androidProfile).toEqual({
+      serviceAccountKeyPath: './path.json',
+      track: 'beta',
+      releaseStatus: 'completed',
+      changesNotSentForReview: false,
+    });
+  } finally {
+    process.env.GOOGLE_SERVICE_ACCOUNT = undefined;
+  }
+});
+
 test('ios config with all required values', async () => {
   await fs.writeJson('/project/eas.json', {
     submit: {

--- a/ts-declarations/env-string/index.d.ts
+++ b/ts-declarations/env-string/index.d.ts
@@ -1,0 +1,3 @@
+declare module 'env-string' {
+  export default function envString(str: string, env?: Record<string, string | undefined>): string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6029,6 +6029,11 @@ env-paths@2.2.0, env-paths@^2.2.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
   integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
 
+env-string@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/env-string/-/env-string-1.0.1.tgz#92ddefeb651c0f2d15bf89dc13be7596733801a4"
+  integrity sha512-/DhCJDf5DSFK32joQiWRpWrT0h7p3hVQfMKxiBb7Nt8C8IF8BYyPtclDnuGGLOoj16d/8udKeiE7JbkotDmorQ==
+
 envinfo@7.8.1, envinfo@^7.7.4:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Closes https://github.com/expo/eas-cli/issues/601

# How

I made it possible to use env var in `android.serviceAccountKeyPath` (eas.json)

# Test Plan

Added unit test.