### PR TITLE
[eas-cli] setup google service account key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - More upload support for Google Service Account Keys. ([#649](https://github.com/expo/eas-cli/pull/649) by [@quinlanj](https://github.com/quinlanj))
 - Allow the user to assign an existing Google Service Account Key to their project. ([#650](https://github.com/expo/eas-cli/pull/650) by [@quinlanj](https://github.com/quinlanj))
 - Allow the user to remove a Google Service Account Key from their account. ([#658](https://github.com/expo/eas-cli/pull/658) by [@quinlanj](https://github.com/quinlanj))
+- Adds setup support for Google Service Account Keys. ([#659](https://github.com/expo/eas-cli/pull/659) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/android/actions/SetupGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/SetupGoogleServiceAccountKey.ts
@@ -1,0 +1,60 @@
+import nullthrows from 'nullthrows';
+import {  CommonAndroidAppCredentialsFragment, GoogleServiceAccountKeyFragment } from '../../../graphql/generated';
+import Log from '../../../log';
+import {  promptAsync } from '../../../prompts';
+import { Context } from '../../context';
+import { AppLookupParams } from '../api/GraphqlClient';
+import { AssignGoogleServiceAccountKey } from './AssignGoogleServiceAccountKey';
+import { CreateGoogleServiceAccountKey } from './CreateGoogleServiceAccountKey';
+import { UseExistingGoogleServiceAccountKey } from './UseExistingGoogleServiceAccountKey';
+
+
+export class SetupGoogleServiceAccountKey {
+  constructor(private app: AppLookupParams) {}
+
+  private async isGoogleServiceAccountKeySetupAsync(ctx: Context): Promise<boolean> {
+    const appCredentials = await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(this.app);
+    return !!(appCredentials?.googleServiceAccountKeyForSubmissions);
+  }
+
+  public async runAsync(ctx: Context): Promise<CommonAndroidAppCredentialsFragment> {
+    if (ctx.nonInteractive) {
+      throw new Error(`Google Service Account Keys cannot be setup in non-interactive mode.`);
+    }
+
+    const isKeySetup = await this.isGoogleServiceAccountKeySetupAsync(ctx);
+    if (isKeySetup) {
+      Log.succeed('Google Service Account Key already setup.')
+      return nullthrows(await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(this.app), 'androidAppCredentials cannot be null if google service account key is already setup');
+    }
+
+    const keysForAccount = await ctx.android.getGoogleServiceAccountKeysForAccountAsync(this.app.account);
+    let googleServiceAccountKey = null;
+    if (keysForAccount.length === 0) {
+      googleServiceAccountKey = await new CreateGoogleServiceAccountKey(this.app.account).runAsync(ctx);
+    } else {
+      googleServiceAccountKey = await this.createOrUseExistingKeyAsync(ctx);
+    }
+    return await new AssignGoogleServiceAccountKey(this.app).runAsync(ctx, googleServiceAccountKey);
+  }
+
+  private async createOrUseExistingKeyAsync(ctx: Context): Promise<GoogleServiceAccountKeyFragment> {
+    const { action } = await promptAsync({
+      type: 'select',
+      name: 'action',
+      message: 'Select the Google Service Account Key to use for your project:',
+      choices: [
+        {
+          title: '[Choose an existing key]',
+          value: 'CHOOSE_EXISTING',
+        },
+        { title: '[Upload a new service account key]', value: 'GENERATE' },
+      ],
+    });
+
+    if (action === 'GENERATE') {
+      return await new CreateGoogleServiceAccountKey(this.app.account).runAsync(ctx);
+    } 
+    return await new UseExistingGoogleServiceAccountKey(this.app.account).runAsync(ctx)?? await this.createOrUseExistingKeyAsync(ctx);
+  }
+}

--- a/packages/eas-cli/src/credentials/android/actions/SetupGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/SetupGoogleServiceAccountKey.ts
@@ -1,44 +1,61 @@
 import nullthrows from 'nullthrows';
-import {  CommonAndroidAppCredentialsFragment, GoogleServiceAccountKeyFragment } from '../../../graphql/generated';
+
+import {
+  CommonAndroidAppCredentialsFragment,
+  GoogleServiceAccountKeyFragment,
+} from '../../../graphql/generated';
 import Log from '../../../log';
-import {  promptAsync } from '../../../prompts';
+import { promptAsync } from '../../../prompts';
 import { Context } from '../../context';
+import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
 import { AssignGoogleServiceAccountKey } from './AssignGoogleServiceAccountKey';
 import { CreateGoogleServiceAccountKey } from './CreateGoogleServiceAccountKey';
 import { UseExistingGoogleServiceAccountKey } from './UseExistingGoogleServiceAccountKey';
 
-
 export class SetupGoogleServiceAccountKey {
   constructor(private app: AppLookupParams) {}
 
   private async isGoogleServiceAccountKeySetupAsync(ctx: Context): Promise<boolean> {
-    const appCredentials = await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(this.app);
-    return !!(appCredentials?.googleServiceAccountKeyForSubmissions);
+    const appCredentials = await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(
+      this.app
+    );
+    return !!appCredentials?.googleServiceAccountKeyForSubmissions;
   }
 
   public async runAsync(ctx: Context): Promise<CommonAndroidAppCredentialsFragment> {
     if (ctx.nonInteractive) {
-      throw new Error(`Google Service Account Keys cannot be setup in non-interactive mode.`);
+      throw new MissingCredentialsNonInteractiveError(
+        'Google Service Account Keys cannot be setup in --non-interactive mode.'
+      );
     }
 
     const isKeySetup = await this.isGoogleServiceAccountKeySetupAsync(ctx);
     if (isKeySetup) {
-      Log.succeed('Google Service Account Key already setup.')
-      return nullthrows(await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(this.app), 'androidAppCredentials cannot be null if google service account key is already setup');
+      Log.succeed('Google Service Account Key already setup.');
+      return nullthrows(
+        await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(this.app),
+        'androidAppCredentials cannot be null if google service account key is already setup'
+      );
     }
 
-    const keysForAccount = await ctx.android.getGoogleServiceAccountKeysForAccountAsync(this.app.account);
+    const keysForAccount = await ctx.android.getGoogleServiceAccountKeysForAccountAsync(
+      this.app.account
+    );
     let googleServiceAccountKey = null;
     if (keysForAccount.length === 0) {
-      googleServiceAccountKey = await new CreateGoogleServiceAccountKey(this.app.account).runAsync(ctx);
+      googleServiceAccountKey = await new CreateGoogleServiceAccountKey(this.app.account).runAsync(
+        ctx
+      );
     } else {
       googleServiceAccountKey = await this.createOrUseExistingKeyAsync(ctx);
     }
     return await new AssignGoogleServiceAccountKey(this.app).runAsync(ctx, googleServiceAccountKey);
   }
 
-  private async createOrUseExistingKeyAsync(ctx: Context): Promise<GoogleServiceAccountKeyFragment> {
+  private async createOrUseExistingKeyAsync(
+    ctx: Context
+  ): Promise<GoogleServiceAccountKeyFragment> {
     const { action } = await promptAsync({
       type: 'select',
       name: 'action',
@@ -54,7 +71,10 @@ export class SetupGoogleServiceAccountKey {
 
     if (action === 'GENERATE') {
       return await new CreateGoogleServiceAccountKey(this.app.account).runAsync(ctx);
-    } 
-    return await new UseExistingGoogleServiceAccountKey(this.app.account).runAsync(ctx)?? await this.createOrUseExistingKeyAsync(ctx);
+    }
+    return (
+      (await new UseExistingGoogleServiceAccountKey(this.app.account).runAsync(ctx)) ??
+      (await this.createOrUseExistingKeyAsync(ctx))
+    );
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetupGoogleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetupGoogleServiceAccountKey-test.ts
@@ -1,0 +1,72 @@
+import { vol } from 'memfs';
+
+import { asMock } from '../../../../__tests__/utils';
+import { promptAsync } from '../../../../prompts';
+import {
+  getNewAndroidApiMock,
+  testAndroidAppCredentialsFragment,
+  testGoogleServiceAccountKeyFragment,
+} from '../../../__tests__/fixtures-android';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { MissingCredentialsNonInteractiveError } from '../../../errors';
+import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
+import { SetupGoogleServiceAccountKey } from '../SetupGoogleServiceAccountKey';
+
+jest.mock('../../../../prompts');
+jest.mock('fs');
+asMock(promptAsync).mockImplementation(() => ({
+  keyJsonPath: '/google-service-account-key.json',
+}));
+
+beforeEach(() => {
+  vol.reset();
+});
+
+describe(SetupGoogleServiceAccountKey, () => {
+  it('skips setup when there is a Google Service Account Key already assigned to the project', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      android: {
+        ...getNewAndroidApiMock(),
+        getAndroidAppCredentialsWithCommonFieldsAsync: jest.fn(
+          () => testAndroidAppCredentialsFragment
+        ),
+      },
+    });
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
+    const setupGoogleServiceAccountKeyAction = new SetupGoogleServiceAccountKey(appLookupParams);
+    await setupGoogleServiceAccountKeyAction.runAsync(ctx);
+
+    expect(ctx.android.createGoogleServiceAccountKeyAsync).not.toHaveBeenCalled();
+    expect(ctx.android.updateAndroidAppCredentialsAsync).not.toHaveBeenCalled();
+  });
+  it('sets up a Google Service Account Key when there is none already setup', async () => {
+    vol.fromJSON({
+      '/google-service-account-key.json': JSON.stringify({ private_key: 'super secret' }),
+    });
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      android: {
+        ...getNewAndroidApiMock(),
+        createGoogleServiceAccountKeyAsync: jest.fn(() => testGoogleServiceAccountKeyFragment),
+        getGoogleServiceAccountKeysForAccountAsync: jest.fn(() => []),
+      },
+    });
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
+    const setupGoogleServiceAccountKeyAction = new SetupGoogleServiceAccountKey(appLookupParams);
+    await setupGoogleServiceAccountKeyAction.runAsync(ctx);
+
+    expect(ctx.android.createGoogleServiceAccountKeyAsync).toHaveBeenCalledTimes(1);
+    expect(ctx.android.updateAndroidAppCredentialsAsync).toHaveBeenCalledTimes(1);
+  });
+  it('errors in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
+    const setupGoogleServiceAccountKeyAction = new SetupGoogleServiceAccountKey(appLookupParams);
+    await expect(setupGoogleServiceAccountKeyAction.runAsync(ctx)).rejects.toThrowError(
+      MissingCredentialsNonInteractiveError
+    );
+  });
+});

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -26,6 +26,7 @@ import { RemoveFcm } from '../android/actions/RemoveFcm';
 import { SelectAndRemoveGoogleServiceAccountKey } from '../android/actions/RemoveGoogleServiceAccountKey';
 import { RemoveKeystore } from '../android/actions/RemoveKeystore';
 import { SetupBuildCredentialsFromCredentialsJson } from '../android/actions/SetupBuildCredentialsFromCredentialsJson';
+import { SetupGoogleServiceAccountKey } from '../android/actions/SetupGoogleServiceAccountKey';
 import { UpdateCredentialsJson } from '../android/actions/UpdateCredentialsJson';
 import { UseExistingGoogleServiceAccountKey } from '../android/actions/UseExistingGoogleServiceAccountKey';
 import {
@@ -56,6 +57,7 @@ enum ActionType {
   CreateGsaKey,
   UseExistingGsaKey,
   RemoveGsaKey,
+  SetupGsaKey,
   UpdateCredentialsJson,
   SetupBuildCredentialsFromCredentialsJson,
 }
@@ -155,6 +157,11 @@ const fcmActions: ActionInfo[] = [
 ];
 
 const gsaKeyActions: ActionInfo[] = [
+  {
+    value: ActionType.SetupGsaKey,
+    title: 'Setup a Google Service Account Key',
+    scope: Scope.Project,
+  },
   {
     value: ActionType.CreateGsaKey,
     title: 'Upload a Google Service Account Key',
@@ -355,6 +362,8 @@ export class ManageAndroid {
       }
     } else if (action === ActionType.RemoveGsaKey) {
       await new SelectAndRemoveGoogleServiceAccountKey(appLookupParams.account).runAsync(ctx);
+    } else if (action === ActionType.SetupGsaKey) {
+      await new SetupGoogleServiceAccountKey(appLookupParams).runAsync(ctx);
     } else if (action === ActionType.UpdateCredentialsJson) {
       const buildCredentials = await new SelectExistingAndroidBuildCredentials(
         appLookupParams


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This PR:
- allows the user to setup a GoogleServiceAccountKey (either use existing or uploading a new one)
- adds an action to setup the key in the credentials management workflow

It will also eventually be used in the submissions workflow.

# Test Plan

- [x] new tests pass
