### PR TITLE
update eas-build-job adds xcode 13 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Added upload support for Google Service Account Keys. ([#642](https://github.com/expo/eas-cli/pull/642) by [@quinlanj](https://github.com/quinlanj))
-- Add Xcode 13 image ([#651](https://github.com/expo/eas-cli/pull/651) by [@wkozyra95](https://github.com/wkozyra95))
+- Add Xcode 13 image. ([#651](https://github.com/expo/eas-cli/pull/651) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Added upload support for Google Service Account Keys. ([#642](https://github.com/expo/eas-cli/pull/642) by [@quinlanj](https://github.com/quinlanj))
+- Add Xcode 13 image ([#651](https://github.com/expo/eas-cli/pull/651) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -11,7 +11,7 @@
     "@expo/apple-utils": "0.0.0-alpha.25",
     "@expo/config": "5.0.9",
     "@expo/config-plugins": "3.1.0",
-    "@expo/eas-build-job": "0.2.46",
+    "@expo/eas-build-job": "0.2.48",
     "@expo/eas-json": "^0.28.2",
     "@expo/json-file": "8.2.33",
     "@expo/pkcs12": "0.0.4",

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.dev>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.46",
+    "@expo/eas-build-job": "0.2.48",
     "@expo/json-file": "8.2.33",
     "env-string": "1.0.1",
     "fs-extra": "10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,10 +889,10 @@
     slugify "^1.3.4"
     sucrase "^3.20.0"
 
-"@expo/eas-build-job@0.2.46":
-  version "0.2.46"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.46.tgz#2742fd21a0fb0fdd2857705f931a4c10c0ad45f7"
-  integrity sha512-D3/RcwlLdywmT7UCtOOylLGy47W+o4UwGxrLH1j8IVYTJxyT+s/n1ss5ipbLkssEPPUfibTBysgZfwVGdCSWkQ==
+"@expo/eas-build-job@0.2.48":
+  version "0.2.48"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.48.tgz#ebc2abea02cb3f23be9714318bea04515980b03d"
+  integrity sha512-QWg44uXndNw3ZKrP+1FD2Li1VSQoSWn94iQ6j6lwMfVfFpp6DiiZ73HXf4Bxix52cl5DTmpaE7hxYyhxSvV0yA==
   dependencies:
     joi "^17.4.2"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

add code 13 image


