### PR TITLE
[eas-cli] Add non-interactive flag to eas update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add non-interactive flag to eas update command. ([#1066](https://github.com/expo/eas-cli/pull/1066) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -275,7 +275,7 @@ export default class UpdatePublish extends EasCommand {
 
     if (!branchName) {
       if (nonInteractive) {
-        throw new Error('Must supply --branch when in non-interactive mode');
+        throw new Error('Must supply --branch or use --auto when in non-interactive mode');
       }
 
       const validationMessage = 'Branch name may not be empty.';
@@ -418,7 +418,7 @@ export default class UpdatePublish extends EasCommand {
 
       if (!message) {
         if (nonInteractive) {
-          throw new Error('Must supply --message when in non-interactive mode');
+          throw new Error('Must supply --message or use --auto when in non-interactive mode');
         }
 
         const validationMessage = 'publish message may not be empty.';


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Currently, we might ask a question about if you want to install expo-updates when running EAS CLI, which can break CI. When CI breaks, there's no indication of what we tried to get input for. Just an error.

We need to throw the log before we throw the error, or we need to add a default choice with a --non-interactive flag.

This PR adds the non-interactive flag to be in alignment with the other commands.

Closes ENG-4590.

# How

Used https://github.com/expo/eas-cli/pull/600/ as inspiration. Added flag, test manually (there's no tests for this command).

# Test Plan

```
~/expo/eas-cli/packages/eas-cli/bin/run update --non-interactive
✔ Linked to project @wschurman/eas-update-test
    Error: Must supply --branch when in non-interactive mode

~/expo/eas-cli/packages/eas-cli/bin/run update --non-interactive --branch preview
✔ Linked to project @wschurman/eas-update-test
    Error: Must supply --message when in non-interactive mode

~/expo/eas-cli/packages/eas-cli/bin/run update --non-interactive --branch preview --message "wat"
✔ Linked to project @wschurman/eas-update-test
✔ Built bundle!
✔ Uploaded assets!
✔ Published!

branch           preview
runtime version  exposdk:44.0.0
platform         android, ios
update group ID  cf31f7dd-2c25-4c9d-bcc7-352b7e811bc4
message          wat
```