### PR TITLE
[eas-cli] add missing @expo/sdk-runtime-versions dependency

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -20,6 +20,7 @@
     "@expo/prebuild-config": "3.0.10",
     "@expo/results": "1.0.0",
     "@expo/rudder-sdk-node": "1.1.1",
+    "@expo/sdk-runtime-versions": "1.0.0",
     "@expo/spawn-async": "1.5.0",
     "@expo/timeago.js": "1.0.0",
     "@oclif/command": "1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,6 +1019,11 @@
     remove-trailing-slash "^0.1.0"
     uuid "^8.3.2"
 
+"@expo/sdk-runtime-versions@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz#d7ebd21b19f1c6b0395e50d78da4416941c57f7c"
+  integrity sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==
+
 "@expo/spawn-async@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.5.0.tgz#799827edd8c10ef07eb1a2ff9dcfe081d596a395"


### PR DESCRIPTION
Fix missing missing `@expo/sdk-runtime-versions` dependency