### PR TITLE
[code-signing-certificates] Move @expo/code-signing-certificates package to eas-cli repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,5 @@ packages/eas-cli/src/submit @barthap @dsokal
 packages/eas-cli/src/commands/submit.ts @barthap @dsokal
 
 packages/eas-json @dsokal @wkozyra95
+
+packages/code-signing-certificates @wschurman

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,3 +15,7 @@ coverage:
         informational: true
         paths:
           - packages/eas-json
+      code-signing-certificates:
+        informational: true
+        paths:
+          - packages/code-signing-certificates

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   projects: [
     require('./packages/eas-cli/jest.config.js'),
     require('./packages/eas-json/jest.config.js'),
+    require('./packages/code-signing-certificates/jest.config.js'),
   ],
   testPathIgnorePatterns: ['.*'],
 };

--- a/packages/code-signing-certificates/README.md
+++ b/packages/code-signing-certificates/README.md
@@ -1,0 +1,3 @@
+# code-signing-certificates
+
+A module for working with expo-updates code signing certificates.

--- a/packages/code-signing-certificates/jest.config.js
+++ b/packages/code-signing-certificates/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  ...require('../../jest/jest.config.js'),
+  rootDir: __dirname,
+  roots: ['src'],
+};

--- a/packages/code-signing-certificates/package.json
+++ b/packages/code-signing-certificates/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@expo/code-signing-certificates",
+  "version": "1.0.0",
+  "description": "A module for working with expo-updates code signing certificates",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "watch": "yarn build --watch --preserveWatchOutput",
+    "typecheck": "tsc",
+    "prepack": "rm -rf build && yarn build",
+    "test": "jest",
+    "clean": "rm -rf build node_modules yarn-error.log"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/eas-cli.git",
+    "directory": "packages/code-signing-certificates"
+  },
+  "keywords": [
+    "code signing"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/expo/eas-cli/issues"
+  },
+  "author": "Expo <support@expo.dev>",
+  "homepage": "https://github.com/expo/eas-cli/tree/main/packages/code-signing-certificates#readme",
+  "files": [
+    "build"
+  ],
+  "dependencies": {
+    "node-forge": "^1.2.1"
+  },
+  "devDependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/code-signing-certificates/src/__tests__/main-test.ts
+++ b/packages/code-signing-certificates/src/__tests__/main-test.ts
@@ -1,0 +1,301 @@
+import { md } from 'node-forge';
+
+import {
+  convertCertificatePEMToCertificate,
+  convertCertificateToCertificatePEM,
+  convertKeyPairPEMToKeyPair,
+  convertKeyPairToPEM,
+  convertPrivateKeyPEMToPrivateKey,
+  generateKeyPair,
+  generateSelfSignedCodeSigningCertificate,
+  signStringRSASHA256AndVerify,
+  validateSelfSignedCertificate,
+} from '..';
+
+describe(generateKeyPair, () => {
+  it('generates a key pair', () => {
+    const keyPair = generateKeyPair();
+    expect(keyPair.privateKey).toBeTruthy();
+    expect(keyPair.publicKey).toBeTruthy();
+
+    const digest = md.sha256.create().update('hello');
+    expect(
+      keyPair.publicKey.verify(digest.digest().getBytes(), keyPair.privateKey.sign(digest))
+    ).toBeTruthy();
+  });
+});
+
+describe(convertKeyPairToPEM, () => {
+  it('converts key pair to PEM', () => {
+    const keyPair = generateKeyPair();
+    const keyPairPEM = convertKeyPairToPEM(keyPair);
+    expect(keyPairPEM.privateKeyPEM).toBeTruthy();
+    expect(keyPairPEM.publicKeyPEM).toBeTruthy();
+  });
+});
+
+describe(convertCertificateToCertificatePEM, () => {
+  it('converts certificate to PEM', () => {
+    const keyPair = generateKeyPair();
+    const validityNotAfter = new Date();
+    validityNotAfter.setFullYear(validityNotAfter.getFullYear() + 1);
+    const certificate = generateSelfSignedCodeSigningCertificate({
+      keyPair,
+      validityNotAfter,
+      validityNotBefore: new Date(),
+      commonName: 'test',
+    });
+    expect(convertCertificateToCertificatePEM(certificate)).toBeTruthy();
+  });
+});
+
+describe(convertKeyPairPEMToKeyPair, () => {
+  it('converts key pair PEM to key pair', () => {
+    const keyPair = generateKeyPair();
+    const keyPairPEM = convertKeyPairToPEM(keyPair);
+    expect(convertKeyPairPEMToKeyPair(keyPairPEM)).toBeTruthy();
+  });
+});
+
+describe(convertCertificatePEMToCertificate, () => {
+  it('converts certificate PEM to certificate', () => {
+    const keyPair = generateKeyPair();
+    const validityNotAfter = new Date();
+    validityNotAfter.setFullYear(validityNotAfter.getFullYear() + 1);
+    const certificate = generateSelfSignedCodeSigningCertificate({
+      keyPair,
+      validityNotAfter,
+      validityNotBefore: new Date(),
+      commonName: 'test',
+    });
+    expect(
+      convertCertificatePEMToCertificate(convertCertificateToCertificatePEM(certificate))
+    ).toBeTruthy();
+  });
+});
+
+describe(generateSelfSignedCodeSigningCertificate, () => {
+  it('generates certificate with correct data', () => {
+    const keyPair = generateKeyPair();
+    const validityNotAfter = new Date();
+    validityNotAfter.setFullYear(validityNotAfter.getFullYear() + 1);
+    const certificate = generateSelfSignedCodeSigningCertificate({
+      keyPair,
+      validityNotAfter,
+      validityNotBefore: new Date(),
+      commonName: 'Test',
+    });
+    // check self-signed
+    expect(certificate.issuer.hash).toEqual(certificate.subject.hash);
+    // check extensions
+    expect(certificate.getExtension('keyUsage')).toMatchObject({
+      critical: true,
+      dataEncipherment: false,
+      digitalSignature: true,
+      id: '2.5.29.15',
+      keyCertSign: false,
+      keyEncipherment: false,
+      name: 'keyUsage',
+      nonRepudiation: false,
+    });
+    expect(certificate.getExtension('extKeyUsage')).toMatchObject({
+      clientAuth: false,
+      codeSigning: true,
+      critical: true,
+      emailProtection: false,
+      id: '2.5.29.37',
+      name: 'extKeyUsage',
+      serverAuth: false,
+      timeStamping: false,
+    });
+  });
+});
+
+describe(validateSelfSignedCertificate, () => {
+  it('does not throw for certificate generated with generateSelfSignedCodeSigningCertificate', () => {
+    const keyPair = generateKeyPair();
+    const validityNotAfter = new Date();
+    validityNotAfter.setFullYear(validityNotAfter.getFullYear() + 1);
+    const certificate = generateSelfSignedCodeSigningCertificate({
+      keyPair,
+      validityNotAfter,
+      validityNotBefore: new Date(),
+      commonName: 'Test',
+    });
+    expect(() => validateSelfSignedCertificate(certificate, keyPair)).not.toThrow();
+  });
+
+  it('throws when certificate is expired', () => {
+    const keyPair = generateKeyPair();
+    const validityNotAfter = new Date();
+    const validity = new Date();
+    validity.setFullYear(validity.getFullYear() - 1);
+    const certificate = generateSelfSignedCodeSigningCertificate({
+      keyPair,
+      validityNotAfter,
+      validityNotBefore: validity,
+      commonName: 'Test',
+    });
+    expect(() => validateSelfSignedCertificate(certificate, keyPair)).toThrow(
+      'Certificate validity expired'
+    );
+  });
+
+  it('throws when missing keyUsage', () => {
+    const keyPair = generateKeyPair();
+    const validityNotAfter = new Date();
+    validityNotAfter.setFullYear(validityNotAfter.getFullYear() + 1);
+    const certificate = generateSelfSignedCodeSigningCertificate({
+      keyPair,
+      validityNotAfter,
+      validityNotBefore: new Date(),
+      commonName: 'Test',
+    });
+    certificate.setExtensions([
+      {
+        name: 'keyUsage',
+        critical: true,
+        keyCertSign: false,
+        digitalSignature: false,
+        nonRepudiation: false,
+        keyEncipherment: false,
+        dataEncipherment: false,
+      },
+    ]);
+    expect(() => validateSelfSignedCertificate(certificate, keyPair)).toThrow(
+      'X509v3 Key Usage: Digital Signature not present'
+    );
+  });
+
+  it('throws when missing extKeyUsage', () => {
+    const keyPair = generateKeyPair();
+    const validityNotAfter = new Date();
+    validityNotAfter.setFullYear(validityNotAfter.getFullYear() + 1);
+    const certificate = generateSelfSignedCodeSigningCertificate({
+      keyPair,
+      validityNotAfter,
+      validityNotBefore: new Date(),
+      commonName: 'Test',
+    });
+    certificate.setExtensions([
+      {
+        name: 'keyUsage',
+        critical: true,
+        keyCertSign: false,
+        digitalSignature: true,
+        nonRepudiation: false,
+        keyEncipherment: false,
+        dataEncipherment: false,
+      },
+      {
+        name: 'extKeyUsage',
+        critical: true,
+        serverAuth: false,
+        clientAuth: false,
+        codeSigning: false,
+        emailProtection: false,
+        timeStamping: false,
+      },
+    ]);
+    expect(() => validateSelfSignedCertificate(certificate, keyPair)).toThrow(
+      'X509v3 Extended Key Usage: Code Signing not present'
+    );
+  });
+
+  it('throws when certificate public key does not match key pair', () => {
+    const keyPair = generateKeyPair();
+    const keyPair2 = generateKeyPair();
+    const validityNotAfter = new Date();
+    validityNotAfter.setFullYear(validityNotAfter.getFullYear() + 1);
+    const certificate = generateSelfSignedCodeSigningCertificate({
+      keyPair,
+      validityNotAfter,
+      validityNotBefore: new Date(),
+      commonName: 'Test',
+    });
+    expect(() => validateSelfSignedCertificate(certificate, keyPair2)).toThrow(
+      'Certificate pubic key does not match key pair public key'
+    );
+  });
+
+  it('throws when private key does not match public key', () => {
+    const keyPair = generateKeyPair();
+    const keyPair2 = generateKeyPair();
+    const validityNotAfter = new Date();
+    validityNotAfter.setFullYear(validityNotAfter.getFullYear() + 1);
+    const certificate = generateSelfSignedCodeSigningCertificate({
+      keyPair,
+      validityNotAfter,
+      validityNotBefore: new Date(),
+      commonName: 'Test',
+    });
+    const keyPairManual = {
+      publicKey: keyPair.publicKey,
+      privateKey: keyPair2.privateKey,
+    };
+    expect(() => validateSelfSignedCertificate(certificate, keyPairManual)).toThrow(
+      'keyPair key mismatch'
+    );
+  });
+});
+
+describe(signStringRSASHA256AndVerify, () => {
+  const testPrivateKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAp1ILmaSl1pUVFgt/nLtzoaGuBW4OPRFN5uU2rYPow3uy4NfU
+LKiir4AWxGETcm4gFIOG3RIbDJys6TAJJLnFEFnzpV+qaNeqaMqnXm4OBspx/WS2
+rSSGIwr7raKy4yrpPYJB1A2D5fZ6oFoWROyjbHJvPddu0PqbbEWSM3PzdZYOKfF1
+3ofzFOPlsTnlo12QWgksxrcTwgeX7cjHsXaUc+I8U9DRR+9SgKhejWdFNPGcMkEc
+5BIXwtkTau+8+DwQzXz775Wlhf0eJwfnNQeleblbLQIp8i+RmfIjPSt8W/iTSN64
+iBROpOvnOeJ9gKX922QDZoqWz9o4RTNCPfyYBQIDAQABAoIBAEKMXVTEqbkJHpPg
+Cud5nuoAdkhul3cudL+LFw44UtG9V04aSadhgyMuXN/KhIOUzWmbTn6K/vsrLZKp
+qllTEdAJFuEFha+hZ4O6ZosmVqnYxzGzZvzCdB9n9OYAugmkPZRbRHdk0LscJ3Wz
+nvvW6sDtWtVL5CV2J28O1LFmQsTXPtEE5aQ5KX3Ix0OW1HBdEMOXRDFFDXhf7AKz
+nlvl3WRsXLyHYBfKs0pQHy8Gi+zl2OgKZDc9elMdU0Mx0jTJUUDtPSgNAsmdKO26
+qmkhbGd/kM1+6h+zngY3m48yD9elDxR3WUIYE2x5tT9fv3T6/xn1QfMz/gtToplx
+qY1DegECgYEA3bGUq91QMIH5rxrr2BBQpniXOTtOPAdvRcRh0/EsYhHcuL+uJEtG
+W9o9MqrREhXMMeD9Y8RorL+qefJjGq+GRwnPHlDjr6NkGTZfDKUn4IFH1xMbspET
+Nen5BsY5inUrQ/LSg1+HiVsSDyIJzGVcGMTOh9qC53M/zIGdiEwHgUECgYEAwTZ3
+AVieag5ETYahGdverxCRKlJ0MFJq3VKEdt6EcZHfeY1gmi17vGZ39q6djmfTT9Il
+QVP4/mxU2/mg/UgRC+rwiAZs3qlhOrtkrGd9qPOIeZ8PJkoNlvhM2WC2rGjTfXsb
+2IKtDEVXetwGgm3SXqpjycI5Xj6/9VlHAmCc4cUCgYAv9dT2AWDxvYyopyhSi+UG
+vpvok73vGqSl8UBAu7IgXUDk7wLbczV7dZE7vtyQDwsn10a6KKmEhcp5q0hpY4On
+JqYaJuG7A5wKIEsbzzb7SLyj+MxLKzt+tGldX9De9U4w2v1T0nzd6EfV4kVAZMUx
+zpHnrgwXykUJFxlffSM6gQKBgQCMxKXHsU0Zb/OLmD7fnDWNzsA02YYVfralMW2Z
+PV25cNIkuUBclC7GgNF+RJI+Ip7uVOkXw5pxo3PgIOuOHWduC2nbcPL49ucD52vd
+wDjpUyVnlt9uwh1MlPNInRH6YxVTItKS2AJEInEt7ghAFstidTnm0T8Czy0EEFuP
++9vREQKBgQDIQxJ5oPIOEibJqn34z6qm5EmUyme/evvHxtQTaVuQi5CrzD5+qw1C
+jOTHmlJQQsb8b1g9wk7n+JbqWYhkRiAE6dwqvp/zDz1VfR90WbAPYQ8ZiXZ07D2P
+8P6ZXR3ZyDchuT6oUBXz5WtHUWOzXRJgPbXnFhrkIU8PkZYiPs/4Bw==
+-----END RSA PRIVATE KEY-----
+`;
+
+  const testCertificate = `
+-----BEGIN CERTIFICATE-----
+MIICyzCCAbOgAwIBAgIJWVXVdVgS9u+DMA0GCSqGSIb3DQEBCwUAMA8xDTALBgNV
+BAMTBFRlc3QwHhcNMjIwMjA0MDEzODU2WhcNMjMwMjA0MDEzODU2WjAPMQ0wCwYD
+VQQDEwRUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp1ILmaSl
+1pUVFgt/nLtzoaGuBW4OPRFN5uU2rYPow3uy4NfULKiir4AWxGETcm4gFIOG3RIb
+DJys6TAJJLnFEFnzpV+qaNeqaMqnXm4OBspx/WS2rSSGIwr7raKy4yrpPYJB1A2D
+5fZ6oFoWROyjbHJvPddu0PqbbEWSM3PzdZYOKfF13ofzFOPlsTnlo12QWgksxrcT
+wgeX7cjHsXaUc+I8U9DRR+9SgKhejWdFNPGcMkEc5BIXwtkTau+8+DwQzXz775Wl
+hf0eJwfnNQeleblbLQIp8i+RmfIjPSt8W/iTSN64iBROpOvnOeJ9gKX922QDZoqW
+z9o4RTNCPfyYBQIDAQABoyowKDAOBgNVHQ8BAf8EBAMCB4AwFgYDVR0lAQH/BAww
+CgYIKwYBBQUHAwMwDQYJKoZIhvcNAQELBQADggEBAHTyG2f/CReXVrS3zZjpgnje
+Vn2/XYevnaHNWYIxjlUVGaASE/k6qWkM832f0gaZwJYXsll2YxJa5Jcdqa1yq8QA
+Ay5YBq8Vv6K6iGTeZ5wTQc3xNys7zcS95eNq7yhDDjbLDbSDdZ8T/1hZqiha2DG5
+itLGfBH+HywW2G9njLgIzNcmKx3d76y3jlVXqug1/AVFK9in+r/0t0TYlk+opqZb
+H7cjJSefHusnq2vvvR6gbkZzyzSYP5FMlj/RjRCSJ+VHNwCn3fS+KDlJgVOk0Cxc
+7n52UGazeFwH3mem89DN+Bhw/uyU0IcIaDLykb6PsTPy2tjHsLpK5kpvfrp2m0o=
+-----END CERTIFICATE-----
+`;
+
+  it('signs and verifies', () => {
+    const privateKey = convertPrivateKeyPEMToPrivateKey(testPrivateKey);
+    const certificate = convertCertificatePEMToCertificate(testCertificate);
+    const signature = signStringRSASHA256AndVerify(privateKey, certificate, 'hello');
+    expect(signature).toEqual(
+      'aPDeSpsFhQXJ1+7RjLW1kASwFoXFJSC4oehm24KaDQG4dHKEz7tVWhrVknGFTRSM54tv4sfXh2p7/6hs+XoMrdlwplpPTIo7PyWmRsE7Md36bkhTGDz/vUXD42uzcLXFNEzcV7TjjN63uF82ytrDUR7Hvc3rj16//oX5LdasiSyDeNKpiaOBZeANtPHgJ1opOVrTGcKJb62LRwTl+c5YyPUjd48wAUGS/PrB2ucbBchxWJ1KfL8kEjD41sCZCWWxbHRYiKPely4z8kaEoMwAGgPb6QUlPgg6XilAcHxT1xPlq/VafVnkxjih5czAfRlTn8bEAtLzwep77tLJs5hSZw=='
+    );
+  });
+});

--- a/packages/code-signing-certificates/src/__tests__/utils-test.ts
+++ b/packages/code-signing-certificates/src/__tests__/utils-test.ts
@@ -1,0 +1,13 @@
+import { toPositiveHex } from '../utils';
+
+describe(toPositiveHex, () => {
+  test.each([
+    ['646a60245faa852fe108ecbbd018dfc8', '646a60245faa852fe108ecbbd018dfc8'],
+    ['eb668fcee52ce9ebd5461a2e71be1269', '6b668fcee52ce9ebd5461a2e71be1269'], // "negative" hex string
+    ['6', '6'],
+    ['e', '6'], // "negative" hex string
+    ['9', '1'], // "negative" hex string
+  ])('case %p', (input, output) => {
+    expect(toPositiveHex(input)).toEqual(output);
+  });
+});

--- a/packages/code-signing-certificates/src/index.ts
+++ b/packages/code-signing-certificates/src/index.ts
@@ -1,0 +1,249 @@
+import assert from 'assert';
+import { md, pki as PKI, random, util } from 'node-forge';
+
+import { toPositiveHex } from './utils';
+
+/**
+ * Generate a public and private RSA key pair.
+ * @returns RSA key pair
+ */
+export function generateKeyPair(): PKI.rsa.KeyPair {
+  return PKI.rsa.generateKeyPair();
+}
+
+/**
+ * Convert a key RSA key pair generated using {@link generateKeyPair} to PEM strings.
+ * @param keyPair RSA key pair
+ * @returns PEM formatted key pair
+ */
+export function convertKeyPairToPEM(
+  keyPair: PKI.rsa.KeyPair
+): { privateKeyPEM: string; publicKeyPEM: string } {
+  return {
+    privateKeyPEM: PKI.privateKeyToPem(keyPair.privateKey),
+    publicKeyPEM: PKI.publicKeyToPem(keyPair.publicKey),
+  };
+}
+
+/**
+ * Convert a X.509 certificate generated using {@link generateSelfSignedCodeSigningCertificate} to a PEM string.
+ * @param certificate X.509 certificate
+ * @returns
+ */
+export function convertCertificateToCertificatePEM(certificate: PKI.Certificate): string {
+  return PKI.certificateToPem(certificate);
+}
+
+/**
+ * Convert a PEM-formatted RSA key pair to a key pair for use with this library.
+ * @param privateKeyPEM PEM formatted private key
+ * @param publicKeyPEM PEM formatted public key
+ * @returns RSA key pair
+ */
+export function convertKeyPairPEMToKeyPair({
+  privateKeyPEM,
+  publicKeyPEM,
+}: {
+  privateKeyPEM: string;
+  publicKeyPEM: string;
+}): PKI.rsa.KeyPair {
+  return {
+    privateKey: PKI.privateKeyFromPem(privateKeyPEM),
+    publicKey: PKI.publicKeyFromPem(publicKeyPEM),
+  };
+}
+
+/**
+ * Convert a PEM-formatted RSA public key to a public key for use with this library.
+ * @param publicKeyPEM PEM formatted public key
+ * @returns RSA public key
+ */
+export function convertPublicKeyPEMToPublicKey(publicKeyPEM: string): PKI.rsa.PublicKey {
+  return PKI.publicKeyFromPem(publicKeyPEM);
+}
+
+/**
+ * Convert a PEM-formatted RSA private key to a private key for use with this library.
+ * @param privateKeyPEM PEM formatted private key
+ * @returns RSA private key
+ */
+export function convertPrivateKeyPEMToPrivateKey(privateKeyPEM: string): PKI.rsa.PrivateKey {
+  return PKI.privateKeyFromPem(privateKeyPEM);
+}
+
+/**
+ * Convert a PEM-formatted X.509 certificate to a certificate for use with this library.
+ * @param certificatePEM PEM formatted X.509 certificate
+ * @returns  X.509 Certificate
+ */
+export function convertCertificatePEMToCertificate(certificatePEM: string): PKI.Certificate {
+  return PKI.certificateFromPem(certificatePEM);
+}
+
+type GenerateParameters = {
+  /**
+   * Public/private key pair generated via {@link generateKeyPair}.
+   */
+  keyPair: PKI.rsa.KeyPair;
+
+  /**
+   * Certificate validity range start.
+   */
+  validityNotBefore: Date;
+
+  /**
+   * Certificate validity range end.
+   */
+  validityNotAfter: Date;
+
+  /**
+   * CN issuer and subject Distinguished Name (DN).
+   * Used for both issuer and subject in the case of self-signed certificates.
+   */
+  commonName: string;
+};
+
+/**
+ * Generate a self-signed code-signing certificate for use with expo-updates.
+ * Note that while certificate chains may be supported at some point in expo-updates, for now
+ * only self-signed certificates are supported.
+ *
+ * @returns PKI.Certificate valid for expo-updates code signing
+ */
+export function generateSelfSignedCodeSigningCertificate({
+  keyPair: { publicKey, privateKey },
+  validityNotBefore,
+  validityNotAfter,
+  commonName,
+}: GenerateParameters): PKI.Certificate {
+  const cert = PKI.createCertificate();
+  cert.publicKey = publicKey;
+  cert.serialNumber = toPositiveHex(util.bytesToHex(random.getBytesSync(9)));
+
+  assert(
+    validityNotAfter > validityNotBefore,
+    'validityNotAfter must be later than validityNotBefore'
+  );
+  cert.validity.notBefore = validityNotBefore;
+  cert.validity.notAfter = validityNotAfter;
+
+  const attrs = [
+    {
+      name: 'commonName',
+      value: commonName,
+    },
+  ];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+
+  cert.setExtensions([
+    {
+      name: 'keyUsage',
+      critical: true,
+      keyCertSign: false,
+      digitalSignature: true,
+      nonRepudiation: false,
+      keyEncipherment: false,
+      dataEncipherment: false,
+    },
+    {
+      name: 'extKeyUsage',
+      critical: true,
+      serverAuth: false,
+      clientAuth: false,
+      codeSigning: true,
+      emailProtection: false,
+      timeStamping: false,
+    },
+  ]);
+
+  cert.sign(privateKey, md.sha256.create());
+  return cert;
+}
+
+function arePublicKeysEqual(key1: PKI.rsa.PublicKey, key2: PKI.rsa.PublicKey): boolean {
+  // typedef for BigInteger doesn't contain equals method
+  return (key1.n as any).equals(key2.n) && (key1.e as any).equals(key2.e);
+}
+
+function doPrivateAndPublicKeysMatch(
+  privateKey: PKI.rsa.PrivateKey,
+  publicKey: PKI.rsa.PublicKey
+): boolean {
+  // typedef for BigInteger doesn't contain equals method
+  return (publicKey.n as any).equals(privateKey.n) && (publicKey.e as any).equals(privateKey.e);
+}
+
+/**
+ * Validate that a certificate and corresponding key pair can be used for expo-updates code signing.
+ * @param certificate X.509 certificate
+ * @param keyPair RSA key pair
+ */
+export function validateSelfSignedCertificate(
+  certificate: PKI.Certificate,
+  keyPair: PKI.rsa.KeyPair
+) {
+  if (certificate.issuer.hash !== certificate.subject.hash) {
+    throw new Error(
+      'Certificate issuer hash does not match subject hash, indicating certificate is not self-signed.'
+    );
+  }
+
+  const now = new Date();
+  if (certificate.validity.notBefore > now || certificate.validity.notAfter < now) {
+    throw new Error('Certificate validity expired');
+  }
+
+  const keyUsage = certificate.getExtension('keyUsage');
+  const digitalSignature = (keyUsage as any).digitalSignature;
+  if (!keyUsage || !digitalSignature) {
+    throw new Error('X509v3 Key Usage: Digital Signature not present');
+  }
+
+  const extKeyUsage = certificate.getExtension('extKeyUsage');
+  const codeSigning = (extKeyUsage as any).codeSigning;
+  if (!extKeyUsage || !codeSigning) {
+    throw new Error('X509v3 Extended Key Usage: Code Signing not present');
+  }
+
+  const isValid = certificate.verify(certificate);
+  if (!isValid) {
+    throw new Error('Certificate signature not valid');
+  }
+
+  const certificatePublicKey = certificate.publicKey as PKI.rsa.PublicKey;
+  if (!arePublicKeysEqual(certificatePublicKey, keyPair.publicKey)) {
+    throw new Error('Certificate pubic key does not match key pair public key');
+  }
+
+  if (!doPrivateAndPublicKeysMatch(keyPair.privateKey, keyPair.publicKey)) {
+    throw new Error('keyPair key mismatch');
+  }
+}
+
+/**
+ * Sign a string with an RSA private key and verify that the signature is valid for the RSA
+ * public key in the certificate.
+ * @param privateKey RSA private key
+ * @param certificate X.509 certificate
+ * @param stringToSign string for which to generate a signature and verify
+ * @returns base64-encoded signature
+ */
+export function signStringRSASHA256AndVerify(
+  privateKey: PKI.rsa.PrivateKey,
+  certificate: PKI.Certificate,
+  stringToSign: string
+): string {
+  const digest = md.sha256.create().update(stringToSign);
+  const digestSignature = privateKey.sign(digest);
+  const isValidSignature = (certificate.publicKey as PKI.rsa.PublicKey).verify(
+    digest.digest().getBytes(),
+    digestSignature
+  );
+
+  if (!isValidSignature) {
+    throw new Error('Signature generated with private key not valid for certificate');
+  }
+
+  return util.encode64(digestSignature);
+}

--- a/packages/code-signing-certificates/src/utils.ts
+++ b/packages/code-signing-certificates/src/utils.ts
@@ -1,0 +1,12 @@
+// a hexString is considered negative if its most significant bit is 1
+// because serial numbers use ones' complement notation
+// this RFC in section 4.1.2.2 requires serial numbers to be positive
+// http://www.ietf.org/rfc/rfc5280.txt
+export function toPositiveHex(hexString: string) {
+  let mostSignificantHexAsInt = parseInt(hexString[0], 16);
+  if (mostSignificantHexAsInt < 8) {
+    return hexString;
+  }
+  mostSignificantHexAsInt -= 8;
+  return mostSignificantHexAsInt.toString(16) + hexString.substring(1);
+}

--- a/packages/code-signing-certificates/tsconfig.build.json
+++ b/packages/code-signing-certificates/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}

--- a/packages/code-signing-certificates/tsconfig.json
+++ b/packages/code-signing-certificates/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "importHelpers": true,
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "noImplicitReturns": true,
+    "strict": true,
+    "target": "ES2019",
+    "outDir": "build",
+    "rootDir": "src",
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../ts-declarations",
+      "./node_modules/@types"
+    ]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
# Why

https://github.com/expo/expo-cli/pull/4169/#issuecomment-1030708057

Originally in that PR it was proposed that these new commands for expo-updates would be part of expo-cli. After talking with @EvanBacon, it was decided that they should instead be in their own CLI within the `expo` repo inside the `expo-updates` package.

That left this library in a weird state, where it was needed by those commands and eas-cli (in future PR). But, we don't really want to make it a package in the expo repo since it doesn't have a native component (just node JS utility functions).

So, it was proposed that it be here in this repo or in its own repo. For release reasons, it seems easier to put it here in this repo.

# How

Copy code over from that PR into this repo.

# Test Plan

`yarn test`, `yarn build`