### PR TITLE
[eas-cli] set runtime version in eas update:configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- set runtime version in eas update:configure. ([#811](https://github.com/expo/eas-cli/pull/811) by [@jkhales](https://github.com/jkhales))
+
 ### 🐛 Bug fixes
 
 - Fix submit for multi-target projects where ascAppId is not specified. ([#809](https://github.com/expo/eas-cli/pull/809) by [@wkozyra95](https://github.com/wkozyra95))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- set runtime version in eas update:configure. ([#811](https://github.com/expo/eas-cli/pull/811) by [@jkhales](https://github.com/jkhales))
+- Set runtime version in eas update:configure. ([#811](https://github.com/expo/eas-cli/pull/811) by [@jkhales](https://github.com/jkhales))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -8,7 +8,7 @@ import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUt
 import { resolveWorkflowAsync } from '../../project/workflow';
 
 const EAS_UPDATE_URL = 'https://u.expo.dev';
-const DEFAULT_RUNTIME_VERSION: { policy: 'sdkVersion' } = { policy: 'sdkVersion' };
+const DEFAULT_RUNTIME_VERSION = { policy: 'sdkVersion' } as const;
 
 export async function getEASUpdateURLAsync(exp: ExpoConfig): Promise<string> {
   const projectId = await getProjectIdAsync(exp);

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -52,10 +52,16 @@ async function configureProjectForEASUpdateAsync(
         )}`
       );
       Log.warn(
-        'In order to finish configuring your project for EAS Update, you are going to need manually add the following:\n\n'
+        `In order to finish configuring your project for EAS Update, you are going to need manually add the following to your app.config.js:\n${learnMore(
+          'https://expo.fyi/eas-update-config.md'
+        )}\n`
       );
-      Log.log(chalk.bold(`"updates": {\n    "url": "${easUpdateURL}"\n  }`));
-      Log.log(learnMore('https://expo.fyi/eas-update-config.md'));
+      Log.log(
+        chalk.bold(
+          `{\n  updates": {\n    "url": "${easUpdateURL}"\n  },\n  "runtimeVersion": {\n    "policy": "sdkVersion"\n  }\n}`
+        )
+      );
+      Log.addNewLineIfNone();
       throw new Error(result.message);
     }
     case 'fail':


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We should set the runtime version to the sdkVersion policy when configuring EAS Update.

# How

Only update if a runtimeVersion hasn't been set.

# Test Plan

tested in demo repo.


<img width="819" alt="Screen Shot 2021-12-01 at 1 08 25 PM" src="https://user-images.githubusercontent.com/1220444/144289459-aa252560-207e-43d8-b1a2-bc56d79c73f3.png">


