### PR TITLE
install missing @oclif/plugin-help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Add missing dependency - `@oclif/plugin-help`. ([#865](https://github.com/expo/eas-cli/pull/865) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [0.42.3](https://github.com/expo/eas-cli/releases/tag/v0.42.3) - 2021-12-21

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -23,6 +23,7 @@
     "@expo/spawn-async": "1.5.0",
     "@expo/timeago.js": "1.0.0",
     "@oclif/core": "1.0.10",
+    "@oclif/plugin-help": "5.1.10",
     "@urql/core": "2.3.1",
     "@urql/exchange-retry": "0.3.0",
     "chalk": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2404,6 +2404,13 @@
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
+"@oclif/plugin-help@5.1.10":
+  version "5.1.10"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-5.1.10.tgz#465aa0397da723c39536780f6f7c1ad9cbd1671e"
+  integrity sha512-ngurn/3kQVCw1Df5TJEURjxU+w7iA9z3Pskw8dJorfnd0Xibe/qlPg+VYV3hB7EhTbV82EVfZ5DhQYD5YvoxeA==
+  dependencies:
+    "@oclif/core" "^1.0.10"
+
 "@oclif/plugin-help@5.1.9":
   version "5.1.9"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-5.1.9.tgz#1365fd76d5382a1a217e6b5c247251211c300d7b"


### PR DESCRIPTION
`@oclif/plugin-help` is missing in EAS CLI production dependencies. It worked locally because it's a dependency of a dev dependency (`oclif`).