### PR TITLE
fix: log binding was incorrect after ora instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Rebind `console.info` correctly after `ora` instance stops. ([#1113](https://github.com/expo/eas-cli/pull/1113) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🧹 Chores
 
 - Update dependencies. ([#1095](https://github.com/expo/eas-cli/pull/1095) by [@dsokal](https://github.com/dsokal))

--- a/packages/eas-cli/src/ora.ts
+++ b/packages/eas-cli/src/ora.ts
@@ -56,7 +56,7 @@ export function ora(options?: Options | string): Ora {
     // eslint-disable-next-line no-console
     console.log = logReal;
     // eslint-disable-next-line no-console
-    console.info = logReal;
+    console.info = infoReal;
     // eslint-disable-next-line no-console
     console.warn = warnReal;
     // eslint-disable-next-line no-console


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

- simple bug, `console.info` was being bound to `console.log` after an ora spinner stopped.
