### PR TITLE
[eas-cli] make deprecation message more generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Add annotations regarding App Store Connect Token session support.  ([#1029](https://github.com/expo/eas-cli/pull/1029) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade dependencies. ([#1043](https://github.com/expo/eas-cli/pull/1043) by [@dsokal](https://github.com/dsokal))
+- Make default deprecation message more generic. ([#1047](https://github.com/expo/eas-cli/pull/1047) by [@wkozyra95](https://github.com/wkozyra95))
 
 ## [0.48.2](https://github.com/expo/eas-cli/releases/tag/v0.48.2) - 2022-03-21
 

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -103,10 +103,7 @@ export function printDeprecationWarnings(deprecationInfo?: EasBuildDeprecationIn
     Log.warn("Changes won't affect your project config.");
     Log.warn(deprecationInfo.message);
   } else if (deprecationInfo.type === EasBuildDeprecationInfoType.UserFacing) {
-    Log.warn('This command is using API that soon will be deprecated, please update eas-cli.');
-    Log.warn(
-      'There might be some changes necessary to your project config, latest eas-cli will provide more specific error messages.'
-    );
+    Log.warn('This command is using API that soon will be deprecated.');
     Log.warn(deprecationInfo.message);
   } else {
     Log.warn('An unexpected warning was encountered. Please report it as a bug:');


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Sometimes we are deprecating stuff that is server-side so the message to update cli is misleading, especially if changes are marked as user-facing

# How

remove part of the message, from now on the messages from turtle-api should be more descriptive

# Test Plan

