### PR TITLE
changelog bot: commit as last commit author

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -37,8 +37,10 @@ jobs:
           PR_COMMENT_BODY: ${{ github.event.comment.body }}
       - name: Commit and push
         run: |
-          git config --global user.email "support+ci@expo.io"
-          git config --global user.name "Expo CI"
+          # use the last commit author name and email
+          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+
           git add CHANGELOG.md
           git commit -m "update CHANGELOG.md"
           git push


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Follow up to https://github.com/expo/eas-cli/pull/676
I've realized that if we commit as @expo-ci then this user appears as the co-author of the commit when the PR gets merged.
<img width="422" alt="Screenshot 2021-10-08 at 16 33 43" src="https://user-images.githubusercontent.com/5256730/136575635-211f2789-588b-4dfe-a578-cf64e46f7c95.png">

# How

Commit CHANGELOG.md changes as the last PR commit author.

# Test Plan

Tested in the forked repo - https://github.com/dsokal/eas-cli/commits/main

Compare the first and the other merge commit:
<img width="476" alt="Screenshot 2021-10-08 at 16 35 53" src="https://user-images.githubusercontent.com/5256730/136575752-76ed7b09-e2a8-4e92-9198-b082dc79a050.png">

