### PR TITLE
Replace eas:secrets with eas:secret

### DIFF
--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -364,7 +364,7 @@ OPTIONS
   --id=id  ID of the secret to delete
 
 DESCRIPTION
-  Unsure where to find the secret's ID? Run eas secrets:list
+  Unsure where to find the secret's ID? Run eas secret:list
 ```
 
 _See code: [src/commands/secret/delete.js](https://github.com/expo/eas-cli/blob/v0.34.1/packages/eas-cli/src/commands/secret/delete.js)_

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -23,7 +23,7 @@ import { promptAsync, toggleConfirmAsync } from '../../prompts';
 
 export default class EnvironmentSecretDelete extends EasCommand {
   static description = `Delete an environment secret by ID.
-Unsure where to find the secret's ID? Run ${chalk.bold('eas secrets:list')}`;
+Unsure where to find the secret's ID? Run ${chalk.bold('eas secret:list')}`;
 
   static flags = {
     id: flags.string({


### PR DESCRIPTION
# Why

`eas secrets` usage wasn't updated to `eas secret`.

# How

Replaced instances with `eas:secret`.