### PR TITLE
do not fail in case of transient network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Prevent ora spinners breaking when debug logs are enabled. ([#575](https://github.com/expo/eas-cli/pull/575) by [@EvanBacon](https://github.com/EvanBacon))
+- Do not fail `eas build` when transient network errors occur. ([#638](https://github.com/expo/eas-cli/pull/638) by [@dsokal](https://github.com/dsokal))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -244,6 +244,7 @@ export async function waitForBuildEndAsync(
         try {
           return await BuildQuery.byIdAsync(buildId, { useCache: false });
         } catch (err) {
+          Log.debug('Failed to fetch the build status', err);
           return null;
         }
       })
@@ -276,8 +277,8 @@ export async function waitForBuildEndAsync(
               throw new Error(`Standalone build failed!`);
             }
           default:
-            spinner.warn('Unknown status.');
-            throw new Error(`Unknown status: ${builds} - aborting!`);
+            spinner.warn('Unknown status');
+            throw new Error(`Unknown build status: ${build.status} - aborting!`);
         }
       } else {
         if (!spinner.text) {
@@ -306,7 +307,7 @@ export async function waitForBuildEndAsync(
         const errored = builds.filter(build => build?.status === BuildStatus.Errored).length;
         const finished = builds.filter(build => build?.status === BuildStatus.Finished).length;
         const canceled = builds.filter(build => build?.status === BuildStatus.Canceled).length;
-        const unknownState = builds.length - newBuilds - inQueue - inProgress - errored - finished;
+        const unknown = builds.length - newBuilds - inQueue - inProgress - errored - finished;
         spinner.text = [
           newBuilds && `Builds created: ${newBuilds}`,
           inQueue && `Builds in queue: ${inQueue}`,
@@ -314,7 +315,7 @@ export async function waitForBuildEndAsync(
           canceled && `Builds canceled: ${canceled}`,
           errored && chalk.red(`Builds failed: ${errored}`),
           finished && chalk.green(`Builds finished: ${finished}`),
-          unknownState && chalk.red(`Builds in unknown state: ${unknownState}`),
+          unknown && chalk.red(`Builds with unknown status: ${unknown}`),
         ]
           .filter(i => i)
           .join('\t');


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1632243270044100
Sometimes, the build command fails when waiting for the build to complete. Usually, it's because of a transient network error.

```
Build details: https://expo.io/...

Waiting for build to complete. You can press Ctrl+C to exit.
    Error: Got unexpected null
```

# How

Do not fail if a transient network error occurs.

# Test Plan

Tested locally.