### PR TITLE
[eas-cli] Use actor `displayName` when printing build info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add ASC Api Key generation workflow. ([#718](https://github.com/expo/eas-cli/pull/718) by [@quinlanj](https://github.com/quinlanj))
 - Add support for removal of App Store Connect Api Keys. ([#721](https://github.com/expo/eas-cli/pull/721) by [@quinlanj](https://github.com/quinlanj))
 - Allow users to assign an ASC Api Key to their project. ([#719](https://github.com/expo/eas-cli/pull/719) by [@quinlanj](https://github.com/quinlanj))
+- Show initiating user display name when selecting a build to submit. ([#730](https://github.com/expo/eas-cli/pull/730) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -120,11 +120,5 @@ export function formatGraphQLBuild(build: BuildFragment): string {
 }
 
 const getActorName = (build: BuildFragment): string => {
-  if (!build.initiatingActor) {
-    return 'unknown';
-  } else if (build.initiatingActor.__typename === 'User') {
-    return build.initiatingActor.username;
-  } else {
-    return build.initiatingActor.firstName ?? 'unknown';
-  }
+  return build.initiatingActor?.displayName || 'unknown';
 };

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5318,10 +5318,10 @@ export type BuildFragment = (
     & Pick<BuildArtifacts, 'buildUrl' | 'xcodeBuildLogsUrl'>
   )>, initiatingActor?: Maybe<(
     { __typename: 'User' }
-    & Pick<User, 'username' | 'id'>
+    & Pick<User, 'id' | 'displayName'>
   ) | (
     { __typename: 'Robot' }
-    & Pick<Robot, 'firstName' | 'id'>
+    & Pick<Robot, 'id' | 'displayName'>
   )>, project: (
     { __typename: 'Snack' }
     & Pick<Snack, 'id' | 'name'>

--- a/packages/eas-cli/src/graphql/types/Build.ts
+++ b/packages/eas-cli/src/graphql/types/Build.ts
@@ -17,12 +17,7 @@ export const BuildFragmentNode = gql`
     initiatingActor {
       __typename
       id
-      ... on User {
-        username
-      }
-      ... on Robot {
-        firstName
-      }
+      displayName
     }
     project {
       __typename

--- a/packages/eas-cli/src/submit/ArchiveSource.ts
+++ b/packages/eas-cli/src/submit/ArchiveSource.ts
@@ -288,6 +288,7 @@ function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choi
     buildProfile,
     appBuildVersion,
     releaseChannel,
+    initiatingActor,
   } = build;
 
   const formatValue = (field?: string | null): string =>
@@ -310,6 +311,7 @@ function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choi
       .filter(it => it != null)
       .join(', '),
     `\tProfile: ${formatValue(buildProfile)}, Release channel: ${formatValue(releaseChannel)}`,
+    `\tAuthored by: ${formatValue(initiatingActor?.displayName)}`,
   ].join('\n');
 
   return {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Resolves #726 

# How

- Took advantage of gql field `Actor.displayName` introduced in https://github.com/expo/universe/pull/8393
- Added `Authored by:` field to submission build choice prompt as requested in #726
- Replaced author name logic in `eas build:list` with the new gql field
- Updated graphql schema

# Test Plan

- [x] Tested manually (screenshots below)
- [x] Current tests still pass

---

<img width="596" alt="Screenshot 2021-11-03 at 11 31 14" src="https://user-images.githubusercontent.com/278340/140046443-44e623fe-c630-43c3-a0b0-1273cffc4133.png">
<img width="555" alt="Screenshot 2021-11-03 at 11 31 58" src="https://user-images.githubusercontent.com/278340/140046449-b052d2d5-f720-47ad-95d7-21209382b4ff.png">
