### PR TITLE
[eas-cli] Enable update bundle output when debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Enable full bundling logging for eas update when debugging. ([#1070](https://github.com/expo/eas-cli/pull/1070) by [@byCedric](https://github.com/byCedric))
+
 ### 🧹 Chores
 
 - Upgrade `@expo/apple-utils@0.0.0-alpha.31` (now with license). ([#1064](https://github.com/expo/eas-cli/pull/1064) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -10,6 +10,7 @@ import { AssetMetadataStatus, PartialManifestAsset } from '../graphql/generated'
 import { PublishMutation } from '../graphql/mutations/PublishMutation';
 import { PresignedPost } from '../graphql/mutations/UploadSessionMutation';
 import { PublishQuery } from '../graphql/queries/PublishQuery';
+import Log from '../log';
 import { uploadWithPresignedPostAsync } from '../uploads';
 import { expoCommandAsync } from '../utils/expoCli';
 import uniqBy from '../utils/expodash/uniqBy';
@@ -159,7 +160,7 @@ export async function buildBundlesAsync({
   await expoCommandAsync(
     projectDir,
     ['export', '--output-dir', inputDir, '--experimental-bundle'],
-    { silent: true }
+    { silent: !Log.isDebug }
   );
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

In rare cases, the bundling could fail with heap out of memory errors in Github Actions. Without these logs, it's super hard to find this cause.

# How

Removed the harcoded `silent: true` and replaced it with `silent: !Log.isDebug`.

# Test Plan

- Linux/MacOS: `$ EXPO_DEBUG=true; eas update`
- Windows: `$ npx cross-env 'EXPO_DEBUG=true' eas update`