### PR TITLE
@kbrandwijk/releasechannel warning

### DIFF
--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -20,6 +20,7 @@ import {
   waitToCompleteAsync as waitForSubmissionsToCompleteAsync,
 } from '../submit/submit';
 import { printSubmissionDetailsUrls } from '../submit/utils/urls';
+import { checkBuildProfileConfigMatchesProjectConfigAsync } from '../update/utils';
 import { printJsonOnlyOutput } from '../utils/json';
 import { ProfileData, getProfilesAsync } from '../utils/profiles';
 import { getVcsClient } from '../vcs';
@@ -77,6 +78,12 @@ export async function runBuildAndSubmitAsync(projectDir: string, flags: BuildFla
     buildProfile: ProfileData<'build'>;
   }[] = [];
   const buildCtxByPlatform: { [p in AppPlatform]?: BuildContext<Platform> } = {};
+
+  // Check only first buildprofile (there should be only one unique one)
+  // Warn only once
+  if (buildProfiles.length > 0) {
+    await checkBuildProfileConfigMatchesProjectConfigAsync(projectDir, buildProfiles[0]);
+  }
 
   for (const buildProfile of buildProfiles) {
     const { build: maybeBuild, buildCtx } = await prepareAndStartBuildAsync({


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

One of the most common issues with EAS Update is that users still have `releaseChannel` in their `eas.json` instead of `channel`. This PR tries to make the user aware of this in three cases.

# How

- When running `eas update:configure`, the CLI will now automatically migrate the `releaseChannel` property to `channel` for all build profiles.
![WindowsTerminal_Htvk4S2GoY](https://user-images.githubusercontent.com/852069/164998757-f2f71c62-8ab9-428c-9fc5-635c2c520374.png)

- When running `eas update`, the CLI will warn if any build profiles are still using the `releaseChannel` property.
![WindowsTerminal_PtGzDdTStW](https://user-images.githubusercontent.com/852069/164998759-8e7e6f6e-14df-4141-9ba9-51c217764ab2.png)

- When running `eas build`, the CLI will warn only if _both_ the project is configured to use EAS Update _and_ the selected build profile has the `releaseChannel` property. 
![WindowsTerminal_5BssOWaPfb](https://user-images.githubusercontent.com/852069/164998761-3c229a3a-e783-4f81-b8ff-20d1ffea7a17.png)

In that last case, I'm on the fence if the CLI should show and error and abort instead of just warn for interactive builds.

# Test Plan

Tested the various use cases manually. There's not many test cases at the points where the changes were made, I can improve on that in a separate PR.