### PR TITLE
use envs from build profile for resolving app config when auto-submiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Use envs from build profile to resolve app config when auto-submitting. ([#614](https://github.com/expo/eas-cli/pull/614) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -315,6 +315,7 @@ export default class Build extends EasCommand {
   }): Promise<SubmissionFragment> {
     const easJsonReader = new EasJsonReader(projectDir);
     const platform = toPlatform(build.platform);
+    const buildProfile = await easJsonReader.readBuildProfileAsync(platform, flags.profile);
     const submitProfile = await easJsonReader.readSubmitProfileAsync(platform, flags.submitProfile);
     const submissionCtx = createSubmissionContext({
       platform,
@@ -323,6 +324,7 @@ export default class Build extends EasCommand {
       profile: submitProfile,
       archiveFlags: { id: build.id },
       nonInteractive: flags.nonInteractive,
+      env: buildProfile.env,
     });
 
     if (moreBuilds) {

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitCommand.ts
@@ -1,4 +1,3 @@
-import { getConfig } from '@expo/config';
 import { Platform } from '@expo/eas-build-job';
 import { AndroidReleaseStatus, AndroidReleaseTrack } from '@expo/eas-json';
 import { Result, result } from '@expo/results';
@@ -60,9 +59,8 @@ export default class AndroidSubmitCommand {
   }
 
   private async maybeGetAndroidPackageFromCurrentProjectAsync(): Promise<string | undefined> {
-    const { exp } = getConfig(this.ctx.projectDir, { skipSDKVersionRequirement: true });
     try {
-      return await getApplicationIdAsync(this.ctx.projectDir, exp);
+      return await getApplicationIdAsync(this.ctx.projectDir, this.ctx.exp);
     } catch {
       return undefined;
     }

--- a/packages/eas-cli/src/submissions/context.ts
+++ b/packages/eas-cli/src/submissions/context.ts
@@ -1,5 +1,8 @@
+import { ExpoConfig } from '@expo/config';
 import { Platform } from '@expo/eas-build-job';
 import { SubmitProfile } from '@expo/eas-json';
+
+import { getExpoConfig } from '../project/expoConfig';
 
 export interface SubmissionContext<T extends Platform> {
   archiveFlags: SubmitArchiveFlags;
@@ -8,6 +11,7 @@ export interface SubmissionContext<T extends Platform> {
   projectDir: string;
   projectId: string;
   nonInteractive: boolean;
+  exp: ExpoConfig;
 }
 
 export interface SubmitArchiveFlags {
@@ -24,6 +28,13 @@ export function createSubmissionContext<T extends Platform>(params: {
   projectDir: string;
   projectId: string;
   nonInteractive: boolean;
+  env?: Record<string, string>;
 }): SubmissionContext<T> {
-  return params;
+  const { projectDir } = params;
+  const exp = getExpoConfig(projectDir, { env: params.env });
+  const { env, ...rest } = params;
+  return {
+    ...rest,
+    exp,
+  };
 }

--- a/packages/eas-cli/src/submissions/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submissions/ios/AppProduce.ts
@@ -1,5 +1,4 @@
 import { App, RequestContext, Session, User } from '@expo/apple-utils';
-import { getConfig } from '@expo/config';
 import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
@@ -32,7 +31,7 @@ type AppStoreResult = {
 export async function ensureAppStoreConnectAppExistsAsync(
   ctx: SubmissionContext<Platform.IOS>
 ): Promise<AppStoreResult> {
-  const { exp } = getConfig(ctx.projectDir, { skipSDKVersionRequirement: true });
+  const { exp } = ctx;
   const { appName, language } = ctx.profile;
   const options = {
     ...ctx.profile,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://github.com/expo/eas-cli/pull/603#issuecomment-917251233

# How

Use env vars from the build profile to resolve app config when running `eas build` with the `--auto-submit` flag.

# Test Plan

Tested manually.
