### PR TITLE
[ENG-1915] show syntax errors in eas.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Use envs from build profile to resolve app config when auto-submitting. ([#614](https://github.com/expo/eas-cli/pull/614) by [@dsokal](https://github.com/dsokal))
 - Support multi flavor Android projects. ([#595](https://github.com/expo/eas-cli/pull/595) by [@wkozyra95](https://github.com/wkozyra95))
 - Improve experience when using the build details page as a build artifact URL in `eas submit`. ([#620](https://github.com/expo/eas-cli/pull/620) by [@dsokal](https://github.com/dsokal))
+- Better error message when eas.json is invalid JSON. ([#618](https://github.com/expo/eas-cli/pull/618) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -259,6 +259,7 @@ export default class Build extends EasCommand {
   }): Promise<BuildFragment | undefined> {
     const easJsonReader = new EasJsonReader(projectDir);
     const buildProfile = await easJsonReader.readBuildProfileAsync(platform, flags.profile);
+
     const buildCtx = await createBuildContextAsync({
       buildProfileName: flags.profile,
       clearCache: flags.clearCache,

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
     "@expo/eas-build-job": "0.2.46",
+    "@expo/json-file": "8.2.33",
     "env-string": "1.0.1",
     "fs-extra": "10.0.0",
     "joi": "17.4.2",


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Fixes https://linear.app/expo/issue/ENG-1915/better-error-message-when-easjson-is-invalid-json

# How

I used `@expo/json-file` to read eas.json. If the JSON is invalid it shows the line with the syntax error.

# Test Plan

```
    JsonFileError: Found invalid JSON in eas.json. Error parsing JSON: {
      "build": {
        "release": {
          "android": {
            "gradleCommand": "blahblah"
          }
          "env": {
            "BLAH": "456"
          }
        }
      },
      "submit": {
        "release": {
          "android": {
            "serviceAccountKeyPath": "$GOOGLE_SERVICE_ACCOUNT",
            "track": "internal",
            "releaseStatus": "draft"
          },
          "ios": {
          }
        }
      }
    }

    ├─ File: /Users/dsokal/work/expo/example-apps/teecee/eas.json
    └─ Cause: SyntaxError: Unexpected string in JSON at position 101
       5 |         "gradleCommand": "blahblah"
       6 |       }
    >  7 |       "env": {
         |       ^
       8 |         "BLAH": "456"
       9 |       }
      10 |     }
    Code: EJSONPARSE
```