### PR TITLE
use keytool service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Use Keystore Service when `keytool` is not installed. ([#754](https://github.com/expo/eas-cli/pull/754) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 - Fix auto-submitting with `--auto-submit-with-profile`. ([#748](https://github.com/expo/eas-cli/pull/748) by [@dsokal](https://github.com/dsokal))

--- a/packages/eas-cli/src/credentials/android/utils/keystore.ts
+++ b/packages/eas-cli/src/credentials/android/utils/keystore.ts
@@ -139,7 +139,7 @@ async function createKeystoreInCloudAsync(
   { showKeytoolDetectionMsg = true } = {}
 ): Promise<KeystoreWithType> {
   if (showKeytoolDetectionMsg) {
-    Log.warn(`Detected that you do not have ${chalk.bold('keytool')} installed locally.`);
+    Log.log(`Detected that you do not have ${chalk.bold('keytool')} installed locally.`);
   }
   const spinner = ora('Generating keystore in the cloud...').start();
   try {

--- a/packages/eas-cli/src/credentials/android/utils/keystore.ts
+++ b/packages/eas-cli/src/credentials/android/utils/keystore.ts
@@ -1,30 +1,34 @@
 import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
 import crypto from 'crypto';
 import fs from 'fs-extra';
+// (dsokal) We actually want to use node-fetch but the change is in progress.
+// See https://github.com/expo/eas-cli/issues/32 for context.
+// eslint-disable-next-line no-restricted-imports
+import fetch from 'node-fetch';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Analytics, BuildEvent } from '../../../analytics/events';
 import { AndroidKeystoreType } from '../../../graphql/generated';
+import { KeystoreGenerationUrlMutation } from '../../../graphql/mutations/KeystoreGenerationUrlMutation';
 import Log from '../../../log';
+import { ora } from '../../../ora';
 import { getTmpDirectory } from '../../../utils/paths';
 import { KeystoreWithType } from '../credentials';
+
+interface KeystoreParams {
+  keystorePassword: string;
+  keyAlias: string;
+  keyPassword: string;
+}
 
 export async function keytoolCommandExistsAsync(): Promise<boolean> {
   try {
     await spawnAsync('keytool');
+    return true;
   } catch (error) {
     return false;
-  }
-  return true;
-}
-
-async function ensureKeytoolCommandExistsAsync(): Promise<void> {
-  if (!(await keytoolCommandExistsAsync())) {
-    Log.error('keytool is required to run this command, make sure you have it installed?');
-    Log.warn('keytool is a part of OpenJDK: https://openjdk.java.net/');
-    Log.warn('Also make sure that keytool is in your PATH after installation.');
-    throw new Error('keytool not found');
   }
 }
 
@@ -35,7 +39,7 @@ enum KeystoreCreateStep {
 }
 
 export async function generateRandomKeystoreAsync(projectId: string): Promise<KeystoreWithType> {
-  const keystoreData = {
+  const keystoreData: KeystoreParams = {
     keystorePassword: crypto.randomBytes(16).toString('hex'),
     keyPassword: crypto.randomBytes(16).toString('hex'),
     keyAlias: crypto.randomBytes(16).toString('hex'),
@@ -44,11 +48,7 @@ export async function generateRandomKeystoreAsync(projectId: string): Promise<Ke
 }
 
 async function createKeystoreAsync(
-  credentials: {
-    keystorePassword: string;
-    keyAlias: string;
-    keyPassword: string;
-  },
+  keystoreParams: KeystoreParams,
   projectId: string
 ): Promise<KeystoreWithType> {
   Analytics.logEvent(BuildEvent.ANDROID_KEYSTORE_CREATE, {
@@ -56,9 +56,28 @@ async function createKeystoreAsync(
     step: KeystoreCreateStep.Attempt,
     type: AndroidKeystoreType.Jks,
   });
-
   try {
-    await ensureKeytoolCommandExistsAsync();
+    let keystore: KeystoreWithType | undefined;
+    let localAttempt = false;
+    if (await keytoolCommandExistsAsync()) {
+      try {
+        localAttempt = true;
+        keystore = await createKeystoreLocallyAsync(keystoreParams);
+      } catch {
+        Log.error('Failed to generate keystore locally. Falling back to cloud generation.');
+      }
+    }
+    if (!keystore) {
+      keystore = await createKeystoreInCloudAsync(keystoreParams, {
+        showKeytoolDetectionMsg: !localAttempt,
+      });
+    }
+    Analytics.logEvent(BuildEvent.ANDROID_KEYSTORE_CREATE, {
+      project_id: projectId,
+      step: KeystoreCreateStep.Success,
+      type: AndroidKeystoreType.Jks,
+    });
+    return keystore;
   } catch (error: any) {
     Analytics.logEvent(BuildEvent.ANDROID_KEYSTORE_CREATE, {
       project_id: projectId,
@@ -68,7 +87,11 @@ async function createKeystoreAsync(
     });
     throw error;
   }
+}
 
+async function createKeystoreLocallyAsync(
+  keystoreParams: KeystoreParams
+): Promise<KeystoreWithType> {
   await fs.mkdirp(getTmpDirectory());
   const keystorePath = path.join(getTmpDirectory(), `${uuidv4()}-keystore.jks`);
   try {
@@ -78,13 +101,13 @@ async function createKeystoreAsync(
       '-storetype',
       'JKS',
       '-storepass',
-      credentials.keystorePassword,
+      keystoreParams.keystorePassword,
       '-keypass',
-      credentials.keyPassword,
+      keystoreParams.keyPassword,
       '-keystore',
       keystorePath,
       '-alias',
-      credentials.keyAlias,
+      keystoreParams.keyAlias,
       '-keyalg',
       'RSA',
       '-keysize',
@@ -94,27 +117,49 @@ async function createKeystoreAsync(
       '-dname',
       `CN=,OU=,O=,L=,S=,C=US`,
     ]);
-
-    Analytics.logEvent(BuildEvent.ANDROID_KEYSTORE_CREATE, {
-      project_id: projectId,
-      step: KeystoreCreateStep.Success,
-      type: AndroidKeystoreType.Jks,
-    });
-
     return {
-      ...credentials,
+      ...keystoreParams,
       keystore: await fs.readFile(keystorePath, 'base64'),
       type: AndroidKeystoreType.Jks,
     };
-  } catch (error: any) {
-    Analytics.logEvent(BuildEvent.ANDROID_KEYSTORE_CREATE, {
-      project_id: projectId,
-      step: KeystoreCreateStep.Fail,
-      reason: error.message,
-      type: AndroidKeystoreType.Jks,
-    });
-    throw error;
   } finally {
     await fs.remove(keystorePath);
+  }
+}
+
+interface KeystoreServiceResult {
+  keystoreBase64: string;
+  keystorePassword: string;
+  keyPassword: string;
+  keyAlias: string;
+}
+
+async function createKeystoreInCloudAsync(
+  keystoreParams: KeystoreParams,
+  { showKeytoolDetectionMsg = true } = {}
+): Promise<KeystoreWithType> {
+  if (showKeytoolDetectionMsg) {
+    Log.warn(`Detected that you do not have ${chalk.bold('keytool')} installed locally.`);
+  }
+  const spinner = ora('Generating keystore in the cloud...').start();
+  try {
+    const url = await KeystoreGenerationUrlMutation.createKeystoreGenerationUrlAsync();
+    const response = await fetch(url, {
+      method: 'POST',
+      body: JSON.stringify(keystoreParams),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const result: KeystoreServiceResult = await response.json();
+    spinner.succeed();
+    return {
+      type: AndroidKeystoreType.Jks,
+      keystore: result.keystoreBase64,
+      keystorePassword: result.keystorePassword,
+      keyAlias: result.keyAlias,
+      keyPassword: result.keyPassword,
+    };
+  } catch (err: any) {
+    spinner.fail();
+    throw err;
   }
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5028,6 +5028,20 @@ export type DeleteEnvironmentSecretMutation = (
   ) }
 );
 
+export type CreateKeystoreGenerationUrlMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type CreateKeystoreGenerationUrlMutation = (
+  { __typename?: 'RootMutation' }
+  & { keystoreGenerationUrl: (
+    { __typename?: 'KeystoreGenerationUrlMutation' }
+    & { createKeystoreGenerationUrl: (
+      { __typename?: 'KeystoreGenerationUrl' }
+      & Pick<KeystoreGenerationUrl, 'id' | 'url'>
+    ) }
+  ) }
+);
+
 export type GetSignedUploadMutationVariables = Exact<{
   contentTypes: Array<Scalars['String']>;
 }>;

--- a/packages/eas-cli/src/graphql/mutations/KeystoreGenerationUrlMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/KeystoreGenerationUrlMutation.ts
@@ -1,0 +1,26 @@
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { CreateKeystoreGenerationUrlMutation } from '../generated';
+
+export const KeystoreGenerationUrlMutation = {
+  async createKeystoreGenerationUrlAsync(): Promise<string> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateKeystoreGenerationUrlMutation>(
+          gql`
+            mutation CreateKeystoreGenerationUrlMutation {
+              keystoreGenerationUrl {
+                createKeystoreGenerationUrl {
+                  id
+                  url
+                }
+              }
+            }
+          `
+        )
+        .toPromise()
+    );
+    return data.keystoreGenerationUrl.createKeystoreGenerationUrl.url;
+  },
+};


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [ ] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

We built a keystore service so ppl don't need to install Java to generate keystores.

# How

Use keystore service if:
- keytool is not installed
- keytool failed to generate keystore

# Test Plan

Tested manually.