### PR TITLE
[eas-cli] add update:list alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add update:list alias for branch:list command. ([#884](https://github.com/expo/eas-cli/pull/884) by [@jkhales](https://github.com/jkhales))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- Add update:list alias for branch:list command. ([#884](https://github.com/expo/eas-cli/pull/884) by [@jkhales](https://github.com/jkhales))
+- Add update:list command. ([#884](https://github.com/expo/eas-cli/pull/884) by [@jkhales](https://github.com/jkhales))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -55,8 +55,7 @@ export async function listBranchesAsync({
 }
 
 export default class BranchList extends EasCommand {
-  static description = 'List all of the branches and updates on this project.';
-  static aliases = ['update:list'];
+  static description = 'List all branches on this project.';
 
   static flags = {
     json: Flags.boolean({

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -55,7 +55,8 @@ export async function listBranchesAsync({
 }
 
 export default class BranchList extends EasCommand {
-  static description = 'List all branches on this project.';
+  static description = 'List all of the branches and updates on this project.';
+  static aliases = ['update:list'];
 
   static flags = {
     json: Flags.boolean({

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -57,7 +57,7 @@ export default class BranchView extends EasCommand {
       }));
     }
 
-    const { app } = await UpdateQuery.viewUpdateBranchAsync({
+    const { app } = await UpdateQuery.viewBranchAsync({
       appId: projectId,
       name,
     });

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -17,9 +17,10 @@ import {
   Update,
   UpdateInfoGroup,
   User,
-  ViewBranchQuery,
+  ViewBranchUpdatesQuery,
 } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
+import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import Log from '../../log';
 import { ora } from '../../ora';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
@@ -39,7 +40,6 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import { getVcsClient } from '../../vcs';
 import { createUpdateBranchOnAppAsync } from '../branch/create';
 import { listBranchesAsync } from '../branch/list';
-import { viewUpdateBranchAsync } from '../branch/view';
 import { createUpdateChannelOnAppAsync } from '../channel/create';
 
 export const defaultPublishPlatforms: PublishPlatform[] = ['android', 'ios'];
@@ -110,11 +110,11 @@ async function ensureBranchExistsAsync({
 }): Promise<{
   id: string;
   updates: Exclude<
-    Exclude<ViewBranchQuery['app'], null | undefined>['byId']['updateBranchByName'],
+    Exclude<ViewBranchUpdatesQuery['app'], null | undefined>['byId']['updateBranchByName'],
     null | undefined
   >['updates'];
 }> {
-  const { app } = await viewUpdateBranchAsync({
+  const { app } = await UpdateQuery.viewUpdateBranchAsync({
     appId,
     name: branchName,
   });
@@ -480,7 +480,7 @@ async function getRuntimeVersionObjectAsync(
 
 function formatUpdateTitle(
   update: Exclude<
-    Exclude<ViewBranchQuery['app'], null | undefined>['byId']['updateBranchByName'],
+    Exclude<ViewBranchUpdatesQuery['app'], null | undefined>['byId']['updateBranchByName'],
     null | undefined
   >['updates'][number]
 ): string {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -114,7 +114,7 @@ async function ensureBranchExistsAsync({
     null | undefined
   >['updates'];
 }> {
-  const { app } = await UpdateQuery.viewUpdateBranchAsync({
+  const { app } = await UpdateQuery.viewBranchAsync({
     appId,
     name: branchName,
   });

--- a/packages/eas-cli/src/commands/update/list.ts
+++ b/packages/eas-cli/src/commands/update/list.ts
@@ -47,7 +47,7 @@ export default class BranchView extends EasCommand {
 
     let updateGroupDescriptions: ReturnType<typeof getUpdateGroupDescriptions>;
     if (all) {
-      const branchesAndUpdates = await UpdateQuery.viewAllUpdatesAsync({ appId: projectId });
+      const branchesAndUpdates = await UpdateQuery.viewAllAsync({ appId: projectId });
       updateGroupDescriptions = getUpdateGroupDescriptions(
         branchesAndUpdates.app.byId.updateBranches
       );
@@ -66,7 +66,7 @@ export default class BranchView extends EasCommand {
         }));
       }
 
-      const { app } = await UpdateQuery.viewUpdateBranchAsync({
+      const { app } = await UpdateQuery.viewBranchUpdatesAsync({
         appId: projectId,
         name: branch!,
       });

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3719,39 +3719,6 @@ export type EditUpdateBranchMutation = (
   ) }
 );
 
-export type ViewBranchQueryVariables = Exact<{
-  appId: Scalars['String'];
-  name: Scalars['String'];
-  limit: Scalars['Int'];
-}>;
-
-
-export type ViewBranchQuery = (
-  { __typename?: 'RootQuery' }
-  & { app: (
-    { __typename?: 'AppQuery' }
-    & { byId: (
-      { __typename?: 'App' }
-      & Pick<App, 'id'>
-      & { updateBranchByName?: Maybe<(
-        { __typename?: 'UpdateBranch' }
-        & Pick<UpdateBranch, 'id' | 'name'>
-        & { updates: Array<(
-          { __typename?: 'Update' }
-          & Pick<Update, 'id' | 'group' | 'message' | 'createdAt' | 'runtimeVersion' | 'platform' | 'manifestFragment'>
-          & { actor?: Maybe<(
-            { __typename?: 'User' }
-            & Pick<User, 'username' | 'id'>
-          ) | (
-            { __typename?: 'Robot' }
-            & Pick<Robot, 'firstName' | 'id'>
-          )> }
-        )> }
-      )> }
-    ) }
-  ) }
-);
-
 export type CancelBuildMutationVariables = Exact<{
   buildId: Scalars['ID'];
 }>;
@@ -5399,6 +5366,39 @@ export type GetAllSubmissionsForAppQuery = (
         { __typename?: 'Submission' }
         & Pick<Submission, 'id'>
         & SubmissionFragment
+      )> }
+    ) }
+  ) }
+);
+
+export type ViewBranchUpdatesQueryVariables = Exact<{
+  appId: Scalars['String'];
+  name: Scalars['String'];
+  limit: Scalars['Int'];
+}>;
+
+
+export type ViewBranchUpdatesQuery = (
+  { __typename?: 'RootQuery' }
+  & { app: (
+    { __typename?: 'AppQuery' }
+    & { byId: (
+      { __typename?: 'App' }
+      & Pick<App, 'id'>
+      & { updateBranchByName?: Maybe<(
+        { __typename?: 'UpdateBranch' }
+        & Pick<UpdateBranch, 'id' | 'name'>
+        & { updates: Array<(
+          { __typename?: 'Update' }
+          & Pick<Update, 'id' | 'group' | 'message' | 'createdAt' | 'runtimeVersion' | 'platform' | 'manifestFragment'>
+          & { actor?: Maybe<(
+            { __typename?: 'User' }
+            & Pick<User, 'username' | 'id'>
+          ) | (
+            { __typename?: 'Robot' }
+            & Pick<Robot, 'firstName' | 'id'>
+          )> }
+        )> }
       )> }
     ) }
   ) }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5371,6 +5371,38 @@ export type GetAllSubmissionsForAppQuery = (
   ) }
 );
 
+export type ViewAllUpdatesQueryVariables = Exact<{
+  appId: Scalars['String'];
+  limit: Scalars['Int'];
+}>;
+
+
+export type ViewAllUpdatesQuery = (
+  { __typename?: 'RootQuery' }
+  & { app: (
+    { __typename?: 'AppQuery' }
+    & { byId: (
+      { __typename?: 'App' }
+      & Pick<App, 'id'>
+      & { updateBranches: Array<(
+        { __typename?: 'UpdateBranch' }
+        & Pick<UpdateBranch, 'id' | 'name'>
+        & { updates: Array<(
+          { __typename?: 'Update' }
+          & Pick<Update, 'id' | 'group' | 'message' | 'createdAt' | 'runtimeVersion' | 'platform'>
+          & { actor?: Maybe<(
+            { __typename?: 'User' }
+            & Pick<User, 'username' | 'id'>
+          ) | (
+            { __typename?: 'Robot' }
+            & Pick<Robot, 'firstName' | 'id'>
+          )> }
+        )> }
+      )> }
+    ) }
+  ) }
+);
+
 export type ViewBranchUpdatesQueryVariables = Exact<{
   appId: Scalars['String'];
   name: Scalars['String'];

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -1,0 +1,101 @@
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ViewBranchUpdatesQuery, ViewBranchUpdatesQueryVariables } from '../generated';
+
+const PAGE_LIMIT = 10_000;
+
+export const UpdateQuery = {
+  async viewAllUpdatesAsync({ appId }: { appId: string }): Promise<any> {
+    return withErrorHandlingAsync<any>(
+      graphqlClient
+        .query<any, any>(
+          gql`
+            query ViewAllUpdates($appId: String!, $limit: Int!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  updateBranches(offset: 0, limit: $limit) {
+                    id
+                    name
+                    updates(offset: 0, limit: $limit) {
+                      id
+                      group
+                      message
+                      createdAt
+                      runtimeVersion
+                      platform
+                      manifestFragment
+                      actor {
+                        id
+                        ... on User {
+                          username
+                        }
+                        ... on Robot {
+                          firstName
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          {
+            appId,
+            limit: PAGE_LIMIT,
+          },
+          { additionalTypenames: ['UpdateBranch', 'Update'] }
+        )
+        .toPromise()
+    );
+  },
+  async viewUpdateBranchAsync({
+    appId,
+    name,
+  }: Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>) {
+    return withErrorHandlingAsync<ViewBranchUpdatesQuery>(
+      graphqlClient
+        .query<ViewBranchUpdatesQuery, ViewBranchUpdatesQueryVariables>(
+          gql`
+            query ViewBranchUpdates($appId: String!, $name: String!, $limit: Int!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  updateBranchByName(name: $name) {
+                    id
+                    name
+                    updates(offset: 0, limit: $limit) {
+                      id
+                      group
+                      message
+                      createdAt
+                      runtimeVersion
+                      platform
+                      manifestFragment
+                      actor {
+                        id
+                        ... on User {
+                          username
+                        }
+                        ... on Robot {
+                          firstName
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          {
+            appId,
+            name,
+            limit: PAGE_LIMIT,
+          },
+          { additionalTypenames: ['UpdateBranch', 'Update'] }
+        )
+        .toPromise()
+    );
+  },
+};

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -1,15 +1,20 @@
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
-import { ViewBranchUpdatesQuery, ViewBranchUpdatesQueryVariables } from '../generated';
+import {
+  ViewAllUpdatesQuery,
+  ViewAllUpdatesQueryVariables,
+  ViewBranchUpdatesQuery,
+  ViewBranchUpdatesQueryVariables,
+} from '../generated';
 
 const PAGE_LIMIT = 10_000;
 
 export const UpdateQuery = {
-  async viewAllUpdatesAsync({ appId }: { appId: string }): Promise<any> {
-    return withErrorHandlingAsync<any>(
+  async viewAllUpdatesAsync({ appId }: { appId: string }): Promise<ViewAllUpdatesQuery> {
+    return withErrorHandlingAsync(
       graphqlClient
-        .query<any, any>(
+        .query<ViewAllUpdatesQuery, ViewAllUpdatesQueryVariables>(
           gql`
             query ViewAllUpdates($appId: String!, $limit: Int!) {
               app {
@@ -25,7 +30,6 @@ export const UpdateQuery = {
                       createdAt
                       runtimeVersion
                       platform
-                      manifestFragment
                       actor {
                         id
                         ... on User {

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -54,10 +54,7 @@ export const UpdateQuery = {
         .toPromise()
     );
   },
-  async viewBranchUpdatesAsync({
-    appId,
-    name,
-  }: Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>) {
+  async viewBranchAsync({ appId, name }: Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>) {
     return withErrorHandlingAsync<ViewBranchUpdatesQuery>(
       graphqlClient
         .query<ViewBranchUpdatesQuery, ViewBranchUpdatesQueryVariables>(

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -11,7 +11,7 @@ import {
 const PAGE_LIMIT = 10_000;
 
 export const UpdateQuery = {
-  async viewAllUpdatesAsync({ appId }: { appId: string }): Promise<ViewAllUpdatesQuery> {
+  async viewAllAsync({ appId }: { appId: string }): Promise<ViewAllUpdatesQuery> {
     return withErrorHandlingAsync(
       graphqlClient
         .query<ViewAllUpdatesQuery, ViewAllUpdatesQueryVariables>(
@@ -54,7 +54,7 @@ export const UpdateQuery = {
         .toPromise()
     );
   },
-  async viewUpdateBranchAsync({
+  async viewBranchUpdatesAsync({
     appId,
     name,
   }: Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

[We want to be able to list all of the projects updates](https://linear.app/expo/issue/ENG-2700/create-an-eas-updatelist-command)

<img width="724" alt="Screen Shot 2022-01-04 at 4 54 31 PM" src="https://user-images.githubusercontent.com/1220444/148128900-5e44c31d-6f92-46c8-95d1-e4e6cb1eba45.png">

# How

When run with the `--all` flag show every update group owned by the project.
<img width="1653" alt="Screen Shot 2022-01-04 at 4 57 15 PM" src="https://user-images.githubusercontent.com/1220444/148129166-1b50131f-abbd-4aa3-b942-61796c0c5418.png">

When run with the `--branch` flag show ever update group owned by the branch.
<img width="1601" alt="Screen Shot 2022-01-04 at 4 57 41 PM" src="https://user-images.githubusercontent.com/1220444/148129215-371e2d5f-bf2d-4f08-ba4c-58eafd78ef35.png">

When run with no flag, ask the user to specify the branch name. If the project is a git repo, suggest the current git branch.
<img width="691" alt="Screen Shot 2022-01-04 at 4 58 03 PM" src="https://user-images.githubusercontent.com/1220444/148129262-9fe8fabf-0303-48fd-8f73-6ec2b76095bd.png">

# Test Plan

Demo repo

