### PR TITLE
[eas-cli] bump config-plugins to 4.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Improve error message for missing ascAppId. ([#813](https://github.com/expo/eas-cli/pull/813) by [@wkozyra95](https://github.com/wkozyra95))
+- Bump @expo/config-plugins to 4.0.11. ([#817](https://github.com/expo/eas-cli/pull/817) by [@jkhales](https://github.com/jkhales))
 
 ## [0.38.3](https://github.com/expo/eas-cli/releases/tag/v0.38.3) - 2021-11-29
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@expo/apple-utils": "0.0.0-alpha.26",
     "@expo/config": "6.0.10",
-    "@expo/config-plugins": "4.0.10",
+    "@expo/config-plugins": "4.0.11",
     "@expo/eas-build-job": "0.2.57",
     "@expo/eas-json": "^0.38.3",
     "@expo/json-file": "8.2.34",
@@ -20,7 +20,6 @@
     "@expo/prebuild-config": "3.0.10",
     "@expo/results": "1.0.0",
     "@expo/rudder-sdk-node": "1.1.1",
-    "@expo/sdk-runtime-versions": "1.0.0",
     "@expo/spawn-async": "1.5.0",
     "@expo/timeago.js": "1.0.0",
     "@oclif/command": "1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,6 +869,28 @@
     xcode "^3.0.1"
     xml2js "0.4.23"
 
+"@expo/config-plugins@4.0.11":
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.0.11.tgz#2c11c63ec0d3f7a56d6cb45c8340a1546f3cfc5c"
+  integrity sha512-hoQq+B1NlIqWeSLKbQQ19g2vzqKhXh2glRwRFCGvqKT2/UaweFU5w7jetNPOBlVIV1+TpQmhLNbTYako6Z3vnQ==
+  dependencies:
+    "@expo/config-types" "^43.0.1"
+    "@expo/json-file" "8.2.34"
+    "@expo/plist" "0.0.16"
+    "@expo/sdk-runtime-versions" "^1.0.0"
+    "@react-native/normalize-color" "^2.0.0"
+    chalk "^4.1.2"
+    debug "^4.3.1"
+    find-up "~5.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    semver "^7.3.5"
+    slash "^3.0.0"
+    xcode "^3.0.1"
+    xml2js "0.4.23"
+
 "@expo/config-types@^43.0.1":
   version "43.0.1"
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-43.0.1.tgz#3e047dccb371741a540980eaff26fb0c95039c30"
@@ -1019,7 +1041,7 @@
     remove-trailing-slash "^0.1.0"
     uuid "^8.3.2"
 
-"@expo/sdk-runtime-versions@1.0.0":
+"@expo/sdk-runtime-versions@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz#d7ebd21b19f1c6b0395e50d78da4416941c57f7c"
   integrity sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

`@expo/sdk-runtime-versions` is not used by directly. It should be imported by @expo/config-plugins.

`@expo/sdk-runtime-versions` is necessary to parse the `sdkVersion` runtime policy.

# How

Added @expo/sdk-runtime-versions to @expo/config-plugins here: https://github.com/expo/expo-cli/blob/main/CHANGELOG.md#-bug-fixes-1

bumped @expo/config-plugins and confirmed there are no breaking changes.

# Test Plan

Tested publish now works in demo repo with `runtimeVersion: { policy: "sdkVersion"}`