### PR TITLE
fix: match capability types more accurately

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "0.0.0-alpha.31",
+    "@expo/apple-utils": "0.0.0-alpha.33",
     "@expo/code-signing-certificates": "0.0.2",
     "@expo/config": "6.0.23",
     "@expo/config-plugins": "4.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,10 +1159,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@expo/apple-utils@0.0.0-alpha.31":
-  version "0.0.0-alpha.31"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.31.tgz#ab18640c384ba4b088e4490977a12f6f41a1e2a0"
-  integrity sha512-lGJOS8eAPcZhaRl5GZFIg4ZNSRY1k10wYeYXjHUbHxbZGE9lkzrATY8OvrVpcu8qQh3lvPguel63V4mrnoAuOA==
+"@expo/apple-utils@0.0.0-alpha.33":
+  version "0.0.0-alpha.33"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.33.tgz#ca3bd7c5b50c200161d27e173e6ac3389ac9ee98"
+  integrity sha512-4tG9Vou0ruvZgBFhMzTVtRPk5IH/hUU6fdpXcdRYPsULGI2QvB15CV6C+ee8utd4lmw/FIX8W9jLB8RehBBsJw==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION

<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

- Fix bug here https://forums.expo.dev/t/eas-build-failed-on-ios-associated-domains-capability/61662/5

# How

- To support both App Store Connect (`FEAT`) and cookies authentication (`BUNDLEID_FEAT`) we were matching capability types with `endsWith`. This caused and issue where projects with `MDM_MANAGED_ASSOCIATED_DOMAINS` enabled and `ASSOCIATED_DOMAINS` in use locally would be corrupted because `MDM_MANAGED_ASSOCIATED_DOMAINS` would match `ASSOCIATED_DOMAINS` and `ASSOCIATED_DOMAINS` would not be enabled remotely. We now have a more complex regex https://github.com/expo/third-party/pull/81 which has a higher accuracy rate.


# Test Plan

- Added tests here and in https://github.com/expo/third-party/pull/81