### PR TITLE
[eas-cli] check EAS Update URL is correctly configured before publish

### DIFF
--- a/packages/eas-cli/src/commands/branch/publish.ts
+++ b/packages/eas-cli/src/commands/branch/publish.ts
@@ -40,6 +40,8 @@ import { createUpdateBranchOnAppAsync } from './create';
 import { listBranchesAsync } from './list';
 import { viewUpdateBranchAsync } from './view';
 
+const EAS_UPDATE_URL = 'https://u.expo.dev';
+
 export const defaultPublishPlatforms: PublishPlatform[] = ['android', 'ios'];
 type PlatformFlag = PublishPlatform | 'all';
 
@@ -204,8 +206,8 @@ export default class BranchPublish extends EasCommand {
     });
 
     const runtimeVersions = await getRuntimeVersionObjectAsync(exp, platformFlag, projectDir);
-
     const projectId = await getProjectIdAsync(exp);
+    await checkEASUpdateURLIsSetAsync(exp);
 
     if (!branchName && autoFlag) {
       branchName =
@@ -472,4 +474,20 @@ function formatUpdateTitle(
     createdAt,
     'mmm dd HH:MM'
   )} by ${actorName}, runtimeVersion: ${runtimeVersion}] ${message}`;
+}
+
+async function getEASUpdateURLAsync(exp: ExpoConfig): Promise<string> {
+  const projectId = await getProjectIdAsync(exp);
+  return new URL(projectId, EAS_UPDATE_URL).href;
+}
+
+async function checkEASUpdateURLIsSetAsync(exp: ExpoConfig): Promise<void> {
+  const configuredURL = exp.updates?.url;
+  const expectedURL = await getEASUpdateURLAsync(exp);
+
+  if (configuredURL !== expectedURL) {
+    throw new Error(
+      `The update URL is incorrectly configured for EAS Update. Please set updates.url to ${expectedURL} in your app.json.`
+    );
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Prevent users from publishing without having configured their updates URL. 

This will prevent frustrating foot guns.

# How

Check app.json and throw if incorrectly configured.


Note: the question of how to keep the url in app.json and native config files is already managed here: https://github.com/expo/expo-cli/blob/master/packages/config-plugins/src/android/Updates.ts#L199

# Test Plan

Tested in demo repo