### PR TITLE
[eas-cli] Fix ASC prompt displayed in --non-interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix `eas submit` to display prompt in non-interactive mode when some ASC API credentials are missing. ([#841](https://github.com/expo/eas-cli/pull/841) by [@barthap](https://github.com/barthap))
+
 ### 🧹 Chores
 
 ## [0.41.0](https://github.com/expo/eas-cli/releases/tag/v0.41.0) - 2021-12-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Fix `eas submit` to display prompt in non-interactive mode when some ASC API credentials are missing. ([#841](https://github.com/expo/eas-cli/pull/841) by [@barthap](https://github.com/barthap))
+- Fix `eas submit` displaying a prompt in non-interactive mode when some ASC API credentials are missing in `eas.json`. ([#841](https://github.com/expo/eas-cli/pull/841) by [@barthap](https://github.com/barthap))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
@@ -172,12 +172,18 @@ export default class IosSubmitCommand {
       });
     }
 
-    // interpret this to mean the user had some intention of passing in ASC Api key
     if (ascApiKeyPath || ascApiKeyIssuerId || ascApiKeyId) {
       Log.warn(`ascApiKeyPath, ascApiKeyIssuerId and ascApiKeyId must all be defined in eas.json`);
-      return result({
-        sourceType: AscApiKeySourceType.prompt,
-      });
+
+      // in interactive mode, interpret this to mean the user had some intention of passing in ASC Api key
+      // skip in non-interactive mode with warning
+      if (!this.ctx.nonInteractive) {
+        return result({
+          sourceType: AscApiKeySourceType.prompt,
+        });
+      } else {
+        Log.warn("Proceeding because you've run this command in non-interactive mode.");
+      }
     }
 
     return result(

--- a/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
@@ -172,18 +172,19 @@ export default class IosSubmitCommand {
       });
     }
 
+    // interpret this to mean the user had some intention of passing in ASC Api key
     if (ascApiKeyPath || ascApiKeyIssuerId || ascApiKeyId) {
-      Log.warn(`ascApiKeyPath, ascApiKeyIssuerId and ascApiKeyId must all be defined in eas.json`);
+      const message = `ascApiKeyPath, ascApiKeyIssuerId and ascApiKeyId must all be defined in eas.json`;
 
-      // in interactive mode, interpret this to mean the user had some intention of passing in ASC Api key
-      // skip in non-interactive mode with warning
-      if (!this.ctx.nonInteractive) {
-        return result({
-          sourceType: AscApiKeySourceType.prompt,
-        });
-      } else {
-        Log.warn("Proceeding because you've run this command in non-interactive mode.");
+      // in non-interactive mode, we should fail
+      if (this.ctx.nonInteractive) {
+        throw new Error(message);
       }
+
+      Log.warn(message);
+      return result({
+        sourceType: AscApiKeySourceType.prompt,
+      });
     }
 
     return result(


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

When testing my answer https://github.com/expo/eas-cli/issues/824#issuecomment-991584905 I discovered that a prompt is displayed in non-interactive mode, when user passed _some, but not all_ ASC API credentials in `eas.json`

# How

Instead of failing right away, I've decided to skip the `eas.json` resolution with a warning, so the CLI can try to resolve them from EAS servers.

# Test Plan

### Before

<img width="863" alt="Screenshot 2021-12-11 at 11 43 58" src="https://user-images.githubusercontent.com/278340/145673709-e9fb5283-6bad-4787-b98e-30d651ce0c43.png">


### After

<img width="850" alt="Screenshot 2021-12-11 at 11 43 02" src="https://user-images.githubusercontent.com/278340/145673665-79b10cbd-f7b5-4ba8-b644-203badd730e5.png">


