### PR TITLE
[eas-cli] fix android print formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Always use async `fs` functions. ([#652](https://github.com/expo/eas-cli/pull/652) by [@dsokal](https://github.com/dsokal))
-- Improve Android credentials printing ([#656](https://github.com/expo/eas-cli/pull/656) by [@quinlanj](https://github.com/quinlanj))
+- Improve Android credentials printing. ([#656](https://github.com/expo/eas-cli/pull/656) by [@quinlanj](https://github.com/quinlanj))
 
 ## [0.29.0](https://github.com/expo/eas-cli/releases/tag/v0.29.0) - 2021-09-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Always use async `fs` functions. ([#652](https://github.com/expo/eas-cli/pull/652) by [@dsokal](https://github.com/dsokal))
+- Improve Android credentials printing ([#656](https://github.com/expo/eas-cli/pull/656) by [@quinlanj](https://github.com/quinlanj))
 
 ## [0.29.0](https://github.com/expo/eas-cli/releases/tag/v0.29.0) - 2021-09-28
 

--- a/packages/eas-cli/src/credentials/android/utils/__tests__/__snapshots__/printCredentials-test.ts.snap
+++ b/packages/eas-cli/src/credentials/android/utils/__tests__/__snapshots__/printCredentials-test.ts.snap
@@ -1,9 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`print credentials prints the AndroidAppCredentials fragment 1`] = `
-"Android Credentials  Project: testApp  Application Identifier: test.com.app  Push Notifications (FCM):    Key: abcd...efgh    Updated 0 second agoGoogle Service Account Key For Submissions  Project ID      sdf.sdf.sdf
+"Android Credentials     
+Project                 testApp
+Application Identifier  test.com.appPush Notifications (FCM)  Key      abcd...efgh
+Updated  0 second agoGoogle Service Account Key For Submissions  Project ID      sdf.sdf.sdf
 Client Email    quin@expo.io
 Client ID       test-client-identifier
 Private Key ID  test-private-key-identifier
-Updated         0 second ago  Configuration: legacy (Default)  Keystore:    Type: JKS    Key Alias: QHdrb3p5cmEvY3JlZGVudGlhbHMtdGVzdA==    MD5 Fingerprint: TE:ST:-M:D5    SHA1 Fingerprint: TE:ST:-S:HA:1    SHA256 Fingerprint: TE:ST:-S:HA:25:6    Updated 0 second ago"
+Updated         0 second agoConfiguration: legacy (Default)  Keystore  Type                JKS
+Key Alias           QHdrb3p5cmEvY3JlZGVudGlhbHMtdGVzdA==
+MD5 Fingerprint     TE:ST:-M:D5
+SHA1 Fingerprint    TE:ST:-S:HA:1
+SHA256 Fingerprint  TE:ST:-S:HA:25:6
+Updated             0 second ago"
 `;

--- a/packages/eas-cli/src/credentials/android/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/utils/printCredentials.ts
@@ -16,32 +16,46 @@ import { AppLookupParams } from '../api/GraphqlClient';
 
 export function displayEmptyAndroidCredentials(appLookupParams: AppLookupParams): void {
   const { projectName, androidApplicationIdentifier } = appLookupParams;
-  Log.log(chalk.bold(`Android Credentials`));
-  Log.log(`  Project: ${projectName}`);
-  Log.log(`  Application Identifier: ${androidApplicationIdentifier}`);
-  Log.log(`  No credentials set up yet!`);
+  const fields = [
+    { label: 'Android Credentials', value: '' },
+    { label: 'Project', value: projectName },
+    { label: 'Application Identifier', value: androidApplicationIdentifier },
+  ];
+  Log.log(formatFields(fields, { labelFormat: chalk.cyan.bold }));
+  Log.log(
+    formatFields([{ label: 'No credentials set up yet!', value: '' }])
+  );
+  Log.newLine();
 }
 
 function displayAndroidFcmCredentials(appCredentials: CommonAndroidAppCredentialsFragment): void {
   const maybeFcm = appCredentials.androidFcm;
-  Log.log(`  Push Notifications (FCM):`);
+  Log.log(
+    formatFields([{ label: 'Push Notifications (FCM)', value: '' }], {
+      labelFormat: chalk.cyan.bold,
+    })
+  );
   if (!maybeFcm) {
-    Log.log(`    None assigned yet`);
+    Log.log(
+      formatFields([{ label: '', value: 'None assigned yet' }])
+    );
     Log.newLine();
     return;
   }
   const { snippet, version, updatedAt } = maybeFcm;
+  let fields = [];
   if (version === AndroidFcmVersion.Legacy) {
     const { firstFourCharacters, lastFourCharacters } = snippet as FcmSnippetLegacy;
-    Log.log(`    Key: ${firstFourCharacters}...${lastFourCharacters}`);
+    fields.push( { label: 'Key', value: `${firstFourCharacters}...${lastFourCharacters}` });
   } else if (version === AndroidFcmVersion.V1) {
     const { projectId, serviceAccountEmail, clientId, keyId } = snippet as FcmSnippetV1;
-    Log.log(`    Project Id: ${projectId}`);
-    Log.log(`    Service Account: ${serviceAccountEmail}`);
-    Log.log(`    Client Id: ${clientId}`);
-    Log.log(`    Key Id: ${keyId}`);
+    fields.push( { label: 'Project ID', value: projectId });
+    fields.push( { label: 'Client Email', value: serviceAccountEmail });
+    fields.push( { label: 'Client ID', value: clientId ?? 'Unknown' });
+    fields.push( { label: 'Private Key ID', value: keyId });
   }
-  Log.log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
+  fields.push( { label: 'Updated', value: `${fromNow(new Date(updatedAt))} ago` });
+  Log.log(formatFields(fields, { labelFormat: chalk.cyan.bold }));
   Log.newLine();
 }
 
@@ -56,9 +70,7 @@ function displayGoogleServiceAccountKeyForSubmissions(
   );
   if (!maybeGsaKey) {
     Log.log(
-      formatFields([{ label: '', value: 'None assigned yet' }], {
-        labelFormat: chalk.cyan.bold,
-      })
+      formatFields([{ label: '', value: 'None assigned yet' }])
     );
     Log.newLine();
     return;
@@ -108,19 +120,26 @@ function formatFingerprint(fingerprint: string | null): string {
 }
 function displayAndroidBuildCredentials(
   buildCredentials: AndroidAppBuildCredentialsFragment,
-  skipConfigurationDisplay?: boolean
 ): void {
-  if (!skipConfigurationDisplay) {
-    const { isDefault, name } = buildCredentials;
-    Log.log(chalk.bold(`  Configuration: ${name}${isDefault ? ' (Default)' : ''}`));
-  }
+  const { isDefault, name } = buildCredentials;
+  Log.log(
+    formatFields([{ label: `Configuration: ${name}${isDefault ? ' (Default)' : ''}`, value: '' }], {
+      labelFormat: chalk.cyan.bold,
+    })
+  );
 
   const maybeKeystore = buildCredentials.androidKeystore;
-  Log.log(`  Keystore:`);
+  Log.log(
+    formatFields([{ label: 'Keystore', value: '' }], {
+      labelFormat: chalk.cyan.bold,
+    })
+  );
   if (maybeKeystore) {
     displayAndroidKeystore(maybeKeystore);
   } else {
-    Log.log(`    None assigned yet`);
+    Log.log(
+      formatFields([{ label: '', value: 'None assigned yet' }])
+    );
   }
   Log.newLine();
 }
@@ -134,13 +153,15 @@ export function displayAndroidKeystore(keystore: AndroidKeystoreFragment): void 
     sha256CertificateFingerprint,
     updatedAt,
   } = keystore;
-  Log.log(`    Type: ${type}`);
-  Log.log(`    Key Alias: ${keyAlias}`);
-
-  Log.log(`    MD5 Fingerprint: ${formatFingerprint(md5CertificateFingerprint ?? null)}`);
-  Log.log(`    SHA1 Fingerprint: ${formatFingerprint(sha1CertificateFingerprint ?? null)}`);
-  Log.log(`    SHA256 Fingerprint: ${formatFingerprint(sha256CertificateFingerprint ?? null)}`);
-  Log.log(`    Updated ${fromNow(new Date(updatedAt))} ago`);
+  const fields = [
+    { label: 'Type', value: type },
+    { label: 'Key Alias', value: keyAlias },
+    { label: 'MD5 Fingerprint', value: formatFingerprint(md5CertificateFingerprint ?? null) },
+    { label: 'SHA1 Fingerprint', value: formatFingerprint(sha1CertificateFingerprint ?? null) },
+    { label: 'SHA256 Fingerprint', value: formatFingerprint(sha256CertificateFingerprint ?? null) },
+    { label: 'Updated', value: `${fromNow(new Date(updatedAt))} ago` },
+  ];
+  Log.log(formatFields(fields, { labelFormat: chalk.cyan.bold }));
 }
 
 export function displayAndroidAppCredentials({
@@ -151,9 +172,12 @@ export function displayAndroidAppCredentials({
   appCredentials: CommonAndroidAppCredentialsFragment | null;
 }): void {
   const { projectName, androidApplicationIdentifier } = appLookupParams;
-  Log.log(chalk.bold(`Android Credentials`));
-  Log.log(`  Project: ${projectName}`);
-  Log.log(`  Application Identifier: ${androidApplicationIdentifier}`);
+  const fields = [
+    { label: 'Android Credentials', value: '' },
+    { label: 'Project', value: projectName },
+    { label: 'Application Identifier', value: androidApplicationIdentifier },
+  ];
+  Log.log(formatFields(fields, { labelFormat: chalk.cyan.bold }));
   Log.newLine();
 
   if (appCredentials) {

--- a/packages/eas-cli/src/credentials/android/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/utils/printCredentials.ts
@@ -22,9 +22,7 @@ export function displayEmptyAndroidCredentials(appLookupParams: AppLookupParams)
     { label: 'Application Identifier', value: androidApplicationIdentifier },
   ];
   Log.log(formatFields(fields, { labelFormat: chalk.cyan.bold }));
-  Log.log(
-    formatFields([{ label: 'No credentials set up yet!', value: '' }])
-  );
+  Log.log(formatFields([{ label: 'No credentials set up yet!', value: '' }]));
   Log.newLine();
 }
 
@@ -36,25 +34,23 @@ function displayAndroidFcmCredentials(appCredentials: CommonAndroidAppCredential
     })
   );
   if (!maybeFcm) {
-    Log.log(
-      formatFields([{ label: '', value: 'None assigned yet' }])
-    );
+    Log.log(formatFields([{ label: '', value: 'None assigned yet' }]));
     Log.newLine();
     return;
   }
   const { snippet, version, updatedAt } = maybeFcm;
-  let fields = [];
+  const fields = [];
   if (version === AndroidFcmVersion.Legacy) {
     const { firstFourCharacters, lastFourCharacters } = snippet as FcmSnippetLegacy;
-    fields.push( { label: 'Key', value: `${firstFourCharacters}...${lastFourCharacters}` });
+    fields.push({ label: 'Key', value: `${firstFourCharacters}...${lastFourCharacters}` });
   } else if (version === AndroidFcmVersion.V1) {
     const { projectId, serviceAccountEmail, clientId, keyId } = snippet as FcmSnippetV1;
-    fields.push( { label: 'Project ID', value: projectId });
-    fields.push( { label: 'Client Email', value: serviceAccountEmail });
-    fields.push( { label: 'Client ID', value: clientId ?? 'Unknown' });
-    fields.push( { label: 'Private Key ID', value: keyId });
+    fields.push({ label: 'Project ID', value: projectId });
+    fields.push({ label: 'Client Email', value: serviceAccountEmail });
+    fields.push({ label: 'Client ID', value: clientId ?? 'Unknown' });
+    fields.push({ label: 'Private Key ID', value: keyId });
   }
-  fields.push( { label: 'Updated', value: `${fromNow(new Date(updatedAt))} ago` });
+  fields.push({ label: 'Updated', value: `${fromNow(new Date(updatedAt))} ago` });
   Log.log(formatFields(fields, { labelFormat: chalk.cyan.bold }));
   Log.newLine();
 }
@@ -69,9 +65,7 @@ function displayGoogleServiceAccountKeyForSubmissions(
     })
   );
   if (!maybeGsaKey) {
-    Log.log(
-      formatFields([{ label: '', value: 'None assigned yet' }])
-    );
+    Log.log(formatFields([{ label: '', value: 'None assigned yet' }]));
     Log.newLine();
     return;
   }
@@ -119,7 +113,7 @@ function formatFingerprint(fingerprint: string | null): string {
   return bytes.join(':');
 }
 function displayAndroidBuildCredentials(
-  buildCredentials: AndroidAppBuildCredentialsFragment,
+  buildCredentials: AndroidAppBuildCredentialsFragment
 ): void {
   const { isDefault, name } = buildCredentials;
   Log.log(
@@ -137,9 +131,7 @@ function displayAndroidBuildCredentials(
   if (maybeKeystore) {
     displayAndroidKeystore(maybeKeystore);
   } else {
-    Log.log(
-      formatFields([{ label: '', value: 'None assigned yet' }])
-    );
+    Log.log(formatFields([{ label: '', value: 'None assigned yet' }]));
   }
   Log.newLine();
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Fix the way we print Android credentials, followup from https://github.com/expo/eas-cli/pull/649#discussion_r717252597 

![Screen Shot 2021-09-28 at 3 40 11 PM](https://user-images.githubusercontent.com/6380927/135175522-9c5e2843-7753-4208-ab40-42676c4ab8a7.png)


# Test Plan

- [x] updated existing snapshots
