### PR TITLE
[eas-cli] integrated credentials service with android submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Integrate credentials service with Android submissions. ([#664](https://github.com/expo/eas-cli/pull/664) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/CreateGoogleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/CreateGoogleServiceAccountKey-test.ts
@@ -22,6 +22,7 @@ describe(CreateGoogleServiceAccountKey, () => {
       '/google-service-account-key.json': JSON.stringify({
         type: 'service_account',
         private_key: 'super secret',
+        client_email: 'beep-boop@iam.gserviceaccount.com',
       }),
     });
 

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetupGoogleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetupGoogleServiceAccountKey-test.ts
@@ -45,6 +45,7 @@ describe(SetupGoogleServiceAccountKey, () => {
       '/google-service-account-key.json': JSON.stringify({
         type: 'service_account',
         private_key: 'super secret',
+        client_email: 'beep-boop@iam.gserviceaccount.com',
       }),
     });
     const ctx = createCtxMock({

--- a/packages/eas-cli/src/credentials/android/credentials.ts
+++ b/packages/eas-cli/src/credentials/android/credentials.ts
@@ -19,6 +19,8 @@ export type KeystoreWithType = Keystore & {
 export type GoogleServiceAccountKey = {
   [key: string]: any;
   private_key: string;
+  type: string;
+  client_email: string;
 };
 
 export type AndroidCredentials = {

--- a/packages/eas-cli/src/credentials/android/utils/__tests__/googleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/utils/__tests__/googleServiceAccountKey-test.ts
@@ -11,6 +11,7 @@ beforeAll(() => {
   const mockDetectableServiceAccountJson = JSON.stringify({
     type: 'service_account',
     private_key: 'super secret',
+    client_email: 'beep-boop@iam.gserviceaccount.com',
   });
 
   vol.fromJSON({

--- a/packages/eas-cli/src/credentials/android/utils/googleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/utils/googleServiceAccountKey.ts
@@ -13,6 +13,7 @@ import { GoogleServiceAccountKey } from '../credentials';
 export const MinimalGoogleServiceAccountKeySchema = Joi.object({
   type: Joi.string().required(),
   private_key: Joi.string().required(),
+  client_email: Joi.string().required(),
 });
 
 function fileIsServiceAccountKey(keyJsonPath: string): boolean {

--- a/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts
@@ -144,12 +144,9 @@ export default class AndroidSubmitCommand {
         sourceType: ServiceAccountSourceType.path,
         path: serviceAccountKeyPath,
       });
-    } else if (this.ctx.nonInteractive) {
-      return result(new Error('Set serviceAccountKeyPath in the submit profile (eas.json).'));
-    } else {
-      return result({
-        sourceType: ServiceAccountSourceType.detect,
-      });
     }
+    return result({
+      sourceType: ServiceAccountSourceType.credentialsService,
+    });
   }
 }

--- a/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
@@ -123,7 +123,7 @@ export default class AndroidSubmitter extends BaseSubmitter<
       releaseStatus: releaseStatus ?? undefined,
       serviceAccountEmail,
       serviceAccountKeySource,
-      serviceAccountKeyPath,
+      ...(serviceAccountKeyPath ? { serviceAccountKeyPath } : {}),
       ...formatArchiveSourceSummary(archive),
     };
   }

--- a/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
@@ -1,5 +1,4 @@
 import { Platform } from '@expo/eas-build-job';
-import fs from 'fs-extra';
 
 import {
   AndroidSubmissionConfigInput,
@@ -16,7 +15,11 @@ import {
   printSummary,
 } from '../utils/summary';
 import { AndroidPackageSource, getAndroidPackageAsync } from './AndroidPackageSource';
-import { ServiceAccountSource, getServiceAccountAsync } from './ServiceAccountSource';
+import {
+  ServiceAccountKeyResult,
+  ServiceAccountSource,
+  getServiceAccountKeyResultAsync,
+} from './ServiceAccountSource';
 
 export interface AndroidSubmissionOptions
   extends Pick<
@@ -32,7 +35,7 @@ export interface AndroidSubmissionOptions
 interface ResolvedSourceOptions {
   androidPackage: string;
   archive: Archive;
-  serviceAccountPath: string;
+  serviceAccountKeyResult: ServiceAccountKeyResult;
 }
 
 export default class AndroidSubmitter extends BaseSubmitter<
@@ -73,19 +76,22 @@ export default class AndroidSubmitter extends BaseSubmitter<
   private async resolveSourceOptionsAsync(): Promise<ResolvedSourceOptions> {
     const androidPackage = await getAndroidPackageAsync(this.options.androidPackageSource);
     const archive = await getArchiveAsync(this.options.archiveSource);
-    const serviceAccountPath = await getServiceAccountAsync(this.options.serviceAccountSource);
+    const serviceAccountKeyResult = await getServiceAccountKeyResultAsync(
+      this.ctx,
+      this.options.serviceAccountSource,
+      androidPackage
+    );
     return {
       androidPackage,
       archive,
-      serviceAccountPath,
+      serviceAccountKeyResult,
     };
   }
 
   private async formatSubmissionConfigAsync(
     options: AndroidSubmissionOptions,
-    { archive, androidPackage, serviceAccountPath }: ResolvedSourceOptions
+    { archive, androidPackage, serviceAccountKeyResult }: ResolvedSourceOptions
   ): Promise<AndroidSubmissionConfigInput> {
-    const serviceAccount = await fs.readFile(serviceAccountPath, 'utf-8');
     const { track, releaseStatus, changesNotSentForReview } = options;
     return {
       applicationIdentifier: androidPackage,
@@ -93,15 +99,21 @@ export default class AndroidSubmitter extends BaseSubmitter<
       track,
       changesNotSentForReview,
       releaseStatus,
-      googleServiceAccountKeyJson: serviceAccount,
+      ...serviceAccountKeyResult.result,
     };
   }
 
   private prepareSummaryData(
     options: AndroidSubmissionOptions,
-    { archive, androidPackage, serviceAccountPath }: ResolvedSourceOptions
+    { archive, androidPackage, serviceAccountKeyResult }: ResolvedSourceOptions
   ): SummaryData {
     const { projectId, track, releaseStatus, changesNotSentForReview } = options;
+    const { summary } = serviceAccountKeyResult;
+    const {
+      email: serviceAccountEmail,
+      path: serviceAccountKeyPath,
+      source: serviceAccountKeySource,
+    } = summary;
 
     // structuring order affects table rows order
     return {
@@ -110,7 +122,9 @@ export default class AndroidSubmitter extends BaseSubmitter<
       track,
       changesNotSentForReview: changesNotSentForReview ?? undefined,
       releaseStatus: releaseStatus ?? undefined,
-      serviceAccountPath,
+      serviceAccountEmail,
+      serviceAccountKeySource,
+      serviceAccountKeyPath,
       ...formatArchiveSourceSummary(archive),
     };
   }
@@ -121,7 +135,9 @@ type SummaryData = {
   changesNotSentForReview?: boolean;
   projectId: string;
   releaseStatus?: SubmissionAndroidReleaseStatus;
-  serviceAccountPath: string;
+  serviceAccountKeySource: string;
+  serviceAccountKeyPath?: string;
+  serviceAccountEmail: string;
   track: SubmissionAndroidTrack;
 } & ArchiveSourceSummaryFields;
 
@@ -133,6 +149,8 @@ const SummaryHumanReadableKeys: Record<keyof SummaryData, string> = {
   formattedBuild: 'Build',
   projectId: 'Project ID',
   releaseStatus: 'Release status',
-  serviceAccountPath: 'Google Service Key',
+  serviceAccountKeySource: 'Google Service Key Source',
+  serviceAccountKeyPath: 'Google Service Key Path',
+  serviceAccountEmail: 'Google Service Account',
   track: 'Release track',
 };

--- a/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
@@ -108,12 +108,11 @@ export default class AndroidSubmitter extends BaseSubmitter<
     { archive, androidPackage, serviceAccountKeyResult }: ResolvedSourceOptions
   ): SummaryData {
     const { projectId, track, releaseStatus, changesNotSentForReview } = options;
-    const { summary } = serviceAccountKeyResult;
     const {
       email: serviceAccountEmail,
       path: serviceAccountKeyPath,
       source: serviceAccountKeySource,
-    } = summary;
+    } = serviceAccountKeyResult.summary;
 
     // structuring order affects table rows order
     return {

--- a/packages/eas-cli/src/submit/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submit/android/ServiceAccountSource.ts
@@ -31,7 +31,7 @@ interface ServiceAccountPromptSource extends ServiceAccountSourceBase {
   sourceType: ServiceAccountSourceType.prompt;
 }
 
-interface ServiceAccountCredentialsServiceSource extends ServiceAccountSourceBase {
+export interface ServiceAccountCredentialsServiceSource extends ServiceAccountSourceBase {
   sourceType: ServiceAccountSourceType.credentialsService;
 }
 

--- a/packages/eas-cli/src/submit/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submit/android/ServiceAccountSource.ts
@@ -15,7 +15,6 @@ export enum ServiceAccountSourceType {
   path,
   prompt,
   credentialsService,
-  // ...
 }
 
 interface ServiceAccountSourceBase {
@@ -66,8 +65,9 @@ export async function getServiceAccountKeyResultAsync(
 ): Promise<ServiceAccountKeyResult> {
   if (source.sourceType === ServiceAccountSourceType.credentialsService) {
     return await getServiceAccountFromCredentialsServiceAsync(ctx, androidApplicationIdentifier);
+  } else {
+    return await getServiceAccountLocallyAsync(source);
   }
-  return await getServiceAccountLocallyAsync(source);
 }
 
 async function getServiceAccountLocallyAsync(

--- a/packages/eas-cli/src/submit/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submit/android/ServiceAccountSource.ts
@@ -1,19 +1,20 @@
+import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
-import glob from 'fast-glob';
 import fs from 'fs-extra';
-import path from 'path';
+import nullthrows from 'nullthrows';
 
+import { SetupGoogleServiceAccountKey } from '../../credentials/android/actions/SetupGoogleServiceAccountKey';
+import { readAndValidateServiceAccountKey } from '../../credentials/android/utils/googleServiceAccountKey';
 import Log, { learnMore } from '../../log';
-import { findProjectRootAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import { filterAsync } from '../../utils/filterAsync';
+import { findAccountByName } from '../../user/Account';
+import { SubmissionContext } from '../context';
 import { isExistingFileAsync } from '../utils/files';
 
 export enum ServiceAccountSourceType {
   path,
   prompt,
-  detect,
-  // credentialsService,
+  credentialsService,
   // ...
 }
 
@@ -30,66 +31,112 @@ interface ServiceAccountPromptSource extends ServiceAccountSourceBase {
   sourceType: ServiceAccountSourceType.prompt;
 }
 
-interface ServiceAccountDetectSource extends ServiceAccountSourceBase {
-  sourceType: ServiceAccountSourceType.detect;
+interface ServiceAccountCredentialsServiceSource extends ServiceAccountSourceBase {
+  sourceType: ServiceAccountSourceType.credentialsService;
 }
+
+export type ServiceAccountKeyResult = {
+  result: ServiceAccountKeyFile | ServiceAccountKeyFromExpoServers;
+  summary: ServiceAccountKeySummary;
+};
+
+type ServiceAccountKeySummary = {
+  source: 'local' | 'Expo servers';
+  path?: string;
+  email: string;
+};
+
+type ServiceAccountKeyFile = {
+  googleServiceAccountKeyJson: string;
+};
+
+type ServiceAccountKeyFromExpoServers = {
+  googleServiceAccountKeyId: string;
+};
 
 export type ServiceAccountSource =
   | ServiceAccountPathSource
   | ServiceAccountPromptSource
-  | ServiceAccountDetectSource;
+  | ServiceAccountCredentialsServiceSource;
 
-export async function getServiceAccountAsync(source: ServiceAccountSource): Promise<string> {
+export async function getServiceAccountKeyResultAsync(
+  ctx: SubmissionContext<Platform.ANDROID>,
+  source: ServiceAccountSource,
+  androidApplicationIdentifier: string
+): Promise<ServiceAccountKeyResult> {
+  if (source.sourceType !== ServiceAccountSourceType.credentialsService) {
+    const serviceAccountKeyPath = await getServiceAccountKeyPathAsync(source);
+    const serviceAccountKey = readAndValidateServiceAccountKey(serviceAccountKeyPath);
+    return {
+      result: { googleServiceAccountKeyJson: await fs.readFile(serviceAccountKeyPath, 'utf-8') },
+      summary: {
+        source: 'local',
+        path: serviceAccountKeyPath,
+        email: serviceAccountKey.client_email,
+      },
+    };
+  }
+  return await getServiceAccountFromCredentialsServiceAsync(
+    ctx,
+    source,
+    androidApplicationIdentifier
+  );
+}
+
+export async function getServiceAccountKeyPathAsync(source: ServiceAccountSource): Promise<string> {
   switch (source.sourceType) {
     case ServiceAccountSourceType.path:
       return await handlePathSourceAsync(source);
     case ServiceAccountSourceType.prompt:
       return await handlePromptSourceAsync(source);
-    case ServiceAccountSourceType.detect:
-      return await handleDetectSourceAsync(source);
   }
+  throw new Error(`ServiceAccountSource ${source} does not return a path.`);
+}
+
+export async function getServiceAccountFromCredentialsServiceAsync(
+  ctx: SubmissionContext<Platform.ANDROID>,
+  _source: ServiceAccountCredentialsServiceSource,
+  androidApplicationIdentifier: string
+): Promise<ServiceAccountKeyResult> {
+  const appLookupParams = {
+    account: nullthrows(
+      findAccountByName(ctx.user.accounts, ctx.accountName),
+      `You do not have access to account: ${ctx.accountName}`
+    ),
+    projectName: ctx.projectName,
+    androidApplicationIdentifier,
+  };
+  const setupGoogleServiceAccountKeyAction = new SetupGoogleServiceAccountKey(appLookupParams);
+  const androidAppCredentials = await setupGoogleServiceAccountKeyAction.runAsync(
+    ctx.credentialsCtx
+  );
+  const googleServiceAccountKey = nullthrows(
+    androidAppCredentials.googleServiceAccountKeyForSubmissions,
+    'Credentials Service must provide a valid GoogleServiceAccountKey'
+  );
+
+  return {
+    result: {
+      googleServiceAccountKeyId: googleServiceAccountKey.id,
+    },
+    summary: {
+      source: 'Expo servers',
+      email: googleServiceAccountKey.clientEmail,
+    },
+  };
 }
 
 async function handlePathSourceAsync(source: ServiceAccountPathSource): Promise<string> {
   if (!(await isExistingFileAsync(source.path))) {
     Log.warn(`File ${source.path} doesn't exist.`);
-    return await getServiceAccountAsync({ sourceType: ServiceAccountSourceType.prompt });
+    return await getServiceAccountKeyPathAsync({ sourceType: ServiceAccountSourceType.prompt });
   }
   return source.path;
 }
 
-async function handleDetectSourceAsync(_source: ServiceAccountDetectSource): Promise<string> {
-  const projectDir = await findProjectRootAsync();
-  const foundFilePaths = await glob('**/*.json', {
-    cwd: projectDir,
-    ignore: ['app.json', 'package*.json', 'tsconfig.json', 'node_modules'],
-  });
-
-  const googleServiceFiles = await filterAsync(
-    foundFilePaths.map(file => path.join(projectDir, file)),
-    fileIsGoogleServicesAsync
-  );
-
-  if (googleServiceFiles.length > 1) {
-    const selectedPath = await displayPathChooserAsync(googleServiceFiles, projectDir);
-
-    if (selectedPath !== false) {
-      return selectedPath;
-    }
-  } else if (googleServiceFiles.length === 1) {
-    const [detectedPath] = googleServiceFiles;
-
-    if (await confirmDetectedPathAsync(detectedPath)) {
-      return detectedPath;
-    }
-  }
-
-  return await getServiceAccountAsync({ sourceType: ServiceAccountSourceType.prompt });
-}
-
 async function handlePromptSourceAsync(_source: ServiceAccountPromptSource): Promise<string> {
   const path = await askForServiceAccountPathAsync();
-  return await getServiceAccountAsync({
+  return await getServiceAccountKeyPathAsync({
     sourceType: ServiceAccountSourceType.path,
     path,
   });
@@ -123,54 +170,4 @@ async function askForServiceAccountPathAsync(): Promise<string> {
     },
   });
   return filePath;
-}
-
-async function displayPathChooserAsync(
-  paths: string[],
-  projectDir: string
-): Promise<string | false> {
-  const choices = paths.map<{ title: string; value: string | false }>(f => ({
-    value: f,
-    title: f.startsWith(projectDir) ? path.relative(projectDir, f) : f,
-  }));
-
-  choices.push({
-    title: 'None of the above',
-    value: false,
-  });
-
-  Log.log(
-    'Multiple Google Service Account JSON keys have been found inside your project directory.'
-  );
-  const { selectedPath } = await promptAsync({
-    name: 'selectedPath',
-    type: 'select',
-    message: 'Choose the key you want to use for this submission:',
-    choices,
-  });
-
-  Log.addNewLineIfNone();
-  return selectedPath;
-}
-
-async function confirmDetectedPathAsync(path: string): Promise<boolean> {
-  Log.log(`A Google Service Account JSON key has been found at\n  ${chalk.underline(path)}`);
-  const { confirmed } = await promptAsync({
-    name: 'confirmed',
-    type: 'confirm',
-    message: 'Would you like to use this file?',
-    initial: true,
-  });
-
-  Log.addNewLineIfNone();
-  return confirmed;
-}
-
-async function fileIsGoogleServicesAsync(path: string): Promise<boolean> {
-  try {
-    const jsonFile = await fs.readJson(path);
-    return jsonFile.type === 'service_account';
-  } catch (e) {
-    return false;
-  }
 }

--- a/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
@@ -44,7 +44,11 @@ describe(AndroidSubmitCommand, () => {
 
   const fakeFiles: Record<string, string> = {
     '/apks/fake.apk': 'fake apk',
-    '/google-service-account.json': JSON.stringify({ service: 'account' }),
+    '/google-service-account.json': JSON.stringify({
+      type: 'service_account',
+      private_key: 'super secret',
+      client_email: 'beep-boop@iam.gserviceaccount.com',
+    }),
   };
 
   const fakeBuildFragment: Partial<BuildFragment> = {

--- a/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
@@ -1,7 +1,6 @@
 import { vol } from 'memfs';
 
 import { asMock } from '../../../__tests__/utils';
-import { findProjectRootAsync } from '../../../project/projectUtils';
 import { promptAsync } from '../../../prompts';
 import {
   ServiceAccountSource,
@@ -96,102 +95,6 @@ describe(getServiceAccountAsync, () => {
       };
       const serviceAccountPath = await getServiceAccountAsync(source);
       expect(promptAsync).toHaveBeenCalledTimes(3);
-      expect(serviceAccountPath).toBe('/google-service-account.json');
-    });
-  });
-
-  describe('when source is ServiceAccountSourceType.detect', () => {
-    it('detects a single google-services file and prompts for confirmation', async () => {
-      asMock(findProjectRootAsync).mockResolvedValueOnce('/project_dir/subdir'); // should find 1 file
-      asMock(promptAsync).mockResolvedValueOnce({
-        confirmed: true,
-      });
-
-      const serviceAccountPath = await getServiceAccountAsync({
-        sourceType: ServiceAccountSourceType.detect,
-      });
-
-      expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'confirm' }));
-      expect(serviceAccountPath).toBe('/project_dir/subdir/service-account.json');
-    });
-
-    it('falls back to prompt, when no valid files are found in the dir', async () => {
-      asMock(findProjectRootAsync).mockResolvedValueOnce('/other_dir'); // no valid files in that dir
-      asMock(promptAsync).mockResolvedValueOnce({
-        filePath: '/google-service-account.json',
-      });
-
-      const serviceAccountPath = await getServiceAccountAsync({
-        sourceType: ServiceAccountSourceType.detect,
-      });
-
-      expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'text' }));
-      expect(serviceAccountPath).toBe('/google-service-account.json');
-    });
-
-    it('falls back to prompt, when user rejects to use detected file', async () => {
-      asMock(findProjectRootAsync).mockResolvedValueOnce('/project_dir/subdir'); // should find 1 file
-      asMock(promptAsync)
-        .mockResolvedValueOnce({
-          confirmed: false,
-        })
-        .mockResolvedValueOnce({
-          filePath: '/google-service-account.json',
-        });
-      const source: ServiceAccountSource = {
-        sourceType: ServiceAccountSourceType.detect,
-      };
-
-      const serviceAccountPath = await getServiceAccountAsync(source);
-
-      expect(promptAsync).toHaveBeenCalledTimes(2);
-      expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'confirm' }));
-      expect(promptAsync).toHaveBeenLastCalledWith(expect.objectContaining({ type: 'text' }));
-      expect(serviceAccountPath).toBe('/google-service-account.json');
-    });
-
-    it('displays a chooser, when multiple files are found', async () => {
-      asMock(findProjectRootAsync).mockResolvedValueOnce('/project_dir'); // should find 2 files here
-      asMock(promptAsync).mockResolvedValueOnce({
-        selectedPath: '/project_dir/another-service-account.json',
-      });
-
-      const serviceAccountPath = await getServiceAccountAsync({
-        sourceType: ServiceAccountSourceType.detect,
-      });
-
-      const expectedChoices = expect.arrayContaining([
-        expect.objectContaining({ value: '/project_dir/another-service-account.json' }),
-        expect.objectContaining({ value: '/project_dir/subdir/service-account.json' }),
-        expect.objectContaining({ value: false }),
-      ]);
-
-      expect(promptAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'select',
-          choices: expectedChoices,
-        })
-      );
-      expect(serviceAccountPath).toBe('/project_dir/another-service-account.json');
-    });
-
-    it('falls back to prompt, when user selects the "None of above"', async () => {
-      asMock(findProjectRootAsync).mockResolvedValueOnce('/project_dir'); // should find 2 files here
-      asMock(promptAsync)
-        .mockResolvedValueOnce({
-          selectedPath: false,
-        })
-        .mockResolvedValueOnce({
-          filePath: '/google-service-account.json',
-        });
-
-      const serviceAccountPath = await getServiceAccountAsync({
-        sourceType: ServiceAccountSourceType.detect,
-      });
-
-      expect(promptAsync).toHaveBeenCalledTimes(2);
-      expect(promptAsync).toHaveBeenCalledWith(expect.objectContaining({ type: 'select' }));
-      expect(promptAsync).toHaveBeenLastCalledWith(expect.objectContaining({ type: 'text' }));
       expect(serviceAccountPath).toBe('/google-service-account.json');
     });
   });

--- a/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
@@ -1,38 +1,70 @@
+import { Platform } from '@expo/eas-build-job';
+import { AndroidReleaseStatus, AndroidReleaseTrack } from '@expo/eas-json';
 import { vol } from 'memfs';
+import { v4 as uuidv4 } from 'uuid';
 
 import { asMock } from '../../../__tests__/utils';
+import { testAndroidAppCredentialsFragment } from '../../../credentials/__tests__/fixtures-android';
+import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
+import { SetupGoogleServiceAccountKey } from '../../../credentials/android/actions/SetupGoogleServiceAccountKey';
+import { createTestProject } from '../../../project/__tests__/project-utils';
 import { promptAsync } from '../../../prompts';
+import { createSubmissionContextAsync } from '../../context';
 import {
   ServiceAccountSource,
   ServiceAccountSourceType,
-  getServiceAccountAsync,
+  getServiceAccountKeyPathAsync,
+  getServiceAccountKeyResultAsync,
 } from '../ServiceAccountSource';
 
 jest.mock('fs');
 jest.mock('../../../prompts');
 jest.mock('../../../project/projectUtils');
+jest.mock('../../../credentials/android/actions/SetupGoogleServiceAccountKey');
+jest.mock('../../../user/User', () => ({
+  getUserAsync: jest.fn(() => mockJester),
+}));
+jest.mock('../../../user/Account', () => ({
+  findAccountByName: jest.fn(() => mockJester.accounts[0]),
+}));
+const testProject = createTestProject(mockJester, {
+  android: {
+    package: 'com.expo.test.project',
+  },
+});
+const mockManifest = { exp: testProject.appJSON.expo };
+jest.mock('@expo/config', () => ({
+  getConfig: jest.fn(() => mockManifest),
+}));
 
-describe(getServiceAccountAsync, () => {
-  beforeAll(() => {
-    const mockDetectableServiceAccountJson = JSON.stringify({
-      type: 'service_account',
-    });
+const projectId = uuidv4();
+const mockDetectableServiceAccountJson = JSON.stringify({
+  type: 'service_account',
+  private_key: 'super secret',
+  client_email: 'foo@bar.com',
+});
 
-    vol.fromJSON({
-      '/google-service-account.json': JSON.stringify({ service: 'account' }),
-      '/project_dir/subdir/service-account.json': mockDetectableServiceAccountJson,
-      '/project_dir/another-service-account.json': mockDetectableServiceAccountJson,
-      '/other_dir/invalid_file.txt': 'this is not even a JSON',
-    });
+beforeAll(() => {
+  vol.fromJSON({
+    '/google-service-account.json': JSON.stringify({ service: 'account' }),
+    '/project_dir/subdir/service-account.json': mockDetectableServiceAccountJson,
+    '/project_dir/another-service-account.json': mockDetectableServiceAccountJson,
+    '/other_dir/invalid_file.txt': 'this is not even a JSON',
   });
-  afterAll(() => {
-    vol.reset();
-  });
+  jest
+    .spyOn(SetupGoogleServiceAccountKey.prototype, 'runAsync')
+    .mockImplementation(async () => testAndroidAppCredentialsFragment);
+});
+afterAll(() => {
+  vol.reset();
+});
 
-  afterEach(() => {
-    asMock(promptAsync).mockClear();
-  });
+afterEach(() => {
+  asMock(promptAsync).mockClear();
+  jest.restoreAllMocks();
+});
 
+describe(getServiceAccountKeyPathAsync, () => {
   describe('when source is ServiceAccountSourceType.path', () => {
     it("prompts for path if the provided file doesn't exist", async () => {
       asMock(promptAsync).mockImplementationOnce(() => ({
@@ -42,7 +74,7 @@ describe(getServiceAccountAsync, () => {
         sourceType: ServiceAccountSourceType.path,
         path: '/doesnt-exist.json',
       };
-      const serviceAccountPath = await getServiceAccountAsync(source);
+      const serviceAccountPath = await getServiceAccountKeyPathAsync(source);
       expect(promptAsync).toHaveBeenCalled();
       expect(serviceAccountPath).toBe('/google-service-account.json');
     });
@@ -52,7 +84,7 @@ describe(getServiceAccountAsync, () => {
         sourceType: ServiceAccountSourceType.path,
         path: '/google-service-account.json',
       };
-      await getServiceAccountAsync(source);
+      await getServiceAccountKeyPathAsync(source);
       expect(promptAsync).not.toHaveBeenCalled();
     });
 
@@ -61,7 +93,7 @@ describe(getServiceAccountAsync, () => {
         sourceType: ServiceAccountSourceType.path,
         path: '/google-service-account.json',
       };
-      const serviceAccountPath = await getServiceAccountAsync(source);
+      const serviceAccountPath = await getServiceAccountKeyPathAsync(source);
       expect(serviceAccountPath).toBe('/google-service-account.json');
     });
   });
@@ -74,7 +106,7 @@ describe(getServiceAccountAsync, () => {
       const source: ServiceAccountSource = {
         sourceType: ServiceAccountSourceType.prompt,
       };
-      const serviceAccountPath = await getServiceAccountAsync(source);
+      const serviceAccountPath = await getServiceAccountKeyPathAsync(source);
       expect(promptAsync).toHaveBeenCalled();
       expect(serviceAccountPath).toBe('/google-service-account.json');
     });
@@ -93,9 +125,105 @@ describe(getServiceAccountAsync, () => {
       const source: ServiceAccountSource = {
         sourceType: ServiceAccountSourceType.prompt,
       };
-      const serviceAccountPath = await getServiceAccountAsync(source);
+      const serviceAccountPath = await getServiceAccountKeyPathAsync(source);
       expect(promptAsync).toHaveBeenCalledTimes(3);
       expect(serviceAccountPath).toBe('/google-service-account.json');
+    });
+  });
+});
+
+describe(getServiceAccountKeyResultAsync, () => {
+  it('returns a local Service Account Key file with a ServiceAccountSourceType.path source', async () => {
+    const ctx = await createSubmissionContextAsync({
+      platform: Platform.ANDROID,
+      projectDir: testProject.projectRoot,
+      projectId,
+      archiveFlags: {
+        url: 'http://expo.dev/fake.apk',
+      },
+      profile: {
+        track: AndroidReleaseTrack.internal,
+        releaseStatus: AndroidReleaseStatus.draft,
+        changesNotSentForReview: false,
+      },
+      nonInteractive: true,
+    });
+    const source: ServiceAccountSource = {
+      sourceType: ServiceAccountSourceType.path,
+      path: '/project_dir/subdir/service-account.json',
+    };
+    const serviceAccountResult = await getServiceAccountKeyResultAsync(ctx, source, 'test.sdf');
+    expect(serviceAccountResult).toMatchObject({
+      result: {
+        googleServiceAccountKeyJson: mockDetectableServiceAccountJson,
+      },
+      summary: {
+        source: 'local',
+        path: '/project_dir/subdir/service-account.json',
+        email: 'foo@bar.com',
+      },
+    });
+  });
+
+  it('returns a local Service Account Key file with a ServiceAccountSourceType.prompt source', async () => {
+    asMock(promptAsync).mockImplementationOnce(() => ({
+      filePath: '/project_dir/subdir/service-account.json',
+    }));
+    const ctx = await createSubmissionContextAsync({
+      platform: Platform.ANDROID,
+      projectDir: testProject.projectRoot,
+      projectId,
+      archiveFlags: {
+        url: 'http://expo.dev/fake.apk',
+      },
+      profile: {
+        track: AndroidReleaseTrack.internal,
+        releaseStatus: AndroidReleaseStatus.draft,
+        changesNotSentForReview: false,
+      },
+      nonInteractive: true,
+    });
+    const source: ServiceAccountSource = {
+      sourceType: ServiceAccountSourceType.prompt,
+    };
+    const serviceAccountResult = await getServiceAccountKeyResultAsync(ctx, source, 'test.sdf');
+    expect(serviceAccountResult).toMatchObject({
+      result: {
+        googleServiceAccountKeyJson: mockDetectableServiceAccountJson,
+      },
+      summary: {
+        source: 'local',
+        path: '/project_dir/subdir/service-account.json',
+        email: 'foo@bar.com',
+      },
+    });
+  });
+
+  it('returns a remote Service Account Key file with a ServiceAccountSourceType.credentialService source', async () => {
+    const ctx = await createSubmissionContextAsync({
+      platform: Platform.ANDROID,
+      projectDir: testProject.projectRoot,
+      projectId,
+      archiveFlags: {
+        url: 'http://expo.dev/fake.apk',
+      },
+      profile: {
+        track: AndroidReleaseTrack.internal,
+        releaseStatus: AndroidReleaseStatus.draft,
+        changesNotSentForReview: false,
+      },
+      nonInteractive: true,
+    });
+    const serviceAccountResult = await getServiceAccountKeyResultAsync(
+      ctx,
+      {
+        sourceType: ServiceAccountSourceType.credentialsService,
+      },
+      'test.application.identiifer'
+    );
+    expect(serviceAccountResult).toMatchObject({
+      result: { googleServiceAccountKeyId: 'test-id' },
+      summary: { source: 'EAS servers', email: 'quin@expo.io' },
     });
   });
 });

--- a/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
@@ -41,12 +41,12 @@ const projectId = uuidv4();
 const mockDetectableServiceAccountJson = JSON.stringify({
   type: 'service_account',
   private_key: 'super secret',
-  client_email: 'foo@bar.com',
+  client_email: 'beep-boop@iam.gserviceaccount.com',
 });
 
 beforeAll(() => {
   vol.fromJSON({
-    '/google-service-account.json': JSON.stringify({ service: 'account' }),
+    '/google-service-account.json': mockDetectableServiceAccountJson,
     '/project_dir/subdir/service-account.json': mockDetectableServiceAccountJson,
     '/project_dir/another-service-account.json': mockDetectableServiceAccountJson,
     '/other_dir/invalid_file.txt': 'this is not even a JSON',
@@ -160,7 +160,7 @@ describe(getServiceAccountKeyResultAsync, () => {
       summary: {
         source: 'local',
         path: '/project_dir/subdir/service-account.json',
-        email: 'foo@bar.com',
+        email: 'beep-boop@iam.gserviceaccount.com',
       },
     });
   });
@@ -194,7 +194,7 @@ describe(getServiceAccountKeyResultAsync, () => {
       summary: {
         source: 'local',
         path: '/project_dir/subdir/service-account.json',
-        email: 'foo@bar.com',
+        email: 'beep-boop@iam.gserviceaccount.com',
       },
     });
   });

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -4,9 +4,12 @@ import { SubmitProfile } from '@expo/eas-json';
 
 import { CredentialsContext } from '../credentials/context';
 import { getExpoConfig } from '../project/expoConfig';
+import { getProjectAccountName } from '../project/projectUtils';
+import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 
 export interface SubmissionContext<T extends Platform> {
+  accountName: string;
   archiveFlags: SubmitArchiveFlags;
   credentialsCtx: CredentialsContext;
   exp: ExpoConfig;
@@ -15,6 +18,8 @@ export interface SubmissionContext<T extends Platform> {
   profile: SubmitProfile<T>;
   projectDir: string;
   projectId: string;
+  projectName: string;
+  user: Actor;
 }
 
 export interface SubmitArchiveFlags {
@@ -37,14 +42,19 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
   const { projectDir, nonInteractive } = params;
   const exp = getExpoConfig(projectDir, { env: params.env });
   const { env, ...rest } = params;
+  const user = await ensureLoggedInAsync();
+  const projectName = exp.slug;
+  const accountName = getProjectAccountName(exp, user);
   let credentialsCtx: CredentialsContext | undefined = params.credentialsCtx;
   if (!credentialsCtx) {
-    const user = await ensureLoggedInAsync();
     credentialsCtx = new CredentialsContext({ projectDir, user, exp, nonInteractive });
   }
   return {
     ...rest,
+    accountName,
     credentialsCtx,
     exp,
+    projectName,
+    user,
   };
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

**I haven't done any testing for this PR yet. I wanted to make sure this PR is on the right track  before I write the tests**

This PR integrates the credentials service into the Android submission workflow. Notable changes:
- If the user passes in the path argument when they run submissions, we use that and fall back to a prompt if there the path they passed was invalid. No credentials are saved on www in this case.
- If there is no path argument when submissions is run, we use the credentials service.

# Test Plan

- [x] manually test important cases
- [x] new tests pass
