### PR TITLE
[eas-cli] fix get branchByNameAsync typing

### DIFF
--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -9,10 +9,10 @@ import {
   CreateUpdateChannelOnAppMutation,
   CreateUpdateChannelOnAppMutationVariables,
 } from '../../graphql/generated';
+import { BranchQuery } from '../../graphql/queries/BranchQuery';
 import Log from '../../log';
 import {
   findProjectRootAsync,
-  getBranchByNameAsync,
   getProjectFullNameAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
@@ -106,14 +106,16 @@ export default class ChannelCreate extends EasCommand {
 
     let branchId: string;
     let branchMessage: string;
-    try {
-      const existingBranch = await getBranchByNameAsync({
-        appId: projectId,
-        name: channelName,
-      });
+    const {
+      app: {
+        byId: { updateBranchByName: existingBranch },
+      },
+    } = await BranchQuery.getBranchByNameAsync({ appId: projectId, name: channelName });
+
+    if (existingBranch) {
       branchId = existingBranch.id;
       branchMessage = `We found a branch with the same name`;
-    } catch (e) {
+    } else {
       const newBranch = await createUpdateBranchOnAppAsync({
         appId: projectId,
         name: channelName,

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -106,11 +106,10 @@ export default class ChannelCreate extends EasCommand {
 
     let branchId: string;
     let branchMessage: string;
-    const {
-      app: {
-        byId: { updateBranchByName: existingBranch },
-      },
-    } = await BranchQuery.getBranchByNameAsync({ appId: projectId, name: channelName });
+    const { updateBranchByName: existingBranch } = await BranchQuery.getBranchByNameAsync({
+      appId: projectId,
+      name: channelName,
+    });
 
     if (existingBranch) {
       branchId = existingBranch.id;

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -106,7 +106,7 @@ export default class ChannelCreate extends EasCommand {
 
     let branchId: string;
     let branchMessage: string;
-    const { updateBranchByName: existingBranch } = await BranchQuery.getBranchByNameAsync({
+    const existingBranch = await BranchQuery.getBranchByNameAsync({
       appId: projectId,
       name: channelName,
     });

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -174,7 +174,7 @@ async function promptForChannelAsync(): Promise<string> {
     type: 'text',
     name: 'name',
     message: 'Please enter the name of the channel to edit:',
-    validate: value => (value ? true : 'A channel name is required to edit a specific channel.'),
+    validate: value => (value ? true : 'The channel name may not be empty.'),
   });
   return name;
 }
@@ -185,7 +185,7 @@ async function promptForBranchAsync(): Promise<string> {
     type: 'text',
     name: 'name',
     message: `To which branch should the channel link?`,
-    validate: value => (value ? true : 'branch name may not be empty.'),
+    validate: value => (value ? true : 'The branch name may not be empty.'),
   });
   return name;
 }

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -134,7 +134,7 @@ export default class ChannelEdit extends EasCommand {
 
     const branchName = flags.branch ?? (await promptForBranchAsync());
 
-    const { updateBranchByName: branch } = await BranchQuery.getBranchByNameAsync({
+    const branch = await BranchQuery.getBranchByNameAsync({
       appId: projectId,
       name: branchName,
     });

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -1,6 +1,5 @@
 import { getConfig } from '@expo/config';
 import { Flags } from '@oclif/core';
-import assert from 'assert';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
@@ -135,11 +134,10 @@ export default class ChannelEdit extends EasCommand {
 
     const branchName = flags.branch ?? (await promptForBranchAsync());
 
-    const {
-      app: {
-        byId: { updateBranchByName: branch },
-      },
-    } = await BranchQuery.getBranchByNameAsync({ appId: projectId, name: branchName });
+    const { updateBranchByName: branch } = await BranchQuery.getBranchByNameAsync({
+      appId: projectId,
+      name: branchName,
+    });
     if (!branch) {
       throw new Error(
         `Could not find a branch named "${branchName}". Please check what branches exist on this project with ${chalk.bold(

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -78,7 +78,7 @@ async function startRolloutAsync({
   getUpdateChannelByNameForAppResult,
 }: {
   channelName?: string;
-  branchName?: string;
+  branchName: string;
   percent?: number;
   jsonFlag: boolean;
   projectId: string;
@@ -93,27 +93,15 @@ async function startRolloutAsync({
   };
   logMessage: string;
 }> {
-  if (!branchName) {
-    const validationMessage = 'A branch must be specified.';
-    if (jsonFlag) {
-      throw new Error(validationMessage);
-    }
-    ({ name: branchName } = await promptAsync({
-      type: 'text',
-      name: 'name',
-      message: `Select a branch to rollout onto ${channelName}`,
-      validate: value => (value ? true : validationMessage),
-    }));
-  }
-
-  const {
-    app: {
-      byId: { updateBranchByName: branch },
-    },
-  } = await BranchQuery.getBranchByNameAsync({ appId: projectId, name: branchName! });
+  const { updateBranchByName: branch } = await BranchQuery.getBranchByNameAsync({
+    appId: projectId,
+    name: branchName,
+  });
   if (!branch) {
     throw new Error(
-      `Could not find a branch named "${branchName}". Please check what branches exist on this project with "eas branch:list".`
+      `Could not find a branch named "${branchName}". Please check what branches exist on this project with ${chalk.bold(
+        'eas branch:list'
+      )}.`
     );
   }
 
@@ -258,14 +246,15 @@ async function endRolloutAsync({
 
   let endOnNewBranch;
   if (branchName) {
-    const {
-      app: {
-        byId: { updateBranchByName: branch },
-      },
-    } = await BranchQuery.getBranchByNameAsync({ appId: projectId, name: branchName! });
+    const { updateBranchByName: branch } = await BranchQuery.getBranchByNameAsync({
+      appId: projectId,
+      name: branchName,
+    });
     if (!branch) {
       throw new Error(
-        `Could not find a branch named "${branchName}". Please check what branches exist on this project with "eas branch:list".`
+        `Could not find a branch named "${branchName}". Please check what branches exist on this project with ${chalk.bold(
+          'eas branch:list'
+        )}.`
       );
     }
 
@@ -412,7 +401,7 @@ export default class ChannelRollout extends EasCommand {
     if (!isRollout) {
       rolloutMutationResult = await startRolloutAsync({
         channelName,
-        branchName,
+        branchName: branchName ?? (await promptForBranchNameAsync(channelName)),
         percent,
         jsonFlag,
         projectId,
@@ -447,4 +436,14 @@ export default class ChannelRollout extends EasCommand {
       Log.withTick(logMessage);
     }
   }
+}
+
+async function promptForBranchNameAsync(channelName: string): Promise<string> {
+  const { name } = await promptAsync({
+    type: 'text',
+    name: 'name',
+    message: `Select a branch to rollout onto ${channelName}`,
+    validate: value => (value ? true : 'A branch must be specified.'),
+  });
+  return name;
 }

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -93,7 +93,7 @@ async function startRolloutAsync({
   };
   logMessage: string;
 }> {
-  const { updateBranchByName: branch } = await BranchQuery.getBranchByNameAsync({
+  const branch = await BranchQuery.getBranchByNameAsync({
     appId: projectId,
     name: branchName,
   });
@@ -246,7 +246,7 @@ async function endRolloutAsync({
 
   let endOnNewBranch;
   if (branchName) {
-    const { updateBranchByName: branch } = await BranchQuery.getBranchByNameAsync({
+    const branch = await BranchQuery.getBranchByNameAsync({
       appId: projectId,
       name: branchName,
     });

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -377,15 +377,8 @@ export default class ChannelRollout extends EasCommand {
       appId: projectId,
       channelName: channelName!,
     });
-
-    const channel = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName;
-    if (!channel) {
-      throw new Error(
-        `Could not find a channel named "${channelName}". Please check what channels exist on this project with "eas channel:list".`
-      );
-    }
     const { branchMapping: currentBranchMapping, isRollout } = getBranchMapping(
-      channel.branchMapping
+      getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.branchMapping
     );
 
     if (currentBranchMapping.data.length === 0) {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4273,6 +4273,14 @@ export type DeleteWebhookMutationVariables = Exact<{
 
 export type DeleteWebhookMutation = { __typename?: 'RootMutation', webhook: { __typename?: 'WebhookMutation', deleteWebhook: { __typename?: 'DeleteWebhookResult', id: string } } };
 
+export type ViewBranchQueryVariables = Exact<{
+  appId: Scalars['String'];
+  name: Scalars['String'];
+}>;
+
+
+export type ViewBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, name: string } | null | undefined } } };
+
 export type BuildsByIdQueryVariables = Exact<{
   buildId: Scalars['ID'];
 }>;

--- a/packages/eas-cli/src/graphql/queries/BranchQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BranchQuery.ts
@@ -1,0 +1,33 @@
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ViewBranchQuery, ViewBranchQueryVariables } from '../generated';
+
+export const BranchQuery = {
+  async getBranchByNameAsync({ appId, name }: { appId: string; name: string }) {
+    return await withErrorHandlingAsync<ViewBranchQuery>(
+      graphqlClient
+        .query<ViewBranchQuery, ViewBranchQueryVariables>(
+          gql`
+            query ViewBranch($appId: String!, $name: String!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  updateBranchByName(name: $name) {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+          `,
+          {
+            appId,
+            name,
+          },
+          { additionalTypenames: ['UpdateBranch'] }
+        )
+        .toPromise()
+    );
+  },
+};

--- a/packages/eas-cli/src/graphql/queries/BranchQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BranchQuery.ts
@@ -4,8 +4,16 @@ import { graphqlClient, withErrorHandlingAsync } from '../client';
 import { ViewBranchQuery, ViewBranchQueryVariables } from '../generated';
 
 export const BranchQuery = {
-  async getBranchByNameAsync({ appId, name }: { appId: string; name: string }) {
-    return await withErrorHandlingAsync<ViewBranchQuery>(
+  async getBranchByNameAsync({
+    appId,
+    name,
+  }: {
+    appId: string;
+    name: string;
+  }): Promise<ViewBranchQuery['app']['byId']> {
+    const {
+      app: { byId },
+    } = await withErrorHandlingAsync<ViewBranchQuery>(
       graphqlClient
         .query<ViewBranchQuery, ViewBranchQueryVariables>(
           gql`
@@ -29,5 +37,6 @@ export const BranchQuery = {
         )
         .toPromise()
     );
+    return byId;
   },
 };

--- a/packages/eas-cli/src/graphql/queries/BranchQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BranchQuery.ts
@@ -10,9 +10,11 @@ export const BranchQuery = {
   }: {
     appId: string;
     name: string;
-  }): Promise<ViewBranchQuery['app']['byId']> {
+  }): Promise<ViewBranchQuery['app']['byId']['updateBranchByName']> {
     const {
-      app: { byId },
+      app: {
+        byId: { updateBranchByName: branch },
+      },
     } = await withErrorHandlingAsync<ViewBranchQuery>(
       graphqlClient
         .query<ViewBranchQuery, ViewBranchQueryVariables>(
@@ -37,6 +39,6 @@ export const BranchQuery = {
         )
         .toPromise()
     );
-    return byId;
+    return branch;
   },
 };

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -1,12 +1,10 @@
 import { AppJSONConfig, ExpoConfig, getConfigFilePaths, modifyConfigAsync } from '@expo/config';
 import { Env } from '@expo/eas-build-job';
 import chalk from 'chalk';
-import gql from 'graphql-tag';
 import path from 'path';
 import pkgDir from 'pkg-dir';
 
-import { graphqlClient, withErrorHandlingAsync } from '../graphql/client';
-import { AppPrivacy, UpdateBranch } from '../graphql/generated';
+import { AppPrivacy } from '../graphql/generated';
 import Log from '../log';
 import { confirmAsync } from '../prompts';
 import { Actor } from '../user/User';
@@ -191,52 +189,6 @@ export function getProjectConfigDescription(projectDir: string): string {
     return path.relative(projectDir, paths.staticConfigPath);
   }
   return 'app.config.js/app.json';
-}
-
-export async function getBranchByNameAsync({
-  appId,
-  name,
-}: {
-  appId: string;
-  name: string;
-}): Promise<UpdateBranch> {
-  const data = await withErrorHandlingAsync(
-    graphqlClient
-      .query<
-        {
-          app: {
-            byId: {
-              updateBranchByName: UpdateBranch;
-            };
-          };
-        },
-        {
-          appId: string;
-          name: string;
-        }
-      >(
-        gql`
-          query ViewBranch($appId: String!, $name: String!) {
-            app {
-              byId(appId: $appId) {
-                id
-                updateBranchByName(name: $name) {
-                  id
-                  name
-                }
-              }
-            }
-          }
-        `,
-        {
-          appId,
-          name,
-        },
-        { additionalTypenames: ['UpdateBranch'] }
-      )
-      .toPromise()
-  );
-  return data.app.byId.updateBranchByName;
 }
 
 // return project id of existing/newly created project, or null if user declines


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

The return type of `getBranchByNameAsync` falsely promises to not be undefined.

This leads to confusing errors such as: https://github.com/expo/eas-cli/issues/926

# How

Refactored `getBranchByNameAsync` to use the generated graphQL types and moved it to the graphQL directory. 

Put in informative errors where appropriate.

# Test Plan

Tested affected commands in a demo repo.