### PR TITLE
[eas-cli] check if package.json is inside git repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add error message when package.json is outside git repository. ([#971](https://github.com/expo/eas-cli/pull/971) by [@wkozyra95](https://github.com/wkozyra95))
+
 ## [0.47.0](https://github.com/expo/eas-cli/releases/tag/v0.47.0) - 2022-02-08
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -68,14 +68,15 @@ export async function findProjectRootAsync({
       return process.cwd();
     }
   } else {
+    let vcsRoot;
     try {
-      const vcsRoot = path.normalize(await getVcsClient().getRootPathAsync());
-      if (vcsRoot.startsWith(projectRootDir) && vcsRoot !== projectRootDir) {
-        throw new Error(
-          `package.json is outside of the current git repository (project root: ${projectRootDir}, git root: ${vcsRoot}.`
-        );
-      }
+      vcsRoot = path.normalize(await getVcsClient().getRootPathAsync());
     } catch {}
+    if (vcsRoot && vcsRoot.startsWith(projectRootDir) && vcsRoot !== projectRootDir) {
+      throw new Error(
+        `package.json is outside of the current git repository (project root: ${projectRootDir}, git root: ${vcsRoot}.`
+      );
+    }
     return projectRootDir;
   }
 }

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -11,6 +11,7 @@ import { confirmAsync } from '../prompts';
 import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import { expoCommandAsync } from '../utils/expoCli';
+import { getVcsClient } from '../vcs';
 import {
   ensureProjectExistsAsync,
   findProjectIdByAccountNameAndSlugNullableAsync,
@@ -67,6 +68,14 @@ export async function findProjectRootAsync({
       return process.cwd();
     }
   } else {
+    try {
+      const vcsRoot = path.normalize(await getVcsClient().getRootPathAsync());
+      if (vcsRoot.startsWith(projectRootDir) && vcsRoot !== projectRootDir) {
+        throw new Error(
+          `package.json is outside of the current git repository (project root: ${projectRootDir}, git root: ${vcsRoot}.`
+        );
+      }
+    } catch {}
     return projectRootDir;
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

if package.json is outside git repo, eas.json is also created there and `git add` is failing

Potentially root cause of https://github.com/expo/eas-cli/issues/967

# How

check projectDir is outside of vcs dir

# Test Plan

reproduced a case described in why section and tun local build
