### PR TITLE
enforce Async suffix for async functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,7 @@
 module.exports = {
   root: true,
   extends: ['universe/node'],
-  overrides: [
-    {
-      files: ['**/__tests__/*'],
-    },
-  ],
-  globals: {
-    jasmine: false,
-  },
+  plugins: ['async-protect'],
   rules: {
     'no-console': 'warn',
     'no-constant-condition': ['warn', { checkLoops: false }],
@@ -42,10 +35,14 @@ module.exports = {
         allowExpressions: true,
       },
     ],
+    'async-protect/async-suffix': 'error',
   },
-  settings: {
-    react: {
-      version: 'detect',
+  overrides: [
+    {
+      files: ['**/__tests__/**/*.ts', '**/__mocks__/**/*.ts'],
+      rules: {
+        'async-protect/async-suffix': 'off',
+      },
     },
-  },
+  ],
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Reduce `eas-cli` size by almost getting rid of `lodash` from dependencies. ([#605](https://github.com/expo/eas-cli/pull/605) by [@dsokal](https://github.com/dsokal))
 - Enforce explicit return type in all functions. ([#619](https://github.com/expo/eas-cli/pull/619) by [@wkozyra95](https://github.com/wkozyra95))
+- Enforce `Async` suffix for async functions. ([#623](https://github.com/expo/eas-cli/pull/623) by [@dsokal](https://github.com/dsokal))
 
 ## [0.27.1](https://github.com/expo/eas-cli/releases/tag/v0.27.1) - 2021-09-10
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/node": "16.7.8",
     "eslint": "7.32.0",
     "eslint-config-universe": "8.0.0",
+    "eslint-plugin-async-protect": "1.1.0",
     "jest": "27.1.0",
     "jest-watch-typeahead": "0.6.4",
     "lerna": "4.0.0",

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -1,4 +1,4 @@
-import { Android, Metadata, Platform, Workflow } from '@expo/eas-build-job';
+import { Android, Job, Metadata, Platform, Workflow } from '@expo/eas-build-job';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
@@ -18,6 +18,7 @@ import { findAccountByName } from '../../user/Account';
 import {
   BuildRequestSender,
   CredentialsResult,
+  JobData,
   prepareBuildRequestForPlatformAsync,
 } from '../build';
 import { BuildContext } from '../context';
@@ -71,7 +72,12 @@ This means that it will most likely produce an AAB and you will not be able to i
     getMetadataContext: () => ({
       gradleContext,
     }),
-    prepareJobAsync,
+    prepareJobAsync: async (
+      ctx: BuildContext<Platform.ANDROID>,
+      jobData: JobData<AndroidCredentials>
+    ): Promise<Job> => {
+      return await prepareJobAsync(ctx, jobData);
+    },
     sendBuildRequestAsync: async (
       appId: string,
       job: Android.Job,

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -14,11 +14,11 @@ import { promptAsync } from '../prompts';
 import { uploadAsync } from '../uploads';
 import { formatBytes } from '../utils/files';
 import { createProgressTracker } from '../utils/progress';
-import { sleep } from '../utils/promise';
+import { sleepAsync } from '../utils/promise';
 import vcs from '../vcs';
 import { BuildContext } from './context';
 import { runLocalBuildAsync } from './local';
-import { MetadataContext, collectMetadata } from './metadata';
+import { MetadataContext, collectMetadataAsync } from './metadata';
 import { TrackingContext } from './types';
 import Analytics, { Event } from './utils/analytics';
 import { printDeprecationWarnings } from './utils/printBuildInfo';
@@ -89,7 +89,7 @@ export async function prepareBuildRequestForPlatformAsync<
       } as const);
 
   const metadataContext = builder.getMetadataContext();
-  const metadata = await collectMetadata(ctx, metadataContext);
+  const metadata = await collectMetadataAsync(ctx, metadataContext);
   const job = await builder.prepareJobAsync(ctx, {
     projectArchive,
     credentials: credentialsResult?.credentials,
@@ -369,7 +369,7 @@ export async function waitForBuildEndAsync(
       }
     }
     time = new Date().getTime();
-    await sleep(intervalSec * 1000);
+    await sleepAsync(intervalSec * 1000);
   }
   spinner.warn('Timed out');
   throw new Error(

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -11,7 +11,7 @@ const PLUGIN_PACKAGE_NAME = 'eas-cli-local-build-plugin';
 export async function runLocalBuildAsync(job: Job): Promise<void> {
   const execNameOrPath =
     process.env.EAS_LOCAL_BUILD_PLUGIN_PATH ??
-    (await findWithNodeResolution()) ??
+    (await findWithNodeResolutionAsync()) ??
     PLUGIN_PACKAGE_NAME;
   try {
     const arg = Buffer.from(JSON.stringify({ job })).toString('base64');
@@ -31,7 +31,7 @@ export async function runLocalBuildAsync(job: Job): Promise<void> {
   }
 }
 
-async function findWithNodeResolution(): Promise<string | undefined> {
+async function findWithNodeResolutionAsync(): Promise<string | undefined> {
   try {
     const resolvedPath = path.resolve(
       path.dirname(require.resolve(PLUGIN_PACKAGE_NAME)),

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -41,7 +41,7 @@ export interface IosMetadataContext {
   buildConfiguration?: string;
 }
 
-export async function collectMetadata<T extends Platform>(
+export async function collectMetadataAsync<T extends Platform>(
   ctx: BuildContext<T>,
   platformContext: MetadataContext<T>
 ): Promise<Metadata> {

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -16,6 +16,9 @@ export default abstract class EasCommand extends Command {
    */
   protected requiresAuthentication = true;
 
+  protected abstract runAsync(): Promise<any>;
+
+  // eslint-disable-next-line async-protect/async-suffix
   async init(): Promise<void> {
     await initAnalyticsAsync();
 
@@ -31,6 +34,12 @@ export default abstract class EasCommand extends Command {
     });
   }
 
+  // eslint-disable-next-line async-protect/async-suffix
+  async run(): Promise<any> {
+    return this.runAsync();
+  }
+
+  // eslint-disable-next-line async-protect/async-suffix
   async finally(err: Error): Promise<any> {
     await flushAnalyticsAsync();
     return super.finally(err);

--- a/packages/eas-cli/src/commandUtils/__tests__/TestEasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/TestEasCommand.ts
@@ -7,7 +7,7 @@ export default class TestEasCommand extends EasCommand {
     return false;
   }
 
-  async run(): Promise<void> {}
+  async runAsync(): Promise<void> {}
 }
 
 TestEasCommand.id = 'TestEasCommand'; // normally oclif will assign ids, but b/c this is located outside the commands folder it will not

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -1,14 +1,14 @@
-import { Command } from '@oclif/command';
-
+import EasCommand from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import { showLoginPromptAsync } from '../../user/actions';
 
-export default class AccountLogin extends Command {
+export default class AccountLogin extends EasCommand {
   static description = 'log in with your Expo account';
-
   static aliases = ['login'];
 
-  async run(): Promise<void> {
+  protected requiresAuthentication = false;
+
+  async runAsync(): Promise<void> {
     Log.log('Log in to EAS');
     await showLoginPromptAsync();
     Log.log('Logged in');

--- a/packages/eas-cli/src/commands/account/logout.ts
+++ b/packages/eas-cli/src/commands/account/logout.ts
@@ -1,14 +1,14 @@
-import { Command } from '@oclif/command';
-
+import EasCommand from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import { logoutAsync } from '../../user/User';
 
-export default class AccountLogout extends Command {
+export default class AccountLogout extends EasCommand {
   static description = 'log out';
-
   static aliases = ['logout'];
 
-  async run(): Promise<void> {
+  protected requiresAuthentication = false;
+
+  async runAsync(): Promise<void> {
     await logoutAsync();
     Log.log('Logged out');
   }

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -1,15 +1,16 @@
-import { Command } from '@oclif/command';
 import chalk from 'chalk';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import { getActorDisplayName, getUserAsync } from '../../user/User';
 
-export default class AccountView extends Command {
+export default class AccountView extends EasCommand {
   static description = 'show the username you are logged in as';
-
   static aliases = ['whoami'];
 
-  async run(): Promise<void> {
+  protected requiresAuthentication = false;
+
+  async runAsync(): Promise<void> {
     const user = await getUserAsync();
     if (user) {
       Log.log(chalk.green(getActorDisplayName(user)));

--- a/packages/eas-cli/src/commands/analytics.ts
+++ b/packages/eas-cli/src/commands/analytics.ts
@@ -1,14 +1,15 @@
-import { Command } from '@oclif/command';
-
+import EasCommand from '../commandUtils/EasCommand';
 import Log from '../log';
 import UserSettings from '../user/UserSettings';
 
-export default class AnalyticsView extends Command {
+export default class AnalyticsView extends EasCommand {
   static description = 'view or change analytics settings';
 
   static args = [{ name: 'STATUS', options: ['on', 'off'] }];
 
-  async run(): Promise<void> {
+  protected requiresAuthentication = false;
+
+  async runAsync(): Promise<void> {
     const { STATUS: status } = this.parse(AnalyticsView).args;
     if (status) {
       await UserSettings.setAsync('amplitudeEnabled', status === 'on');

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -1,8 +1,9 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   CreateUpdateBranchForAppMutation,
@@ -49,7 +50,7 @@ export async function createUpdateBranchOnAppAsync({
   return newBranch;
 }
 
-export default class BranchCreate extends Command {
+export default class BranchCreate extends EasCommand {
   static hidden = true;
   static description = 'Create a branch on the current project.';
 
@@ -68,7 +69,7 @@ export default class BranchCreate extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     let {
       args: { name },
       flags,

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -1,8 +1,9 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   DeleteUpdateBranchMutation,
@@ -73,7 +74,7 @@ async function deleteBranchOnAppAsync({
   return data.updateBranch.deleteUpdateBranch;
 }
 
-export default class BranchDelete extends Command {
+export default class BranchDelete extends EasCommand {
   static hidden = true;
   static description = 'Republish an update group';
 
@@ -91,7 +92,7 @@ export default class BranchDelete extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     let {
       args: { name },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -1,10 +1,11 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import CliTable from 'cli-table3';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   BranchesByAppQuery,
@@ -51,7 +52,7 @@ export async function listBranchesAsync({
   return data?.app?.byId.updateBranches ?? [];
 }
 
-export default class BranchList extends Command {
+export default class BranchList extends EasCommand {
   static hidden = true;
 
   static description = 'List all branches on this project.';
@@ -63,7 +64,7 @@ export default class BranchList extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const { flags } = this.parse(BranchList);
 
     const projectDir = await findProjectRootAsync(process.cwd());

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -1,12 +1,13 @@
 import { ExpoConfig, getConfig, getDefaultTarget } from '@expo/config';
 import { getRuntimeVersionForSDKVersion } from '@expo/sdk-runtime-versions';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import assert from 'assert';
 import chalk from 'chalk';
 import dateFormat from 'dateformat';
 import gql from 'graphql-tag';
 import ora from 'ora';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   GetUpdateGroupAsyncQuery,
@@ -66,7 +67,7 @@ async function getUpdateGroupAsync({
   return updatesByGroup;
 }
 
-async function ensureBranchExists({
+async function ensureBranchExistsAsync({
   appId,
   name: branchName,
 }: {
@@ -93,7 +94,7 @@ async function ensureBranchExists({
   return { id: newUpdateBranch.id, updates: [] };
 }
 
-export default class BranchPublish extends Command {
+export default class BranchPublish extends EasCommand {
   static hidden = true;
   static description = 'Publish an update group to a branch.';
 
@@ -144,7 +145,7 @@ export default class BranchPublish extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     let {
       args: { name: branchName },
       flags: {
@@ -201,7 +202,7 @@ export default class BranchPublish extends Command {
       assert(branchName, 'branch name must be specified.');
     }
 
-    const { id: branchId, updates } = await ensureBranchExists({
+    const { id: branchId, updates } = await ensureBranchExistsAsync({
       appId: projectId,
       name: branchName,
     });

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -1,8 +1,9 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   EditUpdateBranchInput,
@@ -49,7 +50,7 @@ async function renameUpdateBranchOnAppAsync({
   return data.updateBranch.editUpdateBranch;
 }
 
-export default class BranchRename extends Command {
+export default class BranchRename extends EasCommand {
   static hidden = true;
   static description = 'Rename a branch.';
 
@@ -68,7 +69,7 @@ export default class BranchRename extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     let {
       flags: { json: jsonFlag, from: currentName, to: newName },
     } = this.parse(BranchRename);

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -1,9 +1,10 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import Table from 'cli-table3';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import { ViewBranchQuery, ViewBranchQueryVariables } from '../../graphql/generated';
 import Log from '../../log';
@@ -64,7 +65,7 @@ export async function viewUpdateBranchAsync({
   return data;
 }
 
-export default class BranchView extends Command {
+export default class BranchView extends EasCommand {
   static hidden = true;
   static description = 'View a branch.';
 
@@ -83,7 +84,7 @@ export default class BranchView extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     let {
       args: { name },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -1,9 +1,9 @@
 import { getConfig } from '@expo/config';
-import { Command } from '@oclif/command';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 import ora from 'ora';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   Build,
@@ -109,12 +109,12 @@ async function ensureBuildExistsAsync(buildId: string): Promise<void> {
   }
 }
 
-export default class BuildCancel extends Command {
+export default class BuildCancel extends EasCommand {
   static description = 'Cancel a build.';
 
   static args = [{ name: 'BUILD_ID' }];
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const { BUILD_ID: buildIdFromArg } = this.parse(BuildCancel).args;
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -1,14 +1,14 @@
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 
 import { configureAsync } from '../../build/configure';
+import EasCommand from '../../commandUtils/EasCommand';
 import Log, { learnMore } from '../../log';
 import { RequestedPlatform } from '../../platform';
 import { findProjectRootAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import { ensureLoggedInAsync } from '../../user/actions';
 
-export default class BuildConfigure extends Command {
+export default class BuildConfigure extends EasCommand {
   static description = 'Configure the project to support EAS Build.';
 
   static flags = {
@@ -19,7 +19,7 @@ export default class BuildConfigure extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const { flags } = this.parse(BuildConfigure);
     Log.log(
       '💡 The following process will configure your iOS and/or Android project to be compatible with EAS Build. These changes only apply to your local project files and you can safely revert them at any time.'
@@ -29,7 +29,6 @@ export default class BuildConfigure extends Command {
     const platform =
       (flags.platform as RequestedPlatform | undefined) ?? (await promptForPlatformAsync());
 
-    await ensureLoggedInAsync();
     await configureAsync({
       platform,
       projectDir: (await findProjectRootAsync()) ?? process.cwd(),

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -127,7 +127,7 @@ export default class Build extends EasCommand {
 
   private metroConfigValidated = false;
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const { flags: rawFlags } = this.parse(Build);
     if (rawFlags.json) {
       enableJsonOutput();

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -1,10 +1,11 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import ora from 'ora';
 
 import { BuildDistributionType, BuildStatus } from '../../build/types';
 import { formatGraphQLBuild } from '../../build/utils/formatBuild';
+import EasCommand from '../../commandUtils/EasCommand';
 import {
   AppPlatform,
   DistributionType,
@@ -20,7 +21,7 @@ import {
 } from '../../project/projectUtils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
-export default class BuildList extends Command {
+export default class BuildList extends EasCommand {
   static description = 'list all builds for your project';
 
   static flags = {
@@ -58,7 +59,7 @@ export default class BuildList extends Command {
     limit: flags.integer(),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const { flags } = this.parse(BuildList);
     const {
       json,

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -1,8 +1,9 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import ora from 'ora';
 
 import { formatGraphQLBuild } from '../../build/utils/formatBuild';
+import EasCommand from '../../commandUtils/EasCommand';
 import { BuildFragment } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
@@ -13,7 +14,7 @@ import {
 } from '../../project/projectUtils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
-export default class BuildView extends Command {
+export default class BuildView extends EasCommand {
   static description = 'view a build for your project';
 
   static args = [{ name: 'BUILD_ID' }];
@@ -24,7 +25,7 @@ export default class BuildView extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const {
       args: { BUILD_ID: buildId },
       flags,

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -1,8 +1,9 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   CreateUpdateChannelOnAppMutation,
@@ -57,7 +58,7 @@ async function createUpdateChannelOnAppAsync({
   );
 }
 
-export default class ChannelCreate extends Command {
+export default class ChannelCreate extends EasCommand {
   static hidden = true;
   static description = 'Create a channel on the current project.';
 
@@ -77,7 +78,7 @@ export default class ChannelCreate extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     let {
       args: { name: channelName },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -1,8 +1,9 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   GetChannelByNameToEditQuery,
@@ -92,7 +93,7 @@ export async function updateChannelBranchMappingAsync({
   return data.updateChannel.editUpdateChannel!;
 }
 
-export default class ChannelEdit extends Command {
+export default class ChannelEdit extends EasCommand {
   static hidden = true;
   static description = 'Point a channel at a new branch.';
 
@@ -114,7 +115,7 @@ export default class ChannelEdit extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     let {
       args: { name: channelName },
       flags: { branch: branchName, json: jsonFlag },

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -1,7 +1,8 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   GetAllChannelsForAppQuery,
@@ -63,7 +64,7 @@ async function getAllUpdateChannelForAppAsync({
   );
 }
 
-export default class ChannelList extends Command {
+export default class ChannelList extends EasCommand {
   static hidden = true;
   static description = 'List all channels on the current project.';
 
@@ -74,7 +75,7 @@ export default class ChannelList extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const {
       flags: { json: jsonFlag },
     } = this.parse(ChannelList);

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -1,7 +1,8 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { GetChannelByNameForAppQuery, UpdateBranch } from '../../graphql/generated';
 import Log from '../../log';
 import {
@@ -305,7 +306,7 @@ async function endRolloutAsync({
   return { newChannelInfo, logMessage };
 }
 
-export default class ChannelRollout extends Command {
+export default class ChannelRollout extends EasCommand {
   static hidden = true;
   static description = 'Rollout a new branch out to a channel incrementally.';
 
@@ -336,7 +337,7 @@ export default class ChannelRollout extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const {
       args: { channel: channelName },
       flags: { json: jsonFlag, end: endFlag },

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -1,10 +1,11 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import assert from 'assert';
 import chalk from 'chalk';
 import Table from 'cli-table3';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   GetChannelByNameForAppQuery,
@@ -189,7 +190,7 @@ export function logChannelDetails(channel: {
   Log.log(table.toString());
 }
 
-export default class ChannelView extends Command {
+export default class ChannelView extends EasCommand {
   static hidden = true;
   static description = 'View a channel on the current project.';
 
@@ -208,7 +209,7 @@ export default class ChannelView extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     let {
       args: { name: channelName },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -1,15 +1,16 @@
 import { getProjectConfigDescription } from '@expo/config';
 import { Platform } from '@expo/eas-build-job';
 import { EasJsonReader } from '@expo/eas-json';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 
+import EasCommand from '../commandUtils/EasCommand';
 import Log from '../log';
 import { getExpoConfig } from '../project/expoConfig';
 import { findProjectRootAsync } from '../project/projectUtils';
 import { selectAsync } from '../prompts';
 import { handleDeprecatedEasJsonAsync } from './build';
 
-export default class Config extends Command {
+export default class Config extends EasCommand {
   static description = 'show the eas.json config';
 
   static flags = {
@@ -17,7 +18,9 @@ export default class Config extends Command {
     profile: flags.string(),
   };
 
-  async run(): Promise<void> {
+  protected requiresAuthentication = false;
+
+  async runAsync(): Promise<void> {
     const { flags } = this.parse(Config);
     const { platform: maybePlatform, profile: maybeProfile } = flags as {
       platform?: Platform;

--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -5,7 +5,7 @@ import { SelectPlatform } from '../credentials/manager/SelectPlatform';
 export default class Credentials extends EasCommand {
   static description = 'manage your credentials';
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const ctx = await createCredentialsContextAsync(process.cwd(), {});
     await new SelectPlatform().runAsync(ctx);
   }

--- a/packages/eas-cli/src/commands/device/create.ts
+++ b/packages/eas-cli/src/commands/device/create.ts
@@ -1,17 +1,16 @@
-import { Command } from '@oclif/command';
-
+import EasCommand from '../../commandUtils/EasCommand';
 import AppStoreApi from '../../credentials/ios/appstore/AppStoreApi';
-import { createContext } from '../../devices/context';
+import { createContextAsync } from '../../devices/context';
 import DeviceManager from '../../devices/manager';
 import { ensureLoggedInAsync } from '../../user/actions';
 
-export default class DeviceCreate extends Command {
+export default class DeviceCreate extends EasCommand {
   static description = 'register new Apple Devices to use for internal distribution';
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const user = await ensureLoggedInAsync();
 
-    const ctx = await createContext({ appStore: new AppStoreApi(), user });
+    const ctx = await createContextAsync({ appStore: new AppStoreApi(), user });
     const manager = new DeviceManager(ctx);
     await manager.createAsync();
   }

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -1,9 +1,10 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import assert from 'assert';
 import chalk from 'chalk';
 import ora from 'ora';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import { AppleTeamQuery } from '../../credentials/ios/api/graphql/queries/AppleTeamQuery';
 import formatDevice from '../../devices/utils/formatDevice';
@@ -11,14 +12,14 @@ import Log from '../../log';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 
-export default class BuildList extends Command {
+export default class BuildList extends EasCommand {
   static description = 'list all registered devices for your account';
 
   static flags = {
     'apple-team-id': flags.string(),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     let appleTeamIdentifier = this.parse(BuildList).flags['apple-team-id'];
 
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -1,18 +1,18 @@
 import { getConfig } from '@expo/config';
-import { Command } from '@oclif/command';
 import ora from 'ora';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import formatDevice from '../../devices/utils/formatDevice';
 import Log from '../../log';
 import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
 
-export default class DeviceView extends Command {
+export default class DeviceView extends EasCommand {
   static description = 'view a device for your project';
 
   static args = [{ name: 'UDID' }];
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const { UDID } = this.parse(DeviceView).args;
 
     if (!UDID) {
@@ -36,7 +36,7 @@ If you are not sure what is the UDID of the device you are looking for, run:
     const spinner = ora().start(`Fetching device details for ${UDID}…`);
 
     try {
-      const device = await AppleDeviceQuery.getByDeviceIdentifier(accountName, UDID);
+      const device = await AppleDeviceQuery.getByDeviceIdentifierAsync(accountName, UDID);
 
       if (device) {
         spinner.succeed('Fetched device details');

--- a/packages/eas-cli/src/commands/diagnostics.ts
+++ b/packages/eas-cli/src/commands/diagnostics.ts
@@ -1,14 +1,16 @@
-import { Command } from '@oclif/command';
 import envinfo from 'envinfo';
 
+import EasCommand from '../commandUtils/EasCommand';
 import Log from '../log';
 
 const packageJSON = require('../../package.json');
 
-export default class Diagnostics extends Command {
+export default class Diagnostics extends EasCommand {
   static description = 'log environment info to the console';
 
-  async run(): Promise<void> {
+  protected requiresAuthentication = false;
+
+  async runAsync(): Promise<void> {
     const info = await envinfo.run(
       {
         System: ['OS', 'Shell'],

--- a/packages/eas-cli/src/commands/project/info.ts
+++ b/packages/eas-cli/src/commands/project/info.ts
@@ -1,7 +1,7 @@
 import { getConfig } from '@expo/config';
-import { Command } from '@oclif/command';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import { AppInfoQuery, AppInfoQueryVariables } from '../../graphql/generated';
 import Log from '../../log';
@@ -30,10 +30,10 @@ async function projectInfoByIdAsync(appId: string): Promise<AppInfoQuery> {
   return data;
 }
 
-export default class ProjectInfo extends Command {
+export default class ProjectInfo extends EasCommand {
   static description = 'information about the current project';
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const projectDir = await findProjectRootAsync(process.cwd());
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -1,15 +1,15 @@
 import { getConfig } from '@expo/config';
-import { Command } from '@oclif/command';
 import chalk from 'chalk';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import { findProjectRootAsync, setProjectIdAsync } from '../../project/projectUtils';
 
-export default class ProjectInit extends Command {
+export default class ProjectInit extends EasCommand {
   static description = 'create or link an EAS project';
   static aliases = ['init'];
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const projectDir = await findProjectRootAsync(process.cwd());
     if (!projectDir) {
       throw new Error('Please run this command inside a project directory.');

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -1,7 +1,8 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
 import {
   EnvironmentSecretScope,
@@ -22,7 +23,7 @@ import { findAccountByName } from '../../user/Account';
 import { getActorDisplayName } from '../../user/User';
 import { ensureLoggedInAsync } from '../../user/actions';
 
-export default class EnvironmentSecretCreate extends Command {
+export default class EnvironmentSecretCreate extends EasCommand {
   static description = 'Create an environment secret on the current project or owner account.';
 
   static flags = {
@@ -43,7 +44,7 @@ export default class EnvironmentSecretCreate extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const actor = await ensureLoggedInAsync();
     let {
       flags: { name, value: secretValue, scope, force },
@@ -123,7 +124,7 @@ export default class EnvironmentSecretCreate extends Command {
         const existingSecret = existingSecrets.find(secret => secret.name === name);
 
         if (existingSecret) {
-          await EnvironmentSecretMutation.delete(existingSecret.id);
+          await EnvironmentSecretMutation.deleteAsync(existingSecret.id);
           Log.withTick(
             `Deleting existing secret ${chalk.bold(name)} on project ${chalk.bold(
               `@${accountName}/${slug}`
@@ -132,7 +133,7 @@ export default class EnvironmentSecretCreate extends Command {
         }
       }
 
-      const secret = await EnvironmentSecretMutation.createForApp(
+      const secret = await EnvironmentSecretMutation.createForAppAsync(
         { name, value: secretValue },
         projectId
       );
@@ -164,7 +165,7 @@ export default class EnvironmentSecretCreate extends Command {
         const existingSecret = existingSecrets.find(secret => secret.name === name);
 
         if (existingSecret) {
-          await EnvironmentSecretMutation.delete(existingSecret.id);
+          await EnvironmentSecretMutation.deleteAsync(existingSecret.id);
 
           Log.withTick(
             `Deleting existing secret ${chalk.bold(name)} on account ${chalk.bold(
@@ -174,7 +175,7 @@ export default class EnvironmentSecretCreate extends Command {
         }
       }
 
-      const secret = await EnvironmentSecretMutation.createForAccount(
+      const secret = await EnvironmentSecretMutation.createForAccountAsync(
         { name, value: secretValue },
         ownerAccount.id
       );

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -1,7 +1,8 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
 import {
   EnvironmentSecretScope,
@@ -19,9 +20,8 @@ import {
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
-import { ensureLoggedInAsync } from '../../user/actions';
 
-export default class EnvironmentSecretDelete extends Command {
+export default class EnvironmentSecretDelete extends EasCommand {
   static description = `Delete an environment secret by ID.
 Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
 
@@ -31,9 +31,7 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
     }),
   };
 
-  async run(): Promise<void> {
-    await ensureLoggedInAsync();
-
+  async runAsync(): Promise<void> {
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
@@ -93,7 +91,7 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
       process.exit(1);
     }
 
-    await EnvironmentSecretMutation.delete(id);
+    await EnvironmentSecretMutation.deleteAsync(id);
 
     Log.withTick(`️Deleted secret${secret?.name ? ` "${secret?.name}"` : ''} with id "${id}".`);
   }

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -1,9 +1,9 @@
 import { getConfig } from '@expo/config';
-import { Command } from '@oclif/command';
 import chalk from 'chalk';
 import Table from 'cli-table3';
 import dateFormat from 'dateformat';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { EnvironmentSecretsQuery } from '../../graphql/queries/EnvironmentSecretsQuery';
 import Log from '../../log';
 import {
@@ -15,14 +15,11 @@ import {
   getProjectAccountNameAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
-import { ensureLoggedInAsync } from '../../user/actions';
 
-export default class EnvironmentSecretList extends Command {
+export default class EnvironmentSecretList extends EasCommand {
   static description = 'Lists environment secrets available for your current app';
 
-  async run(): Promise<void> {
-    await ensureLoggedInAsync();
-
+  async runAsync(): Promise<void> {
     const projectDir = (await findProjectRootAsync()) ?? process.cwd();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -89,7 +89,7 @@ See how to configure submits with eas.json: ${learnMore('https://docs.expo.dev/s
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const { flags: rawFlags } = this.parse(Submit);
     const flags = await this.sanitizeFlagsAsync(rawFlags);
 

--- a/packages/eas-cli/src/commands/update/delete.ts
+++ b/packages/eas-cli/src/commands/update/delete.ts
@@ -1,7 +1,8 @@
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
   DeleteUpdateGroupMutation,
@@ -33,7 +34,7 @@ async function deleteUpdateGroupAsync({
   );
 }
 
-export default class UpdateDelete extends Command {
+export default class UpdateDelete extends EasCommand {
   static hidden = true;
   static description = 'Delete all the updates in an update Group.';
 
@@ -52,7 +53,7 @@ export default class UpdateDelete extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const {
       args: { groupId: group },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -1,7 +1,8 @@
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import Table from 'cli-table3';
 import gql from 'graphql-tag';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import { UpdatesByGroupQuery, UpdatesByGroupQueryVariables } from '../../graphql/generated';
 import Log from '../../log';
@@ -47,7 +48,7 @@ export async function viewUpdateAsync({
   }
   return data;
 }
-export default class UpdateView extends Command {
+export default class UpdateView extends EasCommand {
   static hidden = true;
   static description = 'Update group details.';
 
@@ -66,7 +67,7 @@ export default class UpdateView extends Command {
     }),
   };
 
-  async run(): Promise<void> {
+  async runAsync(): Promise<void> {
     const {
       args: { groupId },
       flags: { json: jsonFlag },

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -1,14 +1,14 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import ora from 'ora';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
-import { ensureLoggedInAsync } from '../../user/actions';
 import { prepareInputParamsAsync } from '../../webhooks/input';
 
-export default class WebhookCreate extends Command {
+export default class WebhookCreate extends EasCommand {
   static description = 'Create a webhook on the current project.';
 
   static flags = {
@@ -26,8 +26,7 @@ export default class WebhookCreate extends Command {
     }),
   };
 
-  async run(): Promise<void> {
-    await ensureLoggedInAsync();
+  async runAsync(): Promise<void> {
     const { flags } = this.parse(WebhookCreate);
     const webhookInputParams = await prepareInputParamsAsync(flags);
 

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -1,20 +1,19 @@
 import { getConfig } from '@expo/config';
-import { Command } from '@oclif/command';
 import assert from 'assert';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 import ora from 'ora';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { WebhookFragment } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import Log from '../../log';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
-import { ensureLoggedInAsync } from '../../user/actions';
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
-export default class WebhookDelete extends Command {
+export default class WebhookDelete extends EasCommand {
   static description = 'Delete a webhook on the current project.';
 
   static args = [
@@ -25,8 +24,7 @@ export default class WebhookDelete extends Command {
     },
   ];
 
-  async run(): Promise<void> {
-    await ensureLoggedInAsync();
+  async runAsync(): Promise<void> {
     let {
       args: { ID: webhookId },
     } = this.parse(WebhookDelete);

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -1,8 +1,9 @@
 import { getConfig } from '@expo/config';
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import chalk from 'chalk';
 import ora from 'ora';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import Log from '../../log';
@@ -11,10 +12,9 @@ import {
   getProjectFullNameAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
-import { ensureLoggedInAsync } from '../../user/actions';
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
-export default class WebhookList extends Command {
+export default class WebhookList extends EasCommand {
   static description = 'List webhooks on the current project.';
 
   static flags = {
@@ -24,8 +24,7 @@ export default class WebhookList extends Command {
     }),
   };
 
-  async run(): Promise<void> {
-    await ensureLoggedInAsync();
+  async runAsync(): Promise<void> {
     const {
       flags: { event },
     } = this.parse(WebhookList);

--- a/packages/eas-cli/src/commands/webhook/update.ts
+++ b/packages/eas-cli/src/commands/webhook/update.ts
@@ -1,14 +1,14 @@
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import ora from 'ora';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
-import { ensureLoggedInAsync } from '../../user/actions';
 import pick from '../../utils/expodash/pick';
 import { prepareInputParamsAsync } from '../../webhooks/input';
 
-export default class WebhookUpdate extends Command {
+export default class WebhookUpdate extends EasCommand {
   static description = 'Create a webhook on the current project.';
 
   static flags = {
@@ -30,8 +30,7 @@ export default class WebhookUpdate extends Command {
     }),
   };
 
-  async run(): Promise<void> {
-    await ensureLoggedInAsync();
+  async runAsync(): Promise<void> {
     const { flags } = this.parse(WebhookUpdate);
 
     const webhookId = flags.id;

--- a/packages/eas-cli/src/commands/webhook/view.ts
+++ b/packages/eas-cli/src/commands/webhook/view.ts
@@ -1,12 +1,11 @@
-import { Command } from '@oclif/command';
 import ora from 'ora';
 
+import EasCommand from '../../commandUtils/EasCommand';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import Log from '../../log';
-import { ensureLoggedInAsync } from '../../user/actions';
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
-export default class WebhookView extends Command {
+export default class WebhookView extends EasCommand {
   static description = 'View a webhook on the current project.';
 
   static args = [
@@ -17,8 +16,7 @@ export default class WebhookView extends Command {
     },
   ];
 
-  async run(): Promise<void> {
-    await ensureLoggedInAsync();
+  async runAsync(): Promise<void> {
     const {
       args: { ID: webhookId },
     } = this.parse(WebhookView);

--- a/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
@@ -192,7 +192,7 @@ export async function createKeystoreAsync(
   account: Account,
   keystore: KeystoreWithType
 ): Promise<AndroidKeystoreFragment> {
-  return await AndroidKeystoreMutation.createAndroidKeystore(
+  return await AndroidKeystoreMutation.createAndroidKeystoreAsync(
     {
       base64EncodedKeystore: keystore.keystore,
       keystorePassword: keystore.keystorePassword,
@@ -205,7 +205,7 @@ export async function createKeystoreAsync(
 }
 
 export async function deleteKeystoreAsync(keystore: AndroidKeystoreFragment): Promise<void> {
-  return await AndroidKeystoreMutation.deleteAndroidKeystore(keystore.id);
+  return await AndroidKeystoreMutation.deleteAndroidKeystoreAsync(keystore.id);
 }
 
 export async function createFcmAsync(
@@ -213,11 +213,14 @@ export async function createFcmAsync(
   fcmApiKey: string,
   version: AndroidFcmVersion
 ): Promise<AndroidFcmFragment> {
-  return await AndroidFcmMutation.createAndroidFcm({ credential: fcmApiKey, version }, account.id);
+  return await AndroidFcmMutation.createAndroidFcmAsync(
+    { credential: fcmApiKey, version },
+    account.id
+  );
 }
 
 export async function deleteFcmAsync(fcm: AndroidFcmFragment): Promise<void> {
-  return await AndroidFcmMutation.deleteAndroidFcm(fcm.id);
+  return await AndroidFcmMutation.deleteAndroidFcmAsync(fcm.id);
 }
 
 async function getAppAsync(appLookupParams: AppLookupParams): Promise<AppFragment> {

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidFcmMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidFcmMutation.ts
@@ -12,7 +12,7 @@ import {
 import { AndroidFcmFragmentNode } from '../../../../../graphql/types/credentials/AndroidFcm';
 
 const AndroidFcmMutation = {
-  async createAndroidFcm(
+  async createAndroidFcmAsync(
     androidFcmInput: AndroidFcmInput,
     accountId: string
   ): Promise<AndroidFcmFragment> {
@@ -43,7 +43,7 @@ const AndroidFcmMutation = {
     );
     return data.androidFcm.createAndroidFcm;
   },
-  async deleteAndroidFcm(androidFcmId: string): Promise<void> {
+  async deleteAndroidFcmAsync(androidFcmId: string): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteAndroidFcmMutation>(

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
@@ -12,7 +12,7 @@ import {
 import { AndroidKeystoreFragmentNode } from '../../../../../graphql/types/credentials/AndroidKeystore';
 
 const AndroidKeystoreMutation = {
-  async createAndroidKeystore(
+  async createAndroidKeystoreAsync(
     androidKeystoreInput: AndroidKeystoreInput,
     accountId: string
   ): Promise<AndroidKeystoreFragment> {
@@ -49,7 +49,7 @@ const AndroidKeystoreMutation = {
     );
     return data.androidKeystore.createAndroidKeystore;
   },
-  async deleteAndroidKeystore(androidKeystoreId: string): Promise<void> {
+  async deleteAndroidKeystoreAsync(androidKeystoreId: string): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteAndroidKeystoreMutation>(

--- a/packages/eas-cli/src/credentials/ios/actions/DeviceUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DeviceUtils.ts
@@ -2,7 +2,7 @@ import { AppleDevice, AppleDeviceFragment } from '../../../graphql/generated';
 import { APPLE_DEVICE_CLASS_LABELS } from '../../../graphql/types/credentials/AppleDevice';
 import { promptAsync } from '../.././../prompts';
 
-export async function chooseDevices(
+export async function chooseDevicesAsync(
   allDevices: AppleDeviceFragment[],
   preselectedDeviceIdentifiers: string[] = []
 ): Promise<AppleDevice[]> {

--- a/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
@@ -8,7 +8,7 @@ import { fromNow } from '../../../utils/date';
 import { Context } from '../../context';
 import { askForUserProvidedAsync } from '../../utils/promptForCredentials';
 import { PushKey, PushKeyStoreInfo } from '../appstore/Credentials.types';
-import { filterRevokedAndUntrackedPushKeysFromEasServers } from '../appstore/CredentialsUtils';
+import { filterRevokedAndUntrackedPushKeysFromEasServersAsync } from '../appstore/CredentialsUtils';
 import { APPLE_KEYS_TOO_MANY_GENERATED_ERROR } from '../appstore/pushKey';
 import { pushKeySchema } from '../credentials';
 import { isPushKeyValidAndTrackedAsync } from '../validators/validatePushKey';
@@ -137,7 +137,7 @@ export async function getValidAndTrackedPushKeysOnEasServersAsync(
   pushKeysForAccount: ApplePushKeyFragment[]
 ): Promise<ApplePushKeyFragment[]> {
   const pushInfoFromApple = await ctx.appStore.listPushKeysAsync();
-  return await filterRevokedAndUntrackedPushKeysFromEasServers(
+  return await filterRevokedAndUntrackedPushKeysFromEasServersAsync(
     pushKeysForAccount,
     pushInfoFromApple
   );

--- a/packages/eas-cli/src/credentials/ios/actions/SetupAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupAdhocProvisioningProfile.ts
@@ -20,7 +20,7 @@ import { AppLookupParams } from '../api/GraphqlClient';
 import { validateProvisioningProfileAsync } from '../validators/validateProvisioningProfile';
 import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
 import { assignBuildCredentialsAsync, getBuildCredentialsAsync } from './BuildCredentialsUtils';
-import { chooseDevices, formatDeviceLabel } from './DeviceUtils';
+import { chooseDevicesAsync, formatDeviceLabel } from './DeviceUtils';
 import { SetupDistributionCertificate } from './SetupDistributionCertificate';
 
 export class SetupAdhocProvisioningProfile {
@@ -97,7 +97,10 @@ export class SetupAdhocProvisioningProfile {
     const provisionedDeviceIdentifiers = (
       currentBuildCredentials?.provisioningProfile?.appleDevices ?? []
     ).map(i => i.identifier);
-    const chosenDevices = await chooseDevices(registeredAppleDevices, provisionedDeviceIdentifiers);
+    const chosenDevices = await chooseDevicesAsync(
+      registeredAppleDevices,
+      provisionedDeviceIdentifiers
+    );
 
     // 4. Reuse or create the profile on Apple Developer Portal
     const provisioningProfileStoreInfo =

--- a/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupDistributionCertificate.ts
@@ -71,7 +71,7 @@ export class SetupDistributionCertificate {
     const validDistCertsOnFile = await this.getValidDistCertsAsync(ctx);
     return validDistCertsOnFile.length === 0
       ? await this.createNewDistCertAsync(ctx)
-      : await this.createOrReuseDistCert(ctx);
+      : await this.createOrReuseDistCertAsync(ctx);
   }
 
   private async isCurrentCertificateValidAsync(
@@ -107,7 +107,9 @@ export class SetupDistributionCertificate {
     return isValid;
   }
 
-  private async createOrReuseDistCert(ctx: Context): Promise<AppleDistributionCertificateFragment> {
+  private async createOrReuseDistCertAsync(
+    ctx: Context
+  ): Promise<AppleDistributionCertificateFragment> {
     const validDistCerts = await this.getValidDistCertsAsync(ctx);
     const autoselectedDistCert = validDistCerts[0];
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetupPushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupPushKey.ts
@@ -37,16 +37,16 @@ export class SetupPushKey {
     if (pushKeysForAccount.length === 0) {
       pushKey = await new CreatePushKey(this.app.account).runAsync(ctx);
     } else {
-      pushKey = await this.createOrReusePushKey(ctx);
+      pushKey = await this.createOrReusePushKeyAsync(ctx);
     }
     return await new AssignPushKey(this.app).runAsync(ctx, pushKey);
   }
 
-  private async createOrReusePushKey(ctx: Context): Promise<ApplePushKeyFragment> {
+  private async createOrReusePushKeyAsync(ctx: Context): Promise<ApplePushKeyFragment> {
     const pushKeysForAccount = await ctx.ios.getPushKeysForAccountAsync(this.app.account);
     assert(
       pushKeysForAccount.length > 0,
-      'createOrReusePushKey: There are no Push Keys available in your EAS account.'
+      'createOrReusePushKeyAsync: There are no Push Keys available in your EAS account.'
     );
 
     if (ctx.appStore.authCtx) {

--- a/packages/eas-cli/src/credentials/ios/actions/SetupTargetBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupTargetBuildCredentials.ts
@@ -37,14 +37,14 @@ export class SetupTargetBuildCredentials implements Action<IosAppBuildCredential
       );
     }
     try {
-      return await this.setupBuildCredentials(ctx);
+      return await this.setupBuildCredentialsAsync(ctx);
     } catch (error) {
       Log.error('Failed to setup credentials.');
       throw error;
     }
   }
 
-  async setupBuildCredentials(ctx: Context): Promise<IosAppBuildCredentialsFragment> {
+  async setupBuildCredentialsAsync(ctx: Context): Promise<IosAppBuildCredentialsFragment> {
     const { app, distribution, enterpriseProvisioning } = this.options;
     if (distribution === 'internal') {
       if (enterpriseProvisioning === 'adhoc') {

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/DistributionCertificateUtils-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/DistributionCertificateUtils-test.ts
@@ -14,7 +14,7 @@ mockdate.set(new Date('4/20/2021'));
 describe('select credentials', () => {
   it('select an AppleDistributionCertificate fragment', async () => {
     const testDistCerts = (
-      await AppleDistributionCertificateQuery.getAllForAccount('quinAccount')
+      await AppleDistributionCertificateQuery.getAllForAccountAsync('quinAccount')
     ).sort((a, b) => (a.serialNumber > b.serialNumber ? 1 : -1));
     const loggedSoFar = testDistCerts
       .map(cert => formatDistributionCertificate(cert))

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -347,7 +347,7 @@ export async function getDistributionCertificateForAppAsync(
 export async function getDistributionCertificatesForAccountAsync(
   account: Account
 ): Promise<AppleDistributionCertificateFragment[]> {
-  return await AppleDistributionCertificateQuery.getAllForAccount(account.name);
+  return await AppleDistributionCertificateQuery.getAllForAccountAsync(account.name);
 }
 
 export async function createDistributionCertificateAsync(
@@ -358,7 +358,7 @@ export async function createDistributionCertificateAsync(
     appleTeamIdentifier: distCert.teamId,
     appleTeamName: distCert.teamName,
   });
-  return await AppleDistributionCertificateMutation.createAppleDistributionCertificate(
+  return await AppleDistributionCertificateMutation.createAppleDistributionCertificateAsync(
     {
       certP12: distCert.certP12,
       certPassword: distCert.certPassword,
@@ -373,7 +373,7 @@ export async function createDistributionCertificateAsync(
 export async function deleteDistributionCertificateAsync(
   distributionCertificateId: string
 ): Promise<void> {
-  return await AppleDistributionCertificateMutation.deleteAppleDistributionCertificate(
+  return await AppleDistributionCertificateMutation.deleteAppleDistributionCertificateAsync(
     distributionCertificateId
   );
 }
@@ -386,7 +386,7 @@ export async function createPushKeyAsync(
     appleTeamIdentifier: pushKey.teamId,
     appleTeamName: pushKey.teamName,
   });
-  return await ApplePushKeyMutation.createApplePushKey(
+  return await ApplePushKeyMutation.createApplePushKeyAsync(
     {
       keyP8: pushKey.apnsKeyP8,
       keyIdentifier: pushKey.apnsKeyId,
@@ -399,7 +399,7 @@ export async function createPushKeyAsync(
 export async function getPushKeysForAccountAsync(
   account: Account
 ): Promise<ApplePushKeyFragment[]> {
-  return await ApplePushKeyQuery.getAllForAccount(account.name);
+  return await ApplePushKeyQuery.getAllForAccountAsync(account.name);
 }
 
 export async function getPushKeyForAppAsync(
@@ -410,7 +410,7 @@ export async function getPushKeyForAppAsync(
 }
 
 export async function deletePushKeyAsync(pushKeyId: string): Promise<void> {
-  return await ApplePushKeyMutation.deleteApplePushKey(pushKeyId);
+  return await ApplePushKeyMutation.deleteApplePushKeyAsync(pushKeyId);
 }
 
 const formatProjectFullName = ({ account, projectName }: AppLookupParams): string =>

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
@@ -18,7 +18,7 @@ export type AppleDistributionCertificateMutationResult = AppleDistributionCertif
 };
 
 const AppleDistributionCertificateMutation = {
-  async createAppleDistributionCertificate(
+  async createAppleDistributionCertificateAsync(
     appleDistributionCertificateInput: AppleDistributionCertificateInput,
     accountId: string
   ): Promise<AppleDistributionCertificateMutationResult> {
@@ -60,7 +60,9 @@ const AppleDistributionCertificateMutation = {
     );
     return data.appleDistributionCertificate.createAppleDistributionCertificate;
   },
-  async deleteAppleDistributionCertificate(appleDistributionCertificateId: string): Promise<void> {
+  async deleteAppleDistributionCertificateAsync(
+    appleDistributionCertificateId: string
+  ): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteAppleDistributionCertificateMutation>(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/ApplePushKeyMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/ApplePushKeyMutation.ts
@@ -12,7 +12,7 @@ import {
 import { ApplePushKeyFragmentNode } from '../../../../../graphql/types/credentials/ApplePushKey';
 
 const ApplePushKeyMutation = {
-  async createApplePushKey(
+  async createApplePushKeyAsync(
     applePushKeyInput: ApplePushKeyInput,
     accountId: string
   ): Promise<ApplePushKeyFragment> {
@@ -46,7 +46,7 @@ const ApplePushKeyMutation = {
     );
     return data.applePushKey.createApplePushKey;
   },
-  async deleteApplePushKey(applePushKeyId: string): Promise<void> {
+  async deleteApplePushKeyAsync(applePushKeyId: string): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteApplePushKeyMutation>(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -119,7 +119,7 @@ const AppleDeviceQuery = {
     return data.account.byName.appleTeams[0];
   },
 
-  async getByDeviceIdentifier(
+  async getByDeviceIdentifierAsync(
     accountName: string,
     identifier: string
   ): Promise<AppleDevicesByIdentifierQueryResult | null> {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
@@ -71,7 +71,9 @@ const AppleDistributionCertificateQuery = {
         ?.distributionCertificate ?? null
     );
   },
-  async getAllForAccount(accountName: string): Promise<AppleDistributionCertificateFragment[]> {
+  async getAllForAccountAsync(
+    accountName: string
+  ): Promise<AppleDistributionCertificateFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<AppleDistributionCertificateByAccountQuery>(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/ApplePushKeyQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/ApplePushKeyQuery.ts
@@ -6,7 +6,7 @@ import { ApplePushKeyByAccountQuery, ApplePushKeyFragment } from '../../../../..
 import { ApplePushKeyFragmentNode } from '../../../../../graphql/types/credentials/ApplePushKey';
 
 const ApplePushKeyQuery = {
-  async getAllForAccount(accountName: string): Promise<ApplePushKeyFragment[]> {
+  async getAllForAccountAsync(accountName: string): Promise<ApplePushKeyFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<ApplePushKeyByAccountQuery>(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/AppleDistributionCertificateQuery.ts
@@ -1,5 +1,5 @@
 const AppleDistributionCertificateQuery = {
-  getAllForAccount: jest.fn().mockImplementation(() => {
+  getAllForAccountAsync: jest.fn().mockImplementation(() => {
     return [
       {
         id: '6a7422cc-392b-451d-984c-b0b4b027680a',

--- a/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/CredentialsUtils.ts
@@ -14,7 +14,7 @@ import {
  * It is possible an uploaded key could have a valid p8 but invalid identifier, making it impossible for us to
  * track it's status on the Apple Developer Portal
  */
-export async function filterRevokedAndUntrackedPushKeys<T extends PushKey>(
+export async function filterRevokedAndUntrackedPushKeysAsync<T extends PushKey>(
   pushKeys: T[],
   pushInfoFromApple: PushKeyStoreInfo[]
 ): Promise<T[]> {
@@ -30,7 +30,7 @@ export async function filterRevokedAndUntrackedPushKeys<T extends PushKey>(
  * It is possible an uploaded key could have a valid p8 but invalid identifier, making it impossible for us to
  * track it's status on the Apple Developer Portal
  */
-export async function filterRevokedAndUntrackedPushKeysFromEasServers(
+export async function filterRevokedAndUntrackedPushKeysFromEasServersAsync(
   pushKeys: ApplePushKeyFragment[],
   pushInfoFromApple: PushKeyStoreInfo[]
 ): Promise<ApplePushKeyFragment[]> {

--- a/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
@@ -24,7 +24,7 @@ export async function getCertificateBySerialNumberAsync(
   return cert;
 }
 
-export async function getDistributionCertificateAync(
+export async function getDistributionCertificateAsync(
   context: RequestContext,
   serialNumber: string
 ): Promise<Certificate | null> {

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -76,11 +76,11 @@ export async function ensureBundleIdExistsWithNameAsync(
   }
 
   if (options) {
-    await syncCapabilities(bundleId, options);
+    await syncCapabilitiesAsync(bundleId, options);
   }
 }
 
-export async function syncCapabilities(
+export async function syncCapabilitiesAsync(
   bundleId: BundleId,
   { entitlements }: IosCapabilitiesOptions
 ): Promise<void> {

--- a/packages/eas-cli/src/credentials/ios/appstore/keychain.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/keychain.ts
@@ -13,7 +13,7 @@ interface Credentials {
   password: string;
 }
 
-export function deletePasswordAsync({
+export async function deletePasswordAsync({
   username,
   serviceName,
 }: Pick<Credentials, 'username' | 'serviceName'>): Promise<boolean> {
@@ -63,7 +63,7 @@ export async function getPasswordAsync({
   });
 }
 
-export function setPasswordAsync({
+export async function setPasswordAsync({
   serviceName,
   username,
   password,

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -4,7 +4,7 @@ import ora from 'ora';
 import { ProvisioningProfile } from './Credentials.types';
 import { AuthCtx, getRequestContext } from './authenticate';
 import { getBundleIdForIdentifierAsync, getProfilesForBundleIdAsync } from './bundleId';
-import { getDistributionCertificateAync } from './distributionCertificate';
+import { getDistributionCertificateAsync } from './distributionCertificate';
 
 interface ProfileResults {
   didUpdate?: boolean;
@@ -80,7 +80,10 @@ async function findProfileByBundleIdAsync(
   } else if (expoProfiles) {
     // there is an expo managed profile, but it doesn't have our desired certificate
     // append the certificate and update the profile
-    const distributionCertificate = await getDistributionCertificateAync(context, certSerialNumber);
+    const distributionCertificate = await getDistributionCertificateAsync(
+      context,
+      certSerialNumber
+    );
     if (!distributionCertificate) {
       throw new Error(`Certificate for serial number "${certSerialNumber}" does not exist`);
     }
@@ -190,7 +193,7 @@ async function manageAdHocProfilesAsync(
   // No existing profile...
 
   // We need to find user's distribution certificate to make a provisioning profile for it.
-  const distributionCertificate = await getDistributionCertificateAync(context, certSerialNumber);
+  const distributionCertificate = await getDistributionCertificateAsync(context, certSerialNumber);
 
   if (!distributionCertificate) {
     // If the distribution certificate doesn't exist, the user must have deleted it, we can't do anything here :(

--- a/packages/eas-cli/src/credentials/ios/validators/validatePushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validatePushKey.ts
@@ -1,12 +1,12 @@
 import { Context } from '../../context';
 import { PushKey } from '../appstore/Credentials.types';
-import { filterRevokedAndUntrackedPushKeys } from '../appstore/CredentialsUtils';
+import { filterRevokedAndUntrackedPushKeysAsync } from '../appstore/CredentialsUtils';
 
 export async function isPushKeyValidAndTrackedAsync(
   ctx: Context,
   pushKey: PushKey
 ): Promise<boolean> {
   const pushInfoFromApple = await ctx.appStore.listPushKeysAsync();
-  const validPushKeys = await filterRevokedAndUntrackedPushKeys([pushKey], pushInfoFromApple);
+  const validPushKeys = await filterRevokedAndUntrackedPushKeysAsync([pushKey], pushInfoFromApple);
   return validPushKeys.length > 0;
 }

--- a/packages/eas-cli/src/devices/context.ts
+++ b/packages/eas-cli/src/devices/context.ts
@@ -11,7 +11,7 @@ export interface DeviceManagerContext {
   user: Actor;
 }
 
-export async function createContext({
+export async function createContextAsync({
   appStore,
   cwd,
   user,

--- a/packages/eas-cli/src/graphql/mutations/EnvironmentSecretMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/EnvironmentSecretMutation.ts
@@ -11,7 +11,7 @@ import {
 import { EnvironmentSecretFragmentNode } from '../types/EnvironmentSecret';
 
 export const EnvironmentSecretMutation = {
-  async createForAccount(
+  async createForAccountAsync(
     input: { name: string; value: string },
     accountId: string
   ): Promise<EnvironmentSecretFragment> {
@@ -42,7 +42,7 @@ export const EnvironmentSecretMutation = {
 
     return data.environmentSecret.createEnvironmentSecretForAccount;
   },
-  async createForApp(
+  async createForAppAsync(
     input: { name: string; value: string },
     appId: string
   ): Promise<EnvironmentSecretFragment> {
@@ -70,7 +70,7 @@ export const EnvironmentSecretMutation = {
 
     return data.environmentSecret.createEnvironmentSecretForApp;
   },
-  async delete(id: string): Promise<{ id: string }> {
+  async deleteAsync(id: string): Promise<{ id: string }> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteEnvironmentSecretMutation>(

--- a/packages/eas-cli/src/graphql/mutations/UploadSessionMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/UploadSessionMutation.ts
@@ -13,7 +13,7 @@ export interface PresignedPost {
 }
 
 export const UploadSessionMutation = {
-  async createUploadSession(type: UploadSessionType): Promise<PresignedPost> {
+  async createUploadSessionAsync(type: UploadSessionType): Promise<PresignedPost> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<CreateUploadSessionMutation, CreateUploadSessionMutationVariables>(

--- a/packages/eas-cli/src/submissions/ArchiveSource.ts
+++ b/packages/eas-cli/src/submissions/ArchiveSource.ts
@@ -8,7 +8,7 @@ import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log from '../log';
 import { promptAsync } from '../prompts';
 import { getBuildByIdForSubmissionAsync, getLatestBuildForSubmissionAsync } from './utils/builds';
-import { isExistingFile, uploadAppArchiveAsync } from './utils/files';
+import { isExistingFileAsync, uploadAppArchiveAsync } from './utils/files';
 
 export enum ArchiveSourceType {
   url,
@@ -125,7 +125,7 @@ async function handleLatestSourceAsync(source: ArchiveLatestSource): Promise<Arc
 }
 
 async function handlePathSourceAsync(source: ArchivePathSource): Promise<Archive> {
-  if (!(await isExistingFile(source.path))) {
+  if (!(await isExistingFileAsync(source.path))) {
     Log.error(chalk.bold(`${source.path} doesn't exist`));
     return getArchiveAsync({
       ...source,
@@ -246,10 +246,11 @@ async function askForArchivePathAsync(platform: Platform): Promise<string> {
     message: `Path to the app archive file (${isIos ? 'ipa' : 'aab or apk'}):`,
     initial: defaultArchivePath,
     type: 'text',
+    // eslint-disable-next-line async-protect/async-suffix
     validate: async (path: string): Promise<boolean | string> => {
       if (path === defaultArchivePath) {
         return 'That was just an example path, meant to show you the format that we expect for the response.';
-      } else if (!(await isExistingFile(path))) {
+      } else if (!(await isExistingFileAsync(path))) {
         return `File ${path} doesn't exist.`;
       } else {
         return true;

--- a/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submissions/android/AndroidSubmitter.ts
@@ -40,8 +40,11 @@ export default class AndroidSubmitter extends BaseSubmitter<
   AndroidSubmissionOptions
 > {
   async submitAsync(): Promise<SubmissionFragment> {
-    const resolvedSourceOptions = await this.resolveSourceOptions();
-    const submissionConfig = await this.formatSubmissionConfig(this.options, resolvedSourceOptions);
+    const resolvedSourceOptions = await this.resolveSourceOptionsAsync();
+    const submissionConfig = await this.formatSubmissionConfigAsync(
+      this.options,
+      resolvedSourceOptions
+    );
 
     printSummary(
       this.prepareSummaryData(this.options, resolvedSourceOptions),
@@ -67,7 +70,7 @@ export default class AndroidSubmitter extends BaseSubmitter<
     });
   }
 
-  private async resolveSourceOptions(): Promise<ResolvedSourceOptions> {
+  private async resolveSourceOptionsAsync(): Promise<ResolvedSourceOptions> {
     const androidPackage = await getAndroidPackageAsync(this.options.androidPackageSource);
     const archive = await getArchiveAsync(this.options.archiveSource);
     const serviceAccountPath = await getServiceAccountAsync(this.options.serviceAccountSource);
@@ -78,7 +81,7 @@ export default class AndroidSubmitter extends BaseSubmitter<
     };
   }
 
-  private async formatSubmissionConfig(
+  private async formatSubmissionConfigAsync(
     options: AndroidSubmissionOptions,
     { archive, androidPackage, serviceAccountPath }: ResolvedSourceOptions
   ): Promise<AndroidSubmissionConfigInput> {

--- a/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submissions/android/ServiceAccountSource.ts
@@ -7,7 +7,7 @@ import Log, { learnMore } from '../../log';
 import { findProjectRootAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { filterAsync } from '../../utils/filterAsync';
-import { isExistingFile } from '../utils/files';
+import { isExistingFileAsync } from '../utils/files';
 
 export enum ServiceAccountSourceType {
   path,
@@ -51,7 +51,7 @@ export async function getServiceAccountAsync(source: ServiceAccountSource): Prom
 }
 
 async function handlePathSourceAsync(source: ServiceAccountPathSource): Promise<string> {
-  if (!(await isExistingFile(source.path))) {
+  if (!(await isExistingFileAsync(source.path))) {
     Log.warn(`File ${source.path} doesn't exist.`);
     return await getServiceAccountAsync({ sourceType: ServiceAccountSourceType.prompt });
   }
@@ -109,6 +109,7 @@ async function askForServiceAccountPathAsync(): Promise<string> {
     message: 'Path to Google Service Account file:',
     initial: 'api-0000000000000000000-111111-aaaaaabbbbbb.json',
     type: 'text',
+    // eslint-disable-next-line async-protect/async-suffix
     validate: async (filePath: string) => {
       try {
         const stats = await fs.stat(filePath);

--- a/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submissions/ios/IosSubmitter.ts
@@ -28,7 +28,7 @@ interface ResolvedSourceOptions {
 
 export default class IosSubmitter extends BaseSubmitter<Platform.IOS, IosSubmissionOptions> {
   async submitAsync(): Promise<SubmissionFragment> {
-    const resolvedSourceOptions = await this.resolveSourceOptions();
+    const resolvedSourceOptions = await this.resolveSourceOptionsAsync();
     const submissionConfig = await this.formatSubmissionConfigAsync(
       this.options,
       resolvedSourceOptions
@@ -58,7 +58,7 @@ export default class IosSubmitter extends BaseSubmitter<Platform.IOS, IosSubmiss
     });
   }
 
-  private async resolveSourceOptions(): Promise<ResolvedSourceOptions> {
+  private async resolveSourceOptionsAsync(): Promise<ResolvedSourceOptions> {
     const archive = await getArchiveAsync(this.options.archiveSource);
     const appSpecificPassword = await getAppSpecificPasswordAsync(
       this.options.appSpecificPasswordSource

--- a/packages/eas-cli/src/submissions/utils/files.ts
+++ b/packages/eas-cli/src/submissions/utils/files.ts
@@ -4,7 +4,7 @@ import { UploadSessionType } from '../../graphql/generated';
 import { uploadAsync } from '../../uploads';
 import { createProgressTracker } from '../../utils/progress';
 
-export async function isExistingFile(filePath: string): Promise<boolean> {
+export async function isExistingFileAsync(filePath: string): Promise<boolean> {
   try {
     const stats = await fs.stat(filePath);
     return stats.isFile();

--- a/packages/eas-cli/src/submissions/utils/wait.ts
+++ b/packages/eas-cli/src/submissions/utils/wait.ts
@@ -3,7 +3,7 @@ import ora from 'ora';
 import { AppPlatform, SubmissionFragment, SubmissionStatus } from '../../graphql/generated';
 import { SubmissionQuery } from '../../graphql/queries/SubmissionQuery';
 import Log from '../../log';
-import { sleep } from '../../utils/promise';
+import { sleepAsync } from '../../utils/promise';
 
 const APP_STORE_NAMES: Record<AppPlatform, string> = {
   [AppPlatform.Android]: 'Google Play Store',
@@ -62,7 +62,7 @@ export async function waitForSubmissionsEndAsync(
     }
 
     time = new Date().getTime();
-    await sleep(CHECK_INTERVAL_MS);
+    await sleepAsync(CHECK_INTERVAL_MS);
   }
   spinner.warn('Timed out');
   throw new Error('Timeout reached! It is taking longer than expected to complete, aborting...');

--- a/packages/eas-cli/src/uploads.ts
+++ b/packages/eas-cli/src/uploads.ts
@@ -18,7 +18,7 @@ export async function uploadAsync(
   path: string,
   handleProgressEvent: ProgressHandler
 ): Promise<{ url: string; bucketKey: string }> {
-  const presignedPost = await UploadSessionMutation.createUploadSession(type);
+  const presignedPost = await UploadSessionMutation.createUploadSessionAsync(type);
   const url = await uploadWithPresignedPostAsync(
     fs.createReadStream(path),
     presignedPost,

--- a/packages/eas-cli/src/utils/promise.ts
+++ b/packages/eas-cli/src/utils/promise.ts
@@ -4,6 +4,6 @@
  * @param ms A number of milliseconds to sleep.
  * @returns A promise that resolves after the provided number of milliseconds.
  */
-export async function sleep(ms: number): Promise<void> {
+export async function sleepAsync(ms: number): Promise<void> {
   return new Promise(res => setTimeout(res, ms));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5074,6 +5074,11 @@ eslint-module-utils@^2.6.2:
     debug "^3.2.7"
     pkg-dir "^2.0.0"
 
+eslint-plugin-async-protect@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-async-protect/-/eslint-plugin-async-protect-1.1.0.tgz#1b5652f5d4b875064065e5478b5e8c5d1aa6fb71"
+  integrity sha512-RlBCU/TCf4SaQe0NZfmbxjNHoHMv183VCsgRhBidSQBjXz4HJeaSNrvhhFwvhtk8BHapy+tcTTT3L+oJ3iPM7Q==
+
 eslint-plugin-graphql@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-graphql/-/eslint-plugin-graphql-4.0.0.tgz#d238ff2baee4d632cfcbe787a7a70a1f50428358"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

We use `Async` suffix for async functions. Unfortunately, we haven't had any eslint rule that would enforce that convention.

# How

- I installed https://github.com/IPWright83/eslint-plugin-async-protect and enabled the `async-protect/async-suffix` rule for all files except tests and mocks (mostly because `jest.fn()` does not return an async function).
- I refactored all CLI command classes so they extend the `EasCommand` class. This let me avoid adding the `eslint-disable-next-line` statement in every command class. (cc @kgc00)

# Test Plan

CI