### PR TITLE
[eas-cli] allow cloud build without installing node_modules first

### DIFF
--- a/packages/eas-cli/src/project/expoSdk.ts
+++ b/packages/eas-cli/src/project/expoSdk.ts
@@ -6,6 +6,7 @@ import semver from 'semver';
 import { BuildContext } from '../build/context';
 import Log from '../log';
 import { confirmAsync } from '../prompts';
+import { getConfiguredExpoSdkVersion } from './projectUtils';
 
 const SUPPORTED_EXPO_SDK_VERSIONS = '>= 41.0.0';
 assert(semver.validRange(SUPPORTED_EXPO_SDK_VERSIONS), 'Must be a valid version range');
@@ -14,6 +15,10 @@ export async function checkExpoSdkIsSupportedAsync(ctx: BuildContext<Platform>):
   assert(ctx.workflow === Workflow.MANAGED, 'Must be a managed workflow project');
 
   if (ctx.exp.sdkVersion && semver.satisfies(ctx.exp.sdkVersion, SUPPORTED_EXPO_SDK_VERSIONS)) {
+    return;
+  } else if (
+    semver.subset(getConfiguredExpoSdkVersion(ctx.projectDir), SUPPORTED_EXPO_SDK_VERSIONS)
+  ) {
     return;
   }
 

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -211,6 +211,15 @@ export async function promptToCreateProjectIfNotExistsAsync(
   });
 }
 
+export function getConfiguredExpoSdkVersion(projectDir: string): string {
+  const packageJson = getPackageJson(projectDir);
+  if (packageJson.dependencies && packageJson.dependencies['expo']) {
+    return packageJson.dependencies['expo'];
+  }
+
+  return '0';
+}
+
 export function isExpoUpdatesInstalled(projectDir: string): boolean {
   const packageJson = getPackageJson(projectDir);
   return !!(packageJson.dependencies && 'expo-updates' in packageJson.dependencies);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Resolves https://github.com/expo/eas-cli/issues/935.

# How

I fixed the error described in the issue, but that turned out to be the tip of the iceberg for checks that fail when you try to kick off a build without installing packages first. Identified so far:

- [ ] expo-dev-client detection fails because it looks at node_modules/expo-dev-client/package.json presence only
- [ ] plugin detection fails

Leaving this draft open for now to see if there's more, and if it's worth supporting this in the first place. Otherwise, the PR can still be merged because it removes the incorrect error message. 

# Test Plan

TBD
