### PR TITLE
[eas-cli][build] add json output for started builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add json output for started builds when using `--no-wait`. ([#921](https://github.com/expo/eas-cli/pull/921) by [@kbrandwijk](https://github.com/kbrandwijk))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -132,7 +132,7 @@ export async function runBuildAndSubmitAsync(projectDir: string, flags: BuildFla
 
   if (!flags.wait) {
     if (flags.json) {
-      printJsonOnlyOutput(startedBuilds);
+      printJsonOnlyOutput(startedBuilds.map(buildInfo => buildInfo.build));
     }
     return;
   }

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -20,6 +20,7 @@ import {
   waitToCompleteAsync as waitForSubmissionsToCompleteAsync,
 } from '../submit/submit';
 import { printSubmissionDetailsUrls } from '../submit/utils/urls';
+import { printJsonOnlyOutput } from '../utils/json';
 import { ProfileData, getProfilesAsync } from '../utils/profiles';
 import { getVcsClient } from '../vcs';
 import { prepareAndroidBuildAsync } from './android/build';
@@ -130,6 +131,9 @@ export async function runBuildAndSubmitAsync(projectDir: string, flags: BuildFla
   }
 
   if (!flags.wait) {
+    if (flags.json) {
+      printJsonOnlyOutput(startedBuilds);
+    }
     return;
   }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [X] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

- Resolves https://github.com/expo/eas-cli/issues/920

# How

Display identical output as for completed builds

# Test Plan

Ran locally with and without the json flag.