### PR TITLE
[eas-cli] Only configure updates in generic projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix build:configure expo-updates configuration to only run on generic projects. ([#904](https://github.com/expo/eas-cli/pull/904) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🧹 Chores
 
 - Upgrade `node-forge` to 1.0.0. ([#902](https://github.com/expo/eas-cli/pull/902) by [@dependabot](https://github.com/apps/dependabot) + [@dsokal](https://github.com/dsokal))

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '@expo/config';
+import { Platform, Workflow } from '@expo/eas-build-job';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
@@ -11,6 +12,7 @@ import EasCommand from '../../commandUtils/EasCommand';
 import Log, { learnMore } from '../../log';
 import { RequestedPlatform } from '../../platform';
 import { findProjectRootAsync } from '../../project/projectUtils';
+import { resolveWorkflowAsync } from '../../project/workflow';
 import { promptAsync } from '../../prompts';
 import { getVcsClient } from '../../vcs';
 
@@ -57,11 +59,17 @@ export default class BuildConfigure extends EasCommand {
       const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
 
       if ([RequestedPlatform.Android, RequestedPlatform.All].includes(platform)) {
-        await syncAndroidUpdatesConfigurationAsync(projectDir, exp);
+        const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
+        if (workflow === Workflow.GENERIC) {
+          await syncAndroidUpdatesConfigurationAsync(projectDir, exp);
+        }
       }
 
       if ([RequestedPlatform.Ios, RequestedPlatform.All].includes(platform)) {
-        await syncIosUpdatesConfigurationAsync(projectDir, exp);
+        const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
+        if (workflow === Workflow.GENERIC) {
+          await syncIosUpdatesConfigurationAsync(projectDir, exp);
+        }
       }
     }
 


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

In #888 we refactored the `build:configure` command and as a result of that change we ended up attempting to configure native iOS and Android projects for expo-updates even if they don't exist because the project is managed. It's possible to repro this with:

```
expo init project # blank app
cd project && expo install expo-updates
eas build:configure
# Error: Android project folder is missing in project ...
# Same sort of thing for iOS
``` 

# How

I used the same logic that we use in `syncProjectConfiguration` to detect if we are in a generic project or not, then skip running updates configuration in managed projects:

https://github.com/expo/eas-cli/blob/dd2303dbb2b01dcd941591b5ccba01bbd04b29a7/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts#L26-L29

# Test Plan

- Run `easd build:configure` in managed app with `expo-updates` installed, it should just create **eas.json** and nothing else
- Run `easd build:configure` in bare app with `expo-updates` installed, it should sync config from **app.json** to native projects