### PR TITLE
autoclose stale issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          ascending: false
+          operations-per-run: 300
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity. If there is no activity in the next 7 days, the issue will be closed."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale. Please open a new issue if you believe you are encountering a related problem."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          enable-statistics: true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -20,3 +20,4 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           enable-statistics: true
+          exempt-issue-labels: 'needs review'


### PR DESCRIPTION
# Why

Close stale issues automatically (issue becomes stale after 30 days of inactivity and it's close after 7)
Run job once a day

# Test plan

Not tested(copied from expo/expo), workflow will not show up unless before it's merged to main