### PR TITLE
[eas-cli] support removal of asc api keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add ASC Api Key generation workflow. ([#718](https://github.com/expo/eas-cli/pull/718) by [@quinlanj](https://github.com/quinlanj))
+- Add support for removal of App Store Connect Api Keys. ([#721](https://github.com/expo/eas-cli/pull/721) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
@@ -24,5 +24,6 @@ export function getAppstoreMock(): AppStoreApi {
     createOrReuseAdhocProvisioningProfileAsync: jest.fn(),
     createAscApiKeyAsync: jest.fn(),
     getAscApiKeyAsync: jest.fn(),
+    revokeAscApiKeyAsync: jest.fn(),
   } as any;
 }

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -170,6 +170,7 @@ export function getNewIosApiMock(): { [key in keyof typeof IosGraphqlClient]?: a
     getPushKeyForAppAsync: jest.fn(),
     deletePushKeyAsync: jest.fn(),
     createAscApiKeyAsync: jest.fn(),
+    deleteAscApiKeyAsync: jest.fn(),
   };
 }
 

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -195,7 +195,7 @@ async function selectAscApiKeysAsync(
   const { chosenAscApiKey } = await promptAsync({
     type: 'select',
     name: 'chosenAscApiKey',
-    message: 'Select an Api Key from the list.',
+    message: 'Select an Api Key from the list:',
     choices: sortedAscApiKeys.map(ascApiKey => ({
       title: formatAscApiKey(ascApiKey),
       value: ascApiKey,

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -3,8 +3,11 @@ import fs from 'fs-extra';
 import { nanoid } from 'nanoid';
 import path from 'path';
 
+import { AppStoreConnectApiKeyFragment } from '../../../graphql/generated';
 import Log, { learnMore } from '../../../log';
 import { confirmAsync, promptAsync } from '../../../prompts';
+import { Account } from '../../../user/Account';
+import { fromNow } from '../../../utils/date';
 import { CredentialsContext } from '../../context';
 import {
   getCredentialsFromUserAsync,
@@ -18,6 +21,7 @@ import {
   ascApiKeyIssuerIdSchema,
 } from '../credentials';
 import { isAscApiKeyValidAndTrackedAsync } from '../validators/validateAscApiKey';
+import { formatAppleTeam } from './AppleTeamUtils';
 
 export enum AppStoreApiKeyPurpose {
   SUBMISSION_SERVICE = 'EAS Submit',
@@ -157,4 +161,80 @@ async function getBestEffortIssuerIdAsync(
   }
   const ascApiKeyInfo = await ctx.appStore.getAscApiKeyAsync(ascApiKeyId);
   return ascApiKeyInfo?.issuerId ?? null;
+}
+
+export async function selectAscApiKeysFromAccountAsync(
+  ctx: CredentialsContext,
+  account: Account,
+  filterDifferentAppleTeam: boolean = false
+): Promise<AppStoreConnectApiKeyFragment | null> {
+  const ascApiKeysForAccount = await ctx.ios.getAscApiKeysForAccountAsync(account);
+  if (ascApiKeysForAccount.length === 0) {
+    Log.warn(`There are no App Store Connect Api Keys available in your EAS account.`);
+    return null;
+  }
+
+  if (!filterDifferentAppleTeam) {
+    return selectAscApiKeysAsync(ascApiKeysForAccount);
+  }
+
+  const filteredKeys = filterKeysFromDifferentAppleTeam(ctx, ascApiKeysForAccount);
+  if (filteredKeys.length === 0) {
+    Log.warn(
+      `There are no App Store Connect Api Keys in your EAS account matching Apple Team ID: ${ctx.appStore.authCtx?.team.id}`
+    );
+    return null;
+  }
+  return selectAscApiKeysAsync(filteredKeys);
+}
+
+async function selectAscApiKeysAsync(
+  ascApiKeys: AppStoreConnectApiKeyFragment[]
+): Promise<AppStoreConnectApiKeyFragment | null> {
+  const sortedAscApiKeys = sortAscApiKeysByUpdatedAtDesc(ascApiKeys);
+  const { chosenAscApiKey } = await promptAsync({
+    type: 'select',
+    name: 'chosenAscApiKey',
+    message: 'Select an Api Key from the list.',
+    choices: sortedAscApiKeys.map(ascApiKey => ({
+      title: formatAscApiKey(ascApiKey),
+      value: ascApiKey,
+    })),
+  });
+  return chosenAscApiKey;
+}
+
+function filterKeysFromDifferentAppleTeam(
+  ctx: CredentialsContext,
+  keys: AppStoreConnectApiKeyFragment[]
+): AppStoreConnectApiKeyFragment[] {
+  if (!ctx.appStore.authCtx) {
+    return keys;
+  }
+  const teamId = ctx.appStore.authCtx.team.id;
+  return keys.filter(key => !key.appleTeam || key.appleTeam?.id === teamId);
+}
+
+function sortAscApiKeysByUpdatedAtDesc(
+  keys: AppStoreConnectApiKeyFragment[]
+): AppStoreConnectApiKeyFragment[] {
+  return keys.sort(
+    (keyA, keyB) => new Date(keyB.updatedAt).getTime() - new Date(keyA.updatedAt).getTime()
+  );
+}
+
+function formatAscApiKey(ascApiKey: AppStoreConnectApiKeyFragment): string {
+  const { keyIdentifier, appleTeam, name, updatedAt } = ascApiKey;
+  let line: string = '';
+  line += `Key ID: ${keyIdentifier}`;
+
+  if (name) {
+    line += chalk.gray(`\n    Name: ${name}`);
+  }
+  if (appleTeam) {
+    line += chalk.gray(`\n    ${formatAppleTeam(appleTeam)}`);
+  }
+
+  line += chalk.gray(`\n    Updated: ${fromNow(new Date(updatedAt))} ago`);
+  return line;
 }

--- a/packages/eas-cli/src/credentials/ios/actions/RemoveAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemoveAscApiKey.ts
@@ -1,0 +1,53 @@
+import { AppStoreConnectApiKeyFragment } from '../../../graphql/generated';
+import Log from '../../../log';
+import { confirmAsync } from '../../../prompts';
+import { Account } from '../../../user/Account';
+import { CredentialsContext } from '../../context';
+import { selectAscApiKeysFromAccountAsync } from './AscApiKeyUtils';
+
+export class SelectAndRemoveAscApiKey {
+  constructor(private account: Account) {}
+
+  async runAsync(ctx: CredentialsContext): Promise<void> {
+    const selected = await selectAscApiKeysFromAccountAsync(ctx, this.account);
+    if (selected) {
+      await new RemoveAscApiKey(this.account, selected).runAsync(ctx);
+      Log.succeed('Removed App Store Connect Api Key');
+      Log.newLine();
+    }
+  }
+}
+
+export class RemoveAscApiKey {
+  constructor(private account: Account, private ascApiKey: AppStoreConnectApiKeyFragment) {}
+
+  public async runAsync(ctx: CredentialsContext): Promise<void> {
+    if (ctx.nonInteractive) {
+      throw new Error(`Cannot remove App Store Connect Api Keys in non-interactive mode`);
+    }
+
+    // TODO(quin): add an extra edge on AppStoreConnectApiKey to find the apps using it
+    const confirm = await confirmAsync({
+      message: `Deleting this Api Key may affect your projects that rely on it. Do you want to continue?`,
+    });
+    if (!confirm) {
+      Log.log('Aborting');
+      return;
+    }
+
+    Log.log('Removing Api Key');
+    await ctx.ios.deleteAscApiKeyAsync(this.ascApiKey.id);
+
+    let shouldRevoke = false;
+    if (!ctx.nonInteractive) {
+      shouldRevoke = await confirmAsync({
+        message: `Do you also want to revoke this Api Key on the Apple Developer Portal?`,
+      });
+    } else if (ctx.nonInteractive) {
+      Log.log('Skipping Api Key revocation on the Apple Developer Portal.');
+    }
+    if (shouldRevoke) {
+      await ctx.appStore.revokeAscApiKeyAsync(this.ascApiKey.keyIdentifier);
+    }
+  }
+}

--- a/packages/eas-cli/src/credentials/ios/actions/RemoveAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemoveAscApiKey.ts
@@ -23,7 +23,7 @@ export class RemoveAscApiKey {
 
   public async runAsync(ctx: CredentialsContext): Promise<void> {
     if (ctx.nonInteractive) {
-      throw new Error(`Cannot remove App Store Connect Api Keys in non-interactive mode`);
+      throw new Error(`Cannot remove App Store Connect Api Keys in non-interactive mode.`);
     }
 
     // TODO(quin): add an extra edge on AppStoreConnectApiKey to find the apps using it

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/RemoveAscApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/RemoveAscApiKey-test.ts
@@ -1,0 +1,33 @@
+import { asMock } from '../../../../__tests__/utils';
+import { findApplicationTarget } from '../../../../project/ios/target';
+import { confirmAsync } from '../../../../prompts';
+import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { testAscApiKeyFragment, testTargets } from '../../../__tests__/fixtures-ios';
+import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
+import { RemoveAscApiKey } from '../RemoveAscApiKey';
+
+jest.mock('../../../../prompts');
+asMock(confirmAsync).mockImplementation(() => true);
+
+describe(RemoveAscApiKey, () => {
+  it('removes an Asc Api Key', async () => {
+    const ctx = createCtxMock({ nonInteractive: false });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const removeAscApiKeyAction = new RemoveAscApiKey(
+      appLookupParams.account,
+      testAscApiKeyFragment
+    );
+    await removeAscApiKeyAction.runAsync(ctx);
+    expect(ctx.ios.deleteAscApiKeyAsync).toHaveBeenCalledTimes(1);
+    expect(ctx.appStore.revokeAscApiKeyAsync).toHaveBeenCalledTimes(1);
+  });
+  it('errors in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({ nonInteractive: true });
+    const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
+    const removeAscApiKeyAction = new RemoveAscApiKey(
+      appLookupParams.account,
+      testAscApiKeyFragment
+    );
+    await expect(removeAscApiKeyAction.runAsync(ctx)).rejects.toThrowError();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -34,6 +34,7 @@ import { AppleTeamMutation } from './graphql/mutations/AppleTeamMutation';
 import { IosAppBuildCredentialsMutation } from './graphql/mutations/IosAppBuildCredentialsMutation';
 import { IosAppCredentialsMutation } from './graphql/mutations/IosAppCredentialsMutation';
 import { AppQuery } from './graphql/queries/AppQuery';
+import { AppStoreConnectApiKeyQuery } from './graphql/queries/AppStoreConnectApiKeyQuery';
 import { AppleAppIdentifierQuery } from './graphql/queries/AppleAppIdentifierQuery';
 import { AppleDeviceQuery } from './graphql/queries/AppleDeviceQuery';
 import { AppleDistributionCertificateQuery } from './graphql/queries/AppleDistributionCertificateQuery';
@@ -448,6 +449,12 @@ export async function createAscApiKeyAsync(
     },
     account.id
   );
+}
+
+export async function getAscApiKeysForAccountAsync(
+  account: Account
+): Promise<AppStoreConnectApiKeyFragment[]> {
+  return await AppStoreConnectApiKeyQuery.getAllForAccountAsync(account.name);
 }
 
 export async function getAscApiKeyForAppSubmissionsAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppStoreConnectApiKeyQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppStoreConnectApiKeyQuery.ts
@@ -1,0 +1,41 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import {
+  AppStoreConnectApiKeyByAccountQuery,
+  AppStoreConnectApiKeyFragment,
+} from '../../../../../graphql/generated';
+import { AppStoreConnectApiKeyFragmentNode } from '../../../../../graphql/types/credentials/AppStoreConnectApiKey';
+
+export const AppStoreConnectApiKeyQuery = {
+  async getAllForAccountAsync(accountName: string): Promise<AppStoreConnectApiKeyFragment[]> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<AppStoreConnectApiKeyByAccountQuery>(
+          gql`
+            query AppStoreConnectApiKeyByAccountQuery($accountName: String!) {
+              account {
+                byName(accountName: $accountName) {
+                  id
+                  appStoreConnectApiKeys {
+                    id
+                    ...AppStoreConnectApiKeyFragment
+                  }
+                }
+              }
+            }
+            ${print(AppStoreConnectApiKeyFragmentNode)}
+          `,
+          {
+            accountName,
+          },
+          {
+            additionalTypenames: ['AppStoreConnectApiKey'],
+          }
+        )
+        .toPromise()
+    );
+    return data.account.byName.appStoreConnectApiKeys;
+  },
+};

--- a/packages/eas-cli/src/credentials/manager/Actions.ts
+++ b/packages/eas-cli/src/credentials/manager/Actions.ts
@@ -49,4 +49,5 @@ export enum IosActionType {
   UseExistingPushKey,
   RemovePushKey,
   CreateAscApiKeyForSubmissions,
+  RemoveAscApiKey,
 }

--- a/packages/eas-cli/src/credentials/manager/IosActions.ts
+++ b/packages/eas-cli/src/credentials/manager/IosActions.ts
@@ -85,6 +85,11 @@ export function getAscApiKeyActions(ctx: CredentialsContext): ActionInfo[] {
       scope: ctx.hasProjectContext ? Scope.Project : Scope.Account,
     },
     {
+      value: IosActionType.RemoveAscApiKey,
+      title: 'Delete an Api Key',
+      scope: Scope.Account,
+    },
+    {
       value: IosActionType.GoBackToHighLevelActions,
       title: 'Go back',
       scope: Scope.Manager,

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -28,6 +28,7 @@ import { CreateDistributionCertificate } from '../ios/actions/CreateDistribution
 import { CreatePushKey } from '../ios/actions/CreatePushKey';
 import { selectValidDistributionCertificateAsync } from '../ios/actions/DistributionCertificateUtils';
 import { selectPushKeyAsync } from '../ios/actions/PushKeyUtils';
+import { SelectAndRemoveAscApiKey } from '../ios/actions/RemoveAscApiKey';
 import { SelectAndRemoveDistributionCertificate } from '../ios/actions/RemoveDistributionCertificate';
 import { RemoveProvisioningProfiles } from '../ios/actions/RemoveProvisioningProfile';
 import { SelectAndRemovePushKey } from '../ios/actions/RemovePushKey';
@@ -205,6 +206,8 @@ export class ManageIos {
       await new CreateAscApiKey(account).runAsync(ctx, AppStoreApiKeyPurpose.SUBMISSION_SERVICE);
     } else if (action === IosActionType.RemovePushKey) {
       await new SelectAndRemovePushKey(account).runAsync(ctx);
+    } else if (action === IosActionType.RemoveAscApiKey) {
+      await new SelectAndRemoveAscApiKey(account).runAsync(ctx);
     }
   }
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4463,6 +4463,27 @@ export type AppByFullNameQuery = (
   )> }
 );
 
+export type AppStoreConnectApiKeyByAccountQueryVariables = Exact<{
+  accountName: Scalars['String'];
+}>;
+
+
+export type AppStoreConnectApiKeyByAccountQuery = (
+  { __typename?: 'RootQuery' }
+  & { account: (
+    { __typename?: 'AccountQuery' }
+    & { byName: (
+      { __typename?: 'Account' }
+      & Pick<Account, 'id'>
+      & { appStoreConnectApiKeys: Array<(
+        { __typename?: 'AppStoreConnectApiKey' }
+        & Pick<AppStoreConnectApiKey, 'id'>
+        & AppStoreConnectApiKeyFragment
+      )> }
+    ) }
+  ) }
+);
+
 export type AppleAppIdentifierByBundleIdQueryVariables = Exact<{
   accountName: Scalars['String'];
   bundleIdentifier: Scalars['String'];


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Add support for removal of Asc Api Keys in the credentials manager

# Test Plan

- [ ] new tests pass
