### PR TITLE
[update] make runtime version warning more descriptive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Add error message when package.json is outside git repository. ([#971](https://github.com/expo/eas-cli/pull/971) by [@wkozyra95](https://github.com/wkozyra95))
+- Make runtime version policy warning on the update command more descriptive ([#979](https://github.com/expo/eas-cli/pull/979) by [@kbrandwijk](https://github.com/kbrandwijk))
 
 ## [0.47.0](https://github.com/expo/eas-cli/releases/tag/v0.47.0) - 2022-02-08
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -552,7 +552,7 @@ async function getRuntimeVersionObjectAsync(
     if (isPolicy) {
       const isManaged = (await resolveWorkflowAsync(projectDir, platform)) === Workflow.MANAGED;
       if (!isManaged) {
-        throw new Error('Runtime version policies are only supported in the managed workflow.');
+        throw new Error('Runtime version policies are only supported in the managed workflow. In the bare workflow, runtime version needs to be set manually.');
       }
     }
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Minimal runtime version warning on non-managed workflow is confusing end users.

# How

Updated wording.

# Test Plan

Run it in a bare workflow with a runtimeversion policy configured.
