### PR TITLE
print project workflow in `eas diagnostics` + update bug report template - add manged/bare input

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,6 +25,13 @@ body:
     validations:
       required: true
     attributes:
+      label: Managed or bare?
+      description: See the [Workflows](https://docs.expo.dev/introduction/managed-vs-bare/) page for more information.
+      placeholder: Is your project managed or bare? Bare - Android and/or iOS native projects exist in your repo; Managed - you don't have native code (custom or 3rd party) in your project.
+  - type: textarea
+    validations:
+      required: true
+    attributes:
       label: Environment
       placeholder: Run `eas diagnostics` and paste the output here
   - type: textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- Set runtime version in eas update:configure. ([#811](https://github.com/expo/eas-cli/pull/811) by [@jkhales](https://github.com/jkhales))
+- Set runtime version in `eas update:configure`. ([#811](https://github.com/expo/eas-cli/pull/811) by [@jkhales](https://github.com/jkhales))
+- Print project workflow in `eas diagnostics`. ([#822](https://github.com/expo/eas-cli/pull/822) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 
@@ -31,7 +32,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add support for extending submit profiles. ([#794](https://github.com/expo/eas-cli/pull/794) by [@dsokal](https://github.com/dsokal))
-- Add command: 'eas update:configure'. ([#800](https://github.com/expo/eas-cli/pull/800) by [@jkhales](https://github.com/jkhales))
+- Add command: `eas update:configure`. ([#800](https://github.com/expo/eas-cli/pull/800) by [@jkhales](https://github.com/jkhales))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/diagnostics.ts
+++ b/packages/eas-cli/src/commands/diagnostics.ts
@@ -1,7 +1,10 @@
+import { Platform } from '@expo/eas-build-job';
 import envinfo from 'envinfo';
 
 import EasCommand from '../commandUtils/EasCommand';
 import Log from '../log';
+import { findProjectRootAsync } from '../project/projectUtils';
+import { resolveWorkflowAsync } from '../project/workflow';
 import { easCliVersion } from '../utils/easCli';
 
 export default class Diagnostics extends EasCommand {
@@ -32,6 +35,23 @@ export default class Diagnostics extends EasCommand {
         title: `EAS CLI ${easCliVersion} environment info`,
       }
     );
-    Log.log(info);
+
+    Log.log(info.trimEnd());
+    await this.printWorkflowAsync();
+    Log.newLine();
+  }
+
+  private async printWorkflowAsync(): Promise<void> {
+    const projectDir = await findProjectRootAsync();
+    const androidWorkflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
+    const iosWorkflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
+
+    if (androidWorkflow === iosWorkflow) {
+      Log.log(`    Project workflow: ${androidWorkflow}`);
+    } else {
+      Log.log(`    Project Workflow:`);
+      Log.log(`      Android: ${androidWorkflow}`);
+      Log.log(`      iOS: ${iosWorkflow}`);
+    }
   }
 }


### PR DESCRIPTION
When looking into issues, it's helpful to know what's the project workflow.

- Print project workflow in `eas diagnostics`.
- Update issue template to require users to provide project workflow (to catch issues when they think they're using different workflow than they are).


<img width="689" alt="Screenshot 2021-12-06 at 11 49 30" src="https://user-images.githubusercontent.com/5256730/144834318-f54d6d8c-7b9f-4d13-b150-548b2c018fe3.png">

<img width="708" alt="Screenshot 2021-12-06 at 11 49 46" src="https://user-images.githubusercontent.com/5256730/144834332-98fa1d87-21c2-47bb-913b-9bd0faedd049.png">

