### PR TITLE
add PR comment with code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,3 @@
-comment: false
 coverage:
   round: up
   precision: 2


### PR DESCRIPTION
We should start to care more about code coverage. This PR makes the codecov bot comment on the PR so the coverage is more visible to the developers.