### PR TITLE
make eslint disallow use of sync fs functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   extends: ['universe/node'],
-  plugins: ['async-protect'],
+  plugins: ['async-protect', 'node'],
   rules: {
     'no-console': 'warn',
     'no-constant-condition': ['warn', { checkLoops: false }],
@@ -41,6 +41,7 @@ module.exports = {
       },
     ],
     'async-protect/async-suffix': 'error',
+    'node/no-sync': 'error',
   },
   overrides: [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Always use async `fs` functions. ([#652](https://github.com/expo/eas-cli/pull/652) by [@dsokal](https://github.com/dsokal))
+
 ## [0.29.0](https://github.com/expo/eas-cli/releases/tag/v0.29.0) - 2021-09-28
 
 ### 🎉 New features

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint": "7.32.0",
     "eslint-config-universe": "8.0.0",
     "eslint-plugin-async-protect": "1.1.0",
+    "eslint-plugin-node": "11.1.0",
     "jest": "27.1.0",
     "jest-watch-typeahead": "0.6.4",
     "lerna": "4.0.0",

--- a/packages/eas-cli/__mocks__/fs.ts
+++ b/packages/eas-cli/__mocks__/fs.ts
@@ -1,8 +1,10 @@
 import { fs } from 'memfs';
 
 // needed because of a weird bug with tempy (dependency of @expo/config-plugins)
+// eslint-disable-next-line node/no-sync
 fs.mkdirSync('/tmp');
 if (process.env.TMPDIR) {
+  // eslint-disable-next-line node/no-sync
   fs.mkdirSync(process.env.TMPDIR, { recursive: true });
 }
 

--- a/packages/eas-cli/patch-readme.js
+++ b/packages/eas-cli/patch-readme.js
@@ -1,10 +1,12 @@
-const fs = require('fs');
+const { promises: fs } = require('fs');
 
-// Patch `oclif-dev readme` path and link generation
-let readmeContent = fs.readFileSync('README.md', 'utf8');
-readmeContent = readmeContent.replace(/\[build\//g, '[src/');
-readmeContent = readmeContent.replace(/build\/commands/g, 'packages/eas-cli/src/commands');
-fs.writeFileSync('README.md', readmeContent);
+(async () => {
+  // Patch `oclif-dev readme` path and link generation
+  let readmeContent = await fs.readFile('README.md', 'utf8');
+  readmeContent = readmeContent.replace(/\[build\//g, '[src/');
+  readmeContent = readmeContent.replace(/build\/commands/g, 'packages/eas-cli/src/commands');
+  await fs.writeFile('README.md', readmeContent);
 
-// eslint-disable-next-line no-console
-console.log('Patched README path generation');
+  // eslint-disable-next-line no-console
+  console.log('Patched README path generation');
+})();

--- a/packages/eas-cli/src/build/android/__tests__/UpdatesModule-test.ts
+++ b/packages/eas-cli/src/build/android/__tests__/UpdatesModule-test.ts
@@ -6,17 +6,17 @@ import { readChannelSafelyAsync } from '../UpdatesModule';
 
 jest.mock('fs');
 
-afterAll(() => {
+afterAll(async () => {
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.removeSync(os.tmpdir());
+  await fs.remove(os.tmpdir());
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   vol.reset();
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.mkdirpSync(os.tmpdir());
+  await fs.mkdirp(os.tmpdir());
 });
 
 const testChannel = 'test-channel';

--- a/packages/eas-cli/src/build/android/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/android/__tests__/version-test.ts
@@ -9,17 +9,17 @@ import { maybeResolveVersionsAsync } from '../version';
 
 jest.mock('fs');
 
-afterAll(() => {
+afterAll(async () => {
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.removeSync(os.tmpdir());
+  await fs.remove(os.tmpdir());
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   vol.reset();
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.mkdirpSync(os.tmpdir());
+  await fs.mkdirp(os.tmpdir());
 });
 
 describe(maybeResolveVersionsAsync, () => {

--- a/packages/eas-cli/src/build/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/ios/UpdatesModule.ts
@@ -19,7 +19,11 @@ export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig)
       projectDir,
       xcodeProject
     );
-    await fs.writeFile(IOSConfig.Paths.getPBXProjectPath(projectDir), xcodeProject.writeSync());
+    await fs.writeFile(
+      IOSConfig.Paths.getPBXProjectPath(projectDir),
+      // eslint-disable-next-line node/no-sync
+      xcodeProject.writeSync()
+    );
   }
 
   let expoPlist = await readExpoPlistAsync(projectDir);

--- a/packages/eas-cli/src/build/ios/__tests__/UpdatesModule-test.ts
+++ b/packages/eas-cli/src/build/ios/__tests__/UpdatesModule-test.ts
@@ -6,17 +6,17 @@ import { readChannelSafelyAsync } from '../UpdatesModule';
 
 jest.mock('fs');
 
-afterAll(() => {
+afterAll(async () => {
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.removeSync(os.tmpdir());
+  await fs.remove(os.tmpdir());
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   vol.reset();
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.mkdirpSync(os.tmpdir());
+  await fs.mkdirp(os.tmpdir());
 });
 
 const testChannel = 'test-channel';

--- a/packages/eas-cli/src/build/ios/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/ios/__tests__/version-test.ts
@@ -17,17 +17,17 @@ import {
 
 jest.mock('fs');
 
-afterAll(() => {
+afterAll(async () => {
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.removeSync(os.tmpdir());
+  await fs.remove(os.tmpdir());
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   vol.reset();
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.mkdirpSync(os.tmpdir());
+  await fs.mkdirp(os.tmpdir());
 });
 
 describe(evaluateTemplateString, () => {

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -25,7 +25,7 @@ import {
   PublishPlatform,
   buildBundlesAsync,
   buildUnsortedUpdateInfoGroupAsync,
-  collectAssets,
+  collectAssetsAsync,
   uploadAssetsAsync,
 } from '../../project/publish';
 import { promptAsync, selectAsync } from '../../prompts';
@@ -290,7 +290,7 @@ export default class BranchPublish extends EasCommand {
       const assetSpinner = ora('Uploading assets...').start();
       try {
         const platforms = platformFlag === 'all' ? defaultPublishPlatforms : [platformFlag];
-        const assets = collectAssets({ inputDir: inputDir!, platforms });
+        const assets = await collectAssetsAsync({ inputDir: inputDir!, platforms });
         await uploadAssetsAsync(assets);
         unsortedUpdateInfoGroups = await buildUnsortedUpdateInfoGroupAsync(assets, exp);
         assetSpinner.succeed('Uploaded assets!');

--- a/packages/eas-cli/src/credentials/ios/appstore/entitlements.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/entitlements.ts
@@ -3,17 +3,7 @@ import { Workflow } from '@expo/eas-build-job';
 import { JSONObject } from '@expo/json-file';
 import plist from '@expo/plist';
 import { getPrebuildConfig } from '@expo/prebuild-config';
-import fs from 'fs';
-
-function getEntitlementsJson(projectDir: string): JSONObject | null {
-  try {
-    const entitlementsPath = IOSConfig.Paths.getEntitlementsPath(projectDir);
-    if (entitlementsPath) {
-      return plist.parse(fs.readFileSync(entitlementsPath, 'utf8'));
-    }
-  } catch {}
-  return null;
-}
+import fs from 'fs-extra';
 
 export async function getManagedEntitlementsJsonAsync(projectDir: string): Promise<JSONObject> {
   let { exp } = getPrebuildConfig(projectDir, { platforms: ['ios'] });
@@ -31,10 +21,21 @@ export async function resolveEntitlementsJsonAsync(
   workflow: Workflow
 ): Promise<JSONObject> {
   if (workflow === Workflow.GENERIC) {
-    return getEntitlementsJson(projectDir) || {};
+    return (await getEntitlementsJsonAsync(projectDir)) || {};
   } else if (workflow === Workflow.MANAGED) {
-    return getManagedEntitlementsJsonAsync(projectDir);
+    return await getManagedEntitlementsJsonAsync(projectDir);
   } else {
     throw new Error(`Unknown workflow: ${workflow}`);
   }
+}
+
+async function getEntitlementsJsonAsync(projectDir: string): Promise<JSONObject | null> {
+  try {
+    const entitlementsPath = IOSConfig.Paths.getEntitlementsPath(projectDir);
+    if (entitlementsPath) {
+      const entitlementsContents = await fs.readFile(entitlementsPath, 'utf8');
+      return plist.parse(entitlementsContents);
+    }
+  } catch {}
+  return null;
 }

--- a/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
@@ -14,11 +14,12 @@ jest.mock('fs');
 jest.mock('../../../prompts');
 jest.mock('../../../user/actions', () => ({ ensureLoggedInAsync: jest.fn(() => mockJester) }));
 
-beforeEach(() => {
+beforeEach(async () => {
   vol.reset();
+
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.mkdirpSync(os.tmpdir());
+  await fs.mkdirp(os.tmpdir());
 
   asMock(promptAsync).mockReset();
 });
@@ -145,7 +146,8 @@ describe(ensureApplicationIdIsDefinedForManagedProjectAsync, () => {
       await expect(
         ensureApplicationIdIsDefinedForManagedProjectAsync('/app', {} as any)
       ).resolves.toBe('com.expo.notdominik');
-      expect(JSON.parse(fs.readFileSync('/app/app.json', 'utf-8'))).toMatchObject({
+      const appJson = JSON.parse(await fs.readFile('/app/app.json', 'utf-8'));
+      expect(appJson).toMatchObject({
         expo: { android: { package: 'com.expo.notdominik' } },
       });
     });

--- a/packages/eas-cli/src/project/android/__tests__/gradle-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/gradle-test.ts
@@ -11,11 +11,11 @@ jest.mock('fs');
 jest.mock('../../../prompts');
 jest.mock('../../../user/actions', () => ({ ensureLoggedInAsync: jest.fn(() => mockJester) }));
 
-beforeEach(() => {
+beforeEach(async () => {
   vol.reset();
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.mkdirpSync(os.tmpdir());
+  await fs.mkdirp(os.tmpdir());
 
   asMock(promptAsync).mockReset();
 });

--- a/packages/eas-cli/src/project/android/__tests__/gradleUtils-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/gradleUtils-test.ts
@@ -10,14 +10,14 @@ const fsReal = jest.requireActual('fs') as typeof fs;
 jest.mock('fs');
 
 describe(getAppBuildGradleAsync, () => {
-  afterEach(async () => {
+  afterEach(() => {
     vol.reset();
   });
 
   test('parsing build.gradle from managed template', async () => {
     vol.fromJSON(
       {
-        'android/app/build.gradle': fsReal.readFileSync(
+        'android/app/build.gradle': await fsReal.promises.readFile(
           path.join(__dirname, 'fixtures/build.gradle'),
           'utf-8'
         ),
@@ -41,7 +41,7 @@ describe(getAppBuildGradleAsync, () => {
   test('parsing multiflavor build.gradle', async () => {
     vol.fromJSON(
       {
-        'android/app/build.gradle': fsReal.readFileSync(
+        'android/app/build.gradle': await fsReal.promises.readFile(
           path.join(__dirname, 'fixtures/multiflavor-build.gradle'),
           'utf-8'
         ),
@@ -75,7 +75,7 @@ describe(getAppBuildGradleAsync, () => {
   test('parsing build.gradle with flavor dimensions', async () => {
     vol.fromJSON(
       {
-        'android/app/build.gradle': fsReal.readFileSync(
+        'android/app/build.gradle': await fsReal.promises.readFile(
           path.join(__dirname, 'fixtures/multiflavor-with-dimensions-build.gradle'),
           'utf-8'
         ),

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -57,10 +57,10 @@ export async function getApplicationIdAsync(
       try {
         buildGradlePath = AndroidConfig.Paths.getAppBuildGradleFilePath(projectDir);
       } catch {}
-      if (!buildGradlePath || !fs.pathExistsSync(buildGradlePath)) {
+      if (!buildGradlePath || !(await fs.pathExists(buildGradlePath))) {
         throw new Error(errorMessage);
       }
-      const buildGradle = fs.readFileSync(buildGradlePath, 'utf8');
+      const buildGradle = await fs.readFile(buildGradlePath, 'utf8');
       const matchResult = buildGradle.match(/applicationId ['"](.*)['"]/);
       const applicationId = nullthrows(matchResult?.[1], errorMessage);
 

--- a/packages/eas-cli/src/project/ios/__tests__/scheme-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/scheme-test.ts
@@ -9,11 +9,12 @@ import { selectSchemeAsync } from '../scheme';
 jest.mock('fs');
 jest.mock('../../../prompts');
 
-beforeEach(() => {
+beforeEach(async () => {
   vol.reset();
+
   // do not remove the following line
   // this fixes a weird error with tempy in @expo/image-utils
-  fs.mkdirpSync(os.tmpdir());
+  await fs.mkdirp(os.tmpdir());
 
   asMock(promptAsync).mockReset();
 });

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -1,7 +1,7 @@
 import { ExpoConfig, Platform } from '@expo/config';
 import JsonFile from '@expo/json-file';
 import crypto from 'crypto';
-import fs from 'fs';
+import fs from 'fs-extra';
 import Joi from 'joi';
 import mime from 'mime';
 import path from 'path';
@@ -161,9 +161,9 @@ export async function buildBundlesAsync({
   await expoCommandAsync(projectDir, ['export', '--output-dir', inputDir, '--experimental-bundle']);
 }
 
-export function resolveInputDirectory(customInputDirectory: string): string {
+export async function resolveInputDirectoryAsync(customInputDirectory: string): Promise<string> {
   const distRoot = path.resolve(customInputDirectory);
-  if (!fs.existsSync(distRoot)) {
+  if (!(await fs.pathExists(distRoot))) {
     throw new Error(`The input directory "${customInputDirectory}" does not exist.
     You can allow us to build it for you by not setting the --skip-bundler flag.
     If you chose to build it yourself you'll need to run a command to build the JS
@@ -190,14 +190,14 @@ export function loadMetadata(distRoot: string): Metadata {
   return metadata;
 }
 
-export function collectAssets({
+export async function collectAssetsAsync({
   inputDir,
   platforms,
 }: {
   inputDir: string;
   platforms: PublishPlatform[];
-}): CollectedAssets {
-  const distRoot = resolveInputDirectory(inputDir);
+}): Promise<CollectedAssets> {
+  const distRoot = await resolveInputDirectoryAsync(inputDir);
   const metadata = loadMetadata(distRoot);
 
   const assetsFinal: CollectedAssets = {};

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -15,7 +15,7 @@ export default class LocalClient extends Client {
 
   public async makeShallowCopyAsync(destinationPath: string): Promise<void> {
     const srcPath = getRootPath();
-    const ignore = initIgnore();
+    const ignore = await initIgnoreAsync();
     await fs.copy(srcPath, destinationPath, {
       filter: (srcFilePath: string) => {
         if (srcFilePath === srcPath) {
@@ -27,7 +27,7 @@ export default class LocalClient extends Client {
   }
 
   public async isFileIgnoredAsync(filePath: string): Promise<boolean> {
-    return initIgnore().ignores(filePath);
+    return (await initIgnoreAsync()).ignores(filePath);
   }
 }
 
@@ -39,16 +39,16 @@ function getRootPath(): string {
   return rootPath;
 }
 
-function initIgnore(): Ignore {
+async function initIgnoreAsync(): Promise<Ignore> {
   const srcPath = getRootPath();
   const easIgnorePath = path.join(srcPath, '.easignore');
   const gitIgnorePath = path.join(srcPath, '.gitignore');
 
   let ignoreFile = DEFAULT_IGNORE;
-  if (fs.pathExistsSync(easIgnorePath)) {
-    ignoreFile = fs.readFileSync(easIgnorePath, 'utf8');
-  } else if (fs.pathExistsSync(gitIgnorePath)) {
-    ignoreFile = fs.readFileSync(gitIgnorePath, 'utf8');
+  if (await fs.pathExists(easIgnorePath)) {
+    ignoreFile = await fs.readFile(easIgnorePath, 'utf8');
+  } else if (await fs.pathExists(gitIgnorePath)) {
+    ignoreFile = await fs.readFile(gitIgnorePath, 'utf8');
   }
 
   return ignore().add(ignoreFile);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5047,6 +5047,14 @@ eslint-plugin-async-protect@1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-async-protect/-/eslint-plugin-async-protect-1.1.0.tgz#1b5652f5d4b875064065e5478b5e8c5d1aa6fb71"
   integrity sha512-RlBCU/TCf4SaQe0NZfmbxjNHoHMv183VCsgRhBidSQBjXz4HJeaSNrvhhFwvhtk8BHapy+tcTTT3L+oJ3iPM7Q==
 
+eslint-plugin-es@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"
+  integrity sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
 eslint-plugin-graphql@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-graphql/-/eslint-plugin-graphql-4.0.0.tgz#d238ff2baee4d632cfcbe787a7a70a1f50428358"
@@ -5077,6 +5085,18 @@ eslint-plugin-import@^2.23.4:
     read-pkg-up "^3.0.0"
     resolve "^1.20.0"
     tsconfig-paths "^3.11.0"
+
+eslint-plugin-node@11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
+  integrity sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
+  dependencies:
+    eslint-plugin-es "^3.0.0"
+    eslint-utils "^2.0.0"
+    ignore "^5.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.10.1"
+    semver "^6.1.0"
 
 eslint-plugin-prettier@^3.4.0:
   version "3.4.1"
@@ -5122,7 +5142,7 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.1.0:
+eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
@@ -9452,7 +9472,7 @@ regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -9596,7 +9616,7 @@ resolve@^1.10.0, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.20.0:
+resolve@^1.10.1, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -9732,7 +9752,7 @@ semver@7.3.5, semver@7.x, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

It's good practice to always use async functions in node (vs. sync counterparts) if available. We sometimes use sync functions from `fs` and usually without a good reason.

# How

- Add a eslint plugin with `node/no-sync` that disallows use of `...Sync` functions.
- Refactor code to use only async fs functions.

# Test Plan

CI