### PR TITLE
[eas-cli] assign asc api keys to project

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -2,6 +2,8 @@ import { UserRole } from '@expo/apple-utils';
 
 import {
   AppFragment,
+  AppStoreConnectApiKeyFragment,
+  AppStoreConnectUserRole,
   AppleAppIdentifierFragment,
   AppleDistributionCertificateFragment,
   AppleProvisioningProfileFragment,
@@ -53,6 +55,17 @@ export const testAppFragment: AppFragment = {
   id: 'test-app-id',
   fullName: '@testuser/testapp',
   slug: 'testapp',
+};
+
+export const testAscApiKeyFragment: AppStoreConnectApiKeyFragment = {
+  id: 'test-asc-api-key-id',
+  appleTeam: { ...testAppleTeamFragment },
+  issuerIdentifier: 'test-issuerIdentifier',
+  keyIdentifier: 'test-keyIdentifier',
+  name: 'test-name',
+  roles: [AppStoreConnectUserRole.Admin],
+  updatedAt: now,
+  createdAt: now,
 };
 
 export const testPushKey: ApplePushKeyFragment = {

--- a/packages/eas-cli/src/credentials/ios/actions/AssignAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AssignAscApiKey.ts
@@ -1,0 +1,38 @@
+import {
+  AppStoreConnectApiKeyFragment,
+  CommonIosAppCredentialsFragment,
+} from '../../../graphql/generated';
+import Log from '../../../log';
+import { CredentialsContext } from '../../context';
+import { AppLookupParams } from '../api/GraphqlClient';
+import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
+import { AppStoreApiKeyPurpose } from './AscApiKeyUtils';
+
+export class AssignAscApiKey {
+  constructor(private app: AppLookupParams) {}
+
+  public async runAsync(
+    ctx: CredentialsContext,
+    ascApiKey: AppStoreConnectApiKeyFragment,
+    purpose: AppStoreApiKeyPurpose
+  ): Promise<CommonIosAppCredentialsFragment> {
+    const appleTeam =
+      (await resolveAppleTeamIfAuthenticatedAsync(ctx, this.app)) ?? ascApiKey.appleTeam ?? null;
+    const appCredentials = await ctx.ios.createOrGetIosAppCredentialsWithCommonFieldsAsync(
+      this.app,
+      { appleTeam: appleTeam ?? undefined }
+    );
+    let updatedAppCredentials;
+    if (purpose === AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE) {
+      updatedAppCredentials = await ctx.ios.updateIosAppCredentialsAsync(appCredentials, {
+        ascApiKeyIdForSubmissions: ascApiKey.id,
+      });
+    } else {
+      throw new Error(`${purpose} is not yet supported.`);
+    }
+    Log.succeed(
+      `App Store Connect Api Key assigned to ${this.app.projectName}: ${this.app.bundleIdentifier} for ${purpose}.`
+    );
+    return updatedAppCredentials;
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/AssignAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AssignAscApiKey.ts
@@ -23,7 +23,7 @@ export class AssignAscApiKey {
       { appleTeam: appleTeam ?? undefined }
     );
     let updatedAppCredentials;
-    if (purpose === AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE) {
+    if (purpose === AppStoreApiKeyPurpose.SUBMISSION_SERVICE) {
       updatedAppCredentials = await ctx.ios.updateIosAppCredentialsAsync(appCredentials, {
         ascApiKeyIdForSubmissions: ascApiKey.id,
       });

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/AssignAscApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/AssignAscApiKey-test.ts
@@ -1,0 +1,46 @@
+import { findApplicationTarget } from '../../../../project/ios/target';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { testAscApiKeyFragment, testTargets } from '../../../__tests__/fixtures-ios';
+import { AppStoreApiKeyPurpose } from '../AscApiKeyUtils';
+import { AssignAscApiKey } from '../AssignAscApiKey';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+
+describe(AssignAscApiKey, () => {
+  it('assigns an App Store Connect Api Key in Interactive Mode for EAS Submit', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: false,
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const assignAscApiKeyAction = new AssignAscApiKey(appLookupParams);
+    await assignAscApiKeyAction.runAsync(
+      ctx,
+      testAscApiKeyFragment,
+      AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE
+    );
+
+    // expect app credentials to be fetched/created, then updated
+    expect(ctx.ios.createOrGetIosAppCredentialsWithCommonFieldsAsync).toHaveBeenCalledTimes(1);
+    expect(ctx.ios.updateIosAppCredentialsAsync).toHaveBeenCalledTimes(1);
+  });
+  it('works in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const assignAscApiKeyAction = new AssignAscApiKey(appLookupParams);
+    await assignAscApiKeyAction.runAsync(
+      ctx,
+      testAscApiKeyFragment,
+      AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE
+    );
+
+    // dont fail if users are running in non-interactive mode
+    await expect(
+      assignAscApiKeyAction.runAsync(
+        ctx,
+        testAscApiKeyFragment,
+        AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE
+      )
+    ).resolves.not.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/AssignAscApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/AssignAscApiKey-test.ts
@@ -15,7 +15,7 @@ describe(AssignAscApiKey, () => {
     await assignAscApiKeyAction.runAsync(
       ctx,
       testAscApiKeyFragment,
-      AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE
+      AppStoreApiKeyPurpose.SUBMISSION_SERVICE
     );
 
     // expect app credentials to be fetched/created, then updated
@@ -31,7 +31,7 @@ describe(AssignAscApiKey, () => {
     await assignAscApiKeyAction.runAsync(
       ctx,
       testAscApiKeyFragment,
-      AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE
+      AppStoreApiKeyPurpose.SUBMISSION_SERVICE
     );
 
     // dont fail if users are running in non-interactive mode
@@ -39,7 +39,7 @@ describe(AssignAscApiKey, () => {
       assignAscApiKeyAction.runAsync(
         ctx,
         testAscApiKeyFragment,
-        AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE
+        AppStoreApiKeyPurpose.SUBMISSION_SERVICE
       )
     ).resolves.not.toThrowError();
   });

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -166,8 +166,10 @@ export async function updateIosAppCredentialsAsync(
   appCredentials: CommonIosAppCredentialsFragment,
   {
     applePushKeyId,
+    ascApiKeyIdForSubmissions,
   }: {
     applePushKeyId?: string;
+    ascApiKeyIdForSubmissions?: string;
   }
 ): Promise<CommonIosAppCredentialsFragment> {
   let updatedAppCredentials = appCredentials;
@@ -176,6 +178,13 @@ export async function updateIosAppCredentialsAsync(
       updatedAppCredentials.id,
       applePushKeyId
     );
+  }
+  if (ascApiKeyIdForSubmissions) {
+    updatedAppCredentials =
+      await IosAppCredentialsMutation.setAppStoreConnectApiKeyForSubmissionsAsync(
+        updatedAppCredentials.id,
+        ascApiKeyIdForSubmissions
+      );
   }
   return updatedAppCredentials;
 }

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
@@ -7,6 +7,7 @@ import {
   CommonIosAppCredentialsFragment,
   CreateIosAppCredentialsMutation,
   IosAppCredentialsInput,
+  SetAppStoreConnectApiKeyForSubmissionsMutation,
   SetPushKeyMutation,
 } from '../../../../../graphql/generated';
 import { CommonIosAppCredentialsFragmentNode } from '../../../../../graphql/types/credentials/IosAppCredentials';
@@ -79,5 +80,38 @@ export const IosAppCredentialsMutation = {
         .toPromise()
     );
     return data.iosAppCredentials.setPushKey;
+  },
+  async setAppStoreConnectApiKeyForSubmissionsAsync(
+    iosAppCredentialsId: string,
+    ascApiKeyId: string
+  ): Promise<CommonIosAppCredentialsFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<SetAppStoreConnectApiKeyForSubmissionsMutation>(
+          gql`
+            mutation SetAppStoreConnectApiKeyForSubmissionsMutation(
+              $iosAppCredentialsId: ID!
+              $ascApiKeyId: ID!
+            ) {
+              iosAppCredentials {
+                setAppStoreConnectApiKeyForSubmissions(
+                  id: $iosAppCredentialsId
+                  ascApiKeyId: $ascApiKeyId
+                ) {
+                  id
+                  ...CommonIosAppCredentialsFragment
+                }
+              }
+            }
+            ${print(CommonIosAppCredentialsFragmentNode)}
+          `,
+          {
+            iosAppCredentialsId,
+            ascApiKeyId,
+          }
+        )
+        .toPromise()
+    );
+    return data.iosAppCredentials.setAppStoreConnectApiKeyForSubmissions;
   },
 };

--- a/packages/eas-cli/src/credentials/manager/Actions.ts
+++ b/packages/eas-cli/src/credentials/manager/Actions.ts
@@ -34,6 +34,7 @@ export enum IosActionType {
   ManageCredentialsJson,
   ManageBuildCredentials,
   ManagePushKey,
+  ManageAscApiKey,
   GoBackToCaller,
   GoBackToHighLevelActions,
   SetupBuildCredentials,
@@ -47,4 +48,5 @@ export enum IosActionType {
   CreatePushKey,
   UseExistingPushKey,
   RemovePushKey,
+  CreateAscApiKeyForSubmissions,
 }

--- a/packages/eas-cli/src/credentials/manager/IosActions.ts
+++ b/packages/eas-cli/src/credentials/manager/IosActions.ts
@@ -13,6 +13,11 @@ export const highLevelActions: ActionInfo[] = [
     scope: Scope.Manager,
   },
   {
+    value: IosActionType.ManageAscApiKey,
+    title: 'App Store Connect: Manage your Api Key',
+    scope: Scope.Manager,
+  },
+  {
     value: IosActionType.ManageCredentialsJson,
     title: 'credentials.json: Upload/Download credentials between EAS servers and your local json ',
     scope: Scope.Manager,
@@ -63,6 +68,21 @@ export function getPushKeyActions(ctx: CredentialsContext): ActionInfo[] {
       value: IosActionType.RemovePushKey,
       title: 'Remove a push key from your account',
       scope: Scope.Account,
+    },
+    {
+      value: IosActionType.GoBackToHighLevelActions,
+      title: 'Go back',
+      scope: Scope.Manager,
+    },
+  ];
+}
+
+export function getAscApiKeyActions(ctx: CredentialsContext): ActionInfo[] {
+  return [
+    {
+      value: IosActionType.CreateAscApiKeyForSubmissions,
+      title: 'Add a new Api Key For EAS Submit',
+      scope: ctx.hasProjectContext ? Scope.Project : Scope.Account,
     },
     {
       value: IosActionType.GoBackToHighLevelActions,

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -202,7 +202,7 @@ export class ManageIos {
     } else if (action === IosActionType.CreatePushKey) {
       await new CreatePushKey(account).runAsync(ctx);
     } else if (action === IosActionType.CreateAscApiKeyForSubmissions) {
-      await new CreateAscApiKey(account).runAsync(ctx, AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE);
+      await new CreateAscApiKey(account).runAsync(ctx, AppStoreApiKeyPurpose.SUBMISSION_SERVICE);
     } else if (action === IosActionType.RemovePushKey) {
       await new SelectAndRemovePushKey(account).runAsync(ctx);
     }
@@ -330,7 +330,7 @@ export class ManageIos {
       case IosActionType.CreateAscApiKeyForSubmissions: {
         const ascApiKey = await new CreateAscApiKey(appLookupParams.account).runAsync(
           ctx,
-          AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE
+          AppStoreApiKeyPurpose.SUBMISSION_SERVICE
         );
         const confirm = await confirmAsync({
           message: `Do you want ${appLookupParams.projectName} to use the new Api Key?`,
@@ -339,7 +339,7 @@ export class ManageIos {
           await new AssignAscApiKey(appLookupParams).runAsync(
             ctx,
             ascApiKey,
-            AppStoreApiKeyPurpose.SUBMISSIONS_SERVICE
+            AppStoreApiKeyPurpose.SUBMISSION_SERVICE
           );
         }
         return;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4125,6 +4125,40 @@ export type DeleteAppStoreConnectApiKeyMutation = (
   ) }
 );
 
+export type CreateAppStoreConnectApiKeyMutationVariables = Exact<{
+  appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput;
+  accountId: Scalars['ID'];
+}>;
+
+
+export type CreateAppStoreConnectApiKeyMutation = (
+  { __typename?: 'RootMutation' }
+  & { appStoreConnectApiKey: (
+    { __typename?: 'AppStoreConnectApiKeyMutation' }
+    & { createAppStoreConnectApiKey: (
+      { __typename?: 'AppStoreConnectApiKey' }
+      & Pick<AppStoreConnectApiKey, 'id'>
+      & AppStoreConnectApiKeyFragment
+    ) }
+  ) }
+);
+
+export type DeleteAppStoreConnectApiKeyMutationVariables = Exact<{
+  appStoreConnectApiKeyId: Scalars['ID'];
+}>;
+
+
+export type DeleteAppStoreConnectApiKeyMutation = (
+  { __typename?: 'RootMutation' }
+  & { appStoreConnectApiKey: (
+    { __typename?: 'AppStoreConnectApiKeyMutation' }
+    & { deleteAppStoreConnectApiKey: (
+      { __typename?: 'deleteAppStoreConnectApiKeyResult' }
+      & Pick<DeleteAppStoreConnectApiKeyResult, 'id'>
+    ) }
+  ) }
+);
+
 export type CreateAppleAppIdentifierMutationVariables = Exact<{
   appleAppIdentifierInput: AppleAppIdentifierInput;
   accountId: Scalars['ID'];
@@ -4421,6 +4455,24 @@ export type SetPushKeyMutation = (
   & { iosAppCredentials: (
     { __typename?: 'IosAppCredentialsMutation' }
     & { setPushKey: (
+      { __typename?: 'IosAppCredentials' }
+      & Pick<IosAppCredentials, 'id'>
+      & CommonIosAppCredentialsFragment
+    ) }
+  ) }
+);
+
+export type SetAppStoreConnectApiKeyForSubmissionsMutationVariables = Exact<{
+  iosAppCredentialsId: Scalars['ID'];
+  ascApiKeyId: Scalars['ID'];
+}>;
+
+
+export type SetAppStoreConnectApiKeyForSubmissionsMutation = (
+  { __typename?: 'RootMutation' }
+  & { iosAppCredentials: (
+    { __typename?: 'IosAppCredentialsMutation' }
+    & { setAppStoreConnectApiKeyForSubmissions: (
       { __typename?: 'IosAppCredentials' }
       & Pick<IosAppCredentials, 'id'>
       & CommonIosAppCredentialsFragment

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4125,40 +4125,6 @@ export type DeleteAppStoreConnectApiKeyMutation = (
   ) }
 );
 
-export type CreateAppStoreConnectApiKeyMutationVariables = Exact<{
-  appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput;
-  accountId: Scalars['ID'];
-}>;
-
-
-export type CreateAppStoreConnectApiKeyMutation = (
-  { __typename?: 'RootMutation' }
-  & { appStoreConnectApiKey: (
-    { __typename?: 'AppStoreConnectApiKeyMutation' }
-    & { createAppStoreConnectApiKey: (
-      { __typename?: 'AppStoreConnectApiKey' }
-      & Pick<AppStoreConnectApiKey, 'id'>
-      & AppStoreConnectApiKeyFragment
-    ) }
-  ) }
-);
-
-export type DeleteAppStoreConnectApiKeyMutationVariables = Exact<{
-  appStoreConnectApiKeyId: Scalars['ID'];
-}>;
-
-
-export type DeleteAppStoreConnectApiKeyMutation = (
-  { __typename?: 'RootMutation' }
-  & { appStoreConnectApiKey: (
-    { __typename?: 'AppStoreConnectApiKeyMutation' }
-    & { deleteAppStoreConnectApiKey: (
-      { __typename?: 'deleteAppStoreConnectApiKeyResult' }
-      & Pick<DeleteAppStoreConnectApiKeyResult, 'id'>
-    ) }
-  ) }
-);
-
 export type CreateAppleAppIdentifierMutationVariables = Exact<{
   appleAppIdentifierInput: AppleAppIdentifierInput;
   accountId: Scalars['ID'];


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

- Assign an Asc Api Key to a project for EAS Submissions
- Add the create and assign actions to the credentials manager

# Test Plan

- [x] new tests pass
- [x] current tests pass