### PR TITLE
Revert "fix working with local api server (#747)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix auto-submitting with `--auto-submit-with-profile`. ([#748](https://github.com/expo/eas-cli/pull/748) by [@dsokal](https://github.com/dsokal))
+- Use same URL paths for local development of EAS CLI as production. ([#750](https://github.com/expo/eas-cli/pull/750) by [@ide](https://github.com/ide))
 
 ### 🧹 Chores
 
@@ -26,7 +27,6 @@ This is the log of notable changes to EAS CLI and related packages.
 - Handle Apple servers maintenance error in `eas submit`. ([#738](https://github.com/expo/eas-cli/pull/738) by [@barthap](https://github.com/barthap))
 - Integrate ASC Api Key with submissions workflow. ([#737](https://github.com/expo/eas-cli/pull/737) by [@quinlanj](https://github.com/quinlanj))
 - Change EAS API server domain. ([#744](https://github.com/expo/eas-cli/pull/744) by [@ide](https://github.com/ide))
-
 - Only prompt for Apple Id username if authenticating with an App Specific Password. ([#745](https://github.com/expo/eas-cli/pull/745) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix auto-submitting with `--auto-submit-with-profile`. ([#748](https://github.com/expo/eas-cli/pull/748) by [@dsokal](https://github.com/dsokal))
-- Use same URL paths for local development of EAS CLI as production. ([#750](https://github.com/expo/eas-cli/pull/750) by [@ide](https://github.com/ide))
 
 ### 🧹 Chores
+
+- Use same URL paths for local development of EAS CLI as production. ([#750](https://github.com/expo/eas-cli/pull/750) by [@ide](https://github.com/ide))
 
 ## [0.35.0](https://github.com/expo/eas-cli/releases/tag/v0.35.0) - 2021-11-08
 

--- a/packages/eas-cli/src/__tests__/api-test.ts
+++ b/packages/eas-cli/src/__tests__/api-test.ts
@@ -3,12 +3,12 @@ import { RequestError } from 'got/dist/source';
 import nock from 'nock';
 
 import ApiV2Error from '../ApiV2Error';
-import { apiClient, getExpoApiV2Url } from '../api';
+import { apiClient, getExpoApiBaseUrl } from '../api';
 
 describe('apiClient', () => {
   it('converts Expo APIv2 error to ApiV2Error', async () => {
-    nock(getExpoApiV2Url())
-      .post('/test')
+    nock(getExpoApiBaseUrl())
+      .post('/v2/test')
       .reply(400, {
         errors: [
           {
@@ -39,7 +39,7 @@ describe('apiClient', () => {
   });
 
   it('does not convert non-APIv2 error to ApiV2Error', async () => {
-    nock(getExpoApiV2Url()).post('/test').reply(500, 'Something went wrong');
+    nock(getExpoApiBaseUrl()).post('/v2/test').reply(500, 'Something went wrong');
 
     let error: Error | null = null;
     try {

--- a/packages/eas-cli/src/api.ts
+++ b/packages/eas-cli/src/api.ts
@@ -4,7 +4,7 @@ import ApiV2Error from './ApiV2Error';
 import { getAccessToken, getSessionSecret } from './user/sessionStorage';
 
 export const apiClient = got.extend({
-  prefixUrl: getExpoApiV2Url(),
+  prefixUrl: getExpoApiBaseUrl() + '/v2/',
   hooks: {
     beforeRequest: [
       (options: NormalizedOptions) => {
@@ -38,23 +38,13 @@ export const apiClient = got.extend({
   },
 });
 
-export function getExpoApiV2Url(): string {
+export function getExpoApiBaseUrl(): string {
   if (process.env.EXPO_STAGING) {
-    return `https://staging-api.expo.dev/v2`;
+    return `https://staging-api.expo.dev`;
   } else if (process.env.EXPO_LOCAL) {
-    return `http://127.0.0.1:3000/--/api/v2`;
+    return `http://127.0.0.1:3000`;
   } else {
-    return `https://api.expo.dev/v2`;
-  }
-}
-
-export function getExpoGraphqlUrl(): string {
-  if (process.env.EXPO_STAGING) {
-    return `https://staging-api.expo.dev/graphql`;
-  } else if (process.env.EXPO_LOCAL) {
-    return `http://127.0.0.1:3000/--/graphql`;
-  } else {
-    return `https://api.expo.dev/graphql`;
+    return `https://api.expo.dev`;
   }
 }
 

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { getExpoApiV2Url, getExpoWebsiteBaseUrl } from '../../api';
+import { getExpoApiBaseUrl, getExpoWebsiteBaseUrl } from '../../api';
 import { AppPlatform, BuildFragment } from '../../graphql/generated';
 
 export function getProjectDashboardUrl(accountName: string, projectName: string): string {
@@ -22,7 +22,7 @@ export function getArtifactUrl(artifactId: string): string {
 
 export function getInternalDistributionInstallUrl(build: BuildFragment): string {
   if (build.platform === AppPlatform.Ios) {
-    return `itms-services://?action=download-manifest;url=${getExpoApiV2Url()}/projects/${
+    return `itms-services://?action=download-manifest;url=${getExpoApiBaseUrl()}/v2/projects/${
       build.project.id
     }/builds/${build.id}/manifest.plist`;
   }

--- a/packages/eas-cli/src/graphql/client.ts
+++ b/packages/eas-cli/src/graphql/client.ts
@@ -17,7 +17,7 @@ import { DocumentNode } from 'graphql';
 // eslint-disable-next-line
 import fetch from 'node-fetch';
 
-import { getExpoGraphqlUrl } from '../api';
+import { getExpoApiBaseUrl } from '../api';
 import Log from '../log';
 import { getAccessToken, getSessionSecret } from '../user/sessionStorage';
 
@@ -30,7 +30,7 @@ type SessionHeaders = {
 };
 
 export const graphqlClient = createUrqlClient({
-  url: getExpoGraphqlUrl(),
+  url: getExpoApiBaseUrl() + '/graphql',
   exchanges: [
     dedupExchange,
     cacheExchange,


### PR DESCRIPTION
Why
---
Make local development behave more closely to production and use the same API route paths. I made 127.0.0.1 behave the same way as api.expo.test and localhost. Another fix would have been to change 127.0.0.1 to localhost in EAS CLI, but it's a good idea to make the API server treat localhost and 127.0.0.1 similarly (look up PR 8542).

How
---
This reverts commit 5ba3cc66237d8ca8984d1fbd1efff65097f5feaf.

Test Plan
---------
Started the API server locally, then started EAS CLI locally with `EXPO_LOCAL=1 yarn eas login`. Logged in with my staging credentials and saw the API server locally print out that it had made new database connections in the log.