### PR TITLE
[ENG-4968] better spinner placement for multiple builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Update dependencies. ([#1095](https://github.com/expo/eas-cli/pull/1095) by [@dsokal](https://github.com/dsokal))
+- Better spinner placement for multiple builds. ([#1105](https://github.com/expo/eas-cli/pull/1105) by [@dsokal](https://github.com/dsokal))
 
 ## [0.52.0](https://github.com/expo/eas-cli/releases/tag/v0.52.0) - 2022-04-26
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-4968/verify-and-probably-fix-eas-cli-p-all-status-update-behavior

# How

In case when running `eas build -p all`, place the spinner next to "Waiting for builds to complete".

# Test Plan

Single build

<img width="841" alt="Screenshot 2022-05-16 at 15 06 39" src="https://user-images.githubusercontent.com/5256730/168599582-b7b7849e-b099-4af7-bdee-09a7f6770a2e.png">


Multiple builds
<img width="1123" alt="Screenshot 2022-05-16 at 15 07 18" src="https://user-images.githubusercontent.com/5256730/168599593-d1818343-a9c8-4e53-bbd2-5e6922a1b6e6.png">

