### PR TITLE
[eas-cli] install expo-updates when running update:configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add code signing. ([#964](https://github.com/expo/eas-cli/pull/964) by [@wschurman](https://github.com/wschurman))
+- Install expo-updates when running update:configure. ([#977](https://github.com/expo/eas-cli/pull/977) by [@jkhales](https://github.com/jkhales))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -5,7 +5,12 @@ import chalk from 'chalk';
 import { getEASUpdateURL } from '../../api';
 import EasCommand from '../../commandUtils/EasCommand';
 import Log, { learnMore } from '../../log';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
+import {
+  findProjectRootAsync,
+  getProjectIdAsync,
+  installExpoUpdatesAsync,
+  isExpoUpdatesInstalledOrAvailable,
+} from '../../project/projectUtils';
 import { resolveWorkflowAsync } from '../../project/workflow';
 
 const DEFAULT_MANAGED_RUNTIME_VERSION = { policy: 'sdkVersion' } as const;
@@ -84,6 +89,10 @@ export default class UpdateConfigure extends EasCommand {
     const { exp } = getConfig(projectDir, {
       skipSDKVersionRequirement: true,
     });
+
+    if (!isExpoUpdatesInstalledOrAvailable(projectDir, exp.sdkVersion)) {
+      await installExpoUpdatesAsync(projectDir);
+    }
 
     const hasAndroidNativeProject =
       (await resolveWorkflowAsync(projectDir, Platform.ANDROID)) === Workflow.GENERIC;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Starting in SDK 44, expo-updates can no longer be assumed to be installed.
# How

check and install

# Test Plan

Tested in demo repo