### PR TITLE
[eas-cli] Fix code signing error when not yet configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix code signing error when not yet configured. ([#1018](https://github.com/expo/eas-cli/pull/1018) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 ## [0.48.0](https://github.com/expo/eas-cli/releases/tag/v0.48.0) - 2022-03-14

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -225,6 +225,8 @@ export default class UpdatePublish extends EasCommand {
       isPublicConfig: true,
     });
 
+    const codeSigningInfo = await getCodeSigningInfoAsync(exp, privateKeyPath);
+
     if (!isExpoUpdatesInstalledOrAvailable(projectDir, exp.sdkVersion)) {
       const install = await confirmAsync({
         message: `You are creating an update which requires ${chalk.bold(
@@ -427,8 +429,6 @@ export default class UpdatePublish extends EasCommand {
         .filter(pair => pair[1] === runtime)
         .map(pair => pair[0]);
     }
-
-    const codeSigningInfo = await getCodeSigningInfoAsync(exp, privateKeyPath);
 
     // Sort the updates into different groups based on their platform specific runtime versions
     const updateGroups: PublishUpdateGroupInput[] = Object.entries(runtimeToPlatformMapping).map(

--- a/packages/eas-cli/src/utils/code-signing.ts
+++ b/packages/eas-cli/src/utils/code-signing.ts
@@ -28,12 +28,15 @@ export async function getCodeSigningInfoAsync(
   privateKeyPath: string | undefined
 ): Promise<CodeSigningInfo | undefined> {
   const codeSigningCertificatePath = config.updates?.codeSigningCertificate;
-  const codeSigningMetadata = config.updates?.codeSigningMetadata;
+  if (!codeSigningCertificatePath) {
+    return undefined;
+  }
 
-  if (codeSigningCertificatePath && !privateKeyPath) {
+  if (!privateKeyPath) {
     privateKeyPath = path.join(path.dirname(codeSigningCertificatePath), 'private-key.pem');
   }
 
+  const codeSigningMetadata = config.updates?.codeSigningMetadata;
   if (!codeSigningMetadata) {
     throw new Error(
       'Must specify codeSigningMetadata under the "updates" field of your app config file to use EAS code signing'


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

The logic here was incorrect as it was requiring code signing metadata even if there was not code signing certificate.

# How

Fix logic.

# Test Plan

We should really add some tests. Will work on that.