### PR TITLE
[ENG-5022] print learn more link before uploading archive to S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Display project archive docs before compressing/uploading to EAS Build. ([#1127](https://github.com/expo/eas-cli/pull/1127) by [@dsokal](https://github.com/dsokal))
+
 ## [0.53.0](https://github.com/expo/eas-cli/releases/tag/v0.53.0) - 2022-05-30
 
 ### 🛠 Breaking changes

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -157,6 +157,12 @@ async function uploadProjectAsync<TPlatform extends Platform>(
   try {
     return await withAnalyticsAsync(
       async () => {
+        Log.newLine();
+        Log.log(
+          `Compressing project files and uploading to EAS Build. ${learnMore(
+            'https://expo.fyi/eas-build-archive'
+          )}`
+        );
         const projectTarball = await makeProjectTarballAsync();
         projectTarballPath = projectTarball.path;
 
@@ -169,10 +175,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
               `Uploading to EAS Build (${formatBytes(projectTarball.size * ratio)} / ${formatBytes(
                 projectTarball.size
               )})`,
-            completedMessage: (duration: string) =>
-              `Uploaded to EAS ${chalk.dim(duration)} ${learnMore(
-                'https://expo.fyi/eas-build-archive'
-              )}`,
+            completedMessage: (duration: string) => `Uploaded to EAS ${chalk.dim(duration)}`,
           })
         );
         return bucketKey;


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

See https://linear.app/expo/issue/ENG-5022/add-learn-more-link-during-the-archive-uploading-process

# How

Print learn more link above the spinner(s).

# Test Plan

When "Compressing project files" spinner is displayed (when takes longer than 1 second):
<img width="738" alt="Screenshot 2022-05-30 at 16 50 50" src="https://user-images.githubusercontent.com/5256730/171017170-b5877240-6d14-4c00-9df6-829d7abe6d86.png">

Without "Compressing project files":
<img width="716" alt="Screenshot 2022-05-30 at 16 44 46" src="https://user-images.githubusercontent.com/5256730/171017176-293e7652-e5b2-46c5-a7b7-898315505cf3.png">
