### PR TITLE
[eas-cli] pass envs to prebuild config when resolving entitlements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix auto-submitting with `--auto-submit-with-profile`. ([#748](https://github.com/expo/eas-cli/pull/748) by [@dsokal](https://github.com/dsokal))
+- Pass env from build profile when resolving entitlements. ([#751](https://github.com/expo/eas-cli/pull/751) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -20,7 +20,11 @@ export async function ensureIosCredentialsAsync(
     app: getAppFromContext(buildCtx.credentialsCtx),
     targets,
     iosCapabilitiesOptions: {
-      entitlements: await resolveEntitlementsJsonAsync(buildCtx.projectDir, buildCtx.workflow),
+      entitlements: await resolveEntitlementsJsonAsync(
+        buildCtx.projectDir,
+        buildCtx.workflow,
+        buildCtx.buildProfile.env ?? {}
+      ),
     },
     distribution: buildCtx.buildProfile.distribution ?? 'store',
     enterpriseProvisioning: buildCtx.buildProfile.enterpriseProvisioning,

--- a/packages/eas-cli/src/credentials/ios/appstore/entitlements.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/entitlements.ts
@@ -5,25 +5,38 @@ import plist from '@expo/plist';
 import { getPrebuildConfig } from '@expo/prebuild-config';
 import fs from 'fs-extra';
 
-export async function getManagedEntitlementsJsonAsync(projectDir: string): Promise<JSONObject> {
-  let { exp } = getPrebuildConfig(projectDir, { platforms: ['ios'] });
+export async function getManagedEntitlementsJsonAsync(
+  projectDir: string,
+  env: Record<string, string>,
+): Promise<JSONObject> {
+  const originalProcessEnv: NodeJS.ProcessEnv = process.env;
+  try {
+    process.env = {
+      ...process.env,
+      ...env,
+    };
+    let { exp } = getPrebuildConfig(projectDir, { platforms: ['ios'] });
 
-  exp = await compileModsAsync(exp, {
-    projectRoot: projectDir,
-    platforms: ['ios'],
-    introspect: true,
-  });
-  return exp.ios?.entitlements || {};
+    exp = await compileModsAsync(exp, {
+      projectRoot: projectDir,
+      platforms: ['ios'],
+      introspect: true,
+    });
+    return exp.ios?.entitlements || {};
+  } finally {
+    process.env = originalProcessEnv;
+  }
 }
 
 export async function resolveEntitlementsJsonAsync(
   projectDir: string,
-  workflow: Workflow
+  workflow: Workflow,
+  env: Record<string, string>
 ): Promise<JSONObject> {
   if (workflow === Workflow.GENERIC) {
     return (await getEntitlementsJsonAsync(projectDir)) || {};
   } else if (workflow === Workflow.MANAGED) {
-    return await getManagedEntitlementsJsonAsync(projectDir);
+    return await getManagedEntitlementsJsonAsync(projectDir, env);
   } else {
     throw new Error(`Unknown workflow: ${workflow}`);
   }

--- a/packages/eas-cli/src/credentials/ios/appstore/entitlements.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/entitlements.ts
@@ -7,7 +7,7 @@ import fs from 'fs-extra';
 
 export async function getManagedEntitlementsJsonAsync(
   projectDir: string,
-  env: Record<string, string>,
+  env: Record<string, string>
 ): Promise<JSONObject> {
   const originalProcessEnv: NodeJS.ProcessEnv = process.env;
   try {
@@ -15,14 +15,14 @@ export async function getManagedEntitlementsJsonAsync(
       ...process.env,
       ...env,
     };
-    let { exp } = getPrebuildConfig(projectDir, { platforms: ['ios'] });
+    const { exp } = getPrebuildConfig(projectDir, { platforms: ['ios'] });
 
-    exp = await compileModsAsync(exp, {
+    const expWithMods = await compileModsAsync(exp, {
       projectRoot: projectDir,
       platforms: ['ios'],
       introspect: true,
     });
-    return exp.ios?.entitlements || {};
+    return expWithMods.ios?.entitlements || {};
   } finally {
     process.env = originalProcessEnv;
   }

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -229,7 +229,10 @@ export class ManageIos {
         distribution: buildProfile.distribution,
         enterpriseProvisioning: buildProfile.enterpriseProvisioning,
         iosCapabilitiesOptions: {
-          entitlements: await getManagedEntitlementsJsonAsync(ctx.projectDir),
+          entitlements: await getManagedEntitlementsJsonAsync(
+            ctx.projectDir,
+            buildProfile.env ?? {}
+          ),
         },
       }).runAsync(ctx);
       return;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

https://github.com/expo/eas-cli/issues/528#issuecomment-962002509

when entitlements were resolved app.conifg.js did not have env variables set, 

# How

pass env in eas build and eas credentials

# Test Plan

throw error in app.config.js when env is not set, set that value in eas.json, make sure it won't throw were running build
