### PR TITLE
[eas-cli] integrate asc api key into submissions workflow 

### DIFF
--- a/packages/eas-cli/src/credentials/ios/actions/SetupSubmissionCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetupSubmissionCredentials.ts
@@ -1,0 +1,61 @@
+import chalk from 'chalk';
+import wrapAnsi from 'wrap-ansi';
+
+import { CommonIosAppCredentialsFragment } from '../../../graphql/generated';
+import Log, { learnMore } from '../../../log';
+import { promptAsync } from '../../../prompts';
+import { CredentialsContext } from '../../context';
+import { UnsupportedCredentialsChoiceError } from '../../errors';
+import { AppLookupParams } from '../api/GraphqlClient';
+import { AppStoreApiKeyPurpose } from './AscApiKeyUtils';
+import { SetupAscApiKey } from './SetupAscApiKey';
+
+const PROMPT_FOR_APP_SPECIFIC_PASSWORD = 'PROMPT_FOR_APP_SPECIFIC_PASSWORD';
+export class SetupSubmissionCredential {
+  private setupAscApiKeyAction;
+  constructor(app: AppLookupParams) {
+    this.setupAscApiKeyAction = new SetupAscApiKey(app, AppStoreApiKeyPurpose.SUBMISSION_SERVICE);
+    this.setupAscApiKeyAction.choices = this.setupAscApiKeyAction.choices.concat({
+      title: '[Enter an App Specific Password]',
+      value: PROMPT_FOR_APP_SPECIFIC_PASSWORD,
+    });
+  }
+
+  public async runAsync(
+    ctx: CredentialsContext
+  ): Promise<CommonIosAppCredentialsFragment | string> {
+    try {
+      return await this.setupAscApiKeyAction.runAsync(ctx);
+    } catch (e) {
+      if (e instanceof UnsupportedCredentialsChoiceError) {
+        const choice = e.choice;
+        if (choice === PROMPT_FOR_APP_SPECIFIC_PASSWORD) {
+          return await this.promptForAppSpecificPasswordAsync();
+        }
+      }
+      throw e;
+    }
+  }
+
+  async promptForAppSpecificPasswordAsync(): Promise<string> {
+    Log.addNewLineIfNone();
+    Log.warn(
+      wrapAnsi(
+        `This option will be deprecated soon. You will still be able to provide your password with the ${chalk.bold(
+          'EXPO_APPLE_APP_SPECIFIC_PASSWORD'
+        )} environment variable.`,
+        process.stdout.columns || 80
+      )
+    );
+    Log.log(`Please enter your Apple app-specific password.`);
+    Log.log(learnMore('https://expo.fyi/apple-app-specific-password'));
+
+    const { appSpecificPassword } = await promptAsync({
+      name: 'appSpecificPassword',
+      message: 'Your Apple app-specific password:',
+      type: 'password',
+      validate: (val: string) => val !== '' || 'Apple app-specific password cannot be empty!',
+    });
+    return appSpecificPassword;
+  }
+}

--- a/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
@@ -54,6 +54,7 @@ export default class IosSubmitCommand {
         : null;
     const maybeAscApiKeySource =
       'ascApiKeySource' in credentialsSource ? credentialsSource.ascApiKeySource : null;
+    const maybeCredentialsSource = null; // todo
     const ascAppIdentifier = await this.resolveAscAppIdentifierAsync();
     const appleIdUsername = await this.resolveAppleIdUsernameAsync();
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

When setting up credentials for the Submissions workflow, we want to prompt the user whether they want to:

- create a new asc api key
- use an existing one (if applicable)
- input an App Specific Password (we want to eventually phase this out)

# Test Plan

- [ ] todo
