### PR TITLE
[eas-cli] only prompt for appleIdUsername if authenticating via asp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Only prompt for Apple Id username if authenticating with an App Specific Password. ([#745](https://github.com/expo/eas-cli/pull/745) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🧹 Chores
 
 - Clean up credentials prompt method. ([#728](https://github.com/expo/eas-cli/pull/728) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/submit/ios/AppSpecificPasswordSource.ts
+++ b/packages/eas-cli/src/submit/ios/AppSpecificPasswordSource.ts
@@ -17,17 +17,17 @@ interface AppSpecificPasswordUserDefinedSource extends AppSpecificPasswordSource
   appSpecificPassword: string;
 }
 
-export type AppSpecificPassword = {
+export interface AppSpecificPasswordCredentials {
   password: string;
   appleIdUsername: string;
-};
+}
 
 export type AppSpecificPasswordSource = AppSpecificPasswordUserDefinedSource;
 
 export async function getAppSpecificPasswordAsync(
   ctx: SubmissionContext<Platform.IOS>,
   source: AppSpecificPasswordSource
-): Promise<AppSpecificPassword> {
+): Promise<AppSpecificPasswordCredentials> {
   if (source.sourceType === AppSpecificPasswordSourceType.userDefined) {
     return {
       password: source.appSpecificPassword,

--- a/packages/eas-cli/src/submit/ios/CredentialsServiceSource.ts
+++ b/packages/eas-cli/src/submit/ios/CredentialsServiceSource.ts
@@ -6,6 +6,7 @@ import Log from '../../log';
 import { getBundleIdentifierAsync } from '../../project/ios/bundleIdentifier';
 import { findAccountByName } from '../../user/Account';
 import { SubmissionContext } from '../context';
+import { AppSpecificPassword, getAppleIdUsernameAsync } from './AppSpecificPasswordSource';
 import { AscApiKeyResult } from './AscApiKeySource';
 
 /**
@@ -17,7 +18,7 @@ export type CredentialsServiceSource = typeof CREDENTIALS_SERVICE_SOURCE;
 
 export async function getFromCredentialsServiceAsync(
   ctx: SubmissionContext<Platform.IOS>
-): Promise<{ appSpecificPassword: string } | { ascApiKeyResult: AscApiKeyResult }> {
+): Promise<{ appSpecificPassword: AppSpecificPassword } | { ascApiKeyResult: AscApiKeyResult }> {
   const bundleIdentifier = await getBundleIdentifierAsync(ctx.projectDir, ctx.exp);
   Log.log(`Looking up credentials configuration for ${bundleIdentifier}...`);
 
@@ -33,7 +34,12 @@ export async function getFromCredentialsServiceAsync(
   const ascOrAsp = await setupSubmissionCredentialsAction.runAsync(ctx.credentialsCtx);
   const isAppSpecificPassword = typeof ascOrAsp === 'string';
   if (isAppSpecificPassword) {
-    return { appSpecificPassword: ascOrAsp };
+    return {
+      appSpecificPassword: {
+        password: ascOrAsp,
+        appleIdUsername: await getAppleIdUsernameAsync(ctx),
+      },
+    };
   } else {
     const ascKeyForSubmissions = nullthrows(
       ascOrAsp.appStoreConnectApiKeyForSubmissions,

--- a/packages/eas-cli/src/submit/ios/CredentialsServiceSource.ts
+++ b/packages/eas-cli/src/submit/ios/CredentialsServiceSource.ts
@@ -6,7 +6,10 @@ import Log from '../../log';
 import { getBundleIdentifierAsync } from '../../project/ios/bundleIdentifier';
 import { findAccountByName } from '../../user/Account';
 import { SubmissionContext } from '../context';
-import { AppSpecificPassword, getAppleIdUsernameAsync } from './AppSpecificPasswordSource';
+import {
+  AppSpecificPasswordCredentials,
+  getAppleIdUsernameAsync,
+} from './AppSpecificPasswordSource';
 import { AscApiKeyResult } from './AscApiKeySource';
 
 /**
@@ -18,7 +21,9 @@ export type CredentialsServiceSource = typeof CREDENTIALS_SERVICE_SOURCE;
 
 export async function getFromCredentialsServiceAsync(
   ctx: SubmissionContext<Platform.IOS>
-): Promise<{ appSpecificPassword: AppSpecificPassword } | { ascApiKeyResult: AscApiKeyResult }> {
+): Promise<
+  { appSpecificPassword: AppSpecificPasswordCredentials } | { ascApiKeyResult: AscApiKeyResult }
+> {
   const bundleIdentifier = await getBundleIdentifierAsync(ctx.projectDir, ctx.exp);
   Log.log(`Looking up credentials configuration for ${bundleIdentifier}...`);
 

--- a/packages/eas-cli/src/submit/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitter.ts
@@ -13,7 +13,7 @@ import {
   printSummary,
 } from '../utils/summary';
 import {
-  AppSpecificPassword,
+  AppSpecificPasswordCredentials,
   AppSpecificPasswordSource,
   getAppSpecificPasswordAsync,
 } from './AppSpecificPasswordSource';
@@ -39,7 +39,7 @@ export interface IosSubmissionOptions
 
 interface ResolvedSourceOptions {
   archive: Archive;
-  appSpecificPassword?: AppSpecificPassword;
+  appSpecificPassword?: AppSpecificPasswordCredentials;
   ascApiKeyResult?: AscApiKeyResult;
 }
 
@@ -109,7 +109,7 @@ export default class IosSubmitter extends BaseSubmitter<Platform.IOS, IosSubmiss
   }
 
   private formatAppSpecificPassword(
-    appSpecificPassword: AppSpecificPassword
+    appSpecificPassword: AppSpecificPasswordCredentials
   ): Pick<IosSubmissionConfigInput, 'appleAppSpecificPassword' | 'appleIdUsername'> {
     return {
       appleAppSpecificPassword: appSpecificPassword.password,

--- a/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
@@ -7,6 +7,7 @@ import { testCommonIosAppCredentialsFragment } from '../../../credentials/__test
 import { SetUpSubmissionCredentials } from '../../../credentials/ios/actions/SetUpSubmissionCredentials';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { getBundleIdentifierAsync } from '../../../project/ios/bundleIdentifier';
+import { promptAsync } from '../../../prompts';
 import { createSubmissionContextAsync } from '../../context';
 import { getFromCredentialsServiceAsync } from '../CredentialsServiceSource';
 
@@ -48,16 +49,17 @@ describe(getFromCredentialsServiceAsync, () => {
       profile: {
         language: 'en-US',
       },
-      nonInteractive: true,
+      nonInteractive: false,
     });
     jest
       .spyOn(SetUpSubmissionCredentials.prototype, 'runAsync')
       .mockImplementation(async _ctx => 'super secret');
     asMock(getBundleIdentifierAsync).mockImplementation(() => 'com.hello.world');
+    asMock(promptAsync).mockImplementationOnce(() => ({ appleId: 'quin@expo.io' }));
 
     const result = await getFromCredentialsServiceAsync(ctx);
     expect(result).toEqual({
-      appSpecificPassword: 'super secret',
+      appSpecificPassword: { password: 'super secret', appleIdUsername: 'quin@expo.io' },
     });
   });
   it('returns an ASC Api Key from the credentialService source', async () => {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Only prompt for Apple Id Username (ie) `quin@expo.io` if we are authenticating via App Specific Password. We don't need this information if we are using ASC Api Keys.

# TODO

- [x] Land and deploy https://github.com/expo/universe/pull/8518

# Test Plan

- [x] tests still pass
- [x] manual sanity check 