### PR TITLE
[workflows] update `setup-node` action to `v2`

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.event.issue.pull_request && github.event.issue.user.login == github.event.comment.user.login && startsWith(github.event.comment.body, '/changelog-entry ') }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '16'
       - name: Checkout Pull Request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     needs: release
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '16'
       - run: yarn install --frozen-lockfile --check-files
@@ -58,7 +58,7 @@ jobs:
     needs: release
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '16'
       - run: yarn install --frozen-lockfile --check-files
@@ -81,7 +81,7 @@ jobs:
     needs: release
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '16'
       - run: yarn install --frozen-lockfile --check-files
@@ -119,7 +119,7 @@ jobs:
     needs: [build-linux, build-mac, build-windows]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           registry-url: 'https://registry.npmjs.org/'
           scope: 'expo'
@@ -138,7 +138,7 @@ jobs:
     needs: publish-to-npm
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '16'
       - name: Install dependencies

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '16'
       - uses: preactjs/compressed-size-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - run: yarn install --frozen-lockfile --check-files


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

`v2` release has been published a while ago (https://github.com/actions/setup-node/releases/tag/v2.1.4) and it work flawless in other Expo repositories and it is an officially recommended version to use, so let's update the action also in here.

# How

This PR updates all of the `setup-node` action occurrences in the workflows to the `v2` release.

# Test Plan

Run CI?
