### PR TITLE
[eas-cli] lower page limit for UpdateQueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Match bundle identifier capabilities more accurately. ([#1112](https://github.com/expo/eas-cli/pull/1112) by [@EvanBacon](https://github.com/EvanBacon))
+- No longer timeout on publishing updates for branches with many updates. ([#1119](https://github.com/expo/eas-cli/pull/1119)) by [@kgc00](https://github.com/kgc00/)
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -8,7 +8,7 @@ import {
   ViewBranchUpdatesQueryVariables,
 } from '../generated';
 
-const PAGE_LIMIT = 500;
+const PAGE_LIMIT = 300;
 
 export const UpdateQuery = {
   async viewAllAsync({ appId }: { appId: string }): Promise<ViewAllUpdatesQuery> {

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -8,7 +8,7 @@ import {
   ViewBranchUpdatesQueryVariables,
 } from '../generated';
 
-const PAGE_LIMIT = 10_000;
+const PAGE_LIMIT = 500;
 
 export const UpdateQuery = {
   async viewAllAsync({ appId }: { appId: string }): Promise<ViewAllUpdatesQuery> {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

A user has [reported](https://forums.expo.dev/t/eas-update-gateway-timeout/63783) that requests to publish updates started to time out a few weeks ago. 

# How

I inspected the screenshot they provided and saw that they time out after the update has been linked to the project. I then inspected the code in that commands execution path after an update gets linked for any web requests. I found `UpdateQuery.viewBranchAsync` on `.../commands/update/index.ts` ln ~132 and realized that this query times out consistently when i run it for their particular branch. the fix:
 
* lower page limit from 10_000 to 300 in UpdateQuery.ts

# Test Plan

I noticed that the `app.byId.updateBranch*.updates` query started to time out after the branch contained > ~600 updates. I ran queries against production using the website and an API client for a branch that contained ~2k updates:

```
query branchDetail($fullName: String!, $name: String!, $limit: Int!) {
  app {
    byFullName(fullName: $fullName) {
      updateBranchByName(name: $name) {
        updates(offset: 0, limit: $limit) {
          id
          group
          message
          createdAt
          runtimeVersion
          platform
        }
      }
    }
  }
}
```

I started small and increased the limit until the requests started to time out.