### PR TITLE
fix working with local api server

### DIFF
--- a/packages/eas-cli/src/__tests__/api-test.ts
+++ b/packages/eas-cli/src/__tests__/api-test.ts
@@ -3,12 +3,12 @@ import { RequestError } from 'got/dist/source';
 import nock from 'nock';
 
 import ApiV2Error from '../ApiV2Error';
-import { apiClient, getExpoApiBaseUrl } from '../api';
+import { apiClient, getExpoApiV2Url } from '../api';
 
 describe('apiClient', () => {
   it('converts Expo APIv2 error to ApiV2Error', async () => {
-    nock(getExpoApiBaseUrl())
-      .post('/v2/test')
+    nock(getExpoApiV2Url())
+      .post('/test')
       .reply(400, {
         errors: [
           {
@@ -39,7 +39,7 @@ describe('apiClient', () => {
   });
 
   it('does not convert non-APIv2 error to ApiV2Error', async () => {
-    nock(getExpoApiBaseUrl()).post('/v2/test').reply(500, 'Something went wrong');
+    nock(getExpoApiV2Url()).post('/test').reply(500, 'Something went wrong');
 
     let error: Error | null = null;
     try {

--- a/packages/eas-cli/src/api.ts
+++ b/packages/eas-cli/src/api.ts
@@ -4,7 +4,7 @@ import ApiV2Error from './ApiV2Error';
 import { getAccessToken, getSessionSecret } from './user/sessionStorage';
 
 export const apiClient = got.extend({
-  prefixUrl: getExpoApiBaseUrl() + '/v2/',
+  prefixUrl: getExpoApiV2Url(),
   hooks: {
     beforeRequest: [
       (options: NormalizedOptions) => {
@@ -38,13 +38,23 @@ export const apiClient = got.extend({
   },
 });
 
-export function getExpoApiBaseUrl(): string {
+export function getExpoApiV2Url(): string {
   if (process.env.EXPO_STAGING) {
-    return `https://staging-api.expo.dev`;
+    return `https://staging-api.expo.dev/v2`;
   } else if (process.env.EXPO_LOCAL) {
-    return `http://127.0.0.1:3000`;
+    return `http://127.0.0.1:3000/--/api/v2`;
   } else {
-    return `https://api.expo.dev`;
+    return `https://api.expo.dev/v2`;
+  }
+}
+
+export function getExpoGraphqlUrl(): string {
+  if (process.env.EXPO_STAGING) {
+    return `https://staging-api.expo.dev/graphql`;
+  } else if (process.env.EXPO_LOCAL) {
+    return `http://127.0.0.1:3000/--/graphql`;
+  } else {
+    return `https://api.expo.dev/graphql`;
   }
 }
 

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { getExpoApiBaseUrl, getExpoWebsiteBaseUrl } from '../../api';
+import { getExpoApiV2Url, getExpoWebsiteBaseUrl } from '../../api';
 import { AppPlatform, BuildFragment } from '../../graphql/generated';
 
 export function getProjectDashboardUrl(accountName: string, projectName: string): string {
@@ -22,7 +22,7 @@ export function getArtifactUrl(artifactId: string): string {
 
 export function getInternalDistributionInstallUrl(build: BuildFragment): string {
   if (build.platform === AppPlatform.Ios) {
-    return `itms-services://?action=download-manifest;url=${getExpoApiBaseUrl()}/v2/projects/${
+    return `itms-services://?action=download-manifest;url=${getExpoApiV2Url()}/projects/${
       build.project.id
     }/builds/${build.id}/manifest.plist`;
   }

--- a/packages/eas-cli/src/graphql/client.ts
+++ b/packages/eas-cli/src/graphql/client.ts
@@ -17,7 +17,7 @@ import { DocumentNode } from 'graphql';
 // eslint-disable-next-line
 import fetch from 'node-fetch';
 
-import { getExpoApiBaseUrl } from '../api';
+import { getExpoGraphqlUrl } from '../api';
 import Log from '../log';
 import { getAccessToken, getSessionSecret } from '../user/sessionStorage';
 
@@ -30,7 +30,7 @@ type SessionHeaders = {
 };
 
 export const graphqlClient = createUrqlClient({
-  url: getExpoApiBaseUrl() + '/graphql',
+  url: getExpoGraphqlUrl(),
   exchanges: [
     dedupExchange,
     cacheExchange,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Follow-up to https://github.com/expo/eas-cli/pull/744. I didn't notice it before but that PR broke development with the local www server.

# How

Use different API URL when `EXPO_LOCAL` is set.

# Test Plan

`EXPO_LOCAL eas whoami` works now.