### PR TITLE
chore: add annotations about functions that do not support App Store Connect API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Add annotations regarding App Store Connect Token session support.
+- Add annotations regarding App Store Connect Token session support.  ([#1029](https://github.com/expo/eas-cli/pull/1029) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## [0.48.2](https://github.com/expo/eas-cli/releases/tag/v0.48.2) - 2022-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add annotations regarding App Store Connect Token session support.
+
 ## [0.48.2](https://github.com/expo/eas-cli/releases/tag/v0.48.2) - 2022-03-21
 
 ### 🎉 New features

--- a/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
@@ -32,7 +32,7 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
 
   // App Store Connect token authentication is not currently supported,
   // the team ID is required to create capability identifiers.
-  if (!bundleId.context.teamId) {
+  if (bundleId.context.token && !bundleId.context.teamId) {
     Log.warn(
       `Skipping capability identifier syncing because the current Apple authentication session is not using Cookies (username/password).`
     );

--- a/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
@@ -15,6 +15,8 @@ type UpdateCapabilityRequest = Parameters<BundleId['updateBundleIdCapabilityAsyn
  * If a capability identifier is missing, then attempt to create it.
  * Link all of the capability identifiers at the same time after parsing the entitlements file.
  *
+ * **Does not support App Store Connect API (CI).**
+ *
  * @param bundleId Bundle identifier object.
  * @param entitlements JSON representation of the iOS entitlements plist
  *
@@ -25,6 +27,15 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
   entitlements: JSONObject = {}
 ): Promise<{ created: string[]; linked: string[] }> {
   if (EXPO_NO_CAPABILITY_SYNC) {
+    return { created: [], linked: [] };
+  }
+
+  // App Store Connect token authentication is not currently supported,
+  // the team ID is required to create capability identifiers.
+  if (!bundleId.context.teamId) {
+    Log.warn(
+      `Skipping capability identifier syncing because the current Apple authentication session is not using Cookies (username/password).`
+    );
     return { created: [], linked: [] };
   }
 

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
@@ -70,6 +70,7 @@ async function addCertificateToProfileAsync(
 
   // Assign the new certificate
   profile.attributes.certificates = [cert];
+  // This method does not support App Store Connect API.
   return await profile.regenerateAsync();
 }
 

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -89,7 +89,11 @@ async function findProfileByBundleIdAsync(
     }
     const profile = expoProfiles.sort(sortByExpiration)[expoProfiles.length - 1];
     profile.attributes.certificates = [distributionCertificate];
-    return { profile: await profile.regenerateAsync(), didUpdate: true };
+    return {
+      // This method does not support App Store Connect API.
+      profile: await profile.regenerateAsync(),
+      didUpdate: true,
+    };
   }
 
   // there is no valid provisioning profile available
@@ -173,6 +177,8 @@ async function manageAdHocProfilesAsync(
     }
     // We need to add new devices to the list and create a new provisioning profile.
     existingProfile.attributes.devices = devices;
+
+    // This method does not support App Store Connect API.
     await existingProfile.regenerateAsync();
 
     const updatedProfile = (await findProfileByBundleIdAsync(context, bundleId, certSerialNumber))

--- a/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/pushKey.ts
@@ -15,6 +15,10 @@ Please revoke the old ones or reuse existing from your other apps.
 Please remember that Apple Keys are not application specific!
 `;
 
+/**
+ * List all existing push keys on Apple servers.
+ * **Does not support App Store Connect API (CI).**
+ */
 export async function listPushKeysAsync(authCtx: AuthCtx): Promise<PushKeyStoreInfo[]> {
   const spinner = ora(`Fetching Apple push keys`).start();
   try {
@@ -28,6 +32,10 @@ export async function listPushKeysAsync(authCtx: AuthCtx): Promise<PushKeyStoreI
   }
 }
 
+/**
+ * Create a new push key on Apple servers.
+ * **Does not support App Store Connect API (CI).**
+ */
 export async function createPushKeyAsync(
   authCtx: AuthCtx,
   name: string = `Expo Push Notifications Key ${dateformat('yyyymmddHHMMss')}`
@@ -57,6 +65,10 @@ export async function createPushKeyAsync(
   }
 }
 
+/**
+ * Revoke an existing push key on Apple servers.
+ * **Does not support App Store Connect API (CI).**
+ */
 export async function revokePushKeyAsync(authCtx: AuthCtx, ids: string[]): Promise<void> {
   const name = `Apple push key${ids?.length === 1 ? '' : 's'}`;
 


### PR DESCRIPTION


<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Add clarity regarding what methods must be skipped for App Store Connect Token support in `eas build` command.

# Test Plan

Tested that these functionalities do not work with Apple cookie authentication. 