### PR TITLE
[eas-cli] Swallow error when unable to track file in no commit workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Do not include sources in `eas-json` npm package. ([#1248](https://github.com/expo/eas-cli/pull/1248) by [@wkozyra95](https://github.com/wkozyra95))
+- Swallow error when unable to track file in no commit workflow. ([#1109](https://github.com/expo/eas-cli/pull/1109) by [@brentvatne](https://github.com/brentvatne))
 
 ## [0.57.0](https://github.com/expo/eas-cli/releases/tag/v0.57.0) - 2022-08-03
 

--- a/packages/eas-cli/src/vcs/clients/gitNoCommit.ts
+++ b/packages/eas-cli/src/vcs/clients/gitNoCommit.ts
@@ -1,6 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
 import path from 'path';
 
+import Log from '../../log';
 import { Ignore, makeShallowCopyAsync } from '../local';
 import GitClient from './git';
 
@@ -32,6 +34,11 @@ export default class GitNoCommitClient extends GitClient {
     } catch {
       // In the no commit workflow it doesn't matter if we fail to track changes,
       // so we can ignore if this throws an exception
+      Log.warn(
+        `Unable to track ${chalk.bold(path.basename(file))} in Git. Proceeding without tracking.`
+      );
+      Log.warn(`  Reason: the command ${chalk.bold(`"git add ${file}"`)} exited with an error.`);
+      Log.newLine();
     }
   }
 }

--- a/packages/eas-cli/src/vcs/clients/gitNoCommit.ts
+++ b/packages/eas-cli/src/vcs/clients/gitNoCommit.ts
@@ -25,4 +25,13 @@ export default class GitNoCommitClient extends GitClient {
     await ignore.initIgnoreAsync();
     return ignore.ignores(filePath);
   }
+
+  public async trackFileAsync(file: string): Promise<void> {
+    try {
+      await super.trackFileAsync(file);
+    } catch {
+      // In the no commit workflow it doesn't matter if we fail to track changes,
+      // so we can ignore if this throws an exception
+    }
+  }
 }


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

A developer encountered an exception when running a build in Git no commit workflow:

```
All credentials are ready to build @x/y (com.x.y.staging)

✔ Push Notifications setup for x: com.x.y.staging
Error: git exited with non-zero code: 1
    at ChildProcess.completionListener (/usr/local/lib/node_modules/eas-cli/node_modules/@expo/spawn-async/build/spawnAsync.js:43:23)
    at Object.onceWrapper (node:events:642:26)
    at ChildProcess.emit (node:events:527:28)
    at maybeClose (node:internal/child_process:1092:16)
    at Socket.<anonymous> (node:internal/child_process:451:11)
    at Socket.emit (node:events:527:28)
    at Pipe.<anonymous> (node:net:709:12)
    ...
    at spawnAsync (/usr/local/lib/node_modules/eas-cli/node_modules/@expo/spawn-async/build/spawnAsync.js:8:21)
    at GitNoCommitClient.trackFileAsync (/usr/local/lib/node_modules/eas-cli/build/vcs/clients/git.js:121:41)
    at writeExpoPlistAsync (/usr/local/lib/node_modules/eas-cli/build/update/ios/UpdatesModule.js:27:37)
    at async syncUpdatesConfigurationAsync (/usr/local/lib/node_modules/eas-cli/build/update/ios/UpdatesModule.js:16:5)
    at async syncProjectConfigurationAsync 
```

It shouldn't matter in this context whether this command succeeds or not, so one solution here is to swallow there error, and that's what this PR does.

# How

Wrap `trackFileAsync` in no commit client with try/catch.

# Test Plan

I'm not actually sure how to reproduce a repo state where this might happen
