### PR TITLE
[eas-cli] add build inspect command

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -95,7 +95,7 @@ export async function prepareBuildRequestForPlatformAsync<
 
   return async () => {
     if (ctx.local) {
-      await runLocalBuildAsync(job);
+      await runLocalBuildAsync(job, ctx.localBuildOptions);
       return undefined;
     } else {
       try {

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -77,7 +77,7 @@ export async function prepareBuildRequestForPlatformAsync<
     );
   }
 
-  const projectArchive = ctx.local
+  const projectArchive = ctx.localBuildOptions.enable
     ? ({
         type: ArchiveSourceType.PATH,
         path: (await makeProjectTarballAsync()).path,
@@ -94,7 +94,7 @@ export async function prepareBuildRequestForPlatformAsync<
   });
 
   return async () => {
-    if (ctx.local) {
+    if (ctx.localBuildOptions.enable) {
       await runLocalBuildAsync(job, ctx.localBuildOptions);
       return undefined;
     } else {

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -10,6 +10,7 @@ import { RequestedPlatform } from '../platform';
 import { GradleBuildContext } from '../project/android/gradle';
 import { XcodeBuildContext } from '../project/ios/scheme';
 import { Actor } from '../user/User';
+import { LocalBuildOptions } from './local';
 
 export interface ConfigureContext {
   user: Actor;
@@ -45,6 +46,7 @@ export interface BuildContext<T extends Platform> {
   credentialsCtx: CredentialsContext;
   exp: ExpoConfig;
   local: boolean;
+  localBuildOptions: LocalBuildOptions;
   nonInteractive: boolean;
   platform: T;
   projectDir: string;

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -45,7 +45,6 @@ export interface BuildContext<T extends Platform> {
   clearCache: boolean;
   credentialsCtx: CredentialsContext;
   exp: ExpoConfig;
-  local: boolean;
   localBuildOptions: LocalBuildOptions;
   nonInteractive: boolean;
   platform: T;

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -21,8 +21,7 @@ export async function createBuildContextAsync<T extends Platform>({
   buildProfileName,
   buildProfile,
   clearCache = false,
-  local,
-  localBuildOptions = {},
+  localBuildOptions,
   nonInteractive = false,
   platform,
   projectDir,
@@ -31,8 +30,7 @@ export async function createBuildContextAsync<T extends Platform>({
   buildProfileName: string;
   buildProfile: BuildProfile<T>;
   clearCache: boolean;
-  local: boolean;
-  localBuildOptions?: LocalBuildOptions;
+  localBuildOptions: LocalBuildOptions;
   nonInteractive: boolean;
   platform: T;
   projectDir: string;
@@ -77,7 +75,6 @@ export async function createBuildContextAsync<T extends Platform>({
     clearCache,
     credentialsCtx,
     exp,
-    local,
     localBuildOptions,
     nonInteractive,
     platform,

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -15,12 +15,14 @@ import { ensureLoggedInAsync } from '../user/actions';
 import { createAndroidContextAsync } from './android/build';
 import { BuildContext, CommonContext } from './context';
 import { createIosContextAsync } from './ios/build';
+import { LocalBuildOptions } from './local';
 
 export async function createBuildContextAsync<T extends Platform>({
   buildProfileName,
   buildProfile,
   clearCache = false,
   local,
+  localBuildOptions = {},
   nonInteractive = false,
   platform,
   projectDir,
@@ -30,6 +32,7 @@ export async function createBuildContextAsync<T extends Platform>({
   buildProfile: BuildProfile<T>;
   clearCache: boolean;
   local: boolean;
+  localBuildOptions?: LocalBuildOptions;
   nonInteractive: boolean;
   platform: T;
   projectDir: string;
@@ -75,6 +78,7 @@ export async function createBuildContextAsync<T extends Platform>({
     credentialsCtx,
     exp,
     local,
+    localBuildOptions,
     nonInteractive,
     platform,
     projectDir,

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -9,8 +9,9 @@ const PLUGIN_PACKAGE_NAME = 'eas-cli-local-build-plugin';
 const PLUGIN_PACKAGE_VERSION = '0.0.54';
 
 export interface LocalBuildOptions {
+  enable: boolean;
   skipCleanup?: boolean;
-  prepareOnly?: boolean;
+  skipNativeBuild?: boolean;
   artifactsDir?: string;
   workingdir?: string;
   verbose?: boolean;
@@ -20,7 +21,7 @@ export async function runLocalBuildAsync(job: Job, options: LocalBuildOptions): 
   const { command, args } = await getCommandAndArgsAsync(job);
   let spinner;
   if (!options.verbose) {
-    spinner = ora().start(options.prepareOnly ? 'Preparing project' : 'Building project');
+    spinner = ora().start(options.skipNativeBuild ? 'Preparing project' : 'Building project');
   }
   let childProcess: ChildProcess | undefined;
   const interruptHandler = (): void => {
@@ -35,10 +36,10 @@ export async function runLocalBuildAsync(job: Job, options: LocalBuildOptions): 
       env: {
         ...process.env,
         EAS_LOCAL_BUILD_WORKINGDIR: options.workingdir ?? process.env.EAS_LOCAL_BUILD_WORKINGDIR,
-        ...(options.skipCleanup || options.prepareOnly
+        ...(options.skipCleanup || options.skipNativeBuild
           ? { EAS_LOCAL_BUILD_SKIP_CLEANUP: '1' }
           : {}),
-        ...(options.prepareOnly ? { EAS_LOCAL_BUILD_PREPARE_ONLY: '1' } : {}),
+        ...(options.skipNativeBuild ? { EAS_LOCAL_BUILD_SKIP_NATIVE_BUILD: '1' } : {}),
         ...(options.artifactsDir ? { EAS_LOCAL_BUILD_ARTIFACTS_DIR: options.artifactsDir } : {}),
       },
     });

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -1,15 +1,55 @@
 import { Job } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
+import { ChildProcess } from 'child_process';
 import semver from 'semver';
+
+import { ora } from '../ora';
 
 const PLUGIN_PACKAGE_NAME = 'eas-cli-local-build-plugin';
 const PLUGIN_PACKAGE_VERSION = '0.0.54';
 
-export async function runLocalBuildAsync(job: Job): Promise<void> {
+export interface LocalBuildOptions {
+  skipCleanup?: boolean;
+  prepareOnly?: boolean;
+  artifactsDir?: string;
+  workingdir?: string;
+  verbose?: boolean;
+}
+
+export async function runLocalBuildAsync(job: Job, options: LocalBuildOptions): Promise<void> {
   const { command, args } = await getCommandAndArgsAsync(job);
-  await spawnAsync(command, args, {
-    stdio: 'inherit',
-  });
+  let spinner;
+  if (!options.verbose) {
+    spinner = ora().start(options.prepareOnly ? 'Preparing project' : 'Building project');
+  }
+  let childProcess: ChildProcess | undefined;
+  const interruptHandler = (): void => {
+    if (childProcess) {
+      childProcess.kill();
+    }
+  };
+  process.on('SIGINT', interruptHandler);
+  try {
+    const spawnPromise = spawnAsync(command, args, {
+      stdio: options.verbose ? 'inherit' : 'pipe',
+      env: {
+        ...process.env,
+        EAS_LOCAL_BUILD_WORKINGDIR: options.workingdir ?? process.env.EAS_LOCAL_BUILD_WORKINGDIR,
+        ...(options.skipCleanup || options.prepareOnly
+          ? { EAS_LOCAL_BUILD_SKIP_CLEANUP: '1' }
+          : {}),
+        ...(options.prepareOnly ? { EAS_LOCAL_BUILD_PREPARE_ONLY: '1' } : {}),
+        ...(options.artifactsDir ? { EAS_LOCAL_BUILD_ARTIFACTS_DIR: options.artifactsDir } : {}),
+      },
+    });
+    childProcess = spawnPromise.child;
+    await spawnPromise;
+  } finally {
+    process.removeListener('SIGINT', interruptHandler);
+    if (spinner) {
+      spinner.stop();
+    }
+  }
 }
 
 async function getCommandAndArgsAsync(job: Job): Promise<{ command: string; args: string[] }> {

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -46,9 +46,7 @@ export async function runLocalBuildAsync(job: Job, options: LocalBuildOptions): 
     await spawnPromise;
   } finally {
     process.removeListener('SIGINT', interruptHandler);
-    if (spinner) {
-      spinner.stop();
-    }
+    spinner?.stop();
   }
 }
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -41,13 +41,12 @@ export interface BuildFlags {
   skipProjectConfiguration: boolean;
   profile?: string;
   nonInteractive: boolean;
-  local: boolean;
   wait: boolean;
   clearCache: boolean;
   json: boolean;
   autoSubmit: boolean;
   submitProfile?: string;
-  localBuildOptions?: LocalBuildOptions;
+  localBuildOptions: LocalBuildOptions;
 }
 
 export async function runBuildAndSubmitAsync(projectDir: string, flags: BuildFlags): Promise<void> {
@@ -89,7 +88,7 @@ export async function runBuildAndSubmitAsync(projectDir: string, flags: BuildFla
     buildCtxByPlatform[toAppPlatform(buildProfile.platform)] = buildCtx;
   }
 
-  if (flags.local) {
+  if (flags.localBuildOptions.enable) {
     return;
   }
 
@@ -161,7 +160,6 @@ async function prepareAndStartBuildAsync({
     buildProfileName: buildProfile.profileName,
     clearCache: flags.clearCache,
     buildProfile: buildProfile.profile,
-    local: flags.local,
     nonInteractive: flags.nonInteractive,
     platform: buildProfile.platform,
     projectDir,

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -1,0 +1,259 @@
+import { Platform, Workflow } from '@expo/eas-build-job';
+import { BuildProfile, SubmitProfile } from '@expo/eas-json';
+import chalk from 'chalk';
+import nullthrows from 'nullthrows';
+
+import { AppPlatform, BuildFragment, BuildStatus, SubmissionFragment } from '../graphql/generated';
+import { toAppPlatform, toPlatform } from '../graphql/types/AppPlatform';
+import Log from '../log';
+import {
+  RequestedPlatform,
+  appPlatformDisplayNames,
+  appPlatformEmojis,
+  toPlatforms,
+} from '../platform';
+import { checkExpoSdkIsSupportedAsync } from '../project/expoSdk';
+import { validateMetroConfigForManagedWorkflowAsync } from '../project/metroConfig';
+import { createSubmissionContextAsync } from '../submit/context';
+import {
+  submitAsync,
+  waitToCompleteAsync as waitForSubmissionsToCompleteAsync,
+} from '../submit/submit';
+import { printSubmissionDetailsUrls } from '../submit/utils/urls';
+import { ProfileData, getProfilesAsync } from '../utils/profiles';
+import { getVcsClient } from '../vcs';
+import { prepareAndroidBuildAsync } from './android/build';
+import { BuildRequestSender, waitForBuildEndAsync } from './build';
+import { ensureProjectConfiguredAsync } from './configure';
+import { BuildContext } from './context';
+import { createBuildContextAsync } from './createContext';
+import { prepareIosBuildAsync } from './ios/build';
+import { LocalBuildOptions } from './local';
+import { ensureExpoDevClientInstalledForDevClientBuildsAsync } from './utils/devClient';
+import { printBuildResults, printLogsUrls } from './utils/printBuildInfo';
+import { ensureRepoIsCleanAsync } from './utils/repository';
+
+let metroConfigValidated = false;
+let sdkVersionChecked = false;
+
+export interface BuildFlags {
+  requestedPlatform: RequestedPlatform;
+  skipProjectConfiguration: boolean;
+  profile?: string;
+  nonInteractive: boolean;
+  local: boolean;
+  wait: boolean;
+  clearCache: boolean;
+  json: boolean;
+  autoSubmit: boolean;
+  submitProfile?: string;
+  localBuildOptions?: LocalBuildOptions;
+}
+
+export async function runBuildAndSubmitAsync(projectDir: string, flags: BuildFlags): Promise<void> {
+  await getVcsClient().ensureRepoExistsAsync();
+  await ensureRepoIsCleanAsync(flags.nonInteractive);
+
+  await ensureProjectConfiguredAsync(projectDir, flags.requestedPlatform);
+
+  const platforms = toPlatforms(flags.requestedPlatform);
+  const buildProfiles = await getProfilesAsync({
+    type: 'build',
+    projectDir,
+    platforms,
+    profileName: flags.profile ?? undefined,
+  });
+
+  await ensureExpoDevClientInstalledForDevClientBuildsAsync({
+    projectDir,
+    nonInteractive: flags.nonInteractive,
+    buildProfiles,
+  });
+
+  const startedBuilds: {
+    build: BuildFragment;
+    buildProfile: ProfileData<'build'>;
+  }[] = [];
+  const buildCtxByPlatform: { [p in AppPlatform]?: BuildContext<Platform> } = {};
+
+  for (const buildProfile of buildProfiles) {
+    const { build: maybeBuild, buildCtx } = await prepareAndStartBuildAsync({
+      projectDir,
+      flags,
+      moreBuilds: platforms.length > 1,
+      buildProfile,
+    });
+    if (maybeBuild) {
+      startedBuilds.push({ build: maybeBuild, buildProfile });
+    }
+    buildCtxByPlatform[toAppPlatform(buildProfile.platform)] = buildCtx;
+  }
+
+  if (flags.local) {
+    return;
+  }
+
+  Log.newLine();
+  printLogsUrls(startedBuilds.map(startedBuild => startedBuild.build));
+  Log.newLine();
+
+  const submissions: SubmissionFragment[] = [];
+  if (flags.autoSubmit) {
+    const submitProfiles = await getProfilesAsync({
+      projectDir,
+      platforms,
+      profileName: flags.submitProfile,
+      type: 'submit',
+    });
+    for (const startedBuild of startedBuilds) {
+      const submitProfile = nullthrows(
+        submitProfiles.find(
+          ({ platform }) => toAppPlatform(platform) === startedBuild.build.platform
+        )
+      ).profile;
+      const submission = await prepareAndStartSubmissionAsync({
+        build: startedBuild.build,
+        buildCtx: nullthrows(buildCtxByPlatform[startedBuild.build.platform]),
+        moreBuilds: startedBuilds.length > 1,
+        projectDir,
+        buildProfile: startedBuild.buildProfile.profile,
+        submitProfile,
+        nonInteractive: flags.nonInteractive,
+      });
+      submissions.push(submission);
+    }
+
+    Log.newLine();
+    printSubmissionDetailsUrls(submissions);
+    Log.newLine();
+  }
+
+  if (!flags.wait) {
+    return;
+  }
+
+  const builds = await waitForBuildEndAsync(startedBuilds.map(({ build }) => build.id));
+  printBuildResults(builds, flags.json);
+
+  const haveAllBuildsFailedOrCanceled = builds.every(
+    build => build?.status && [BuildStatus.Errored, BuildStatus.Canceled].includes(build?.status)
+  );
+  if (haveAllBuildsFailedOrCanceled || !flags.autoSubmit) {
+    exitWithNonZeroCodeIfSomeBuildsFailed(builds);
+  } else {
+    // the following function also exits with non zero code if any of the submissions failed
+    await waitForSubmissionsToCompleteAsync(submissions);
+  }
+}
+
+async function prepareAndStartBuildAsync({
+  projectDir,
+  flags,
+  moreBuilds,
+  buildProfile,
+}: {
+  projectDir: string;
+  flags: BuildFlags;
+  moreBuilds: boolean;
+  buildProfile: ProfileData<'build'>;
+}): Promise<{ build: BuildFragment | undefined; buildCtx: BuildContext<Platform> }> {
+  const buildCtx = await createBuildContextAsync({
+    buildProfileName: buildProfile.profileName,
+    clearCache: flags.clearCache,
+    buildProfile: buildProfile.profile,
+    local: flags.local,
+    nonInteractive: flags.nonInteractive,
+    platform: buildProfile.platform,
+    projectDir,
+    skipProjectConfiguration: flags.skipProjectConfiguration,
+    localBuildOptions: flags.localBuildOptions,
+  });
+
+  if (moreBuilds) {
+    Log.newLine();
+    const appPlatform = toAppPlatform(buildProfile.platform);
+    Log.log(
+      `${appPlatformEmojis[appPlatform]} ${chalk.bold(
+        `${appPlatformDisplayNames[appPlatform]} build`
+      )}`
+    );
+  }
+
+  if (buildCtx.workflow === Workflow.MANAGED) {
+    if (!sdkVersionChecked) {
+      await checkExpoSdkIsSupportedAsync(buildCtx);
+      sdkVersionChecked = true;
+    }
+    if (!metroConfigValidated) {
+      await validateMetroConfigForManagedWorkflowAsync(buildCtx);
+      metroConfigValidated = true;
+    }
+  }
+
+  const build = await startBuildAsync(buildCtx);
+  return {
+    build,
+    buildCtx,
+  };
+}
+
+async function startBuildAsync(ctx: BuildContext<Platform>): Promise<BuildFragment | undefined> {
+  let sendBuildRequestAsync: BuildRequestSender;
+  if (ctx.platform === Platform.ANDROID) {
+    sendBuildRequestAsync = await prepareAndroidBuildAsync(ctx as BuildContext<Platform.ANDROID>);
+  } else {
+    sendBuildRequestAsync = await prepareIosBuildAsync(ctx as BuildContext<Platform.IOS>);
+  }
+  return await sendBuildRequestAsync();
+}
+
+async function prepareAndStartSubmissionAsync({
+  build,
+  buildCtx,
+  moreBuilds,
+  projectDir,
+  buildProfile,
+  submitProfile,
+  nonInteractive,
+}: {
+  build: BuildFragment;
+  buildCtx: BuildContext<Platform>;
+  moreBuilds: boolean;
+  projectDir: string;
+  buildProfile: BuildProfile;
+  submitProfile: SubmitProfile;
+  nonInteractive: boolean;
+}): Promise<SubmissionFragment> {
+  const platform = toPlatform(build.platform);
+  const submissionCtx = await createSubmissionContextAsync({
+    platform,
+    projectDir,
+    projectId: build.project.id,
+    profile: submitProfile,
+    archiveFlags: { id: build.id },
+    nonInteractive,
+    env: buildProfile.env,
+    credentialsCtx: buildCtx.credentialsCtx,
+    applicationIdentifier: buildCtx.android?.applicationId ?? buildCtx.ios?.bundleIdentifier,
+  });
+
+  if (moreBuilds) {
+    Log.newLine();
+    Log.log(
+      `${appPlatformEmojis[build.platform]} ${chalk.bold(
+        `${appPlatformDisplayNames[build.platform]} submission`
+      )}`
+    );
+  }
+
+  return await submitAsync(submissionCtx);
+}
+
+function exitWithNonZeroCodeIfSomeBuildsFailed(maybeBuilds: (BuildFragment | null)[]): void {
+  const failedBuilds = (maybeBuilds.filter(i => i) as BuildFragment[]).filter(
+    i => i.status === BuildStatus.Errored
+  );
+  if (failedBuilds.length > 0) {
+    process.exit(1);
+  }
+}

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -136,10 +136,11 @@ export default class Build extends EasCommand {
       skipProjectConfiguration: flags['skip-project-configuration'],
       profile,
       nonInteractive,
-      local: flags['local'],
-      localBuildOptions: {
-        verbose: true,
-      },
+      localBuildOptions: flags['local']
+        ? { enable: true, verbose: true }
+        : {
+            enable: false,
+          },
       wait: flags['wait'],
       clearCache: flags['clear-cache'],
       json: flags['json'],

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -1,50 +1,19 @@
-import { Platform, Workflow } from '@expo/eas-build-job';
-import { BuildProfile, EasJsonReader, SubmitProfile } from '@expo/eas-json';
+import { EasJsonReader } from '@expo/eas-json';
 import { flags } from '@oclif/command';
 import { error } from '@oclif/errors';
 import chalk from 'chalk';
 import figures from 'figures';
 import fs from 'fs-extra';
-import nullthrows from 'nullthrows';
 
-import { prepareAndroidBuildAsync } from '../../build/android/build';
-import { BuildRequestSender, waitForBuildEndAsync } from '../../build/build';
-import { ensureProjectConfiguredAsync } from '../../build/configure';
-import { BuildContext } from '../../build/context';
-import { createBuildContextAsync } from '../../build/createContext';
-import { prepareIosBuildAsync } from '../../build/ios/build';
-import { ensureExpoDevClientInstalledForDevClientBuildsAsync } from '../../build/utils/devClient';
-import { printBuildResults, printLogsUrls } from '../../build/utils/printBuildInfo';
+import { BuildFlags, runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import { ensureRepoIsCleanAsync, reviewAndCommitChangesAsync } from '../../build/utils/repository';
 import EasCommand from '../../commandUtils/EasCommand';
-import {
-  AppPlatform,
-  BuildFragment,
-  BuildStatus,
-  SubmissionFragment,
-} from '../../graphql/generated';
-import { toAppPlatform, toPlatform } from '../../graphql/types/AppPlatform';
 import Log, { learnMore, link } from '../../log';
-import {
-  RequestedPlatform,
-  appPlatformDisplayNames,
-  appPlatformEmojis,
-  selectRequestedPlatformAsync,
-  toPlatforms,
-} from '../../platform';
-import { checkExpoSdkIsSupportedAsync } from '../../project/expoSdk';
-import { validateMetroConfigForManagedWorkflowAsync } from '../../project/metroConfig';
+import { RequestedPlatform, selectRequestedPlatformAsync } from '../../platform';
 import { findProjectRootAsync } from '../../project/projectUtils';
 import { selectAsync } from '../../prompts';
-import { createSubmissionContextAsync } from '../../submit/context';
-import {
-  submitAsync,
-  waitToCompleteAsync as waitForSubmissionsToCompleteAsync,
-} from '../../submit/submit';
-import { printSubmissionDetailsUrls } from '../../submit/utils/urls';
 import { easCliVersion } from '../../utils/easCli';
 import { enableJsonOutput } from '../../utils/json';
-import { ProfileData, getProfilesAsync } from '../../utils/profiles';
 import { getVcsClient, setVcsClient } from '../../vcs';
 import GitClient from '../../vcs/clients/git';
 
@@ -60,19 +29,6 @@ interface RawBuildFlags {
   json: boolean;
   'auto-submit': boolean;
   'auto-submit-with-profile'?: string;
-}
-
-interface BuildFlags {
-  requestedPlatform: RequestedPlatform;
-  skipProjectConfiguration: boolean;
-  profile?: string;
-  nonInteractive: boolean;
-  local: boolean;
-  wait: boolean;
-  clearCache: boolean;
-  json: boolean;
-  autoSubmit: boolean;
-  submitProfile?: string;
 }
 
 export default class Build extends EasCommand {
@@ -130,113 +86,17 @@ export default class Build extends EasCommand {
     }),
   };
 
-  private metroConfigValidated = false;
-  private sdkVersionChecked = false;
-
   async runAsync(): Promise<void> {
     const { flags: rawFlags } = this.parse(Build);
     if (rawFlags.json) {
       enableJsonOutput();
     }
     const flags = await this.sanitizeFlagsAsync(rawFlags);
-    const { requestedPlatform } = flags;
 
     const projectDir = await findProjectRootAsync();
     await handleDeprecatedEasJsonAsync(projectDir, flags.nonInteractive);
 
-    await getVcsClient().ensureRepoExistsAsync();
-    await ensureRepoIsCleanAsync(flags.nonInteractive);
-
-    await ensureProjectConfiguredAsync(projectDir, requestedPlatform);
-
-    const platforms = toPlatforms(requestedPlatform);
-    const buildProfiles = await getProfilesAsync({
-      type: 'build',
-      projectDir,
-      platforms,
-      profileName: flags.profile ?? undefined,
-    });
-
-    await ensureExpoDevClientInstalledForDevClientBuildsAsync({
-      projectDir,
-      nonInteractive: flags.nonInteractive,
-      buildProfiles,
-    });
-
-    const startedBuilds: {
-      build: BuildFragment;
-      buildProfile: ProfileData<'build'>;
-    }[] = [];
-    const buildCtxByPlatform: { [p in AppPlatform]?: BuildContext<Platform> } = {};
-
-    for (const buildProfile of buildProfiles) {
-      const { build: maybeBuild, buildCtx } = await this.prepareAndStartBuildAsync({
-        projectDir,
-        flags,
-        moreBuilds: platforms.length > 1,
-        buildProfile,
-      });
-      if (maybeBuild) {
-        startedBuilds.push({ build: maybeBuild, buildProfile });
-      }
-      buildCtxByPlatform[toAppPlatform(buildProfile.platform)] = buildCtx;
-    }
-
-    if (flags.local) {
-      return;
-    }
-
-    Log.newLine();
-    printLogsUrls(startedBuilds.map(startedBuild => startedBuild.build));
-    Log.newLine();
-
-    const submissions: SubmissionFragment[] = [];
-    if (flags.autoSubmit) {
-      const submitProfiles = await getProfilesAsync({
-        projectDir,
-        platforms,
-        profileName: flags.submitProfile,
-        type: 'submit',
-      });
-      for (const startedBuild of startedBuilds) {
-        const submitProfile = nullthrows(
-          submitProfiles.find(
-            ({ platform }) => toAppPlatform(platform) === startedBuild.build.platform
-          )
-        ).profile;
-        const submission = await this.prepareAndStartSubmissionAsync({
-          build: startedBuild.build,
-          buildCtx: nullthrows(buildCtxByPlatform[startedBuild.build.platform]),
-          moreBuilds: startedBuilds.length > 1,
-          projectDir,
-          buildProfile: startedBuild.buildProfile.profile,
-          submitProfile,
-          nonInteractive: flags.nonInteractive,
-        });
-        submissions.push(submission);
-      }
-
-      Log.newLine();
-      printSubmissionDetailsUrls(submissions);
-      Log.newLine();
-    }
-
-    if (!flags.wait) {
-      return;
-    }
-
-    const builds = await waitForBuildEndAsync(startedBuilds.map(({ build }) => build.id));
-    printBuildResults(builds, flags.json);
-
-    const haveAllBuildsFailedOrCanceled = builds.every(
-      build => build?.status && [BuildStatus.Errored, BuildStatus.Canceled].includes(build?.status)
-    );
-    if (haveAllBuildsFailedOrCanceled || !flags.autoSubmit) {
-      this.exitWithNonZeroCodeIfSomeBuildsFailed(builds);
-    } else {
-      // the following function also exits with non zero code if any of the submissions failed
-      await waitForSubmissionsToCompleteAsync(submissions);
-    }
+    await runBuildAndSubmitAsync(projectDir, flags);
   }
 
   private async sanitizeFlagsAsync(flags: RawBuildFlags): Promise<BuildFlags> {
@@ -277,123 +137,15 @@ export default class Build extends EasCommand {
       profile,
       nonInteractive,
       local: flags['local'],
+      localBuildOptions: {
+        verbose: true,
+      },
       wait: flags['wait'],
       clearCache: flags['clear-cache'],
       json: flags['json'],
       autoSubmit: flags['auto-submit'] || flags['auto-submit-with-profile'] !== undefined,
       submitProfile: flags['auto-submit-with-profile'] ?? profile,
     };
-  }
-
-  private async prepareAndStartBuildAsync({
-    projectDir,
-    flags,
-    moreBuilds,
-    buildProfile,
-  }: {
-    projectDir: string;
-    flags: BuildFlags;
-    moreBuilds: boolean;
-    buildProfile: ProfileData<'build'>;
-  }): Promise<{ build: BuildFragment | undefined; buildCtx: BuildContext<Platform> }> {
-    const buildCtx = await createBuildContextAsync({
-      buildProfileName: buildProfile.profileName,
-      clearCache: flags.clearCache,
-      buildProfile: buildProfile.profile,
-      local: flags.local,
-      nonInteractive: flags.nonInteractive,
-      platform: buildProfile.platform,
-      projectDir,
-      skipProjectConfiguration: flags.skipProjectConfiguration,
-    });
-
-    if (moreBuilds) {
-      Log.newLine();
-      const appPlatform = toAppPlatform(buildProfile.platform);
-      Log.log(
-        `${appPlatformEmojis[appPlatform]} ${chalk.bold(
-          `${appPlatformDisplayNames[appPlatform]} build`
-        )}`
-      );
-    }
-
-    if (buildCtx.workflow === Workflow.MANAGED) {
-      if (!this.sdkVersionChecked) {
-        await checkExpoSdkIsSupportedAsync(buildCtx);
-        this.sdkVersionChecked = true;
-      }
-      if (!this.metroConfigValidated) {
-        await validateMetroConfigForManagedWorkflowAsync(buildCtx);
-        this.metroConfigValidated = true;
-      }
-    }
-
-    const build = await this.startBuildAsync(buildCtx);
-    return {
-      build,
-      buildCtx,
-    };
-  }
-
-  private async startBuildAsync(ctx: BuildContext<Platform>): Promise<BuildFragment | undefined> {
-    let sendBuildRequestAsync: BuildRequestSender;
-    if (ctx.platform === Platform.ANDROID) {
-      sendBuildRequestAsync = await prepareAndroidBuildAsync(ctx as BuildContext<Platform.ANDROID>);
-    } else {
-      sendBuildRequestAsync = await prepareIosBuildAsync(ctx as BuildContext<Platform.IOS>);
-    }
-    return await sendBuildRequestAsync();
-  }
-
-  private async prepareAndStartSubmissionAsync({
-    build,
-    buildCtx,
-    moreBuilds,
-    projectDir,
-    buildProfile,
-    submitProfile,
-    nonInteractive,
-  }: {
-    build: BuildFragment;
-    buildCtx: BuildContext<Platform>;
-    moreBuilds: boolean;
-    projectDir: string;
-    buildProfile: BuildProfile;
-    submitProfile: SubmitProfile;
-    nonInteractive: boolean;
-  }): Promise<SubmissionFragment> {
-    const platform = toPlatform(build.platform);
-    const submissionCtx = await createSubmissionContextAsync({
-      platform,
-      projectDir,
-      projectId: build.project.id,
-      profile: submitProfile,
-      archiveFlags: { id: build.id },
-      nonInteractive,
-      env: buildProfile.env,
-      credentialsCtx: buildCtx.credentialsCtx,
-      applicationIdentifier: buildCtx.android?.applicationId ?? buildCtx.ios?.bundleIdentifier,
-    });
-
-    if (moreBuilds) {
-      Log.newLine();
-      Log.log(
-        `${appPlatformEmojis[build.platform]} ${chalk.bold(
-          `${appPlatformDisplayNames[build.platform]} submission`
-        )}`
-      );
-    }
-
-    return await submitAsync(submissionCtx);
-  }
-
-  private exitWithNonZeroCodeIfSomeBuildsFailed(maybeBuilds: (BuildFragment | null)[]): void {
-    const failedBuilds = (maybeBuilds.filter(i => i) as BuildFragment[]).filter(
-      i => i.status === BuildStatus.Errored
-    );
-    if (failedBuilds.length > 0) {
-      process.exit(1);
-    }
   }
 }
 

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -1,0 +1,124 @@
+import { flags } from '@oclif/command';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
+import EasCommand from '../../commandUtils/EasCommand';
+import Log from '../../log';
+import { ora } from '../../ora';
+import { RequestedPlatform } from '../../platform';
+import { findProjectRootAsync } from '../../project/projectUtils';
+import { getTmpDirectory } from '../../utils/paths';
+import { getVcsClient } from '../../vcs';
+
+enum InspectStage {
+  UPLOAD = 'upload',
+  PREPARE = 'prepare',
+  POST_BUILD = 'postbuild',
+}
+
+const STAGE_DESCRIPTION = `Stage of the build you want to reproduce.
+    upload - copy of the project that would be uploaded to EAS when building.
+    prepare - state of the project just before gradle/xcode build is started.
+    postbuild - state of the workingdir after build (the same as "eas build --local").`;
+
+export default class BuildInspect extends EasCommand {
+  static description =
+    'Inspect the state of the project at specific build stages. Useful for troubleshooting.';
+
+  static flags = {
+    platform: flags.enum({
+      options: [RequestedPlatform.Android, RequestedPlatform.Ios],
+      required: true,
+    }),
+    profile: flags.string({
+      description: 'Name of the build profile from eas.json.',
+      helpValue: 'PROFILE_NAME',
+    }),
+    stage: flags.enum({
+      description: STAGE_DESCRIPTION,
+      options: [InspectStage.UPLOAD, InspectStage.PREPARE, InspectStage.POST_BUILD],
+      required: true,
+    }),
+    output: flags.string({
+      description: 'Directory where results will be copied.',
+      required: true,
+      helpValue: 'OUTPUT_DIRECTORY',
+    }),
+    force: flags.boolean({
+      description: 'Force override if "OUTPUT_DIRECTORY" directory already exists.',
+      default: false,
+    }),
+    verbose: flags.boolean({
+      default: false,
+    }),
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = this.parse(BuildInspect);
+    const outputDirectory = path.resolve(flags.output);
+    await this.prepareOutputDirAsync(outputDirectory, flags.force);
+    if (flags.stage === InspectStage.UPLOAD) {
+      const vcs = getVcsClient();
+      await vcs.ensureRepoExistsAsync();
+      await vcs.makeShallowCopyAsync(outputDirectory);
+    } else {
+      const projectDir = await findProjectRootAsync();
+      const tmpWorkingdir = path.join(getTmpDirectory(), uuidv4());
+      try {
+        await runBuildAndSubmitAsync(projectDir, {
+          skipProjectConfiguration: false,
+          nonInteractive: false,
+          wait: true,
+          clearCache: false,
+          json: false,
+          autoSubmit: false,
+          requestedPlatform: flags.platform,
+          profile: flags.profile,
+          local: true,
+          localBuildOptions: {
+            ...(flags.stage === InspectStage.PREPARE ? { prepareOnly: true } : {}),
+            ...(flags.stage === InspectStage.POST_BUILD ? { skipCleanup: true } : {}),
+            verbose: flags.verbose,
+            workingdir: tmpWorkingdir,
+            artifactsDir: path.join(tmpWorkingdir, 'artifacts'),
+          },
+        });
+        if (!flags.verbose) {
+          Log.log(chalk.green('Build successful'));
+        }
+      } catch (err) {
+        if (!flags.verbose) {
+          Log.error('Build failed');
+          Log.error('Re-run this command with "--verbose" flag to see the error');
+        }
+      } finally {
+        const spinner = ora().start('Copying project to output directory');
+        try {
+          const tmpBuildDirectory = path.join(tmpWorkingdir, 'build');
+          if (await fs.pathExists(tmpBuildDirectory)) {
+            await fs.copy(tmpBuildDirectory, outputDirectory);
+          }
+          await fs.remove(tmpWorkingdir);
+          spinner.succeed(`Project written to ${outputDirectory}`);
+        } catch (err) {
+          spinner.fail();
+          throw err;
+        }
+      }
+    }
+  }
+
+  private async prepareOutputDirAsync(outputDir: string, force: boolean): Promise<void> {
+    if (await fs.pathExists(outputDir)) {
+      if (force) {
+        await fs.remove(outputDir);
+      } else {
+        throw new Error(`File ${outputDir} already exists`);
+      }
+    }
+    await fs.mkdirp(outputDir);
+  }
+}

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -94,17 +94,17 @@ export default class BuildInspect extends EasCommand {
       } catch (err) {
         if (!flags.verbose) {
           Log.error('Build failed');
-          Log.error('Re-run this command with "--verbose" flag to see the error');
+          Log.error(`Re-run this command with ${chalk.bold('--verbose')} flag to see the logs`);
         }
       } finally {
-        const spinner = ora().start('Copying project to output directory');
+        const spinner = ora().start(`Copying project build directory to ${outputDirectory}`);
         try {
           const tmpBuildDirectory = path.join(tmpWorkingdir, 'build');
           if (await fs.pathExists(tmpBuildDirectory)) {
             await fs.copy(tmpBuildDirectory, outputDirectory);
           }
           await fs.remove(tmpWorkingdir);
-          spinner.succeed(`Project written to ${outputDirectory}`);
+          spinner.succeed(`Project build directory saved to ${outputDirectory}`);
         } catch (err) {
           spinner.fail();
           throw err;
@@ -118,7 +118,7 @@ export default class BuildInspect extends EasCommand {
       if (force) {
         await fs.remove(outputDir);
       } else {
-        throw new Error(`File ${outputDir} already exists`);
+        throw new Error(`Directory ${outputDir} already exists`);
       }
     }
     await fs.mkdirp(outputDir);

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -14,15 +14,15 @@ import { getTmpDirectory } from '../../utils/paths';
 import { getVcsClient } from '../../vcs';
 
 enum InspectStage {
-  UPLOAD = 'upload',
-  PREPARE = 'prepare',
-  POST_BUILD = 'postbuild',
+  ARCHIVE = 'archive'
+  PRE_BUILD = 'pre-build',
+  POST_BUILD = 'post-build',
 }
 
-const STAGE_DESCRIPTION = `Stage of the build you want to reproduce.
-    upload - copy of the project that would be uploaded to EAS when building.
-    prepare - state of the project just before gradle/xcode build is started.
-    postbuild - state of the workingdir after build (the same as "eas build --local").`;
+const STAGE_DESCRIPTION = `Stage of the build you want to inspect.
+    archive - builds the project archive that would be uploaded to EAS when building
+    pre-build - prepares the project to be built with Gradle/Xcode. Does not run the native build.
+    post-build - builds the native project and leaves the output directory for inspection`;
 
 export default class BuildInspect extends EasCommand {
   static description =
@@ -30,25 +30,27 @@ export default class BuildInspect extends EasCommand {
 
   static flags = {
     platform: flags.enum({
+      char: 'p',
       options: [RequestedPlatform.Android, RequestedPlatform.Ios],
       required: true,
     }),
     profile: flags.string({
-      description: 'Name of the build profile from eas.json.',
+      description: 'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
       helpValue: 'PROFILE_NAME',
     }),
     stage: flags.enum({
+      char: 's',
       description: STAGE_DESCRIPTION,
       options: [InspectStage.UPLOAD, InspectStage.PREPARE, InspectStage.POST_BUILD],
       required: true,
     }),
     output: flags.string({
-      description: 'Directory where results will be copied.',
+      description: 'Output directory.',
       required: true,
       helpValue: 'OUTPUT_DIRECTORY',
     }),
     force: flags.boolean({
-      description: 'Force override if "OUTPUT_DIRECTORY" directory already exists.',
+      description: 'Delete OUTPUT_DIRECTORY if it already exists.',
       default: false,
     }),
     verbose: flags.boolean({


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Provide a way for users to debug their builds locally

# How

- add new `buidl:inspect` command
- `--stage upload` is implemented using vcs client that would be used for a build
- `--stage prepare` runs local build, but aborts it just before gradle/fastlane call
- `--stage postbuild` runs full local build, the only difference to `build --local` is that artifact is not copied into current directory
- `--verbose` option will show the same logs as `build --local`, by default no logs are shown

# Test Plan

![20211209_15h47m04s_grim](https://user-images.githubusercontent.com/9753141/145418096-671d8b4f-ab49-46ba-9598-2a01b6200b51.png)

prepare and post build can fail, but project will still be copied to the output directory

![20211209_15h52m14s_grim](https://user-images.githubusercontent.com/9753141/145418959-667be01f-25f1-42e6-9ad3-54f0f3ac5eef.png)
