### PR TITLE
fix evaluating template strings from info.plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix reading app version and app build version of iOS projects. ([#798](https://github.com/expo/eas-cli/pull/798) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [0.38.1](https://github.com/expo/eas-cli/releases/tag/v0.38.1) - 2021-11-25

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -130,6 +130,7 @@ export async function maybeResolveVersionsAsync(
     };
   } catch (err: any) {
     Log.warn('Failed to read app versions.');
+    Log.debug(err);
     Log.warn(err.message);
     Log.warn('Proceeding anyway...');
     return {};
@@ -200,7 +201,12 @@ function ensureStaticConfigExists(projectDir: string): void {
   }
 }
 
-export function evaluateTemplateString(s: string, vars: Record<string, any>): string {
+export function evaluateTemplateString(
+  s: string,
+  buildSettings: XCBuildConfiguration['buildSettings']
+): string {
+  // necessary because XCBuildConfiguration['buildSettings'] is not a plain object
+  const vars = { ...buildSettings };
   return s.replace(/\$\((\w+)\)/g, (match, key) => {
     if (vars.hasOwnProperty(key)) {
       const value = String(vars[key]);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Reported by @brentvatne 

<img width="1123" alt="Screenshot 2021-11-26 at 11 15 50" src="https://user-images.githubusercontent.com/5256730/143564837-83dec6bb-6603-4cfa-af5e-19fa842f49cf.png">

Project: https://github.com/brentvatne/runverter-cloud

# How

`evaluateTemplateString` didn't always receive the correct type of the `vars` argument. 
It was sometimes a plain object (it has `.hasOwnProperty`) and sometimes an object with null prototype (without `.hasOwnProperty`).
Solution: convert the argument to plain object.

# Test Plan

Tested with https://github.com/brentvatne/runverter-cloud
