### PR TITLE
Bump @expo/apple-utils@0.0.0-alpha.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Improve error message for outdated Apple PLA error ([#889](https://github.com/expo/eas-cli/pull/889) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `--output` flag to the build command. ([#885](https://github.com/expo/eas-cli/pull/885) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "0.0.0-alpha.26",
+    "@expo/apple-utils": "0.0.0-alpha.27",
     "@expo/config": "6.0.11",
     "@expo/config-plugins": "4.0.11",
     "@expo/eas-build-job": "0.2.61",

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -67,7 +67,11 @@ export async function ensureBundleIdExistsWithNameAsync(
       spinner.fail(`Failed to register bundle identifier ${chalk.dim(bundleIdentifier)}`);
 
       // Assert contract errors for easier resolution when the user has an expired developer account.
-      if (err.message.match(/forbidden for security reasons/)) {
+      if (
+        err.message.match(/forbidden for security reasons/) ||
+        // Unable to process request - PLA Update available - You currently don't have access to this membership resource. To resolve this issue, agree to the latest Program License Agreement in your developer account.
+        err.message.match(/agree/)
+      ) {
         await assertContractMessagesAsync(context);
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -833,10 +833,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@expo/apple-utils@0.0.0-alpha.26":
-  version "0.0.0-alpha.26"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.26.tgz#cf5a893b7c9cc779af5b54a482196325dcde1426"
-  integrity sha512-t+xOhn4bYSAXkXamhDPUiI2Ol+QIwHRHLn/2QiCmNAGHolaVan/hMaVveSzvCYitpaJ16b4nthvcWFoJipxGlA==
+"@expo/apple-utils@0.0.0-alpha.27":
+  version "0.0.0-alpha.27"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.27.tgz#5b77cd4522d19fa75a7801071c49da04b9162cd7"
+  integrity sha512-oprlh8UpNM5nqz6clGpCr7u8Uf1WjmnOkETKLEFDnW2JRcOkSrVwJrV4CfKfm3qvIoAwEk4ZONDMr0ZiI21dzQ==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

- https://github.com/expo/third-party/pull/70

# How

- Bump apple-utils to 27
- Check for agreements when the error message says 'agree'

New error results:

```
✖ Failed to register bundle identifier com.bacon.yolo76

Messages from App Store Connect:

› Apple Developer Program License Agreement Updated
The updated Apple Developer Program License Agreement needs to be reviewed. In order to update your existing apps and submit new apps to the App Store, the Account Holder must review and accept the updated agreement by signing in to their account
(https://developer.apple.com/account) on the Apple Developer website.

    Error: App Store Connect has agreement updates that must be resolved
```

# Test Plan

`eas build -p ios` in a new project.