### PR TITLE
[eas-cli] Require private-key-path to be specified for updating when code signing configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Prompt for user/password authentication where required. ([#1055](https://github.com/expo/eas-cli/pull/1055) by [@quinlanj](https://github.com/quinlanj))
+- Require private-key-path to be specified for updating when code signing configured. ([#1059](https://github.com/expo/eas-cli/pull/1059) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -225,7 +225,12 @@ export default class UpdatePublish extends EasCommand {
       isPublicConfig: true,
     });
 
-    const codeSigningInfo = await getCodeSigningInfoAsync(exp, privateKeyPath);
+    const { exp: expPrivate } = getConfig(projectDir, {
+      skipSDKVersionRequirement: true,
+      isPublicConfig: false,
+    });
+
+    const codeSigningInfo = await getCodeSigningInfoAsync(expPrivate, privateKeyPath);
 
     if (!isExpoUpdatesInstalledOrAvailable(projectDir, exp.sdkVersion)) {
       const install = await confirmAsync({

--- a/packages/eas-cli/src/utils/__tests__/code-signing-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/code-signing-test.ts
@@ -36,7 +36,7 @@ describe(getCodeSigningInfoAsync, () => {
           slug: 'test',
           updates: {
             codeSigningCertificate: 'wat',
-          } as any,
+          },
         },
         'test'
       )

--- a/packages/eas-cli/src/utils/code-signing.ts
+++ b/packages/eas-cli/src/utils/code-signing.ts
@@ -13,7 +13,6 @@ import isDeepEqual from 'fast-deep-equal';
 import { promises as fs } from 'fs';
 import { pki as PKI } from 'node-forge';
 import nullthrows from 'nullthrows';
-import path from 'path';
 
 import { Response } from '../fetch';
 import { PartialManifest, PartialManifestAsset } from '../graphql/generated';
@@ -34,7 +33,7 @@ export async function getCodeSigningInfoAsync(
   }
 
   if (!privateKeyPath) {
-    privateKeyPath = path.join(path.dirname(codeSigningCertificatePath), 'private-key.pem');
+    throw new Error('Must specify --private-key-path argument to sign update for code signing');
   }
 
   const codeSigningMetadata = config.updates?.codeSigningMetadata;
@@ -51,18 +50,16 @@ export async function getCodeSigningInfoAsync(
     );
   }
 
-  return codeSigningCertificatePath && privateKeyPath
-    ? {
-        ...(await getKeyAndCertificateFromPathsAsync({
-          codeSigningCertificatePath,
-          privateKeyPath,
-        })),
-        codeSigningMetadata: {
-          alg,
-          keyid,
-        },
-      }
-    : undefined;
+  return {
+    ...(await getKeyAndCertificateFromPathsAsync({
+      codeSigningCertificatePath,
+      privateKeyPath,
+    })),
+    codeSigningMetadata: {
+      alg,
+      keyid,
+    },
+  };
 }
 
 async function readFileAsync(path: string, errorMessage: string): Promise<string> {


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Corresponding PR for https://github.com/expo/expo/pull/16979. Now that private code signing keys are encouraged to be kept offline or encrypted in a separate directory from the certificate, this argument needs to be required when code signing is configured to know how to locate the private key to use to sign the manifest.

# How

Make argument required when code signing is configured.

# Test Plan

Run tests.

```
DEBUG=true ~/expo/eas-cli/packages/eas-cli/bin/run update --branch preview --message "Updating the app 3"
    Error: Must specify --private-key-path argument to sign update for code
    signing
```