### PR TITLE
fix building monorepo projects on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix `--json` flag when running EAS CLI on GitHub actions. ([#669](https://github.com/expo/eas-cli/pull/669) by [@dsokal](https://github.com/dsokal))
-- Fix `"ios: mods.ios.infoPlist: Failed to find Info.plist linked to Xcode project."` warning when running `eas build` in a managed project.([#670](https://github.com/expo/eas-cli/pull/670) by [@brentvatne](https://github.com/brentvatne)) 
+- Fix `"ios: mods.ios.infoPlist: Failed to find Info.plist linked to Xcode project."` warning when running `eas build` in a managed project.([#670](https://github.com/expo/eas-cli/pull/670) by [@brentvatne](https://github.com/brentvatne))
+- Fix building monorepo projects on Windows. ([#671](https://github.com/expo/eas-cli/pull/671) by [@dsokal](https://github.com/dsokal))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -61,6 +61,7 @@
     "qrcode-terminal": "0.12.0",
     "resolve-from": "5.0.0",
     "semver": "7.3.5",
+    "slash": "3.0.0",
     "strip-ansi": "6.0.0",
     "tar": "6.1.11",
     "terminal-link": "2.1.1",

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -1,6 +1,7 @@
 import { Android, ArchiveSource, Job, Platform, sanitizeJob } from '@expo/eas-build-job';
 import { AndroidBuildProfile } from '@expo/eas-json';
 import path from 'path';
+import slash from 'slash';
 
 import { AndroidCredentials } from '../../credentials/android/AndroidCredentialsProvider';
 import { getUsername } from '../../project/projectUtils';
@@ -26,7 +27,7 @@ export async function prepareJobAsync(
   const username = getUsername(ctx.exp, await ensureLoggedInAsync());
   const buildProfile: AndroidBuildProfile = ctx.buildProfile;
   const projectRootDirectory =
-    path.posix.relative(await vcs.getRootPathAsync(), ctx.projectDir) || '.';
+    slash(path.relative(await vcs.getRootPathAsync(), ctx.projectDir)) || '.';
   const { credentials } = jobData;
   const buildCredentials = credentials
     ? {

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -25,7 +25,8 @@ export async function prepareJobAsync(
 ): Promise<Job> {
   const username = getUsername(ctx.exp, await ensureLoggedInAsync());
   const buildProfile: AndroidBuildProfile = ctx.buildProfile;
-  const projectRootDirectory = path.relative(await vcs.getRootPathAsync(), ctx.projectDir) || '.';
+  const projectRootDirectory =
+    path.posix.relative(await vcs.getRootPathAsync(), ctx.projectDir) || '.';
   const { credentials } = jobData;
   const buildCredentials = credentials
     ? {

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -1,6 +1,7 @@
 import { ArchiveSource, Ios, Job, Platform, sanitizeJob } from '@expo/eas-build-job';
 import path from 'path';
 import semver from 'semver';
+import slash from 'slash';
 
 import { IosCredentials, TargetCredentials } from '../../credentials/ios/types';
 import { getUsername } from '../../project/projectUtils';
@@ -25,7 +26,7 @@ export async function prepareJobAsync(
   jobData: JobData
 ): Promise<Job> {
   const projectRootDirectory =
-    path.posix.relative(await vcs.getRootPathAsync(), ctx.projectDir) || '.';
+    slash(path.relative(await vcs.getRootPathAsync(), ctx.projectDir)) || '.';
   const username = getUsername(ctx.exp, await ensureLoggedInAsync());
   const buildCredentials: Ios.Job['secrets']['buildCredentials'] = {};
   if (jobData.credentials) {

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -24,7 +24,8 @@ export async function prepareJobAsync(
   ctx: BuildContext<Platform.IOS>,
   jobData: JobData
 ): Promise<Job> {
-  const projectRootDirectory = path.relative(await vcs.getRootPathAsync(), ctx.projectDir) || '.';
+  const projectRootDirectory =
+    path.posix.relative(await vcs.getRootPathAsync(), ctx.projectDir) || '.';
   const username = getUsername(ctx.exp, await ensureLoggedInAsync());
   const buildCredentials: Ios.Job['secrets']['buildCredentials'] = {};
   if (jobData.credentials) {

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -75,11 +75,7 @@ export default class BranchCreate extends EasCommand {
       flags,
     } = this.parse(BranchCreate);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
-
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const fullName = await getProjectFullNameAsync(exp);
     const projectId = await getProjectIdAsync(exp);

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -98,10 +98,7 @@ export default class BranchDelete extends EasCommand {
       flags: { json: jsonFlag },
     } = this.parse(BranchDelete);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const fullName = await getProjectFullNameAsync(exp);
     const projectId = await getProjectIdAsync(exp);

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -67,10 +67,7 @@ export default class BranchList extends EasCommand {
   async runAsync(): Promise<void> {
     const { flags } = this.parse(BranchList);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
     const branches = await listBranchesAsync({ projectId });

--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -162,11 +162,7 @@ export default class BranchPublish extends EasCommand {
     // If a group was specified, that means we are republishing it.
     republish = group ? true : republish;
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
-
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, {
       skipSDKVersionRequirement: true,
       isPublicConfig: true,

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -74,10 +74,7 @@ export default class BranchRename extends EasCommand {
       flags: { json: jsonFlag, from: currentName, to: newName },
     } = this.parse(BranchRename);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const fullName = await getProjectFullNameAsync(exp);
     const projectId = await getProjectIdAsync(exp);

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -90,11 +90,7 @@ export default class BranchView extends EasCommand {
       flags: { json: jsonFlag },
     } = this.parse(BranchView);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
-
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
 

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -117,7 +117,7 @@ export default class BuildCancel extends EasCommand {
   async runAsync(): Promise<void> {
     const { BUILD_ID: buildIdFromArg } = this.parse(BuildCancel).args;
 
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
     const projectFullName = await getProjectFullNameAsync(exp);

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -31,7 +31,7 @@ export default class BuildConfigure extends EasCommand {
 
     await configureAsync({
       platform,
-      projectDir: (await findProjectRootAsync()) ?? process.cwd(),
+      projectDir: await findProjectRootAsync(),
     });
 
     Log.newLine();

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -143,7 +143,7 @@ export default class Build extends EasCommand {
     const flags = await this.sanitizeFlagsAsync(rawFlags);
     const { requestedPlatform } = flags;
 
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     await handleDeprecatedEasJsonAsync(projectDir, flags.nonInteractive);
 
     await vcs.ensureRepoExistsAsync();

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -76,7 +76,7 @@ export default class BuildList extends EasCommand {
     const graphqlBuildStatus = toGraphQLBuildStatus(buildStatus);
     const graphqlBuildDistribution = toGraphQLBuildDistribution(buildDistribution);
 
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
     const projectName = await getProjectFullNameAsync(exp);

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -34,7 +34,7 @@ export default class BuildView extends EasCommand {
       enableJsonOutput();
     }
 
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
     const projectName = await getProjectFullNameAsync(exp);

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -84,10 +84,7 @@ export default class ChannelCreate extends EasCommand {
       flags: { json: jsonFlag },
     } = this.parse(ChannelCreate);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
 

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -121,10 +121,7 @@ export default class ChannelEdit extends EasCommand {
       flags: { branch: branchName, json: jsonFlag },
     } = this.parse(ChannelEdit);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
 

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -80,10 +80,7 @@ export default class ChannelList extends EasCommand {
       flags: { json: jsonFlag },
     } = this.parse(ChannelList);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
 

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -346,10 +346,7 @@ export default class ChannelRollout extends EasCommand {
       flags: { branch: branchName, percent },
     } = this.parse(ChannelRollout);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const fullName = await getProjectFullNameAsync(exp);
     const projectId = await getProjectIdAsync(exp);

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -215,10 +215,7 @@ export default class ChannelView extends EasCommand {
       flags: { json: jsonFlag },
     } = this.parse(ChannelView);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
 

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -27,7 +27,7 @@ export default class Config extends EasCommand {
       profile?: string;
     };
 
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     await handleDeprecatedEasJsonAsync(projectDir, false);
 
     const reader = new EasJsonReader(projectDir);

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -22,7 +22,7 @@ export default class BuildList extends EasCommand {
   async runAsync(): Promise<void> {
     let appleTeamIdentifier = this.parse(BuildList).flags['apple-team-id'];
 
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const accountName = await getProjectAccountNameAsync(exp);
 

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -29,7 +29,7 @@ If you are not sure what is the UDID of the device you are looking for, run:
       throw new Error('Device UDID is missing');
     }
 
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const accountName = await getProjectAccountNameAsync(exp);
 

--- a/packages/eas-cli/src/commands/project/info.ts
+++ b/packages/eas-cli/src/commands/project/info.ts
@@ -34,10 +34,7 @@ export default class ProjectInfo extends EasCommand {
   static description = 'information about the current project';
 
   async runAsync(): Promise<void> {
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
     const { app } = await projectInfoByIdAsync(projectId);

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -10,10 +10,7 @@ export default class ProjectInit extends EasCommand {
   static aliases = ['init'];
 
   async runAsync(): Promise<void> {
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
 
     if (exp.extra?.eas?.projectId) {

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -50,7 +50,7 @@ export default class EnvironmentSecretCreate extends EasCommand {
       flags: { name, value: secretValue, scope, force },
     } = this.parse(EnvironmentSecretCreate);
 
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const accountName = await getProjectAccountNameAsync(exp);
 

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -32,7 +32,7 @@ Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
   };
 
   async runAsync(): Promise<void> {
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
     const projectAccountName = await getProjectAccountNameAsync(exp);

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -20,7 +20,7 @@ export default class EnvironmentSecretList extends EasCommand {
   static description = 'Lists environment secrets available for your current app';
 
   async runAsync(): Promise<void> {
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
     const projectAccountName = await getProjectAccountNameAsync(exp);

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -93,7 +93,7 @@ See how to configure submits with eas.json: ${learnMore('https://docs.expo.dev/s
     const { flags: rawFlags } = this.parse(Submit);
     const flags = await this.sanitizeFlagsAsync(rawFlags);
 
-    const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
 

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -30,10 +30,7 @@ export default class WebhookCreate extends EasCommand {
     const { flags } = this.parse(WebhookCreate);
     const webhookInputParams = await prepareInputParamsAsync(flags);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
 

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -29,10 +29,7 @@ export default class WebhookDelete extends EasCommand {
       args: { ID: webhookId },
     } = this.parse(WebhookDelete);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
 

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -29,10 +29,7 @@ export default class WebhookList extends EasCommand {
       flags: { event },
     } = this.parse(WebhookList);
 
-    const projectDir = await findProjectRootAsync(process.cwd());
-    if (!projectDir) {
-      throw new Error('Please run this command inside a project directory.');
-    }
+    const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     const projectId = await getProjectIdAsync(exp);
     const projectFullName = await getProjectFullNameAsync(exp);

--- a/packages/eas-cli/src/devices/context.ts
+++ b/packages/eas-cli/src/devices/context.ts
@@ -20,7 +20,7 @@ export async function createContextAsync({
   cwd?: string;
   user: Actor;
 }): Promise<DeviceManagerContext> {
-  const projectDir = await findProjectRootAsync(cwd);
+  const projectDir = await findProjectRootAsync({ cwd });
   let exp: ExpoConfig | null = null;
   if (projectDir) {
     const config = getConfig(projectDir, { skipSDKVersionRequirement: true });

--- a/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
@@ -1,5 +1,4 @@
 import { vol } from 'memfs';
-import * as pkgDir from 'pkg-dir';
 
 import { asMock } from '../../__tests__/utils';
 import { confirmAsync } from '../../prompts';
@@ -17,14 +16,6 @@ import {
 
 jest.mock('@expo/config');
 jest.mock('fs');
-jest.mock('pkg-dir', () => {
-  const pkdDirMod = jest.requireActual('pkg-dir');
-  return {
-    ...pkdDirMod,
-    __esModule: true,
-    default: jest.fn(pkdDirMod.default),
-  };
-});
 
 jest.mock('../../prompts');
 jest.mock('../../user/User');
@@ -74,24 +65,6 @@ describe(findProjectRootAsync, () => {
     );
     const projectRoot = await findProjectRootAsync({ cwd: '/app/src' });
     expect(projectRoot).toBe('/app');
-  });
-
-  it('returns posix path on Windows', async () => {
-    const processCwdSpy = jest
-      .spyOn(process, 'cwd')
-      .mockReturnValue('C:\\Users\\User\\expo\\fakeproject\\apps\\managed');
-
-    const pkgDirSpy = jest
-      .spyOn(pkgDir, 'default')
-      .mockResolvedValue('C:\\Users\\User\\expo\\fakeproject\\apps\\managed');
-
-    try {
-      const projectRoot = await findProjectRootAsync();
-      expect(projectRoot).toBe('C:/Users/User/expo/fakeproject/apps/managed');
-    } finally {
-      processCwdSpy.mockRestore();
-      pkgDirSpy.mockRestore();
-    }
   });
 });
 

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 import gql from 'graphql-tag';
 import path from 'path';
 import pkgDir from 'pkg-dir';
-import slash from 'slash';
 
 import { graphqlClient, withErrorHandlingAsync } from '../graphql/client';
 import { AppPrivacy, UpdateBranch } from '../graphql/generated';
@@ -65,10 +64,10 @@ export async function findProjectRootAsync({
     if (!defaultToProcessCwd) {
       throw new Error('Please run this command inside a project directory.');
     } else {
-      return slash(process.cwd());
+      return process.cwd();
     }
   } else {
-    return slash(projectRootDir);
+    return projectRootDir;
   }
 }
 

--- a/packages/eas-cli/src/submit/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submit/android/ServiceAccountSource.ts
@@ -59,7 +59,7 @@ async function handlePathSourceAsync(source: ServiceAccountPathSource): Promise<
 }
 
 async function handleDetectSourceAsync(_source: ServiceAccountDetectSource): Promise<string> {
-  const projectDir = (await findProjectRootAsync()) ?? process.cwd();
+  const projectDir = await findProjectRootAsync();
   const foundFilePaths = await glob('**/*.json', {
     cwd: projectDir,
     ignore: ['app.json', 'package*.json', 'tsconfig.json', 'node_modules'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9656,7 +9656,7 @@ sisteransi@^1.0.4:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
-slash@^3.0.0:
+slash@3.0.0, slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Fixes https://github.com/expo/eas-cli/issues/663

# How

Turtle expects posix paths. However, when running on Windows, `path` module returns non-posix paths. I forced using posix paths on all systems.

# Test Plan

Unit test + tested manually on Windows.