### PR TITLE
[eas-cli] remove google service account key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - More upload support for Google Service Account Keys. ([#649](https://github.com/expo/eas-cli/pull/649) by [@quinlanj](https://github.com/quinlanj))
 - Allow the user to assign an existing Google Service Account Key to their project. ([#650](https://github.com/expo/eas-cli/pull/650) by [@quinlanj](https://github.com/quinlanj))
+- Allow the user to remove a Google Service Account Key from their account. ([#658](https://github.com/expo/eas-cli/pull/658) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-android.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-android.ts
@@ -143,6 +143,7 @@ export function getNewAndroidApiMock(): { [key in keyof typeof AndroidGraphqlCli
     createOrUpdateAndroidAppBuildCredentialsByNameAsync: jest.fn(),
     createKeystoreAsync: jest.fn(),
     createGoogleServiceAccountKeyAsync: jest.fn(),
+    deleteGoogleServiceAccountKeyAsync: jest.fn(),
     getGoogleServiceAccountKeysForAccountAsync: jest.fn(),
     createFcmAsync: jest.fn(),
     deleteKeystoreAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
@@ -33,7 +33,7 @@ export class SelectAndRemoveGoogleServiceAccountKey {
 export class RemoveGoogleServiceAccountKey {
   constructor(private googleServiceAccountKey: GoogleServiceAccountKeyFragment) {}
 
-  public async runAsync(ctx: Context): Promise<void> {
+  public async runAsync(ctx: CredentialsContext): Promise<void> {
     if (ctx.nonInteractive) {
       throw new Error(`Cannot remove Google Service Account Keys in non-interactive mode`);
     }

--- a/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
@@ -13,7 +13,7 @@ export class SelectAndRemoveGoogleServiceAccountKey {
       this.account
     );
     if (gsaKeyFragments.length === 0) {
-      Log.error("There aren't any Google Service Account Keys associated with your account.");
+      Log.warn("There aren't any Google Service Account Keys associated with your account.");
       return;
     }
 

--- a/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
@@ -1,0 +1,47 @@
+import { GoogleServiceAccountKeyFragment } from '../../../graphql/generated';
+import Log from '../../../log';
+import { confirmAsync } from '../../../prompts';
+import { Account } from '../../../user/Account';
+import { Context } from '../../context';
+import { selectGoogleServiceAccountKeyAsync } from '../utils/googleServiceAccountKey';
+
+export class SelectAndRemoveGoogleServiceAccountKey {
+  constructor(private account: Account) {}
+
+  async runAsync(ctx: Context): Promise<void> {
+    const gsaKeyFragments = await ctx.android.getGoogleServiceAccountKeysForAccountAsync(
+      this.account
+    );
+    if (gsaKeyFragments.length === 0) {
+      Log.error("There aren't any Google Service Account Keys associated with your account.");
+      return;
+    }
+
+    const selected = await selectGoogleServiceAccountKeyAsync(gsaKeyFragments);
+    await new RemoveGoogleServiceAccountKey(selected).runAsync(ctx);
+    Log.succeed('Removed Google Service Account Key');
+    Log.newLine();
+  }
+}
+
+export class RemoveGoogleServiceAccountKey {
+  constructor(private googleServiceAccountKey: GoogleServiceAccountKeyFragment) {}
+
+  public async runAsync(ctx: Context): Promise<void> {
+    if (ctx.nonInteractive) {
+      throw new Error(`Cannot remove Google Service Account Keys in non-interactive mode`);
+    }
+
+    // TODO(quin): add an extra edge on GoogleServiceAccountKey to find the apps using it
+    const confirm = await confirmAsync({
+      message: `Deleting this Google Service Account Key may affect your projects that rely on it. Do you want to continue?`,
+    });
+    if (!confirm) {
+      Log.log('Aborting');
+      return;
+    }
+
+    Log.log('Removing Google Service Account Key');
+    await ctx.android.deleteGoogleServiceAccountKeyAsync(this.googleServiceAccountKey);
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
@@ -9,6 +9,12 @@ export class SelectAndRemoveGoogleServiceAccountKey {
   constructor(private account: Account) {}
 
   async runAsync(ctx: Context): Promise<void> {
+    if (ctx.nonInteractive) {
+      throw new Error(
+        `Cannot select and remove Google Service Account Keys in non-interactive mode.`
+      );
+    }
+
     const gsaKeyFragments = await ctx.android.getGoogleServiceAccountKeysForAccountAsync(
       this.account
     );
@@ -19,7 +25,7 @@ export class SelectAndRemoveGoogleServiceAccountKey {
 
     const selected = await selectGoogleServiceAccountKeyAsync(gsaKeyFragments);
     await new RemoveGoogleServiceAccountKey(selected).runAsync(ctx);
-    Log.succeed('Removed Google Service Account Key');
+    Log.succeed('Removed Google Service Account Key.');
     Log.newLine();
   }
 }
@@ -41,7 +47,7 @@ export class RemoveGoogleServiceAccountKey {
       return;
     }
 
-    Log.log('Removing Google Service Account Key');
+    Log.log('Removing Google Service Account Key.');
     await ctx.android.deleteGoogleServiceAccountKeyAsync(this.googleServiceAccountKey);
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
@@ -2,13 +2,13 @@ import { GoogleServiceAccountKeyFragment } from '../../../graphql/generated';
 import Log from '../../../log';
 import { confirmAsync } from '../../../prompts';
 import { Account } from '../../../user/Account';
-import { Context } from '../../context';
+import { CredentialsContext } from '../../context';
 import { selectGoogleServiceAccountKeyAsync } from '../utils/googleServiceAccountKey';
 
 export class SelectAndRemoveGoogleServiceAccountKey {
   constructor(private account: Account) {}
 
-  async runAsync(ctx: Context): Promise<void> {
+  async runAsync(ctx: CredentialsContext): Promise<void> {
     if (ctx.nonInteractive) {
       throw new Error(
         `Cannot select and remove Google Service Account Keys in non-interactive mode.`

--- a/packages/eas-cli/src/credentials/android/actions/UseExistingGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/UseExistingGoogleServiceAccountKey.ts
@@ -1,11 +1,8 @@
-import chalk from 'chalk';
-
 import { GoogleServiceAccountKeyFragment } from '../../../graphql/generated';
 import Log from '../../../log';
-import { promptAsync } from '../../../prompts';
 import { Account } from '../../../user/Account';
-import { fromNow } from '../../../utils/date';
 import { CredentialsContext } from '../../context';
+import { selectGoogleServiceAccountKeyAsync } from '../utils/googleServiceAccountKey';
 
 export class UseExistingGoogleServiceAccountKey {
   constructor(private account: Account) {}
@@ -23,47 +20,6 @@ export class UseExistingGoogleServiceAccountKey {
       Log.error("There aren't any Google Service Account Keys associated with your account.");
       return null;
     }
-    return await this.selectGoogleServiceAccountKeyAsync(gsaKeyFragments);
-  }
-
-  private async selectGoogleServiceAccountKeyAsync(
-    keys: GoogleServiceAccountKeyFragment[]
-  ): Promise<GoogleServiceAccountKeyFragment | null> {
-    const sortedKeys = this.sortGoogleServiceAccountKeysByUpdatedAtDesc(keys);
-    const { chosenKey } = await promptAsync({
-      type: 'select',
-      name: 'chosenKey',
-      message: 'Select a Google Service Account Key:',
-      choices: sortedKeys.map(key => ({
-        title: this.formatGoogleServiceAccountKey(key),
-        value: key,
-      })),
-    });
-    return chosenKey;
-  }
-
-  private sortGoogleServiceAccountKeysByUpdatedAtDesc(
-    keys: GoogleServiceAccountKeyFragment[]
-  ): GoogleServiceAccountKeyFragment[] {
-    return keys.sort(
-      (keyA, keyB) =>
-        new Date(keyB.updatedAt).getMilliseconds() - new Date(keyA.updatedAt).getMilliseconds()
-    );
-  }
-
-  private formatGoogleServiceAccountKey({
-    projectIdentifier,
-    privateKeyIdentifier,
-    clientEmail,
-    clientIdentifier,
-    updatedAt,
-  }: GoogleServiceAccountKeyFragment): string {
-    let line: string = '';
-    line += `Client Email: ${clientEmail}, Project Id: ${projectIdentifier}`;
-    line += chalk.gray(
-      `\n    Client Id: ${clientIdentifier}, Private Key Id: ${privateKeyIdentifier}`
-    );
-    line += chalk.gray(`\n    Updated: ${fromNow(new Date(updatedAt))} ago,`);
-    return line;
+    return await selectGoogleServiceAccountKeyAsync(gsaKeyFragments);
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveGoogleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveGoogleServiceAccountKey-test.ts
@@ -1,0 +1,34 @@
+import { asMock } from '../../../../__tests__/utils';
+import { confirmAsync } from '../../../../prompts';
+import {
+  getNewAndroidApiMock,
+  testGoogleServiceAccountKeyFragment,
+} from '../../../__tests__/fixtures-android';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { RemoveGoogleServiceAccountKey } from '../RemoveGoogleServiceAccountKey';
+
+jest.mock('../../../../prompts');
+asMock(confirmAsync).mockImplementation(() => true);
+
+describe(RemoveGoogleServiceAccountKey, () => {
+  it('removes an Google Service Account Key', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      android: {
+        ...getNewAndroidApiMock(),
+      },
+    });
+    const removeGoogleServiceAccountKeyAction = new RemoveGoogleServiceAccountKey(
+      testGoogleServiceAccountKeyFragment
+    );
+    await removeGoogleServiceAccountKeyAction.runAsync(ctx);
+    expect(ctx.android.deleteGoogleServiceAccountKeyAsync).toHaveBeenCalledTimes(1);
+  });
+  it('errors in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({ nonInteractive: true });
+    const removeGoogleServiceAccountKeyAction = new RemoveGoogleServiceAccountKey(
+      testGoogleServiceAccountKeyFragment
+    );
+    await expect(removeGoogleServiceAccountKeyAction.runAsync(ctx)).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
@@ -252,6 +252,14 @@ export async function createGoogleServiceAccountKeyAsync(
   );
 }
 
+export async function deleteGoogleServiceAccountKeyAsync(
+  googleServiceAccountKey: GoogleServiceAccountKeyFragment
+): Promise<void> {
+  return await GoogleServiceAccountKeyMutation.deleteGoogleServiceAccountKeyAsync(
+    googleServiceAccountKey.id
+  );
+}
+
 export async function getGoogleServiceAccountKeysForAccountAsync(
   account: Account
 ): Promise<GoogleServiceAccountKeyFragment[]> {

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/GoogleServiceAccountKeyMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/GoogleServiceAccountKeyMutation.ts
@@ -5,6 +5,7 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   CreateGoogleServiceAccountKeyMutation,
+  DeleteGoogleServiceAccountKeyMutation,
   GoogleServiceAccountKeyFragment,
   GoogleServiceAccountKeyInput,
 } from '../../../../../graphql/generated';
@@ -47,5 +48,28 @@ export const GoogleServiceAccountKeyMutation = {
       'GraphQL: `createAndroidFcm` not defined in server response'
     );
     return data.googleServiceAccountKey.createGoogleServiceAccountKey;
+  },
+  async deleteGoogleServiceAccountKeyAsync(googleServiceAccountKeyId: string): Promise<void> {
+    await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeleteGoogleServiceAccountKeyMutation>(
+          gql`
+            mutation DeleteGoogleServiceAccountKeyMutation($googleServiceAccountKeyId: ID!) {
+              googleServiceAccountKey {
+                deleteGoogleServiceAccountKey(id: $googleServiceAccountKeyId) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            googleServiceAccountKeyId,
+          },
+          {
+            additionalTypenames: ['GoogleServiceAccountKey', 'AndroidAppCredentials'],
+          }
+        )
+        .toPromise()
+    );
   },
 };

--- a/packages/eas-cli/src/credentials/android/utils/googleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/utils/googleServiceAccountKey.ts
@@ -71,8 +71,7 @@ function formatGoogleServiceAccountKey({
   clientIdentifier,
   updatedAt,
 }: GoogleServiceAccountKeyFragment): string {
-  let line: string = '';
-  line += `Client Email: ${clientEmail}, Project Id: ${projectIdentifier}`;
+  let line = `Client Email: ${clientEmail}, Project Id: ${projectIdentifier}`;
   line += chalk.gray(
     `\n    Client Id: ${clientIdentifier}, Private Key Id: ${privateKeyIdentifier}`
   );

--- a/packages/eas-cli/src/credentials/android/utils/googleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/utils/googleServiceAccountKey.ts
@@ -59,8 +59,7 @@ function sortGoogleServiceAccountKeysByUpdatedAtDesc(
   keys: GoogleServiceAccountKeyFragment[]
 ): GoogleServiceAccountKeyFragment[] {
   return keys.sort(
-    (keyA, keyB) =>
-      new Date(keyB.updatedAt).getMilliseconds() - new Date(keyA.updatedAt).getMilliseconds()
+    (keyA, keyB) => new Date(keyB.updatedAt).getTime() - new Date(keyA.updatedAt).getTime()
   );
 }
 

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -23,6 +23,7 @@ import { CreateGoogleServiceAccountKey } from '../android/actions/CreateGoogleSe
 import { CreateKeystore } from '../android/actions/CreateKeystore';
 import { DownloadKeystore } from '../android/actions/DownloadKeystore';
 import { RemoveFcm } from '../android/actions/RemoveFcm';
+import { SelectAndRemoveGoogleServiceAccountKey } from '../android/actions/RemoveGoogleServiceAccountKey';
 import { RemoveKeystore } from '../android/actions/RemoveKeystore';
 import { SetupBuildCredentialsFromCredentialsJson } from '../android/actions/SetupBuildCredentialsFromCredentialsJson';
 import { UpdateCredentialsJson } from '../android/actions/UpdateCredentialsJson';
@@ -54,6 +55,7 @@ enum ActionType {
   RemoveFcm,
   CreateGsaKey,
   UseExistingGsaKey,
+  RemoveGsaKey,
   UpdateCredentialsJson,
   SetupBuildCredentialsFromCredentialsJson,
 }
@@ -161,6 +163,11 @@ const gsaKeyActions: ActionInfo[] = [
   {
     value: ActionType.UseExistingGsaKey,
     title: 'Use an existing Google Service Account Key',
+    scope: Scope.Project,
+  },
+  {
+    value: ActionType.RemoveGsaKey,
+    title: 'Delete a Google Service Account Key',
     scope: Scope.Project,
   },
   {
@@ -346,6 +353,8 @@ export class ManageAndroid {
       if (gsaKey) {
         await new AssignGoogleServiceAccountKey(appLookupParams).runAsync(ctx, gsaKey);
       }
+    } else if (action === ActionType.RemoveGsaKey) {
+      await new SelectAndRemoveGoogleServiceAccountKey(appLookupParams.account).runAsync(ctx);
     } else if (action === ActionType.UpdateCredentialsJson) {
       const buildCredentials = await new SelectExistingAndroidBuildCredentials(
         appLookupParams

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4034,6 +4034,22 @@ export type CreateGoogleServiceAccountKeyMutation = (
   ) }
 );
 
+export type DeleteGoogleServiceAccountKeyMutationVariables = Exact<{
+  googleServiceAccountKeyId: Scalars['ID'];
+}>;
+
+
+export type DeleteGoogleServiceAccountKeyMutation = (
+  { __typename?: 'RootMutation' }
+  & { googleServiceAccountKey: (
+    { __typename?: 'GoogleServiceAccountKeyMutation' }
+    & { deleteGoogleServiceAccountKey: (
+      { __typename?: 'DeleteGoogleServiceAccountKeyResult' }
+      & Pick<DeleteGoogleServiceAccountKeyResult, 'id'>
+    ) }
+  ) }
+);
+
 export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQueryVariables = Exact<{
   projectFullName: Scalars['String'];
   applicationIdentifier?: Maybe<Scalars['String']>;
@@ -4055,6 +4071,27 @@ export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifi
       )> }
     ) }
   )> }
+);
+
+export type GoogleServiceAccountKeyByAccountQueryVariables = Exact<{
+  accountName: Scalars['String'];
+}>;
+
+
+export type GoogleServiceAccountKeyByAccountQuery = (
+  { __typename?: 'RootQuery' }
+  & { account: (
+    { __typename?: 'AccountQuery' }
+    & { byName: (
+      { __typename?: 'Account' }
+      & Pick<Account, 'id'>
+      & { googleServiceAccountKeys: Array<(
+        { __typename?: 'GoogleServiceAccountKey' }
+        & Pick<GoogleServiceAccountKey, 'id'>
+        & GoogleServiceAccountKeyFragment
+      )> }
+    ) }
+  ) }
 );
 
 export type CreateAppleAppIdentifierMutationVariables = Exact<{
@@ -4634,27 +4671,6 @@ export type AppleTeamByIdentifierQuery = (
       & Pick<AppleTeam, 'id'>
       & AppleTeamFragment
     )> }
-  ) }
-);
-
-export type GoogleServiceAccountKeyByAccountQueryVariables = Exact<{
-  accountName: Scalars['String'];
-}>;
-
-
-export type GoogleServiceAccountKeyByAccountQuery = (
-  { __typename?: 'RootQuery' }
-  & { account: (
-    { __typename?: 'AccountQuery' }
-    & { byName: (
-      { __typename?: 'Account' }
-      & Pick<Account, 'id'>
-      & { googleServiceAccountKeys: Array<(
-        { __typename?: 'GoogleServiceAccountKey' }
-        & Pick<GoogleServiceAccountKey, 'id'>
-        & GoogleServiceAccountKeyFragment
-      )> }
-    ) }
   ) }
 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This PR:

- allows the user to remove a GoogleServiceAccountKey from their account
- adds this action to the credentials management workflow

# Test Plan

- [x] new tests pass
