### PR TITLE
unify reading app.json

### DIFF
--- a/packages/eas-cli/src/build/utils/appJson.ts
+++ b/packages/eas-cli/src/build/utils/appJson.ts
@@ -1,6 +1,6 @@
 import * as ExpoConfig from '@expo/config';
+import JsonFile from '@expo/json-file';
 import assert from 'assert';
-import fs from 'fs-extra';
 
 export async function updateAppJsonConfigAsync(
   {
@@ -15,10 +15,19 @@ export async function updateAppJsonConfigAsync(
   const paths = ExpoConfig.getConfigFilePaths(projectDir);
   assert(paths.staticConfigPath, "can't update dynamic config");
 
-  const rawStaticConfig = await fs.readJSON(paths.staticConfigPath);
+  const rawStaticConfig = readAppJson(paths.staticConfigPath);
   rawStaticConfig.expo = rawStaticConfig.expo ?? {};
   modifyConfig(rawStaticConfig.expo);
-  await fs.writeJson(paths.staticConfigPath, rawStaticConfig, { spaces: 2 });
+  await JsonFile.writeAsync(paths.staticConfigPath, rawStaticConfig, { json5: false });
 
   modifyConfig(exp);
+}
+
+// TODO: remove this once @expo/config exports getStaticConfig
+export function readAppJson(appJsonPath: string): any {
+  const config = JsonFile.read(appJsonPath, { json5: true });
+  if (config) {
+    return config as any;
+  }
+  throw new Error(`Failed to read app.json`);
 }

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import nullthrows from 'nullthrows';
 
+import { readAppJson } from '../../build/utils/appJson';
 import Log, { learnMore } from '../../log';
 import { getProjectConfigDescription, getUsername } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
@@ -112,7 +113,7 @@ async function configureApplicationIdAsync(projectDir: string, exp: ExpoConfig):
     validate: value => (isApplicationIdValid(value) ? true : INVALID_APPLICATION_ID_MESSAGE),
   });
 
-  const rawStaticConfig = await fs.readJSON(paths.staticConfigPath);
+  const rawStaticConfig = readAppJson(paths.staticConfigPath);
   rawStaticConfig.expo = {
     ...rawStaticConfig.expo,
     android: { ...rawStaticConfig.expo?.android, package: packageName },

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -5,6 +5,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
+import { readAppJson } from '../../build/utils/appJson';
 import Log, { learnMore } from '../../log';
 import { promptAsync } from '../../prompts';
 import { ensureLoggedInAsync } from '../../user/actions';
@@ -107,7 +108,7 @@ async function configureBundleIdentifierAsync(
     validate: value => (isBundleIdentifierValid(value) ? true : INVALID_BUNDLE_IDENTIFIER_MESSAGE),
   });
 
-  const rawStaticConfig = await fs.readJSON(paths.staticConfigPath);
+  const rawStaticConfig = readAppJson(paths.staticConfigPath);
   rawStaticConfig.expo = {
     ...rawStaticConfig.expo,
     ios: { ...rawStaticConfig.expo?.ios, bundleIdentifier },


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Follow up to https://github.com/expo/eas-cli/issues/689
It turns out that `@expo/config` reads `app.json` slightly differently than EAS CLI.

`@expo/config` uses `require('@expo/json-file').read` - https://github.com/expo/expo-cli/blob/master/packages/config/src/getConfig.ts#L36
EAS CLI uses `await fs.readJSON`.

As a result, EAS CLI fails when app.json has redundant dangling commas.

# How

Use `require('@expo/json-file').read`.

# Test Plan

Tested manually with auto-increment.
