### PR TITLE
[ENG-4615] unify google service account prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Unify Google Service Account key prompts. ([#1063](https://github.com/expo/eas-cli/pull/1063) by [@dsokal](https://github.com/dsokal))
+
 ## [0.50.0](https://github.com/expo/eas-cli/releases/tag/v0.50.0) - 2022-04-11
 
 ### 🎉 New features

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/CreateGoogleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/CreateGoogleServiceAccountKey-test.ts
@@ -9,7 +9,7 @@ import { CreateGoogleServiceAccountKey } from '../CreateGoogleServiceAccountKey'
 jest.mock('../../../../prompts');
 jest.mock('fs');
 asMock(promptAsync).mockImplementation(() => ({
-  keyJsonPath: '/google-service-account-key.json',
+  filePath: '/google-service-account-key.json',
 }));
 
 beforeEach(() => {

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetUpGoogleServiceAccountKey-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetUpGoogleServiceAccountKey-test.ts
@@ -15,7 +15,7 @@ import { SetUpGoogleServiceAccountKey } from '../SetUpGoogleServiceAccountKey';
 jest.mock('../../../../prompts');
 jest.mock('fs');
 asMock(promptAsync).mockImplementation(() => ({
-  keyJsonPath: '/google-service-account-key.json',
+  filePath: '/google-service-account-key.json',
 }));
 
 beforeEach(() => {

--- a/packages/eas-cli/src/submit/android/ServiceAccountSource.ts
+++ b/packages/eas-cli/src/submit/android/ServiceAccountSource.ts
@@ -169,7 +169,8 @@ async function askForServiceAccountPathAsync(): Promise<string> {
       'A Google Service Account JSON key is required to upload your app to Google Play Store'
     )}.\n` +
       `If you're not sure what this is or how to create one, ${learnMore(
-        'https://expo.fyi/creating-google-service-account'
+        'https://expo.fyi/creating-google-service-account',
+        { learnMoreMessage: 'learn more' }
       )}`
   );
   const { filePath } = await promptAsync({


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
<img width="914" alt="Screenshot 2022-04-13 at 14 59 23" src="https://user-images.githubusercontent.com/5256730/163194692-65ab7097-72d0-4e08-98a7-4ec287f9c521.png">

# Why

I had to create a Google Service Account key for my new app. I noticed we're missing the URL to the FYI page on how to create the key.

# How

It turns out that we have a similar prompt in two places but it doesn't look the same. 
It'd be best to refactor the code so the function is reused but I didn't want to spend too much time on it.
Instead, I copy-pasted the better implementation.

This can be refactored in a follow-up PR.

# Test Plan
<img width="915" alt="Screenshot 2022-04-13 at 15 01 58" src="https://user-images.githubusercontent.com/5256730/163194705-23cc8673-ab3c-4d6e-84b3-9549aa81e88c.png">


