### PR TITLE
[ENG-1347] eas submit: suggest using build id instead of build details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Use envs from build profile to resolve app config when auto-submitting. ([#614](https://github.com/expo/eas-cli/pull/614) by [@dsokal](https://github.com/dsokal))
-- Support multiflavor Android projects. ([#595](https://github.com/expo/eas-cli/pull/595) by [@wkozyra95](https://github.com/wkozyra95))
+- Support multi flavor Android projects. ([#595](https://github.com/expo/eas-cli/pull/595) by [@wkozyra95](https://github.com/wkozyra95))
+- Improve experience when using the build details page as a build artifact URL in `eas submit`. ([#620](https://github.com/expo/eas-cli/pull/620) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/submissions/__tests__/ArchiveSource-test.ts
+++ b/packages/eas-cli/src/submissions/__tests__/ArchiveSource-test.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { asMock } from '../../__tests__/utils';
 import { AppPlatform, BuildFragment, UploadSessionType } from '../../graphql/generated';
 import { toAppPlatform } from '../../graphql/types/AppPlatform';
-import { promptAsync, confirmAsync } from '../../prompts';
+import { confirmAsync, promptAsync } from '../../prompts';
 import { uploadAsync } from '../../uploads';
 import { Archive, ArchiveSourceType, getArchiveAsync } from '../ArchiveSource';
 import { getBuildByIdForSubmissionAsync, getLatestBuildForSubmissionAsync } from '../utils/builds';

--- a/packages/eas-cli/src/submissions/commons.ts
+++ b/packages/eas-cli/src/submissions/commons.ts
@@ -1,7 +1,6 @@
 import { Platform } from '@expo/eas-build-job';
-import * as uuid from 'uuid';
 
-import { ArchiveSource, ArchiveSourceType } from './ArchiveSource';
+import { ArchiveSource, ArchiveSourceType, isUuidV4 } from './ArchiveSource';
 import { SubmissionContext } from './context';
 
 export function resolveArchiveSource<T extends Platform>(
@@ -20,6 +19,7 @@ export function resolveArchiveSource<T extends Platform>(
       url,
       platform,
       projectId: ctx.projectId,
+      nonInteractive: ctx.nonInteractive,
     };
   } else if (path) {
     return {
@@ -27,22 +27,25 @@ export function resolveArchiveSource<T extends Platform>(
       path,
       platform,
       projectId: ctx.projectId,
+      nonInteractive: ctx.nonInteractive,
     };
   } else if (id) {
-    if (!uuid.validate(id)) {
-      throw new Error(`${id} is not an ID`);
+    if (!isUuidV4(id)) {
+      throw new Error(`${id} is not a valid ID`);
     }
     return {
       sourceType: ArchiveSourceType.buildId,
       id,
       platform,
       projectId: ctx.projectId,
+      nonInteractive: ctx.nonInteractive,
     };
   } else if (latest) {
     return {
       sourceType: ArchiveSourceType.latest,
       platform,
       projectId: ctx.projectId,
+      nonInteractive: ctx.nonInteractive,
     };
   } else if (ctx.nonInteractive) {
     throw new Error('You need to specify the archive source when running in non-interactive mode ');
@@ -51,6 +54,7 @@ export function resolveArchiveSource<T extends Platform>(
       sourceType: ArchiveSourceType.prompt,
       platform,
       projectId: ctx.projectId,
+      nonInteractive: ctx.nonInteractive,
     };
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://linear.app/expo/issue/ENG-1347/improve-feedback-when-user-enters-incorrect-url-for-build-eas-submit

# How

Detect if the user provided the build details page URL as the build artifact URL and ask if they know what they're doing. EAS CLI parses the URL and suggests submitting the build with the id from the URL.

# Test Plan

Tested manually + unit test.

<img width="1172" alt="Screenshot 2021-09-15 at 17 10 05" src="https://user-images.githubusercontent.com/5256730/133460040-f01682eb-dd1a-4a85-a6b9-55ca8095c0dc.png">
