### PR TITLE
[eas-cli] allow eas-cli to be run outside of expo projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Allow eas to be run outside of an expo project. ([#851](https://github.com/expo/eas-cli/pull/851) by [@jkhales](https://github.com/jkhales))
+- Allow eas to be run outside of a project. ([#851](https://github.com/expo/eas-cli/pull/851) by [@jkhales](https://github.com/jkhales))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Allow eas to be run outside of a project. ([#851](https://github.com/expo/eas-cli/pull/851) by [@jkhales](https://github.com/jkhales))
+- Allow select eas commands to be run outside of a project. ([#851](https://github.com/expo/eas-cli/pull/851) by [@jkhales](https://github.com/jkhales))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Allow eas to be run outside of an expo project. ([#851](https://github.com/expo/eas-cli/pull/851) by [@jkhales](https://github.com/jkhales))
+
 ### 🧹 Chores
 
 ## [0.41.0](https://github.com/expo/eas-cli/releases/tag/v0.41.0) - 2021-12-13

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -21,14 +21,14 @@ export default abstract class EasCommand extends Command {
    * force the user to log in
    */
   protected requiresAuthentication = true;
-  protected mustBeRunInsideAnExpoProject = true;
+  protected mustBeRunInsideProject = true;
 
   protected abstract runAsync(): Promise<any>;
 
   // eslint-disable-next-line async-protect/async-suffix
   async run(): Promise<any> {
     await initAnalyticsAsync();
-    if (this.mustBeRunInsideAnExpoProject) {
+    if (this.mustBeRunInsideProject) {
       await this.applyCliConfigAsync();
     }
 

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -1,6 +1,5 @@
 import { EasJsonReader } from '@expo/eas-json';
 import { Command } from '@oclif/command';
-import pkgDir from 'pkg-dir';
 import semver from 'semver';
 
 import {
@@ -22,13 +21,14 @@ export default abstract class EasCommand extends Command {
    * force the user to log in
    */
   protected requiresAuthentication = true;
+  protected mustBeRunInsideAnExpoProject = true;
 
   protected abstract runAsync(): Promise<any>;
 
   // eslint-disable-next-line async-protect/async-suffix
   async run(): Promise<any> {
     await initAnalyticsAsync();
-    if (await pkgDir()) {
+    if (this.mustBeRunInsideAnExpoProject) {
       await this.applyCliConfigAsync();
     }
 

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -1,5 +1,6 @@
 import { EasJsonReader } from '@expo/eas-json';
 import { Command } from '@oclif/command';
+import pkgDir from 'pkg-dir';
 import semver from 'semver';
 
 import {
@@ -27,7 +28,9 @@ export default abstract class EasCommand extends Command {
   // eslint-disable-next-line async-protect/async-suffix
   async run(): Promise<any> {
     await initAnalyticsAsync();
-    await this.applyCliConfigAsync();
+    if (await pkgDir()) {
+      await this.applyCliConfigAsync();
+    }
 
     if (this.requiresAuthentication) {
       const { flags } = this.parse();

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -6,7 +6,7 @@ export default class AccountLogin extends EasCommand {
   static description = 'log in with your Expo account';
   static aliases = ['login'];
 
-  protected mustBeRunInsideAnExpoProject = false;
+  protected mustBeRunInsideProject = false;
   protected requiresAuthentication = false;
 
   async runAsync(): Promise<void> {

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -6,6 +6,7 @@ export default class AccountLogin extends EasCommand {
   static description = 'log in with your Expo account';
   static aliases = ['login'];
 
+  protected mustBeRunInsideAnExpoProject = false;
   protected requiresAuthentication = false;
 
   async runAsync(): Promise<void> {

--- a/packages/eas-cli/src/commands/account/logout.ts
+++ b/packages/eas-cli/src/commands/account/logout.ts
@@ -6,6 +6,7 @@ export default class AccountLogout extends EasCommand {
   static description = 'log out';
   static aliases = ['logout'];
 
+  protected mustBeRunInsideAnExpoProject = false;
   protected requiresAuthentication = false;
 
   async runAsync(): Promise<void> {

--- a/packages/eas-cli/src/commands/account/logout.ts
+++ b/packages/eas-cli/src/commands/account/logout.ts
@@ -6,7 +6,7 @@ export default class AccountLogout extends EasCommand {
   static description = 'log out';
   static aliases = ['logout'];
 
-  protected mustBeRunInsideAnExpoProject = false;
+  protected mustBeRunInsideProject = false;
   protected requiresAuthentication = false;
 
   async runAsync(): Promise<void> {

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -8,7 +8,7 @@ export default class AccountView extends EasCommand {
   static description = 'show the username you are logged in as';
   static aliases = ['whoami'];
 
-  protected mustBeRunInsideAnExpoProject = false;
+  protected mustBeRunInsideProject = false;
   protected requiresAuthentication = false;
 
   async runAsync(): Promise<void> {

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -8,6 +8,7 @@ export default class AccountView extends EasCommand {
   static description = 'show the username you are logged in as';
   static aliases = ['whoami'];
 
+  protected mustBeRunInsideAnExpoProject = false;
   protected requiresAuthentication = false;
 
   async runAsync(): Promise<void> {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We want to be able to run commands like `eas whoami` and `eas login` outside of a project.

# How

Currently, this throws an error when running `applyCliConfigAsync`: https://github.com/expo/eas-cli/blame/487316370b5028d0aef78303e68d05a7ce3bdbcc/packages/eas-cli/src/commandUtils/EasCommand.ts#L30

This was added to allow a "commit free" workflow here: 
https://github.com/expo/eas-cli/pull/695

Since a command run outside of a project should not be connected to anything requiring (or opting out of requiring) a git commit, we should only run this when inside of a project.

# Test Plan

tested in a demo repo and out side of a project.