### PR TITLE
fix release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,9 @@ jobs:
       - run: yarn build
       - name: Build tarballs
         working-directory: ${{ github.workspace }}/packages/eas-cli
-        run: yarn oclif pack:tarballs --no-xz --targets linux-x64,linux-arm
+        run: |
+          yarn pretarball-ci
+          yarn oclif pack:tarballs --no-xz --targets linux-x64,linux-arm
       - id: x64
         run: echo "::set-output name=filename::$(ls eas-*-x64.tar.gz)"
         working-directory: ${{ github.workspace }}/packages/eas-cli/dist
@@ -71,7 +73,9 @@ jobs:
       - run: yarn build
       - name: Build tarballs
         working-directory: ${{ github.workspace }}/packages/eas-cli
-        run: yarn oclif pack:tarballs --no-xz --targets darwin-x64
+        run: |
+          yarn pretarball-ci
+          yarn oclif pack:tarballs --no-xz --targets darwin-x64
       - id: x64
         run: echo "::set-output name=filename::$(ls eas-*-x64.tar.gz)"
         working-directory: ${{ github.workspace }}/packages/eas-cli/dist
@@ -96,7 +100,9 @@ jobs:
       - run: yarn install --frozen-lockfile --check-files
       - run: sudo apt-get install nsis
       - run: yarn build
-      - run: yarn oclif pack:win
+      - run: |
+          yarn pretarball-ci
+          yarn oclif pack:win
         working-directory: ${{ github.workspace }}/packages/eas-cli
       - id: x64
         run: echo "::set-output name=filename::$(ls eas-*-x64.exe)"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "lerna run build",
     "build:tarballs:linux": "yarn build-for-size-check",
-    "build-for-size-check": "yarn build && CLI_SIZE_CHECK=1 yarn workspace eas-cli oclif pack:tarballs --no-xz --targets linux-x64",
+    "build-for-size-check": "yarn build && yarn workspace eas-cli pretarball-ci && CLI_SIZE_CHECK=1 yarn workspace eas-cli oclif pack:tarballs --no-xz --targets linux-x64",
     "typecheck": "lerna run typecheck",
     "start": "lerna run watch --parallel",
     "watch": "yarn start",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch": "yarn start",
     "eas": "packages/eas-cli/bin/run",
     "lint": "eslint .",
-    "release": "./scripts/bin/run update-local-plugin && lerna version",
+    "release": "./scripts/bin/run update-local-plugin && lerna version --exact",
     "test": "jest",
     "clean": "lerna run clean && rm -rf node_modules coverage"
   },

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -174,6 +174,7 @@
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "./scripts/prepack.sh",
+    "pretarball-ci": "./scripts/pretarball-ci.sh",
     "build": "tsc --project tsconfig.build.json",
     "watch": "yarn build --watch --preserveWatchOutput",
     "typecheck": "tsc",

--- a/packages/eas-cli/scripts/pretarball-ci.sh
+++ b/packages/eas-cli/scripts/pretarball-ci.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+EAS_CLI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+PACKAGE_JSON_PATH="$EAS_CLI_DIR/package.json"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/\\\"@expo\/eas-json\\\": \\\".*\\\"/\\\"@expo\/eas-json\\\": \\\"file:..\/..\/..\/eas-json\\\"/g" $PACKAGE_JSON_PATH
+else
+  sed -i  "s/\\\"@expo\/eas-json\\\": \\\".*\\\"/\\\"@expo\/eas-json\\\": \\\"file:..\/..\/..\/eas-json\\\"/g" $PACKAGE_JSON_PATH
+fi


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

When working on https://github.com/expo/eas-cli/pull/858 I didn't realize that we forked the old oclif dev cli because there is a problem with installing dependencies from the monorepo workspaces.

This made the release fail - https://github.com/expo/eas-cli/runs/4593517219?check_suite_focus=true

# How

Instead of forking the oclif cli, explicitly run a script that does the same job.

# Test Plan

I ran `yarn pretarball-ci` and then `yarn oclif pack:tarballs --no-xz --targets darwin-x64` and it worked fine.