### PR TITLE
[ENG-1792] Validate that project includes expo-dev-client when building with developmentClient flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Improve experience when using the build details page as a build artifact URL in `eas submit`. ([#620](https://github.com/expo/eas-cli/pull/620) by [@dsokal](https://github.com/dsokal))
 - Better error message when eas.json is invalid JSON. ([#618](https://github.com/expo/eas-cli/pull/618) by [@dsokal](https://github.com/dsokal))
 - Add warning about the legacy build service IDs in `eas submit`. ([#624](https://github.com/expo/eas-cli/pull/624) by [@dsokal](https://github.com/dsokal))
+- Validate that project includes `expo-dev-client` when building with `developmentClient` flag. ([#627](https://github.com/expo/eas-cli/pull/627) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -10,7 +10,6 @@ import { BuildResult } from '../graphql/mutations/BuildMutation';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
 import Log, { learnMore } from '../log';
 import { requestedPlatformDisplayNames } from '../platform';
-import { promptAsync } from '../prompts';
 import { uploadAsync } from '../uploads';
 import { formatBytes } from '../utils/files';
 import { createProgressTracker } from '../utils/progress';
@@ -22,7 +21,7 @@ import { MetadataContext, collectMetadataAsync } from './metadata';
 import { TrackingContext } from './types';
 import Analytics, { Event } from './utils/analytics';
 import { printDeprecationWarnings } from './utils/printBuildInfo';
-import { commitPromptAsync, makeProjectTarballAsync } from './utils/repository';
+import { makeProjectTarballAsync, reviewAndCommitChangesAsync } from './utils/repository';
 
 export interface CredentialsResult<Credentials> {
   source: CredentialsSource.LOCAL | CredentialsSource.REMOTE;
@@ -227,58 +226,6 @@ async function withAnalyticsAsync<Result>(
       reason: error.message,
     });
     throw error;
-  }
-}
-
-enum ShouldCommitChanges {
-  Yes,
-  ShowDiffFirst,
-  Abort,
-}
-
-async function reviewAndCommitChangesAsync(
-  initialCommitMessage: string,
-  { nonInteractive, askedFirstTime = true }: { nonInteractive: boolean; askedFirstTime?: boolean }
-): Promise<void> {
-  if (process.env.EAS_BUILD_AUTOCOMMIT) {
-    await vcs.commitAsync({ commitMessage: initialCommitMessage, commitAllFiles: false });
-    Log.withTick('Committed changes.');
-    return;
-  }
-  if (nonInteractive) {
-    throw new Error(
-      'Cannot commit changes when --non-interactive is specified. Run the command in interactive mode or set EAS_BUILD_AUTOCOMMIT=1 in your environment.'
-    );
-  }
-  const { selected } = await promptAsync({
-    type: 'select',
-    name: 'selected',
-    message: 'Can we commit these changes to git for you?',
-    choices: [
-      { title: 'Yes', value: ShouldCommitChanges.Yes },
-      ...(askedFirstTime
-        ? [{ title: 'Show the diff and ask me again', value: ShouldCommitChanges.ShowDiffFirst }]
-        : []),
-      {
-        title: 'Abort build process',
-        value: ShouldCommitChanges.Abort,
-      },
-    ],
-  });
-
-  if (selected === ShouldCommitChanges.Abort) {
-    throw new Error(
-      "Aborting, run the command again once you're ready. Make sure to commit any changes you've made."
-    );
-  } else if (selected === ShouldCommitChanges.Yes) {
-    await commitPromptAsync({ initialCommitMessage });
-    Log.withTick('Committed changes.');
-  } else if (selected === ShouldCommitChanges.ShowDiffFirst) {
-    await vcs.showDiffAsync();
-    await reviewAndCommitChangesAsync(initialCommitMessage, {
-      nonInteractive,
-      askedFirstTime: false,
-    });
   }
 }
 

--- a/packages/eas-cli/src/build/utils/devClient.ts
+++ b/packages/eas-cli/src/build/utils/devClient.ts
@@ -1,0 +1,108 @@
+import { Platform, Workflow } from '@expo/eas-build-job';
+import { EasJsonReader } from '@expo/eas-json';
+import { error } from '@oclif/errors';
+import chalk from 'chalk';
+import resolveFrom from 'resolve-from';
+
+import { toAppPlatform } from '../../graphql/types/AppPlatform';
+import Log from '../../log';
+import { appPlatformDisplayNames } from '../../platform';
+import { resolveWorkflowAsync } from '../../project/workflow';
+import { confirmAsync } from '../../prompts';
+import { expoCommandAsync } from '../../utils/expoCommand';
+import zipObject from '../../utils/expodash/zipObject';
+import { reviewAndCommitChangesAsync } from './repository';
+
+export async function ensureExpoDevClientInstalledForDevClientBuildsAsync({
+  projectDir,
+  platforms,
+  profile,
+  nonInteractive = false,
+}: {
+  projectDir: string;
+  platforms: Platform[];
+  profile: string;
+  nonInteractive?: boolean;
+}): Promise<void> {
+  if (await isExpoDevClientInstalledAsync(projectDir)) {
+    return;
+  }
+
+  const easJsonReader = new EasJsonReader(projectDir);
+  const devClientPerPlatformList = await Promise.all(
+    platforms.map(async platform => {
+      const buildProfile = await easJsonReader.readBuildProfileAsync(platform, profile);
+      return buildProfile.developmentClient ?? false;
+    })
+  );
+
+  const isDevClientRequired = devClientPerPlatformList.some(i => i);
+  if (!isDevClientRequired) {
+    return;
+  }
+
+  const devClientPerPlatform = zipObject(platforms, devClientPerPlatformList);
+  const platformsToCheck = platforms.filter(platform => devClientPerPlatform[platform]);
+  const workflowPerPlatformList = await Promise.all(
+    platformsToCheck.map(platform => resolveWorkflowAsync(projectDir, platform))
+  );
+
+  Log.error(
+    `You want to build a development client build for platforms: ${platformsToCheck
+      .map(i => chalk.bold(appPlatformDisplayNames[toAppPlatform(i)]))
+      .join(', ')}`
+  );
+  Log.error(
+    `However, we detected that you don't have ${chalk.bold(
+      'expo-dev-client'
+    )} installed for your project.`
+  );
+  const areAllManaged = workflowPerPlatformList.every(i => i === Workflow.MANAGED);
+  if (areAllManaged) {
+    const install = await confirmAsync({
+      message: 'Do you want EAS CLI to install expo-dev-client for you?',
+      instructions: 'The command will abort unless you agree.',
+    });
+    if (install) {
+      await installExpoDevClientAsync(projectDir, { nonInteractive });
+    } else {
+      error(`Install ${chalk.bold('expo-dev-client')} on your own and come back later.`, {
+        exit: 1,
+      });
+    }
+  } else {
+    Log.warn(`Unfortunately, you need to install ${chalk.bold('expo-dev-client')} on your own.`);
+    Log.warn('If you proceed anyway, you might not get the build you want.');
+    const shouldContinue = await confirmAsync({
+      message: 'Do you want to proceed anyway?',
+      initial: false,
+    });
+    if (!shouldContinue) {
+      error('Come back later', { exit: 1 });
+    }
+  }
+}
+
+async function isExpoDevClientInstalledAsync(projectDir: string): Promise<boolean> {
+  try {
+    resolveFrom(projectDir, 'expo-dev-client/package.json');
+    return true;
+  } catch (err: any) {
+    Log.debug(err);
+    return false;
+  }
+}
+
+async function installExpoDevClientAsync(
+  projectDir: string,
+  { nonInteractive }: { nonInteractive: boolean }
+): Promise<void> {
+  Log.newLine();
+  Log.log(`Running ${chalk.bold('expo install expo-dev-client')}`);
+  Log.newLine();
+  await expoCommandAsync(projectDir, ['install', 'expo-dev-client']);
+  Log.newLine();
+  await reviewAndCommitChangesAsync('Install expo-dev-client', {
+    nonInteractive,
+  });
+}

--- a/packages/eas-cli/src/build/utils/devClient.ts
+++ b/packages/eas-cli/src/build/utils/devClient.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import resolveFrom from 'resolve-from';
 
 import { toAppPlatform } from '../../graphql/types/AppPlatform';
-import Log from '../../log';
+import Log, { learnMore } from '../../log';
 import { appPlatformDisplayNames } from '../../platform';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { confirmAsync } from '../../prompts';
@@ -47,6 +47,7 @@ export async function ensureExpoDevClientInstalledForDevClientBuildsAsync({
     platformsToCheck.map(platform => resolveWorkflowAsync(projectDir, platform))
   );
 
+  Log.newLine();
   Log.error(
     `You want to build a development client build for platforms: ${platformsToCheck
       .map(i => chalk.bold(appPlatformDisplayNames[toAppPlatform(i)]))
@@ -72,7 +73,14 @@ export async function ensureExpoDevClientInstalledForDevClientBuildsAsync({
     }
   } else {
     Log.warn(`Unfortunately, you need to install ${chalk.bold('expo-dev-client')} on your own.`);
+    Log.warn(
+      learnMore('https://docs.expo.dev/clients/installation/', {
+        learnMoreMessage: 'See installation instructions on how to do it',
+        dim: false,
+      })
+    );
     Log.warn('If you proceed anyway, you might not get the build you want.');
+    Log.newLine();
     const shouldContinue = await confirmAsync({
       message: 'Do you want to proceed anyway?',
       initial: false,

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -14,6 +14,7 @@ import { BuildRequestSender, waitForBuildEndAsync } from '../../build/build';
 import { ensureProjectConfiguredAsync } from '../../build/configure';
 import { BuildContext, createBuildContextAsync } from '../../build/context';
 import { prepareIosBuildAsync } from '../../build/ios/build';
+import { ensureExpoDevClientInstalledForDevClientBuildsAsync } from '../../build/utils/devClient';
 import { printBuildResults, printLogsUrls } from '../../build/utils/printBuildInfo';
 import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
 import EasCommand from '../../commandUtils/EasCommand';
@@ -144,6 +145,12 @@ export default class Build extends EasCommand {
     await ensureProjectConfiguredAsync(projectDir, requestedPlatform);
 
     const platforms = toPlatforms(requestedPlatform);
+    await ensureExpoDevClientInstalledForDevClientBuildsAsync({
+      platforms,
+      projectDir,
+      profile: flags.profile,
+      nonInteractive: flags.nonInteractive,
+    });
 
     const startedBuilds: BuildFragment[] = [];
     for (const platform of platforms) {

--- a/packages/eas-cli/src/commands/diagnostics.ts
+++ b/packages/eas-cli/src/commands/diagnostics.ts
@@ -18,14 +18,16 @@ export default class Diagnostics extends EasCommand {
         Utilities: ['Git'],
         npmPackages: [
           'expo',
+          'expo-cli',
           'react',
           'react-dom',
           'react-native',
           'react-native-web',
           'react-navigation',
           '@expo/webpack-config',
+          'expo-dev-client',
         ],
-        npmGlobalPackages: ['eas-cli'],
+        npmGlobalPackages: ['eas-cli', 'expo-cli'],
       },
       {
         title: `EAS CLI ${packageJSON.version} environment info`,

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -32,6 +32,12 @@ export default class Log {
     Log.consoleWarn(...Log.withTextColor(args, chalk.yellow));
   }
 
+  public static debug(...args: any[]): void {
+    if (Log.isDebug) {
+      Log.consoleLog(...args);
+    }
+  }
+
   public static gray(...args: any[]): void {
     Log.consoleLog(...Log.withTextColor(args, chalk.gray));
   }

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -13,6 +13,7 @@ import { PresignedPost } from '../graphql/mutations/UploadSessionMutation';
 import { PublishQuery } from '../graphql/queries/PublishQuery';
 import Log from '../log';
 import { uploadWithPresignedPostAsync } from '../uploads';
+import { expoCommandAsync } from '../utils/expoCommand';
 import uniqBy from '../utils/expodash/uniqBy';
 
 export const TIMEOUT_LIMIT = 60_000; // 1 minute
@@ -158,28 +159,7 @@ export async function buildBundlesAsync({
   }
 
   Log.withTick(`Building bundle with expo-cli...`);
-  const spawnPromise = spawnAsync(
-    'yarn',
-    ['expo', 'export', '--output-dir', inputDir, '--experimental-bundle'],
-    { stdio: ['inherit', 'pipe', 'pipe'] } // inherit stdin so user can install a missing expo-cli from inside this command
-  );
-  const {
-    child: { stdout, stderr },
-  } = spawnPromise;
-  if (!(stdout && stderr)) {
-    throw new Error('Failed to spawn expo-cli');
-  }
-  stdout.on('data', data => {
-    for (const line of data.toString().trim().split('\n')) {
-      Log.log(`[expo-cli]${line}`);
-    }
-  });
-  stderr.on('data', data => {
-    for (const line of data.toString().trim().split('\n')) {
-      Log.warn(`[expo-cli]${line}`);
-    }
-  });
-  await spawnPromise;
+  await expoCommandAsync(projectDir, ['export', '--output-dir', inputDir, '--experimental-bundle']);
 }
 
 export function resolveInputDirectory(customInputDirectory: string): string {

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -1,6 +1,5 @@
 import { ExpoConfig, Platform } from '@expo/config';
 import JsonFile from '@expo/json-file';
-import spawnAsync from '@expo/spawn-async';
 import crypto from 'crypto';
 import fs from 'fs';
 import Joi from 'joi';

--- a/packages/eas-cli/src/user/UserSettings.ts
+++ b/packages/eas-cli/src/user/UserSettings.ts
@@ -11,13 +11,10 @@ export type UserSettingsData = {
   amplitudeEnabled?: boolean;
 };
 
-const UserSettings: JsonFile<UserSettingsData> = new JsonFile<UserSettingsData>(
-  SETTINGS_FILE_PATH,
-  {
-    jsonParseErrorDefault: {},
-    cantReadFileDefault: {},
-    ensureDir: true,
-  }
-);
+const UserSettings = new JsonFile<UserSettingsData>(SETTINGS_FILE_PATH, {
+  jsonParseErrorDefault: {},
+  cantReadFileDefault: {},
+  ensureDir: true,
+});
 
 export default UserSettings;

--- a/packages/eas-cli/src/utils/expoCommand.ts
+++ b/packages/eas-cli/src/utils/expoCommand.ts
@@ -1,0 +1,29 @@
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import resolveFrom from 'resolve-from';
+
+import Log from '../log';
+
+export async function expoCommandAsync(projectDir: string, args: string[]): Promise<void> {
+  const expoCliPath = resolveFrom(projectDir, 'expo/bin/cli.js');
+  const spawnPromise = spawnAsync(expoCliPath, args, {
+    stdio: ['inherit', 'pipe', 'pipe'], // inherit stdin so user can install a missing expo-cli from inside this command
+  });
+  const {
+    child: { stdout, stderr },
+  } = spawnPromise;
+  if (!(stdout && stderr)) {
+    throw new Error('Failed to spawn expo-cli');
+  }
+  stdout.on('data', data => {
+    for (const line of data.toString().trim().split('\n')) {
+      Log.log(`${chalk.gray('[expo-cli]')} ${line}`);
+    }
+  });
+  stderr.on('data', data => {
+    for (const line of data.toString().trim().split('\n')) {
+      Log.warn(`${chalk.gray('[expo-cli]')} ${line}`);
+    }
+  });
+  await spawnPromise;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://linear.app/expo/issue/ENG-1792/validate-that-project-includes-expo-dev-client-when-building-with
We want to validate that project includes `expo-dev-client` when building with `developmentClient` flag.

# How

If `developmentClient` is set to `true` but `expo-dev-client` is not installed:
- [managed] offer to install the package with `expo install ...` and then commit the changes
- [bare] ask the user if they want to proceed, and print instructions on how to install `expo-dev-client` if they don't proceed

# Test Plan

Tested manually.

Managed project:
<img width="633" alt="Screenshot 2021-09-17 at 12 57 20" src="https://user-images.githubusercontent.com/5256730/133771725-23b2e3ef-da2e-4357-b6dd-39270f44cbf3.png">


Bare project:
<img width="674" alt="Screenshot 2021-09-17 at 12 54 42" src="https://user-images.githubusercontent.com/5256730/133771428-0b47f152-1d28-49bb-acd5-3de8ee33b958.png">


