### PR TITLE
[eas-cli] pass bundle identifier when resolving asc app id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix submit for multi-target projects where ascAppId is not specified. ([#809](https://github.com/expo/eas-cli/pull/809) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [0.38.3](https://github.com/expo/eas-cli/releases/tag/v0.38.3) - 2021-11-29

--- a/packages/eas-cli/src/submit/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submit/ios/AppProduce.ts
@@ -35,7 +35,10 @@ export async function ensureAppStoreConnectAppExistsAsync(
   const { appName, language } = ctx.profile;
   const options = {
     ...ctx.profile,
-    bundleIdentifier: await getBundleIdentifierAsync(ctx.projectDir, exp),
+    bundleIdentifier:
+      ctx.applicationIdentifierOverride ??
+      ctx.profile.bundleIdentifier ??
+      (await getBundleIdentifierAsync(ctx.projectDir, exp)),
     appName: appName ?? exp.name ?? (await promptForAppNameAsync()),
     language: sanitizeLanguage(language),
   };


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

if submit profile does not have ascAppId specified and  there is multiple bundleIdentifier in the project, submit fails even if bundleIdentifier is specified in submit profile 

# How


# Test Plan

TODO