### PR TITLE
[eas-cli] require userAuthCtx for methods that don't support jwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Prompt for user/password authentication where required. ([#1055](https://github.com/expo/eas-cli/pull/1055) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🧹 Chores
 
 ## [0.49.0](https://github.com/expo/eas-cli/releases/tag/v0.49.0) - 2022-04-05

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -101,7 +101,7 @@ export class CredentialsContext {
     }
 
     if (this.appStore.defaultAuthenticationMode === AuthenticationMode.API_KEY) {
-      await this.appStore.ensureAuthenticatedAsync({ mode: AuthenticationMode.API_KEY });
+      await this.appStore.ensureAuthenticatedAsync();
       return;
     }
 

--- a/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
@@ -69,7 +69,8 @@ export default class AppStoreApi {
 
   public async ensureAuthenticatedAsync(options?: AuthenticateOptions): Promise<AuthCtx> {
     if (!this.authCtx) {
-      this.authCtx = await authenticateAsync(options);
+      const mode = options?.mode ?? this.defaultAuthenticationMode;
+      this.authCtx = await authenticateAsync({ mode, ...options });
     }
     return this.authCtx;
   }
@@ -173,22 +174,22 @@ export default class AppStoreApi {
   }
 
   public async listAscApiKeysAsync(): Promise<AscApiKeyInfo[]> {
-    const ctx = await this.ensureAuthenticatedAsync();
-    return await listAscApiKeysAsync(ctx);
+    const userCtx = await this.ensureUserAuthenticatedAsync();
+    return await listAscApiKeysAsync(userCtx);
   }
 
   public async getAscApiKeyAsync(keyId: string): Promise<AscApiKeyInfo | null> {
-    const ctx = await this.ensureAuthenticatedAsync();
-    return await getAscApiKeyAsync(ctx, keyId);
+    const userCtx = await this.ensureUserAuthenticatedAsync();
+    return await getAscApiKeyAsync(userCtx, keyId);
   }
 
   public async createAscApiKeyAsync({ nickname }: { nickname: string }): Promise<AscApiKey> {
-    const ctx = await this.ensureAuthenticatedAsync();
-    return await createAscApiKeyAsync(ctx, { nickname });
+    const userCtx = await this.ensureUserAuthenticatedAsync();
+    return await createAscApiKeyAsync(userCtx, { nickname });
   }
 
   public async revokeAscApiKeyAsync(keyId: string): Promise<AscApiKeyInfo> {
-    const ctx = await this.ensureAuthenticatedAsync();
-    return await revokeAscApiKeyAsync(ctx, keyId);
+    const userCtx = await this.ensureUserAuthenticatedAsync();
+    return await revokeAscApiKeyAsync(userCtx, keyId);
   }
 }

--- a/packages/eas-cli/src/credentials/ios/appstore/ascApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ascApiKey.ts
@@ -4,31 +4,39 @@ import Log from '../../../log';
 import { ora } from '../../../ora';
 import { AscApiKey, AscApiKeyInfo } from './Credentials.types';
 import { getRequestContext } from './authenticate';
-import { AuthCtx } from './authenticateTypes';
+import { AuthCtx, UserAuthCtx } from './authenticateTypes';
 
