### PR TITLE
[eas-cli] Api -> API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Use same URL paths for local development of EAS CLI as production. ([#750](https://github.com/expo/eas-cli/pull/750) by [@ide](https://github.com/ide))
+- Grammar: Api -> API. ([#755](https://github.com/expo/eas-cli/pull/755) by [@quinlanj](https://github.com/quinlanj))
 
 ## [0.35.0](https://github.com/expo/eas-cli/releases/tag/v0.35.0) - 2021-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- Add ASC Api Key generation workflow. ([#718](https://github.com/expo/eas-cli/pull/718) by [@quinlanj](https://github.com/quinlanj))
-- Add support for removal of ASC Api Keys. ([#721](https://github.com/expo/eas-cli/pull/721) by [@quinlanj](https://github.com/quinlanj))
-- Allow users to assign an ASC Api Key to their project. ([#719](https://github.com/expo/eas-cli/pull/719) by [@quinlanj](https://github.com/quinlanj))
-- Add setup support for ASC Api Keys. ([#733](https://github.com/expo/eas-cli/pull/733) by [@quinlanj](https://github.com/quinlanj))
+- Add ASC API Key generation workflow. ([#718](https://github.com/expo/eas-cli/pull/718) by [@quinlanj](https://github.com/quinlanj))
+- Add support for removal of ASC API Keys. ([#721](https://github.com/expo/eas-cli/pull/721) by [@quinlanj](https://github.com/quinlanj))
+- Allow users to assign an ASC API Key to their project. ([#719](https://github.com/expo/eas-cli/pull/719) by [@quinlanj](https://github.com/quinlanj))
+- Add setup support for ASC API Keys. ([#733](https://github.com/expo/eas-cli/pull/733) by [@quinlanj](https://github.com/quinlanj))
 - Show initiating user display name when selecting a build to submit. ([#730](https://github.com/expo/eas-cli/pull/730) by [@barthap](https://github.com/barthap))
 - Handle Apple servers maintenance error in `eas submit`. ([#738](https://github.com/expo/eas-cli/pull/738) by [@barthap](https://github.com/barthap))
-- Integrate ASC Api Key with submissions workflow. ([#737](https://github.com/expo/eas-cli/pull/737) by [@quinlanj](https://github.com/quinlanj))
+- Integrate ASC API Key with submissions workflow. ([#737](https://github.com/expo/eas-cli/pull/737) by [@quinlanj](https://github.com/quinlanj))
 - Change EAS API server domain. ([#744](https://github.com/expo/eas-cli/pull/744) by [@ide](https://github.com/ide))
 - Only prompt for Apple Id username if authenticating with an App Specific Password. ([#745](https://github.com/expo/eas-cli/pull/745) by [@quinlanj](https://github.com/quinlanj))
 
@@ -46,7 +46,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Add App Store Connect Api Key graphql type and print support. ([#717](https://github.com/expo/eas-cli/pull/717) by [@quinlanj](https://github.com/quinlanj))
+- Add App Store Connect API Key graphql type and print support. ([#717](https://github.com/expo/eas-cli/pull/717) by [@quinlanj](https://github.com/quinlanj))
 
 ## [0.34.0](https://github.com/expo/eas-cli/releases/tag/v0.34.0) - 2021-11-01
 
@@ -107,7 +107,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- Add App Store Connect Api Key support to iOS submissions. ([#678](https://github.com/expo/eas-cli/pull/678) by [@quinlanj](https://github.com/quinlanj))
+- Add App Store Connect API Key support to iOS submissions. ([#678](https://github.com/expo/eas-cli/pull/678) by [@quinlanj](https://github.com/quinlanj))
 - Create/list/revoke App Store Connect Api keys via Apple apis. ([#687](https://github.com/expo/eas-cli/pull/687) by [@quinlanj](https://github.com/quinlanj))
 - Add ability to select a build from a list in `eas submit` interactive mode. ([#688](https://github.com/expo/eas-cli/pull/688) by [@barthap](https://github.com/barthap))
 
@@ -117,7 +117,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Add App Store Connect Api Key fields to `eas.json`. ([#684](https://github.com/expo/eas-cli/pull/684) by [@quinlanj](https://github.com/quinlanj))
+- Add App Store Connect API Key fields to `eas.json`. ([#684](https://github.com/expo/eas-cli/pull/684) by [@quinlanj](https://github.com/quinlanj))
 - Enable no-underscore-dangle eslint rule. ([#686](https://github.com/expo/eas-cli/pull/686) by [@dsokal](https://github.com/dsokal))
 
 ## [0.31.1](https://github.com/expo/eas-cli/releases/tag/v0.31.1) - 2021-10-08

--- a/packages/eas-cli/src/credentials/android/actions/RemoveFcm.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveFcm.ts
@@ -9,7 +9,7 @@ export class RemoveFcm {
   async runAsync(ctx: CredentialsContext): Promise<void> {
     if (ctx.nonInteractive) {
       throw new Error(
-        "Deleting an FCM Api Key is a destructive operation. Start the CLI without the '--non-interactive' flag to delete the credentials."
+        "Deleting an FCM API Key is a destructive operation. Start the CLI without the '--non-interactive' flag to delete the credentials."
       );
     }
     const appCredentials = await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(
@@ -18,7 +18,7 @@ export class RemoveFcm {
     const fcm = appCredentials?.androidFcm;
     if (!fcm) {
       Log.warn(
-        `There is no valid FCM Api Key defined for ${formatProjectFullName(this.app)}, ${
+        `There is no valid FCM API Key defined for ${formatProjectFullName(this.app)}, ${
           this.app.androidApplicationIdentifier
         }`
       );
@@ -26,7 +26,7 @@ export class RemoveFcm {
     }
 
     const confirm = await confirmAsync({
-      message: 'Permanently delete the FCM Api Key from Expo servers?',
+      message: 'Permanently delete the FCM API Key from Expo servers?',
       initial: false,
     });
     if (!confirm) {
@@ -34,6 +34,6 @@ export class RemoveFcm {
     }
 
     await ctx.android.deleteFcmAsync(fcm);
-    Log.succeed('FCM Api Key removed');
+    Log.succeed('FCM API Key removed');
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveFcm-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/RemoveFcm-test.ts
@@ -12,7 +12,7 @@ jest.mock('../../../../prompts');
 asMock(confirmAsync).mockImplementation(() => true);
 
 describe(RemoveFcm, () => {
-  it('removes an FCM Api Key', async () => {
+  it('removes an FCM API Key', async () => {
     const ctx = createCtxMock({
       nonInteractive: false,
       android: {

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -64,7 +64,7 @@ export async function provideOrGenerateAscApiKeyAsync(
   purpose: AppStoreApiKeyPurpose
 ): Promise<MinimalAscApiKey> {
   if (ctx.nonInteractive) {
-    return await generateAscApiKeyAsync(ctx, purpose);
+    throw new Error(`A new App Store Connect API Key cannot be created in non-interactive mode.`);
   }
 
   const userProvided = await promptForAscApiKeyAsync(ctx);
@@ -73,7 +73,7 @@ export async function provideOrGenerateAscApiKeyAsync(
   }
 
   if (!ctx.appStore.authCtx) {
-    Log.warn('Unable to validate App Store Connect Api Key, you are not authenticated with Apple.');
+    Log.warn('Unable to validate App Store Connect API Key, you are not authenticated with Apple.');
     return userProvided;
   }
 
@@ -82,7 +82,7 @@ export async function provideOrGenerateAscApiKeyAsync(
     return userProvided;
   }
   const useUserProvided = await confirmAsync({
-    message: `App Store Connect Api Key with ID ${userProvided.keyId} is not valid on Apple's servers. Proceed anyway?`,
+    message: `App Store Connect API Key with ID ${userProvided.keyId} is not valid on Apple's servers. Proceed anyway?`,
   });
   if (useUserProvided) {
     return userProvided;
@@ -94,6 +94,7 @@ async function generateAscApiKeyAsync(
   ctx: CredentialsContext,
   purpose: AppStoreApiKeyPurpose
 ): Promise<MinimalAscApiKey> {
+  //console.log('debug');
   await ctx.appStore.ensureAuthenticatedAsync();
   const ascApiKey = await ctx.appStore.createAscApiKeyAsync({
     nickname: getAscApiKeyName(purpose),
@@ -129,7 +130,7 @@ async function promptForKeyP8AndIdAsync(): Promise<Pick<AscApiKeyPath, 'keyP8Pat
   const { keyP8Path } = await promptAsync({
     type: 'text',
     name: 'keyP8Path',
-    message: 'Path to App Store Connect Api Key:',
+    message: 'Path to App Store Connect API Key:',
     initial: 'AuthKey_ABCD.p8',
     // eslint-disable-next-line async-protect/async-suffix
     validate: async (filePath: string) => {
@@ -189,12 +190,12 @@ export async function selectAscApiKeysFromAccountAsync(
     if (filterDifferentAppleTeam) {
       const maybeAppleTeamId = ctx.appStore.authCtx?.team.id;
       Log.warn(
-        `There are no App Store Connect Api Keys in your EAS account${
+        `There are no App Store Connect API Keys in your EAS account${
           maybeAppleTeamId ? ` matching Apple Team ID: ${maybeAppleTeamId}.` : '.'
         }`
       );
     } else {
-      Log.warn(`There are no App Store Connect Api Keys available in your EAS account.`);
+      Log.warn(`There are no App Store Connect API Keys available in your EAS account.`);
     }
     return null;
   }
@@ -208,7 +209,7 @@ async function selectAscApiKeysAsync(
   const { chosenAscApiKey } = await promptAsync({
     type: 'select',
     name: 'chosenAscApiKey',
-    message: 'Select an Api Key from the list:',
+    message: 'Select an API Key from the list:',
     choices: sortedAscApiKeys.map(ascApiKey => ({
       title: formatAscApiKey(ascApiKey),
       value: ascApiKey,

--- a/packages/eas-cli/src/credentials/ios/actions/AssignAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AssignAscApiKey.ts
@@ -31,7 +31,7 @@ export class AssignAscApiKey {
       throw new Error(`${purpose} is not yet supported.`);
     }
     Log.succeed(
-      `App Store Connect Api Key assigned to ${this.app.projectName}: ${this.app.bundleIdentifier} for ${purpose}.`
+      `App Store Connect API Key assigned to ${this.app.projectName}: ${this.app.bundleIdentifier} for ${purpose}.`
     );
     return updatedAppCredentials;
   }

--- a/packages/eas-cli/src/credentials/ios/actions/CreateAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateAscApiKey.ts
@@ -12,12 +12,12 @@ export class CreateAscApiKey {
     purpose: AppStoreApiKeyPurpose
   ): Promise<AppStoreConnectApiKeyFragment> {
     if (ctx.nonInteractive) {
-      throw new Error(`A new App Store Connect Api Key cannot be created in non-interactive mode.`);
+      throw new Error(`A new App Store Connect API Key cannot be created in non-interactive mode.`);
     }
 
     const ascApiKey = await provideOrGenerateAscApiKeyAsync(ctx, purpose);
     const result = await ctx.ios.createAscApiKeyAsync(this.account, ascApiKey);
-    Log.succeed('Created App Store Connect Api Key');
+    Log.succeed('Created App Store Connect API Key');
     return result;
   }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/RemoveAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemoveAscApiKey.ts
@@ -12,7 +12,7 @@ export class SelectAndRemoveAscApiKey {
     const selected = await selectAscApiKeysFromAccountAsync(ctx, this.account);
     if (selected) {
       await new RemoveAscApiKey(this.account, selected).runAsync(ctx);
-      Log.succeed('Removed App Store Connect Api Key');
+      Log.succeed('Removed App Store Connect API Key');
       Log.newLine();
     }
   }
@@ -23,28 +23,28 @@ export class RemoveAscApiKey {
 
   public async runAsync(ctx: CredentialsContext): Promise<void> {
     if (ctx.nonInteractive) {
-      throw new Error(`Cannot remove App Store Connect Api Keys in non-interactive mode.`);
+      throw new Error(`Cannot remove App Store Connect API Keys in non-interactive mode.`);
     }
 
     // TODO(quin): add an extra edge on AppStoreConnectApiKey to find the apps using it
     const confirm = await confirmAsync({
-      message: `Deleting this Api Key may affect your projects that rely on it. Do you want to continue?`,
+      message: `Deleting this API Key may affect your projects that rely on it. Do you want to continue?`,
     });
     if (!confirm) {
       Log.log('Aborting');
       return;
     }
 
-    Log.log('Removing Api Key');
+    Log.log('Removing API Key');
     await ctx.ios.deleteAscApiKeyAsync(this.ascApiKey.id);
 
     let shouldRevoke = false;
     if (!ctx.nonInteractive) {
       shouldRevoke = await confirmAsync({
-        message: `Do you also want to revoke this Api Key on the Apple Developer Portal?`,
+        message: `Do you also want to revoke this API Key on the Apple Developer Portal?`,
       });
     } else if (ctx.nonInteractive) {
-      Log.log('Skipping Api Key revocation on the Apple Developer Portal.');
+      Log.log('Skipping API Key revocation on the Apple Developer Portal.');
     }
     if (shouldRevoke) {
       await ctx.appStore.revokeAscApiKeyAsync(this.ascApiKey.keyIdentifier);

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpAscApiKey.ts
@@ -31,10 +31,10 @@ export enum SetupAscApiKeyChoice {
 export class SetUpAscApiKey {
   public choices: { title: string; value: string }[] = [
     {
-      title: '[Choose an existing ASC Api Key]',
+      title: '[Choose an existing ASC API Key]',
       value: SetupAscApiKeyChoice.USE_EXISTING,
     },
-    { title: '[Add a new ASC Api Key]', value: SetupAscApiKeyChoice.GENERATE },
+    { title: '[Add a new ASC API Key]', value: SetupAscApiKeyChoice.GENERATE },
   ];
 
   constructor(private app: AppLookupParams, private purpose: AppStoreApiKeyPurpose) {}
@@ -42,15 +42,15 @@ export class SetUpAscApiKey {
   public async runAsync(ctx: CredentialsContext): Promise<CommonIosAppCredentialsFragment> {
     const isKeySetup = await this.isAscApiKeySetupAsync(ctx, this.purpose);
     if (isKeySetup) {
-      Log.succeed('App Store Connect Api Key already set up.');
+      Log.succeed('App Store Connect API Key already set up.');
       return nullthrows(
         await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(this.app),
-        'iosAppCredentials cannot be null if App Store Connect Api Key is already set up'
+        'iosAppCredentials cannot be null if App Store Connect API Key is already set up'
       );
     }
     if (ctx.nonInteractive) {
       throw new MissingCredentialsNonInteractiveError(
-        'App Store Connect Api Keys cannot be set up in --non-interactive mode.'
+        'App Store Connect API Keys cannot be set up in --non-interactive mode.'
       );
     }
 
@@ -88,11 +88,11 @@ export class SetUpAscApiKey {
     }
     const [autoselectedKey] = sortAscApiKeysByUpdatedAtDesc(validKeys);
     const useAutoselected = await confirmAsync({
-      message: `Reuse this App Store Connect Api Key?\n${formatAscApiKey(autoselectedKey)}`,
+      message: `Reuse this App Store Connect API Key?\n${formatAscApiKey(autoselectedKey)}`,
     });
 
     if (useAutoselected) {
-      Log.log(`Using App Store Connect Api Key with ID ${autoselectedKey.keyIdentifier}`);
+      Log.log(`Using App Store Connect API Key with ID ${autoselectedKey.keyIdentifier}`);
       return autoselectedKey;
     } else {
       return null;
@@ -105,7 +105,7 @@ export class SetUpAscApiKey {
   ): Promise<boolean> {
     const appCredentials = await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(this.app);
     if (purpose !== AppStoreApiKeyPurpose.SUBMISSION_SERVICE) {
-      throw new Error(`App Store Connect Api Key setup is not yet supported for ${purpose}.`);
+      throw new Error(`App Store Connect API Key setup is not yet supported for ${purpose}.`);
     }
     return !!appCredentials?.appStoreConnectApiKeyForSubmissions;
   }

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpSubmissionCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpSubmissionCredentials.ts
@@ -18,7 +18,7 @@ export class SetUpSubmissionCredentials {
 
   constructor(app: AppLookupParams) {
     this.setupAscApiKeyAction = new SetUpAscApiKey(app, AppStoreApiKeyPurpose.SUBMISSION_SERVICE);
-    // Add this unrelated choice to ASC Api Key setup for legacy purposes -- we will deprecate it soon
+    // Add this unrelated choice to ASC API Key setup for legacy purposes -- we will deprecate it soon
     this.setupAscApiKeyAction.choices = this.setupAscApiKeyAction.choices.concat({
       title: '[Enter an App Specific Password]',
       value: PROMPT_FOR_APP_SPECIFIC_PASSWORD,
@@ -32,9 +32,9 @@ export class SetUpSubmissionCredentials {
       const iosAppCredentials = await this.setupAscApiKeyAction.runAsync(ctx);
       const { keyIdentifier, name } = nullthrows(
         iosAppCredentials.appStoreConnectApiKeyForSubmissions,
-        'ASC Api Key must be defined for EAS Submit'
+        'ASC API Key must be defined for EAS Submit'
       );
-      Log.log(`Using Api Key ID: ${keyIdentifier}${name ? ` (${name})` : ''}`);
+      Log.log(`Using API Key ID: ${keyIdentifier}${name ? ` (${name})` : ''}`);
       return iosAppCredentials;
     } catch (e) {
       if (e instanceof UnsupportedCredentialsChoiceError) {

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/AssignAscApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/AssignAscApiKey-test.ts
@@ -6,7 +6,7 @@ import { AssignAscApiKey } from '../AssignAscApiKey';
 import { getAppLookupParamsFromContext } from '../BuildCredentialsUtils';
 
 describe(AssignAscApiKey, () => {
-  it('assigns an App Store Connect Api Key in Interactive Mode for EAS Submit', async () => {
+  it('assigns an App Store Connect API Key in Interactive Mode for EAS Submit', async () => {
     const ctx = createCtxMock({
       nonInteractive: false,
     });

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateAscApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateAscApiKey-test.ts
@@ -12,7 +12,7 @@ jest.mock('../../../../prompts');
 asMock(confirmAsync).mockImplementation(() => true);
 
 describe(CreateAscApiKey, () => {
-  it('creates a App Store Api Key in Interactive Mode', async () => {
+  it('creates a App Store API Key in Interactive Mode', async () => {
     const ctx = createCtxMock({
       nonInteractive: false,
       appStore: {

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/RemoveAscApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/RemoveAscApiKey-test.ts
@@ -10,7 +10,7 @@ jest.mock('../../../../prompts');
 asMock(confirmAsync).mockImplementation(() => true);
 
 describe(RemoveAscApiKey, () => {
-  it('removes an Asc Api Key', async () => {
+  it('removes an Asc API Key', async () => {
     const ctx = createCtxMock({ nonInteractive: false });
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const removeAscApiKeyAction = new RemoveAscApiKey(

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAscApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAscApiKey-test.ts
@@ -18,7 +18,7 @@ jest.mock('../../../../prompts');
 asMock(confirmAsync).mockImplementation(() => true);
 
 describe(SetUpAscApiKey, () => {
-  it('skips setting up a ASC Api Key if it is already configured', async () => {
+  it('skips setting up a ASC API Key if it is already configured', async () => {
     const ctx = createCtxMock({
       nonInteractive: false,
       ios: {
@@ -35,12 +35,12 @@ describe(SetUpAscApiKey, () => {
     );
     await setupAscApiKeyAction.runAsync(ctx);
 
-    // expect not to create a new ASC Api Key on expo servers
+    // expect not to create a new ASC API Key on expo servers
     expect(asMock(ctx.ios.createAscApiKeyAsync).mock.calls.length).toBe(0);
-    // expect configuration not to be updated with a new ASC Api Key
+    // expect configuration not to be updated with a new ASC API Key
     expect(asMock(ctx.ios.updateIosAppCredentialsAsync).mock.calls.length).toBe(0);
   });
-  it('sets up a ASC Api Key, creating a new one if there are no existing ASC Api Keys', async () => {
+  it('sets up a ASC API Key, creating a new one if there are no existing ASC API Keys', async () => {
     const ctx = createCtxMock({
       nonInteractive: false,
       appStore: {
@@ -60,12 +60,12 @@ describe(SetUpAscApiKey, () => {
     );
     await setupAscApiKeyAction.runAsync(ctx);
 
-    // expect to create a new ASC Api Key on expo servers
+    // expect to create a new ASC API Key on expo servers
     expect(asMock(ctx.ios.createAscApiKeyAsync).mock.calls.length).toBe(1);
-    // expect configuration to be updated with a new ASC Api Key
+    // expect configuration to be updated with a new ASC API Key
     expect(asMock(ctx.ios.updateIosAppCredentialsAsync).mock.calls.length).toBe(1);
   });
-  it('sets up a ASC Api Key, use autoselected ASC Api Key when there are existing keys', async () => {
+  it('sets up a ASC API Key, use autoselected ASC API Key when there are existing keys', async () => {
     const ctx = createCtxMock({
       nonInteractive: false,
       appStore: {
@@ -86,12 +86,12 @@ describe(SetUpAscApiKey, () => {
     );
     await setupAscApiKeyAction.runAsync(ctx);
 
-    // expect not to create a new ASC Api Key on expo servers, we are using the existing one
+    // expect not to create a new ASC API Key on expo servers, we are using the existing one
     expect(asMock(ctx.ios.createAscApiKeyAsync).mock.calls.length).toBe(0);
-    // expect configuration to be updated with a new ASC Api Key
+    // expect configuration to be updated with a new ASC API Key
     expect(asMock(ctx.ios.updateIosAppCredentialsAsync).mock.calls.length).toBe(1);
   });
-  it('sets up a ASC Api Key, allowing user to choose existing keys', async () => {
+  it('sets up a ASC API Key, allowing user to choose existing keys', async () => {
     const ctx = createCtxMock({
       nonInteractive: false,
       ios: {
@@ -110,9 +110,9 @@ describe(SetUpAscApiKey, () => {
     );
     await setupAscApiKeyAction.runAsync(ctx);
 
-    // expect not to create a new ASC Api Key on expo servers, we are using the existing one
+    // expect not to create a new ASC API Key on expo servers, we are using the existing one
     expect(asMock(ctx.ios.createAscApiKeyAsync).mock.calls.length).toBe(0);
-    // expect configuration to be updated with a new ASC Api Key
+    // expect configuration to be updated with a new ASC API Key
     expect(asMock(ctx.ios.updateIosAppCredentialsAsync).mock.calls.length).toBe(1);
   });
   it('works in Non Interactive Mode if ASC Key is configured', async () => {

--- a/packages/eas-cli/src/credentials/ios/appstore/ascApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ascApiKey.ts
@@ -6,14 +6,14 @@ import { AscApiKey, AscApiKeyInfo } from './Credentials.types';
 import { AuthCtx, getRequestContext } from './authenticate';
 
 export async function listAscApiKeysAsync(authCtx: AuthCtx): Promise<AscApiKeyInfo[]> {
-  const spinner = ora(`Fetching App Store Connect Api Keys.`).start();
+  const spinner = ora(`Fetching App Store Connect API Keys.`).start();
   try {
     const context = getRequestContext(authCtx);
     const keys = await ApiKey.getAsync(context);
-    spinner.succeed(`Fetched App Store Connect Api Keys.`);
+    spinner.succeed(`Fetched App Store Connect API Keys.`);
     return keys.map(key => getAscApiKeyInfo(key, authCtx));
   } catch (error) {
-    spinner.fail(`Failed to fetch App Store Connect Api Keys.`);
+    spinner.fail(`Failed to fetch App Store Connect API Keys.`);
     throw error;
   }
 }
@@ -22,11 +22,11 @@ export async function getAscApiKeyAsync(
   authCtx: AuthCtx,
   keyId: string
 ): Promise<AscApiKeyInfo | null> {
-  const spinner = ora(`Fetching App Store Connect Api Key.`).start();
+  const spinner = ora(`Fetching App Store Connect API Key.`).start();
   try {
     const context = getRequestContext(authCtx);
     const apiKey = await ApiKey.infoAsync(context, { id: keyId });
-    spinner.succeed(`Fetched App Store Connect Api Key (ID: ${keyId}).`);
+    spinner.succeed(`Fetched App Store Connect API Key (ID: ${keyId}).`);
     return getAscApiKeyInfo(apiKey, authCtx);
   } catch (error: any) {
     const message = error?.message ?? '';
@@ -35,7 +35,7 @@ export async function getAscApiKeyAsync(
       return null;
     }
     Log.error(error);
-    spinner.fail(`Failed to fetch App Store Connect Api Key.`);
+    spinner.fail(`Failed to fetch App Store Connect API Key.`);
     throw error;
   }
 }
@@ -49,7 +49,7 @@ export async function createAscApiKeyAsync(
     keyType,
   }: Partial<Pick<ApiKeyProps, 'nickname' | 'roles' | 'allAppsVisible' | 'keyType'>>
 ): Promise<AscApiKey> {
-  const spinner = ora(`Creating App Store Connect Api Key.`).start();
+  const spinner = ora(`Creating App Store Connect API Key.`).start();
   try {
     const context = getRequestContext(authCtx);
     const key = await ApiKey.createAsync(context, {
@@ -74,13 +74,13 @@ export async function createAscApiKeyAsync(
     }
     // this object has more optional parameters populated
     const fullKey = await ApiKey.infoAsync(context, { id: key.id });
-    spinner.succeed(`Created App Store Connect Api Key.`);
+    spinner.succeed(`Created App Store Connect API Key.`);
     return {
       ...getAscApiKeyInfo(fullKey, authCtx),
       keyP8,
     };
   } catch (err: any) {
-    spinner.fail('Failed to create App Store Connect Api Key.');
+    spinner.fail('Failed to create App Store Connect API Key.');
     throw err;
   }
 }
@@ -89,16 +89,16 @@ export async function revokeAscApiKeyAsync(
   authCtx: AuthCtx,
   keyId: string
 ): Promise<AscApiKeyInfo> {
-  const spinner = ora(`Revoking App Store Connect Api Key.`).start();
+  const spinner = ora(`Revoking App Store Connect API Key.`).start();
   try {
     const context = getRequestContext(authCtx);
     const apiKey = await ApiKey.infoAsync(context, { id: keyId });
     const revokedKey = await apiKey.revokeAsync();
-    spinner.succeed(`Revoked App Store Connect Api Key.`);
+    spinner.succeed(`Revoked App Store Connect API Key.`);
     return getAscApiKeyInfo(revokedKey, authCtx);
   } catch (error) {
     Log.error(error);
-    spinner.fail(`Failed to revoke App Store Connect Api Key.`);
+    spinner.fail(`Failed to revoke App Store Connect API Key.`);
     throw error;
   }
 }

--- a/packages/eas-cli/src/credentials/ios/credentials.ts
+++ b/packages/eas-cli/src/credentials/ios/credentials.ts
@@ -119,7 +119,7 @@ export interface AscApiKeyPath {
 }
 
 export const ascApiKeyIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'keyId'>> = {
-  name: 'App Store Connect Api Key',
+  name: 'App Store Connect API Key',
   questions: [
     {
       field: 'keyId',
@@ -130,7 +130,7 @@ export const ascApiKeyIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'keyId'>
 };
 
 export const ascApiKeyIssuerIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'issuerId'>> = {
-  name: 'App Store Connect Api Key',
+  name: 'App Store Connect API Key',
   questions: [
     {
       field: 'issuerId',

--- a/packages/eas-cli/src/credentials/ios/utils/__tests__/__snapshots__/printCredentials-test.ts.snap
+++ b/packages/eas-cli/src/credentials/ios/utils/__tests__/__snapshots__/printCredentials-test.ts.snap
@@ -12,7 +12,7 @@ Developer Portal ID        9839M6AY8W
 Apple Team                 77KQ969CHE 
 Updated                    6 months ago
                            
-App Store Connect Api Key  
+App Store Connect API Key  
 Developer Portal ID        NYN468XNN3
 Name                       Expo Submissions pl94k8_lnS
 Issuer ID                  69a6de93-e4e4-47e3-e053-5b8c7c11a4d1

--- a/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
@@ -239,7 +239,7 @@ function displayAscApiKey(
   maybeAscApiKey: AppStoreConnectApiKeyFragment | null,
   fields: { label: string; value: string }[]
 ): void {
-  fields.push({ label: 'App Store Connect Api Key', value: '' });
+  fields.push({ label: 'App Store Connect API Key', value: '' });
   if (maybeAscApiKey) {
     const { keyIdentifier, issuerIdentifier, appleTeam, name, roles, updatedAt } = maybeAscApiKey;
     fields.push({ label: 'Developer Portal ID', value: keyIdentifier });

--- a/packages/eas-cli/src/credentials/manager/AndroidActions.ts
+++ b/packages/eas-cli/src/credentials/manager/AndroidActions.ts
@@ -8,7 +8,7 @@ export const highLevelActions: ActionInfo[] = [
   },
   {
     value: AndroidActionType.ManageFcm,
-    title: 'Push Notifications: Manage your FCM Api Key',
+    title: 'Push Notifications: Manage your FCM API Key',
     scope: Scope.Manager,
   },
   {
@@ -72,12 +72,12 @@ export const buildCredentialsActions: ActionInfo[] = [
 export const fcmActions: ActionInfo[] = [
   {
     value: AndroidActionType.CreateFcm,
-    title: 'Upload an FCM Api Key',
+    title: 'Upload an FCM API Key',
     scope: Scope.Project,
   },
   {
     value: AndroidActionType.RemoveFcm,
-    title: 'Delete your FCM Api Key',
+    title: 'Delete your FCM API Key',
     scope: Scope.Project,
   },
   {

--- a/packages/eas-cli/src/credentials/manager/IosActions.ts
+++ b/packages/eas-cli/src/credentials/manager/IosActions.ts
@@ -14,7 +14,7 @@ export const highLevelActions: ActionInfo[] = [
   },
   {
     value: IosActionType.ManageAscApiKey,
-    title: 'App Store Connect: Manage your Api Key',
+    title: 'App Store Connect: Manage your API Key',
     scope: Scope.Manager,
   },
   {
@@ -81,22 +81,22 @@ export function getAscApiKeyActions(ctx: CredentialsContext): ActionInfo[] {
   return [
     {
       value: IosActionType.SetUpAscApiKeyForSubmissions,
-      title: 'Set up your project to use an Api Key for EAS Submit',
+      title: 'Set up your project to use an API Key for EAS Submit',
       scope: Scope.Project,
     },
     {
       value: IosActionType.UseExistingAscApiKeyForSubmissions,
-      title: 'Use an existing Api Key for EAS Submit',
+      title: 'Use an existing API Key for EAS Submit',
       scope: Scope.Project,
     },
     {
       value: IosActionType.CreateAscApiKeyForSubmissions,
-      title: 'Add a new Api Key For EAS Submit',
+      title: 'Add a new API Key For EAS Submit',
       scope: ctx.hasProjectContext ? Scope.Project : Scope.Account,
     },
     {
       value: IosActionType.RemoveAscApiKey,
-      title: 'Delete an Api Key',
+      title: 'Delete an API Key',
       scope: Scope.Account,
     },
     {

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -363,7 +363,7 @@ export class ManageIos {
           AppStoreApiKeyPurpose.SUBMISSION_SERVICE
         );
         const confirm = await confirmAsync({
-          message: `Do you want ${appLookupParams.projectName} to use the new Api Key?`,
+          message: `Do you want ${appLookupParams.projectName} to use the new API Key?`,
         });
         if (confirm) {
           await new AssignAscApiKey(appLookupParams).runAsync(

--- a/packages/eas-cli/src/submit/ios/CredentialsServiceSource.ts
+++ b/packages/eas-cli/src/submit/ios/CredentialsServiceSource.ts
@@ -13,7 +13,7 @@ import {
 import { AscApiKeyResult } from './AscApiKeySource';
 
 /**
- * The Credentials Service will either return an ASC Api Key or an App Specific Password
+ * The Credentials Service will either return an ASC API Key or an App Specific Password
  * When we no longer support the App Specific Password user prompt, refactor this into the AscApiKeySource
  */
 export const CREDENTIALS_SERVICE_SOURCE = 'CREDENTIALS_SERVICE_SOURCE';
@@ -48,7 +48,7 @@ export async function getFromCredentialsServiceAsync(
   } else {
     const ascKeyForSubmissions = nullthrows(
       ascOrAsp.appStoreConnectApiKeyForSubmissions,
-      `An EAS Submit ASC Api Key could not be found for ${ascOrAsp.appleAppIdentifier.bundleIdentifier}`
+      `An EAS Submit ASC API Key could not be found for ${ascOrAsp.appleAppIdentifier.bundleIdentifier}`
     );
     const { id, keyIdentifier, name } = ascKeyForSubmissions;
     return {

--- a/packages/eas-cli/src/submit/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitter.ts
@@ -162,7 +162,7 @@ const SummaryHumanReadableKeys: Record<keyof SummaryData, string> = {
   archiveUrl: 'Archive URL',
   archivePath: 'Archive Path',
   formattedBuild: 'Build',
-  formattedAscApiKey: 'App Store Connect Api Key',
+  formattedAscApiKey: 'App Store Connect API Key',
 };
 
 function formatAscApiKeySummary({ summary }: AscApiKeyResult): string {

--- a/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
@@ -168,7 +168,7 @@ describe(getAscApiKeyPathAsync, () => {
 });
 
 describe(getAscApiKeyLocallyAsync, () => {
-  it('returns a local Asc Api Key file with a AscApiKeySourceType.path source', async () => {
+  it('returns a local Asc API Key file with a AscApiKeySourceType.path source', async () => {
     const ctx = await getIosSubmissionContextAsync();
     const source: AscApiKeySource = {
       sourceType: AscApiKeySourceType.path,
@@ -189,7 +189,7 @@ describe(getAscApiKeyLocallyAsync, () => {
     });
   });
 
-  it('returns a local Asc Api Key file with a AscApiKeySourceType.prompt source', async () => {
+  it('returns a local Asc API Key file with a AscApiKeySourceType.prompt source', async () => {
     asMock(promptAsync).mockImplementationOnce(() => ({
       keyP8Path: '/asc-api-key.p8',
     }));

--- a/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
@@ -62,7 +62,7 @@ describe(getFromCredentialsServiceAsync, () => {
       appSpecificPassword: { password: 'super secret', appleIdUsername: 'quin@expo.io' },
     });
   });
-  it('returns an ASC Api Key from the credentialService source', async () => {
+  it('returns an ASC API Key from the credentialService source', async () => {
     const ctx = await createSubmissionContextAsync({
       platform: Platform.IOS,
       projectDir: testProject.projectRoot,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

GA nits: When shown to the user, we should display `API`. Whereas as part of variable naming, we should use `Api`.

# Test Plan

- [ ] tests still pass
