### PR TITLE
fix --json flag when running on GitHub Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix `--json` flag when running EAS CLI on GitHub actions. ([#669](https://github.com/expo/eas-cli/pull/669) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [0.30.0](https://github.com/expo/eas-cli/releases/tag/v0.30.0) - 2021-10-05

--- a/packages/eas-cli/src/utils/json.ts
+++ b/packages/eas-cli/src/utils/json.ts
@@ -9,9 +9,7 @@ export function enableJsonOutput(): void {
     return;
   }
   stdoutWrite = process.stdout.write;
-  process.stdout.write = (...args: any) => {
-    return process.stderr.write.call(null, args);
-  };
+  process.stdout.write = process.stderr.write.bind(process.stderr);
 }
 
 export function printJsonOnlyOutput(value: object): void {
@@ -20,9 +18,7 @@ export function printJsonOnlyOutput(value: object): void {
     process.stdout.write = stdoutWrite;
     Log.log(JSON.stringify(sanitizeValue(value), null, 2));
   } finally {
-    process.stdout.write = (...args: any) => {
-      return process.stderr.write.call(null, args);
-    };
+    process.stdout.write = process.stderr.write.bind(process.stderr);
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Fixes https://github.com/expo/eas-cli/issues/666

`--json` doesn't seem to work when running EAS CLI on GitHub Actions.

https://github.com/cheeaun/hackerweb-native-2/runs/3774224934?check_suite_focus=true

<img width="1029" alt="Screenshot_2021-10-02_at_2 45 04_PM" src="https://user-images.githubusercontent.com/5256730/136033005-e82d888c-e180-4dc6-ba0a-efea1f0ca642.png">

# How

Use `.bind(...)` instead of `.call(null, ...)`.

# Test Plan

Patched `json.js` and verified it works fine now - https://github.com/dsokal/eas-test/commit/ede28d1ac742fcd41f62c8b812c87afffd42e6da