### PR TITLE
print meaningful error message when not logged in in non-interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Better error message when eas.json is invalid JSON. ([#618](https://github.com/expo/eas-cli/pull/618) by [@dsokal](https://github.com/dsokal))
 - Add warning about the legacy build service IDs in `eas submit`. ([#624](https://github.com/expo/eas-cli/pull/624) by [@dsokal](https://github.com/dsokal))
 - Validate that project includes `expo-dev-client` when building with `developmentClient` flag. ([#627](https://github.com/expo/eas-cli/pull/627) by [@dsokal](https://github.com/dsokal))
+- Better experience when not logged in in non-interactive mode. ([#628](https://github.com/expo/eas-cli/pull/628) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -19,11 +19,13 @@ export default abstract class EasCommand extends Command {
   protected abstract runAsync(): Promise<any>;
 
   // eslint-disable-next-line async-protect/async-suffix
-  async init(): Promise<void> {
+  async run(): Promise<any> {
     await initAnalyticsAsync();
 
     if (this.requiresAuthentication) {
-      await ensureLoggedInAsync();
+      const { flags } = this.parse();
+      const nonInteractive = (flags as any)['non-interactive'] ?? false;
+      await ensureLoggedInAsync({ nonInteractive });
     } else {
       await getUserAsync();
     }
@@ -32,10 +34,6 @@ export default abstract class EasCommand extends Command {
       // commands/submit === submit, commands/build/list === build:list
       action: `eas ${this.id}`,
     });
-  }
-
-  // eslint-disable-next-line async-protect/async-suffix
-  async run(): Promise<any> {
     return this.runAsync();
   }
 

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -19,6 +19,17 @@ jest.mock('../../analytics', () => {
   };
 });
 
+let originalProcessArgv: string[];
+
+beforeAll(() => {
+  originalProcessArgv = process.argv;
+  process.argv = [];
+});
+
+afterAll(() => {
+  process.argv = originalProcessArgv;
+});
+
 beforeEach(() => {
   (getUserAsync as jest.Mock).mockReset().mockImplementation(() => mockJester);
   (ensureLoggedInAsync as jest.Mock).mockReset().mockImplementation(() => mockJester);

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -9,7 +9,6 @@ export default class AccountLogin extends EasCommand {
   protected requiresAuthentication = false;
 
   async runAsync(): Promise<void> {
-    Log.log('Log in to EAS');
     await showLoginPromptAsync();
     Log.log('Logged in');
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Fixes https://github.com/expo/eas-cli/issues/625

# How

Don't show prompt when ran a command with `--non-interactive` and not logged in, throw a meaningful error instead

# Test Plan

<img width="1314" alt="Screenshot 2021-09-17 at 15 31 00" src="https://user-images.githubusercontent.com/5256730/133790955-68ad5f4b-c48e-417c-a968-5c1c60e1c1c7.png">


