### PR TITLE
[ENG-2052] ask user to select profile if release does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Ask user to select profile if `release` does not exist. ([#829](https://github.com/expo/eas-cli/pull/829) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -3,6 +3,10 @@ import prompts, { Answers, Choice, Options, PromptType, PromptObject as Question
 
 export { PromptType, Question, Choice };
 
+export interface ExpoChoice<T> extends Choice {
+  value: T;
+}
+
 type NamelessQuestion = Omit<Question<'value'>, 'name' | 'type'>;
 
 export async function promptAsync<T extends string = string>(
@@ -35,11 +39,6 @@ export async function confirmAsync(
   );
   return value;
 }
-
-interface ExpoChoice<T> extends Choice {
-  value: T;
-}
-
 export async function selectAsync<T>(
   message: string,
   choices: ExpoChoice<T>[],

--- a/packages/eas-cli/src/utils/profiles.ts
+++ b/packages/eas-cli/src/utils/profiles.ts
@@ -106,7 +106,7 @@ export async function getProfilesAsync<T extends ProfileType>({
     });
     if (profileNames.length === 0) {
       throw new errors.MissingProfileError(
-        `Missing profile in eas.json: ${profileName ?? 'release'}`
+        `Missing profile in eas.json: ${profileName ?? 'production'}`
       );
     }
     const choices: ExpoChoice<string>[] = profileNames.map(profileName => ({
@@ -114,7 +114,7 @@ export async function getProfilesAsync<T extends ProfileType>({
       value: profileName,
     }));
     const chosenProfileName = await selectAsync(
-      'The "release" profile is missing in eas.json. Pick another profile:',
+      'The "production" profile is missing in eas.json. Pick another profile:',
       choices
     );
     const profile = await readProfileAsync({

--- a/packages/eas-cli/src/utils/profiles.ts
+++ b/packages/eas-cli/src/utils/profiles.ts
@@ -7,8 +7,10 @@ import {
   errors,
   getDefaultSubmitProfile,
 } from '@expo/eas-json';
+import chalk from 'chalk';
 
 import Log from '../log';
+import { ExpoChoice, selectAsync } from '../prompts';
 
 type EasProfile<T extends ProfileType> = T extends 'build'
   ? BuildProfile<Platform>
@@ -23,7 +25,7 @@ export type ProfileData<T extends ProfileType> = {
 export async function getProfilesAsync<T extends ProfileType>({
   projectDir,
   platforms,
-  profileName: profileNameArg,
+  profileName,
   type,
 }: {
   projectDir: string;
@@ -32,42 +34,98 @@ export async function getProfilesAsync<T extends ProfileType>({
   type: T;
 }): Promise<ProfileData<T>[]> {
   const results = platforms.map(async function (platform) {
-    let profile: EasProfile<T>;
-    let profileName = profileNameArg;
-
-    if (!profileName) {
-      try {
-        profileName = 'production';
-        profile = await readProfileAsync({ projectDir, platform, type, profileName });
-      } catch (errorOuter) {
-        if (!(errorOuter instanceof errors.MissingProfileError)) {
-          throw errorOuter;
-        }
-        try {
-          profileName = 'release';
-          profile = await readProfileAsync({ projectDir, platform, type, profileName });
-          Log.warn(
-            'The default profile changed from "release" to "production". We detected that you still have a "release" build profile, so we are using it. Update eas.json to have a profile named "production" under the `build` key, or specify which profile you\'d like to use with the --profile flag. This fallback behavior will be removed in the next major version of EAS CLI.'
-          );
-        } catch (errorInner) {
-          if (!(errorInner instanceof errors.MissingProfileError)) {
-            throw errorInner;
-          }
-          const defaultProfile = getDefaultProfile({ platform, type });
-          if (!defaultProfile) {
-            throw errorInner;
-          }
-          profileName = '__default__';
-          profile = defaultProfile;
-        }
-      }
-    } else {
-      profile = await readProfileAsync({ projectDir, platform, type, profileName });
+    if (profileName) {
+      const profile = await readProfileAsync({ projectDir, platform, type, profileName });
+      return {
+        profile,
+        profileName,
+        platform,
+      };
     }
 
+    try {
+      const profile = await readProfileAsync({
+        projectDir,
+        platform,
+        type,
+        profileName: 'production',
+      });
+      return {
+        profile,
+        profileName: 'production',
+        platform,
+      };
+    } catch (error) {
+      if (!(error instanceof errors.MissingProfileError)) {
+        throw error;
+      }
+    }
+
+    try {
+      const profile = await readProfileAsync({
+        projectDir,
+        platform,
+        type,
+        profileName: 'release',
+      });
+      Log.warn(
+        `The default profile changed from ${chalk.bold('release')} to ${chalk.bold(
+          'production'
+        )}. We detected that you still have a ${chalk.bold(
+          'release'
+        )} build profile, so we are using it. Update eas.json to have a profile named ${chalk.bold(
+          'production'
+        )} under the ${chalk.bold(
+          'build'
+        )} key, or specify which profile you'd like to use with the ${chalk.bold(
+          '--profile'
+        )} flag. This fallback behavior will be removed in the next major version of EAS CLI.`
+      );
+      return {
+        profile,
+        profileName: 'release',
+        platform,
+      };
+    } catch (error) {
+      if (!(error instanceof errors.MissingProfileError)) {
+        throw error;
+      }
+    }
+    const defaultProfile = getDefaultProfile({ platform, type });
+    if (defaultProfile) {
+      return {
+        profile: defaultProfile,
+        profileName: '__default__',
+        platform,
+      };
+    }
+
+    const profileNames = await readProfileNamesAsync({
+      projectDir,
+      type,
+    });
+    if (profileNames.length === 0) {
+      throw new errors.MissingProfileError(
+        `Missing profile in eas.json: ${profileName ?? 'release'}`
+      );
+    }
+    const choices: ExpoChoice<string>[] = profileNames.map(profileName => ({
+      title: profileName,
+      value: profileName,
+    }));
+    const chosenProfileName = await selectAsync(
+      'The "release" profile is missing in eas.json. Pick another profile:',
+      choices
+    );
+    const profile = await readProfileAsync({
+      projectDir,
+      platform,
+      type,
+      profileName: chosenProfileName,
+    });
     return {
       profile,
-      profileName,
+      profileName: chosenProfileName,
       platform,
     };
   });
@@ -105,5 +163,20 @@ function getDefaultProfile<T extends ProfileType>({
     return null;
   } else {
     return getDefaultSubmitProfile(platform) as EasProfile<T>;
+  }
+}
+
+async function readProfileNamesAsync({
+  projectDir,
+  type,
+}: {
+  projectDir: string;
+  type: ProfileType;
+}): Promise<string[]> {
+  const easJsonReader = new EasJsonReader(projectDir);
+  if (type === 'build') {
+    return await easJsonReader.getBuildProfileNamesAsync();
+  } else {
+    return await easJsonReader.getSubmitProfileNamesAsync();
   }
 }

--- a/packages/eas-json/src/__tests__/reader-submit-test.ts
+++ b/packages/eas-json/src/__tests__/reader-submit-test.ts
@@ -195,3 +195,28 @@ test('valid profile extending other profile', async () => {
     ascApiKeyId: 'ABCD',
   });
 });
+
+test('get profile names', async () => {
+  await fs.writeJson('/project/eas.json', {
+    submit: {
+      production: {
+        android: {
+          serviceAccountKeyPath: './path.json',
+          track: 'beta',
+          releaseStatus: 'completed',
+        },
+      },
+      blah: {
+        android: {
+          serviceAccountKeyPath: './path.json',
+          track: 'internal',
+          releaseStatus: 'completed',
+        },
+      },
+    },
+  });
+
+  const reader = new EasJsonReader('/project');
+  const allProfileNames = await reader.getSubmitProfileNamesAsync();
+  expect(allProfileNames.sort()).toEqual(['production', 'blah'].sort());
+});

--- a/packages/eas-json/src/reader.ts
+++ b/packages/eas-json/src/reader.ts
@@ -77,6 +77,11 @@ export class EasJsonReader {
     }
   }
 
+  public async getSubmitProfileNamesAsync(): Promise<string[]> {
+    const easJson = await this.readAsync();
+    return Object.keys(easJson?.submit ?? {});
+  }
+
   public async getSubmitProfileAsync<T extends Platform>(
     platform: T,
     profileName: string

--- a/packages/eas-json/src/submit/resolver.ts
+++ b/packages/eas-json/src/submit/resolver.ts
@@ -48,7 +48,7 @@ function resolveProfile<T extends Platform>({
   const profile = easJson.submit?.[profileName];
   if (!profile) {
     if (depth === 0) {
-      throw new MissingProfileError(`There is no submit profile named ${profileName} in eas.json`);
+      throw new MissingProfileError(`Missing submit profile in eas.json: ${profileName}`);
     } else {
       throw new MissingParentProfileError(
         `Extending non-existent submit profile in eas.json: ${profileName}`


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes https://linear.app/expo/issue/ENG-2052/prompt-user-to-pick-profile-if-release-doesnt-exist

# How

Ask the user to pick the profile if `release` does not exist.

# Test Plan

Tests + tested manually