### PR TITLE
[eas-cli] import getRuntimeVersionNullabe from config-plugins

### DIFF
--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -21,18 +21,6 @@ import {
 } from './ios/UpdatesModule';
 import { maybeResolveVersionsAsync as maybeResolveIosVersionsAsync } from './ios/version';
 
-// TODO(JJ): Replace this with the getRuntimeVersionNullable function in @expo/config-plugins
-function getRuntimeVersionNullable(
-  ...[config, platform]: Parameters<typeof Updates.getRuntimeVersion>
-): string | null {
-  try {
-    return Updates.getRuntimeVersion(config, platform);
-  } catch (e) {
-    Log.debug(e);
-    return null;
-  }
-}
-
 export async function collectMetadataAsync<T extends Platform>(
   ctx: BuildContext<T>
 ): Promise<Metadata> {
@@ -48,7 +36,7 @@ export async function collectMetadataAsync<T extends Platform>(
     workflow: ctx.workflow,
     credentialsSource: ctx.buildProfile.credentialsSource,
     sdkVersion: ctx.exp.sdkVersion,
-    runtimeVersion: getRuntimeVersionNullable(ctx.exp, ctx.platform) ?? undefined,
+    runtimeVersion: Updates.getRuntimeVersionNullable(ctx.exp, ctx.platform) ?? undefined,
     reactNativeVersion: await getReactNativeVersionAsync(ctx),
     ...channelOrReleaseChannel,
     distribution,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Reduce code duplication by importing nullable function from config-plugins

for reference the code for the nullable function: https://github.com/expo/expo-cli/blob/main/packages/config-plugins/src/utils/Updates.ts#L86

