### PR TITLE
[eas-cli] fixed wrong JSON output

### DIFF
--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -59,7 +59,7 @@ async function configureProjectForEASUpdateAsync(
       );
       Log.log(
         chalk.bold(
-          `{\n  updates": {\n    "url": "${easUpdateURL}"\n  },\n  "runtimeVersion": {\n    "policy": "sdkVersion"\n  }\n}`
+          `{\n  "updates": {\n    "url": "${easUpdateURL}"\n  },\n  "runtimeVersion": {\n    "policy": "sdkVersion"\n  }\n}`
         )
       );
       Log.addNewLineIfNone();


### PR DESCRIPTION
The current output is:

It looks like you are using a dynamic configuration! Learn more: https://docs.expo.dev/workflow/configuration/#dynamic-configuration-with-appconfigjs)
In order to finish configuring your project for EAS Update, you are going to need manually add the following to your app.config.js:
Learn more: https://expo.fyi/eas-update-config.md

```json
{
  updates": {
    "url": "https://u.expo.dev/"
  },
  "runtimeVersion": {
    "policy": "sdkVersion"
  }
}
```

