### PR TITLE
[eas-cli] change export style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Move away from weird convention of exports. ([#647](https://github.com/expo/eas-cli/pull/647) by [@quinlanj](https://github.com/quinlanj))
+
 ## [0.28.2](https://github.com/expo/eas-cli/releases/tag/v0.28.2) - 2021-09-23
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/__tests__/project-utils.ts
+++ b/packages/eas-cli/src/__tests__/project-utils.ts
@@ -25,7 +25,7 @@ interface AppJSON {
   };
 }
 
-function createTestProject(
+export function createTestProject(
   user: Actor,
   appJSONExtraData?: Record<string, object | string>
 ): MockProject {
@@ -58,5 +58,3 @@ function createTestProject(
     },
   };
 }
-
-export { createTestProject };

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppBuildCredentialsMutation.ts
@@ -15,7 +15,7 @@ export type AndroidAppBuildCredentialsMetadataInput = Omit<
   AndroidAppBuildCredentialsInput,
   'keystoreId'
 >;
-const AndroidAppBuildCredentialsMutation = {
+export const AndroidAppBuildCredentialsMutation = {
   async createAndroidAppBuildCredentialsAsync(
     androidAppBuildCredentialsInput: AndroidAppBuildCredentialsInput,
     androidAppCredentialsId: string
@@ -85,5 +85,3 @@ const AndroidAppBuildCredentialsMutation = {
     return data.androidAppBuildCredentials.setKeystore;
   },
 };
-
-export { AndroidAppBuildCredentialsMutation };

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppCredentialsMutation.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../../../graphql/generated';
 import { CommonAndroidAppCredentialsFragmentNode } from '../../../../../graphql/types/credentials/AndroidAppCredentials';
 
-const AndroidAppCredentialsMutation = {
+export const AndroidAppCredentialsMutation = {
   async createAndroidAppCredentialsAsync(
     androidAppCredentialsInput: {
       fcmId?: string;
@@ -83,5 +83,3 @@ const AndroidAppCredentialsMutation = {
     return data.androidAppCredentials.setFcm;
   },
 };
-
-export { AndroidAppCredentialsMutation };

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidFcmMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidFcmMutation.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../../graphql/generated';
 import { AndroidFcmFragmentNode } from '../../../../../graphql/types/credentials/AndroidFcm';
 
-const AndroidFcmMutation = {
+export const AndroidFcmMutation = {
   async createAndroidFcmAsync(
     androidFcmInput: AndroidFcmInput,
     accountId: string
@@ -67,5 +67,3 @@ const AndroidFcmMutation = {
     );
   },
 };
-
-export { AndroidFcmMutation };

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../../graphql/generated';
 import { AndroidKeystoreFragmentNode } from '../../../../../graphql/types/credentials/AndroidKeystore';
 
-const AndroidKeystoreMutation = {
+export const AndroidKeystoreMutation = {
   async createAndroidKeystoreAsync(
     androidKeystoreInput: AndroidKeystoreInput,
     accountId: string
@@ -73,5 +73,3 @@ const AndroidKeystoreMutation = {
     );
   },
 };
-
-export { AndroidKeystoreMutation };

--- a/packages/eas-cli/src/credentials/android/api/graphql/queries/AndroidAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/queries/AndroidAppCredentialsQuery.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../../../graphql/generated';
 import { CommonAndroidAppCredentialsFragmentNode } from '../../../../../graphql/types/credentials/AndroidAppCredentials';
 
-const AndroidAppCredentialsQuery = {
+export const AndroidAppCredentialsQuery = {
   async withCommonFieldsByApplicationIdentifierAsync(
     projectFullName: string,
     {
@@ -66,5 +66,3 @@ const AndroidAppCredentialsQuery = {
     return data.app.byFullName.androidAppCredentials[0] ?? null;
   },
 };
-
-export { AndroidAppCredentialsQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../../../graphql/generated';
 import { AppleAppIdentifierFragmentNode } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
 
-const AppleAppIdentifierMutation = {
+export const AppleAppIdentifierMutation = {
   async createAppleAppIdentifierAsync(
     appleAppIdentifierInput: AppleAppIdentifierInput,
     accountId: string
@@ -49,5 +49,3 @@ const AppleAppIdentifierMutation = {
     return data.appleAppIdentifier.createAppleAppIdentifier;
   },
 };
-
-export { AppleAppIdentifierMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../../../graphql/generated';
 import { AppleDeviceFragmentNode } from '../../../../../graphql/types/credentials/AppleDevice';
 
-const AppleDeviceMutation = {
+export const AppleDeviceMutation = {
   async createAppleDeviceAsync(
     appleDeviceInput: AppleDeviceInput,
     accountId: string
@@ -41,5 +41,3 @@ const AppleDeviceMutation = {
     return data.appleDevice.createAppleDevice;
   },
 };
-
-export { AppleDeviceMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../../../graphql/generated';
 import { AppleDeviceRegistrationRequestFragmentNode } from '../../../../../graphql/types/credentials/AppleDeviceRegistrationRequest';
 
-const AppleDeviceRegistrationRequestMutation = {
+export const AppleDeviceRegistrationRequestMutation = {
   async createAppleDeviceRegistrationRequestAsync(
     appleTeamId: string,
     accountId: string
@@ -43,5 +43,3 @@ const AppleDeviceRegistrationRequestMutation = {
     return data.appleDeviceRegistrationRequest.createAppleDeviceRegistrationRequest;
   },
 };
-
-export { AppleDeviceRegistrationRequestMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
@@ -17,7 +17,7 @@ export type AppleDistributionCertificateMutationResult = AppleDistributionCertif
   appleTeam?: AppleTeamFragment | null;
 };
 
-const AppleDistributionCertificateMutation = {
+export const AppleDistributionCertificateMutation = {
   async createAppleDistributionCertificateAsync(
     appleDistributionCertificateInput: AppleDistributionCertificateInput,
     accountId: string
@@ -88,5 +88,3 @@ const AppleDistributionCertificateMutation = {
     );
   },
 };
-
-export { AppleDistributionCertificateMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
@@ -16,7 +16,7 @@ export type AppleProvisioningProfileMutationResult = AppleProvisioningProfileFra
   appleTeam?: AppleTeamFragment | null;
 };
 
-const AppleProvisioningProfileMutation = {
+export const AppleProvisioningProfileMutation = {
   async createAppleProvisioningProfileAsync(
     appleProvisioningProfileInput: AppleProvisioningProfileInput,
     accountId: string,
@@ -124,5 +124,3 @@ const AppleProvisioningProfileMutation = {
     );
   },
 };
-
-export { AppleProvisioningProfileMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/ApplePushKeyMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/ApplePushKeyMutation.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../../graphql/generated';
 import { ApplePushKeyFragmentNode } from '../../../../../graphql/types/credentials/ApplePushKey';
 
-const ApplePushKeyMutation = {
+export const ApplePushKeyMutation = {
   async createApplePushKeyAsync(
     applePushKeyInput: ApplePushKeyInput,
     accountId: string
@@ -70,5 +70,3 @@ const ApplePushKeyMutation = {
     );
   },
 };
-
-export { ApplePushKeyMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
@@ -14,7 +14,7 @@ export type AppleTeamMutationResult = AppleTeamFragment & {
   account: Account;
 };
 
-const AppleTeamMutation = {
+export const AppleTeamMutation = {
   async createAppleTeamAsync(
     appleTeamInput: AppleTeamInput,
     accountId: string
@@ -47,5 +47,3 @@ const AppleTeamMutation = {
     return data.appleTeam.createAppleTeam;
   },
 };
-
-export { AppleTeamMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../../graphql/generated';
 import { IosAppBuildCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
 
-const IosAppBuildCredentialsMutation = {
+export const IosAppBuildCredentialsMutation = {
   async createIosAppBuildCredentialsAsync(
     iosAppBuildCredentialsInput: IosAppBuildCredentialsInput,
     iosAppCredentialsId: string
@@ -120,5 +120,3 @@ const IosAppBuildCredentialsMutation = {
     return data.iosAppBuildCredentials.setProvisioningProfile;
   },
 };
-
-export { IosAppBuildCredentialsMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../../graphql/generated';
 import { CommonIosAppCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppCredentials';
 
-const IosAppCredentialsMutation = {
+export const IosAppCredentialsMutation = {
   async createIosAppCredentialsAsync(
     iosAppCredentialsInput: IosAppCredentialsInput,
     appId: string,
@@ -81,5 +81,3 @@ const IosAppCredentialsMutation = {
     return data.iosAppCredentials.setPushKey;
   },
 };
-
-export { IosAppCredentialsMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/__mocks__/AppleDeviceMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/__mocks__/AppleDeviceMutation.ts
@@ -1,6 +1,6 @@
 import { AppleDevice } from '../../../../../../graphql/generated';
 
-const AppleDeviceMutation = {
+export const AppleDeviceMutation = {
   createAppleDeviceAsync: jest.fn().mockImplementation(() => {
     const appleDevice: Pick<AppleDevice, 'id' | 'identifier'> = {
       id: 'apple-device-id',
@@ -9,5 +9,3 @@ const AppleDeviceMutation = {
     return appleDevice;
   }),
 };
-
-export { AppleDeviceMutation };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppQuery.ts
@@ -6,7 +6,7 @@ import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/cl
 import { AppByFullNameQuery, AppFragment } from '../../../../../graphql/generated';
 import { AppFragmentNode } from '../../../../../graphql/types/App';
 
-const AppQuery = {
+export const AppQuery = {
   async byFullNameAsync(fullName: string): Promise<AppFragment> {
     const data = await withErrorHandlingAsync(
       graphqlClient
@@ -31,5 +31,3 @@ const AppQuery = {
     return data.app.byFullName;
   },
 };
-
-export { AppQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../../../graphql/generated';
 import { AppleAppIdentifierFragmentNode } from '../../../../../graphql/types/credentials/AppleAppIdentifier';
 
-const AppleAppIdentifierQuery = {
+export const AppleAppIdentifierQuery = {
   async byBundleIdentifierAsync(
     accountName: string,
     bundleIdentifier: string
@@ -46,5 +46,3 @@ const AppleAppIdentifierQuery = {
     return data.account.byName.appleAppIdentifiers[0];
   },
 };
-
-export { AppleAppIdentifierQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -31,7 +31,7 @@ export type AppleDevicesByIdentifierQueryResult = AppleDeviceQueryResult & {
   appleTeam: AppleTeamFragment;
 };
 
-const AppleDeviceQuery = {
+export const AppleDeviceQuery = {
   async getAllByAppleTeamIdentifierAsync(
     accountId: string,
     appleTeamIdentifier: string,
@@ -155,5 +155,3 @@ const AppleDeviceQuery = {
     return data.account.byName.appleDevices[0] ?? null;
   },
 };
-
-export { AppleDeviceQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
@@ -12,7 +12,7 @@ import {
 import { AppleDistributionCertificateFragmentNode } from '../../../../../graphql/types/credentials/AppleDistributionCertificate';
 import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
-const AppleDistributionCertificateQuery = {
+export const AppleDistributionCertificateQuery = {
   async getForAppAsync(
     projectFullName: string,
     {
@@ -100,5 +100,3 @@ const AppleDistributionCertificateQuery = {
     return data.account.byName.appleDistributionCertificates;
   },
 };
-
-export { AppleDistributionCertificateQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
@@ -19,7 +19,7 @@ import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/
 export type AppleProvisioningProfileQueryResult = AppleProvisioningProfileFragment & {
   appleTeam?: AppleTeamFragment | null;
 } & { appleDevices: AppleDeviceFragment[] } & { appleAppIdentifier: AppleAppIdentifierFragment };
-const AppleProvisioningProfileQuery = {
+export const AppleProvisioningProfileQuery = {
   async getForAppAsync(
     projectFullName: string,
     {
@@ -89,5 +89,3 @@ const AppleProvisioningProfileQuery = {
     );
   },
 };
-
-export { AppleProvisioningProfileQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/ApplePushKeyQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/ApplePushKeyQuery.ts
@@ -5,7 +5,7 @@ import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/cl
 import { ApplePushKeyByAccountQuery, ApplePushKeyFragment } from '../../../../../graphql/generated';
 import { ApplePushKeyFragmentNode } from '../../../../../graphql/types/credentials/ApplePushKey';
 
-const ApplePushKeyQuery = {
+export const ApplePushKeyQuery = {
   async getAllForAccountAsync(accountName: string): Promise<ApplePushKeyFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
@@ -33,5 +33,3 @@ const ApplePushKeyQuery = {
     return data.account.byName.applePushKeys;
   },
 };
-
-export { ApplePushKeyQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../../../graphql/generated';
 import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
-const AppleTeamQuery = {
+export const AppleTeamQuery = {
   async getAllForAccountAsync(accountName: string): Promise<AppleTeamFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
@@ -64,5 +64,3 @@ const AppleTeamQuery = {
     return data.appleTeam.byAppleTeamIdentifier ?? null;
   },
 };
-
-export { AppleTeamQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../../../graphql/generated';
 import { IosAppBuildCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppBuildCredentials';
 
-const IosAppBuildCredentialsQuery = {
+export const IosAppBuildCredentialsQuery = {
   async byAppIdentifierIdAndDistributionTypeAsync(
     projectFullName: string,
     {
@@ -59,5 +59,3 @@ const IosAppBuildCredentialsQuery = {
     return data.app.byFullName.iosAppCredentials[0]?.iosAppBuildCredentialsList[0] ?? null;
   },
 };
-
-export { IosAppBuildCredentialsQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
@@ -15,7 +15,7 @@ import {
   CommonIosAppCredentialsWithoutBuildCredentialsFragmentNode,
 } from '../../../../../graphql/types/credentials/IosAppCredentials';
 
-const IosAppCredentialsQuery = {
+export const IosAppCredentialsQuery = {
   async withBuildCredentialsByAppIdentifierIdAsync(
     projectFullName: string,
     {
@@ -110,5 +110,3 @@ const IosAppCredentialsQuery = {
     return data.app.byFullName.iosAppCredentials[0] ?? null;
   },
 };
-
-export { IosAppCredentialsQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/AppleDistributionCertificateQuery.ts
@@ -1,4 +1,4 @@
-const AppleDistributionCertificateQuery = {
+export const AppleDistributionCertificateQuery = {
   getAllForAccountAsync: jest.fn().mockImplementation(() => {
     return [
       {
@@ -40,5 +40,3 @@ const AppleDistributionCertificateQuery = {
     ];
   }),
 };
-
-export { AppleDistributionCertificateQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/AppleTeamQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/AppleTeamQuery.ts
@@ -1,6 +1,6 @@
 import { AppleTeam } from '../../../../../../graphql/generated';
 
-const AppleTeamQuery = {
+export const AppleTeamQuery = {
   byAppleTeamIdentifierAsync: jest.fn().mockImplementation(() => {
     const appleTeam: Pick<AppleTeam, 'id' | 'appleTeamIdentifier' | 'appleTeamName'> = {
       id: 'apple-team-id',
@@ -10,5 +10,3 @@ const AppleTeamQuery = {
     return appleTeam;
   }),
 };
-
-export { AppleTeamQuery };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/IosAppCredentialsQuery.ts
@@ -1,4 +1,4 @@
-const IosAppCredentialsQuery = {
+export const IosAppCredentialsQuery = {
   withCommonFieldsByAppIdentifierIdAsync: jest.fn().mockImplementation(() => {
     return {
       id: '48d0cd34-96d8-447c-9de8-40dd2c3ca0f8',
@@ -112,5 +112,3 @@ const IosAppCredentialsQuery = {
     };
   }),
 };
-
-export { IosAppCredentialsQuery };

--- a/packages/eas-cli/src/credentials/ios/utils/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/provisioningProfile.ts
@@ -5,7 +5,7 @@ interface AppleTeam {
   teamName: string;
 }
 
-function readAppleTeam(dataBase64: string): AppleTeam {
+export function readAppleTeam(dataBase64: string): AppleTeam {
   const profilePlist = parse(dataBase64);
   const teamId = (profilePlist['TeamIdentifier'] as PlistArray)?.[0] as string;
   const teamName = profilePlist['TeamName'] as string;
@@ -15,18 +15,18 @@ function readAppleTeam(dataBase64: string): AppleTeam {
   return { teamId, teamName };
 }
 
-function readProfileName(dataBase64: string): string {
+export function readProfileName(dataBase64: string): string {
   const profilePlist = parse(dataBase64);
   return profilePlist['Name'] as string;
 }
 
-function isAdHocProfile(dataBase64: string): boolean {
+export function isAdHocProfile(dataBase64: string): boolean {
   const profilePlist = parse(dataBase64);
   const provisionedDevices = profilePlist['ProvisionedDevices'] as string[] | undefined;
   return Array.isArray(provisionedDevices);
 }
 
-function parse(dataBase64: string): PlistObject {
+export function parse(dataBase64: string): PlistObject {
   try {
     const buffer = Buffer.from(dataBase64, 'base64');
     const profile = buffer.toString('utf8');
@@ -35,5 +35,3 @@ function parse(dataBase64: string): PlistObject {
     throw new Error('Provisioning profile is malformed');
   }
 }
-
-export { readAppleTeam, readProfileName, isAdHocProfile, parse };

--- a/packages/eas-cli/src/devices/actions/create/__mocks__/inputMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/__mocks__/inputMethod.ts
@@ -1,3 +1,1 @@
-const runInputMethodAsync = jest.fn();
-
-export { runInputMethodAsync };
+export const runInputMethodAsync = jest.fn();

--- a/packages/eas-cli/src/devices/actions/create/__mocks__/registrationUrlMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/__mocks__/registrationUrlMethod.ts
@@ -1,3 +1,1 @@
-const runRegistrationUrlMethodAsync = jest.fn();
-
-export { runRegistrationUrlMethodAsync };
+export const runRegistrationUrlMethodAsync = jest.fn();

--- a/packages/eas-cli/src/graphql/mutations/AppMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/AppMutation.ts
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import { AppPrivacy, CreateAppMutation, CreateAppMutationVariables } from '../generated';
 
-const AppMutation = {
+export const AppMutation = {
   async createAppAsync(appInput: {
     accountId: string;
     projectName: string;
@@ -33,5 +33,3 @@ const AppMutation = {
     return appId;
   },
 };
-
-export { AppMutation };

--- a/packages/eas-cli/src/graphql/mutations/BuildMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/BuildMutation.ts
@@ -21,7 +21,7 @@ export interface BuildResult {
   deprecationInfo?: EasBuildDeprecationInfo | null;
 }
 
-const BuildMutation = {
+export const BuildMutation = {
   async createAndroidBuildAsync(input: {
     appId: string;
     job: AndroidJobInput;
@@ -93,5 +93,3 @@ const BuildMutation = {
     return nullthrows(data.build?.createIosBuild);
   },
 };
-
-export { BuildMutation };

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import { PublishUpdateGroupInput, UpdatePublishMutation } from '../generated';
 
-const PublishMutation = {
+export const PublishMutation = {
   async getUploadURLsAsync(contentTypes: string[]): Promise<{ specifications: string[] }> {
     const data = await withErrorHandlingAsync(
       graphqlClient
@@ -54,5 +54,3 @@ const PublishMutation = {
     return data.updateBranch.publishUpdateGroups;
   },
 };
-
-export { PublishMutation };

--- a/packages/eas-cli/src/graphql/queries/ProjectQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ProjectQuery.ts
@@ -5,7 +5,7 @@ import { Project, ProjectByUsernameAndSlugQuery } from '../generated';
 
 type ProjectQueryResult = Pick<Project, 'id'>;
 
-const ProjectQuery = {
+export const ProjectQuery = {
   async byUsernameAndSlugAsync(username: string, slug: string): Promise<ProjectQueryResult> {
     const data = await withErrorHandlingAsync(
       graphqlClient
@@ -27,5 +27,3 @@ const ProjectQuery = {
     return data.project.byUsernameAndSlug;
   },
 };
-
-export { ProjectQuery };

--- a/packages/eas-cli/src/graphql/queries/PublishQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/PublishQuery.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import { AssetMetadataResult, GetAssetMetadataQuery } from '../generated';
 
-const PublishQuery = {
+export const PublishQuery = {
   async getAssetMetadataAsync(storageKeys: string[]): Promise<AssetMetadataResult[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
@@ -28,5 +28,3 @@ const PublishQuery = {
     return data.asset.metadata;
   },
 };
-
-export { PublishQuery };

--- a/packages/eas-cli/src/graphql/queries/UserQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UserQuery.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import { CurrentUserQuery } from '../generated';
 
-const UserQuery = {
+export const UserQuery = {
   async currentUserAsync(): Promise<CurrentUserQuery['meActor']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
@@ -34,5 +34,3 @@ const UserQuery = {
     return data.meActor;
   },
 };
-
-export { UserQuery };

--- a/packages/eas-cli/src/project/__tests__/project-utils.ts
+++ b/packages/eas-cli/src/project/__tests__/project-utils.ts
@@ -25,7 +25,7 @@ interface AppJSON {
   };
 }
 
-function createTestProject(
+export function createTestProject(
   user: Actor,
   appJSONExtraData?: Record<string, object | string>
 ): MockProject {
@@ -58,5 +58,3 @@ function createTestProject(
     },
   };
 }
-
-export { createTestProject };


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# famous quote
'We're trying to move away from this weird convention of exports' - dominik

# Why

Followup PR from https://github.com/expo/eas-cli/pull/642#discussion_r715401434 . Made changes except for:
- default exports 
-  files that import a resource and immediately export it

# How

Change export style from 
```
class Foo {...}
export { Foo };
```
to
```
export class Foo {...}
```

# Test Plan

- [ ] current tests still pass
