### PR TITLE
show plist path when parsing failed

### DIFF
--- a/packages/eas-cli/src/build/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/build/ios/UpdatesModule.ts
@@ -4,9 +4,9 @@ import { IOSConfig } from '@expo/config-plugins';
 import Log from '../../log';
 import { getProjectAccountName } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
+import { readPlistAsync, writePlistAsync } from '../../utils/plist';
 import { getVcsClient } from '../../vcs';
 import { ensureValidVersions } from '../utils/updates';
-import { readPlistAsync, writePlistAsync } from './plist';
 
 export async function configureUpdatesAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
   ensureValidVersions(exp);
@@ -59,7 +59,7 @@ async function ensureUpdatesConfiguredAsync(projectDir: string): Promise<void> {
 
 async function readExpoPlistAsync(projectDir: string): Promise<IOSConfig.ExpoPlist> {
   const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(projectDir);
-  return (await readPlistAsync(expoPlistPath)) as IOSConfig.ExpoPlist;
+  return ((await readPlistAsync(expoPlistPath)) ?? {}) as IOSConfig.ExpoPlist;
 }
 
 async function writeExpoPlistAsync(

--- a/packages/eas-cli/src/build/ios/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/ios/__tests__/version-test.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import { vol } from 'memfs';
 import os from 'os';
 
-import { readPlistAsync } from '../plist';
+import { readPlistAsync } from '../../../utils/plist';
 import {
   BumpStrategy,
   bumpVersionAsync,

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -8,9 +8,9 @@ import type { XCBuildConfiguration } from 'xcode';
 import Log from '../../log';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { promptAsync } from '../../prompts';
+import { readPlistAsync, writePlistAsync } from '../../utils/plist';
 import { updateAppJsonConfigAsync } from '../utils/appJson';
 import { bumpAppVersionAsync } from '../utils/version';
-import { readPlistAsync, writePlistAsync } from './plist';
 
 export enum BumpStrategy {
   APP_VERSION,
@@ -128,7 +128,10 @@ export async function maybeResolveVersionsAsync(
       appBuildVersion: await readBuildNumberAsync(projectDir, exp, buildSettings),
       appVersion: await readShortVersionAsync(projectDir, exp, buildSettings),
     };
-  } catch {
+  } catch (err: any) {
+    Log.error('Failed to read app versions.');
+    Log.error(err.message);
+    Log.error('Proceeding anyway...');
     return {};
   }
 }
@@ -174,7 +177,7 @@ async function readInfoPlistAsync(
   buildSettings: XCBuildConfiguration['buildSettings']
 ): Promise<IOSConfig.InfoPlist> {
   const infoPlistPath = getInfoPlistPath(projectDir, buildSettings);
-  return (await readPlistAsync(infoPlistPath)) as IOSConfig.InfoPlist;
+  return ((await readPlistAsync(infoPlistPath)) ?? {}) as IOSConfig.InfoPlist;
 }
 
 async function writeInfoPlistAsync({

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -129,9 +129,9 @@ export async function maybeResolveVersionsAsync(
       appVersion: await readShortVersionAsync(projectDir, exp, buildSettings),
     };
   } catch (err: any) {
-    Log.error('Failed to read app versions.');
-    Log.error(err.message);
-    Log.error('Proceeding anyway...');
+    Log.warn('Failed to read app versions.');
+    Log.warn(err.message);
+    Log.warn('Proceeding anyway...');
     return {};
   }
 }

--- a/packages/eas-cli/src/credentials/ios/appstore/entitlements.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/entitlements.ts
@@ -1,9 +1,9 @@
 import { IOSConfig, compileModsAsync } from '@expo/config-plugins';
 import { Workflow } from '@expo/eas-build-job';
 import { JSONObject } from '@expo/json-file';
-import plist from '@expo/plist';
 import { getPrebuildConfig } from '@expo/prebuild-config';
-import fs from 'fs-extra';
+
+import { readPlistAsync } from '../../../utils/plist';
 
 export async function getManagedEntitlementsJsonAsync(
   projectDir: string,
@@ -43,12 +43,11 @@ export async function resolveEntitlementsJsonAsync(
 }
 
 async function getEntitlementsJsonAsync(projectDir: string): Promise<JSONObject | null> {
-  try {
-    const entitlementsPath = IOSConfig.Paths.getEntitlementsPath(projectDir);
-    if (entitlementsPath) {
-      const entitlementsContents = await fs.readFile(entitlementsPath, 'utf8');
-      return plist.parse(entitlementsContents);
-    }
-  } catch {}
-  return null;
+  const entitlementsPath = IOSConfig.Paths.getEntitlementsPath(projectDir);
+  if (entitlementsPath) {
+    const plist = await readPlistAsync(entitlementsPath);
+    return plist ? (plist as unknown as JSONObject) : null;
+  } else {
+    return null;
+  }
 }

--- a/packages/eas-cli/src/utils/plist.ts
+++ b/packages/eas-cli/src/utils/plist.ts
@@ -3,12 +3,17 @@ import plist from '@expo/plist';
 import fs from 'fs-extra';
 import path from 'path';
 
-export async function readPlistAsync(plistPath: string): Promise<object> {
+export async function readPlistAsync(plistPath: string): Promise<object | null> {
   if (await fs.pathExists(plistPath)) {
     const expoPlistContent = await fs.readFile(plistPath, 'utf8');
-    return plist.parse(expoPlistContent);
+    try {
+      return plist.parse(expoPlistContent);
+    } catch (err: any) {
+      err.message = `Failed to parse ${plistPath}. ${err.message}`;
+      throw err;
+    }
   } else {
-    return {};
+    return null;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes https://github.com/expo/eas-cli/issues/519

# How

Add the plist path to the error message when parsing failed.

# Test Plan

Tested manually.
<img width="975" alt="Screenshot 2021-11-16 at 15 18 47" src="https://user-images.githubusercontent.com/5256730/142003163-d3b1fac2-6436-49b9-8f9d-a41622c9bb8f.png">