### PR TITLE
[eas-cli] use google service key detection in credentials service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Ports detection for Google Service Account Keys into the credentials service. ([#660](https://github.com/expo/eas-cli/pull/660) by [@quinlanj](https://github.com/quinlanj))
+
 ## [0.29.1](https://github.com/expo/eas-cli/releases/tag/v0.29.1) - 2021-09-29
 
 ### 🎉 New features

--- a/packages/eas-cli/src/credentials/android/actions/CreateGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/CreateGoogleServiceAccountKey.ts
@@ -4,7 +4,10 @@ import { promptAsync } from '../../../prompts';
 import { Account } from '../../../user/Account';
 import { CredentialsContext } from '../../context';
 import { GoogleServiceAccountKey } from '../credentials';
-import { readAndValidateServiceAccountKey } from '../utils/googleServiceAccountKey';
+import {
+  detectGoogleServiceAccountKeyPathAsync,
+  readAndValidateServiceAccountKey,
+} from '../utils/googleServiceAccountKey';
 
 export class CreateGoogleServiceAccountKey {
   constructor(private account: Account) {}
@@ -13,7 +16,7 @@ export class CreateGoogleServiceAccountKey {
     if (ctx.nonInteractive) {
       throw new Error(`New Google Service Account Key cannot be created in non-interactive mode.`);
     }
-    const jsonKeyObject = await this.provideAsync();
+    const jsonKeyObject = await this.provideAsync(ctx);
     const gsaKeyFragment = await ctx.android.createGoogleServiceAccountKeyAsync(
       this.account,
       jsonKeyObject
@@ -22,20 +25,30 @@ export class CreateGoogleServiceAccountKey {
     return gsaKeyFragment;
   }
 
-  private async provideAsync(): Promise<GoogleServiceAccountKey> {
+  private async provideAsync(ctx: CredentialsContext): Promise<GoogleServiceAccountKey> {
     try {
-      const { keyJsonPath } = await promptAsync([
-        {
-          type: 'text',
-          name: 'keyJsonPath',
-          message: 'Path to Google Service Account Key JSON file:',
-          validate: (value: string) => value.length > 0 || "Path can't be empty",
-        },
-      ]);
+      const keyJsonPath = await this.provideKeyJsonPathAsync(ctx);
       return readAndValidateServiceAccountKey(keyJsonPath);
     } catch (e) {
       Log.error(e);
-      return await this.provideAsync();
+      return await this.provideAsync(ctx);
     }
+  }
+
+  private async provideKeyJsonPathAsync(ctx: CredentialsContext): Promise<string> {
+    const detectedPath = await detectGoogleServiceAccountKeyPathAsync(ctx.projectDir);
+    if (detectedPath) {
+      return detectedPath;
+    }
+
+    const { keyJsonPath } = await promptAsync([
+      {
+        type: 'text',
+        name: 'keyJsonPath',
+        message: 'Path to Google Service Account Key JSON file:',
+        validate: (value: string) => value.length > 0 || "Path can't be empty",
+      },
+    ]);
+    return keyJsonPath;
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/CreateGoogleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/CreateGoogleServiceAccountKey-test.ts
@@ -19,7 +19,10 @@ beforeEach(() => {
 describe(CreateGoogleServiceAccountKey, () => {
   it('creates a Google Service Account Key in Interactive Mode', async () => {
     vol.fromJSON({
-      '/google-service-account-key.json': JSON.stringify({ private_key: 'super secret' }),
+      '/google-service-account-key.json': JSON.stringify({
+        type: 'service_account',
+        private_key: 'super secret',
+      }),
     });
 
     const ctx = createCtxMock({ nonInteractive: false });

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetupGoogleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetupGoogleServiceAccountKey-test.ts
@@ -42,7 +42,10 @@ describe(SetupGoogleServiceAccountKey, () => {
   });
   it('sets up a Google Service Account Key when there is none already setup', async () => {
     vol.fromJSON({
-      '/google-service-account-key.json': JSON.stringify({ private_key: 'super secret' }),
+      '/google-service-account-key.json': JSON.stringify({
+        type: 'service_account',
+        private_key: 'super secret',
+      }),
     });
     const ctx = createCtxMock({
       nonInteractive: false,

--- a/packages/eas-cli/src/credentials/android/utils/__tests__/googleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/utils/__tests__/googleServiceAccountKey-test.ts
@@ -1,0 +1,92 @@
+import { vol } from 'memfs';
+
+import { asMock } from '../../../../__tests__/utils';
+import { promptAsync } from '../../../../prompts';
+import { detectGoogleServiceAccountKeyPathAsync } from '../googleServiceAccountKey';
+
+jest.mock('fs');
+jest.mock('../../../../prompts');
+
+beforeAll(() => {
+  const mockDetectableServiceAccountJson = JSON.stringify({
+    type: 'service_account',
+    private_key: 'super secret',
+  });
+
+  vol.fromJSON({
+    '/project_dir/subdir/service-account.json': mockDetectableServiceAccountJson,
+    '/project_dir/another-service-account.json': mockDetectableServiceAccountJson,
+    '/other_dir/invalid_file.txt': 'this is not even a JSON',
+  });
+});
+afterAll(() => {
+  vol.reset();
+});
+
+afterEach(() => {
+  asMock(promptAsync).mockClear();
+});
+
+describe('Google Service Account Key path detection', () => {
+  it('detects a single google-services file and prompts for confirmation', async () => {
+    asMock(promptAsync).mockResolvedValueOnce({
+      confirmed: true,
+    });
+    const serviceAccountPath = await detectGoogleServiceAccountKeyPathAsync('/project_dir/subdir');
+
+    expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'confirm' }));
+    expect(serviceAccountPath).toBe('/project_dir/subdir/service-account.json');
+  });
+
+  it('returns null, when no valid files are found in the dir', async () => {
+    const serviceAccountPath = await detectGoogleServiceAccountKeyPathAsync('/other_dir'); // no valid files in that dir
+    expect(promptAsync).not.toHaveBeenCalled();
+    expect(serviceAccountPath).toBe(null);
+  });
+
+  it('returns null, when user rejects to use detected file', async () => {
+    asMock(promptAsync).mockResolvedValueOnce({
+      confirmed: false,
+    });
+
+    const serviceAccountPath = await detectGoogleServiceAccountKeyPathAsync('/project_dir/subdir');
+
+    expect(promptAsync).toHaveBeenCalledTimes(1);
+    expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'confirm' }));
+    expect(serviceAccountPath).toBe(null);
+  });
+
+  it('displays a chooser, when multiple files are found', async () => {
+    asMock(promptAsync).mockResolvedValueOnce({
+      selectedPath: '/project_dir/another-service-account.json',
+    });
+
+    const serviceAccountPath = await detectGoogleServiceAccountKeyPathAsync('/project_dir'); // should find 2 files here
+
+    const expectedChoices = expect.arrayContaining([
+      expect.objectContaining({ value: '/project_dir/another-service-account.json' }),
+      expect.objectContaining({ value: '/project_dir/subdir/service-account.json' }),
+      expect.objectContaining({ value: false }),
+    ]);
+
+    expect(promptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'select',
+        choices: expectedChoices,
+      })
+    );
+    expect(serviceAccountPath).toBe('/project_dir/another-service-account.json');
+  });
+
+  it('returns null, when user selects the "None of above"', async () => {
+    asMock(promptAsync).mockResolvedValueOnce({
+      selectedPath: false,
+    });
+
+    const serviceAccountPath = await detectGoogleServiceAccountKeyPathAsync('/project_dir'); // should find 2 files here
+
+    expect(promptAsync).toHaveBeenCalledTimes(1);
+    expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'select' }));
+    expect(serviceAccountPath).toBe(null);
+  });
+});

--- a/packages/eas-cli/src/credentials/android/utils/googleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/utils/googleServiceAccountKey.ts
@@ -1,6 +1,8 @@
 import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
+import glob from 'fast-glob';
 import Joi from 'joi';
+import path from 'path';
 
 import { GoogleServiceAccountKeyFragment } from '../../../graphql/generated';
 import Log, { learnMore } from '../../../log';
@@ -9,8 +11,18 @@ import { fromNow } from '../../../utils/date';
 import { GoogleServiceAccountKey } from '../credentials';
 
 export const MinimalGoogleServiceAccountKeySchema = Joi.object({
+  type: Joi.string().required(),
   private_key: Joi.string().required(),
 });
+
+function fileIsServiceAccountKey(keyJsonPath: string): boolean {
+  try {
+    readAndValidateServiceAccountKey(keyJsonPath);
+    return true;
+  } catch (err: any) {
+    return false;
+  }
+}
 
 export function readAndValidateServiceAccountKey(keyJsonPath: string): GoogleServiceAccountKey {
   try {
@@ -76,4 +88,74 @@ function formatGoogleServiceAccountKey({
   );
   line += chalk.gray(`\n    Updated: ${fromNow(new Date(updatedAt))} ago,`);
   return line;
+}
+
+export async function detectGoogleServiceAccountKeyPathAsync(
+  projectDir: string
+): Promise<string | null> {
+  const foundFilePaths = await glob('**/*.json', {
+    cwd: projectDir,
+    ignore: ['app.json', 'package*.json', 'tsconfig.json', 'node_modules'],
+  });
+
+  const googleServiceFiles = foundFilePaths
+    .map(file => path.join(projectDir, file))
+    .filter(fileIsServiceAccountKey);
+
+  if (googleServiceFiles.length > 1) {
+    const selectedPath = await displayPathChooserAsync(googleServiceFiles, projectDir);
+
+    if (selectedPath !== false) {
+      return selectedPath;
+    }
+  } else if (googleServiceFiles.length === 1) {
+    const [detectedPath] = googleServiceFiles;
+
+    if (await confirmDetectedPathAsync(detectedPath)) {
+      return detectedPath;
+    }
+  }
+
+  return null;
+}
+
+async function displayPathChooserAsync(
+  paths: string[],
+  projectDir: string
+): Promise<string | false> {
+  const choices = paths.map<{ title: string; value: string | false }>(f => ({
+    value: f,
+    title: f.startsWith(projectDir) ? path.relative(projectDir, f) : f,
+  }));
+
+  choices.push({
+    title: 'None of the above',
+    value: false,
+  });
+
+  Log.log(
+    'Multiple Google Service Account JSON keys have been found inside your project directory.'
+  );
+  const { selectedPath } = await promptAsync({
+    name: 'selectedPath',
+    type: 'select',
+    message: 'Choose the key you want to use:',
+    choices,
+  });
+
+  Log.addNewLineIfNone();
+  return selectedPath;
+}
+
+async function confirmDetectedPathAsync(path: string): Promise<boolean> {
+  Log.log(`A Google Service Account JSON key has been found at\n  ${chalk.underline(path)}`);
+  const { confirmed } = await promptAsync({
+    name: 'confirmed',
+    type: 'confirm',
+    message: 'Would you like to use this file?',
+    initial: true,
+  });
+
+  Log.addNewLineIfNone();
+  return confirmed;
 }

--- a/packages/eas-cli/src/credentials/android/utils/googleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/utils/googleServiceAccountKey.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 import { GoogleServiceAccountKeyFragment } from '../../../graphql/generated';
 import Log, { learnMore } from '../../../log';
-import { promptAsync } from '../../../prompts';
+import { confirmAsync, promptAsync } from '../../../prompts';
 import { fromNow } from '../../../utils/date';
 import { GoogleServiceAccountKey } from '../credentials';
 
@@ -105,7 +105,7 @@ export async function detectGoogleServiceAccountKeyPathAsync(
   if (googleServiceFiles.length > 1) {
     const selectedPath = await displayPathChooserAsync(googleServiceFiles, projectDir);
 
-    if (selectedPath !== false) {
+    if (selectedPath) {
       return selectedPath;
     }
   } else if (googleServiceFiles.length === 1) {
@@ -122,15 +122,15 @@ export async function detectGoogleServiceAccountKeyPathAsync(
 async function displayPathChooserAsync(
   paths: string[],
   projectDir: string
-): Promise<string | false> {
-  const choices = paths.map<{ title: string; value: string | false }>(f => ({
+): Promise<string | null> {
+  const choices = paths.map<{ title: string; value: string | null }>(f => ({
     value: f,
     title: f.startsWith(projectDir) ? path.relative(projectDir, f) : f,
   }));
 
   choices.push({
     title: 'None of the above',
-    value: false,
+    value: null,
   });
 
   Log.log(
@@ -149,13 +149,9 @@ async function displayPathChooserAsync(
 
 async function confirmDetectedPathAsync(path: string): Promise<boolean> {
   Log.log(`A Google Service Account JSON key has been found at\n  ${chalk.underline(path)}`);
-  const { confirmed } = await promptAsync({
-    name: 'confirmed',
-    type: 'confirm',
+  const confirm = await confirmAsync({
     message: 'Would you like to use this file?',
-    initial: true,
   });
-
   Log.addNewLineIfNone();
-  return confirmed;
+  return confirm;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

The current logic in the Android submission service has some features that detect potential Google Service Jsons and suggest them to the user. I think this is a very good idea, so I've taken most of this logic, made minor adjustments to it, and put it in the credentials service. 

This logic is copied over instead of refactored because in a followup PR, I'm thinking the submissions logic [here](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts#L142) can be changed to something like this:

```
 // path is explicitly passed in
 if (serviceAccountKeyPath) {
      return result({
        sourceType: ServiceAccountSourceType.path,
        path: serviceAccountKeyPath,
      });
    } 

 // fallback to credentials service otherwise
 if (keyIsSetupOnCredentialsService) {
    return savedKey;
 }

 return await (new SetupGoogleServiceAccountKey().runAsync(credentialsCtx));
```

# Test Plan

- [x] modified tests pass
