### PR TITLE
[api] Change API domain for EAS CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Show initiating user display name when selecting a build to submit. ([#730](https://github.com/expo/eas-cli/pull/730) by [@barthap](https://github.com/barthap))
 - Handle Apple servers maintenance error in `eas submit`. ([#738](https://github.com/expo/eas-cli/pull/738) by [@barthap](https://github.com/barthap))
 - Integrate ASC Api Key with submissions workflow. ([#737](https://github.com/expo/eas-cli/pull/737) by [@quinlanj](https://github.com/quinlanj))
+- Change EAS API server domain. ([#744](https://github.com/expo/eas-cli/pull/744) by [@ide](https://github.com/ide))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql-codegen.yml
+++ b/packages/eas-cli/graphql-codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://staging.exp.host/--/graphql'
+schema: 'https://staging-api.expo.dev/graphql'
 documents:
   - 'src/graphql/**/!(*.d).{ts,tsx}'
   - 'src/credentials/ios/api/graphql/**/!(*.d).{ts,tsx}'

--- a/packages/eas-cli/src/__tests__/api-test.ts
+++ b/packages/eas-cli/src/__tests__/api-test.ts
@@ -8,7 +8,7 @@ import { apiClient, getExpoApiBaseUrl } from '../api';
 describe('apiClient', () => {
   it('converts Expo APIv2 error to ApiV2Error', async () => {
     nock(getExpoApiBaseUrl())
-      .post('/--/api/v2/test')
+      .post('/v2/test')
       .reply(400, {
         errors: [
           {
@@ -39,7 +39,7 @@ describe('apiClient', () => {
   });
 
   it('does not convert non-APIv2 error to ApiV2Error', async () => {
-    nock(getExpoApiBaseUrl()).post('/--/api/v2/test').reply(500, 'Something went wrong');
+    nock(getExpoApiBaseUrl()).post('/v2/test').reply(500, 'Something went wrong');
 
     let error: Error | null = null;
     try {

--- a/packages/eas-cli/src/api.ts
+++ b/packages/eas-cli/src/api.ts
@@ -4,7 +4,7 @@ import ApiV2Error from './ApiV2Error';
 import { getAccessToken, getSessionSecret } from './user/sessionStorage';
 
 export const apiClient = got.extend({
-  prefixUrl: getExpoApiBaseUrl() + '/--/api/v2/',
+  prefixUrl: getExpoApiBaseUrl() + '/v2/',
   hooks: {
     beforeRequest: [
       (options: NormalizedOptions) => {
@@ -40,11 +40,11 @@ export const apiClient = got.extend({
 
 export function getExpoApiBaseUrl(): string {
   if (process.env.EXPO_STAGING) {
-    return `https://staging.exp.host`;
+    return `https://staging-api.expo.dev`;
   } else if (process.env.EXPO_LOCAL) {
     return `http://127.0.0.1:3000`;
   } else {
-    return `https://exp.host`;
+    return `https://api.expo.dev`;
   }
 }
 

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -22,7 +22,7 @@ export function getArtifactUrl(artifactId: string): string {
 
 export function getInternalDistributionInstallUrl(build: BuildFragment): string {
   if (build.platform === AppPlatform.Ios) {
-    return `itms-services://?action=download-manifest;url=${getExpoApiBaseUrl()}/--/api/v2/projects/${
+    return `itms-services://?action=download-manifest;url=${getExpoApiBaseUrl()}/v2/projects/${
       build.project.id
     }/builds/${build.id}/manifest.plist`;
   }

--- a/packages/eas-cli/src/graphql/client.ts
+++ b/packages/eas-cli/src/graphql/client.ts
@@ -30,7 +30,7 @@ type SessionHeaders = {
 };
 
 export const graphqlClient = createUrqlClient({
-  url: getExpoApiBaseUrl() + '/--/graphql',
+  url: getExpoApiBaseUrl() + '/graphql',
   exchanges: [
     dedupExchange,
     cacheExchange,


### PR DESCRIPTION
Checklist
---

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

Why
---
To match the API server domain the website uses, this commit switches the API domain for EAS CLI from exp.host to api.expo.dev.

How
---
URL paths for api.expo.dev are different than those for exp.host.

* GraphQL: api.expo.dev/graphql
* API v2: api.expo.dev/v2/...

Updated the main functions that return the API server origin and the API v2 and GraphQL clients that create the URLs for each type of API.

Test Plan
---------
Looked at the places `getExpoApiBaseUrl()` is called and made sure the call sites were updated. Searched for `--/` and `/--` to find likely exp.host code to update.

* Unit tests: `yarn test`
* Log in and out: `yarn eas login`, `yarn eas logout` (tests API v2)
* Project management: `yarn eas project:view` (tests GraphQL) -> confirm project gets created on expo.de