### PR TITLE
chore: add `requireCommit` setting to warning if git is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add `requireCommit` setting information to warning displayed when git is not installed. ([#856](https://github.com/expo/eas-cli/pull/856) by [@kbrandwijk(https://github.com/kbrandwijk))
+
 ## [0.41.0](https://github.com/expo/eas-cli/releases/tag/v0.41.0) - 2021-12-13
 
 ### 🎉 New features

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -18,9 +18,11 @@ export default class GitClient extends Client {
   public async ensureRepoExistsAsync(): Promise<void> {
     if (!(await isGitInstalledAsync())) {
       Log.error(
-        `${chalk.bold('git')} command not found. Install it before proceeding or set ${chalk.bold(
+        `${chalk.bold('git')} command not found. Install it before proceeding, or set ${chalk.bold(
           'EAS_NO_VCS=1'
-        )} to use EAS CLI without Git (or any other version control system).`
+        )} or ${chalk.bold(
+          'requireCommit: false'
+        )} in eas.json to use EAS CLI without Git (or any other version control system).`
       );
       Log.error(learnMore('https://expo.fyi/eas-vcs-workflow'));
       exit(1);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [X] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

eas-cli > 34 allows setting requireCommit to false in eas.json. The current warning doesn't mention that option.

# How

...

# Test Plan

Manual