### PR TITLE
make iOS submission message less scary: App Store -> App Store Connect

### DIFF
--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -52,7 +52,7 @@ function logSuccess(platform: RequestedPlatform): void {
     storesText = 'the Google Play Store';
   } else if (platform === 'ios') {
     platformsText = 'iOS project is';
-    storesText = 'the Apple App Store';
+    storesText = 'the Apple App Store Connect';
   }
 
   Log.log(`🎉 Your ${platformsText} ready to build.

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -42,7 +42,7 @@ interface Flags {
 }
 
 export default class Submit extends EasCommand {
-  static description = `submit build archive to app store
+  static description = `submit build archive to App Store Connect
 See how to configure submits with eas.json: ${link('https://docs.expo.dev/submit/eas-json/')}`;
   static aliases = ['build:submit'];
 

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -119,7 +119,9 @@ async function promptForAscApiKeyAsync(ctx: CredentialsContext): Promise<Minimal
 
 async function promptForKeyP8AndIdAsync(): Promise<Pick<AscApiKeyPath, 'keyP8Path' | 'keyId'>> {
   Log.log(
-    chalk.bold('An App Store Connect Api key is required to upload your app to the Apple App Store')
+    chalk.bold(
+      'An App Store Connect Api key is required to upload your app to the Apple App Store Connect'
+    )
   );
   Log.log(
     `If you're not sure what this is or how to create one, ${learnMore(

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -162,11 +162,13 @@ export async function ensureAppExistsAsync(
   }
 ): Promise<App> {
   const context = getRequestContext(authCtx);
-  const spinner = ora(`Linking to App Store ${chalk.dim(bundleIdentifier)}`).start();
+  const spinner = ora(`Linking to App Store Connect ${chalk.dim(bundleIdentifier)}`).start();
 
   let app = await App.findAsync(context, { bundleId: bundleIdentifier });
   if (!app) {
-    spinner.text = `Creating App Store app ${chalk.bold(name)} ${chalk.dim(bundleIdentifier)}`;
+    spinner.text = `Creating App Store Connect app ${chalk.bold(name)} ${chalk.dim(
+      bundleIdentifier
+    )}`;
     try {
       // Assert contract errors when the user needs to create an app.
       await assertContractMessagesAsync(context, spinner);
@@ -194,6 +196,8 @@ export async function ensureAppExistsAsync(
   } else {
     // TODO: Update app name when API gives us that possibility
   }
-  spinner.succeed(`Prepared App Store for ${chalk.bold(name)} ${chalk.dim(bundleIdentifier)}`);
+  spinner.succeed(
+    `Prepared App Store Connect for ${chalk.bold(name)} ${chalk.dim(bundleIdentifier)}`
+  );
   return app;
 }

--- a/packages/eas-cli/src/submit/utils/wait.ts
+++ b/packages/eas-cli/src/submit/utils/wait.ts
@@ -8,7 +8,7 @@ import { sleepAsync } from '../../utils/promise';
 
 const APP_STORE_NAMES: Record<AppPlatform, string> = {
   [AppPlatform.Android]: 'Google Play Store',
-  [AppPlatform.Ios]: 'Apple App Store',
+  [AppPlatform.Ios]: 'Apple App Store Connect',
 };
 
 const CHECK_TIMEOUT_MS = 3600_000;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

`eas submit -p ios` uploads apps to App Store Connect. It seems it sounds scary to some people when they see that EAS CLI states the app was uploaded to App Store.

# How

Be more explicit about where the app gets uploaded.

# Test Plan

None
