### PR TITLE
implement submit webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Improve unknown capability syncing error message. ([#775](https://github.com/expo/eas-cli/pulls/775) by [@EvanBacon](https://github.com/EvanBacon))
+- Add submit webhooks. ([#777](https://github.com/expo/eas-cli/pull/777) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -10674,6 +10674,12 @@
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "SUBMIT",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -14,8 +14,7 @@ export default class WebhookCreate extends EasCommand {
   static flags = {
     event: flags.enum({
       description: 'Event type that triggers the webhook',
-      options: [WebhookType.Build],
-      default: WebhookType.Build,
+      options: [WebhookType.Build, WebhookType.Submit],
     }),
     url: flags.string({
       description: 'Webhook URL',

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -20,7 +20,7 @@ export default class WebhookList extends EasCommand {
   static flags = {
     event: flags.enum({
       description: 'Event type that triggers the webhook',
-      options: [WebhookType.Build],
+      options: [WebhookType.Build, WebhookType.Submit],
     }),
   };
 

--- a/packages/eas-cli/src/commands/webhook/update.ts
+++ b/packages/eas-cli/src/commands/webhook/update.ts
@@ -18,8 +18,7 @@ export default class WebhookUpdate extends EasCommand {
     }),
     event: flags.enum({
       description: 'Event type that triggers the webhook',
-      options: [WebhookType.Build],
-      default: WebhookType.Build,
+      options: [WebhookType.Build, WebhookType.Submit],
     }),
     url: flags.string({
       description: 'Webhook URL',

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1411,7 +1411,8 @@ export type WebhookFilter = {
 };
 
 export enum WebhookType {
-  Build = 'BUILD'
+  Build = 'BUILD',
+  Submit = 'SUBMIT'
 }
 
 export type Webhook = {

--- a/packages/eas-cli/src/webhooks/input.ts
+++ b/packages/eas-cli/src/webhooks/input.ts
@@ -7,18 +7,35 @@ import { promptAsync } from '../prompts';
 
 export async function prepareInputParamsAsync(
   {
-    event,
+    event: maybeEvent,
     url: maybeUrl,
     secret: maybeSecret,
   }: {
-    event: WebhookType;
+    event?: WebhookType;
     url?: string;
     secret?: string;
   },
   existingWebhook?: WebhookFragment
 ): Promise<WebhookInput> {
+  let event: WebhookType | undefined = maybeEvent;
   let url: string | undefined = maybeUrl;
   let secret: string | undefined = maybeSecret;
+
+  if (!event) {
+    const choices = [
+      { title: 'Build', value: WebhookType.Build },
+      { title: 'Submit', value: WebhookType.Submit },
+    ];
+    ({ event } = await promptAsync({
+      type: 'select',
+      name: 'event',
+      message: 'Webhook event type:',
+      choices,
+      initial: existingWebhook?.event
+        ? choices.findIndex(choice => choice.value === existingWebhook.event)
+        : undefined,
+    }));
+  }
 
   if (!url || !validateURL(url)) {
     const urlValidationMessage =
@@ -50,7 +67,7 @@ export async function prepareInputParamsAsync(
   }
 
   return {
-    event,
+    event: nullthrows(event),
     url: nullthrows(url),
     secret: nullthrows(secret),
   };


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

Merge after https://github.com/expo/universe/pull/8627 is deployed.

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

People want to define webhooks that would be called when a submission finishes/fails/cancels.

# How

Add a new type of webhooks.

# Test Plan

Tested manually:
- I stated a webhook server.
- I created a submit webhook.
- I ran `eas submit -p android`.
- I observed that the webhook was called after the submission finished.
