### PR TITLE
fix experience with validating metro config in non-interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Don't display prompt in non-interactive mode when the metro config seems invalid. ([#644](https://github.com/expo/eas-cli/pull/644) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [0.28.2](https://github.com/expo/eas-cli/releases/tag/v0.28.2) - 2021-09-23

--- a/packages/eas-cli/src/project/metroConfig.ts
+++ b/packages/eas-cli/src/project/metroConfig.ts
@@ -1,4 +1,5 @@
 import { Platform } from '@expo/eas-build-job';
+import { exit } from '@oclif/errors';
 import chalk from 'chalk';
 import type MetroConfig from 'metro-config';
 import resolveFrom from 'resolve-from';
@@ -27,19 +28,28 @@ export async function validateMetroConfigForManagedWorkflowAsync(
     Log.warn(
       'This can result in unexpected and hard to debug issues, like missing assets in the production bundle.'
     );
-    Log.warn(`We recommend you to abort, fix the ${chalk.bold('metro.config.js')}, and try again.`);
+    if (!ctx.nonInteractive) {
+      Log.warn(
+        `We recommend you to abort, fix the ${chalk.bold('metro.config.js')}, and try again.`
+      );
+    }
     Log.warn(
       learnMore('https://docs.expo.dev/guides/customizing-metro/', {
         learnMoreMessage: 'Learn more on customizing Metro',
       })
     );
 
+    if (ctx.nonInteractive) {
+      Log.warn("You've run EAS CLI in non-interactive mode, proceeding...");
+      return;
+    }
+
     const shouldAbort = await confirmAsync({
       message: 'Would you like to abort?',
     });
     if (shouldAbort) {
-      Log.log('Aborting...');
-      process.exit(1);
+      Log.error('Aborting...');
+      exit(1);
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Fixes https://github.com/expo/eas-cli/issues/643

# How

Check if running in non-interactive mode and proceed even if the metro config seems invalid

# Test Plan

<img width="847" alt="Screenshot 2021-09-24 at 10 40 04" src="https://user-images.githubusercontent.com/5256730/134645656-513eea1f-08df-4624-ade3-27f7cfe760d1.png">
