### PR TITLE
[eas-cli] pass build profile env to credentials ctx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Pass build profile environment to credentials command. ([#828](https://github.com/expo/eas-cli/pull/828) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🧹 Chores
 
 ## [0.39.0](https://github.com/expo/eas-cli/releases/tag/v0.39.0) - 2021-12-06

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -49,7 +49,7 @@ export async function createBuildContextAsync<T extends Platform>({
     nonInteractive,
     projectDir,
     user,
-    buildProfile,
+    env: buildProfile.env,
   });
 
   const devClientProperties = getDevClientEventProperties({

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -49,6 +49,7 @@ export async function createBuildContextAsync<T extends Platform>({
     nonInteractive,
     projectDir,
     user,
+    buildProfile,
   });
 
   const devClientProperties = getDevClientEventProperties({

--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -1,16 +1,10 @@
 import EasCommand from '../commandUtils/EasCommand';
-import { CredentialsContext } from '../credentials/context';
 import { SelectPlatform } from '../credentials/manager/SelectPlatform';
-import { ensureLoggedInAsync } from '../user/actions';
 
 export default class Credentials extends EasCommand {
   static description = 'manage your credentials';
 
   async runAsync(): Promise<void> {
-    const ctx = new CredentialsContext({
-      projectDir: process.cwd(),
-      user: await ensureLoggedInAsync(),
-    });
-    await new SelectPlatform().runAsync(ctx);
+    await new SelectPlatform().runAsync();
   }
 }

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -37,13 +37,18 @@ export class CredentialsContext {
 
     this.resolvedExp = options.exp;
     if (!this.resolvedExp) {
-      this.resolvedExp = CredentialsContext.getExpoConfigInProject(this.projectDir) ?? undefined;
+      this.resolvedExp =
+        CredentialsContext.getExpoConfigInProject(this.projectDir, { env: options.env }) ??
+        undefined;
     }
   }
 
-  static getExpoConfigInProject(projectDir: string): ExpoConfig | null {
+  static getExpoConfigInProject(
+    projectDir: string,
+    { env }: { env?: Env } = {}
+  ): ExpoConfig | null {
     try {
-      return getExpoConfig(projectDir);
+      return getExpoConfig(projectDir, { env });
     } catch (error) {
       // ignore error, context might be created outside of expo project
       return null;

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig, getConfig } from '@expo/config';
+import { BuildProfile } from '@expo/eas-json';
 import chalk from 'chalk';
 
 import Log from '../log';
@@ -27,6 +28,7 @@ export class CredentialsContext {
       nonInteractive?: boolean;
       projectDir: string;
       user: Actor;
+      buildProfile?: BuildProfile;
     }
   ) {
     this.projectDir = options.projectDir;
@@ -36,7 +38,7 @@ export class CredentialsContext {
     this.resolvedExp = options.exp;
     if (!this.resolvedExp) {
       try {
-        this.resolvedExp = getExpoConfig(options.projectDir);
+        this.resolvedExp = getExpoConfig(options.projectDir, { env: options.buildProfile?.env });
       } catch (error) {
         // ignore error, context might be created outside of expo project
       }
@@ -110,5 +112,14 @@ export class CredentialsContext {
       );
     }
     this.shouldAskAuthenticateAppStore = false;
+  }
+}
+
+export function hasProjectContext(projectDir: string): boolean {
+  try {
+    getExpoConfig(projectDir);
+    return true;
+  } catch (error) {
+    return false;
   }
 }

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig, getConfig } from '@expo/config';
-import { BuildProfile } from '@expo/eas-json';
+import { Env } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
 import Log from '../log';
@@ -28,7 +28,7 @@ export class CredentialsContext {
       nonInteractive?: boolean;
       projectDir: string;
       user: Actor;
-      buildProfile?: BuildProfile;
+      env?: Env;
     }
   ) {
     this.projectDir = options.projectDir;
@@ -37,11 +37,16 @@ export class CredentialsContext {
 
     this.resolvedExp = options.exp;
     if (!this.resolvedExp) {
-      try {
-        this.resolvedExp = getExpoConfig(options.projectDir, { env: options.buildProfile?.env });
-      } catch (error) {
-        // ignore error, context might be created outside of expo project
-      }
+      this.resolvedExp = CredentialsContext.getExpoConfigInProject(this.projectDir) ?? undefined;
+    }
+  }
+
+  static getExpoConfigInProject(projectDir: string): ExpoConfig | null {
+    try {
+      return getExpoConfig(projectDir);
+    } catch (error) {
+      // ignore error, context might be created outside of expo project
+      return null;
     }
   }
 
@@ -112,14 +117,5 @@ export class CredentialsContext {
       );
     }
     this.shouldAskAuthenticateAppStore = false;
-  }
-}
-
-export function hasProjectContext(projectDir: string): boolean {
-  try {
-    getExpoConfig(projectDir);
-    return true;
-  } catch (error) {
-    return false;
   }
 }

--- a/packages/eas-cli/src/credentials/manager/SelectBuildProfileFromEasJson.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectBuildProfileFromEasJson.ts
@@ -3,7 +3,6 @@ import { BuildProfile, EasJsonReader } from '@expo/eas-json';
 
 import Log from '../../log';
 import { promptAsync } from '../../prompts';
-import { CredentialsContext } from '../context';
 
 export class SelectBuildProfileFromEasJson<T extends Platform> {
   private easJsonReader: EasJsonReader;
@@ -12,14 +11,14 @@ export class SelectBuildProfileFromEasJson<T extends Platform> {
     this.easJsonReader = new EasJsonReader(projectDir);
   }
 
-  async runAsync(ctx: CredentialsContext): Promise<BuildProfile<T>> {
-    const profileName = await this.getProfileNameFromEasConfigAsync(ctx);
+  async runAsync(): Promise<BuildProfile<T>> {
+    const profileName = await this.getProfileNameFromEasConfigAsync();
     const easConfig = await this.easJsonReader.getBuildProfileAsync<T>(this.platform, profileName);
     Log.succeed(`Using build profile: ${profileName}`);
     return easConfig;
   }
 
-  async getProfileNameFromEasConfigAsync(ctx: CredentialsContext): Promise<string> {
+  async getProfileNameFromEasConfigAsync(): Promise<string> {
     const buildProfileNames = await this.easJsonReader.getBuildProfileNamesAsync();
     if (buildProfileNames.length === 0) {
       throw new Error(
@@ -27,11 +26,6 @@ export class SelectBuildProfileFromEasJson<T extends Platform> {
       );
     } else if (buildProfileNames.length === 1) {
       return buildProfileNames[0];
-    }
-    if (ctx.nonInteractive) {
-      throw new Error(
-        'You have multiple build profiles. Please run this command in interactive mode.'
-      );
     }
     const { profileName } = await promptAsync({
       type: 'select',

--- a/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
@@ -1,10 +1,9 @@
 import { promptAsync } from '../../prompts';
-import { CredentialsContext } from '../context';
 import { ManageAndroid } from './ManageAndroid';
 import { ManageIos } from './ManageIos';
 
 export class SelectPlatform {
-  async runAsync(ctx: CredentialsContext): Promise<void> {
+  async runAsync(): Promise<void> {
     const { platform } = await promptAsync({
       type: 'select',
       name: 'platform',
@@ -16,8 +15,8 @@ export class SelectPlatform {
     });
 
     if (platform === 'ios') {
-      return await new ManageIos(new SelectPlatform()).runAsync(ctx);
+      return await new ManageIos(new SelectPlatform(), process.cwd()).runAsync();
     }
-    return await new ManageAndroid(new SelectPlatform()).runAsync(ctx);
+    return await new ManageAndroid(new SelectPlatform(), process.cwd()).runAsync();
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes https://github.com/expo/eas-cli/issues/820

Pass the `env` properties defined in an `eas.json` buildProfile into the expo config. In order to do this, I've needed to create the `buildProfile` before the `CredentialsContext`.

# Test Plan

- [x] manually tested with the repro steps in https://github.com/expo/eas-cli/issues/820
- [x] current tests still pass
