### PR TITLE
[eas-cli] clean up eas update logs

### DIFF
--- a/packages/eas-cli/src/build/utils/devClient.ts
+++ b/packages/eas-cli/src/build/utils/devClient.ts
@@ -105,7 +105,7 @@ async function installExpoDevClientAsync(
   Log.newLine();
   Log.log(`Running ${chalk.bold('expo install expo-dev-client')}`);
   Log.newLine();
-  await expoCommandAsync(projectDir, ['install', 'expo-dev-client']);
+  await expoCommandAsync(projectDir, ['install', 'expo-dev-client'], {});
   Log.newLine();
   if (await getVcsClient().isCommitRequiredAsync()) {
     await reviewAndCommitChangesAsync('Install expo-dev-client', {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -358,8 +358,13 @@ export default class UpdatePublish extends EasCommand {
       // build bundle and upload assets for a new publish
       if (!skipBundler) {
         const bundleSpinner = ora().start('Building bundle...');
-        await buildBundlesAsync({ projectDir, inputDir });
-        bundleSpinner.succeed('Built bundle!');
+        try {
+          await buildBundlesAsync({ projectDir, inputDir });
+          bundleSpinner.succeed('Built bundle!');
+        } catch (e) {
+          bundleSpinner.fail('Failed to build bundle!');
+          throw e;
+        }
       }
 
       const assetSpinner = ora().start('Uploading assets...');

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -357,10 +357,12 @@ export default class UpdatePublish extends EasCommand {
 
       // build bundle and upload assets for a new publish
       if (!skipBundler) {
+        const bundleSpinner = ora().start('Building bundle...');
         await buildBundlesAsync({ projectDir, inputDir });
+        bundleSpinner.succeed('Built bundle!');
       }
 
-      const assetSpinner = ora('Uploading assets...').start();
+      const assetSpinner = ora().start('Uploading assets...');
       try {
         const platforms = platformFlag === 'all' ? defaultPublishPlatforms : [platformFlag];
         const assets = await collectAssetsAsync({ inputDir: inputDir!, platforms });

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -159,7 +159,7 @@ export async function buildBundlesAsync({
   await expoCommandAsync(
     projectDir,
     ['export', '--output-dir', inputDir, '--experimental-bundle'],
-    /*silent*/ true
+    { silent: true }
   );
 }
 

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -10,7 +10,6 @@ import { AssetMetadataStatus, PartialManifestAsset } from '../graphql/generated'
 import { PublishMutation } from '../graphql/mutations/PublishMutation';
 import { PresignedPost } from '../graphql/mutations/UploadSessionMutation';
 import { PublishQuery } from '../graphql/queries/PublishQuery';
-import Log from '../log';
 import { uploadWithPresignedPostAsync } from '../uploads';
 import { expoCommandAsync } from '../utils/expoCli';
 import uniqBy from '../utils/expodash/uniqBy';
@@ -157,8 +156,11 @@ export async function buildBundlesAsync({
     throw new Error('Could not locate package.json');
   }
 
-  Log.withTick(`Building bundle with expo-cli...`);
-  await expoCommandAsync(projectDir, ['export', '--output-dir', inputDir, '--experimental-bundle']);
+  await expoCommandAsync(
+    projectDir,
+    ['export', '--output-dir', inputDir, '--experimental-bundle'],
+    /*silent*/ true
+  );
 }
 
 export async function resolveInputDirectoryAsync(customInputDirectory: string): Promise<string> {

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -7,7 +7,7 @@ import Log from '../log';
 export async function expoCommandAsync(
   projectDir: string,
   args: string[],
-  silent?: boolean
+  { silent }: { silent?: boolean }
 ): Promise<void> {
   const expoCliPath = resolveFrom(projectDir, 'expo/bin/cli.js');
   const spawnPromise = spawnAsync(expoCliPath, args, {

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -4,7 +4,11 @@ import resolveFrom from 'resolve-from';
 
 import Log from '../log';
 
-export async function expoCommandAsync(projectDir: string, args: string[]): Promise<void> {
+export async function expoCommandAsync(
+  projectDir: string,
+  args: string[],
+  silent?: boolean
+): Promise<void> {
   const expoCliPath = resolveFrom(projectDir, 'expo/bin/cli.js');
   const spawnPromise = spawnAsync(expoCliPath, args, {
     stdio: ['inherit', 'pipe', 'pipe'], // inherit stdin so user can install a missing expo-cli from inside this command
@@ -15,15 +19,17 @@ export async function expoCommandAsync(projectDir: string, args: string[]): Prom
   if (!(stdout && stderr)) {
     throw new Error('Failed to spawn expo-cli');
   }
-  stdout.on('data', data => {
-    for (const line of data.toString().trim().split('\n')) {
-      Log.log(`${chalk.gray('[expo-cli]')} ${line}`);
-    }
-  });
-  stderr.on('data', data => {
-    for (const line of data.toString().trim().split('\n')) {
-      Log.warn(`${chalk.gray('[expo-cli]')} ${line}`);
-    }
-  });
+  if (!silent) {
+    stdout.on('data', data => {
+      for (const line of data.toString().trim().split('\n')) {
+        Log.log(`${chalk.gray('[expo-cli]')} ${line}`);
+      }
+    });
+    stderr.on('data', data => {
+      for (const line of data.toString().trim().split('\n')) {
+        Log.warn(`${chalk.gray('[expo-cli]')} ${line}`);
+      }
+    });
+  }
   await spawnPromise;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Currently there is too much logging when using `eas update`. We want to supply the user only with information they need.

# How

Added a silent option to `expoCommand` and added an ora spinner.
 
# Test Plan

demo repo