### PR TITLE
enforce return type in all functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,12 @@ module.exports = {
         ],
       },
     ],
+    '@typescript-eslint/explicit-function-return-type': [
+      'warn',
+      {
+        allowExpressions: true,
+      },
+    ],
   },
   settings: {
     react: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Reduce `eas-cli` size by almost getting rid of `lodash` from dependencies. ([#605](https://github.com/expo/eas-cli/pull/605) by [@dsokal](https://github.com/dsokal))
+- Enforce explicit return type in all functions. ([#619](https://github.com/expo/eas-cli/pull/619) by [@wkozyra95](https://github.com/wkozyra95))
 
 ## [0.27.1](https://github.com/expo/eas-cli/releases/tag/v0.27.1) - 2021-09-10
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -325,22 +325,6 @@
             "deprecationReason": null
           },
           {
-            "name": "easBuild",
-            "description": "Top-level query object for querying EAS Build configuration.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "EasBuildQuery",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "experimentation",
             "description": "Top-level query object for querying Experimentation configuration.",
             "args": [],
@@ -6510,8 +6494,8 @@
               "name": "SubmissionAndroidArchiveType",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "archiveType is deprecated and will be null"
           },
           {
             "name": "track",
@@ -7375,8 +7359,8 @@
             "deprecationReason": null
           },
           {
-            "name": "channel",
-            "description": "",
+            "name": "channelName",
+            "description": "The name of this deployment's associated channel. It is specified separately from the `channel`\nfield to allow specifying a deployment before an EAS Update channel has been created.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7386,6 +7370,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "channel",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "UpdateChannel",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7415,18 +7411,6 @@
             "deprecationReason": null
           },
           {
-            "name": "branchMapping",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "UpdateBranch",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "mostRecentlyUpdatedAt",
             "description": "",
             "args": [],
@@ -7437,6 +7421,170 @@
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UpdateChannel",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appId",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "branchMapping",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateBranches",
+            "description": "",
+            "args": [
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UpdateBranch",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -10013,170 +10161,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "UpdateChannel",
-        "description": "",
-        "fields": [
-          {
-            "name": "id",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "appId",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "branchMapping",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updateBranches",
-            "description": "",
-            "args": [
-              {
-                "name": "offset",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "UpdateBranch",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "EnvironmentSecret",
         "description": "",
         "fields": [
@@ -12248,113 +12232,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "EasBuildQuery",
-        "description": "",
-        "fields": [
-          {
-            "name": "killSwitches",
-            "description": "Get EAS Build kill switches state",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "EasBuildKillSwitch",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "EasBuildKillSwitch",
-        "description": "",
-        "fields": [
-          {
-            "name": "name",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "EasBuildKillSwitchName",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "value",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "EasBuildKillSwitchName",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "STOP_ACCEPTING_BUILDS",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "STOP_SCHEDULING_BUILDS",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "STOP_ACCEPTING_NORMAL_PRIORITY_BUILDS",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "ExperimentationQuery",
         "description": "",
         "fields": [
@@ -13481,22 +13358,6 @@
             "deprecationReason": null
           },
           {
-            "name": "easBuildKillSwitch",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "EasBuildKillSwitchMutation",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "emailSubscription",
             "description": "Mutations that modify an EmailSubscription",
             "args": [],
@@ -14146,108 +14007,6 @@
             "deprecationReason": null
           },
           {
-            "name": "extendOffer",
-            "description": "Extend offer to account",
-            "args": [
-              {
-                "name": "accountName",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offer",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "StandardOffer",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "suppressMessage",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Account",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sendEmail",
-            "description": "Send an email to primary account email",
-            "args": [
-              {
-                "name": "accountName",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "emailTemplate",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "EmailTemplate",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Account",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "setPushSecurityEnabled",
             "description": "Require authorization to send push notifications for experiences owned by this account",
             "args": [
@@ -14345,64 +14104,6 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "StandardOffer",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "DEFAULT",
-            "description": "$29 USD per month, 30 day trial",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "YEARLY_SUB",
-            "description": "$348 USD per year, 30 day trial",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "YC_DEALS",
-            "description": "$29 USD per month, 1 year trial",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SUPPORT",
-            "description": "$800 USD per month",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "EmailTemplate",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "DEV_SERVICES_OFFER_EXTENDED",
-            "description": "Able to purchase Developer Services",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "DEV_SERVICES_ONBOARDING",
-            "description": "Developer Services Signup",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
         "possibleTypes": null
       },
       {
@@ -20529,18 +20230,6 @@
             "deprecationReason": null
           },
           {
-            "name": "archiveType",
-            "description": "",
-            "type": {
-              "kind": "ENUM",
-              "name": "SubmissionAndroidArchiveType",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "applicationIdentifier",
             "description": "",
             "type": {
@@ -22895,90 +22584,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "EasBuildKillSwitchMutation",
-        "description": "",
-        "fields": [
-          {
-            "name": "set",
-            "description": "Set an EAS Build kill switch to a given value",
-            "args": [
-              {
-                "name": "name",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "EasBuildKillSwitchName",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "value",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "EasBuildKillSwitch",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "resetAll",
-            "description": "Reset all EAS Build kill switches (set them to false)",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "EasBuildKillSwitch",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "EmailSubscriptionMutation",
         "description": "",
         "fields": [
@@ -23680,6 +23285,41 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "StandardOffer",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DEFAULT",
+            "description": "$29 USD per month, 30 day trial",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "YEARLY_SUB",
+            "description": "$348 USD per year, 30 day trial",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "YC_DEALS",
+            "description": "$29 USD per month, 1 year trial",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUPPORT",
+            "description": "$800 USD per month",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/src/analytics.ts
+++ b/packages/eas-cli/src/analytics.ts
@@ -98,7 +98,7 @@ export async function flushAsync(): Promise<void> {
   }
 }
 
-export function logEvent(name: string, properties: Record<string, any> = {}) {
+export function logEvent(name: string, properties: Record<string, any> = {}): void {
   if (!amplitudeClient && !rudderstackClient) {
     return;
   }
@@ -128,7 +128,7 @@ export function logEvent(name: string, properties: Record<string, any> = {}) {
   }
 }
 
-function ensureUserIdentified() {
+function ensureUserIdentified(): void {
   if (!(rudderstackClient || amplitudeClient) || userIdentified || !identifyData) {
     return;
   }
@@ -146,7 +146,7 @@ function ensureUserIdentified() {
   userIdentified = true;
 }
 
-function getAmplitudeContext() {
+function getAmplitudeContext(): Record<string, string> {
   const platform = PLATFORM_TO_ANALYTICS_PLATFORM[os.platform()] || os.platform();
   return {
     os_name: platform,
@@ -156,7 +156,7 @@ function getAmplitudeContext() {
   };
 }
 
-function getRudderStackContext() {
+function getRudderStackContext(): Record<string, any> {
   const platform = PLATFORM_TO_ANALYTICS_PLATFORM[os.platform()] || os.platform();
   return {
     os: { name: platform, version: os.release() },

--- a/packages/eas-cli/src/build/utils/credentials.ts
+++ b/packages/eas-cli/src/build/utils/credentials.ts
@@ -5,7 +5,10 @@ import chalk from 'chalk';
 import Log from '../../log';
 import { requestedPlatformDisplayNames } from '../../platform';
 
-export function logCredentialsSource(credentialsSource: CredentialsSource, platform: Platform) {
+export function logCredentialsSource(
+  credentialsSource: CredentialsSource,
+  platform: Platform
+): void {
   let message = `Using ${credentialsSource} ${requestedPlatformDisplayNames[platform]} credentials`;
   if (credentialsSource === CredentialsSource.LOCAL) {
     message += ` ${chalk.dim('(credentials.json)')}`;

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -9,7 +9,7 @@ import { appPlatformDisplayNames } from '../../platform';
 import formatFields from '../../utils/formatFields';
 import { getBuildLogsUrl } from './url';
 
-export function formatGraphQLBuild(build: BuildFragment) {
+export function formatGraphQLBuild(build: BuildFragment): string {
   const actor = getActorName(build);
   const fields: { label: string; value?: string | null }[] = [
     { label: 'ID', value: build.id },

--- a/packages/eas-cli/src/build/utils/updates.ts
+++ b/packages/eas-cli/src/build/utils/updates.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig, getPackageJson } from '@expo/config';
 
-export function isExpoUpdatesInstalled(projectDir: string) {
+export function isExpoUpdatesInstalled(projectDir: string): boolean {
   const packageJson = getPackageJson(projectDir);
   return packageJson.dependencies && 'expo-updates' in packageJson.dependencies;
 }

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -16,7 +16,7 @@ export default abstract class EasCommand extends Command {
    */
   protected requiresAuthentication = true;
 
-  async init() {
+  async init(): Promise<void> {
     await initAnalyticsAsync();
 
     if (this.requiresAuthentication) {
@@ -31,7 +31,7 @@ export default abstract class EasCommand extends Command {
     });
   }
 
-  async finally(err: Error) {
+  async finally(err: Error): Promise<any> {
     await flushAnalyticsAsync();
     return super.finally(err);
   }

--- a/packages/eas-cli/src/commandUtils/__tests__/TestEasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/TestEasCommand.ts
@@ -3,11 +3,11 @@ import EasCommand from '../EasCommand';
 export default class TestEasCommand extends EasCommand {
   requiresAuthentication = this.authValue();
 
-  authValue() {
+  authValue(): boolean {
     return false;
   }
 
-  async run() {}
+  async run(): Promise<void> {}
 }
 
 TestEasCommand.id = 'TestEasCommand'; // normally oclif will assign ids, but b/c this is located outside the commands folder it will not

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -8,7 +8,7 @@ export default class AccountLogin extends Command {
 
   static aliases = ['login'];
 
-  async run() {
+  async run(): Promise<void> {
     Log.log('Log in to EAS');
     await showLoginPromptAsync();
     Log.log('Logged in');

--- a/packages/eas-cli/src/commands/account/logout.ts
+++ b/packages/eas-cli/src/commands/account/logout.ts
@@ -8,7 +8,7 @@ export default class AccountLogout extends Command {
 
   static aliases = ['logout'];
 
-  async run() {
+  async run(): Promise<void> {
     await logoutAsync();
     Log.log('Logged out');
   }

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -9,7 +9,7 @@ export default class AccountView extends Command {
 
   static aliases = ['whoami'];
 
-  async run() {
+  async run(): Promise<void> {
     const user = await getUserAsync();
     if (user) {
       Log.log(chalk.green(getActorDisplayName(user)));

--- a/packages/eas-cli/src/commands/analytics.ts
+++ b/packages/eas-cli/src/commands/analytics.ts
@@ -8,7 +8,7 @@ export default class AnalyticsView extends Command {
 
   static args = [{ name: 'STATUS', options: ['on', 'off'] }];
 
-  async run() {
+  async run(): Promise<void> {
     const { STATUS: status } = this.parse(AnalyticsView).args;
     if (status) {
       await UserSettings.setAsync('amplitudeEnabled', status === 'on');

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -68,7 +68,7 @@ export default class BranchCreate extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     let {
       args: { name },
       flags,

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -91,7 +91,7 @@ export default class BranchDelete extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     let {
       args: { name },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -144,7 +144,7 @@ export default class BranchPublish extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     let {
       args: { name: branchName },
       flags: {

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -68,7 +68,7 @@ export default class BranchRename extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     let {
       flags: { json: jsonFlag, from: currentName, to: newName },
     } = this.parse(BranchRename);

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -83,7 +83,7 @@ export default class BranchView extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     let {
       args: { name },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -114,7 +114,7 @@ export default class BuildCancel extends Command {
 
   static args = [{ name: 'BUILD_ID' }];
 
-  async run() {
+  async run(): Promise<void> {
     const { BUILD_ID: buildIdFromArg } = this.parse(BuildCancel).args;
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -19,7 +19,7 @@ export default class BuildConfigure extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     const { flags } = this.parse(BuildConfigure);
     Log.log(
       '💡 The following process will configure your iOS and/or Android project to be compatible with EAS Build. These changes only apply to your local project files and you can safely revert them at any time.'
@@ -40,7 +40,7 @@ export default class BuildConfigure extends Command {
   }
 }
 
-function logSuccess(platform: RequestedPlatform) {
+function logSuccess(platform: RequestedPlatform): void {
   let platformsText = 'iOS and Android projects are';
   let storesText = 'the Apple App Store or Google Play Store';
 

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -58,7 +58,7 @@ export default class BuildList extends Command {
     limit: flags.integer(),
   };
 
-  async run() {
+  async run(): Promise<void> {
     const { flags } = this.parse(BuildList);
     const {
       json,

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -24,7 +24,7 @@ export default class BuildView extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     const {
       args: { BUILD_ID: buildId },
       flags,

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -77,7 +77,7 @@ export default class ChannelCreate extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     let {
       args: { name: channelName },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -114,7 +114,7 @@ export default class ChannelEdit extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     let {
       args: { name: channelName },
       flags: { branch: branchName, json: jsonFlag },

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -74,7 +74,7 @@ export default class ChannelList extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     const {
       flags: { json: jsonFlag },
     } = this.parse(ChannelList);

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -336,7 +336,7 @@ export default class ChannelRollout extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     const {
       args: { channel: channelName },
       flags: { json: jsonFlag, end: endFlag },

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -208,7 +208,7 @@ export default class ChannelView extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     let {
       args: { name: channelName },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -17,7 +17,7 @@ export default class Config extends Command {
     profile: flags.string(),
   };
 
-  async run() {
+  async run(): Promise<void> {
     const { flags } = this.parse(Config);
     const { platform: maybePlatform, profile: maybeProfile } = flags as {
       platform?: Platform;

--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -5,7 +5,7 @@ import { SelectPlatform } from '../credentials/manager/SelectPlatform';
 export default class Credentials extends EasCommand {
   static description = 'manage your credentials';
 
-  async run() {
+  async run(): Promise<void> {
     const ctx = await createCredentialsContextAsync(process.cwd(), {});
     await new SelectPlatform().runAsync(ctx);
   }

--- a/packages/eas-cli/src/commands/device/create.ts
+++ b/packages/eas-cli/src/commands/device/create.ts
@@ -8,7 +8,7 @@ import { ensureLoggedInAsync } from '../../user/actions';
 export default class DeviceCreate extends Command {
   static description = 'register new Apple Devices to use for internal distribution';
 
-  async run() {
+  async run(): Promise<void> {
     const user = await ensureLoggedInAsync();
 
     const ctx = await createContext({ appStore: new AppStoreApi(), user });

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -18,7 +18,7 @@ export default class BuildList extends Command {
     'apple-team-id': flags.string(),
   };
 
-  async run() {
+  async run(): Promise<void> {
     let appleTeamIdentifier = this.parse(BuildList).flags['apple-team-id'];
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -12,7 +12,7 @@ export default class DeviceView extends Command {
 
   static args = [{ name: 'UDID' }];
 
-  async run() {
+  async run(): Promise<void> {
     const { UDID } = this.parse(DeviceView).args;
 
     if (!UDID) {

--- a/packages/eas-cli/src/commands/diagnostics.ts
+++ b/packages/eas-cli/src/commands/diagnostics.ts
@@ -8,7 +8,7 @@ const packageJSON = require('../../package.json');
 export default class Diagnostics extends Command {
   static description = 'log environment info to the console';
 
-  async run() {
+  async run(): Promise<void> {
     const info = await envinfo.run(
       {
         System: ['OS', 'Shell'],

--- a/packages/eas-cli/src/commands/project/info.ts
+++ b/packages/eas-cli/src/commands/project/info.ts
@@ -33,7 +33,7 @@ async function projectInfoByIdAsync(appId: string): Promise<AppInfoQuery> {
 export default class ProjectInfo extends Command {
   static description = 'information about the current project';
 
-  async run() {
+  async run(): Promise<void> {
     const projectDir = await findProjectRootAsync(process.cwd());
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -9,7 +9,7 @@ export default class ProjectInit extends Command {
   static description = 'create or link an EAS project';
   static aliases = ['init'];
 
-  async run() {
+  async run(): Promise<void> {
     const projectDir = await findProjectRootAsync(process.cwd());
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -43,7 +43,7 @@ export default class EnvironmentSecretCreate extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     const actor = await ensureLoggedInAsync();
     let {
       flags: { name, value: secretValue, scope, force },

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -31,7 +31,7 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     await ensureLoggedInAsync();
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();

--- a/packages/eas-cli/src/commands/update/delete.ts
+++ b/packages/eas-cli/src/commands/update/delete.ts
@@ -52,7 +52,7 @@ export default class UpdateDelete extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     const {
       args: { groupId: group },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -66,7 +66,7 @@ export default class UpdateView extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     const {
       args: { groupId },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -26,7 +26,7 @@ export default class WebhookCreate extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     await ensureLoggedInAsync();
     const { flags } = this.parse(WebhookCreate);
     const webhookInputParams = await prepareInputParamsAsync(flags);

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -25,7 +25,7 @@ export default class WebhookDelete extends Command {
     },
   ];
 
-  async run() {
+  async run(): Promise<void> {
     await ensureLoggedInAsync();
     let {
       args: { ID: webhookId },

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -24,7 +24,7 @@ export default class WebhookList extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     await ensureLoggedInAsync();
     const {
       flags: { event },

--- a/packages/eas-cli/src/commands/webhook/update.ts
+++ b/packages/eas-cli/src/commands/webhook/update.ts
@@ -30,7 +30,7 @@ export default class WebhookUpdate extends Command {
     }),
   };
 
-  async run() {
+  async run(): Promise<void> {
     await ensureLoggedInAsync();
     const { flags } = this.parse(WebhookUpdate);
 

--- a/packages/eas-cli/src/commands/webhook/view.ts
+++ b/packages/eas-cli/src/commands/webhook/view.ts
@@ -17,7 +17,7 @@ export default class WebhookView extends Command {
     },
   ];
 
-  async run() {
+  async run(): Promise<void> {
     await ensureLoggedInAsync();
     const {
       args: { ID: webhookId },

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-android.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-android.ts
@@ -7,6 +7,7 @@ import {
   AppFragment,
   CommonAndroidAppCredentialsFragment,
 } from '../../graphql/generated';
+import * as AndroidGraphqlClient from '../android/api/GraphqlClient';
 import { Keystore } from '../android/credentials';
 import {
   testKeystore2Base64,
@@ -115,7 +116,7 @@ export const testAndroidAppCredentialsFragment: CommonAndroidAppCredentialsFragm
   androidAppBuildCredentialsList: [testLegacyAndroidBuildCredentialsFragment],
 };
 
-export function getNewAndroidApiMock() {
+export function getNewAndroidApiMock(): { [key in keyof typeof AndroidGraphqlClient]?: any } {
   return {
     getAndroidAppCredentialsWithCommonFieldsAsync: jest.fn(),
     getAndroidAppBuildCredentialsListAsync: jest.fn(() => []),

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
@@ -1,3 +1,4 @@
+import AppStoreApi from '../ios/appstore/AppStoreApi';
 import { AuthCtx } from '../ios/appstore/authenticate';
 
 export const testAuthCtx: AuthCtx = {
@@ -6,7 +7,7 @@ export const testAuthCtx: AuthCtx = {
   team: { id: 'test-team-id', name: 'test-team-name', inHouse: false },
 };
 
-export function getAppstoreMock() {
+export function getAppstoreMock(): AppStoreApi {
   return {
     ensureAuthenticatedAsync: jest.fn(),
     ensureBundleIdExistsAsync: jest.fn(),
@@ -21,5 +22,5 @@ export function getAppstoreMock() {
     createProvisioningProfileAsync: jest.fn(),
     revokeProvisioningProfileAsync: jest.fn(),
     createOrReuseAdhocProvisioningProfileAsync: jest.fn(),
-  };
+  } as any;
 }

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -9,6 +9,7 @@ import {
   IosAppBuildCredentialsFragment,
   IosDistributionType,
 } from '../../graphql/generated';
+import * as IosGraphqlClient from '../ios/api/GraphqlClient';
 import { DistributionCertificate, ProvisioningProfile } from '../ios/appstore/Credentials.types';
 import { Target } from '../ios/types';
 import { testProvisioningProfileBase64 } from './fixtures-base64-data';
@@ -117,7 +118,7 @@ export const testAppleTeam = {
   id: 'test-team-id',
 };
 
-export function getNewIosApiMock() {
+export function getNewIosApiMock(): { [key in keyof typeof IosGraphqlClient]?: any } {
   return {
     getIosAppCredentialsWithCommonFieldsAsync: jest.fn(),
     createOrGetIosAppCredentialsWithCommonFieldsAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/android/actions/RemoveKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveKeystore.ts
@@ -41,7 +41,7 @@ export class RemoveKeystore {
     Log.succeed('Keystore removed');
   }
 
-  displayWarning() {
+  displayWarning(): void {
     Log.newLine();
     Log.warn(
       `Clearing your Android build credentials from our build servers is a ${chalk.bold(

--- a/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
@@ -184,7 +184,7 @@ export async function createOrUpdateAndroidAppBuildCredentialsByNameAsync(
   });
 }
 
-export async function createOrUpdateDefaultIosAppBuildCredentialsAsync() {
+export async function createOrUpdateDefaultIosAppBuildCredentialsAsync(): Promise<void> {
   throw new Error('This requires user prompting. Look for me in BuildCredentialsUtils');
 }
 

--- a/packages/eas-cli/src/credentials/android/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/utils/printCredentials.ts
@@ -91,7 +91,7 @@ function displayAndroidBuildCredentials(
   Log.newLine();
 }
 
-export function displayAndroidKeystore(keystore: AndroidKeystoreFragment) {
+export function displayAndroidKeystore(keystore: AndroidKeystoreFragment): void {
   const {
     keyAlias,
     type,

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -85,7 +85,7 @@ class CredentialsContext implements Context {
     return this._exp!;
   }
 
-  public ensureProjectContext() {
+  public ensureProjectContext(): void {
     if (this.hasProjectContext) {
       return;
     }
@@ -93,7 +93,7 @@ class CredentialsContext implements Context {
     getConfig(this.projectDir, { skipSDKVersionRequirement: true });
   }
 
-  public logOwnerAndProject() {
+  public logOwnerAndProject(): void {
     if (this.hasProjectContext) {
       const owner = getProjectAccountName(this.exp, this.user);
       // Figure out if User A is configuring credentials as admin for User B's project

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -300,7 +300,7 @@ async function isFileUntrackedAsync(path: string): Promise<boolean> {
   return false;
 }
 
-function displayUntrackedFilesWarning(newFilePaths: string[]) {
+function displayUntrackedFilesWarning(newFilePaths: string[]): void {
   if (newFilePaths.length === 1) {
     Log.warn(
       `File ${newFilePaths[0]} is currently untracked, remember to add it to .gitignore, or to encrypt it (e.g. with git-crypt).`

--- a/packages/eas-cli/src/credentials/ios/actions/DeviceUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DeviceUtils.ts
@@ -7,7 +7,7 @@ export async function chooseDevices(
   preselectedDeviceIdentifiers: string[] = []
 ): Promise<AppleDevice[]> {
   const preselectedDeviceIdentifierSet = new Set(preselectedDeviceIdentifiers);
-  const isSelected = (device: AppleDeviceFragment) =>
+  const isSelected = (device: AppleDeviceFragment): boolean =>
     preselectedDeviceIdentifierSet.size === 0 ||
     preselectedDeviceIdentifierSet.has(device.identifier);
   const { devices } = await promptAsync({

--- a/packages/eas-cli/src/credentials/ios/actions/SetupTargetBuildCredentialsFromCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupTargetBuildCredentialsFromCredentialsJson.ts
@@ -170,7 +170,7 @@ export class SetupTargetBuildCredentialsFromCredentialsJson {
 function displaySingleTargetProjectCredentials(
   app: AppLookupParams,
   buildCredentials: IosAppBuildCredentialsFragment
-) {
+): void {
   const targetName = app.projectName;
   displayProjectCredentials(app, { [targetName]: buildCredentials }, [
     { targetName, bundleIdentifier: app.bundleIdentifier },

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/capabilityIdentifiers-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/capabilityIdentifiers-test.ts
@@ -1,6 +1,6 @@
 import { syncCapabilityIdentifiersForEntitlementsAsync } from '../capabilityIdentifiers';
 
-function mockCapabilities(Apple: any) {
+function mockCapabilities(Apple: any): void {
   Apple.MerchantId.getAsync = jest.fn(() => [
     {
       id: 'XXX-merch-1',
@@ -149,12 +149,14 @@ describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {
   it(`throws when creating a missing capability that is reserved`, async () => {
     const Apple = require('@expo/apple-utils');
     mockCapabilities(Apple);
-    Apple.MerchantId.createAsync = jest.fn((ctx: any, { identifier }: { identifier: string }) => {
-      // e2e test with: merchant.expodemo
-      throw new Error(
-        `There is a problem with the request entity - A Merchant ID with Identifier '${identifier}' is not available. Please enter a different string.`
-      );
-    });
+    Apple.MerchantId.createAsync = jest.fn(
+      (ctx: any, { identifier }: { identifier: string }): any => {
+        // e2e test with: merchant.expodemo
+        throw new Error(
+          `There is a problem with the request entity - A Merchant ID with Identifier '${identifier}' is not available. Please enter a different string.`
+        );
+      }
+    );
     const bundleId = {
       context: {},
       updateBundleIdCapabilityAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
@@ -127,7 +127,7 @@ async function loginWithUserCredentialsAsync({
   password?: string;
   teamId?: string;
   providerId?: number;
-}) {
+}): Promise<Session.AuthState> {
   // Start a new login flow
   const newSession = await Auth.loginWithUserCredentialsAsync({
     username,

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -106,10 +106,19 @@ export async function syncCapabilitiesForEntitlementsAsync(
   return { enabled: enabledCapabilityNames, disabled: disabledCapabilityNames };
 }
 
+interface CapabilitiesRequest {
+  capabilityType: CapabilityType;
+  option: any;
+}
+
 function getCapabilitiesToEnable(
   currentCapabilities: BundleIdCapability[],
   entitlements: JSONObject
-) {
+): {
+  enabledCapabilityNames: string[];
+  request: CapabilitiesRequest[];
+  remainingCapabilities: BundleIdCapability[];
+} {
   const enabledCapabilityNames: string[] = [];
   const request: { capabilityType: CapabilityType; option: any }[] = [];
   const remainingCapabilities = [...currentCapabilities];
@@ -177,8 +186,8 @@ export function assertValidOptions(classifier: CapabilityClassifier, value: any)
 function getCapabilitiesToDisable(
   bundleId: BundleId,
   currentCapabilities: BundleIdCapability[],
-  request: { capabilityType: CapabilityType; option: any }[]
-) {
+  request: CapabilitiesRequest[]
+): { disabledCapabilityNames: string[]; request: CapabilitiesRequest[] } {
   if (Log.isDebug) {
     Log.log(
       `Existing to disable: `,

--- a/packages/eas-cli/src/credentials/ios/appstore/contractMessages.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/contractMessages.ts
@@ -17,7 +17,9 @@ async function getContractStatusAsync(
   }
 }
 
-async function getContractMessagesAsync(context: RequestContext) {
+async function getContractMessagesAsync(
+  context: RequestContext
+): Promise<ITCAgreements.ITCContractMessage[] | null> {
   try {
     return await ITCAgreements.getContractMessagesAsync(context);
   } catch (error: any) {
@@ -75,7 +77,10 @@ export function formatContractMessage(message: ITCAgreements.ITCContractMessage)
   });
 }
 
-export async function assertContractMessagesAsync(context: RequestContext, spinner?: Ora) {
+export async function assertContractMessagesAsync(
+  context: RequestContext,
+  spinner?: Ora
+): Promise<void> {
   const { messages, isFatal } = await getRequiredContractMessagesAsync(context);
 
   if (Array.isArray(messages) && messages.length) {

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -23,7 +23,7 @@ export async function ensureBundleIdExistsAsync(
   authCtx: AuthCtx,
   { accountName, projectName, bundleIdentifier }: AppLookupParams,
   options?: IosCapabilitiesOptions
-) {
+): Promise<void> {
   return ensureBundleIdExistsWithNameAsync(
     authCtx,
     {
@@ -38,7 +38,7 @@ export async function ensureBundleIdExistsWithNameAsync(
   authCtx: AuthCtx,
   { name, bundleIdentifier }: { name: string; bundleIdentifier: string },
   options?: IosCapabilitiesOptions
-) {
+): Promise<void> {
   const context = getRequestContext(authCtx);
   const spinner = ora(`Linking bundle identifier ${chalk.dim(bundleIdentifier)}`).start();
 
@@ -111,7 +111,7 @@ export async function syncCapabilities(
   await syncCapabilityIdentifiersAsync(bundleId, { entitlements });
 }
 
-const buildMessage = (title: string, items: string[]) =>
+const buildMessage = (title: string, items: string[]): string =>
   items.length ? `${title}: ${items.join(', ')}` : '';
 
 export async function syncCapabilityIdentifiersAsync(
@@ -160,7 +160,7 @@ export async function ensureAppExistsAsync(
     bundleIdentifier: string;
     sku?: string;
   }
-) {
+): Promise<App> {
   const context = getRequestContext(authCtx);
   const spinner = ora(`Linking to App Store ${chalk.dim(bundleIdentifier)}`).start();
 

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
@@ -57,7 +57,7 @@ async function addCertificateToProfileAsync(
     profileId: string;
     bundleIdentifier: string;
   }
-) {
+): Promise<Profile> {
   const cert = await getCertificateBySerialNumberAsync(context, serialNumber);
 
   const profiles = await getProfilesForBundleIdAsync(context, bundleIdentifier);

--- a/packages/eas-cli/src/credentials/ios/credentials.ts
+++ b/packages/eas-cli/src/credentials/ios/credentials.ts
@@ -15,7 +15,10 @@ export interface AppLookupParams {
   bundleIdentifier: string;
 }
 
-export function getAppLookupParams(experienceName: string, bundleIdentifier: string) {
+export function getAppLookupParams(
+  experienceName: string,
+  bundleIdentifier: string
+): AppLookupParams {
   const matchedExperienceName = experienceName.match(/@(.+)\/(.+)/);
   if (!matchedExperienceName || matchedExperienceName.length < 3) {
     throw new Error('invalid experience name');

--- a/packages/eas-cli/src/credentials/ios/utils/convertHTMLToASCII.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/convertHTMLToASCII.ts
@@ -6,7 +6,7 @@ import wrapAnsi from 'wrap-ansi';
 
 const turndownServices: Record<string, any> = {};
 
-function getService(rootUrl: string) {
+function getService(rootUrl: string): TurndownService {
   if (turndownServices[rootUrl]) {
     return turndownServices[rootUrl];
   }

--- a/packages/eas-cli/src/credentials/ios/validators/validatePushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validatePushKey.ts
@@ -2,7 +2,10 @@ import { Context } from '../../context';
 import { PushKey } from '../appstore/Credentials.types';
 import { filterRevokedAndUntrackedPushKeys } from '../appstore/CredentialsUtils';
 
-export async function isPushKeyValidAndTrackedAsync(ctx: Context, pushKey: PushKey) {
+export async function isPushKeyValidAndTrackedAsync(
+  ctx: Context,
+  pushKey: PushKey
+): Promise<boolean> {
   const pushInfoFromApple = await ctx.appStore.listPushKeysAsync();
   const validPushKeys = await filterRevokedAndUntrackedPushKeys([pushKey], pushInfoFromApple);
   return validPushKeys.length > 0;

--- a/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
+++ b/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
@@ -22,7 +22,7 @@ export type CredentialSchema<T> = {
 };
 
 let expertPromptLogged = false;
-const EXPERT_PROMPT = () => {
+const EXPERT_PROMPT = (): void => {
   if (expertPromptLogged) {
     return;
   }
@@ -63,7 +63,9 @@ export async function getCredentialsFromUserAsync<T>(
     : (results as T);
 }
 
-async function shouldAutoGenerateCredentialsAsync<T>(schema: CredentialSchema<T>) {
+async function shouldAutoGenerateCredentialsAsync<T>(
+  schema: CredentialSchema<T>
+): Promise<boolean> {
   const answer = await confirmAsync({
     message: schema?.provideMethodQuestion?.question ?? `Generate a new ${schema.name}?`,
     initial: true,

--- a/packages/eas-cli/src/devices/actions/create/registrationUrlMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/registrationUrlMethod.ts
@@ -27,7 +27,7 @@ export async function runRegistrationUrlMethodAsync(
 async function generateDeviceRegistrationURLAsync(
   accountId: string,
   appleTeam: Pick<AppleTeam, 'id'>
-) {
+): Promise<string> {
   const appleDeviceRegistrationRequest =
     await AppleDeviceRegistrationRequestMutation.createAppleDeviceRegistrationRequestAsync(
       appleTeam.id,

--- a/packages/eas-cli/src/devices/utils/formatDevice.ts
+++ b/packages/eas-cli/src/devices/utils/formatDevice.ts
@@ -5,7 +5,7 @@ type Device = Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'deviceClass' | '
 
 type Team = Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName'>;
 
-export default function formatDevice(device: Device, team?: Team) {
+export default function formatDevice(device: Device, team?: Team): string {
   const fields = [
     { label: 'ID', value: device.id },
     { label: 'Name', value: device.name ?? 'Unknown' },

--- a/packages/eas-cli/src/graphql/types/UpdateBranch.ts
+++ b/packages/eas-cli/src/graphql/types/UpdateBranch.ts
@@ -1,0 +1,26 @@
+import gql from 'graphql-tag';
+
+export const UpdateBranchFragmentNode = gql`
+  fragment UpdateBranchFragment on UpdateBranch {
+    id
+    name
+    updates(offset: 0, limit: 10) {
+      id
+      actor {
+        __typename
+        id
+        ... on User {
+          username
+        }
+        ... on Robot {
+          firstName
+        }
+      }
+      createdAt
+      message
+      runtimeVersion
+      group
+      platform
+    }
+  }
+`;

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -10,65 +10,65 @@ type Color = (...text: string[]) => string;
 export default class Log {
   public static readonly isDebug = boolish('EXPO_DEBUG', false);
 
-  public static log(...args: any[]) {
+  public static log(...args: any[]): void {
     Log.consoleLog(...args);
   }
 
-  public static newLine() {
+  public static newLine(): void {
     Log.consoleLog();
   }
 
-  public static addNewLineIfNone() {
+  public static addNewLineIfNone(): void {
     if (!Log.isLastLineNewLine) {
       Log.newLine();
     }
   }
 
-  public static error(...args: any[]) {
+  public static error(...args: any[]): void {
     Log.consoleError(...Log.withTextColor(args, chalk.red));
   }
 
-  public static warn(...args: any[]) {
+  public static warn(...args: any[]): void {
     Log.consoleWarn(...Log.withTextColor(args, chalk.yellow));
   }
 
-  public static gray(...args: any[]) {
+  public static gray(...args: any[]): void {
     Log.consoleLog(...Log.withTextColor(args, chalk.gray));
   }
 
-  public static warnDeprecatedFlag(flag: string, message: string) {
+  public static warnDeprecatedFlag(flag: string, message: string): void {
     Log.warn(`› ${chalk.bold('--' + flag)} flag is deprecated. ${message}`);
   }
 
-  public static succeed(message: string) {
+  public static succeed(message: string): void {
     ora().succeed(message);
   }
 
-  public static withTick(...args: any[]) {
+  public static withTick(...args: any[]): void {
     Log.consoleLog(chalk.green(figures.tick), ...args);
   }
 
-  private static consoleLog(...args: any[]) {
+  private static consoleLog(...args: any[]): void {
     Log.updateIsLastLineNewLine(args);
     console.log(...args);
   }
 
-  private static consoleWarn(...args: any[]) {
+  private static consoleWarn(...args: any[]): void {
     Log.updateIsLastLineNewLine(args);
     console.warn(...args);
   }
 
-  private static consoleError(...args: any[]) {
+  private static consoleError(...args: any[]): void {
     Log.updateIsLastLineNewLine(args);
     console.error(...args);
   }
 
-  private static withTextColor(args: any[], chalkColor: Color) {
+  private static withTextColor(args: any[], chalkColor: Color): string[] {
     return args.map(arg => chalkColor(arg));
   }
 
   private static isLastLineNewLine = false;
-  private static updateIsLastLineNewLine(args: any[]) {
+  private static updateIsLastLineNewLine(args: any[]): void {
     if (args.length === 0) {
       Log.isLastLineNewLine = true;
     } else {

--- a/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
@@ -89,7 +89,7 @@ describe(getProjectAccountName, () => {
   });
 
   it('throws for robot actor when owner is undefined', () => {
-    const resolveProjectAccountName = () =>
+    const resolveProjectAccountName = (): string =>
       getProjectAccountName(expWithoutOwner, {
         __typename: 'Robot',
         id: 'userId',

--- a/packages/eas-cli/src/project/android/__tests__/gradleUtils-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/gradleUtils-test.ts
@@ -128,7 +128,7 @@ describe(parseGradleCommand, () => {
     expect(result).toEqual({ moduleName: 'app', flavor: 'Example', buildType: 'release' });
   });
   test('parsing :app:buildExampleDebug when flavor does not exists', async () => {
-    const result = () => {
+    const result = (): any => {
       parseGradleCommand(':app:buildExampleRelease', {
         android: { productFlavors: {} },
       });

--- a/packages/eas-cli/src/project/isEasEnabledForProject.ts
+++ b/packages/eas-cli/src/project/isEasEnabledForProject.ts
@@ -27,6 +27,6 @@ export const EAS_UNAVAILABLE_MESSAGE = `Your account doesn't have access to Expo
   'https://expo.dev/eas'
 )}`;
 
-export function warnEasUnavailable() {
+export function warnEasUnavailable(): void {
   Log.warn(EAS_UNAVAILABLE_MESSAGE);
 }

--- a/packages/eas-cli/src/project/metroConfig.ts
+++ b/packages/eas-cli/src/project/metroConfig.ts
@@ -7,7 +7,9 @@ import { BuildContext } from '../build/context';
 import Log, { learnMore } from '../log';
 import { confirmAsync } from '../prompts';
 
-export async function validateMetroConfigForManagedWorkflowAsync(ctx: BuildContext<Platform>) {
+export async function validateMetroConfigForManagedWorkflowAsync(
+  ctx: BuildContext<Platform>
+): Promise<void> {
   if (!(await configExistsAsync(ctx.projectDir))) {
     return;
   }

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -143,7 +143,7 @@ export async function getProjectIdAsync(
   return newLocalProjectId;
 }
 
-const toAppPrivacy = (privacy: ExpoConfig['privacy']) => {
+const toAppPrivacy = (privacy: ExpoConfig['privacy']): AppPrivacy => {
   if (privacy === 'public') {
     return AppPrivacy.Public;
   } else if (privacy === 'hidden') {

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -151,7 +151,7 @@ export async function buildBundlesAsync({
 }: {
   projectDir: string;
   inputDir: string;
-}) {
+}): Promise<void> {
   const packageJSON = JsonFile.read(path.resolve(projectDir, 'package.json'));
   if (!packageJSON) {
     throw new Error('Could not locate package.json');

--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -80,7 +80,7 @@ export async function toggleConfirmAsync(
   return value ?? null;
 }
 
-export async function pressAnyKeyToContinueAsync() {
+export async function pressAnyKeyToContinueAsync(): Promise<void> {
   process.stdin.setRawMode(true);
   process.stdin.resume();
   process.stdin.setEncoding('utf8');

--- a/packages/eas-cli/src/submissions/__tests__/ArchiveSource-test.ts
+++ b/packages/eas-cli/src/submissions/__tests__/ArchiveSource-test.ts
@@ -183,7 +183,7 @@ function assertArchiveResult(
   archive: Archive,
   expectedSourceType: ArchiveSourceType,
   expectedUrl: string = ARCHIVE_URL
-) {
+): void {
   expect(archive.source.sourceType).toBe(expectedSourceType);
   if (archive.url) {
     expect(archive.url).toBe(expectedUrl);

--- a/packages/eas-cli/src/submissions/android/AndroidPackageSource.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidPackageSource.ts
@@ -20,7 +20,7 @@ interface AndroidPackagePromptSource extends AndroidPackageSourceBase {
 
 export type AndroidPackageSource = AndroidPackageUserDefinedSource | AndroidPackagePromptSource;
 
-export async function getAndroidPackageAsync(source: AndroidPackageSource) {
+export async function getAndroidPackageAsync(source: AndroidPackageSource): Promise<string> {
   if (source.sourceType === AndroidPackageSourceType.userDefined) {
     return source.androidPackage;
   } else if (source.sourceType === AndroidPackageSourceType.prompt) {

--- a/packages/eas-cli/src/submissions/ios/AppSpecificPasswordSource.ts
+++ b/packages/eas-cli/src/submissions/ios/AppSpecificPasswordSource.ts
@@ -26,7 +26,9 @@ export type AppSpecificPasswordSource =
   | AppSpecificPasswordUserDefinedSource
   | AppSpecificPasswordPromptSource;
 
-export async function getAppSpecificPasswordAsync(source: AppSpecificPasswordSource) {
+export async function getAppSpecificPasswordAsync(
+  source: AppSpecificPasswordSource
+): Promise<string> {
   if (source.sourceType === AppSpecificPasswordSourceType.userDefined) {
     return source.appSpecificPassword;
   } else if (source.sourceType === AppSpecificPasswordSourceType.prompt) {

--- a/packages/eas-cli/src/submissions/utils/files.ts
+++ b/packages/eas-cli/src/submissions/utils/files.ts
@@ -4,7 +4,7 @@ import { UploadSessionType } from '../../graphql/generated';
 import { uploadAsync } from '../../uploads';
 import { createProgressTracker } from '../../utils/progress';
 
-export async function isExistingFile(filePath: string) {
+export async function isExistingFile(filePath: string): Promise<boolean> {
   try {
     const stats = await fs.stat(filePath);
     return stats.isFile();

--- a/packages/eas-cli/src/submissions/utils/summary.ts
+++ b/packages/eas-cli/src/submissions/utils/summary.ts
@@ -10,7 +10,7 @@ export interface ArchiveSourceSummaryFields {
   formattedBuild?: string;
 }
 
-function formatSubmissionBuildSummary(build: BuildFragment) {
+function formatSubmissionBuildSummary(build: BuildFragment): string {
   const fields = [
     {
       label: 'Build ID',

--- a/packages/eas-cli/src/user/User.ts
+++ b/packages/eas-cli/src/user/User.ts
@@ -87,7 +87,7 @@ export async function loginAsync({
   });
 }
 
-export async function logoutAsync() {
+export async function logoutAsync(): Promise<void> {
   currentUser = undefined;
   await setSessionAsync(undefined);
 }

--- a/packages/eas-cli/src/utils/files.ts
+++ b/packages/eas-cli/src/utils/files.ts
@@ -9,7 +9,10 @@ function getRenamedFilename(filename: string, num: number): string {
   return `${basename}_OLD_${num}${ext}`;
 }
 
-export async function maybeRenameExistingFileAsync(projectDir: string, filename: string) {
+export async function maybeRenameExistingFileAsync(
+  projectDir: string,
+  filename: string
+): Promise<void> {
   const desiredFilePath = path.resolve(projectDir, filename);
 
   if (await fs.pathExists(desiredFilePath)) {

--- a/packages/eas-cli/src/utils/filterAsync.ts
+++ b/packages/eas-cli/src/utils/filterAsync.ts
@@ -7,4 +7,5 @@
 export const filterAsync = async <T>(
   arr: T[],
   predicate: (value: T, index: number, array: T[]) => Promise<boolean>
-) => Promise.all(arr.map(predicate)).then(results => arr.filter((_v, index) => results[index]));
+): Promise<T[]> =>
+  Promise.all(arr.map(predicate)).then(results => arr.filter((_v, index) => results[index]));

--- a/packages/eas-cli/src/utils/formatFields.ts
+++ b/packages/eas-cli/src/utils/formatFields.ts
@@ -7,7 +7,7 @@ type FormatFieldsOptions = {
 export default function formatFields(
   fields: { label: string; value: string }[],
   options: FormatFieldsOptions = { labelFormat: chalk.dim }
-) {
+): string {
   const columnWidth = fields.reduce((a, b) => (a.label.length > b.label.length ? a : b)).label
     .length;
 

--- a/packages/eas-cli/src/utils/json.ts
+++ b/packages/eas-cli/src/utils/json.ts
@@ -4,7 +4,7 @@ import Log from '../log';
 
 let stdoutWrite: NodeJS.WriteStream['write'] | undefined;
 
-export function enableJsonOutput() {
+export function enableJsonOutput(): void {
   if (stdoutWrite) {
     return;
   }

--- a/packages/eas-cli/src/utils/paths.ts
+++ b/packages/eas-cli/src/utils/paths.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 // The ~/.expo directory is used to store authentication sessions,
 // which are shared between EAS CLI and Expo CLI.
-function dotExpoHomeDirectory() {
+function dotExpoHomeDirectory(): string {
   const home = homedir();
   if (!home) {
     throw new Error(
@@ -23,7 +23,7 @@ function dotExpoHomeDirectory() {
   return dirPath;
 }
 
-const getStateJsonPath = () => path.join(dotExpoHomeDirectory(), 'state.json');
+const getStateJsonPath = (): string => path.join(dotExpoHomeDirectory(), 'state.json');
 
 // Paths for storing things like data, config, cache, etc.
 // Should use the correct OS-specific paths (e.g. XDG base directory on Linux)
@@ -35,11 +35,11 @@ const {
   temp: TEMP_PATH,
 } = envPaths('eas-cli');
 
-const getDataDirectory = () => DATA_PATH;
-const getConfigDirectory = () => CONFIG_PATH;
-const getCacheDirectory = () => CACHE_PATH;
-const getLogDirectory = () => LOG_PATH;
-const getTmpDirectory = () => TEMP_PATH;
+const getDataDirectory = (): string => DATA_PATH;
+const getConfigDirectory = (): string => CONFIG_PATH;
+const getCacheDirectory = (): string => CACHE_PATH;
+const getLogDirectory = (): string => LOG_PATH;
+const getTmpDirectory = (): string => TEMP_PATH;
 
 export {
   getDataDirectory,

--- a/packages/eas-cli/src/utils/progress.ts
+++ b/packages/eas-cli/src/utils/progress.ts
@@ -26,7 +26,7 @@ function createProgressTracker({
 
   const timerLabel = String(Date.now());
 
-  const getMessage = (v: number) => {
+  const getMessage = (v: number): string => {
     const ratio = Math.min(Math.max(v, 0), 1);
     const percent = Math.floor(ratio * 100);
     return typeof message === 'string' ? `${message} ${percent.toFixed(0)}%` : message(ratio);

--- a/packages/eas-cli/src/utils/timer.ts
+++ b/packages/eas-cli/src/utils/timer.ts
@@ -5,11 +5,11 @@ export function hasTimer(label: string): number | null {
   return startTimes[label] ?? null;
 }
 
-export function startTimer(label = LABEL) {
+export function startTimer(label = LABEL): void {
   startTimes[label] = Date.now();
 }
 
-export function endTimer(label = LABEL, clear: boolean = true) {
+export function endTimer(label = LABEL, clear: boolean = true): number {
   const endTime = Date.now();
   const startTime = startTimes[label];
   if (startTime) {
@@ -30,7 +30,7 @@ export function endTimer(label = LABEL, clear: boolean = true) {
  * @example `40s`
  * @param duration
  */
-export function formatMilliseconds(duration: number) {
+export function formatMilliseconds(duration: number): string {
   const portions: string[] = [];
 
   const msInHour = 1000 * 60 * 60;

--- a/packages/eas-cli/src/vcs/git.ts
+++ b/packages/eas-cli/src/vcs/git.ts
@@ -135,7 +135,7 @@ export default class GitClient extends Client {
     }
   }
 
-  public async showDiffAsync() {
+  public async showDiffAsync(): Promise<void> {
     const outputTooLarge = (await getGitDiffOutputAsync()).split(/\r\n|\r|\n/).length > 100;
     await gitDiffAsync({ withPager: outputTooLarge });
   }

--- a/packages/eas-json/src/DeprecatedEasJsonSchema.ts
+++ b/packages/eas-json/src/DeprecatedEasJsonSchema.ts
@@ -1,7 +1,7 @@
 import { Android, Ios } from '@expo/eas-build-job';
 import Joi, { CustomHelpers } from 'joi';
 
-const semverSchemaCheck = (value: any, helpers: CustomHelpers) => {
+const semverSchemaCheck = (value: any, helpers: CustomHelpers): any => {
   if (/^[0-9]+\.[0-9]+\.[0-9]+$/.test(value)) {
     return value;
   } else {

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -28,7 +28,7 @@ const defaults = {
 } as const;
 
 export class EasJsonReader {
-  public static formatEasJsonPath(projectDir: string) {
+  public static formatEasJsonPath(projectDir: string): string {
     return path.join(projectDir, 'eas.json');
   }
 
@@ -151,7 +151,7 @@ export class EasJsonReader {
     }
   }
 
-  private ensureBuildProfileExists(easJson: EasJson, profileName: string) {
+  private ensureBuildProfileExists(easJson: EasJson, profileName: string): void {
     if (!easJson.build || !easJson.build[profileName]) {
       throw new Error(`There is no profile named ${profileName} in eas.json.`);
     }

--- a/packages/eas-json/src/EasJsonSchema.ts
+++ b/packages/eas-json/src/EasJsonSchema.ts
@@ -3,7 +3,7 @@ import Joi from 'joi';
 
 import { AndroidReleaseStatus, AndroidReleaseTrack } from './EasSubmit.types';
 
-const semverSchemaCheck = (value: any) => {
+const semverSchemaCheck = (value: any): any => {
   if (/^[0-9]+\.[0-9]+\.[0-9]+$/.test(value)) {
     return value;
   } else {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

enforce explicit definition of return type

# Test Plan

tested `branch:list` command because it was only change that was not purely affecting types