### PR TITLE
[eas-cli] creds manager: stop prompting every iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Credentials manager: stop prompting for an Android build profile every iteration. ([#641](https://github.com/expo/eas-cli/pull/641) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🧹 Chores
 
 ## [0.28.2](https://github.com/expo/eas-cli/releases/tag/v0.28.2) - 2021-09-23

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -145,17 +145,17 @@ export class ManageAndroid {
   constructor(private callingAction: Action) {}
 
   async runAsync(ctx: Context, currentActions: ActionInfo[] = highLevelActions): Promise<void> {
+    const accountName = ctx.hasProjectContext
+      ? getProjectAccountName(ctx.exp, ctx.user)
+      : ensureActorHasUsername(ctx.user);
+    const account = findAccountByName(ctx.user.accounts, accountName);
+    if (!account) {
+      throw new Error(`You do not have access to account: ${accountName}`);
+    }
+    const { gradleContext } = await this.createProjectContextAsync(ctx);
+
     while (true) {
       try {
-        const accountName = ctx.hasProjectContext
-          ? getProjectAccountName(ctx.exp, ctx.user)
-          : ensureActorHasUsername(ctx.user);
-
-        const account = findAccountByName(ctx.user.accounts, accountName);
-        if (!account) {
-          throw new Error(`You do not have access to account: ${accountName}`);
-        }
-        const { gradleContext } = await this.createProjectContextAsync(ctx);
         if (ctx.hasProjectContext) {
           const maybeProjectId = await promptToCreateProjectIfNotExistsAsync(ctx.exp);
           if (!maybeProjectId) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why
Stop asking user for android build profile every time they choose an action. Instead, prompt the user once and then use the chosen profile for the rest of the actions.

![Screen Shot 2021-09-23 at 6 07 49 PM](https://user-images.githubusercontent.com/6380927/134627000-f77eaef0-72cc-4642-a53e-1d946edc0935.png)

# Test Plan

- [x] manually tested
- [x] current tests still pass