### PR TITLE
[eas-cli] fix proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix proxy support. ([#1032](https://github.com/expo/eas-cli/pull/1032) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 - Add annotations regarding App Store Connect Token session support.  ([#1029](https://github.com/expo/eas-cli/pull/1029) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "0.0.0-alpha.28",
+    "@expo/apple-utils": "0.0.0-alpha.29",
     "@expo/code-signing-certificates": "0.0.2",
     "@expo/config": "6.0.19",
     "@expo/config-plugins": "4.1.0",

--- a/packages/eas-cli/src/fetch.ts
+++ b/packages/eas-cli/src/fetch.ts
@@ -10,18 +10,21 @@ export class RequestError extends Error {
   }
 }
 
-function createHttpAgent(): Agent | null {
-  const httpProxyUrl = process.env.http_proxy;
-  if (!httpProxyUrl) {
+function createHttpsAgent(): Agent | null {
+  const httpsProxyUrl = process.env.https_proxy;
+  if (!httpsProxyUrl) {
     return null;
   }
-  return createHttpsProxyAgent(httpProxyUrl);
+  return createHttpsProxyAgent(httpsProxyUrl);
 }
 
-export const httpProxyAgent: Agent | null = createHttpAgent();
+export const httpsProxyAgent: Agent | null = createHttpsAgent();
 
 export default async function (url: RequestInfo, init?: RequestInit): Promise<Response> {
-  const response = await fetch(url, init);
+  const response = await fetch(url, {
+    ...init,
+    ...(httpsProxyAgent ? { agent: httpsProxyAgent } : {}),
+  });
   if (response.status >= 400) {
     throw new RequestError(`Request failed: ${response.status} (${response.statusText})`, response);
   }

--- a/packages/eas-cli/src/graphql/client.ts
+++ b/packages/eas-cli/src/graphql/client.ts
@@ -15,7 +15,7 @@ import { DocumentNode } from 'graphql';
 import fetch from 'node-fetch';
 
 import { getExpoApiBaseUrl } from '../api';
-import { httpProxyAgent } from '../fetch';
+import { httpsProxyAgent } from '../fetch';
 import Log from '../log';
 import { getAccessToken, getSessionSecret } from '../user/sessionStorage';
 
@@ -49,7 +49,7 @@ export const graphqlClient = createUrqlClient({
       headers['expo-session'] = sessionSecret;
     }
     return {
-      ...(httpProxyAgent ? { agent: httpProxyAgent } : {}),
+      ...(httpsProxyAgent ? { agent: httpsProxyAgent } : {}),
       headers,
     };
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1178,10 +1178,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@expo/apple-utils@0.0.0-alpha.28":
-  version "0.0.0-alpha.28"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.28.tgz#fd8045f25ae9000471ce000093080ccd319cfb59"
-  integrity sha512-0BgHkNlzF21MQccCoAZ9h331Xej2TKjs7UZkzktUlvdpAjnpj5LC58TMXTKuPrpGzPzrzESbUzXHkt4hB60NSg==
+"@expo/apple-utils@0.0.0-alpha.29":
+  version "0.0.0-alpha.29"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.29.tgz#d7cbfc69b85a2188f028de8c357f6fe51bcaf968"
+  integrity sha512-6CDkd9ai10HUjkVpEoh3TwADiSNcNsGNQpm3+BiUYP7h8Ufn3aR8q2QcS4vwrHGi3dWMwhrIjQLIhYLHGUacBg==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fix proxy support

# How

- pass agent to fetch wrapper (currently it was only used by ggraphql)
- use `https_proxy` instead of `http_proxy`
- update @expo/apple-utils


# Test Plan

run build with and without proxy