### PR TITLE
[eas-cli] make the missing eas.json messages better

### DIFF
--- a/packages/eas-cli/src/credentials/manager/SelectBuildProfileFromEasJson.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectBuildProfileFromEasJson.ts
@@ -14,15 +14,6 @@ export class SelectBuildProfileFromEasJson<T extends Platform> {
   }
 
   async runAsync(ctx: CredentialsContext): Promise<BuildProfile<T>> {
-    const easJsonPath = EasJsonReader.formatEasJsonPath(this.projectDir);
-    if (!(await fs.pathExists(easJsonPath))) {
-      throw new Error(
-        `An eas.json file could not be found at ${easJsonPath}. You must make one in order to proceed. ${learnMore(
-          'https://expo.fyi/eas-json'
-        )}`
-      );
-    }
-
     const profileName = await this.getProfileNameFromEasConfigAsync(ctx);
     const easConfig = await this.easJsonReader.readBuildProfileAsync<T>(this.platform, profileName);
     Log.succeed(`Using build profile: ${profileName}`);

--- a/packages/eas-cli/src/credentials/manager/SelectBuildProfileFromEasJson.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectBuildProfileFromEasJson.ts
@@ -1,15 +1,14 @@
 import { Platform } from '@expo/eas-build-job';
 import { BuildProfile, EasJsonReader } from '@expo/eas-json';
-import fs from 'fs-extra';
 
-import Log, { learnMore } from '../../log';
+import Log from '../../log';
 import { promptAsync } from '../../prompts';
 import { CredentialsContext } from '../context';
 
 export class SelectBuildProfileFromEasJson<T extends Platform> {
   private easJsonReader: EasJsonReader;
 
-  constructor(private projectDir: string, private platform: T) {
+  constructor(projectDir: string, private platform: T) {
     this.easJsonReader = new EasJsonReader(projectDir);
   }
 

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -1,6 +1,7 @@
 import { Platform } from '@expo/eas-build-job';
 import JsonFile from '@expo/json-file';
 import envString from 'env-string';
+import fs from 'fs-extra';
 import path from 'path';
 
 import { BuildProfile } from './EasBuild.types';
@@ -168,6 +169,9 @@ export class EasJsonReader {
   public async readRawAsync(): Promise<EasJsonPreValidation> {
     try {
       const easJsonPath = EasJsonReader.formatEasJsonPath(this.projectDir);
+      if (!(await fs.pathExists(easJsonPath))) {
+        throw new Error(`An eas.json file could not be found at ${easJsonPath}.`);
+      }
       const rawEasJson = JsonFile.read(easJsonPath);
       const { value, error } = MinimalEasJsonSchema.validate(rawEasJson, { abortEarly: false });
       if (error) {

--- a/packages/eas-json/src/EasJsonReader.ts
+++ b/packages/eas-json/src/EasJsonReader.ts
@@ -170,7 +170,9 @@ export class EasJsonReader {
     try {
       const easJsonPath = EasJsonReader.formatEasJsonPath(this.projectDir);
       if (!(await fs.pathExists(easJsonPath))) {
-        throw new Error(`An eas.json file could not be found at ${easJsonPath}.`);
+        throw new Error(
+          `An eas.json file could not be found at ${easJsonPath}. You must make one in order to proceed. Learn more at https://expo.fyi/eas-json`
+        );
       }
       const rawEasJson = JsonFile.read(easJsonPath);
       const { value, error } = MinimalEasJsonSchema.validate(rawEasJson, { abortEarly: false });


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes https://github.com/expo/eas-cli/issues/767 . Anything that calls out to read an eas.json should throw this type of error message since it implicitly requires an `eas.json` to exist. The user would want to know how to fix a missing `eas.json` in most contexts, not just in a credentials-specific case.

I also yolo committed https://github.com/expo/fyi/blob/master/eas-json.md so feel free to amend whatever is there as well 

# Test Plan

- [ ] manually tested
