### PR TITLE
[eas-cli] check if commit is required after dev client install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Fix commit prompt, after dev client is installed. ([#722](https://github.com/expo/eas-cli/pull/722) by [@wkozyra95](https://github.com/wkozyra95))
+- Don't show commit prompt in no-commit workflow after dev client is installed. ([#722](https://github.com/expo/eas-cli/pull/722) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix commit prompt, after dev client is installed. ([#722](https://github.com/expo/eas-cli/pull/722) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 - Add App Store Connect Api Key graphql type and print support. ([#717](https://github.com/expo/eas-cli/pull/717) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/build/utils/devClient.ts
+++ b/packages/eas-cli/src/build/utils/devClient.ts
@@ -11,6 +11,7 @@ import { resolveWorkflowAsync } from '../../project/workflow';
 import { confirmAsync } from '../../prompts';
 import { expoCommandAsync } from '../../utils/expoCli';
 import { ProfileData } from '../../utils/profiles';
+import { getVcsClient } from '../../vcs';
 import { reviewAndCommitChangesAsync } from './repository';
 
 export async function ensureExpoDevClientInstalledForDevClientBuildsAsync({
@@ -107,7 +108,9 @@ async function installExpoDevClientAsync(
   Log.newLine();
   await expoCommandAsync(projectDir, ['install', 'expo-dev-client']);
   Log.newLine();
-  await reviewAndCommitChangesAsync('Install expo-dev-client', {
-    nonInteractive,
-  });
+  if (await getVcsClient().isCommitRequiredAsync()) {
+    await reviewAndCommitChangesAsync('Install expo-dev-client', {
+      nonInteractive,
+    });
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Commit should not be required in default workflow, but the prompt shows up after installing dev client

# How

check if commit required before triggering commit prompt

# Test Plan

`expo init`
`eas build --profile development --platform android`