### PR TITLE
fix auto-submitting in fresh project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Use `log-symbols` to unify green ticks style. ([#639](https://github.com/expo/eas-cli/pull/639) by [@dsokal](https://github.com/dsokal))
+- Fix `eas build --auto-submit` in fresh projects. ([#640](https://github.com/expo/eas-cli/pull/640) by [@dsokal](https://github.com/dsokal))
 
 ### 🧹 Chores
 

--- a/packages/eas-json/src/EasJson.types.ts
+++ b/packages/eas-json/src/EasJson.types.ts
@@ -1,3 +1,5 @@
+import { Platform } from '@expo/eas-build-job';
+
 import { AndroidBuildProfile, CommonBuildProfile, IosBuildProfile } from './EasBuild.types';
 import { AndroidSubmitProfile, IosSubmitProfile } from './EasSubmit.types';
 
@@ -8,13 +10,13 @@ export enum CredentialsSource {
 
 export interface RawBuildProfile extends Partial<CommonBuildProfile> {
   extends?: string;
-  android?: Partial<AndroidBuildProfile>;
-  ios?: Partial<IosBuildProfile>;
+  [Platform.ANDROID]?: Partial<AndroidBuildProfile>;
+  [Platform.IOS]?: Partial<IosBuildProfile>;
 }
 
 export interface EasSubmitConfiguration {
-  android?: AndroidSubmitProfile;
-  ios?: IosSubmitProfile;
+  [Platform.ANDROID]?: AndroidSubmitProfile;
+  [Platform.IOS]?: IosSubmitProfile;
 }
 
 export interface EasJson {

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -94,11 +94,16 @@ export class EasJsonReader {
       }
     }
     const easJson = await this.readAndValidateAsync();
-    const profile = easJson?.submit?.[profileName]?.[platform];
+    const profile = easJson?.submit?.[profileName];
     if (!profile) {
-      throw new Error(`There is no profile named ${profileName} in eas.json for ${platform}.`);
+      throw new Error(`There is no profile named ${profileName} in eas.json`);
     }
-    return this.evaluateFields(platform, profile as SubmitProfile<T>);
+    const platformProfile = profile[platform];
+    if (platformProfile) {
+      return this.evaluateFields(platform, platformProfile as SubmitProfile<T>);
+    } else {
+      return getDefaultSubmitProfile(platform);
+    }
   }
 
   public async readAndValidateAsync(): Promise<EasJson> {
@@ -144,7 +149,7 @@ export class EasJsonReader {
     }
     const buildProfile = easJson.build[profileName];
     if (!buildProfile) {
-      throw new Error(`There is no profile named ${profileName}`);
+      throw new Error(`There is no profile named ${profileName} in eas.json`);
     }
     const { extends: baseProfileName, ...buildProfileRest } = buildProfile;
     if (baseProfileName) {
@@ -159,7 +164,7 @@ export class EasJsonReader {
 
   private ensureBuildProfileExists(easJson: EasJson, profileName: string): void {
     if (!easJson.build || !easJson.build[profileName]) {
-      throw new Error(`There is no profile named ${profileName} in eas.json.`);
+      throw new Error(`There is no profile named ${profileName} in eas.json`);
     }
   }
 

--- a/packages/eas-json/src/__tests__/EasJsonReader-build-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-build-test.ts
@@ -225,7 +225,7 @@ test('valid eas.json with missing profile', async () => {
 
   const reader = new EasJsonReader('/project');
   const promise = reader.readBuildProfileAsync(Platform.ANDROID, 'debug');
-  await expect(promise).rejects.toThrowError('There is no profile named debug in eas.json.');
+  await expect(promise).rejects.toThrowError('There is no profile named debug in eas.json');
 });
 
 test('invalid eas.json when using wrong buildType', async () => {
@@ -247,7 +247,7 @@ test('empty json', async () => {
 
   const reader = new EasJsonReader('/project');
   const promise = reader.readBuildProfileAsync(Platform.ANDROID, 'release');
-  await expect(promise).rejects.toThrowError('There is no profile named release in eas.json.');
+  await expect(promise).rejects.toThrowError('There is no profile named release in eas.json');
 });
 
 test('invalid semver value', async () => {

--- a/packages/eas-json/src/__tests__/EasJsonReader-submit-test.ts
+++ b/packages/eas-json/src/__tests__/EasJsonReader-submit-test.ts
@@ -14,10 +14,7 @@ beforeEach(async () => {
 test('minimal allowed eas.json for both platforms', async () => {
   await fs.writeJson('/project/eas.json', {
     submit: {
-      release: {
-        android: {},
-        ios: {},
-      },
+      release: {},
     },
   });
 
@@ -110,23 +107,4 @@ test('ios config with all required values', async () => {
     ascAppId: '1223423523',
     language: 'en-US',
   });
-});
-
-test('missing ios profile', async () => {
-  await fs.writeJson('/project/eas.json', {
-    submit: {
-      release: {
-        android: {
-          serviceAccountKeyPath: './path.json',
-          track: 'beta',
-          releaseStatus: 'completed',
-        },
-      },
-    },
-  });
-
-  const reader = new EasJsonReader('/project');
-  const promise = reader.readSubmitProfileAsync(Platform.IOS, 'release');
-
-  expect(promise).rejects.toThrow('There is no profile named release in eas.json for ios.');
 });


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

When running `eas build --auto-submit` in a fresh project, the CLI creates the `eas.json` for the user. The default configuration looks like this:
```
{
  build: {
    release: {},
    development: {
      developmentClient: true,
      distribution: 'internal',
    },
  },
  submit: {
    release: {},
  },
}
```

Note that the `release` submit profile doesn't have the `android` and `ios` empty objects. There's a bug so that the eas.json reader assumes the profile doesn't exist if an empty object for a platform does not exist.

# How

Return the default profile if the platform-specific profile is not defined but the submit profile exists (`{ submit: { release: {} } }`)

# Test Plan

Unit tests + tested manually.
