### PR TITLE
interactively configure git user.name and user.email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Auto create channel on publish. ([#766](https://github.com/expo/eas-cli/pull/766) by [@jkhales](https://github.com/jkhales))
+- Interactively configure Git `user.name` and `user.email`. ([#772](https://github.com/expo/eas-cli/pull/772) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -136,6 +136,7 @@ export async function reviewAndCommitChangesAsync(
     await getVcsClient().commitAsync({
       commitMessage: initialCommitMessage,
       commitAllFiles: false,
+      nonInteractive,
     });
     Log.withTick('Committed changes.');
     return;

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -59,12 +59,11 @@ export default class GitClient extends Client {
   }): Promise<void> {
     await ensureGitConfiguredAsync({ nonInteractive });
 
-    if (commitAllFiles) {
-      await spawnAsync('git', ['add', '-A']);
-    }
-
-    await spawnAsync('git', ['add', '-u']);
     try {
+      if (commitAllFiles) {
+        await spawnAsync('git', ['add', '-A']);
+      }
+      await spawnAsync('git', ['add', '-u']);
       await spawnAsync('git', ['commit', '-m', commitMessage]);
     } catch (err: any) {
       if (err?.stdout) {

--- a/packages/eas-cli/src/vcs/vcs.ts
+++ b/packages/eas-cli/src/vcs/vcs.ts
@@ -34,9 +34,10 @@ export abstract class Client {
   // - Should be implemented if hasUncommittedChangesAsync is implemented
   // - If it's not implemented method `makeShallowCopyAsync` needs to be able to include uncommitted changes
   // in project copy
-  public async commitAsync(arg: {
+  public async commitAsync(_arg: {
     commitMessage: string;
     commitAllFiles?: boolean;
+    nonInteractive?: boolean;
   }): Promise<void> {
     // it should not be called unless hasUncommittedChangesAsync is implemented
     throw new Error('commitAsync is not implemented');
@@ -44,7 +45,7 @@ export abstract class Client {
 
   // (optional) mark file as tracked, if this method is called on file, the next call to
   // `commitAsync({ commitAllFiles: false })` should commit that file
-  public async trackFileAsync(file: string): Promise<void> {}
+  public async trackFileAsync(_file: string): Promise<void> {}
 
   // (optional) print diff of the changes that will be commited in the next call to
   // `commitAsync({ commitAllFiles: false })`
@@ -74,7 +75,7 @@ export abstract class Client {
   //
   // @param filePath has to be a relative normalized path pointing to a file
   // located under the root of the repository
-  public async isFileIgnoredAsync(filePath: string): Promise<boolean> {
+  public async isFileIgnoredAsync(_filePath: string): Promise<boolean> {
     return false;
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

According to @wkozyra95, `git commit` can fail if `user.name` and/or `user.email` are not set (I couldn't repro this though). 

# How

- Check if Git `user.name` and `user.email` are configured before committing. Prompt for the values if they are not configured.
- Print stdout and stderr when `git commit` fails.

# Test Plan

Tested manually.

<img width="763" alt="Screenshot 2021-11-17 at 16 59 06" src="https://user-images.githubusercontent.com/5256730/142235457-cd4e5411-8318-4ff2-8052-51af5d79802f.png">
