### PR TITLE
[eas-cli] do not follow symlinks with fast-glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix creating project archive with symlink cycle. ([#891](https://github.com/expo/eas-cli/pull/891) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [0.43.0](https://github.com/expo/eas-cli/releases/tag/v0.43.0) - 2022-01-03

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -44,7 +44,11 @@ export class Ignore {
       return;
     }
     const ignoreFilePaths = (
-      await fg(`**/${GITIGNORE_FILENAME}`, { cwd: this.rootDir, ignore: ['node_modules'] })
+      await fg(`**/${GITIGNORE_FILENAME}`, {
+        cwd: this.rootDir,
+        ignore: ['node_modules'],
+        followSymbolicLinks: false,
+      })
     )
       // ensure that parent dir is before child directories
       .sort((a, b) => a.length - b.length && a.localeCompare(b));


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

When there is a symlink on macos to the parent directory that contains .gitingore `fast-glob` is entering in cycle crashing after some time

# How

do not follow symlinks when searching for .gitignore files

# Test Plan

created symlink to the root of the repo and run build:inspect -s archive