### PR TITLE
use single version of @oclif/core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Update dependencies. ([#1095](https://github.com/expo/eas-cli/pull/1095) by [@dsokal](https://github.com/dsokal))
+- Update dependencies. ([#1095](https://github.com/expo/eas-cli/pull/1095), [#1115](https://github.com/expo/eas-cli/pull/1115) by [@dsokal](https://github.com/dsokal))
 - Better spinner placement for multiple builds. ([#1105](https://github.com/expo/eas-cli/pull/1105) by [@dsokal](https://github.com/dsokal))
 - Use getExpoConfig to access config. ([#1122](https://github.com/expo/eas-cli/pull/1122) by [@wkozyra95](https://github.com/wkozyra95))
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -21,7 +21,7 @@
     "@expo/plist": "0.0.18",
     "@expo/plugin-autocomplete": "1.4.0",
     "@expo/plugin-help": "5.2.0",
-    "@expo/plugin-warn-if-update-available": "2.1.0",
+    "@expo/plugin-warn-if-update-available": "2.3.0",
     "@expo/prebuild-config": "3.1.6",
     "@expo/results": "1.0.0",
     "@expo/rudder-sdk-node": "1.1.1",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -25,7 +25,7 @@
     "@expo/rudder-sdk-node": "1.1.1",
     "@expo/spawn-async": "1.6.0",
     "@expo/timeago.js": "1.0.0",
-    "@oclif/core": "1.8.0",
+    "@oclif/core": "1.9.0",
     "@oclif/plugin-autocomplete": "1.3.0",
     "@oclif/plugin-help": "5.1.12",
     "@urql/core": "2.4.4",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -19,6 +19,8 @@
     "@expo/multipart-body-parser": "1.1.0",
     "@expo/pkcs12": "0.0.8",
     "@expo/plist": "0.0.18",
+    "@expo/plugin-autocomplete": "1.4.0",
+    "@expo/plugin-help": "5.2.0",
     "@expo/plugin-warn-if-update-available": "2.1.0",
     "@expo/prebuild-config": "3.1.6",
     "@expo/results": "1.0.0",
@@ -26,8 +28,6 @@
     "@expo/spawn-async": "1.6.0",
     "@expo/timeago.js": "1.0.0",
     "@oclif/core": "1.9.0",
-    "@oclif/plugin-autocomplete": "1.3.0",
-    "@oclif/plugin-help": "5.1.12",
     "@urql/core": "2.4.4",
     "@urql/exchange-retry": "0.3.3",
     "chalk": "4.1.2",
@@ -122,8 +122,8 @@
     "bin": "eas",
     "commands": "./build/commands",
     "plugins": [
-      "@oclif/plugin-autocomplete",
-      "@oclif/plugin-help",
+      "@expo/plugin-autocomplete",
+      "@expo/plugin-help",
       "@expo/plugin-warn-if-update-available"
     ],
     "topics": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,10 +3081,10 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@1.8.0", "@oclif/core@^1.7.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.8.0.tgz#ac1e63aebf8ddaf157d3664911d4a0eb2f013b6f"
-  integrity sha512-XAaqkacs4JiCOKWAX43jhuWcs7IdVMQaYWkeRiD8wan/wlmd7/WlvTFzpNeLOwylbty7uwiPQOFVYHdKj6UPvQ==
+"@oclif/core@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.9.0.tgz#bb2a7820a9176f28921f449c0f577d39c15e74d0"
+  integrity sha512-duvlaRQf4JM+mKuwwos1DNa/Q9x6tnF3khV5RU0fy5hhETF7THlTmxioKlIvKMyQDVpySqtZXZ0OKHeCi2EWuQ==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
     "@oclif/screen" "^3.0.2"
@@ -3103,11 +3103,10 @@
     indent-string "^4.0.0"
     is-wsl "^2.2.0"
     js-yaml "^3.14.1"
-    lodash "^4.17.21"
     natural-orderby "^2.0.3"
     object-treeify "^1.1.33"
     password-prompt "^1.1.2"
-    semver "^7.3.5"
+    semver "^7.3.7"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
     supports-color "^8.1.1"
@@ -3223,6 +3222,41 @@
     clean-stack "^3.0.1"
     cli-progress "^3.10.0"
     debug "^4.3.3"
+    ejs "^3.1.6"
+    fs-extra "^9.1.0"
+    get-package-type "^0.1.0"
+    globby "^11.1.0"
+    hyperlinker "^1.0.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.14.1"
+    lodash "^4.17.21"
+    natural-orderby "^2.0.3"
+    object-treeify "^1.1.33"
+    password-prompt "^1.1.2"
+    semver "^7.3.5"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    supports-color "^8.1.1"
+    supports-hyperlinks "^2.2.0"
+    tslib "^2.3.1"
+    widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
+
+"@oclif/core@^1.7.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.8.0.tgz#ac1e63aebf8ddaf157d3664911d4a0eb2f013b6f"
+  integrity sha512-XAaqkacs4JiCOKWAX43jhuWcs7IdVMQaYWkeRiD8wan/wlmd7/WlvTFzpNeLOwylbty7uwiPQOFVYHdKj6UPvQ==
+  dependencies:
+    "@oclif/linewrap" "^1.0.0"
+    "@oclif/screen" "^3.0.2"
+    ansi-escapes "^4.3.2"
+    ansi-styles "^4.3.0"
+    cardinal "^2.1.1"
+    chalk "^4.1.2"
+    clean-stack "^3.0.1"
+    cli-progress "^3.10.0"
+    debug "^4.3.4"
     ejs "^3.1.6"
     fs-extra "^9.1.0"
     get-package-type "^0.1.0"
@@ -11162,7 +11196,7 @@ semver@7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
-semver@7.3.7:
+semver@7.3.7, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,6 +1355,23 @@
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
 
+"@expo/plugin-autocomplete@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@expo/plugin-autocomplete/-/plugin-autocomplete-1.4.0.tgz#c5e18638c9bb2c494c57d358b888f900f23072bb"
+  integrity sha512-HK+lq5kWXvP2NOg/mME9ZlbCWRzwvslIZmVvYHnoRmIGvPUXku7eoOtlSEpmOk77wM+wu/IoFRAY8kBYeAZEbQ==
+  dependencies:
+    "@oclif/core" "^1.9.0"
+    chalk "^4.1.0"
+    debug "^4.3.4"
+    fs-extra "^10.1.0"
+
+"@expo/plugin-help@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@expo/plugin-help/-/plugin-help-5.2.0.tgz#c73dab76c7e95f82efc0ed8055c6ad1c291f82a2"
+  integrity sha512-YOI+D93hqAQHxOhlbGXXeQZX8FwWE338vk22GQNmVdVEBafrBHqvCWm0uEQKorf1mNwl8p0hcb/9NrGov5p5Lw==
+  dependencies:
+    "@oclif/core" "^1.9.0"
+
 "@expo/plugin-warn-if-update-available@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@expo/plugin-warn-if-update-available/-/plugin-warn-if-update-available-2.1.0.tgz#a075ca71c5fc5cb2dc3316e6c6cefabd9f8ff8cf"
@@ -3081,7 +3098,7 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@1.9.0":
+"@oclif/core@1.9.0", "@oclif/core@^1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.9.0.tgz#bb2a7820a9176f28921f449c0f577d39c15e74d0"
   integrity sha512-duvlaRQf4JM+mKuwwos1DNa/Q9x6tnF3khV5RU0fy5hhETF7THlTmxioKlIvKMyQDVpySqtZXZ0OKHeCi2EWuQ==
@@ -3243,57 +3260,12 @@
     widest-line "^3.1.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^1.7.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.8.0.tgz#ac1e63aebf8ddaf157d3664911d4a0eb2f013b6f"
-  integrity sha512-XAaqkacs4JiCOKWAX43jhuWcs7IdVMQaYWkeRiD8wan/wlmd7/WlvTFzpNeLOwylbty7uwiPQOFVYHdKj6UPvQ==
-  dependencies:
-    "@oclif/linewrap" "^1.0.0"
-    "@oclif/screen" "^3.0.2"
-    ansi-escapes "^4.3.2"
-    ansi-styles "^4.3.0"
-    cardinal "^2.1.1"
-    chalk "^4.1.2"
-    clean-stack "^3.0.1"
-    cli-progress "^3.10.0"
-    debug "^4.3.4"
-    ejs "^3.1.6"
-    fs-extra "^9.1.0"
-    get-package-type "^0.1.0"
-    globby "^11.1.0"
-    hyperlinker "^1.0.0"
-    indent-string "^4.0.0"
-    is-wsl "^2.2.0"
-    js-yaml "^3.14.1"
-    lodash "^4.17.21"
-    natural-orderby "^2.0.3"
-    object-treeify "^1.1.33"
-    password-prompt "^1.1.2"
-    semver "^7.3.5"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-    supports-color "^8.1.1"
-    supports-hyperlinks "^2.2.0"
-    tslib "^2.3.1"
-    widest-line "^3.1.0"
-    wrap-ansi "^7.0.0"
-
 "@oclif/linewrap@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
-"@oclif/plugin-autocomplete@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-autocomplete/-/plugin-autocomplete-1.3.0.tgz#ee03fe517e015cfe9e7ab4636a029a23515ceac4"
-  integrity sha512-N2DRWKvuSXTGuaYf4buRbRfh5yNybb1cjQmPl9viY0BIqTwZgtQdzSD6ZSOkwda51RbGcQomYcc/h8T+ZFAkMQ==
-  dependencies:
-    "@oclif/core" "^1.7.0"
-    chalk "^4.1.0"
-    debug "^4.3.4"
-    fs-extra "^9.0.1"
-
-"@oclif/plugin-help@5.1.12", "@oclif/plugin-help@^5.1.12":
+"@oclif/plugin-help@^5.1.12":
   version "5.1.12"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-5.1.12.tgz#24a18631eb9b22cb55e1a3b8e4f6039fd42727e6"
   integrity sha512-HvH/RubJxqCinP0vUWQLTOboT+SfjfL8h40s+PymkWaldIcXlpoRaJX50vz+SjZIs7uewZwEk8fzLqpF/BWXlg==
@@ -6628,7 +6600,7 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@10.1.0:
+fs-extra@10.1.0, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,18 +1372,19 @@
   dependencies:
     "@oclif/core" "^1.9.0"
 
-"@expo/plugin-warn-if-update-available@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@expo/plugin-warn-if-update-available/-/plugin-warn-if-update-available-2.1.0.tgz#a075ca71c5fc5cb2dc3316e6c6cefabd9f8ff8cf"
-  integrity sha512-9P0cLu/GP2SkbQfl7JPgtva3hUuxLvu9rDMaOIPwI99khrypj6eWjaXo2qcofewnPok2Nb+PDviZVFE9UItEMA==
+"@expo/plugin-warn-if-update-available@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@expo/plugin-warn-if-update-available/-/plugin-warn-if-update-available-2.3.0.tgz#1e48287aaa503c852f917b8f83d982e5717c097f"
+  integrity sha512-GBHwvWNt23aOrpFW2kw2RBkInnWKPa3j4h5gp09cxjYawcI3jl2FKyOEokxCiFhE+9QnIFTEm0fWJDceGmBe0w==
   dependencies:
-    "@oclif/core" "^1.3.0"
+    "@oclif/core" "^1.9.0"
     chalk "^4.1.0"
-    debug "^4.1.0"
-    ejs "^3.1.6"
-    fs-extra "^9.0.1"
+    debug "^4.3.4"
+    ejs "^3.1.7"
+    fs-extra "^10.1.0"
     http-call "^5.2.2"
-    semver "^7.3.2"
+    semver "^7.3.7"
+    tslib "^2.4.0"
 
 "@expo/prebuild-config@3.1.6":
   version "3.1.6"
@@ -3155,7 +3156,7 @@
     widest-line "^3.1.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^1.2.1", "@oclif/core@^1.3.0":
+"@oclif/core@^1.2.1":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.3.0.tgz#f0547d2ca9b13c2a54f1c1d88e03a8c8ca7799bb"
   integrity sha512-YSy1N3SpOn/8vmY8lllmTzQ4+KGjTlyFoNr/PxvebuYxo0iO0uQSpXIr8qDoNGQUTy+3Z5feUxoV04uUgAlI6Q==
@@ -4255,6 +4256,11 @@ async@0.9.x:
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
+async@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -4722,7 +4728,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@4.1.2, chalk@^4.1.1, chalk@^4.1.2:
+chalk@4.1.2, chalk@^4.0.2, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -5764,6 +5770,13 @@ ejs@^3.1.6:
   integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==
   dependencies:
     jake "^10.6.1"
+
+ejs@^3.1.7:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
+  integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
+  dependencies:
+    jake "^10.8.5"
 
 electron-to-chromium@^1.4.118:
   version "1.4.137"
@@ -7979,6 +7992,16 @@ jake@^10.6.1:
   dependencies:
     async "0.9.x"
     chalk "^2.4.2"
+    filelist "^1.0.1"
+    minimatch "^3.0.4"
+
+jake@^10.8.5:
+  version "10.8.5"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
+  integrity sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==
+  dependencies:
+    async "^3.2.3"
+    chalk "^4.0.2"
     filelist "^1.0.1"
     minimatch "^3.0.4"
 
@@ -12125,7 +12148,7 @@ tsconfig-paths@^3.12.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@2.4.0, tslib@~2.4.0:
+tslib@2.4.0, tslib@^2.4.0, tslib@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This PR makes EAS CLI a single version of `@oclif/core`.

# How

- `@oclif/plugin-*` libs don't seem to be actively maintained. I decided to fork all of them we're using and upgraded `@oclif/core` to the same version. In the future, I'll make `@oclif/core` a peer dependency of those libs so we don't have to touch them again.
- I upgraded `@oclif/core` to 1.9.0 here.

# Test Plan

Smoke test by running `easd build`.