### PR TITLE
[eas-cli] asc api key graphql type and print support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add App Store Connect Api Key graphql type and print support. ([#717](https://github.com/expo/eas-cli/pull/717) by [@quinlanj](https://github.com/quinlanj))
+
 ## [0.34.0](https://github.com/expo/eas-cli/releases/tag/0.34.0) - 2021-11-01
 
 ### 🛠 Breaking changes

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1866,30 +1866,6 @@
             "deprecationReason": null
           },
           {
-            "name": "appleAppSpecificPasswords",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "AppleAppSpecificPassword",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "appStoreConnectApiKeys",
             "description": "",
             "args": [],
@@ -2931,6 +2907,30 @@
             "deprecationReason": null
           },
           {
+            "name": "releaseChannels",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "builds",
             "description": "(EAS Build) Builds associated with this app",
             "args": [
@@ -3630,6 +3630,46 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "ActivityTimelineProjectActivityType",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filterPlatforms",
+                "description": "",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "AppPlatform",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filterReleaseChannels",
+                "description": "",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
                       "ofType": null
                     }
                   }
@@ -8090,18 +8130,6 @@
             "deprecationReason": null
           },
           {
-            "name": "appSpecificPassword",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "AppleAppSpecificPassword",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "iosAppBuildCredentialsArray",
             "description": "",
             "args": [
@@ -9564,109 +9592,6 @@
             "deprecationReason": null
           }
         ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AppleAppSpecificPassword",
-        "description": "",
-        "fields": [
-          {
-            "name": "id",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "account",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "appleIdUsername",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "passwordLabel",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -13549,22 +13474,6 @@
             "deprecationReason": null
           },
           {
-            "name": "appleAppSpecificPassword",
-            "description": "Mutations that modify an App Specific Password for an Apple User Account",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AppleAppSpecificPasswordMutation",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "appleDevice",
             "description": "Mutations that modify an Apple Device",
             "args": [],
@@ -15834,121 +15743,6 @@
               "kind": "SCALAR",
               "name": "ID",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AppleAppSpecificPasswordMutation",
-        "description": "",
-        "fields": [
-          {
-            "name": "createAppleAppSpecificPassword",
-            "description": "Create an App Specific Password for an Apple User Account",
-            "args": [
-              {
-                "name": "appleAppSpecificPasswordInput",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "AppleAppSpecificPasswordInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "accountId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AppleAppSpecificPassword",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "AppleAppSpecificPasswordInput",
-        "description": "",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "appleIdUsername",
-            "description": "",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "passwordLabel",
-            "description": "",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "appSpecificPassword",
-            "description": "",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -925,6 +925,22 @@
             "deprecationReason": null
           },
           {
+            "name": "displayName",
+            "description": "Best-effort human readable name for this actor for use in user interfaces during action attribution.\nFor example, when displaying a sentence indicating that actor X created a build or published an update.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "accounts",
             "description": "Associated accounts",
             "args": [],
@@ -5153,6 +5169,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -11267,6 +11299,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "nextInvoice",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "willCancel",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -11802,8 +11858,8 @@
                 }
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "App directory no longer supported"
           }
         ],
         "inputFields": null,
@@ -19665,6 +19721,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/__mocks__/IosAppCredentialsQuery.ts
@@ -30,6 +30,21 @@ export const IosAppCredentialsQuery = {
         },
         __typename: 'ApplePushKey',
       },
+      appStoreConnectApiKeyForSubmissions: {
+        id: 'b8fe2225-3024-4ebe-9e36-7b9022d3b13e',
+        appleTeam: {
+          id: 'ca27f9f6-c7cb-40d1-8c41-c168e8548261',
+          appleTeamIdentifier: '77KQ969CHE',
+          appleTeamName: null,
+          __typename: 'AppleTeam',
+        },
+        issuerIdentifier: '69a6de93-e4e4-47e3-e053-5b8c7c11a4d1',
+        keyIdentifier: 'NYN468XNN3',
+        name: 'Expo Submissions pl94k8_lnS',
+        roles: ['ADMIN'],
+        updatedAt: '2020-10-13T18:39:04.463Z',
+        __typename: 'AppStoreConnectApiKey',
+      },
       iosAppBuildCredentialsList: [
         {
           id: '6f8d0175-0caf-4922-b09b-eae757b83144',

--- a/packages/eas-cli/src/credentials/ios/utils/__tests__/__snapshots__/printCredentials-test.ts.snap
+++ b/packages/eas-cli/src/credentials/ios/utils/__tests__/__snapshots__/printCredentials-test.ts.snap
@@ -2,47 +2,55 @@
 
 exports[`print credentials prints the IosAppCredentials map 1`] = `
 Array [
-  "iOS Credentials           
-Project                   @quinlanj/test52
-Bundle Identifier         com.quinlanj.test52
-Apple Team                test-apple-identifier 
-                          
-Push Key                  
-Developer Portal ID       9839M6AY8W
-Apple Team                77KQ969CHE 
-Updated                   6 months ago
-                          
-                          
-App Store Configuration   
-                          
-Distribution Certificate  
-Serial Number             test-serial
-Expiration Date           Wed, 13 Oct 2021 18:28:44 UTC
-Apple Team                test-apple-identifier 
-Updated                   6 months ago
-                          
-Provisioning Profile      
-Developer Portal ID       test-profile-id
-Status                    active
-Expiration                Wed, 13 Oct 2021 18:28:44 UTC
-Apple Team                test-apple-identifier 
-Updated                   5 months ago
-                          
-                          
-Ad Hoc Configuration      
-                          
-Distribution Certificate  
-Serial Number             test-serial
-Expiration Date           Wed, 13 Oct 2021 18:28:44 UTC
-Apple Team                test-apple-identifier 
-Updated                   6 months ago
-                          
-Provisioning Profile      
-Developer Portal ID       test-profile-id
-Status                    active
-Expiration                Wed, 13 Oct 2021 18:28:44 UTC
-Apple Team                test-apple-identifier 
-Updated                   5 months ago
-                          ",
+  "iOS Credentials            
+Project                    @quinlanj/test52
+Bundle Identifier          com.quinlanj.test52
+Apple Team                 test-apple-identifier 
+                           
+Push Key                   
+Developer Portal ID        9839M6AY8W
+Apple Team                 77KQ969CHE 
+Updated                    6 months ago
+                           
+App Store Connect Api Key  
+Developer Portal ID        NYN468XNN3
+Name                       Expo Submissions pl94k8_lnS
+Issuer ID                  69a6de93-e4e4-47e3-e053-5b8c7c11a4d1
+Roles                      ADMIN
+Apple Team                 77KQ969CHE 
+Updated                    6 months ago
+                           
+                           
+App Store Configuration    
+                           
+Distribution Certificate   
+Serial Number              test-serial
+Expiration Date            Wed, 13 Oct 2021 18:28:44 UTC
+Apple Team                 test-apple-identifier 
+Updated                    6 months ago
+                           
+Provisioning Profile       
+Developer Portal ID        test-profile-id
+Status                     active
+Expiration                 Wed, 13 Oct 2021 18:28:44 UTC
+Apple Team                 test-apple-identifier 
+Updated                    5 months ago
+                           
+                           
+Ad Hoc Configuration       
+                           
+Distribution Certificate   
+Serial Number              test-serial
+Expiration Date            Wed, 13 Oct 2021 18:28:44 UTC
+Apple Team                 test-apple-identifier 
+Updated                    6 months ago
+                           
+Provisioning Profile       
+Developer Portal ID        test-profile-id
+Status                     active
+Expiration                 Wed, 13 Oct 2021 18:28:44 UTC
+Apple Team                 test-apple-identifier 
+Updated                    5 months ago
+                           ",
 ]
 `;

--- a/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import dateformat from 'dateformat';
 
 import {
+  AppStoreConnectApiKeyFragment,
   AppleDeviceFragment,
   ApplePushKeyFragment,
   IosAppBuildCredentialsFragment,
@@ -91,7 +92,7 @@ export function displayIosCredentials(
       continue;
     }
 
-    const { appleTeam, pushKey } = targetAppCredentials;
+    const { appleTeam, pushKey, appStoreConnectApiKeyForSubmissions } = targetAppCredentials;
     if (appleTeam) {
       const { appleTeamIdentifier, appleTeamName } = appleTeam;
       fields.push({
@@ -103,6 +104,10 @@ export function displayIosCredentials(
 
     if (pushKey) {
       displayApplePushKey(pushKey, fields);
+    }
+
+    if (appStoreConnectApiKeyForSubmissions) {
+      displayAscApiKey(appStoreConnectApiKeyForSubmissions, fields);
     }
 
     const sortedIosAppBuildCredentialsList = sortBuildCredentialsByDistributionType(
@@ -216,6 +221,35 @@ function displayApplePushKey(
   if (maybePushKey) {
     const { keyIdentifier, appleTeam, updatedAt } = maybePushKey;
     fields.push({ label: 'Developer Portal ID', value: keyIdentifier });
+    if (appleTeam) {
+      const { appleTeamIdentifier, appleTeamName } = appleTeam;
+      fields.push({
+        label: 'Apple Team',
+        value: `${appleTeamIdentifier} ${appleTeamName ? `(${appleTeamName})` : ''}`,
+      });
+    }
+    fields.push({ label: 'Updated', value: `${fromNow(new Date(updatedAt))} ago` });
+  } else {
+    fields.push({ label: '', value: 'None assigned yet' });
+  }
+  fields.push({ label: '', value: '' });
+}
+
+function displayAscApiKey(
+  maybeAscApiKey: AppStoreConnectApiKeyFragment | null,
+  fields: { label: string; value: string }[]
+): void {
+  fields.push({ label: 'App Store Connect Api Key', value: '' });
+  if (maybeAscApiKey) {
+    const { keyIdentifier, issuerIdentifier, appleTeam, name, roles, updatedAt } = maybeAscApiKey;
+    fields.push({ label: 'Developer Portal ID', value: keyIdentifier });
+    if (name) {
+      fields.push({ label: 'Name', value: name });
+    }
+    fields.push({ label: 'Issuer ID', value: issuerIdentifier });
+    if (roles) {
+      fields.push({ label: 'Roles', value: roles.join(',') });
+    }
     if (appleTeam) {
       const { appleTeamIdentifier, appleTeamName } = appleTeam;
       fields.push({

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -147,6 +147,11 @@ export type Actor = {
   firstName?: Maybe<Scalars['String']>;
   created: Scalars['DateTime'];
   isExpoAdmin: Scalars['Boolean'];
+  /**
+   * Best-effort human readable name for this actor for use in user interfaces during action attribution.
+   * For example, when displaying a sentence indicating that actor X created a build or published an update.
+   */
+  displayName: Scalars['String'];
   /** Associated accounts */
   accounts: Array<Account>;
   /** Access Tokens belonging to this actor */
@@ -736,6 +741,7 @@ export type User = Actor & {
   appetizeCode?: Maybe<Scalars['String']>;
   emailVerified: Scalars['Boolean'];
   isExpoAdmin: Scalars['Boolean'];
+  displayName: Scalars['String'];
   isSecondFactorAuthenticationEnabled: Scalars['Boolean'];
   /** Get all certified second factor authentication methods */
   secondFactorDevices: Array<UserSecondFactorDevice>;
@@ -1466,6 +1472,8 @@ export type AddonDetails = {
   id: Scalars['ID'];
   planId: Scalars['String'];
   name: Scalars['String'];
+  nextInvoice?: Maybe<Scalars['DateTime']>;
+  willCancel?: Maybe<Scalars['Boolean']>;
 };
 
 export type Charge = {
@@ -1541,7 +1549,10 @@ export type AppQuery = {
   /** Look up app by app id */
   byId: App;
   byFullName: App;
-  /** Public apps in the app directory */
+  /**
+   * Public apps in the app directory
+   * @deprecated App directory no longer supported
+   */
   all: Array<App>;
 };
 
@@ -2851,6 +2862,7 @@ export type Robot = Actor & {
   firstName?: Maybe<Scalars['String']>;
   created: Scalars['DateTime'];
   isExpoAdmin: Scalars['Boolean'];
+  displayName: Scalars['String'];
   /** Associated accounts */
   accounts: Array<Account>;
   /** Access Tokens belonging to this actor */

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -212,7 +212,6 @@ export type Account = {
   applePushKeys: Array<ApplePushKey>;
   appleProvisioningProfiles: Array<AppleProvisioningProfile>;
   appleDevices: Array<AppleDevice>;
-  appleAppSpecificPasswords: Array<AppleAppSpecificPassword>;
   appStoreConnectApiKeys: Array<AppStoreConnectApiKey>;
   /** Android credentials for account */
   googleServiceAccountKeys: Array<GoogleServiceAccountKey>;
@@ -436,6 +435,7 @@ export type App = Project & {
   privacySetting: AppPrivacy;
   latestReleaseId: Scalars['ID'];
   pushSecurityEnabled: Scalars['Boolean'];
+  releaseChannels: Array<Scalars['String']>;
   /** (EAS Build) Builds associated with this app */
   builds: Array<Build>;
   buildJobs: Array<BuildJob>;
@@ -591,6 +591,8 @@ export type AppActivityTimelineProjectActivitiesArgs = {
   limit: Scalars['Int'];
   createdBefore?: Maybe<Scalars['DateTime']>;
   filterTypes?: Maybe<Array<ActivityTimelineProjectActivityType>>;
+  filterPlatforms?: Maybe<Array<AppPlatform>>;
+  filterReleaseChannels?: Maybe<Array<Scalars['String']>>;
 };
 
 
@@ -1115,7 +1117,6 @@ export type IosAppCredentials = {
   iosAppBuildCredentialsList: Array<IosAppBuildCredentials>;
   pushKey?: Maybe<ApplePushKey>;
   appStoreConnectApiKeyForSubmissions?: Maybe<AppStoreConnectApiKey>;
-  appSpecificPassword?: Maybe<AppleAppSpecificPassword>;
   /** @deprecated use iosAppBuildCredentialsList instead */
   iosAppBuildCredentialsArray: Array<IosAppBuildCredentials>;
 };
@@ -1278,16 +1279,6 @@ export enum AppStoreConnectUserRole {
   ImageManager = 'IMAGE_MANAGER',
   Unknown = 'UNKNOWN'
 }
-
-export type AppleAppSpecificPassword = {
-  __typename?: 'AppleAppSpecificPassword';
-  id: Scalars['ID'];
-  account: Account;
-  appleIdUsername: Scalars['String'];
-  passwordLabel?: Maybe<Scalars['String']>;
-  createdAt: Scalars['DateTime'];
-  updatedAt: Scalars['DateTime'];
-};
 
 export type AndroidAppCredentialsFilter = {
   legacyOnly?: Maybe<Scalars['Boolean']>;
@@ -1877,8 +1868,6 @@ export type RootMutation = {
   googleServiceAccountKey: GoogleServiceAccountKeyMutation;
   /** Mutations that modify an Identifier for an iOS App */
   appleAppIdentifier: AppleAppIdentifierMutation;
-  /** Mutations that modify an App Specific Password for an Apple User Account */
-  appleAppSpecificPassword: AppleAppSpecificPasswordMutation;
   /** Mutations that modify an Apple Device */
   appleDevice: AppleDeviceMutation;
   /** Mutations that modify an Apple Device registration request */
@@ -2276,24 +2265,6 @@ export type AppleAppIdentifierInput = {
   bundleIdentifier: Scalars['String'];
   appleTeamId?: Maybe<Scalars['ID']>;
   parentAppleAppId?: Maybe<Scalars['ID']>;
-};
-
-export type AppleAppSpecificPasswordMutation = {
-  __typename?: 'AppleAppSpecificPasswordMutation';
-  /** Create an App Specific Password for an Apple User Account */
-  createAppleAppSpecificPassword: AppleAppSpecificPassword;
-};
-
-
-export type AppleAppSpecificPasswordMutationCreateAppleAppSpecificPasswordArgs = {
-  appleAppSpecificPasswordInput: AppleAppSpecificPasswordInput;
-  accountId: Scalars['ID'];
-};
-
-export type AppleAppSpecificPasswordInput = {
-  appleIdUsername: Scalars['String'];
-  passwordLabel?: Maybe<Scalars['String']>;
-  appSpecificPassword: Scalars['String'];
 };
 
 export type AppleDeviceMutation = {
@@ -5376,6 +5347,16 @@ export type AndroidKeystoreFragment = (
   & Pick<AndroidKeystore, 'id' | 'type' | 'keystore' | 'keystorePassword' | 'keyAlias' | 'keyPassword' | 'md5CertificateFingerprint' | 'sha1CertificateFingerprint' | 'sha256CertificateFingerprint' | 'createdAt' | 'updatedAt'>
 );
 
+export type AppStoreConnectApiKeyFragment = (
+  { __typename?: 'AppStoreConnectApiKey' }
+  & Pick<AppStoreConnectApiKey, 'id' | 'issuerIdentifier' | 'keyIdentifier' | 'name' | 'roles' | 'createdAt' | 'updatedAt'>
+  & { appleTeam?: Maybe<(
+    { __typename?: 'AppleTeam' }
+    & Pick<AppleTeam, 'id'>
+    & AppleTeamFragment
+  )> }
+);
+
 export type AppleAppIdentifierFragment = (
   { __typename?: 'AppleAppIdentifier' }
   & Pick<AppleAppIdentifier, 'id' | 'bundleIdentifier'>
@@ -5505,6 +5486,10 @@ export type CommonIosAppCredentialsWithoutBuildCredentialsFragment = (
     { __typename?: 'ApplePushKey' }
     & Pick<ApplePushKey, 'id'>
     & ApplePushKeyFragment
+  )>, appStoreConnectApiKeyForSubmissions?: Maybe<(
+    { __typename?: 'AppStoreConnectApiKey' }
+    & Pick<AppStoreConnectApiKey, 'id'>
+    & AppStoreConnectApiKeyFragment
   )> }
 );
 

--- a/packages/eas-cli/src/graphql/types/credentials/AppStoreConnectApiKey.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/AppStoreConnectApiKey.ts
@@ -1,0 +1,21 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { AppleTeamFragmentNode } from './AppleTeam';
+
+export const AppStoreConnectApiKeyFragmentNode = gql`
+  fragment AppStoreConnectApiKeyFragment on AppStoreConnectApiKey {
+    id
+    appleTeam {
+      id
+      ...AppleTeamFragment
+    }
+    issuerIdentifier
+    keyIdentifier
+    name
+    roles
+    createdAt
+    updatedAt
+  }
+  ${print(AppleTeamFragmentNode)}
+`;

--- a/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
+++ b/packages/eas-cli/src/graphql/types/credentials/IosAppCredentials.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 
 import { AppFragmentNode } from '../App';
+import { AppStoreConnectApiKeyFragmentNode } from './AppStoreConnectApiKey';
 import { AppleAppIdentifierFragmentNode } from './AppleAppIdentifier';
 import { ApplePushKeyFragmentNode } from './ApplePushKey';
 import { AppleTeamFragmentNode } from './AppleTeam';
@@ -25,11 +26,16 @@ export const CommonIosAppCredentialsWithoutBuildCredentialsFragmentNode = gql`
       id
       ...ApplePushKeyFragment
     }
+    appStoreConnectApiKeyForSubmissions {
+      id
+      ...AppStoreConnectApiKeyFragment
+    }
   }
   ${AppFragmentNode}
   ${AppleTeamFragmentNode}
   ${AppleAppIdentifierFragmentNode}
   ${ApplePushKeyFragmentNode}
+  ${AppStoreConnectApiKeyFragmentNode}
 `;
 
 export const CommonIosAppCredentialsFragmentNode = gql`


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Asc Api Key graphql types and printing support

# Test Plan

- [x] amended tests pass
