### PR TITLE
[eas-cli] Export ora as default from mock

### DIFF
--- a/packages/eas-cli/src/__mocks__/ora.ts
+++ b/packages/eas-cli/src/__mocks__/ora.ts
@@ -7,3 +7,6 @@ export const ora = jest.fn().mockReturnValue({
   stopAndPersist: jest.fn(),
   succeed: jest.fn(),
 });
+
+// Ora is imported as default import
+export default ora;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

This is a mock-fix only, so I don't think it should be listed in the changelogs. It's just an internal thing.

# Why

We import `ora` as default import in **[src/ora.ts](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/ora.ts#L2)**. Whenever we test anything that includes Ora code, it would fail with this error ([source](https://github.com/expo/eas-cli/runs/6655213156?check_suite_focus=true#step:6:197)):

```
TypeError: (0 , ora_1.default) is not a function
  24 |   const inputOptions = typeof options === 'string' ? { text: options } : options ?? {};
  25 |   const disabled = Log.isDebug || !process.stdin.isTTY;
> 26 |   const spinner = oraReal({
     |                          ^
  27 |     // Ensure our non-interactive mode emulates CI mode.
  28 |     isEnabled: !disabled,
  29 |     // In non-interactive mode, send the stream to stdout so it prevents looking like an error.
```

# How

Export the ora stub as default from the mock.

# Test Plan

Add this export as default, and try to test code using ora (e.g. see PR #1116)
