### PR TITLE
[eas-cli] Add --output flag to build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `--output` flag to the build command. ([#885](https://github.com/expo/eas-cli/pull/885) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -13,6 +13,7 @@ export interface LocalBuildOptions {
   skipCleanup?: boolean;
   skipNativeBuild?: boolean;
   artifactsDir?: string;
+  artifactPath?: string;
   workingdir?: string;
   verbose?: boolean;
 }
@@ -41,6 +42,7 @@ export async function runLocalBuildAsync(job: Job, options: LocalBuildOptions): 
           : {}),
         ...(options.skipNativeBuild ? { EAS_LOCAL_BUILD_SKIP_NATIVE_BUILD: '1' } : {}),
         ...(options.artifactsDir ? { EAS_LOCAL_BUILD_ARTIFACTS_DIR: options.artifactsDir } : {}),
+        ...(options.artifactPath ? { EAS_LOCAL_BUILD_ARTIFACT_PATH: options.artifactPath } : {}),
       },
     });
     childProcess = spawnPromise.child;

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -66,7 +66,7 @@ export default class Build extends EasCommand {
       description: 'Run build locally [experimental]',
     }),
     output: Flags.string({
-      description: 'Output path for local build.',
+      description: 'Output path for local build',
     }),
     wait: Flags.boolean({
       default: true,

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -3,6 +3,7 @@ import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
 import figures from 'figures';
 import fs from 'fs-extra';
+import path from 'path';
 
 import { BuildFlags, runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import { ensureRepoIsCleanAsync, reviewAndCommitChangesAsync } from '../../build/utils/repository';
@@ -23,6 +24,7 @@ interface RawBuildFlags {
   profile?: string;
   'non-interactive': boolean;
   local: boolean;
+  output?: string;
   wait: boolean;
   'clear-cache': boolean;
   json: boolean;
@@ -63,6 +65,9 @@ export default class Build extends EasCommand {
       default: false,
       description: 'Run build locally [experimental]',
     }),
+    output: Flags.string({
+      description: 'Output path for local build.',
+    }),
     wait: Flags.boolean({
       default: true,
       allowNo: true,
@@ -100,6 +105,9 @@ export default class Build extends EasCommand {
 
   private async sanitizeFlagsAsync(flags: RawBuildFlags): Promise<BuildFlags> {
     const nonInteractive = flags['non-interactive'];
+    if (!flags.local && flags.output) {
+      Errors.error('--output is allowed only for local builds', { exit: 1 });
+    }
     if (!flags.platform && nonInteractive) {
       Errors.error('--platform is required when building in non-interactive mode', { exit: 1 });
     }
@@ -138,7 +146,11 @@ export default class Build extends EasCommand {
       profile,
       nonInteractive,
       localBuildOptions: flags['local']
-        ? { enable: true, verbose: true }
+        ? {
+            enable: true,
+            verbose: true,
+            artifactPath: flags.output && path.resolve(process.cwd(), flags.output),
+          }
         : {
             enable: false,
           },


### PR DESCRIPTION


# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Add `--output` option for local builds

# How



# Test Plan

run local build