### PR TITLE
[eas-cli] Fix code signing error on unconfigured eas project

### DIFF
--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -225,8 +225,6 @@ export default class UpdatePublish extends EasCommand {
       isPublicConfig: true,
     });
 
-    const codeSigningInfo = await getCodeSigningInfoAsync(exp, privateKeyPath);
-
     if (!isExpoUpdatesInstalledOrAvailable(projectDir, exp.sdkVersion)) {
       const install = await confirmAsync({
         message: `You are creating an update which requires ${chalk.bold(
@@ -429,6 +427,8 @@ export default class UpdatePublish extends EasCommand {
         .filter(pair => pair[1] === runtime)
         .map(pair => pair[0]);
     }
+
+    const codeSigningInfo = await getCodeSigningInfoAsync(exp, privateKeyPath);
 
     // Sort the updates into different groups based on their platform specific runtime versions
     const updateGroups: PublishUpdateGroupInput[] = Object.entries(runtimeToPlatformMapping).map(


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

regression was never published, so I'm not adding anything to changelog

# Why

If I run `eas update` on project that was not configured to use eas update I'm getting 
```
    Error: Must specify codeSigningMetadata under the "updates" field of your app config file to use EAS code signing
```

# How

move getCodeSigningInfoAsync

# Test Plan
steps starting form unconfigured project: 
`eas update` throws     `Error: There is neither a value or a policy set for the runtime version on "android"`
`eas update:configure`
`eas update` - works correctly`
