### PR TITLE
[eas-cli] add analytic attempt events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Use same URL paths for local development of EAS CLI as production. ([#750](https://github.com/expo/eas-cli/pull/750) by [@ide](https://github.com/ide))
 - Grammar: Api -> API. ([#755](https://github.com/expo/eas-cli/pull/755) by [@quinlanj](https://github.com/quinlanj))
+- Add an 'attempt' event to build and submit analytics. ([#757](https://github.com/expo/eas-cli/pull/757) by [@quinlanj](https://github.com/quinlanj))
 
 ## [0.35.0](https://github.com/expo/eas-cli/releases/tag/v0.35.0) - 2021-11-08
 

--- a/packages/eas-cli/src/analytics/common.ts
+++ b/packages/eas-cli/src/analytics/common.ts
@@ -5,6 +5,7 @@ export type TrackingContext = Record<string, string | number | boolean>;
 export async function withAnalyticsAsync<Result>(
   fn: () => Promise<Result>,
   analytics: {
+    attemptEvent: Event;
     successEvent: Event;
     failureEvent: Event;
     trackingCtx: TrackingContext;

--- a/packages/eas-cli/src/analytics/events.ts
+++ b/packages/eas-cli/src/analytics/events.ts
@@ -3,32 +3,42 @@ export type Event = BuildEvent | SubmissionEvent;
 
 export enum SubmissionEvent {
   SUBMIT_COMMAND = 'submit cli submit command',
+  SUBMIT_COMMAND_ATTEMPT = 'submit cli attempt',
   SUBMIT_COMMAND_SUCCESS = 'submit cli success',
   SUBMIT_COMMAND_FAIL = 'submit cli fail',
+  GATHER_CREDENTIALS_ATTEMPT = 'submit cli gather credentials attempt',
   GATHER_CREDENTIALS_SUCCESS = 'submit cli gather credentials success',
   GATHER_CREDENTIALS_FAIL = 'submit cli gather credentials fail',
+  GATHER_ARCHIVE_ATTEMPT = 'submit cli gather archive attempt',
   GATHER_ARCHIVE_SUCCESS = 'submit cli gather archive success',
   GATHER_ARCHIVE_FAIL = 'submit cli gather archive fail',
+  SUBMIT_REQUEST_ATTEMPT = 'submit cli request attempt',
   SUBMIT_REQUEST_SUCCESS = 'submit cli request success',
   SUBMIT_REQUEST_FAIL = 'submit cli request fail',
 }
 
 export enum BuildEvent {
   BUILD_COMMAND = 'build cli build command',
+  PROJECT_UPLOAD_ATTEMPT = 'build cli project upload attempt',
   PROJECT_UPLOAD_SUCCESS = 'build cli project upload success',
   PROJECT_UPLOAD_FAIL = 'build cli project upload fail',
+  GATHER_CREDENTIALS_ATTEMPT = 'build cli gather credentials attempt',
   GATHER_CREDENTIALS_SUCCESS = 'build cli gather credentials success',
   GATHER_CREDENTIALS_FAIL = 'build cli gather credentials fail',
+  CONFIGURE_PROJECT_ATTEMPT = 'build cli configure project attempt',
   CONFIGURE_PROJECT_SUCCESS = 'build cli configure project success',
   CONFIGURE_PROJECT_FAIL = 'build cli configure project fail',
+  BUILD_REQUEST_ATTEMPT = 'build cli build request attempt',
   BUILD_REQUEST_SUCCESS = 'build cli build request success',
   BUILD_REQUEST_FAIL = 'build cli build request fail',
 
   BUILD_STATUS_COMMAND = 'build cli build status',
 
   CREDENTIALS_SYNC_COMMAND = 'build cli credentials sync command',
+  CREDENTIALS_SYNC_UPDATE_LOCAL_ATTEMPT = 'build cli credentials sync update local attempt',
   CREDENTIALS_SYNC_UPDATE_LOCAL_SUCCESS = 'build cli credentials sync update local success',
   CREDENTIALS_SYNC_UPDATE_LOCAL_FAIL = 'build cli credentials sync update local fail',
+  CREDENTIALS_SYNC_UPDATE_REMOTE_ATTEMPT = 'build cli credentials sync update remote attempt',
   CREDENTIALS_SYNC_UPDATE_REMOTE_SUCCESS = 'build cli credentials sync update remote success',
   CREDENTIALS_SYNC_UPDATE_REMOTE_FAIL = 'build cli credentials sync update remote fail',
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -55,6 +55,7 @@ export async function prepareBuildRequestForPlatformAsync<
   const credentialsResult = await withAnalyticsAsync(
     async () => await builder.ensureCredentialsAsync(ctx),
     {
+      attemptEvent: BuildEvent.GATHER_CREDENTIALS_ATTEMPT,
       successEvent: BuildEvent.GATHER_CREDENTIALS_SUCCESS,
       failureEvent: BuildEvent.GATHER_CREDENTIALS_FAIL,
       trackingCtx: ctx.trackingCtx,
@@ -62,6 +63,7 @@ export async function prepareBuildRequestForPlatformAsync<
   );
   if (!ctx.skipProjectConfiguration) {
     await withAnalyticsAsync(async () => await builder.ensureProjectConfiguredAsync(ctx), {
+      attemptEvent: BuildEvent.CONFIGURE_PROJECT_ATTEMPT,
       successEvent: BuildEvent.CONFIGURE_PROJECT_SUCCESS,
       failureEvent: BuildEvent.CONFIGURE_PROJECT_FAIL,
       trackingCtx: ctx.trackingCtx,
@@ -166,6 +168,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         return bucketKey;
       },
       {
+        attemptEvent: BuildEvent.PROJECT_UPLOAD_ATTEMPT,
         successEvent: BuildEvent.PROJECT_UPLOAD_SUCCESS,
         failureEvent: BuildEvent.PROJECT_UPLOAD_FAIL,
         trackingCtx: ctx.trackingCtx,
@@ -200,6 +203,7 @@ async function sendBuildRequestAsync<TPlatform extends Platform, Credentials, TJ
       return build;
     },
     {
+      attemptEvent: BuildEvent.BUILD_REQUEST_ATTEMPT,
       successEvent: BuildEvent.BUILD_REQUEST_SUCCESS,
       failureEvent: BuildEvent.BUILD_REQUEST_FAIL,
       trackingCtx: ctx.trackingCtx,

--- a/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
@@ -61,10 +61,12 @@ export default class AndroidSubmitter extends BaseSubmitter<
     };
     const sourceOptionsAnalytics = {
       archive: {
+        attemptEvent: SubmissionEvent.GATHER_ARCHIVE_ATTEMPT,
         successEvent: SubmissionEvent.GATHER_ARCHIVE_SUCCESS,
         failureEvent: SubmissionEvent.GATHER_ARCHIVE_FAIL,
       },
       serviceAccountKeyResult: {
+        attemptEvent: SubmissionEvent.GATHER_CREDENTIALS_ATTEMPT,
         successEvent: SubmissionEvent.GATHER_CREDENTIALS_SUCCESS,
         failureEvent: SubmissionEvent.GATHER_CREDENTIALS_FAIL,
       },

--- a/packages/eas-cli/src/submit/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitter.ts
@@ -79,10 +79,12 @@ export default class IosSubmitter extends BaseSubmitter<
     };
     const sourceOptionsAnalytics = {
       archive: {
+        attemptEvent: SubmissionEvent.GATHER_ARCHIVE_ATTEMPT,
         successEvent: SubmissionEvent.GATHER_ARCHIVE_SUCCESS,
         failureEvent: SubmissionEvent.GATHER_ARCHIVE_FAIL,
       },
       credentials: {
+        attemptEvent: SubmissionEvent.GATHER_CREDENTIALS_ATTEMPT,
         successEvent: SubmissionEvent.GATHER_CREDENTIALS_SUCCESS,
         failureEvent: SubmissionEvent.GATHER_CREDENTIALS_FAIL,
       },

--- a/packages/eas-cli/src/submit/submit.ts
+++ b/packages/eas-cli/src/submit/submit.ts
@@ -24,6 +24,7 @@ export async function submitAsync<T extends Platform>(
       return command.runAsync();
     },
     {
+      attemptEvent: SubmissionEvent.SUBMIT_COMMAND_ATTEMPT,
       successEvent: SubmissionEvent.SUBMIT_COMMAND_SUCCESS,
       failureEvent: SubmissionEvent.SUBMIT_COMMAND_FAIL,
       trackingCtx: ctx.trackingCtx,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
- [x] I've tagged the changelog entry with `[EAS BUILD API]` if it's a part of a breaking change to EAS Build API (only possible when updating `@expo/eas-build-job` package).

# Why

Adding `attempt` events to the build and submit command, based on discussion here: https://github.com/expo/eas-cli/pull/752#discussion_r747120167

# Test Plan

- [x] tests still pass
- [x] manual sanity check
