### PR TITLE
fix url placeholder for iOS submits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix URL placeholder for iOS submits. ([#941](https://github.com/expo/eas-cli/pull/941) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 - Unify EAS command descriptions style. ([#925](https://github.com/expo/eas-cli/pull/925) by [@dsokal](https://github.com/dsokal))

--- a/packages/eas-cli/src/submit/ArchiveSource.ts
+++ b/packages/eas-cli/src/submit/ArchiveSource.ts
@@ -344,7 +344,7 @@ async function handlePromptSourceAsync(source: ArchivePromptSource): Promise<Arc
   const sourceType = sourceTypeRaw as ArchiveSourceType;
   switch (sourceType) {
     case ArchiveSourceType.url: {
-      const url = await askForArchiveUrlAsync();
+      const url = await askForArchiveUrlAsync(source.platform);
       return getArchiveAsync({
         ...source,
         sourceType: ArchiveSourceType.url,
@@ -378,8 +378,9 @@ async function handlePromptSourceAsync(source: ArchivePromptSource): Promise<Arc
   }
 }
 
-async function askForArchiveUrlAsync(): Promise<string> {
-  const defaultArchiveUrl = 'https://url.to/your/archive.aab';
+async function askForArchiveUrlAsync(platform: Platform): Promise<string> {
+  const isIos = platform === Platform.IOS;
+  const defaultArchiveUrl = `https://url.to/your/archive.${isIos ? 'ipa' : 'aab'}`;
   const { url } = await promptAsync({
     name: 'url',
     message: 'URL:',


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes https://github.com/expo/eas-cli/issues/937

# How

Check platform and print `.ipa` or `.aab`.

# Test Plan

- I ran `eas submit -p android` and checked the placeholder.
- I ran `eas submit -p ios` and checked the placeholder.