### PR TITLE
[eas-json] use semver for version validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix validating tool versions in eas.json. ([#832](https://github.com/expo/eas-cli/pull/832) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [0.40.0](https://github.com/expo/eas-cli/releases/tag/v0.40.0) - 2021-12-08

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -12,6 +12,7 @@
     "fs-extra": "10.0.0",
     "joi": "17.4.2",
     "log-symbols": "4.1.0",
+    "semver": "7.3.5",
     "tslib": "2.3.1"
   },
   "devDependencies": {

--- a/packages/eas-json/src/__tests__/reader-build-test.ts
+++ b/packages/eas-json/src/__tests__/reader-build-test.ts
@@ -253,14 +253,14 @@ test('empty json', async () => {
 test('invalid semver value', async () => {
   await fs.writeJson('/project/eas.json', {
     build: {
-      production: { node: '12.0.0-alpha' },
+      production: { node: 'alpha' },
     },
   });
 
   const reader = new EasJsonReader('/project');
   const promise = reader.getBuildProfileAsync(Platform.ANDROID, 'production');
   await expect(promise).rejects.toThrowError(
-    'eas.json is not valid [ValidationError: "build.production.node" failed custom validation because 12.0.0-alpha is not a valid version]'
+    'eas.json is not valid [ValidationError: "build.production.node" failed custom validation because alpha is not a valid version]'
   );
 });
 
@@ -279,7 +279,7 @@ test('invalid release channel', async () => {
 test('get profile names', async () => {
   await fs.writeJson('/project/eas.json', {
     build: {
-      production: { node: '12.0.0' },
+      production: { node: '12.0.0-alpha' },
       blah: { node: '12.0.0' },
     },
   });

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -1,5 +1,6 @@
 import { Android, Ios } from '@expo/eas-build-job';
 import Joi from 'joi';
+import semver from 'semver';
 
 const CacheSchema = Joi.object({
   disabled: Joi.boolean(),
@@ -16,9 +17,9 @@ const CommonBuildProfileSchema = Joi.object({
   channel: Joi.string().regex(/^[a-z\d][a-z\d._-]*$/),
   developmentClient: Joi.boolean(),
 
-  node: Joi.string().empty(null).custom(semverSchemaCheck),
-  yarn: Joi.string().empty(null).custom(semverSchemaCheck),
-  expoCli: Joi.string().empty(null).custom(semverSchemaCheck),
+  node: Joi.string().empty(null).custom(semverCheck),
+  yarn: Joi.string().empty(null).custom(semverCheck),
+  expoCli: Joi.string().empty(null).custom(semverCheck),
   env: Joi.object().pattern(Joi.string(), Joi.string().empty(null)),
 });
 
@@ -29,7 +30,7 @@ const AndroidBuildProfileSchema = CommonBuildProfileSchema.concat(
     withoutCredentials: Joi.boolean(),
 
     image: Joi.string().valid(...Android.builderBaseImages),
-    ndk: Joi.string().empty(null).custom(semverSchemaCheck),
+    ndk: Joi.string().empty(null).custom(semverCheck),
     autoIncrement: Joi.alternatives().try(
       Joi.boolean(),
       Joi.string().valid('version', 'versionCode')
@@ -54,9 +55,9 @@ const IosBuildProfileSchema = CommonBuildProfileSchema.concat(
     simulator: Joi.boolean(),
 
     image: Joi.string().valid(...Ios.builderBaseImages),
-    bundler: Joi.string().empty(null).custom(semverSchemaCheck),
-    fastlane: Joi.string().empty(null).custom(semverSchemaCheck),
-    cocoapods: Joi.string().empty(null).custom(semverSchemaCheck),
+    bundler: Joi.string().empty(null).custom(semverCheck),
+    fastlane: Joi.string().empty(null).custom(semverCheck),
+    cocoapods: Joi.string().empty(null).custom(semverCheck),
 
     artifactPath: Joi.string(),
     scheme: Joi.string(),
@@ -72,8 +73,8 @@ export const BuildProfileSchema = CommonBuildProfileSchema.concat(
   })
 );
 
-function semverSchemaCheck(value: any): any {
-  if (/^[0-9]+\.[0-9]+\.[0-9]+$/.test(value)) {
+function semverCheck(value: any): any {
+  if (semver.valid(value)) {
     return value;
   } else {
     throw new Error(`${value} is not a valid version`);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes https://github.com/expo/eas-cli/issues/558#issuecomment-989162199
We use a custom regex for version validation in eas.json. The regex does not allow alpha versions.

# How

Use `semver.valid` for version validation.

# Test Plan

Tests
