### PR TITLE
[eas-cli] eas submit: Fix error message not displayed

### DIFF
--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -32,6 +32,12 @@ export default class Log {
     Log.consoleWarn(...Log.withTextColor(args, chalk.yellow));
   }
 
+  public static debug(...args: any[]): void {
+    if (Log.isDebug) {
+      Log.consoleLog(...args);
+    }
+  }
+
   public static gray(...args: any[]): void {
     Log.consoleLog(...Log.withTextColor(args, chalk.gray));
   }

--- a/packages/eas-cli/src/submissions/ArchiveSource.ts
+++ b/packages/eas-cli/src/submissions/ArchiveSource.ts
@@ -162,7 +162,11 @@ async function handleBuildIdSourceAsync(source: ArchiveBuildIdSource): Promise<A
 
     if (build.platform !== toAppPlatform(source.platform)) {
       Log.error(
-        `Build platform doesn't match! Expected '${source.platform}', but the build platform is '${build.platform}'.`
+        chalk.bold(
+          `Build platform doesn't match! Expected '${
+            source.platform
+          }', but the build platform is '${build.platform.toLowerCase()}'.`
+        )
       );
 
       return getArchiveAsync({

--- a/packages/eas-cli/src/submissions/ArchiveSource.ts
+++ b/packages/eas-cli/src/submissions/ArchiveSource.ts
@@ -166,7 +166,7 @@ async function handleBuildIdSourceAsync(source: ArchiveBuildIdSource): Promise<A
       const receivedPlatformName = appPlatformDisplayNames[build.platform];
       Log.error(
         chalk.bold(
-          `Build platform doesn't match! Expected ${expectedPlatformName} build, but got ${receivedPlatformName}.`
+          `Build platform doesn't match! Expected ${expectedPlatformName} build but got ${receivedPlatformName}.`
         )
       );
 

--- a/packages/eas-cli/src/submissions/ArchiveSource.ts
+++ b/packages/eas-cli/src/submissions/ArchiveSource.ts
@@ -166,7 +166,7 @@ async function handleBuildIdSourceAsync(source: ArchiveBuildIdSource): Promise<A
       const receivedPlatformName = appPlatformDisplayNames[build.platform];
       Log.error(
         chalk.bold(
-          `Build platform doesn't match! Expected ${expectedPlatformName}, but the build platform is ${receivedPlatformName}.`
+          `Build platform doesn't match! Expected ${expectedPlatformName} build, but got ${receivedPlatformName}.`
         )
       );
 

--- a/packages/eas-cli/src/submissions/ArchiveSource.ts
+++ b/packages/eas-cli/src/submissions/ArchiveSource.ts
@@ -7,6 +7,7 @@ import { BuildFragment } from '../graphql/generated';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log, { learnMore } from '../log';
+import { appPlatformDisplayNames } from '../platform';
 import { confirmAsync, promptAsync } from '../prompts';
 import { getLatestBuildForSubmissionAsync } from './utils/builds';
 import { isExistingFileAsync, uploadAppArchiveAsync } from './utils/files';
@@ -161,11 +162,11 @@ async function handleBuildIdSourceAsync(source: ArchiveBuildIdSource): Promise<A
     const build = await BuildQuery.byIdAsync(source.id);
 
     if (build.platform !== toAppPlatform(source.platform)) {
+      const expectedPlatformName = appPlatformDisplayNames[toAppPlatform(source.platform)];
+      const receivedPlatformName = appPlatformDisplayNames[build.platform];
       Log.error(
         chalk.bold(
-          `Build platform doesn't match! Expected '${
-            source.platform
-          }', but the build platform is '${build.platform.toLowerCase()}'.`
+          `Build platform doesn't match! Expected ${expectedPlatformName}, but the build platform is ${receivedPlatformName}.`
         )
       );
 

--- a/packages/eas-cli/src/submissions/utils/builds.ts
+++ b/packages/eas-cli/src/submissions/utils/builds.ts
@@ -1,22 +1,6 @@
 import { AppPlatform, BuildFragment, BuildStatus } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 
-/**
- * Gets build by ID and ensures that `artifacts.buildUrl` exists
- */
-export async function getBuildByIdForSubmissionAsync(
-  platform: AppPlatform,
-  buildId: string
-): Promise<BuildFragment> {
-  const build = await BuildQuery.byIdAsync(buildId);
-
-  if (build.platform !== platform) {
-    throw new Error("Build platform doesn't match!");
-  }
-
-  return build;
-}
-
 export async function getLatestBuildForSubmissionAsync(
   platform: AppPlatform,
   appId: string


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. 

# Why

Fixes https://github.com/expo/eas-cli/commit/b7ae91892cfc33606ac77f1d80c978a0efc9b56f made error about platform mismatch not displayed

# How

- Move the platform mismatch handling outside helper function and got rid of it.
- Display original error message in debug mode

# Test Plan

Updated tests


---

Platform mismatch:
<img alt="Screenshot 2021-09-17 at 12 11 35" src="https://user-images.githubusercontent.com/278340/133766571-2bb763ee-4902-4f5a-814b-94bff3a8def1.png" width="800" />

<details>
<summary>`EXPO_DEBUG=1`:</summary>

![Screenshot 2021-09-17 at 12 14 41](https://user-images.githubusercontent.com/278340/133766728-0ce4e080-60c0-4b94-a070-e14d6a338592.png)

</details>
