### PR TITLE
[eas-cli] fix secrets mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fixed force-creation, app secret creation, and secret deletion mutations. ([#606](https://github.com/expo/eas-cli/pull/606) by [@fiberjw](https://github.com/fiberjw))
+
 ### 🧹 Chores
 
 ## [0.27.0](https://github.com/expo/eas-cli/releases/tag/v0.27.0) - 2021-09-10

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -160,9 +160,7 @@ export default class EnvironmentSecretCreate extends Command {
       }
 
       if (force) {
-        const existingSecrets = await EnvironmentSecretsQuery.byAcccountNameAsync(
-          ownerAccount.name
-        );
+        const existingSecrets = await EnvironmentSecretsQuery.byAccountNameAsync(ownerAccount.name);
         const existingSecret = existingSecrets.find(secret => secret.name === name);
 
         if (existingSecret) {

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -149,6 +149,7 @@ export default class EnvironmentSecretCreate extends Command {
       );
     } else if (scope === EnvironmentSecretScope.ACCOUNT) {
       const ownerAccount = findAccountByName(actor.accounts, accountName);
+
       if (!ownerAccount) {
         Log.warn(
           `Your account (${getActorDisplayName(actor)}) doesn't have access to the ${chalk.bold(
@@ -159,11 +160,14 @@ export default class EnvironmentSecretCreate extends Command {
       }
 
       if (force) {
-        const existingSecrets = await EnvironmentSecretsQuery.byAcccountNameAsync(projectId);
+        const existingSecrets = await EnvironmentSecretsQuery.byAcccountNameAsync(
+          ownerAccount.name
+        );
         const existingSecret = existingSecrets.find(secret => secret.name === name);
 
         if (existingSecret) {
           await EnvironmentSecretMutation.delete(existingSecret.id);
+
           Log.withTick(
             `Deleting existing secret ${chalk.bold(name)} on account ${chalk.bold(
               ownerAccount.name

--- a/packages/eas-cli/src/graphql/mutations/EnvironmentSecretMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/EnvironmentSecretMutation.ts
@@ -48,7 +48,7 @@ export const EnvironmentSecretMutation = {
   ): Promise<EnvironmentSecretFragment> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<CreateEnvironmentSecretForAppMutation>(
+        .mutation<CreateEnvironmentSecretForAppMutation>(
           gql`
             mutation CreateEnvironmentSecretForApp(
               $input: CreateEnvironmentSecretInput!
@@ -73,7 +73,7 @@ export const EnvironmentSecretMutation = {
   async delete(id: string): Promise<{ id: string }> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<DeleteEnvironmentSecretMutation>(
+        .mutation<DeleteEnvironmentSecretMutation>(
           gql`
             mutation DeleteEnvironmentSecret($id: String!) {
               environmentSecret {

--- a/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
@@ -19,7 +19,7 @@ export type EnvironmentSecretWithScope = EnvironmentSecretFragment & {
 };
 
 export const EnvironmentSecretsQuery = {
-  async byAcccountNameAsync(accountName: string): Promise<EnvironmentSecretFragment[]> {
+  async byAccountNameAsync(accountName: string): Promise<EnvironmentSecretFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<EnvironmentSecretsByAccountNameQuery>(
@@ -74,7 +74,7 @@ export const EnvironmentSecretsQuery = {
     projectFullName: string
   ): Promise<EnvironmentSecretWithScope[]> {
     const [accountSecrets, appSecrets] = await Promise.all([
-      this.byAcccountNameAsync(projectAccountName),
+      this.byAccountNameAsync(projectAccountName),
       this.byAppIdAsync(projectFullName),
     ]);
 


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.

# Why

We got a report that force-creation of secrets wasn't working. https://forums.expo.dev/t/cant-delete-or-force-update-a-secret/56640 

This report also included other mutation bugs.

# How

- Supplied the correct parameter to a secrets lookup call
- Fixed mutation helpers (it was previously calling a query with a mutation string rather than a proper mutation).

# Test Plan

The following reproduction plan should no longer result in errors:

```
eas secret:create --scope=account --name=WHATEVER --value=a_secret

eas secret:create --scope=account --name=WHATEVER --value=a_new_secret --force

eas secret:delete --id=<my-secret-id>

eas secret:create --scope=project --name=WHATEVER_PROJECT_SECRET --value=a_secret
```