### PR TITLE
[eas-cli] Make all EAS Update related commands public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Adds commands for EAS Update, which is now in preview for subscribers. EAS Update makes fixing small bugs and pushing quick fixes a snap in between app store submissions. It accomplishes this by allowing an end-user's app to swap out the non-native parts of their app (for example, JS, styling, and image changes) with a new update that contains bug fixes and other updates.
+  - Adds `eas update`, which can bundle and publish updates on a branch.
+  - Adds `eas branch`, which manages branches. Branches contain a list of updates and are linked to channels.
+  - Adds `eas channel`, which manages channels. Channels are specified inside builds and are linked to branches, allowing us to link specific updates with specific builds.
+  - Read more in our [feature preview docs](https://docs.expo.dev/eas-update/introduction/).
+
 ### 🐛 Bug fixes
 
 - Fix `eas submit` displaying a prompt in non-interactive mode when some ASC API credentials are missing in `eas.json`. ([#841](https://github.com/expo/eas-cli/pull/841) by [@barthap](https://github.com/barthap))

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -51,7 +51,6 @@ export async function createUpdateBranchOnAppAsync({
 }
 
 export default class BranchCreate extends EasCommand {
-  static hidden = true;
   static description = 'Create a branch on the current project.';
 
   static args = [

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -76,7 +76,6 @@ async function deleteBranchOnAppAsync({
 }
 
 export default class BranchDelete extends EasCommand {
-  static hidden = true;
   static description = 'Delete a branch on the current project';
 
   static args = [

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -54,8 +54,6 @@ export async function listBranchesAsync({
 }
 
 export default class BranchList extends EasCommand {
-  static hidden = true;
-
   static description = 'List all branches on this project.';
 
   static flags = {

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -51,7 +51,6 @@ async function renameUpdateBranchOnAppAsync({
 }
 
 export default class BranchRename extends EasCommand {
-  static hidden = true;
   static description = 'Rename a branch.';
 
   static flags = {

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -67,7 +67,6 @@ export async function viewUpdateBranchAsync({
 }
 
 export default class BranchView extends EasCommand {
-  static hidden = true;
   static description = 'View a branch.';
 
   static args = [

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -59,7 +59,6 @@ export async function createUpdateChannelOnAppAsync({
 }
 
 export default class ChannelCreate extends EasCommand {
-  static hidden = true;
   static description = 'Create a channel on the current project.';
 
   static args = [

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -95,7 +95,6 @@ export async function updateChannelBranchMappingAsync({
 }
 
 export default class ChannelEdit extends EasCommand {
-  static hidden = true;
   static description = 'Point a channel at a new branch.';
 
   static args = [

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -66,7 +66,6 @@ async function getAllUpdateChannelForAppAsync({
 }
 
 export default class ChannelList extends EasCommand {
-  static hidden = true;
   static description = 'List all channels on the current project.';
 
   static flags = {

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -192,7 +192,6 @@ export function logChannelDetails(channel: {
 }
 
 export default class ChannelView extends EasCommand {
-  static hidden = true;
   static description = 'View a channel on the current project.';
 
   static args = [

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -77,7 +77,6 @@ async function configureProjectForEASUpdateAsync(
 }
 
 export default class UpdateConfigure extends EasCommand {
-  static hidden = true;
   static description = 'Configure the project to support EAS Update.';
 
   async runAsync(): Promise<void> {

--- a/packages/eas-cli/src/commands/update/delete.ts
+++ b/packages/eas-cli/src/commands/update/delete.ts
@@ -35,7 +35,6 @@ async function deleteUpdateGroupAsync({
 }
 
 export default class UpdateDelete extends EasCommand {
-  static hidden = true;
   static description = 'Delete all the updates in an update Group.';
 
   static args = [

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -131,7 +131,6 @@ async function ensureBranchExistsAsync({
 }
 
 export default class UpdatePublish extends EasCommand {
-  static hidden = true;
   static description = 'Publish an update group.';
 
   static flags = {

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -50,7 +50,6 @@ export async function viewUpdateAsync({
   return data;
 }
 export default class UpdateView extends EasCommand {
-  static hidden = true;
   static description = 'Update group details.';
 
   static args = [


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We are ready to make the EAS Update preview public. This PR removes all the hidden flags from each of those commands.

<img width="950" alt="Screen Shot 2021-12-15 at 12 14 37 PM" src="https://user-images.githubusercontent.com/6455018/146233270-9f8be8fd-071b-49e8-bca6-52e4b4d5434d.png">

# Test Plan

Make sure that all the commands necessary for EAS Update are public.
