### PR TITLE
submit - add custom error message for expired apple certs problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Handle new EAS Submit common error - expired Apple's certificates. ([#1068](https://github.com/expo/eas-cli/pull/1068) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -226,7 +226,7 @@ type MaybeBuildFragment = BuildFragment | null;
 export async function waitForBuildEndAsync(
   { buildIds, accountName }: { buildIds: string[]; accountName: string },
   {
-    // 2 hours (max build time limit) + 10 minutes (possible queue time )
+    // 2 hours (max build time limit) + 10 minutes (possible queue time)
     timeoutSec = 2 * 60 * 60 + 10 * 60,
     intervalSec = 10,
   } = {}

--- a/packages/eas-cli/src/submit/utils/errors.ts
+++ b/packages/eas-cli/src/submit/utils/errors.ts
@@ -17,6 +17,7 @@ enum SubmissionErrorCode {
   IOS_INCORRECT_CREDENTIALS = 'SUBMISSION_SERVICE_IOS_INVALID_CREDENTIALS',
   IOS_IPAD_INVALID_ORIENTATION = 'SUBMISSION_SERVICE_IOS_IPAD_INVALID_ORIENTATION',
   IOS_APPLE_MAINTENANCE = 'SUBMISSION_SERVICE_IOS_APPLE_MAINTENANCE',
+  IOS_INVALID_PROVISIONING_PROFILE_SIGNATURE = 'SUBMISSION_SERVICE_IOS_INVALID_PROVISIONING_PROFILE_SIGNATURE',
 }
 
 const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
@@ -65,6 +66,10 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
     `${learnMore('https://expo.fyi/ipad-requires-fullscreen')}`,
   [SubmissionErrorCode.IOS_APPLE_MAINTENANCE]:
     'It looks like Apple servers are undergoing an unscheduled maintenance. Please try again later.',
+  [SubmissionErrorCode.IOS_INVALID_PROVISIONING_PROFILE_SIGNATURE]:
+    'Invalid Provisioning Profile Signature (ITMS-90165)\n' +
+    "Some of the Apple's certificates have expired.\n" +
+    'Please regenerate your Distribution Certificate and Provisioning Profile. Then rebuild the app, and try submitting it to App Store again.',
 };
 
 export function printSubmissionError(error: SubmissionError): boolean {

--- a/packages/eas-cli/src/submit/utils/errors.ts
+++ b/packages/eas-cli/src/submit/utils/errors.ts
@@ -68,8 +68,8 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
     'It looks like Apple servers are undergoing an unscheduled maintenance. Please try again later.',
   [SubmissionErrorCode.IOS_INVALID_PROVISIONING_PROFILE_SIGNATURE]:
     'Invalid Provisioning Profile Signature (ITMS-90165)\n' +
-    "Some of the Apple's certificates have expired.\n" +
-    'Please regenerate your Distribution Certificate and Provisioning Profile. Then rebuild the app, and try submitting it to App Store again.',
+    "Some of Apple's certificates have expired.\n" +
+    'Please delete your Provisioning Profile from your account. Then rebuild the app interactively to generate a new one, and try submitting it to the App Store again.',
 };
 
 export function printSubmissionError(error: SubmissionError): boolean {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Companion to https://github.com/expo/turtle-v2/pull/922/files
Some of Apple's certificates have expired. This results in app rejections.

# How

Handle the new error code.

# Test Plan

None