### PR TITLE
[eas-cli] pass identifier from build to submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Compute runtime version policies. ([#783](https://github.com/expo/eas-cli/pull/783), [#785](https://github.com/expo/eas-cli/pull/785) by [@jkhales](https://github.com/jkhales))
 - Fix local builds with npm < 7. ([#787](https://github.com/expo/eas-cli/pull/787) by [@dsokal](https://github.com/dsokal))
+- Override `applicationId`/`bundleIdentifier` when auto-submitting after build. ([#780](https://github.com/expo/eas-cli/pull/780) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -18,7 +18,7 @@ import { sleepAsync } from '../utils/promise';
 import { getVcsClient } from '../vcs';
 import { BuildContext } from './context';
 import { runLocalBuildAsync } from './local';
-import { MetadataContext, collectMetadataAsync } from './metadata';
+import { collectMetadataAsync } from './metadata';
 import { printDeprecationWarnings } from './utils/printBuildInfo';
 import { makeProjectTarballAsync, reviewAndCommitChangesAsync } from './utils/repository';
 
@@ -39,7 +39,6 @@ interface Builder<TPlatform extends Platform, Credentials, TJob extends Job> {
     ctx: BuildContext<TPlatform>
   ): Promise<CredentialsResult<Credentials> | undefined>;
   ensureProjectConfiguredAsync(ctx: BuildContext<TPlatform>): Promise<void>;
-  getMetadataContext: () => MetadataContext<TPlatform>;
   prepareJobAsync(ctx: BuildContext<TPlatform>, jobData: JobData<Credentials>): Promise<Job>;
   sendBuildRequestAsync(appId: string, job: TJob, metadata: Metadata): Promise<BuildResult>;
 }
@@ -88,8 +87,7 @@ export async function prepareBuildRequestForPlatformAsync<
         bucketKey: await uploadProjectAsync(ctx),
       } as const);
 
-  const metadataContext = builder.getMetadataContext();
-  const metadata = await collectMetadataAsync(ctx, metadataContext);
+  const metadata = await collectMetadataAsync(ctx);
   const job = await builder.prepareJobAsync(ctx, {
     projectArchive,
     credentials: credentialsResult?.credentials,

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -1,20 +1,15 @@
 import { ExpoConfig } from '@expo/config';
 import { Platform, Workflow } from '@expo/eas-build-job';
-import { AndroidBuildProfile, BuildProfile, IosBuildProfile } from '@expo/eas-json';
-import JsonFile from '@expo/json-file';
-import resolveFrom from 'resolve-from';
-import { v4 as uuidv4 } from 'uuid';
+import { BuildProfile } from '@expo/eas-json';
+import type { XCBuildConfiguration } from 'xcode';
 
 import { TrackingContext } from '../analytics/common';
-import { Analytics, BuildEvent } from '../analytics/events';
 import { CredentialsContext } from '../credentials/context';
+import { Target } from '../credentials/ios/types';
 import { RequestedPlatform } from '../platform';
-import { getExpoConfig } from '../project/expoConfig';
-import { getProjectAccountName, getProjectIdAsync } from '../project/projectUtils';
-import { resolveWorkflowAsync } from '../project/workflow';
-import { findAccountByName } from '../user/Account';
+import { GradleBuildContext } from '../project/android/gradle';
+import { XcodeBuildContext } from '../project/ios/scheme';
 import { Actor } from '../user/User';
-import { ensureLoggedInAsync } from '../user/actions';
 
 export interface ConfigureContext {
   user: Actor;
@@ -25,6 +20,21 @@ export interface ConfigureContext {
   shouldConfigureIos: boolean;
   hasAndroidNativeProject: boolean;
   hasIosNativeProject: boolean;
+}
+
+export type CommonContext<T extends Platform> = Omit<BuildContext<T>, 'android' | 'ios'>;
+
+export interface AndroidBuildContext {
+  applicationId: string;
+  gradleContext?: GradleBuildContext;
+}
+
+export interface IosBuildContext {
+  bundleIdentifier: string;
+  applicationTargetBuildSettings: XCBuildConfiguration['buildSettings'];
+  applicationTarget: Target;
+  targets: Target[];
+  xcodeBuildContext: XcodeBuildContext;
 }
 
 export interface BuildContext<T extends Platform> {
@@ -44,112 +54,6 @@ export interface BuildContext<T extends Platform> {
   trackingCtx: TrackingContext;
   user: Actor;
   workflow: Workflow;
-}
-
-export async function createBuildContextAsync<T extends Platform>({
-  buildProfileName,
-  buildProfile,
-  clearCache = false,
-  local,
-  nonInteractive = false,
-  platform,
-  projectDir,
-  skipProjectConfiguration = false,
-}: {
-  buildProfileName: string;
-  buildProfile: BuildProfile<T>;
-  clearCache: boolean;
-  local: boolean;
-  nonInteractive: boolean;
-  platform: T;
-  projectDir: string;
-  skipProjectConfiguration: boolean;
-}): Promise<BuildContext<T>> {
-  const exp = getExpoConfig(projectDir, { env: buildProfile.env });
-
-  const user = await ensureLoggedInAsync();
-  const accountName = getProjectAccountName(exp, user);
-  const projectName = exp.slug;
-  const projectId = await getProjectIdAsync(exp, { env: buildProfile.env });
-  const workflow = await resolveWorkflowAsync(projectDir, platform);
-  const accountId = findAccountByName(user.accounts, accountName)?.id;
-
-  const credentialsCtx = new CredentialsContext({
-    exp,
-    nonInteractive,
-    projectDir,
-    user,
-  });
-
-  const devClientProperties = getDevClientEventProperties({
-    platform,
-    projectDir,
-    buildProfile,
-  });
-  const trackingCtx = {
-    tracking_id: uuidv4(),
-    platform,
-    ...(accountId && { account_id: accountId }),
-    account_name: accountName,
-    project_id: projectId,
-    project_type: workflow,
-    ...devClientProperties,
-  };
-  Analytics.logEvent(BuildEvent.BUILD_COMMAND, trackingCtx);
-
-  return {
-    accountName,
-    buildProfile,
-    buildProfileName,
-    clearCache,
-    credentialsCtx,
-    exp,
-    local,
-    nonInteractive,
-    platform,
-    projectDir,
-    projectId,
-    projectName,
-    skipProjectConfiguration,
-    trackingCtx,
-    user,
-    workflow,
-  };
-}
-
-function getDevClientEventProperties({
-  platform,
-  projectDir,
-  buildProfile,
-}: {
-  platform: Platform;
-  projectDir: string;
-  buildProfile: AndroidBuildProfile | IosBuildProfile;
-}): Partial<TrackingContext> {
-  let includesDevClient;
-  const version = tryGetDevClientVersion(projectDir);
-  if (platform === Platform.ANDROID && 'gradleCommand' in buildProfile) {
-    includesDevClient = Boolean(version && buildProfile.gradleCommand?.includes('Debug'));
-  } else if (platform === Platform.IOS && 'buildConfiguration' in buildProfile) {
-    includesDevClient = Boolean(version && buildProfile.buildConfiguration === 'Debug');
-  } else if (buildProfile.developmentClient) {
-    includesDevClient = true;
-  } else {
-    includesDevClient = false;
-  }
-
-  if (version) {
-    return { dev_client: includesDevClient, dev_client_version: version };
-  } else {
-    return { dev_client: includesDevClient };
-  }
-}
-
-function tryGetDevClientVersion(projectDir: string): string | null {
-  try {
-    const pkg = JsonFile.read(resolveFrom(projectDir, 'expo-dev-client/package.json'));
-    return pkg.version?.toString() ?? null;
-  } catch {
-    return null;
-  }
+  android: T extends Platform.ANDROID ? AndroidBuildContext : undefined;
+  ios: T extends Platform.IOS ? IosBuildContext : undefined;
 }

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -1,0 +1,138 @@
+import { Platform } from '@expo/eas-build-job';
+import { AndroidBuildProfile, BuildProfile, IosBuildProfile } from '@expo/eas-json';
+import JsonFile from '@expo/json-file';
+import resolveFrom from 'resolve-from';
+import { v4 as uuidv4 } from 'uuid';
+
+import { TrackingContext } from '../analytics/common';
+import { Analytics, BuildEvent } from '../analytics/events';
+import { CredentialsContext } from '../credentials/context';
+import { getExpoConfig } from '../project/expoConfig';
+import { getProjectAccountName, getProjectIdAsync } from '../project/projectUtils';
+import { resolveWorkflowAsync } from '../project/workflow';
+import { findAccountByName } from '../user/Account';
+import { ensureLoggedInAsync } from '../user/actions';
+import { createAndroidContextAsync } from './android/build';
+import { BuildContext, CommonContext } from './context';
+import { createIosContextAsync } from './ios/build';
+
+export default async function createBuildContextAsync<T extends Platform>({
+  buildProfileName,
+  buildProfile,
+  clearCache = false,
+  local,
+  nonInteractive = false,
+  platform,
+  projectDir,
+  skipProjectConfiguration = false,
+}: {
+  buildProfileName: string;
+  buildProfile: BuildProfile<T>;
+  clearCache: boolean;
+  local: boolean;
+  nonInteractive: boolean;
+  platform: T;
+  projectDir: string;
+  skipProjectConfiguration: boolean;
+}): Promise<BuildContext<T>> {
+  const exp = getExpoConfig(projectDir, { env: buildProfile.env });
+
+  const user = await ensureLoggedInAsync();
+  const accountName = getProjectAccountName(exp, user);
+  const projectName = exp.slug;
+  const projectId = await getProjectIdAsync(exp, { env: buildProfile.env });
+  const workflow = await resolveWorkflowAsync(projectDir, platform);
+  const accountId = findAccountByName(user.accounts, accountName)?.id;
+
+  const credentialsCtx = new CredentialsContext({
+    exp,
+    nonInteractive,
+    projectDir,
+    user,
+  });
+
+  const devClientProperties = getDevClientEventProperties({
+    platform,
+    projectDir,
+    buildProfile,
+  });
+  const trackingCtx = {
+    tracking_id: uuidv4(),
+    platform,
+    ...(accountId && { account_id: accountId }),
+    account_name: accountName,
+    project_id: projectId,
+    project_type: workflow,
+    ...devClientProperties,
+  };
+  Analytics.logEvent(BuildEvent.BUILD_COMMAND, trackingCtx);
+
+  const commonContext: CommonContext<T> = {
+    accountName,
+    buildProfile, // TODO: move to android/ios object
+    buildProfileName,
+    clearCache,
+    credentialsCtx,
+    exp,
+    local,
+    nonInteractive,
+    platform,
+    projectDir,
+    projectId,
+    projectName,
+    skipProjectConfiguration,
+    trackingCtx,
+    user,
+    workflow,
+  };
+  if (platform === Platform.ANDROID) {
+    const common = commonContext as CommonContext<Platform.ANDROID>;
+    return {
+      ...common,
+      android: await createAndroidContextAsync(common),
+    } as BuildContext<T>;
+  } else {
+    const common = commonContext as CommonContext<Platform.IOS>;
+    return {
+      ...common,
+      ios: await createIosContextAsync(common),
+    } as BuildContext<T>;
+  }
+}
+
+function getDevClientEventProperties({
+  platform,
+  projectDir,
+  buildProfile,
+}: {
+  platform: Platform;
+  projectDir: string;
+  buildProfile: AndroidBuildProfile | IosBuildProfile;
+}): Partial<TrackingContext> {
+  let includesDevClient;
+  const version = tryGetDevClientVersion(projectDir);
+  if (platform === Platform.ANDROID && 'gradleCommand' in buildProfile) {
+    includesDevClient = Boolean(version && buildProfile.gradleCommand?.includes('Debug'));
+  } else if (platform === Platform.IOS && 'buildConfiguration' in buildProfile) {
+    includesDevClient = Boolean(version && buildProfile.buildConfiguration === 'Debug');
+  } else if (buildProfile.developmentClient) {
+    includesDevClient = true;
+  } else {
+    includesDevClient = false;
+  }
+
+  if (version) {
+    return { dev_client: includesDevClient, dev_client_version: version };
+  } else {
+    return { dev_client: includesDevClient };
+  }
+}
+
+function tryGetDevClientVersion(projectDir: string): string | null {
+  try {
+    const pkg = JsonFile.read(resolveFrom(projectDir, 'expo-dev-client/package.json'));
+    return pkg.version?.toString() ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -16,7 +16,7 @@ import { createAndroidContextAsync } from './android/build';
 import { BuildContext, CommonContext } from './context';
 import { createIosContextAsync } from './ios/build';
 
-export default async function createBuildContextAsync<T extends Platform>({
+export async function createBuildContextAsync<T extends Platform>({
   buildProfileName,
   buildProfile,
   clearCache = false,
@@ -69,7 +69,7 @@ export default async function createBuildContextAsync<T extends Platform>({
 
   const commonContext: CommonContext<T> = {
     accountName,
-    buildProfile, // TODO: move to android/ios object
+    buildProfile,
     buildProfileName,
     clearCache,
     credentialsCtx,

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -2,17 +2,7 @@ import { Updates } from '@expo/config-plugins';
 import { Metadata, Platform, sanitizeMetadata } from '@expo/eas-build-job';
 import { IosEnterpriseProvisioning } from '@expo/eas-json';
 
-<<<<<<< HEAD
 import Log from '../log';
-import { getApplicationIdAsync } from '../project/android/applicationId';
-import { GradleBuildContext } from '../project/android/gradle';
-import { getBundleIdentifierAsync } from '../project/ios/bundleIdentifier';
-||||||| parent of 26f2ab54 (pass identifier from build to submit)
-import { getApplicationIdAsync } from '../project/android/applicationId';
-import { GradleBuildContext } from '../project/android/gradle';
-import { getBundleIdentifierAsync } from '../project/ios/bundleIdentifier';
-=======
->>>>>>> 26f2ab54 (pass identifier from build to submit)
 import { getUsername } from '../project/projectUtils';
 import { ensureLoggedInAsync } from '../user/actions';
 import { easCliVersion } from '../utils/easCli';

--- a/packages/eas-cli/src/build/validate.ts
+++ b/packages/eas-cli/src/build/validate.ts
@@ -4,9 +4,9 @@ import path from 'path';
 
 import Log, { learnMore } from '../log';
 import { getVcsClient } from '../vcs';
-import { BuildContext } from './context';
+import { CommonContext } from './context';
 
-export function checkNodeEnvVariable(ctx: BuildContext<Platform>): void {
+export function checkNodeEnvVariable(ctx: CommonContext<Platform>): void {
   if (ctx.buildProfile.env?.NODE_ENV === 'production') {
     Log.warn(
       'You set NODE_ENV=production in the build profile. Remember that it will be available during the entire build process. In particular, it will make yarn/npm install only production packages.'
@@ -16,7 +16,7 @@ export function checkNodeEnvVariable(ctx: BuildContext<Platform>): void {
 }
 
 export async function checkGoogleServicesFileAsync<T extends Platform>(
-  ctx: BuildContext<T>
+  ctx: CommonContext<T>
 ): Promise<void> {
   if (ctx.workflow === Workflow.GENERIC || ctx.buildProfile?.env?.GOOGLE_SERVICES_FILE) {
     return;

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -10,13 +10,13 @@ import nullthrows from 'nullthrows';
 import { prepareAndroidBuildAsync } from '../../build/android/build';
 import { BuildRequestSender, waitForBuildEndAsync } from '../../build/build';
 import { ensureProjectConfiguredAsync } from '../../build/configure';
-import { BuildContext, createBuildContextAsync } from '../../build/context';
+import { BuildContext } from '../../build/context';
+import createBuildContextAsync from '../../build/createContext';
 import { prepareIosBuildAsync } from '../../build/ios/build';
 import { ensureExpoDevClientInstalledForDevClientBuildsAsync } from '../../build/utils/devClient';
 import { printBuildResults, printLogsUrls } from '../../build/utils/printBuildInfo';
 import { ensureRepoIsCleanAsync, reviewAndCommitChangesAsync } from '../../build/utils/repository';
 import EasCommand from '../../commandUtils/EasCommand';
-import { CredentialsContext } from '../../credentials/context';
 import {
   AppPlatform,
   BuildFragment,
@@ -193,9 +193,7 @@ export default class Build extends EasCommand {
       for (const startedBuild of startedBuilds) {
         const submission = await this.prepareAndStartSubmissionAsync({
           build: startedBuild.build,
-          credentialsCtx: nullthrows(
-            buildCtxByPlatform[startedBuild.build.platform]?.credentialsCtx
-          ),
+          buildCtx: nullthrows(buildCtxByPlatform[startedBuild.build.platform]),
           flags,
           moreBuilds: startedBuilds.length > 1,
           projectDir,
@@ -329,14 +327,14 @@ export default class Build extends EasCommand {
 
   private async prepareAndStartSubmissionAsync({
     build,
-    credentialsCtx,
+    buildCtx,
     flags,
     moreBuilds,
     projectDir,
     buildProfile,
   }: {
     build: BuildFragment;
-    credentialsCtx: CredentialsContext;
+    buildCtx: BuildContext<Platform>;
     flags: BuildFlags;
     moreBuilds: boolean;
     projectDir: string;
@@ -353,7 +351,8 @@ export default class Build extends EasCommand {
       archiveFlags: { id: build.id },
       nonInteractive: flags.nonInteractive,
       env: buildProfile.profile.env,
-      credentialsCtx,
+      credentialsCtx: buildCtx.credentialsCtx,
+      applicationIdentifier: buildCtx.android?.applicationId ?? buildCtx.ios?.bundleIdentifier,
     });
 
     if (moreBuilds) {

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -11,7 +11,7 @@ import { prepareAndroidBuildAsync } from '../../build/android/build';
 import { BuildRequestSender, waitForBuildEndAsync } from '../../build/build';
 import { ensureProjectConfiguredAsync } from '../../build/configure';
 import { BuildContext } from '../../build/context';
-import createBuildContextAsync from '../../build/createContext';
+import { createBuildContextAsync } from '../../build/createContext';
 import { prepareIosBuildAsync } from '../../build/ios/build';
 import { ensureExpoDevClientInstalledForDevClientBuildsAsync } from '../../build/utils/devClient';
 import { printBuildResults, printLogsUrls } from '../../build/utils/printBuildInfo';

--- a/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts
@@ -128,7 +128,8 @@ export default class AndroidSubmitCommand {
         path: serviceAccountKeyPath,
       });
     }
-    let androidApplicationIdentifier: string | undefined = this.ctx.profile.applicationId;
+    let androidApplicationIdentifier: string | undefined =
+      this.ctx.applicationIdentifierOverride ?? this.ctx.profile.applicationId;
     if (!androidApplicationIdentifier) {
       const androidApplicationIdentifierResult =
         await this.maybeGetAndroidPackageFromCurrentProjectAsync();

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -25,6 +25,7 @@ export interface SubmissionContext<T extends Platform> {
   projectId: string;
   projectName: string;
   user: Actor;
+  applicationIdentifierOverride?: string;
 }
 
 export interface SubmitArchiveFlags {
@@ -43,8 +44,9 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
   profile: SubmitProfile<T>;
   projectDir: string;
   projectId: string;
+  applicationIdentifier?: string;
 }): Promise<SubmissionContext<T>> {
-  const { projectDir, nonInteractive } = params;
+  const { applicationIdentifier, projectDir, nonInteractive } = params;
   const exp = getExpoConfig(projectDir, { env: params.env });
   const { env, ...rest } = params;
   const user = await ensureLoggedInAsync();
@@ -74,5 +76,6 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
     projectName,
     user,
     trackingCtx,
+    applicationIdentifierOverride: applicationIdentifier,
   };
 }

--- a/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
@@ -119,7 +119,8 @@ export default class IosSubmitCommand {
       return { appSpecificPasswordSource: this.resolveAppSpecificPasswordSource() };
     }
 
-    let bundleIdentifier = this.ctx.profile.bundleIdentifier;
+    let bundleIdentifier =
+      this.ctx.applicationIdentifierOverride ?? this.ctx.profile.bundleIdentifier;
     if (!bundleIdentifier) {
       const bundleIdentifierResult = await this.maybeGetIosBundleIdentifierAsync();
       if (!bundleIdentifierResult.ok) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Pass applicationId/bundleIdentifier from build process to submit when aoutosubmit.

# How

- value from build take precedence over values defined in submit profile in eas.json
- extend build context with platform-specific values

# Test Plan

Run build with autosubmit (make sure that value passed  from build is used)
