### PR TITLE
[eas-cli][build] add support for `prebuildCommand` in eas.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add `eas device:delete`. ([#890](https://github.com/expo/eas-cli/pull/890) by [@kbrandwijk](https://github.com/kbrandwijk))
+- Add support to `eas build` for specifying a custom `prebuildCommand` in `eas.json`. ([#919](https://github.com/expo/eas-cli/pull/919) by [@kbrandwijk](https://github.com/kbrandwijk))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/android/graphql.ts
+++ b/packages/eas-cli/src/build/android/graphql.ts
@@ -18,6 +18,7 @@ export function transformJob(job: Android.Job): AndroidJobInput {
     username: job.username,
     buildType: job.buildType && transformBuildType(job.buildType),
     developmentClient: job.developmentClient,
+    experimental: job.experimental,
   };
 }
 

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -75,6 +75,9 @@ export async function prepareJobAsync(
     artifactPath: buildProfile.artifactPath,
     buildType,
     username,
+    experimental: {
+      prebuildCommand: ctx.buildProfile.prebuildCommand,
+    },
   };
 
   return sanitizeJob(job);

--- a/packages/eas-cli/src/build/ios/graphql.ts
+++ b/packages/eas-cli/src/build/ios/graphql.ts
@@ -20,6 +20,7 @@ export function transformJob(job: Ios.Job): IosJobInput {
     username: job.username,
     developmentClient: job.developmentClient,
     simulator: job.simulator,
+    experimental: job.experimental,
   };
 }
 

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -66,6 +66,9 @@ export async function prepareJobAsync(
     buildConfiguration: ctx.buildProfile.buildConfiguration,
     artifactPath: ctx.buildProfile.artifactPath,
     username,
+    experimental: {
+      prebuildCommand: ctx.buildProfile.prebuildCommand,
+    },
   };
   return sanitizeJob(job);
 }

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -6,7 +6,7 @@ import semver from 'semver';
 import { ora } from '../ora';
 
 const PLUGIN_PACKAGE_NAME = 'eas-cli-local-build-plugin';
-const PLUGIN_PACKAGE_VERSION = '0.0.58';
+const PLUGIN_PACKAGE_VERSION = '0.0.62';
 
 export interface LocalBuildOptions {
   enable: boolean;

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -16,6 +16,7 @@ const CommonBuildProfileSchema = Joi.object({
   releaseChannel: Joi.string().regex(/^[a-z\d][a-z\d._-]*$/),
   channel: Joi.string().regex(/^[a-z\d][a-z\d._-]*$/),
   developmentClient: Joi.boolean(),
+  prebuildCommand: Joi.string(),
 
   node: Joi.string().empty(null).custom(semverCheck),
   yarn: Joi.string().empty(null).custom(semverCheck),

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -20,6 +20,7 @@ export interface CommonBuildProfile {
   releaseChannel?: string;
   channel?: string;
   developmentClient?: boolean;
+  prebuildCommand?: string;
 
   node?: string;
   yarn?: string;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [X] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Resolves https://github.com/expo/eas-cli/issues/887.

# How

Extend job objects and schemas with the new `eas.json` field.

# Test Plan

Ran tests on staging, as well as locally.

In 'draft' because it depends on a pending release of `local-build-plugin` of which the version number is already included.