### PR TITLE
[ENG-2134] don't use term "generic project"

### DIFF
--- a/packages/eas-cli/src/build/android/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/android/__tests__/version-test.ts
@@ -31,7 +31,7 @@ beforeEach(async () => {
   await fs.mkdirp(os.tmpdir());
 });
 
-// generic workflow
+// bare workflow
 describe(bumpVersionAsync, () => {
   it('throws an informative error when multiple flavors are detected in the android project', async () => {
     await initProjectWithGradleFileAsync(
@@ -69,7 +69,7 @@ describe(bumpVersionAsync, () => {
   });
   it('bumps expo.android.versionCode and buildGradle versionCode when strategy = BumpStrategy.VERSION_CODE', async () => {
     const nativeVersionCode = 100; // this should be overwritten by bumpVersionAsync
-    const fakeExp = initGenericProject({ versionCode: nativeVersionCode });
+    const fakeExp = initBareWorkflowProject({ versionCode: nativeVersionCode });
 
     await bumpVersionAsync({
       bumpStrategy: BumpStrategy.VERSION_CODE,
@@ -91,7 +91,7 @@ describe(bumpVersionAsync, () => {
 
   it('bumps expo.version and gradle versionCode when strategy = BumpStrategy.SHORT_VERSION', async () => {
     const nativeVersionName = '1.0.0'; // this should be overwritten by bumpVersionAsync
-    const fakeExp = initGenericProject({ versionName: nativeVersionName });
+    const fakeExp = initBareWorkflowProject({ versionName: nativeVersionName });
 
     await bumpVersionAsync({
       bumpStrategy: BumpStrategy.APP_VERSION,
@@ -112,7 +112,7 @@ describe(bumpVersionAsync, () => {
   });
 
   it('does not bump any version when strategy = BumpStrategy.NOOP', async () => {
-    const fakeExp = initGenericProject();
+    const fakeExp = initBareWorkflowProject();
 
     await bumpVersionAsync({
       bumpStrategy: BumpStrategy.NOOP,
@@ -185,9 +185,9 @@ describe(bumpVersionInAppJsonAsync, () => {
 });
 
 describe(maybeResolveVersionsAsync, () => {
-  describe('generic project', () => {
+  describe('bare project', () => {
     it('reads the versions from native code', async () => {
-      const exp = initGenericProject();
+      const exp = initBareWorkflowProject();
       const { appVersion, appBuildVersion } = await maybeResolveVersionsAsync(
         '/repo',
         exp,
@@ -211,7 +211,7 @@ describe(maybeResolveVersionsAsync, () => {
   });
 });
 
-function initGenericProject({
+function initBareWorkflowProject({
   versionCode = 123,
   versionName = '3.0.0',
 }: {

--- a/packages/eas-cli/src/build/android/configure.ts
+++ b/packages/eas-cli/src/build/android/configure.ts
@@ -6,7 +6,7 @@ import { AndroidBuildProfile, AndroidVersionAutoIncrement } from '@expo/eas-json
 import Log from '../../log';
 import {
   ensureApplicationIdIsDefinedForManagedProjectAsync,
-  warnIfAndroidPackageDefinedInAppConfigForGenericProject,
+  warnIfAndroidPackageDefinedInAppConfigForBareWorkflowProject,
 } from '../../project/android/applicationId';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import vcs from '../../vcs';
@@ -21,7 +21,7 @@ export async function configureAndroidAsync(ctx: ConfigureContext): Promise<void
     return;
   }
 
-  warnIfAndroidPackageDefinedInAppConfigForGenericProject(ctx.projectDir, ctx.exp);
+  warnIfAndroidPackageDefinedInAppConfigForBareWorkflowProject(ctx.projectDir, ctx.exp);
 
   await AndroidConfig.EasBuild.configureEasBuildAsync(ctx.projectDir);
 

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -108,7 +108,7 @@ const EAS_JSON_MANAGED_DEFAULT: EasJson = {
   },
 };
 
-const EAS_JSON_GENERIC_DEFAULT: EasJson = {
+const EAS_JSON_BARE_DEFAULT: EasJson = {
   build: {
     release: {},
     development: {
@@ -139,7 +139,7 @@ export async function ensureEasJsonExistsAsync(ctx: ConfigureContext): Promise<v
 
   const easJson =
     ctx.hasAndroidNativeProject && ctx.hasIosNativeProject
-      ? EAS_JSON_GENERIC_DEFAULT
+      ? EAS_JSON_BARE_DEFAULT
       : EAS_JSON_MANAGED_DEFAULT;
 
   await fs.writeFile(easJsonPath, `${JSON.stringify(easJson, null, 2)}\n`);

--- a/packages/eas-cli/src/build/ios/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/ios/__tests__/version-test.ts
@@ -49,10 +49,10 @@ describe(evaluateTemplateString, () => {
   });
 });
 
-// generic workflow
+// bare workflow
 describe(bumpVersionAsync, () => {
   it('bumps expo.ios.buildNumber and CFBundleVersion when strategy = BumpStrategy.BUILD_NUMBER', async () => {
-    const fakeExp = initGenericProject();
+    const fakeExp = initBareWorkflowProject();
 
     await bumpVersionAsync({
       bumpStrategy: BumpStrategy.BUILD_NUMBER,
@@ -74,7 +74,7 @@ describe(bumpVersionAsync, () => {
   });
 
   it('bumps expo.ios.buildNumber and CFBundleVersion for non default Info.plist location', async () => {
-    const fakeExp = initGenericProject({ infoPlistName: 'Info2.plist' });
+    const fakeExp = initBareWorkflowProject({ infoPlistName: 'Info2.plist' });
 
     await bumpVersionAsync({
       bumpStrategy: BumpStrategy.BUILD_NUMBER,
@@ -98,7 +98,7 @@ describe(bumpVersionAsync, () => {
   });
 
   it('bumps expo.version and CFBundleShortVersionString when strategy = BumpStrategy.SHORT_VERSION', async () => {
-    const fakeExp = initGenericProject();
+    const fakeExp = initBareWorkflowProject();
 
     await bumpVersionAsync({
       bumpStrategy: BumpStrategy.APP_VERSION,
@@ -120,7 +120,7 @@ describe(bumpVersionAsync, () => {
   });
 
   it('does not bump any version when strategy = BumpStrategy.NOOP', async () => {
-    const fakeExp = initGenericProject();
+    const fakeExp = initBareWorkflowProject();
 
     await bumpVersionAsync({
       bumpStrategy: BumpStrategy.NOOP,
@@ -194,9 +194,9 @@ describe(bumpVersionInAppJsonAsync, () => {
 });
 
 describe(readBuildNumberAsync, () => {
-  describe('generic project', () => {
+  describe('bare project', () => {
     it('reads the build number from native code', async () => {
-      const exp = initGenericProject();
+      const exp = initBareWorkflowProject();
       const buildNumber = await readBuildNumberAsync('/repo', exp, {});
       expect(buildNumber).toBe('1');
     });
@@ -212,14 +212,14 @@ describe(readBuildNumberAsync, () => {
 });
 
 describe(readShortVersionAsync, () => {
-  describe('generic project', () => {
+  describe('bare project', () => {
     it('reads the short version from native code', async () => {
-      const exp = initGenericProject();
+      const exp = initBareWorkflowProject();
       const appVersion = await readShortVersionAsync('/repo', exp, {});
       expect(appVersion).toBe('1.0.0');
     });
     it('evaluates interpolated build number', async () => {
-      const exp = initGenericProject({
+      const exp = initBareWorkflowProject({
         appVersion: '$(CURRENT_PROJECT_VERSION)',
       });
       const buildNumber = await readShortVersionAsync('/repo', exp, {
@@ -231,7 +231,7 @@ describe(readShortVersionAsync, () => {
 
   describe('managed project', () => {
     it('reads the version from app config', async () => {
-      const exp = initGenericProject();
+      const exp = initBareWorkflowProject();
       const appVersion = await readShortVersionAsync('/repo', exp, {});
       expect(appVersion).toBe('1.0.0');
     });
@@ -286,7 +286,7 @@ describe(getInfoPlistPath, () => {
   });
 });
 
-function initGenericProject({
+function initBareWorkflowProject({
   appVersion = '1.0.0',
   version = '1',
   infoPlistName = 'Info.plist',

--- a/packages/eas-cli/src/build/ios/configure.ts
+++ b/packages/eas-cli/src/build/ios/configure.ts
@@ -6,7 +6,7 @@ import type { XCBuildConfiguration } from 'xcode';
 import Log from '../../log';
 import {
   ensureBundleIdentifierIsDefinedForManagedProjectAsync,
-  warnIfBundleIdentifierDefinedInAppConfigForGenericProject,
+  warnIfBundleIdentifierDefinedInAppConfigForBareWorkflowProject,
 } from '../../project/ios/bundleIdentifier';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { ConfigureContext } from '../context';
@@ -20,7 +20,7 @@ export async function configureIosAsync(ctx: ConfigureContext): Promise<void> {
     return;
   }
 
-  warnIfBundleIdentifierDefinedInAppConfigForGenericProject(ctx.projectDir, ctx.exp);
+  warnIfBundleIdentifierDefinedInAppConfigForBareWorkflowProject(ctx.projectDir, ctx.exp);
 
   if (isExpoUpdatesInstalled(ctx.projectDir)) {
     await configureUpdatesAsync(ctx.projectDir, ctx.exp);

--- a/packages/eas-cli/src/project/__tests__/workflow-test.ts
+++ b/packages/eas-cli/src/project/__tests__/workflow-test.ts
@@ -12,7 +12,7 @@ describe(resolveWorkflowAsync, () => {
 
   const projectDir = '/app';
 
-  test('generic workflow for both platforms', async () => {
+  test('bare workflow for both platforms', async () => {
     vol.fromJSON(
       {
         './ios/helloworld.xcodeproj/project.pbxproj': 'fake',
@@ -27,7 +27,7 @@ describe(resolveWorkflowAsync, () => {
     await expect(resolveWorkflowAsync(projectDir, Platform.IOS)).resolves.toBe(Workflow.GENERIC);
   });
 
-  test('generic workflow for single platform', async () => {
+  test('bare workflow for single platform', async () => {
     vol.fromJSON(
       {
         './ios/helloworld.xcodeproj/project.pbxproj': 'fake',

--- a/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
@@ -25,7 +25,7 @@ beforeEach(async () => {
 });
 
 describe(getApplicationIdAsync, () => {
-  describe('generic projects', () => {
+  describe('bare projects', () => {
     it('reads applicationId from build.gradle', async () => {
       vol.fromJSON(
         {

--- a/packages/eas-cli/src/project/android/__tests__/gradle-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/gradle-test.ts
@@ -21,7 +21,7 @@ beforeEach(async () => {
 });
 
 describe(resolveGradleBuildContextAsync, () => {
-  describe('generic projects', () => {
+  describe('bare projects', () => {
     it('resolves to default config (no flavor)', async () => {
       vol.fromJSON(
         {

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -39,7 +39,7 @@ export async function getApplicationIdAsync(
 ): Promise<string> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
   if (workflow === Workflow.GENERIC) {
-    warnIfAndroidPackageDefinedInAppConfigForGenericProject(projectDir, exp);
+    warnIfAndroidPackageDefinedInAppConfigForBareWorkflowProject(projectDir, exp);
 
     const errorMessage = 'Could not read application id from Android project.';
     if (gradleContext) {
@@ -129,7 +129,7 @@ function isApplicationIdValid(applicationId: string): boolean {
 }
 
 let warnPrinted = false;
-export function warnIfAndroidPackageDefinedInAppConfigForGenericProject(
+export function warnIfAndroidPackageDefinedInAppConfigForBareWorkflowProject(
   projectDir: string,
   exp: ExpoConfig
 ): void {
@@ -137,7 +137,7 @@ export function warnIfAndroidPackageDefinedInAppConfigForGenericProject(
     Log.warn(
       `Specifying "android.package" in ${getProjectConfigDescription(
         projectDir
-      )} is deprecated for generic projects.\n` +
+      )} is deprecated for bare workflow projects.\n` +
         'EAS Build depends only on the value in the native code. Please remove the deprecated configuration.'
     );
     warnPrinted = true;

--- a/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
@@ -29,7 +29,7 @@ beforeEach(async () => {
 const originalFs = jest.requireActual('fs') as typeof fs;
 
 describe(getBundleIdentifierAsync, () => {
-  describe('generic projects', () => {
+  describe('bare projects', () => {
     it('reads bundle identifier from project.', async () => {
       vol.fromJSON(
         {

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -34,7 +34,7 @@ export async function getBundleIdentifierAsync(
 ): Promise<string> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
   if (workflow === Workflow.GENERIC) {
-    warnIfBundleIdentifierDefinedInAppConfigForGenericProject(projectDir, exp);
+    warnIfBundleIdentifierDefinedInAppConfigForBareWorkflowProject(projectDir, exp);
 
     const bundleIdentifier = IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj(projectDir, {
       targetName,
@@ -124,7 +124,7 @@ function isBundleIdentifierValid(bundleIdentifier: string): boolean {
 }
 
 let warnPrinted = false;
-export function warnIfBundleIdentifierDefinedInAppConfigForGenericProject(
+export function warnIfBundleIdentifierDefinedInAppConfigForBareWorkflowProject(
   projectDir: string,
   exp: ExpoConfig
 ): void {
@@ -132,7 +132,7 @@ export function warnIfBundleIdentifierDefinedInAppConfigForGenericProject(
     Log.warn(
       `Specifying "ios.bundleIdentifier" in ${getProjectConfigDescription(
         projectDir
-      )} is deprecated for generic projects.\n` +
+      )} is deprecated for bare workflow projects.\n` +
         'EAS Build depends only on the value in the native code. Please remove the deprecated configuration.'
     );
     warnPrinted = true;

--- a/packages/eas-json/src/__tests__/migrate-test.ts
+++ b/packages/eas-json/src/__tests__/migrate-test.ts
@@ -35,7 +35,7 @@ test('migration for default manged eas.json', async () => {
   });
 });
 
-test('migration for default generic eas.json', async () => {
+test('migration for default bare workflow eas.json', async () => {
   const easJson = {
     builds: {
       android: {
@@ -194,7 +194,7 @@ test('migration for example manged eas.json', async () => {
   });
 });
 
-test('migration for example generic eas.json', async () => {
+test('migration for example bare workflow eas.json', async () => {
   const easJson = {
     builds: {
       android: {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://linear.app/expo/issue/ENG-2134/improve-message-when-iosbundleidentifier-is-set-in-appjson

# How

Find all "generic workflow" occurrences and replace them with "bare workflow".

# Test Plan

CI