-export async function listAscApiKeysAsync(authCtx: AuthCtx): Promise<AscApiKeyInfo[]> {
+/**
+ * List App Store Connect API Keys.
+ * **Does not support App Store Connect API (CI).**
+ */
+export async function listAscApiKeysAsync(userAuthCtx: UserAuthCtx): Promise<AscApiKeyInfo[]> {
   const spinner = ora(`Fetching App Store Connect API Keys.`).start();
   try {
-    const context = getRequestContext(authCtx);
+    const context = getRequestContext(userAuthCtx);
     const keys = await ApiKey.getAsync(context);
     spinner.succeed(`Fetched App Store Connect API Keys.`);
-    return keys.map(key => getAscApiKeyInfo(key, authCtx));
+    return keys.map(key => getAscApiKeyInfo(key, userAuthCtx));
   } catch (error) {
     spinner.fail(`Failed to fetch App Store Connect API Keys.`);
     throw error;
   }
 }
 
+/**
+ * Get an App Store Connect API Key.
+ * **Does not support App Store Connect API (CI).**
+ */
 export async function getAscApiKeyAsync(
-  authCtx: AuthCtx,
+  userAuthCtx: UserAuthCtx,
   keyId: string
 ): Promise<AscApiKeyInfo | null> {
   const spinner = ora(`Fetching App Store Connect API Key.`).start();
   try {
-    const context = getRequestContext(authCtx);
+    const context = getRequestContext(userAuthCtx);
     const apiKey = await ApiKey.infoAsync(context, { id: keyId });
     spinner.succeed(`Fetched App Store Connect API Key (ID: ${keyId}).`);
-    return getAscApiKeyInfo(apiKey, authCtx);
+    return getAscApiKeyInfo(apiKey, userAuthCtx);
   } catch (error: any) {
     const message = error?.message ?? '';
     if (message.includes("There is no resource of type 'apiKeys' with id")) {
@@ -41,8 +49,12 @@ export async function getAscApiKeyAsync(
   }
 }
 
+/**
+ * Create an App Store Connect API Key.
+ * **Does not support App Store Connect API (CI).**
+ */
 export async function createAscApiKeyAsync(
-  authCtx: AuthCtx,
+  userAuthCtx: UserAuthCtx,
   {
     nickname,
     allAppsVisible,
@@ -52,7 +64,7 @@ export async function createAscApiKeyAsync(
 ): Promise<AscApiKey> {
   const spinner = ora(`Creating App Store Connect API Key.`).start();
   try {
-    const context = getRequestContext(authCtx);
+    const context = getRequestContext(userAuthCtx);
     const key = await ApiKey.createAsync(context, {
       nickname: nickname ?? `[expo] ${new Date().getTime()}`,
       allAppsVisible: allAppsVisible ?? true,
@@ -77,7 +89,7 @@ export async function createAscApiKeyAsync(
     const fullKey = await ApiKey.infoAsync(context, { id: key.id });
     spinner.succeed(`Created App Store Connect API Key.`);
     return {
-      ...getAscApiKeyInfo(fullKey, authCtx),
+      ...getAscApiKeyInfo(fullKey, userAuthCtx),
       keyP8,
     };
   } catch (err: any) {
@@ -86,17 +98,21 @@ export async function createAscApiKeyAsync(
   }
 }
 
+/**
+ * Revoke an App Store Connect API Key.
+ * **Does not support App Store Connect API (CI).**
+ */
 export async function revokeAscApiKeyAsync(
-  authCtx: AuthCtx,
+  userAuthCtx: UserAuthCtx,
   keyId: string
 ): Promise<AscApiKeyInfo> {
   const spinner = ora(`Revoking App Store Connect API Key.`).start();
   try {
-    const context = getRequestContext(authCtx);
+    const context = getRequestContext(userAuthCtx);
     const apiKey = await ApiKey.infoAsync(context, { id: keyId });
     const revokedKey = await apiKey.revokeAsync();
     spinner.succeed(`Revoked App Store Connect API Key.`);
-    return getAscApiKeyInfo(revokedKey, authCtx);
+    return getAscApiKeyInfo(revokedKey, userAuthCtx);
   } catch (error) {
     Log.error(error);
     spinner.fail(`Failed to revoke App Store Connect API Key.`);

--- a/packages/eas-cli/src/credentials/ios/appstore/contractMessages.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/contractMessages.ts
@@ -5,6 +5,9 @@ import Log from '../../../log';
 import type { Ora } from '../../../ora';
 import { convertHTMLToASCII } from '../utils/convertHTMLToASCII';
 
+/**
+ * **Does not support App Store Connect API (CI).**
+ */
 async function getContractStatusAsync(
   context: RequestContext
 ): Promise<ITCAgreements.ITCContractStatus | null> {
@@ -17,6 +20,9 @@ async function getContractStatusAsync(
   }
 }
 
+/**
+ * **Does not support App Store Connect API (CI).**
+ */
 async function getContractMessagesAsync(
   context: RequestContext
 ): Promise<ITCAgreements.ITCContractMessage[] | null> {
@@ -28,6 +34,9 @@ async function getContractMessagesAsync(
   }
 }
 
+/**
+ * **Does not support App Store Connect API (CI).**
+ */
 async function getRequiredContractMessagesAsync(
   context: RequestContext
 ): Promise<{ messages: ITCAgreements.ITCContractMessage[]; isFatal: boolean }> {
@@ -77,6 +86,9 @@ export function formatContractMessage(message: ITCAgreements.ITCContractMessage)
   });
 }
 
+/**
+ * **Does not support App Store Connect API (CI).**
+ */
 export async function assertContractMessagesAsync(
   context: RequestContext,
   spinner?: Ora

--- a/packages/eas-cli/src/submit/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submit/ios/AppProduce.ts
@@ -1,4 +1,4 @@
-import { App, BundleId, RequestContext, Session, User } from '@expo/apple-utils';
+import { App, RequestContext, Session, User } from '@expo/apple-utils';
 import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
 

--- a/packages/eas-cli/src/submit/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submit/ios/AppProduce.ts
@@ -1,8 +1,8 @@
-import { App, RequestContext, Session, User } from '@expo/apple-utils';
+import { App, BundleId, RequestContext, Session, User } from '@expo/apple-utils';
 import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
-import { getRequestContext, isUserAuthCtx } from '../../credentials/ios/appstore/authenticate';
+import { getRequestContext } from '../../credentials/ios/appstore/authenticate';
 import {
   ensureAppExistsAsync,
   ensureBundleIdExistsWithNameAsync,
@@ -66,31 +66,29 @@ async function createAppStoreConnectAppAsync(
     sku,
   } = options;
 
-  const authCtx = await ctx.credentialsCtx.appStore.ensureAuthenticatedAsync({
+  const userAuthCtx = await ctx.credentialsCtx.appStore.ensureUserAuthenticatedAsync({
     appleId,
     teamId: appleTeamId,
   });
-  const requestCtx = getRequestContext(authCtx);
+  const requestCtx = getRequestContext(userAuthCtx);
 
   Log.addNewLineIfNone();
 
   if (await isProvisioningAvailableAsync(requestCtx)) {
-    await ensureBundleIdExistsWithNameAsync(authCtx, {
+    await ensureBundleIdExistsWithNameAsync(userAuthCtx, {
       name: appName,
       bundleIdentifier: bundleId,
     });
   } else {
-    const entity = isUserAuthCtx(authCtx)
-      ? `Apple User: ${authCtx.appleId}`
-      : `API Key ID ${authCtx.ascApiKey.keyId} for Apple Team ${authCtx.team.id}`;
-
-    Log.warn(`Provisioning is not available for ${entity}, skipping bundle identifier check.`);
+    Log.warn(
+      `Provisioning is not available for Apple User: ${userAuthCtx.appleId}, skipping bundle identifier check.`
+    );
   }
 
   let app: App | null = null;
 
   try {
-    app = await ensureAppExistsAsync(authCtx, {
+    app = await ensureAppExistsAsync(userAuthCtx, {
       name: appName,
       language,
       companyName,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Require user/password authentication for methods that don't support api key authentication (jwt). Followup to https://github.com/expo/eas-cli/pull/1051#discussion_r844938222 . Also fixed a couple auth bugs - we weren't using api key authentication where we should've been.

# More Unsupported Methods
## Create App
- App.createAsync: tested manually, received error. Seems like only cookies are supported, see https://github.com/expo/third-party/blob/main/packages/app-store/src/connect/models/App.ts#L146

## ITunes Contract messages
These all fail with this class of error: `Failed to get iTunes contract status: Invalid client request. Missing providerId in request context`
- getContractStatusAsync: tested manually
- getContractMessagesAsync: tested manually

## ASC Api Key operations
All received this class of error: `UnexpectedAppleResponse: The URL path is not valid - The resource 'apiKeys' does not exist`
- revokeAscApiKeyAsync: tested manually
- createAscApiKeyAsync: tested manually
- getAscApiKeyAsync: tested manually
- listAscApiKeyAsync: tested manually

# Test Plan

- [x] `eas submit` works, prompts for user authentication if wrong type is given
- [x] `eas build` for ios works, only prompts for user authentication for push key operations
- [x] `eas credentials` for ios works, prompts for user authentication where neccessary
