### PR TITLE
use log-symbols to unify green ticks style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Use `log-symbols` to unify green ticks style. ([#639](https://github.com/expo/eas-cli/pull/639) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [0.28.1](https://github.com/expo/eas-cli/releases/tag/v0.28.1) - 2021-09-22

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -48,6 +48,7 @@
     "jks-js": "1.0.1",
     "joi": "17.4.2",
     "keychain": "1.3.0",
+    "log-symbols": "4.1.0",
     "mime": "2.5.2",
     "minimatch": "3.0.4",
     "nanoid": "3.1.25",

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import figures from 'figures';
 import { boolish } from 'getenv';
+import logSymbols from 'log-symbols';
 import terminalLink from 'terminal-link';
 
 type Color = (...text: string[]) => string;
@@ -45,7 +46,7 @@ export default class Log {
   }
 
   public static succeed(message: string): void {
-    Log.log(`${chalk.green('√')} ${message}`);
+    Log.log(`${chalk.green(logSymbols.success)} ${message}`);
   }
 
   public static withTick(...args: any[]): void {

--- a/packages/eas-cli/src/utils/progress.ts
+++ b/packages/eas-cli/src/utils/progress.ts
@@ -10,7 +10,7 @@ type ProgressHandler = (props: {
   error?: Error;
 }) => void;
 
-function createProgressTracker({
+export function createProgressTracker({
   total,
   message,
   completedMessage,
@@ -75,5 +75,3 @@ function createProgressTracker({
     }
   };
 }
-
-export { createProgressTracker };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6625,6 +6625,11 @@ is-unc-path@^1.0.0:
   dependencies:
     unc-path-regex "^0.1.2"
 
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
 is-windows@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -7709,6 +7714,14 @@ lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@~4.17
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+log-symbols@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

The green ticks style is not consistent. Reported by @EvanBacon on Slack.

<img width="141" alt="Screen Shot 2021-09-22 at 6 18 21 PM" src="https://user-images.githubusercontent.com/5256730/134471860-81dc9bf7-ba2c-4b1f-bb10-2ea4c929bebb.png">


# How

Use `log-symbols` (`ora` is using it under the hood) to unify green ticks style.

# Test Plan

<img width="597" alt="Screenshot 2021-09-23 at 09 52 00" src="https://user-images.githubusercontent.com/5256730/134472082-0c0627e3-2324-498b-97d3-6a5ae1efc8f3.png">
