### PR TITLE
[ENG-2279] warn when attempting to use EAS CLI on managed SDK < 41 project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Warn when building managed project with  SDK < 41. ([#833](https://github.com/expo/eas-cli/pull/833) by [@dsokal](https://github.com/dsokal))
+
 ## [0.40.0](https://github.com/expo/eas-cli/releases/tag/v0.40.0) - 2021-12-08
 
 ### 🛠 Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Warn when building managed project with  SDK < 41. ([#833](https://github.com/expo/eas-cli/pull/833) by [@dsokal](https://github.com/dsokal))
+- Warn when building managed project with SDK < 41. ([#833](https://github.com/expo/eas-cli/pull/833) by [@dsokal](https://github.com/dsokal))
 
 ## [0.40.0](https://github.com/expo/eas-cli/releases/tag/v0.40.0) - 2021-12-08
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -32,6 +32,7 @@ import {
   selectRequestedPlatformAsync,
   toPlatforms,
 } from '../../platform';
+import { checkExpoSdkIsSupportedAsync } from '../../project/expoSdk';
 import { validateMetroConfigForManagedWorkflowAsync } from '../../project/metroConfig';
 import { findProjectRootAsync } from '../../project/projectUtils';
 import { selectAsync } from '../../prompts';
@@ -130,6 +131,7 @@ export default class Build extends EasCommand {
   };
 
   private metroConfigValidated = false;
+  private sdkVersionChecked = false;
 
   async runAsync(): Promise<void> {
     const { flags: rawFlags } = this.parse(Build);
@@ -315,9 +317,15 @@ export default class Build extends EasCommand {
       );
     }
 
-    if (buildCtx.workflow === Workflow.MANAGED && !this.metroConfigValidated) {
-      await validateMetroConfigForManagedWorkflowAsync(buildCtx);
-      this.metroConfigValidated = true;
+    if (buildCtx.workflow === Workflow.MANAGED) {
+      if (!this.sdkVersionChecked) {
+        await checkExpoSdkIsSupportedAsync(buildCtx);
+        this.sdkVersionChecked = true;
+      }
+      if (!this.metroConfigValidated) {
+        await validateMetroConfigForManagedWorkflowAsync(buildCtx);
+        this.metroConfigValidated = true;
+      }
     }
 
     const build = await this.startBuildAsync(buildCtx);

--- a/packages/eas-cli/src/project/expoSdk.ts
+++ b/packages/eas-cli/src/project/expoSdk.ts
@@ -1,0 +1,35 @@
+import { Platform, Workflow } from '@expo/eas-build-job';
+import { exit } from '@oclif/errors';
+import assert from 'assert';
+import semver from 'semver';
+
+import { BuildContext } from '../build/context';
+import Log from '../log';
+import { confirmAsync } from '../prompts';
+
+const SUPPORTED_EXPO_SDK_VERSIONS = '>= 41.0.0';
+assert(semver.validRange(SUPPORTED_EXPO_SDK_VERSIONS), 'Must be a valid version range');
+
+export async function checkExpoSdkIsSupportedAsync(ctx: BuildContext<Platform>): Promise<void> {
+  assert(ctx.workflow === Workflow.MANAGED, 'Must be a managed workflow project');
+
+  if (ctx.exp.sdkVersion && semver.satisfies(ctx.exp.sdkVersion, SUPPORTED_EXPO_SDK_VERSIONS)) {
+    return;
+  }
+
+  const unsupportedSdkMessage =
+    'EAS Build does not officially support building managed project with Expo SDK < 41.';
+  if (ctx.nonInteractive) {
+    Log.warn(
+      `${unsupportedSdkMessage} Proceeding because you are running in non-interactive mode.`
+    );
+    return;
+  }
+
+  const proceed = await confirmAsync({
+    message: `${unsupportedSdkMessage} Do you want to proceed?`,
+  });
+  if (!proceed) {
+    exit(1);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes https://linear.app/expo/issue/ENG-2279/loudly-warn-when-attempting-to-use-eas-cli-on-managed-sdk-41-project

Projects with SDK < 41 are not supported.

# How

Ask the user if they want to proceed if EAS CLI detects the project is using SDK < 41. Print warning and proceed in non-interactive mode.

# Test Plan

_Screenshots were made when I had a typo in the message. I changed 42 -> 41_

Unsupported SDK:
<img width="760" alt="Screenshot 2021-12-09 at 14 57 28" src="https://user-images.githubusercontent.com/5256730/145410029-d4465fa4-864c-4863-9da8-f8e595fe5757.png">

Supported SDK:
<img width="841" alt="Screenshot 2021-12-09 at 14 56 57" src="https://user-images.githubusercontent.com/5256730/145410032-7af95223-5345-4216-984c-cfc6d0c99b52.png">
