### PR TITLE
eas submit: warn about turtle v1 build ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Support multi flavor Android projects. ([#595](https://github.com/expo/eas-cli/pull/595) by [@wkozyra95](https://github.com/wkozyra95))
 - Improve experience when using the build details page as a build artifact URL in `eas submit`. ([#620](https://github.com/expo/eas-cli/pull/620) by [@dsokal](https://github.com/dsokal))
 - Better error message when eas.json is invalid JSON. ([#618](https://github.com/expo/eas-cli/pull/618) by [@dsokal](https://github.com/dsokal))
+- Add warning about the legacy build service IDs in `eas submit`. ([#624](https://github.com/expo/eas-cli/pull/624) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/submissions/ArchiveSource.ts
+++ b/packages/eas-cli/src/submissions/ArchiveSource.ts
@@ -163,8 +163,11 @@ async function handleBuildIdSourceAsync(source: ArchiveBuildIdSource): Promise<A
       source,
     };
   } catch (err) {
-    Log.error(chalk.bold(`Couldn't find build for id ${source.id}`));
-    Log.error(err);
+    Log.error(chalk.bold(`Could not find build with id ${source.id}`));
+    Log.warn(
+      'Are you sure you did not pass the build id from the legacy build service (expo build:(android|ios))?'
+    );
+    Log.warn('Only EAS Build build ids are supported.');
     return getArchiveAsync({
       ...source,
       sourceType: ArchiveSourceType.prompt,

--- a/packages/eas-cli/src/submissions/ArchiveSource.ts
+++ b/packages/eas-cli/src/submissions/ArchiveSource.ts
@@ -163,11 +163,11 @@ async function handleBuildIdSourceAsync(source: ArchiveBuildIdSource): Promise<A
       source,
     };
   } catch (err) {
-    Log.error(chalk.bold(`Could not find build with id ${source.id}`));
+    Log.error(chalk.bold(`Could not find build with ID ${source.id}`));
     Log.warn(
-      'Are you sure you did not pass the build id from the legacy build service (expo build:(android|ios))?'
+      'Are you sure you did not pass the build ID from the legacy build service (expo build:(android|ios))?'
     );
-    Log.warn('Only EAS Build build ids are supported.');
+    Log.warn('Only EAS Build build IDs are supported.');
     return getArchiveAsync({
       ...source,
       sourceType: ArchiveSourceType.prompt,
@@ -191,7 +191,7 @@ async function handlePromptSourceAsync(source: ArchivePromptSource): Promise<Arc
         value: ArchiveSourceType.path,
       },
       {
-        title: 'A build identified by a build id',
+        title: 'A build identified by a build ID',
         value: ArchiveSourceType.buildId,
       },
     ],

--- a/packages/eas-cli/src/submissions/ArchiveSource.ts
+++ b/packages/eas-cli/src/submissions/ArchiveSource.ts
@@ -5,7 +5,7 @@ import * as uuid from 'uuid';
 
 import { BuildFragment } from '../graphql/generated';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
-import Log from '../log';
+import Log, { learnMore } from '../log';
 import { confirmAsync, promptAsync } from '../prompts';
 import { getBuildByIdForSubmissionAsync, getLatestBuildForSubmissionAsync } from './utils/builds';
 import { isExistingFileAsync, uploadAppArchiveAsync } from './utils/files';
@@ -164,10 +164,12 @@ async function handleBuildIdSourceAsync(source: ArchiveBuildIdSource): Promise<A
     };
   } catch (err) {
     Log.error(chalk.bold(`Could not find build with ID ${source.id}`));
+    Log.warn('Are you sure that the given ID corresponds to a build from EAS Build?');
     Log.warn(
-      'Are you sure you did not pass the build ID from the legacy build service (expo build:(android|ios))?'
+      `Build IDs from the classic build service (expo build:[android|ios]) are not supported. ${learnMore(
+        'https://docs.expo.dev/submit/classic-builds/'
+      )}`
     );
-    Log.warn('Only EAS Build build IDs are supported.');
     return getArchiveAsync({
       ...source,
       sourceType: ArchiveSourceType.prompt,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Some users expect EAS Submit to recognize the Turtle v1 build ids.

# How

Print a warning about Turtle v1 when couldn't find the build with the provided ID.

# Test Plan

<img width="764" alt="Screenshot 2021-09-16 at 12 32 33" src="https://user-images.githubusercontent.com/5256730/133597192-41477112-0190-489e-8921-51ce9ff03f83.png">

