### PR TITLE
[eas-cli] cleanup up creds prompt method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Cleanup up credentials prompt method. ([#728](https://github.com/expo/eas-cli/pull/728) by [@quinlanj](https://github.com/quinlanj))
+
 ## [0.34.1](https://github.com/expo/eas-cli/releases/tag/0.34.1) - 2021-11-02
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Cleanup up credentials prompt method. ([#728](https://github.com/expo/eas-cli/pull/728) by [@quinlanj](https://github.com/quinlanj))
+- Clean up credentials prompt method. ([#728](https://github.com/expo/eas-cli/pull/728) by [@quinlanj](https://github.com/quinlanj))
 
 ## [0.34.1](https://github.com/expo/eas-cli/releases/tag/0.34.1) - 2021-11-02
 

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -44,7 +44,7 @@ export async function promptForIssuerIdAsync(): Promise<string> {
   );
 
   // Do not perform uuid validation - Apple's issuerIds are not RFC4122 compliant
-  const { issuerId } = await getCredentialsFromUserAsync(ascApiKeyIssuerIdSchema, {});
+  const { issuerId } = await getCredentialsFromUserAsync(ascApiKeyIssuerIdSchema);
   return issuerId;
 }
 

--- a/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
+++ b/packages/eas-cli/src/credentials/utils/promptForCredentials.ts
@@ -49,7 +49,7 @@ export async function askForUserProvidedAsync<T>(
 
 export async function getCredentialsFromUserAsync<T>(
   credentialsSchema: CredentialSchema<T>,
-  initialValues: Partial<T>
+  initialValues: Partial<T> = {}
 ): Promise<T> {
   const results: any = {};
   for (const question of credentialsSchema.questions) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

 followup from https://github.com/expo/eas-cli/pull/718#discussion_r740837814


# Test Plan

- [x] stuff still passes
