### PR TITLE
[eas-cli] return an informative error if rollout channel dne

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Return informative error when running 'eas channel:rollout' with a channel that does not exist. ([#930](https://github.com/expo/eas-cli/pull/930) by [@jkhales](https://github.com/jkhales))
+
 ### 🧹 Chores
 
 ## [0.46.0](https://github.com/expo/eas-cli/releases/tag/v0.46.0) - 2022-01-26

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -366,8 +366,15 @@ export default class ChannelRollout extends EasCommand {
       appId: projectId,
       channelName: channelName!,
     });
+
+    const channel = getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName;
+    if (!channel) {
+      throw new Error(
+        `Could not find a channel named "${channelName}". Please check what channels exist on this project with "eas channel:list".`
+      );
+    }
     const { branchMapping: currentBranchMapping, isRollout } = getBranchMapping(
-      getUpdateChannelByNameForAppResult.app?.byId.updateChannelByName?.branchMapping
+      channel.branchMapping
     );
 
     if (currentBranchMapping.data.length === 0) {

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -354,7 +354,9 @@ export default class ChannelRollout extends EasCommand {
     });
     if (!channel) {
       throw new Error(
-        `Could not find a channel named "${channelName}". Please check what channels exist on this project with "eas channel:list".`
+        `Could not find a channel named "${channelName}". Please check what channels exist on this project with ${chalk.bold(
+          'eas channel:list'
+        )}.`
       );
     }
 

--- a/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
@@ -1,0 +1,63 @@
+import gql from 'graphql-tag';
+
+import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { GetChannelByNameForAppQuery, GetChannelByNameForAppQueryVariables } from '../generated';
+
+export const ChannelQuery = {
+  async getUpdateChannelByNameForAppAsync({
+    appId,
+    channelName,
+  }: GetChannelByNameForAppQueryVariables): Promise<
+    GetChannelByNameForAppQuery['app']['byId']['updateChannelByName']
+  > {
+    const {
+      app: {
+        byId: { updateChannelByName },
+      },
+    } = await withErrorHandlingAsync(
+      graphqlClient
+        .query<GetChannelByNameForAppQuery, GetChannelByNameForAppQueryVariables>(
+          gql`
+            query GetChannelByNameForApp($appId: String!, $channelName: String!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  updateChannelByName(name: $channelName) {
+                    id
+                    name
+                    createdAt
+                    branchMapping
+                    updateBranches(offset: 0, limit: 1000) {
+                      id
+                      name
+                      updates(offset: 0, limit: 10) {
+                        id
+                        group
+                        message
+                        runtimeVersion
+                        createdAt
+                        platform
+                        actor {
+                          id
+                          ... on User {
+                            username
+                          }
+                          ... on Robot {
+                            firstName
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          { appId, channelName },
+          { additionalTypenames: ['UpdateChannel', 'UpdateBranch', 'Update'] }
+        )
+        .toPromise()
+    );
+    return updateChannelByName;
+  },
+};


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

giving a non-existent channel to `eas channel:rollout does-not-exist` results in a non-informative error.

# How

Confirm the channel is defined at the call site and throw an informative error if it is not.

Since we know the channel is defined, we can simplify the types passed through the code.

# Test Plan

Tested affected rollout routes in a demo repo.