### PR TITLE
[eas-cli] Remove Amplitude

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,8 +8,6 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@amplitude/identify": "1.7.0",
-    "@amplitude/node": "1.7.0",
     "@expo/apple-utils": "0.0.0-alpha.25",
     "@expo/config": "5.0.9",
     "@expo/config-plugins": "3.1.0",

--- a/packages/eas-cli/src/commands/analytics.ts
+++ b/packages/eas-cli/src/commands/analytics.ts
@@ -12,13 +12,13 @@ export default class AnalyticsView extends EasCommand {
   async runAsync(): Promise<void> {
     const { STATUS: status } = this.parse(AnalyticsView).args;
     if (status) {
-      await UserSettings.setAsync('amplitudeEnabled', status === 'on');
+      await UserSettings.setAsync('analyticsEnabled', status === 'on');
       Log.withTick(`${status === 'on' ? 'Enabling' : 'Disabling'} analytics.`);
     } else {
-      const amplitudeEnabled = await UserSettings.getAsync('amplitudeEnabled', null);
+      const analyticsEnabled = await UserSettings.getAsync('analyticsEnabled', null);
       Log.log(
         `Analytics are ${
-          amplitudeEnabled === false ? 'disabled' : 'enabled'
+          analyticsEnabled === false ? 'disabled' : 'enabled'
         } on this eas-cli installation.`
       );
     }

--- a/packages/eas-cli/src/user/UserSettings.ts
+++ b/packages/eas-cli/src/user/UserSettings.ts
@@ -9,6 +9,8 @@ export type UserSettingsData = {
   appleId?: string;
   amplitudeDeviceId?: string;
   amplitudeEnabled?: boolean;
+  analyticsDeviceId?: string;
+  analyticsEnabled?: boolean;
 };
 
 const UserSettings: JsonFile<UserSettingsData> = new JsonFile<UserSettingsData>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,38 +2,6 @@
 # yarn lockfile v1
 
 
-"@amplitude/identify@1.7.0", "@amplitude/identify@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@amplitude/identify/-/identify-1.7.0.tgz#ea8e435d55e55027ced0abfe1a5e250038e75f6c"
-  integrity sha512-AhaYj76cExvABu2C2Q6oO4aRNQhQkP7foQb7Lk7qW5ZPhdiWpAOGThdMre0pu5CSYF21G+FUnM6/1WQ5Cfkw3A==
-  dependencies:
-    "@amplitude/types" "^1.7.0"
-    "@amplitude/utils" "^1.7.0"
-    tslib "^1.9.3"
-
-"@amplitude/node@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@amplitude/node/-/node-1.7.0.tgz#534745e79a621ef74b1153c19c5683559ff930ac"
-  integrity sha512-+2z0V+3fVbSihbJipADvFPb2bDCLvpgDnzLkNUka606DTyLWPuoDKzawUgl2yanuFXowFYEmQ2EltuQHoXd3YQ==
-  dependencies:
-    "@amplitude/identify" "^1.7.0"
-    "@amplitude/types" "^1.7.0"
-    "@amplitude/utils" "^1.7.0"
-    tslib "^1.9.3"
-
-"@amplitude/types@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.7.0.tgz#c9f6636245f2de0ab58ee667b442cef58c42c453"
-  integrity sha512-zPENZDWlh64WHj/7Jjghu2HGWywMPundf25ycxn0tYXtxTvPmK2m/MMV6GvUN5uW0kg65eeKETCfge1UJ9MXlQ==
-
-"@amplitude/utils@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@amplitude/utils/-/utils-1.7.0.tgz#91ef07f203223ad4f5309f0c8950ebb5de6bd8eb"
-  integrity sha512-+WsKdFbA+rR/xSTlho90C+GlzDL7Sn51J4bmmGtOSTZk5oEPohvHzHO8pVBGDB8UvNAs2LjQQ7q7b2qRWdUtvA==
-  dependencies:
-    "@amplitude/types" "^1.7.0"
-    tslib "^1.9.3"
-
 "@ardatan/aggregate-error@0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz#fe6924771ea40fc98dc7a7045c2e872dc8527609"


### PR DESCRIPTION
# Checklist
- [x] I've added an entry to CHANGELOG.md if necessary.
- [ ] I've tagged the changelog entry with [EAS BUILD API] if it's a part of a breaking change to EAS Build API (only possible when updating @expo/eas-build-job package).
 
# Why

This is a follow up to #563 which removes amplitude (currently we're double tracking to ensure event volumes match). Everything's been looking good, so it seems as good a time as any to remove amplitude.

# How

Deleted references to Amplitude, uninstalled packages.

As per comments in the previous PR, I renamed user settings with `amplitude` in the name to `analytics` and included some logic to check for both strings. Eventually, we can just check for the presence of `analytics...`

# Test Plan

Ran `yarn test`, tried enabling/disabling analytics, made sure events made it to the backend when they should.