### PR TITLE
[eas-cli] create + validate asc api key, infer issuer ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add ASC Api Key generation workflow. ([#718](https://github.com/expo/eas-cli/pull/718) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
@@ -22,5 +22,7 @@ export function getAppstoreMock(): AppStoreApi {
     createProvisioningProfileAsync: jest.fn(),
     revokeProvisioningProfileAsync: jest.fn(),
     createOrReuseAdhocProvisioningProfileAsync: jest.fn(),
+    createAscApiKeyAsync: jest.fn(),
+    getAscApiKeyAsync: jest.fn(),
   } as any;
 }

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -1,3 +1,5 @@
+import { UserRole } from '@expo/apple-utils';
+
 import {
   AppFragment,
   AppleAppIdentifierFragment,
@@ -10,11 +12,26 @@ import {
   IosDistributionType,
 } from '../../graphql/generated';
 import * as IosGraphqlClient from '../ios/api/GraphqlClient';
-import { DistributionCertificate, ProvisioningProfile } from '../ios/appstore/Credentials.types';
+import {
+  AscApiKey,
+  DistributionCertificate,
+  ProvisioningProfile,
+} from '../ios/appstore/Credentials.types';
 import { Target } from '../ios/types';
 import { testProvisioningProfileBase64 } from './fixtures-base64-data';
 
 const now = new Date();
+
+export const testAscApiKey: AscApiKey = {
+  keyId: 'test-id',
+  issuerId: 'test-issuer-id-from-apple',
+  teamId: 'test-team-id',
+  teamName: 'test-team-name',
+  name: 'test-name',
+  roles: [UserRole.ADMIN],
+  isRevoked: false,
+  keyP8: 'test-key-p8',
+};
 
 export const testProvisioningProfile: ProvisioningProfile = {
   provisioningProfileId: 'test-id',
@@ -139,6 +156,7 @@ export function getNewIosApiMock(): { [key in keyof typeof IosGraphqlClient]?: a
     createPushKeyAsync: jest.fn(),
     getPushKeyForAppAsync: jest.fn(),
     deletePushKeyAsync: jest.fn(),
+    createAscApiKeyAsync: jest.fn(),
   };
 }
 

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -21,7 +21,6 @@ import { isAscApiKeyValidAndTrackedAsync } from '../validators/validateAscApiKey
 
 export enum AppStoreApiKeyPurpose {
   SUBMISSION_SERVICE = 'EAS Submit',
-  UNKNOWN = 'Unknown',
 }
 
 export async function promptForAscApiKeyPathAsync(ctx: CredentialsContext): Promise<AscApiKeyPath> {
@@ -99,11 +98,7 @@ async function generateAscApiKeyAsync(
 }
 
 export function getAscApiKeyName(purpose: AppStoreApiKeyPurpose): string {
-  const nameParts = [
-    'Expo',
-    ...(purpose !== AppStoreApiKeyPurpose.UNKNOWN ? [purpose] : []),
-    nanoid(10),
-  ];
+  const nameParts = ['[Expo]', purpose, nanoid(10)];
   return nameParts.join(' ');
 }
 

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -20,7 +20,7 @@ import {
 import { isAscApiKeyValidAndTrackedAsync } from '../validators/validateAscApiKey';
 
 export enum AppStoreApiKeyPurpose {
-  SUBMISSIONS_SERVICE = 'Submissions',
+  SUBMISSION_SERVICE = 'EAS Submit',
   UNKNOWN = 'Unknown',
 }
 
@@ -70,7 +70,7 @@ export async function provideOrGenerateAscApiKeyAsync(
   }
 
   if (!ctx.appStore.authCtx) {
-    Log.warn('Unable to validate App Store Connect Api Key due to insufficient Apple Credentials');
+    Log.warn('Unable to validate App Store Connect Api Key, you are not authenticated with Apple.');
     return userProvided;
   }
 

--- a/packages/eas-cli/src/credentials/ios/actions/CreateAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateAscApiKey.ts
@@ -1,0 +1,23 @@
+import { AppStoreConnectApiKeyFragment } from '../../../graphql/generated';
+import Log from '../../../log';
+import { Account } from '../../../user/Account';
+import { CredentialsContext } from '../../context';
+import { AppStoreApiKeyPurpose, provideOrGenerateAscApiKeyAsync } from './AscApiKeyUtils';
+
+export class CreateAscApiKey {
+  constructor(private account: Account) {}
+
+  public async runAsync(
+    ctx: CredentialsContext,
+    purpose: AppStoreApiKeyPurpose
+  ): Promise<AppStoreConnectApiKeyFragment> {
+    if (ctx.nonInteractive) {
+      throw new Error(`A new App Store Connect Api Key cannot be created in non-interactive mode.`);
+    }
+
+    const ascApiKey = await provideOrGenerateAscApiKeyAsync(ctx, purpose);
+    const result = await ctx.ios.createAscApiKeyAsync(this.account, ascApiKey);
+    Log.succeed('Created App Store Connect Api Key');
+    return result;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -159,7 +159,7 @@ export async function provideOrGenerateDistributionCertificateAsync(
     if (userProvided) {
       if (!ctx.appStore.authCtx) {
         Log.warn(
-          'Unable to validate distribution certificate due to insufficient Apple Credentials'
+          'Unable to validate distribution certificate, you are not authenticated with Apple.'
         );
         return userProvided;
       } else {

--- a/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
@@ -19,7 +19,7 @@ export async function provideOrGeneratePushKeyAsync(ctx: CredentialsContext): Pr
     const userProvided = await promptForPushKeyAsync(ctx);
     if (userProvided) {
       if (!ctx.appStore.authCtx) {
-        Log.warn('Unable to validate push key due to insufficient Apple Credentials');
+        Log.warn('Unable to validate push key, you are not authenticated with Apple.');
         return userProvided;
       } else {
         const isValidAndTracked = await isPushKeyValidAndTrackedAsync(ctx, userProvided);

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/AscApiKeyUtils-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/AscApiKeyUtils-test.ts
@@ -1,0 +1,90 @@
+import { asMock } from '../../../../__tests__/utils';
+import { promptAsync } from '../../../../prompts';
+import { getAppstoreMock, testAuthCtx } from '../../../__tests__/fixtures-appstore';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { testAscApiKey } from '../../../__tests__/fixtures-ios';
+import { getCredentialsFromUserAsync } from '../../../utils/promptForCredentials';
+import {
+  AppStoreApiKeyPurpose,
+  getAscApiKeyName,
+  promptForAscApiKeyPathAsync,
+} from '../AscApiKeyUtils';
+
+jest.mock('../../../../prompts');
+jest.mock('../../../utils/promptForCredentials');
+
+function enumKeys<O extends object, K extends keyof O = keyof O>(obj: O): K[] {
+  return Object.keys(obj) as K[];
+}
+
+afterEach(() => {
+  asMock(promptAsync).mockClear();
+  asMock(getCredentialsFromUserAsync).mockClear();
+});
+
+describe(getAscApiKeyName, () => {
+  // Apple enforces a 30 char limit on this name
+  it('produces a name under 30 chars', async () => {
+    for (const value of enumKeys(AppStoreApiKeyPurpose)) {
+      const purpose = AppStoreApiKeyPurpose[value];
+      const name = getAscApiKeyName(purpose);
+      expect(name.length < 30).toBe(true);
+    }
+  });
+});
+
+describe(promptForAscApiKeyPathAsync, () => {
+  it('prompts for keyId, keyP8Path and issuerId when user is not authenticated to Apple', async () => {
+    asMock(promptAsync).mockImplementationOnce(() => ({
+      keyP8Path: '/asc-api-key.p8',
+    }));
+    asMock(getCredentialsFromUserAsync).mockImplementation(() => ({
+      keyId: 'test-key-id',
+      issuerId: 'test-issuer-id',
+    }));
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => {
+          throw new Error('this should not be called');
+        }),
+        authCtx: null,
+      },
+    });
+    const ascApiKeyPath = await promptForAscApiKeyPathAsync(ctx);
+    expect(ascApiKeyPath).toEqual({
+      keyId: 'test-key-id',
+      issuerId: 'test-issuer-id',
+      keyP8Path: '/asc-api-key.p8',
+    });
+    expect(promptAsync).toHaveBeenCalledTimes(1); // keyP8Path
+    expect(getCredentialsFromUserAsync).toHaveBeenCalledTimes(2); // keyId, issuerId
+  });
+  it('prompts for keyId, keyP8Path and detects issuerId when user is authenticated to Apple', async () => {
+    asMock(promptAsync).mockImplementationOnce(() => ({
+      keyP8Path: '/asc-api-key.p8',
+    }));
+    asMock(getCredentialsFromUserAsync).mockImplementation(() => ({
+      keyId: 'test-key-id',
+    }));
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+        authCtx: testAuthCtx,
+        getAscApiKeyAsync: jest.fn(() => testAscApiKey),
+      },
+    });
+    const ascApiKeyPath = await promptForAscApiKeyPathAsync(ctx);
+    expect(ascApiKeyPath).toEqual({
+      keyId: 'test-key-id',
+      issuerId: 'test-issuer-id-from-apple',
+      keyP8Path: '/asc-api-key.p8',
+    });
+    expect(promptAsync).toHaveBeenCalledTimes(1); // keyP8Path
+    expect(getCredentialsFromUserAsync).toHaveBeenCalledTimes(1); // keyId
+    expect(asMock(ctx.appStore.getAscApiKeyAsync).mock.calls.length).toBe(1); // issuerId
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateAscApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateAscApiKey-test.ts
@@ -1,0 +1,44 @@
+import { asMock } from '../../../../__tests__/utils';
+import { findApplicationTarget } from '../../../../project/ios/target';
+import { confirmAsync } from '../../../../prompts';
+import { getAppstoreMock, testAuthCtx } from '../../../__tests__/fixtures-appstore';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { testAscApiKey, testTargets } from '../../../__tests__/fixtures-ios';
+import { AppStoreApiKeyPurpose } from '../AscApiKeyUtils';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { CreateAscApiKey } from '../CreateAscApiKey';
+
+jest.mock('../../../../prompts');
+asMock(confirmAsync).mockImplementation(() => true);
+
+describe(CreateAscApiKey, () => {
+  it('creates a App Store Api Key in Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
+        authCtx: testAuthCtx,
+        createAscApiKeyAsync: jest.fn(() => testAscApiKey),
+      },
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const createAscApiKeyAction = new CreateAscApiKey(appLookupParams.account);
+    await createAscApiKeyAction.runAsync(ctx, AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE);
+
+    // expect api key to be created on expo servers
+    expect(asMock(ctx.ios.createAscApiKeyAsync).mock.calls.length).toBe(1);
+    // expect api key to be created on apple portal
+    expect(asMock(ctx.appStore.createAscApiKeyAsync).mock.calls.length).toBe(1);
+  });
+  it('errors in Non Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const createAscApiKeyAction = new CreateAscApiKey(appLookupParams.account);
+    await expect(
+      createAscApiKeyAction.runAsync(ctx, AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE)
+    ).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateAscApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateAscApiKey-test.ts
@@ -24,7 +24,7 @@ describe(CreateAscApiKey, () => {
     });
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const createAscApiKeyAction = new CreateAscApiKey(appLookupParams.account);
-    await createAscApiKeyAction.runAsync(ctx, AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE);
+    await createAscApiKeyAction.runAsync(ctx, AppStoreApiKeyPurpose.SUBMISSION_SERVICE);
 
     // expect api key to be created on expo servers
     expect(asMock(ctx.ios.createAscApiKeyAsync).mock.calls.length).toBe(1);
@@ -38,7 +38,7 @@ describe(CreateAscApiKey, () => {
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const createAscApiKeyAction = new CreateAscApiKey(appLookupParams.account);
     await expect(
-      createAscApiKeyAction.runAsync(ctx, AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE)
+      createAscApiKeyAction.runAsync(ctx, AppStoreApiKeyPurpose.SUBMISSION_SERVICE)
     ).rejects.toThrowError();
   });
 });

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -1,7 +1,10 @@
+import { UserRole } from '@expo/apple-utils';
 import nullthrows from 'nullthrows';
 
 import {
   AppFragment,
+  AppStoreConnectApiKeyFragment,
+  AppStoreConnectUserRole,
   AppleAppIdentifierFragment,
   AppleDeviceFragment,
   AppleDistributionCertificateFragment,
@@ -14,7 +17,9 @@ import {
 import { isWildcardBundleIdentifier } from '../../../project/ios/bundleIdentifier';
 import { Account } from '../../../user/Account';
 import { DistributionCertificate, PushKey } from '../appstore/Credentials.types';
+import { MinimalAscApiKey } from '../credentials';
 import { AppleTeamMissingError } from '../errors';
+import { AppStoreConnectApiKeyMutation } from './graphql/mutations/AppStoreConnectApiKeyMutation';
 import { AppleAppIdentifierMutation } from './graphql/mutations/AppleAppIdentifierMutation';
 import {
   AppleDistributionCertificateMutation,
@@ -161,8 +166,10 @@ export async function updateIosAppCredentialsAsync(
   appCredentials: CommonIosAppCredentialsFragment,
   {
     applePushKeyId,
+    ascApiKeyIdForSubmissions,
   }: {
     applePushKeyId?: string;
+    ascApiKeyIdForSubmissions?: string;
   }
 ): Promise<CommonIosAppCredentialsFragment> {
   let updatedAppCredentials = appCredentials;
@@ -171,6 +178,13 @@ export async function updateIosAppCredentialsAsync(
       updatedAppCredentials.id,
       applePushKeyId
     );
+  }
+  if (ascApiKeyIdForSubmissions) {
+    updatedAppCredentials =
+      await IosAppCredentialsMutation.setAppStoreConnectApiKeyForSubmissionsAsync(
+        updatedAppCredentials.id,
+        ascApiKeyIdForSubmissions
+      );
   }
   return updatedAppCredentials;
 }
@@ -411,6 +425,79 @@ export async function getPushKeyForAppAsync(
 
 export async function deletePushKeyAsync(pushKeyId: string): Promise<void> {
   return await ApplePushKeyMutation.deleteApplePushKeyAsync(pushKeyId);
+}
+
+export async function createAscApiKeyAsync(
+  account: Account,
+  ascApiKey: MinimalAscApiKey
+): Promise<AppStoreConnectApiKeyFragment> {
+  const maybeAppleTeam = ascApiKey.teamId
+    ? await createOrGetExistingAppleTeamAsync(account, {
+        appleTeamIdentifier: ascApiKey.teamId,
+        appleTeamName: ascApiKey.teamName,
+      })
+    : null;
+  return await AppStoreConnectApiKeyMutation.createAppStoreConnectApiKeyAsync(
+    {
+      issuerIdentifier: ascApiKey.issuerId,
+      keyIdentifier: ascApiKey.keyId,
+      keyP8: ascApiKey.keyP8,
+      name: ascApiKey.name ?? null,
+      roles: ascApiKey.roles?.map(role => convertUserRoleToGraphqlType(role)) ?? null,
+      appleTeamId: maybeAppleTeam ? maybeAppleTeam.id : null,
+    },
+    account.id
+  );
+}
+
+/* export async function getAscApiKeysForAccountAsync(
+  account: Account
+): Promise<ApplePushKeyFragment[]> {
+  return await AppStoreConnectApiKeyQuery.getAllForAccountAsync(account.name);
+} */
+
+export async function getAscApiKeyForAppSubmissionsAsync(
+  appLookupParams: AppLookupParams
+): Promise<AppStoreConnectApiKeyFragment | null> {
+  const maybeIosAppCredentials = await getIosAppCredentialsWithCommonFieldsAsync(appLookupParams);
+  return maybeIosAppCredentials?.appStoreConnectApiKeyForSubmissions ?? null;
+}
+
+export async function deleteAscApiKeyAsync(ascApiKeyId: string): Promise<void> {
+  return await AppStoreConnectApiKeyMutation.deleteAppStoreConnectApiKeyAsync(ascApiKeyId);
+}
+
+function convertUserRoleToGraphqlType(userRole: UserRole): AppStoreConnectUserRole {
+  switch (userRole) {
+    case UserRole.ADMIN:
+      return AppStoreConnectUserRole.Admin;
+    case UserRole.ACCESS_TO_REPORTS:
+      return AppStoreConnectUserRole.AccessToReports;
+    case UserRole.ACCOUNT_HOLDER:
+      return AppStoreConnectUserRole.AccountHolder;
+    case UserRole.APP_MANAGER:
+      return AppStoreConnectUserRole.AppManager;
+    case UserRole.CLOUD_MANAGED_APP_DISTRIBUTION:
+      return AppStoreConnectUserRole.CloudManagedAppDistribution;
+    case UserRole.CLOUD_MANAGED_DEVELOPER_ID:
+      return AppStoreConnectUserRole.CloudManagedDeveloperId;
+    case UserRole.CREATE_APPS:
+      return AppStoreConnectUserRole.CreateApps;
+    case UserRole.CUSTOMER_SUPPORT:
+      return AppStoreConnectUserRole.CustomerSupport;
+    case UserRole.DEVELOPER:
+      return AppStoreConnectUserRole.Developer;
+    case UserRole.FINANCE:
+      return AppStoreConnectUserRole.Finance;
+    case UserRole.MARKETING:
+      return AppStoreConnectUserRole.Marketing;
+    case UserRole.READ_ONLY:
+      return AppStoreConnectUserRole.ReadOnly;
+    case UserRole.SALES:
+      return AppStoreConnectUserRole.Sales;
+    case UserRole.TECHNICAL:
+      return AppStoreConnectUserRole.Technical;
+  }
 }
 
 const formatProjectFullName = ({ account, projectName }: AppLookupParams): string =>

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -450,12 +450,6 @@ export async function createAscApiKeyAsync(
   );
 }
 
-/* export async function getAscApiKeysForAccountAsync(
-  account: Account
-): Promise<ApplePushKeyFragment[]> {
-  return await AppStoreConnectApiKeyQuery.getAllForAccountAsync(account.name);
-} */
-
 export async function getAscApiKeyForAppSubmissionsAsync(
   appLookupParams: AppLookupParams
 ): Promise<AppStoreConnectApiKeyFragment | null> {

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -166,10 +166,8 @@ export async function updateIosAppCredentialsAsync(
   appCredentials: CommonIosAppCredentialsFragment,
   {
     applePushKeyId,
-    ascApiKeyIdForSubmissions,
   }: {
     applePushKeyId?: string;
-    ascApiKeyIdForSubmissions?: string;
   }
 ): Promise<CommonIosAppCredentialsFragment> {
   let updatedAppCredentials = appCredentials;
@@ -178,13 +176,6 @@ export async function updateIosAppCredentialsAsync(
       updatedAppCredentials.id,
       applePushKeyId
     );
-  }
-  if (ascApiKeyIdForSubmissions) {
-    updatedAppCredentials =
-      await IosAppCredentialsMutation.setAppStoreConnectApiKeyForSubmissionsAsync(
-        updatedAppCredentials.id,
-        ascApiKeyIdForSubmissions
-      );
   }
   return updatedAppCredentials;
 }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppStoreConnectApiKeyMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppStoreConnectApiKeyMutation.ts
@@ -1,0 +1,75 @@
+import assert from 'assert';
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import {
+  AppStoreConnectApiKeyFragment,
+  AppStoreConnectApiKeyInput,
+  CreateAppStoreConnectApiKeyMutation,
+  DeleteAppStoreConnectApiKeyMutation,
+} from '../../../../../graphql/generated';
+import { AppStoreConnectApiKeyFragmentNode } from '../../../../../graphql/types/credentials/AppStoreConnectApiKey';
+
+export const AppStoreConnectApiKeyMutation = {
+  async createAppStoreConnectApiKeyAsync(
+    appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput,
+    accountId: string
+  ): Promise<AppStoreConnectApiKeyFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateAppStoreConnectApiKeyMutation>(
+          gql`
+            mutation CreateAppStoreConnectApiKeyMutation(
+              $appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput!
+              $accountId: ID!
+            ) {
+              appStoreConnectApiKey {
+                createAppStoreConnectApiKey(
+                  appStoreConnectApiKeyInput: $appStoreConnectApiKeyInput
+                  accountId: $accountId
+                ) {
+                  id
+                  ...AppStoreConnectApiKeyFragment
+                }
+              }
+            }
+            ${print(AppStoreConnectApiKeyFragmentNode)}
+          `,
+          {
+            appStoreConnectApiKeyInput,
+            accountId,
+          }
+        )
+        .toPromise()
+    );
+    assert(
+      data.appStoreConnectApiKey.createAppStoreConnectApiKey,
+      'GraphQL: `createAppStoreConnectApiKey` not defined in server response'
+    );
+    return data.appStoreConnectApiKey.createAppStoreConnectApiKey;
+  },
+  async deleteAppStoreConnectApiKeyAsync(appStoreConnectApiKeyId: string): Promise<void> {
+    await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeleteAppStoreConnectApiKeyMutation>(
+          gql`
+            mutation DeleteAppStoreConnectApiKeyMutation($appStoreConnectApiKeyId: ID!) {
+              appStoreConnectApiKey {
+                deleteAppStoreConnectApiKey(id: $appStoreConnectApiKeyId) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            appStoreConnectApiKeyId,
+          },
+          {
+            additionalTypenames: ['AppStoreConnectApiKey', 'IosAppCredentials'],
+          }
+        )
+        .toPromise()
+    );
+  },
+};

--- a/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
@@ -150,7 +150,7 @@ export default class AppStoreApi {
     return await listAscApiKeysAsync(ctx);
   }
 
-  public async getAscApiKeyAsync(keyId: string): Promise<AscApiKeyInfo> {
+  public async getAscApiKeyAsync(keyId: string): Promise<AscApiKeyInfo | null> {
     const ctx = await this.ensureAuthenticatedAsync();
     return await getAscApiKeyAsync(ctx, keyId);
   }

--- a/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
@@ -76,6 +76,7 @@ export type AscApiKeyInfo = {
   name: string;
   teamName?: string;
   roles: UserRole[];
+  isRevoked: boolean;
 };
 
 export type AscApiKey = AscApiKeyInfo & {

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/ascApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/ascApiKey-test.ts
@@ -47,6 +47,7 @@ const mockAscApiKeyInfo = {
   roles: ['ADMIN'],
   teamId: 'test-id',
   teamName: 'test-name',
+  isRevoked: false,
 };
 
 beforeEach(() => {

--- a/packages/eas-cli/src/credentials/ios/appstore/ascApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ascApiKey.ts
@@ -6,14 +6,14 @@ import { AscApiKey, AscApiKeyInfo } from './Credentials.types';
 import { AuthCtx, getRequestContext } from './authenticate';
 
 export async function listAscApiKeysAsync(authCtx: AuthCtx): Promise<AscApiKeyInfo[]> {
-  const spinner = ora(`Fetching App Store Connect API Keys.`).start();
+  const spinner = ora(`Fetching App Store Connect Api Keys.`).start();
   try {
     const context = getRequestContext(authCtx);
     const keys = await ApiKey.getAsync(context);
-    spinner.succeed(`Fetched App Store Connect API Keys.`);
+    spinner.succeed(`Fetched App Store Connect Api Keys.`);
     return keys.map(key => getAscApiKeyInfo(key, authCtx));
   } catch (error) {
-    spinner.fail(`Failed to fetch App Store Connect API Keys.`);
+    spinner.fail(`Failed to fetch App Store Connect Api Keys.`);
     throw error;
   }
 }
@@ -22,11 +22,11 @@ export async function getAscApiKeyAsync(
   authCtx: AuthCtx,
   keyId: string
 ): Promise<AscApiKeyInfo | null> {
-  const spinner = ora(`Fetching App Store Connect API Key.`).start();
+  const spinner = ora(`Fetching App Store Connect Api Key.`).start();
   try {
     const context = getRequestContext(authCtx);
     const apiKey = await ApiKey.infoAsync(context, { id: keyId });
-    spinner.succeed(`Fetched App Store Connect API Key (ID: ${keyId}).`);
+    spinner.succeed(`Fetched App Store Connect Api Key (ID: ${keyId}).`);
     return getAscApiKeyInfo(apiKey, authCtx);
   } catch (error: any) {
     const message = error?.message ?? '';
@@ -35,7 +35,7 @@ export async function getAscApiKeyAsync(
       return null;
     }
     Log.error(error);
-    spinner.fail(`Failed to fetch App Store Connect API Key.`);
+    spinner.fail(`Failed to fetch App Store Connect Api Key.`);
     throw error;
   }
 }
@@ -49,7 +49,7 @@ export async function createAscApiKeyAsync(
     keyType,
   }: Partial<Pick<ApiKeyProps, 'nickname' | 'roles' | 'allAppsVisible' | 'keyType'>>
 ): Promise<AscApiKey> {
-  const spinner = ora(`Creating App Store Connect API Key.`).start();
+  const spinner = ora(`Creating App Store Connect Api Key.`).start();
   try {
     const context = getRequestContext(authCtx);
     const key = await ApiKey.createAsync(context, {
@@ -74,13 +74,13 @@ export async function createAscApiKeyAsync(
     }
     // this object has more optional parameters populated
     const fullKey = await ApiKey.infoAsync(context, { id: key.id });
-    spinner.succeed(`Created App Store Connect API Key.`);
+    spinner.succeed(`Created App Store Connect Api Key.`);
     return {
       ...getAscApiKeyInfo(fullKey, authCtx),
       keyP8,
     };
   } catch (err: any) {
-    spinner.fail('Failed to create App Store Connect API Key.');
+    spinner.fail('Failed to create App Store Connect Api Key.');
     throw err;
   }
 }
@@ -89,16 +89,16 @@ export async function revokeAscApiKeyAsync(
   authCtx: AuthCtx,
   keyId: string
 ): Promise<AscApiKeyInfo> {
-  const spinner = ora(`Revoking App Store Connect API Key.`).start();
+  const spinner = ora(`Revoking App Store Connect Api Key.`).start();
   try {
     const context = getRequestContext(authCtx);
     const apiKey = await ApiKey.infoAsync(context, { id: keyId });
     const revokedKey = await apiKey.revokeAsync();
-    spinner.succeed(`Revoked App Store Connect API Key.`);
+    spinner.succeed(`Revoked App Store Connect Api Key.`);
     return getAscApiKeyInfo(revokedKey, authCtx);
   } catch (error) {
     Log.error(error);
-    spinner.fail(`Failed to revoke App Store Connect API Key.`);
+    spinner.fail(`Failed to revoke App Store Connect Api Key.`);
     throw error;
   }
 }

--- a/packages/eas-cli/src/credentials/ios/credentials.ts
+++ b/packages/eas-cli/src/credentials/ios/credentials.ts
@@ -118,7 +118,7 @@ export interface AscApiKeyPath {
   issuerId: string;
 }
 
-export const ascApiKeyMetadataSchema: CredentialSchema<Omit<MinimalAscApiKey, 'keyP8'>> = {
+export const ascApiKeyIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'keyId'>> = {
   name: 'App Store Connect API Key',
   questions: [
     {
@@ -126,6 +126,12 @@ export const ascApiKeyMetadataSchema: CredentialSchema<Omit<MinimalAscApiKey, 'k
       type: 'string',
       question: 'Key ID:',
     },
+  ],
+};
+
+export const ascApiKeyIssuerIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'issuerId'>> = {
+  name: 'App Store Connect API Key',
+  questions: [
     {
       field: 'issuerId',
       type: 'string',

--- a/packages/eas-cli/src/credentials/ios/credentials.ts
+++ b/packages/eas-cli/src/credentials/ios/credentials.ts
@@ -119,7 +119,7 @@ export interface AscApiKeyPath {
 }
 
 export const ascApiKeyIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'keyId'>> = {
-  name: 'App Store Connect API Key',
+  name: 'App Store Connect Api Key',
   questions: [
     {
       field: 'keyId',
@@ -130,7 +130,7 @@ export const ascApiKeyIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'keyId'>
 };
 
 export const ascApiKeyIssuerIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'issuerId'>> = {
-  name: 'App Store Connect API Key',
+  name: 'App Store Connect Api Key',
   questions: [
     {
       field: 'issuerId',

--- a/packages/eas-cli/src/credentials/ios/validators/validateAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validateAscApiKey.ts
@@ -1,0 +1,13 @@
+import { CredentialsContext } from '../../context';
+import { MinimalAscApiKey } from '../credentials';
+
+export async function isAscApiKeyValidAndTrackedAsync(
+  ctx: CredentialsContext,
+  ascApiKey: MinimalAscApiKey
+): Promise<boolean> {
+  const ascApiKeyInfo = await ctx.appStore.getAscApiKeyAsync(ascApiKey.keyId);
+  if (!ascApiKeyInfo) {
+    return false;
+  }
+  return !ascApiKeyInfo.isRevoked;
+}

--- a/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
+++ b/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
@@ -63,7 +63,7 @@ export async function getCredentialsFromUserAsync<T>(
     : (results as T);
 }
 
-async function shouldAutoGenerateCredentialsAsync<T>(
+export async function shouldAutoGenerateCredentialsAsync<T>(
   schema: CredentialSchema<T>
 ): Promise<boolean> {
   const answer = await confirmAsync({

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4091,6 +4091,40 @@ export type GoogleServiceAccountKeyByAccountQuery = (
   ) }
 );
 
+export type CreateAppStoreConnectApiKeyMutationVariables = Exact<{
+  appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput;
+  accountId: Scalars['ID'];
+}>;
+
+
+export type CreateAppStoreConnectApiKeyMutation = (
+  { __typename?: 'RootMutation' }
+  & { appStoreConnectApiKey: (
+    { __typename?: 'AppStoreConnectApiKeyMutation' }
+    & { createAppStoreConnectApiKey: (
+      { __typename?: 'AppStoreConnectApiKey' }
+      & Pick<AppStoreConnectApiKey, 'id'>
+      & AppStoreConnectApiKeyFragment
+    ) }
+  ) }
+);
+
+export type DeleteAppStoreConnectApiKeyMutationVariables = Exact<{
+  appStoreConnectApiKeyId: Scalars['ID'];
+}>;
+
+
+export type DeleteAppStoreConnectApiKeyMutation = (
+  { __typename?: 'RootMutation' }
+  & { appStoreConnectApiKey: (
+    { __typename?: 'AppStoreConnectApiKeyMutation' }
+    & { deleteAppStoreConnectApiKey: (
+      { __typename?: 'deleteAppStoreConnectApiKeyResult' }
+      & Pick<DeleteAppStoreConnectApiKeyResult, 'id'>
+    ) }
+  ) }
+);
+
 export type CreateAppleAppIdentifierMutationVariables = Exact<{
   appleAppIdentifierInput: AppleAppIdentifierInput;
   accountId: Scalars['ID'];

--- a/packages/eas-cli/src/submit/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitter.ts
@@ -69,7 +69,7 @@ export default class IosSubmitter extends BaseSubmitter<Platform.IOS, IosSubmiss
       ? await getAppSpecificPasswordAsync(this.options.appSpecificPasswordSource)
       : null;
     const maybeAppStoreConnectApiKey = this.options.ascApiKeySource
-      ? await getAscApiKeyLocallyAsync(this.options.ascApiKeySource)
+      ? await getAscApiKeyLocallyAsync(this.ctx, this.options.ascApiKeySource)
       : null;
     return {
       archive,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

This PR adds support for the following:
- Creating an Asc Api Key using baconlane and saving it to www
- Automatically getting Issuer ID if user is authenticated in the prompt case
- Validating Asc Api Keys
- Cleaning up some Apple quirks (their uuids aren't rfc compliant), char limits in their naming, api weirdness etc

# Test Plan

- [x] added new tests
- [x] current tests pass
