### PR TITLE
unify command descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Unify EAS command descriptions style. ([#925](https://github.com/expo/eas-cli/pull/925) by [@dsokal](https://github.com/dsokal))
+
 ## [0.45.1](https://github.com/expo/eas-cli/releases/tag/v0.45.1) - 2022-01-19
 
 ### 🎉 New features

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -121,7 +121,10 @@
     ],
     "topics": {
       "account": {
-        "description": "manage your account"
+        "description": "manage account"
+      },
+      "branch": {
+        "description": "manage update branches"
       },
       "build": {
         "description": "build app binaries"
@@ -130,10 +133,10 @@
         "description": "manage update channels"
       },
       "device": {
-        "description": "manage your Apple devices for internal distribution"
+        "description": "manage Apple devices for Internal Distribution"
       },
       "project": {
-        "description": "manage your project"
+        "description": "manage project"
       },
       "release": {
         "description": "manage update releases"

--- a/packages/eas-cli/src/commands/analytics.ts
+++ b/packages/eas-cli/src/commands/analytics.ts
@@ -3,7 +3,7 @@ import Log from '../log';
 import UserSettings from '../user/UserSettings';
 
 export default class AnalyticsView extends EasCommand {
-  static description = 'view or change analytics settings';
+  static description = 'display or change analytics settings';
 
   static args = [{ name: 'STATUS', options: ['on', 'off'] }];
 

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -52,7 +52,7 @@ export async function createUpdateBranchOnAppAsync({
 }
 
 export default class BranchCreate extends EasCommand {
-  static description = 'create a branch on the current project';
+  static description = 'create a branch';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -52,7 +52,7 @@ export async function createUpdateBranchOnAppAsync({
 }
 
 export default class BranchCreate extends EasCommand {
-  static description = 'Create a branch on the current project.';
+  static description = 'create a branch on the current project';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -77,7 +77,7 @@ async function deleteBranchOnAppAsync({
 }
 
 export default class BranchDelete extends EasCommand {
-  static description = 'delete a branch on the current project';
+  static description = 'delete a branch';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -77,7 +77,7 @@ async function deleteBranchOnAppAsync({
 }
 
 export default class BranchDelete extends EasCommand {
-  static description = 'Delete a branch on the current project';
+  static description = 'delete a branch on the current project';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -55,7 +55,7 @@ export async function listBranchesAsync({
 }
 
 export default class BranchList extends EasCommand {
-  static description = 'List all branches on this project.';
+  static description = 'list all branches on this project';
 
   static flags = {
     json: Flags.boolean({

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -55,7 +55,7 @@ export async function listBranchesAsync({
 }
 
 export default class BranchList extends EasCommand {
-  static description = 'list all branches on this project';
+  static description = 'list all branches';
 
   static flags = {
     json: Flags.boolean({

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -52,7 +52,7 @@ async function renameUpdateBranchOnAppAsync({
 }
 
 export default class BranchRename extends EasCommand {
-  static description = 'Rename a branch.';
+  static description = 'rename a branch';
 
   static flags = {
     from: Flags.string({

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -14,7 +14,7 @@ import formatFields from '../../utils/formatFields';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class BranchView extends EasCommand {
-  static description = 'View a branch.';
+  static description = 'view a branch';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -110,7 +110,7 @@ async function ensureBuildExistsAsync(buildId: string): Promise<void> {
 }
 
 export default class BuildCancel extends EasCommand {
-  static description = 'Cancel a build.';
+  static description = 'cancel a build';
 
   static args = [{ name: 'BUILD_ID' }];
 

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -17,7 +17,7 @@ import { promptAsync } from '../../prompts';
 import { getVcsClient } from '../../vcs';
 
 export default class BuildConfigure extends EasCommand {
-  static description = 'Configure the project to support EAS Build.';
+  static description = 'configure the project to support EAS Build';
 
   static flags = {
     platform: Flags.enum({

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -33,7 +33,7 @@ interface RawBuildFlags {
 }
 
 export default class Build extends EasCommand {
-  static description = 'Start a build';
+  static description = 'start a build';
 
   static flags = {
     platform: Flags.enum({

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -26,7 +26,7 @@ const STAGE_DESCRIPTION = `Stage of the build you want to inspect.
 
 export default class BuildInspect extends EasCommand {
   static description =
-    'Inspect the state of the project at specific build stages. Useful for troubleshooting.';
+    'inspect the state of the project at specific build stages, useful for troubleshooting';
 
   static flags = {
     platform: Flags.enum({

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -60,7 +60,7 @@ export async function createUpdateChannelOnAppAsync({
 }
 
 export default class ChannelCreate extends EasCommand {
-  static description = 'Create a channel on the current project.';
+  static description = 'create a channel on the current project';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -60,7 +60,7 @@ export async function createUpdateChannelOnAppAsync({
 }
 
 export default class ChannelCreate extends EasCommand {
-  static description = 'create a channel on the current project';
+  static description = 'create a channel';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/channel/delete.ts
+++ b/packages/eas-cli/src/commands/channel/delete.ts
@@ -22,7 +22,7 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class ChannelDelete extends EasCommand {
   static hidden = true;
-  static description = 'Delete a channel on the current project';
+  static description = 'Delete a channel';
 
   static args = [
     {
@@ -33,7 +33,7 @@ export default class ChannelDelete extends EasCommand {
   ];
   static flags = {
     json: Flags.boolean({
-      description: `Delete a channel on the current project`,
+      description: 'print output as a JSON object',
       default: false,
     }),
     'non-interactive': Flags.boolean({

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -96,7 +96,7 @@ export async function updateChannelBranchMappingAsync({
 }
 
 export default class ChannelEdit extends EasCommand {
-  static description = 'Point a channel at a new branch.';
+  static description = 'point a channel at a new branch';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -67,7 +67,7 @@ async function getAllUpdateChannelForAppAsync({
 }
 
 export default class ChannelList extends EasCommand {
-  static description = 'list all channels on the current project';
+  static description = 'list all channels';
 
   static flags = {
     json: Flags.boolean({

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -67,7 +67,7 @@ async function getAllUpdateChannelForAppAsync({
 }
 
 export default class ChannelList extends EasCommand {
-  static description = 'List all channels on the current project.';
+  static description = 'list all channels on the current project';
 
   static flags = {
     json: Flags.boolean({

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -193,7 +193,7 @@ export function logChannelDetails(channel: {
 }
 
 export default class ChannelView extends EasCommand {
-  static description = 'View a channel on the current project.';
+  static description = 'view a channel on the current project';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -193,7 +193,7 @@ export function logChannelDetails(channel: {
 }
 
 export default class ChannelView extends EasCommand {
-  static description = 'view a channel on the current project';
+  static description = 'view a channel';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -2,16 +2,19 @@ import { getProjectConfigDescription } from '@expo/config';
 import { Platform } from '@expo/eas-build-job';
 import { EasJsonReader } from '@expo/eas-json';
 import { Flags } from '@oclif/core';
+import chalk from 'chalk';
 
 import EasCommand from '../commandUtils/EasCommand';
+import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log from '../log';
+import { appPlatformEmojis } from '../platform';
 import { getExpoConfig } from '../project/expoConfig';
 import { findProjectRootAsync } from '../project/projectUtils';
 import { selectAsync } from '../prompts';
 import { handleDeprecatedEasJsonAsync } from './build';
 
 export default class Config extends EasCommand {
-  static description = 'show the eas.json config';
+  static description = 'display project configuration (app.json + eas.json)';
 
   static flags = {
     platform: Flags.enum({ char: 'p', options: ['android', 'ios'] }),
@@ -58,12 +61,15 @@ export default class Config extends EasCommand {
     const profile = await reader.getBuildProfileAsync(platform, profileName);
     const config = getExpoConfig(projectDir, { env: profile.env, isPublicConfig: true });
 
-    Log.log(getProjectConfigDescription(projectDir));
+    Log.addNewLineIfNone();
+    Log.log(chalk.bold(getProjectConfigDescription(projectDir)));
     Log.newLine();
     Log.log(JSON.stringify(config, null, 2));
     Log.newLine();
     Log.newLine();
-    Log.log(`Build profile "${profileName}" from eas.json for platform ${platform}`);
+    const appPlatform = toAppPlatform(platform);
+    const platformEmoji = appPlatformEmojis[appPlatform];
+    Log.log(`${platformEmoji} ${chalk.bold(`Build profile "${profileName}"`)}`);
     Log.newLine();
     Log.log(JSON.stringify(profile, null, 2));
   }

--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -2,7 +2,7 @@ import EasCommand from '../commandUtils/EasCommand';
 import { SelectPlatform } from '../credentials/manager/SelectPlatform';
 
 export default class Credentials extends EasCommand {
-  static description = 'manage your credentials';
+  static description = 'manage credentials';
 
   async runAsync(): Promise<void> {
     await new SelectPlatform().runAsync();

--- a/packages/eas-cli/src/commands/diagnostics.ts
+++ b/packages/eas-cli/src/commands/diagnostics.ts
@@ -8,7 +8,7 @@ import { resolveWorkflowAsync } from '../project/workflow';
 import { easCliVersion } from '../utils/easCli';
 
 export default class Diagnostics extends EasCommand {
-  static description = 'log environment info to the console';
+  static description = 'display environment info';
 
   protected requiresAuthentication = false;
 

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -20,7 +20,7 @@ import { getActorDisplayName } from '../../user/User';
 import { ensureLoggedInAsync } from '../../user/actions';
 
 export default class EnvironmentSecretCreate extends EasCommand {
-  static description = 'Create an environment secret on the current project or owner account.';
+  static description = 'create an environment secret on the current project or owner account';
 
   static flags = {
     scope: Flags.enum({

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -1,6 +1,5 @@
 import { getConfig } from '@expo/config';
 import { Flags } from '@oclif/core';
-import chalk from 'chalk';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -17,7 +17,7 @@ import {
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
 
 export default class EnvironmentSecretDelete extends EasCommand {
-  static description = `delete an environment secret by ID`;
+  static description = 'delete an environment secret by ID';
 
   static flags = {
     id: Flags.string({

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -18,8 +18,7 @@ import {
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
 
 export default class EnvironmentSecretDelete extends EasCommand {
-  static description = `Delete an environment secret by ID.
-Unsure where to find the secret's ID? Run ${chalk.bold('eas secret:list')}`;
+  static description = `delete an environment secret by ID`;
 
   static flags = {
     id: Flags.string({

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -13,7 +13,7 @@ import {
 } from '../../project/projectUtils';
 
 export default class EnvironmentSecretList extends EasCommand {
-  static description = 'Lists environment secrets available for your current app';
+  static description = 'list environment secrets available for your current app';
 
   async runAsync(): Promise<void> {
     const projectDir = await findProjectRootAsync();

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -41,8 +41,7 @@ interface CommandFlags {
 }
 
 export default class Submit extends EasCommand {
-  static description = `Submit build archive to App Store Connect
-See how to configure submits with eas.json: ${link('https://docs.expo.dev/submit/eas-json/')}`;
+  static description = `submit app binary to app store`;
   static aliases = ['build:submit'];
 
   static flags = {

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -41,7 +41,7 @@ interface CommandFlags {
 }
 
 export default class Submit extends EasCommand {
-  static description = `submit app binary to app store`;
+  static description = 'submit app binary to app store';
   static aliases = ['build:submit'];
 
   static flags = {

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import EasCommand from '../commandUtils/EasCommand';
 import { SubmissionFragment } from '../graphql/generated';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
-import Log, { link } from '../log';
+import Log from '../log';
 import {
   RequestedPlatform,
   appPlatformDisplayNames,

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -73,7 +73,7 @@ async function configureProjectForEASUpdateAsync(
 }
 
 export default class UpdateConfigure extends EasCommand {
-  static description = 'Configure the project to support EAS Update.';
+  static description = 'configure the project to support EAS Update';
 
   async runAsync(): Promise<void> {
     Log.log(

--- a/packages/eas-cli/src/commands/update/delete.ts
+++ b/packages/eas-cli/src/commands/update/delete.ts
@@ -36,7 +36,7 @@ async function deleteUpdateGroupAsync({
 }
 
 export default class UpdateDelete extends EasCommand {
-  static description = 'Delete all the updates in an update Group.';
+  static description = 'delete all the updates in an update group';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -132,7 +132,7 @@ async function ensureBranchExistsAsync({
 }
 
 export default class UpdatePublish extends EasCommand {
-  static description = 'Publish an update group.';
+  static description = 'publish an update group';
 
   static flags = {
     branch: Flags.string({

--- a/packages/eas-cli/src/commands/update/list.ts
+++ b/packages/eas-cli/src/commands/update/list.ts
@@ -23,7 +23,7 @@ type UpdateGroupDescription = FormatUpdateParameter & {
 };
 
 export default class BranchView extends EasCommand {
-  static description = 'View the recent updates for a branch';
+  static description = 'view the recent updates for a branch';
 
   static flags = {
     branch: Flags.string({

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -51,7 +51,7 @@ export async function viewUpdateAsync({
   return data;
 }
 export default class UpdateView extends EasCommand {
-  static description = 'Update group details.';
+  static description = 'update group details';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -9,7 +9,7 @@ import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUt
 import { prepareInputParamsAsync } from '../../webhooks/input';
 
 export default class WebhookCreate extends EasCommand {
-  static description = 'Create a webhook on the current project.';
+  static description = 'create a webhook on the current project';
 
   static flags = {
     event: Flags.enum({

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -9,7 +9,7 @@ import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUt
 import { prepareInputParamsAsync } from '../../webhooks/input';
 
 export default class WebhookCreate extends EasCommand {
-  static description = 'create a webhook on the current project';
+  static description = 'create a webhook';
 
   static flags = {
     event: Flags.enum({

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -14,7 +14,7 @@ import { promptAsync, toggleConfirmAsync } from '../../prompts';
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
 export default class WebhookDelete extends EasCommand {
-  static description = 'delete a webhook on the current project';
+  static description = 'delete a webhook';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -14,7 +14,7 @@ import { promptAsync, toggleConfirmAsync } from '../../prompts';
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
 export default class WebhookDelete extends EasCommand {
-  static description = 'Delete a webhook on the current project.';
+  static description = 'delete a webhook on the current project';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -15,7 +15,7 @@ import {
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
 export default class WebhookList extends EasCommand {
-  static description = 'List webhooks on the current project.';
+  static description = 'list webhooks on the current project';
 
   static flags = {
     event: Flags.enum({

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -15,7 +15,7 @@ import {
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
 export default class WebhookList extends EasCommand {
-  static description = 'list webhooks on the current project';
+  static description = 'list webhooks';
 
   static flags = {
     event: Flags.enum({

--- a/packages/eas-cli/src/commands/webhook/update.ts
+++ b/packages/eas-cli/src/commands/webhook/update.ts
@@ -9,7 +9,7 @@ import pick from '../../utils/expodash/pick';
 import { prepareInputParamsAsync } from '../../webhooks/input';
 
 export default class WebhookUpdate extends EasCommand {
-  static description = 'update a webhook on the current project';
+  static description = 'update a webhook';
 
   static flags = {
     id: Flags.string({

--- a/packages/eas-cli/src/commands/webhook/update.ts
+++ b/packages/eas-cli/src/commands/webhook/update.ts
@@ -9,7 +9,7 @@ import pick from '../../utils/expodash/pick';
 import { prepareInputParamsAsync } from '../../webhooks/input';
 
 export default class WebhookUpdate extends EasCommand {
-  static description = 'Update a webhook on the current project.';
+  static description = 'update a webhook on the current project';
 
   static flags = {
     id: Flags.string({

--- a/packages/eas-cli/src/commands/webhook/view.ts
+++ b/packages/eas-cli/src/commands/webhook/view.ts
@@ -5,7 +5,7 @@ import { ora } from '../../ora';
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
 export default class WebhookView extends EasCommand {
-  static description = 'view a webhook on the current project';
+  static description = 'view a webhook';
 
   static args = [
     {

--- a/packages/eas-cli/src/commands/webhook/view.ts
+++ b/packages/eas-cli/src/commands/webhook/view.ts
@@ -5,7 +5,7 @@ import { ora } from '../../ora';
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
 export default class WebhookView extends EasCommand {
-  static description = 'View a webhook on the current project.';
+  static description = 'view a webhook on the current project';
 
   static args = [
     {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We use a few different styles for command descriptions.

# How

Unify command descriptions.

# Test Plan

Run
- `echo "account\nbranch\nbuild\nchannel\ndevice\nproject\nsecret\nupdate\nwebhook" | xargs -I {} easd {} --help`
- `easd --help`
and verified all the command descriptions are written in the same style (except for the description for `eas help` but it'd require modifying `@oclif/plugin-help` .