### PR TITLE
[eas-cli] use existing google service account key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - More upload support for Google Service Account Keys. ([#649](https://github.com/expo/eas-cli/pull/649) by [@quinlanj](https://github.com/quinlanj))
+- Allow the user to assign an existing Google Service Account Key to their project. ([#650](https://github.com/expo/eas-cli/pull/650) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-android.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-android.ts
@@ -143,6 +143,7 @@ export function getNewAndroidApiMock(): { [key in keyof typeof AndroidGraphqlCli
     createOrUpdateAndroidAppBuildCredentialsByNameAsync: jest.fn(),
     createKeystoreAsync: jest.fn(),
     createGoogleServiceAccountKeyAsync: jest.fn(),
+    getGoogleServiceAccountKeysForAccountAsync: jest.fn(),
     createFcmAsync: jest.fn(),
     deleteKeystoreAsync: jest.fn(),
     deleteFcmAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/android/actions/UseExistingGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/UseExistingGoogleServiceAccountKey.ts
@@ -33,7 +33,7 @@ export class UseExistingGoogleServiceAccountKey {
     const { chosenKey } = await promptAsync({
       type: 'select',
       name: 'chosenKey',
-      message: 'Select a Google Service Account Key.',
+      message: 'Select a Google Service Account Key:',
       choices: sortedKeys.map(key => ({
         title: this.formatGoogleServiceAccountKey(key),
         value: key,
@@ -42,7 +42,7 @@ export class UseExistingGoogleServiceAccountKey {
     return chosenKey;
   }
 
-  sortGoogleServiceAccountKeysByUpdatedAtDesc(
+  private sortGoogleServiceAccountKeysByUpdatedAtDesc(
     keys: GoogleServiceAccountKeyFragment[]
   ): GoogleServiceAccountKeyFragment[] {
     return keys.sort(
@@ -51,11 +51,14 @@ export class UseExistingGoogleServiceAccountKey {
     );
   }
 
-  private formatGoogleServiceAccountKey(key: GoogleServiceAccountKeyFragment): string {
-    const { projectIdentifier, privateKeyIdentifier, clientEmail, clientIdentifier, updatedAt } =
-      key;
+  private formatGoogleServiceAccountKey({
+    projectIdentifier,
+    privateKeyIdentifier,
+    clientEmail,
+    clientIdentifier,
+    updatedAt,
+  }: GoogleServiceAccountKeyFragment): string {
     let line: string = '';
-
     line += `Client Email: ${clientEmail}, Project Id: ${projectIdentifier}`;
     line += chalk.gray(
       `\n    Client Id: ${clientIdentifier}, Private Key Id: ${privateKeyIdentifier}`

--- a/packages/eas-cli/src/credentials/android/actions/UseExistingGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/UseExistingGoogleServiceAccountKey.ts
@@ -1,0 +1,66 @@
+import chalk from 'chalk';
+
+import { GoogleServiceAccountKeyFragment } from '../../../graphql/generated';
+import Log from '../../../log';
+import { promptAsync } from '../../../prompts';
+import { Account } from '../../../user/Account';
+import { fromNow } from '../../../utils/date';
+import { Context } from '../../context';
+
+export class UseExistingGoogleServiceAccountKey {
+  constructor(private account: Account) {}
+
+  public async runAsync(ctx: Context): Promise<GoogleServiceAccountKeyFragment | null> {
+    if (ctx.nonInteractive) {
+      throw new Error(
+        `Existing Google Service Account Key cannot be chosen in non-interactive mode.`
+      );
+    }
+    const gsaKeyFragments = await ctx.android.getGoogleServiceAccountKeysForAccountAsync(
+      this.account
+    );
+    if (gsaKeyFragments.length === 0) {
+      Log.error("There aren't any Google Service Account Keys associated with your account.");
+      return null;
+    }
+    return await this.selectGoogleServiceAccountKeyAsync(gsaKeyFragments);
+  }
+
+  private async selectGoogleServiceAccountKeyAsync(
+    keys: GoogleServiceAccountKeyFragment[]
+  ): Promise<GoogleServiceAccountKeyFragment | null> {
+    const sortedKeys = this.sortGoogleServiceAccountKeysByUpdatedAtDesc(keys);
+    const { chosenKey } = await promptAsync({
+      type: 'select',
+      name: 'chosenKey',
+      message: 'Select a Google Service Account Key.',
+      choices: sortedKeys.map(key => ({
+        title: this.formatGoogleServiceAccountKey(key),
+        value: key,
+      })),
+    });
+    return chosenKey;
+  }
+
+  sortGoogleServiceAccountKeysByUpdatedAtDesc(
+    keys: GoogleServiceAccountKeyFragment[]
+  ): GoogleServiceAccountKeyFragment[] {
+    return keys.sort(
+      (keyA, keyB) =>
+        new Date(keyB.updatedAt).getMilliseconds() - new Date(keyA.updatedAt).getMilliseconds()
+    );
+  }
+
+  private formatGoogleServiceAccountKey(key: GoogleServiceAccountKeyFragment): string {
+    const { projectIdentifier, privateKeyIdentifier, clientEmail, clientIdentifier, updatedAt } =
+      key;
+    let line: string = '';
+
+    line += `Client Email: ${clientEmail}, Project Id: ${projectIdentifier}`;
+    line += chalk.gray(
+      `\n    Client Id: ${clientIdentifier}, Private Key Id: ${privateKeyIdentifier}`
+    );
+    line += chalk.gray(`\n    Updated: ${fromNow(new Date(updatedAt))} ago,`);
+    return line;
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/UseExistingGoogleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/UseExistingGoogleServiceAccountKey-test.ts
@@ -12,7 +12,7 @@ jest.mock('../../../../prompts');
 asMock(promptAsync).mockImplementation(() => ({ chosenKey: testGoogleServiceAccountKeyFragment }));
 
 describe(UseExistingGoogleServiceAccountKey, () => {
-  it('uses an existing an Google Service Account Key in Interactive Mode', async () => {
+  it('uses an existing Google Service Account Key in Interactive Mode', async () => {
     const ctx = createCtxMock({
       nonInteractive: false,
       android: {

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/UseExistingGoogleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/UseExistingGoogleServiceAccountKey-test.ts
@@ -1,0 +1,59 @@
+import { asMock } from '../../../../__tests__/utils';
+import { promptAsync } from '../../../../prompts';
+import {
+  getNewAndroidApiMock,
+  testGoogleServiceAccountKeyFragment,
+} from '../../../__tests__/fixtures-android';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
+import { UseExistingGoogleServiceAccountKey } from '../UseExistingGoogleServiceAccountKey';
+
+jest.mock('../../../../prompts');
+asMock(promptAsync).mockImplementation(() => ({ chosenKey: testGoogleServiceAccountKeyFragment }));
+
+describe(UseExistingGoogleServiceAccountKey, () => {
+  it('uses an existing an Google Service Account Key in Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      android: {
+        ...getNewAndroidApiMock(),
+        getGoogleServiceAccountKeysForAccountAsync: jest.fn(() => [
+          testGoogleServiceAccountKeyFragment,
+        ]),
+      },
+    });
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
+    const useExistingGoogleServiceAccountKeyAction = new UseExistingGoogleServiceAccountKey(
+      appLookupParams.account
+    );
+    const selectedKey = await useExistingGoogleServiceAccountKeyAction.runAsync(ctx);
+    expect(ctx.android.getGoogleServiceAccountKeysForAccountAsync).toHaveBeenCalledTimes(1);
+    expect(selectedKey).toMatchObject(testGoogleServiceAccountKeyFragment);
+  });
+  it("returns null if the account doesn't have any Google Service Account Keys", async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      android: {
+        ...getNewAndroidApiMock(),
+        getGoogleServiceAccountKeysForAccountAsync: jest.fn(() => []),
+      },
+    });
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
+    const useExistingGoogleServiceAccountKeyAction = new UseExistingGoogleServiceAccountKey(
+      appLookupParams.account
+    );
+    const selectedKey = await useExistingGoogleServiceAccountKeyAction.runAsync(ctx);
+    expect(ctx.android.getGoogleServiceAccountKeysForAccountAsync).toHaveBeenCalledTimes(1);
+    expect(selectedKey).toBe(null);
+  });
+  it('errors in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({ nonInteractive: true });
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
+    const useExistingGoogleServiceAccountKeyAction = new UseExistingGoogleServiceAccountKey(
+      appLookupParams.account
+    );
+
+    // fail if users are running in non-interactive mode
+    await expect(useExistingGoogleServiceAccountKeyAction.runAsync(ctx)).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
@@ -16,6 +16,7 @@ import { AndroidFcmMutation } from './graphql/mutations/AndroidFcmMutation';
 import { AndroidKeystoreMutation } from './graphql/mutations/AndroidKeystoreMutation';
 import { GoogleServiceAccountKeyMutation } from './graphql/mutations/GoogleServiceAccountKeyMutation';
 import { AndroidAppCredentialsQuery } from './graphql/queries/AndroidAppCredentialsQuery';
+import { GoogleServiceAccountKeyQuery } from './graphql/queries/GoogleServiceAccountKeyQuery';
 
 export interface AppLookupParams {
   account: Account;
@@ -249,6 +250,12 @@ export async function createGoogleServiceAccountKeyAsync(
     { jsonKey },
     account.id
   );
+}
+
+export async function getGoogleServiceAccountKeysForAccountAsync(
+  account: Account
+): Promise<GoogleServiceAccountKeyFragment[]> {
+  return await GoogleServiceAccountKeyQuery.getAllForAccountAsync(account.name);
 }
 
 async function getAppAsync(appLookupParams: AppLookupParams): Promise<AppFragment> {

--- a/packages/eas-cli/src/credentials/android/api/graphql/queries/GoogleServiceAccountKeyQuery.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/queries/GoogleServiceAccountKeyQuery.ts
@@ -1,0 +1,38 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import {
+  GoogleServiceAccountKeyByAccountQuery,
+  GoogleServiceAccountKeyFragment,
+} from '../../../../../graphql/generated';
+import { GoogleServiceAccountKeyFragmentNode } from '../../../../../graphql/types/credentials/GoogleServiceAccountKey';
+
+export const GoogleServiceAccountKeyQuery = {
+  async getAllForAccountAsync(accountName: string): Promise<GoogleServiceAccountKeyFragment[]> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<GoogleServiceAccountKeyByAccountQuery>(
+          gql`
+            query GoogleServiceAccountKeyByAccountQuery($accountName: String!) {
+              account {
+                byName(accountName: $accountName) {
+                  id
+                  googleServiceAccountKeys {
+                    id
+                    ...GoogleServiceAccountKeyFragment
+                  }
+                }
+              }
+            }
+            ${print(GoogleServiceAccountKeyFragmentNode)}
+          `,
+          {
+            accountName,
+          }
+        )
+        .toPromise()
+    );
+    return data.account.byName.googleServiceAccountKeys;
+  },
+};

--- a/packages/eas-cli/src/credentials/android/utils/__tests__/__snapshots__/printCredentials-test.ts.snap
+++ b/packages/eas-cli/src/credentials/android/utils/__tests__/__snapshots__/printCredentials-test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`print credentials prints the AndroidAppCredentials fragment 1`] = `
 "Android Credentials  Project: testApp  Application Identifier: test.com.app  Push Notifications (FCM):    Key: abcd...efgh    Updated 0 second agoGoogle Service Account Key For Submissions  Project ID      sdf.sdf.sdf
-Private Key ID  test-private-key-identifier
 Client Email    quin@expo.io
 Client ID       test-client-identifier
+Private Key ID  test-private-key-identifier
 Updated         0 second ago  Configuration: legacy (Default)  Keystore:    Type: JKS    Key Alias: QHdrb3p5cmEvY3JlZGVudGlhbHMtdGVzdA==    MD5 Fingerprint: TE:ST:-M:D5    SHA1 Fingerprint: TE:ST:-S:HA:1    SHA256 Fingerprint: TE:ST:-S:HA:25:6    Updated 0 second ago"
 `;

--- a/packages/eas-cli/src/credentials/android/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/utils/printCredentials.ts
@@ -68,9 +68,9 @@ function displayGoogleServiceAccountKeyForSubmissions(
 
   const fields = [
     { label: 'Project ID', value: projectIdentifier },
-    { label: 'Private Key ID', value: privateKeyIdentifier },
     { label: 'Client Email', value: clientEmail },
     { label: 'Client ID', value: clientIdentifier },
+    { label: 'Private Key ID', value: privateKeyIdentifier },
     { label: 'Updated', value: `${fromNow(new Date(updatedAt))} ago` },
   ];
   Log.log(formatFields(fields, { labelFormat: chalk.cyan.bold }));

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -26,6 +26,7 @@ import { RemoveFcm } from '../android/actions/RemoveFcm';
 import { RemoveKeystore } from '../android/actions/RemoveKeystore';
 import { SetupBuildCredentialsFromCredentialsJson } from '../android/actions/SetupBuildCredentialsFromCredentialsJson';
 import { UpdateCredentialsJson } from '../android/actions/UpdateCredentialsJson';
+import { UseExistingGoogleServiceAccountKey } from '../android/actions/UseExistingGoogleServiceAccountKey';
 import {
   displayAndroidAppCredentials,
   displayEmptyAndroidCredentials,
@@ -52,6 +53,7 @@ enum ActionType {
   CreateFcm,
   RemoveFcm,
   CreateGsaKey,
+  UseExistingGsaKey,
   UpdateCredentialsJson,
   SetupBuildCredentialsFromCredentialsJson,
 }
@@ -154,6 +156,11 @@ const gsaKeyActions: ActionInfo[] = [
   {
     value: ActionType.CreateGsaKey,
     title: 'Upload a Google Service Account Key',
+    scope: Scope.Project,
+  },
+  {
+    value: ActionType.UseExistingGsaKey,
+    title: 'Use an existing Google Service Account Key',
     scope: Scope.Project,
   },
   {
@@ -329,6 +336,13 @@ export class ManageAndroid {
     } else if (action === ActionType.CreateGsaKey) {
       const gsaKey = await new CreateGoogleServiceAccountKey(appLookupParams.account).runAsync(ctx);
       await new AssignGoogleServiceAccountKey(appLookupParams).runAsync(ctx, gsaKey);
+    } else if (action === ActionType.UseExistingGsaKey) {
+      const gsaKey = await new UseExistingGoogleServiceAccountKey(appLookupParams.account).runAsync(
+        ctx
+      );
+      if (gsaKey) {
+        await new AssignGoogleServiceAccountKey(appLookupParams).runAsync(ctx, gsaKey);
+      }
     } else if (action === ActionType.UpdateCredentialsJson) {
       const buildCredentials = await new SelectExistingAndroidBuildCredentials(
         appLookupParams

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4637,6 +4637,27 @@ export type AppleTeamByIdentifierQuery = (
   ) }
 );
 
+export type GoogleServiceAccountKeyByAccountQueryVariables = Exact<{
+  accountName: Scalars['String'];
+}>;
+
+
+export type GoogleServiceAccountKeyByAccountQuery = (
+  { __typename?: 'RootQuery' }
+  & { account: (
+    { __typename?: 'AccountQuery' }
+    & { byName: (
+      { __typename?: 'Account' }
+      & Pick<Account, 'id'>
+      & { googleServiceAccountKeys: Array<(
+        { __typename?: 'GoogleServiceAccountKey' }
+        & Pick<GoogleServiceAccountKey, 'id'>
+        & GoogleServiceAccountKeyFragment
+      )> }
+    ) }
+  ) }
+);
+
 export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQueryVariables = Exact<{
   projectFullName: Scalars['String'];
   appleAppIdentifierId: Scalars['String'];


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This PR:
- allows the user to assign an existing GoogleServiceAccountKey to their project on the www servers
- adds an action to assign an existing key in the credentials management workflow

It will also eventually be used in the submissions workflow.

# Test Plan

- [x] new tests pass
- [x] manually tested new credentials management action
