### PR TITLE
[eas-cli] removes account name from analytics events

### DIFF
--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -60,7 +60,6 @@ export async function createBuildContextAsync<T extends Platform>({
     tracking_id: uuidv4(),
     platform,
     ...(accountId && { account_id: accountId }),
-    account_name: accountName,
     project_id: projectId,
     project_type: workflow,
     ...devClientProperties,

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -62,7 +62,6 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
     tracking_id: uuidv4(),
     platform: params.platform,
     ...(accountId && { account_id: accountId }),
-    account_name: accountName,
     project_id: params.projectId,
   };
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We'd like to anonymize analytics events to hit GDPR regulations by removing account names. e.g. https://www.notion.so/expo/PII-Audit-6bde8ab95e2640a7a330441b3677e8ab#34c4e2eafa8446cf8a5e0915311bb9da

I'll follow this PR up with a PR to remove or scrub the `reason` property from `_fail` events.

# How

Removed account_name from tracking_context at each callsite.

# Test Plan

Fired a few events locally, confirmed they did not contain account name.