### PR TITLE
[eas-cli] Add metadata store config serializers

### DIFF
--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/ageRatingDeclaration.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/ageRatingDeclaration.ts
@@ -1,0 +1,23 @@
+import { AgeRatingDeclaration, KidsAge } from '@expo/apple-utils';
+
+import { AttributesOf } from '../../../../utils/asc';
+
+export const kidsSixToEightAdvisory: AttributesOf<AgeRatingDeclaration> = {
+  alcoholTobaccoOrDrugUseOrReferences: null,
+  gamblingSimulated: null,
+  gambling: null,
+  contests: null,
+  medicalOrTreatmentInformation: null,
+  profanityOrCrudeHumor: null,
+  sexualContentGraphicAndNudity: null,
+  sexualContentOrNudity: null,
+  horrorOrFearThemes: null,
+  matureOrSuggestiveThemes: null,
+  violenceCartoonOrFantasy: null,
+  violenceRealisticProlongedGraphicOrSadistic: null,
+  violenceRealistic: null,
+  unrestrictedWebAccess: false,
+  seventeenPlus: false,
+  kidsAgeBand: KidsAge.SIX_TO_EIGHT,
+  gamblingAndContests: false,
+};

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appInfo.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appInfo.ts
@@ -1,0 +1,23 @@
+import { AppCategory, AppInfo, BundleIdPlatform } from '@expo/apple-utils';
+
+import { AttributesOf } from '../../../../utils/asc';
+
+export const primaryOnlyCategory: Pick<AttributesOf<AppInfo>, 'primaryCategory'> = {
+  primaryCategory: new AppCategory({} as any, 'ENTERTAINMENT', {
+    platforms: [BundleIdPlatform.IOS, BundleIdPlatform.MAC_OS],
+  }),
+};
+
+export const secondaryOnlyCategory: Pick<AttributesOf<AppInfo>, 'secondaryCategory'> = {
+  secondaryCategory: new AppCategory({} as any, 'GAMES', {
+    platforms: [BundleIdPlatform.IOS, BundleIdPlatform.MAC_OS],
+  }),
+};
+
+export const primaryAndSecondaryCategory: Pick<
+  AttributesOf<AppInfo>,
+  'primaryCategory' | 'secondaryCategory'
+> = {
+  ...primaryOnlyCategory,
+  ...secondaryOnlyCategory,
+};

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appInfoLocalization.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appInfoLocalization.ts
@@ -1,0 +1,21 @@
+import { AppInfoLocalization } from '@expo/apple-utils';
+
+import { AttributesOf } from '../../../../utils/asc';
+
+export const englishInfo: AttributesOf<AppInfoLocalization> = {
+  locale: 'en-US',
+  name: 'Awesome test app',
+  subtitle: 'This is just a test',
+  privacyPolicyUrl: 'https://example.com/en/privacy-policy',
+  privacyChoicesUrl: 'https://exmaple.com/en/privacy-choices',
+  privacyPolicyText: 'This is some privacy policy text',
+};
+
+export const dutchInfo: AttributesOf<AppInfoLocalization> = {
+  locale: 'nl-NL',
+  name: 'Geweldige test app',
+  subtitle: 'Dit is maar een test',
+  privacyPolicyUrl: 'https://example.com/nl/privacy-policy',
+  privacyChoicesUrl: 'https://exmaple.com/nl/privacy-choices',
+  privacyPolicyText: 'Dit is wat privacy policy tekst',
+};

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreVersion.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreVersion.ts
@@ -1,0 +1,48 @@
+import { AppStoreState, AppStoreVersion, Platform, ReleaseType } from '@expo/apple-utils';
+
+import { AttributesOf } from '../../../../utils/asc';
+
+export const manualRelease: AttributesOf<AppStoreVersion> = {
+  platform: Platform.IOS,
+  versionString: '1.0.0',
+  appStoreState: AppStoreState.WAITING_FOR_REVIEW,
+  storeIcon: null,
+  watchStoreIcon: null,
+  copyright: '2022 - ACME',
+  releaseType: ReleaseType.MANUAL,
+  earliestReleaseDate: null,
+  usesIdfa: null,
+  isWatchOnly: false,
+  downloadable: false,
+  createdDate: '2022-05-23T00:00:00.000Z',
+};
+
+export const automaticRelease: AttributesOf<AppStoreVersion> = {
+  platform: Platform.IOS,
+  versionString: '2.0.0',
+  appStoreState: AppStoreState.WAITING_FOR_REVIEW,
+  storeIcon: null,
+  watchStoreIcon: null,
+  copyright: '2022 - ACME',
+  releaseType: ReleaseType.AFTER_APPROVAL,
+  earliestReleaseDate: null,
+  usesIdfa: null,
+  isWatchOnly: false,
+  downloadable: false,
+  createdDate: '2022-05-23T00:00:00.000Z',
+};
+
+export const scheduledRelease: AttributesOf<AppStoreVersion> = {
+  platform: Platform.IOS,
+  versionString: '3.0.0',
+  appStoreState: AppStoreState.READY_FOR_SALE,
+  storeIcon: null,
+  watchStoreIcon: null,
+  copyright: '2022 - ACME',
+  releaseType: ReleaseType.SCHEDULED,
+  earliestReleaseDate: '2022-05-29T00:00:00.000Z',
+  usesIdfa: null,
+  isWatchOnly: false,
+  downloadable: false,
+  createdDate: '2022-05-23T00:00:00.000Z',
+};

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreVersionLocalization.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreVersionLocalization.ts
@@ -1,0 +1,23 @@
+import { AppStoreVersionLocalization } from '@expo/apple-utils';
+
+import { AttributesOf } from '../../../../utils/asc';
+
+export const englishVersion: AttributesOf<AppStoreVersionLocalization> = {
+  locale: 'en-US',
+  description: 'This is a description of this version',
+  keywords: 'some, description',
+  marketingUrl: 'https://example.com/en/marketing',
+  promotionalText: 'This is some promotional text',
+  supportUrl: 'https://example.com/en/support',
+  whatsNew: 'Bugfixes and improvements',
+};
+
+export const dutchVersion: AttributesOf<AppStoreVersionLocalization> = {
+  locale: 'nl-NL',
+  description: 'Dit is een beschrijving van deze versie',
+  keywords: 'een, beschrijving',
+  marketingUrl: 'https://example.com/nl/marketing',
+  promotionalText: 'Dit is wat promotie tekst',
+  supportUrl: 'https://example.com/nl/support',
+  whatsNew: 'Beestreparaties en verbeteringen',
+};

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -1,0 +1,151 @@
+import { AppleConfigWriter } from '../writer';
+import { kidsSixToEightAdvisory } from './fixtures/ageRatingDeclaration';
+import { primaryAndSecondaryCategory, secondaryOnlyCategory } from './fixtures/appInfo';
+import { dutchInfo, englishInfo } from './fixtures/appInfoLocalization';
+import { automaticRelease, manualRelease, scheduledRelease } from './fixtures/appStoreVersion';
+import { dutchVersion, englishVersion } from './fixtures/appStoreVersionLocalization';
+
+describe('toSchema', () => {
+  it('returns object with apple schema', () => {
+    const writer = new AppleConfigWriter();
+    expect(writer.toSchema()).toMatchObject({
+      configVersion: 0,
+      apple: expect.any(Object),
+    });
+  });
+});
+
+describe('setAgeRating', () => {
+  it('modifies the advisory', () => {
+    const writer = new AppleConfigWriter();
+    writer.setAgeRating(kidsSixToEightAdvisory);
+    expect(writer.schema.advisory).toMatchObject(kidsSixToEightAdvisory);
+  });
+});
+
+describe('setInfoLocale', () => {
+  it('creates and modifies the locale', () => {
+    const writer = new AppleConfigWriter();
+    writer.setInfoLocale(englishInfo);
+    expect(writer.schema.info?.[englishInfo.locale]).toMatchObject({
+      title: englishInfo.name,
+      subtitle: englishInfo.subtitle,
+      privacyPolicyUrl: englishInfo.privacyPolicyUrl,
+      privacyPolicyText: englishInfo.privacyPolicyText,
+      privacyChoicesUrl: englishInfo.privacyChoicesUrl,
+    });
+  });
+
+  it('modifies existing locales', () => {
+    const writer = new AppleConfigWriter();
+    writer.setInfoLocale(englishInfo);
+    writer.setInfoLocale(dutchInfo);
+    writer.setInfoLocale({
+      ...englishInfo,
+      name: 'This is now different',
+      privacyPolicyText: null,
+    });
+
+    expect(writer.schema.info?.[dutchInfo.locale]).toHaveProperty('title', dutchInfo.name);
+    expect(writer.schema.info?.[englishInfo.locale]).toMatchObject({
+      title: 'This is now different',
+      privacyPolicyText: undefined,
+    });
+  });
+});
+
+describe('setCategories', () => {
+  it('modifies the categories', () => {
+    const writer = new AppleConfigWriter();
+    writer.setCategories(primaryAndSecondaryCategory as any);
+    expect(writer.schema.categories).toHaveLength(2);
+    expect((writer.schema.categories as any)[0]).toBe(
+      primaryAndSecondaryCategory.primaryCategory?.id
+    );
+    expect((writer.schema.categories as any)[1]).toBe(
+      primaryAndSecondaryCategory.secondaryCategory?.id
+    );
+  });
+
+  it('skips secondary category without primary category', () => {
+    const writer = new AppleConfigWriter();
+    writer.setCategories(secondaryOnlyCategory as any);
+    expect(writer.schema.categories).toHaveLength(0);
+  });
+});
+
+describe('setVersion', () => {
+  it('modifies the copyright', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersion(manualRelease);
+    expect(writer.schema.copyright).toBe(manualRelease.copyright);
+  });
+});
+
+describe('setVersionRelease', () => {
+  it('modifies scheduled release', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionRelease(scheduledRelease);
+    expect(writer.schema.release).toMatchObject({
+      autoReleaseDate: scheduledRelease.earliestReleaseDate,
+    });
+  });
+
+  it('modifies automatic release', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionRelease(automaticRelease);
+    expect(writer.schema.release).toMatchObject({
+      automaticRelease: true,
+    });
+  });
+
+  it('modifies manual release', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionRelease(manualRelease);
+    expect(writer.schema.release).toMatchObject({
+      automaticRelease: false,
+    });
+  });
+
+  it('overwrites all release fields', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionRelease(scheduledRelease);
+    writer.setVersionRelease(manualRelease);
+    expect(writer.schema.release).not.toHaveProperty('autoReleaseDate');
+  });
+});
+
+describe('setVersionLocale', () => {
+  it('creates and modifies the locale', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionLocale(englishVersion);
+    expect(writer.schema.info?.[englishVersion.locale]).toMatchObject({
+      description: englishVersion.description,
+      keywords: englishVersion.keywords?.split(', '),
+      releaseNotes: englishVersion.whatsNew,
+      marketingUrl: englishVersion.marketingUrl,
+      promoText: englishVersion.promotionalText,
+      supportUrl: englishVersion.supportUrl,
+    });
+  });
+
+  it('modifies existing locales', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionLocale(englishVersion);
+    writer.setVersionLocale(dutchVersion);
+    writer.setVersionLocale({
+      ...englishVersion,
+      description: 'This is now different',
+      whatsNew: null,
+    });
+
+    expect(writer.schema.info?.[dutchVersion.locale]).toHaveProperty(
+      'description',
+      dutchVersion.description
+    );
+    expect(writer.schema.info?.[englishVersion.locale]).toMatchObject({
+      description: 'This is now different',
+      releaseNotes: undefined,
+    });
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -1,0 +1,121 @@
+import {
+  AgeRatingDeclaration,
+  AppInfoLocalization,
+  AppStoreVersion,
+  AppStoreVersionLocalization,
+  CategoryIds,
+  ReleaseType,
+} from '@expo/apple-utils';
+
+import { unique } from '../../utils/array';
+import { AttributesOf } from '../../utils/asc';
+import { removeDatePrecision } from '../../utils/date';
+import { AppleMetadata } from '../types';
+
+type PartialExcept<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;
+
+// TODO: find out if we can move this to default JSON schema normalization
+export const DEFAULT_WHATSNEW = 'Bug fixes and improved stability';
+
+/**
+ * Deserializes the metadata config schema into attributes for different models.
+ * This uses version 0 of the config schema.
+ */
+export class AppleConfigReader {
+  constructor(public readonly schema: AppleMetadata) {}
+
+  getAgeRating(): Partial<AttributesOf<AgeRatingDeclaration>> | null {
+    return this.schema.advisory || null;
+  }
+
+  getLocales(): string[] {
+    // TODO: filter "default" locales, add option to add non-localized info to the config
+    return unique(Object.keys(this.schema.info || {}));
+  }
+
+  getInfoLocale(
+    locale: string
+  ): PartialExcept<AttributesOf<AppInfoLocalization>, 'locale' | 'name'> | null {
+    const info = this.schema.info?.[locale];
+    if (!info) {
+      return null;
+    }
+
+    return {
+      locale,
+      name: info.title || 'no name provided',
+      subtitle: info.subtitle,
+      privacyChoicesUrl: info.privacyChoicesUrl,
+      privacyPolicyText: info.privacyPolicyText,
+      privacyPolicyUrl: info.privacyPolicyUrl,
+    };
+  }
+
+  getCategories(): CategoryIds | null {
+    if (Array.isArray(this.schema.categories) && this.schema.categories.length > 0) {
+      return {
+        primaryCategory: this.schema.categories[0],
+        secondaryCategory: this.schema.categories[1],
+      };
+    }
+
+    return null;
+  }
+
+  getVersion(): Partial<
+    Omit<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
+  > | null {
+    return this.schema.copyright ? { copyright: this.schema.copyright } : null;
+  }
+
+  getVersionRelease(): Partial<
+    Pick<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
+  > | null {
+    const { release } = this.schema;
+
+    if (release?.autoReleaseDate) {
+      return {
+        releaseType: ReleaseType.SCHEDULED,
+        // Convert time format to 2020-06-17T12:00:00-07:00
+        earliestReleaseDate: removeDatePrecision(release.autoReleaseDate)?.toISOString() ?? null,
+      };
+    }
+
+    if (release?.automaticRelease === true) {
+      return {
+        releaseType: ReleaseType.AFTER_APPROVAL,
+        earliestReleaseDate: null,
+      };
+    }
+
+    if (release?.automaticRelease === false) {
+      return {
+        releaseType: ReleaseType.MANUAL,
+        earliestReleaseDate: null,
+      };
+    }
+
+    return null;
+  }
+
+  getVersionLocale(
+    locale: string,
+    context: { versionIsFirst: boolean }
+  ): Partial<AttributesOf<AppStoreVersionLocalization>> | null {
+    const info = this.schema.info?.[locale];
+    if (!info) {
+      return null;
+    }
+
+    return {
+      locale,
+      description: info.description,
+      keywords: info.keywords?.join(', '),
+      // TODO: maybe move this to task logic, it's more an exception than data handling
+      whatsNew: context.versionIsFirst ? undefined : info.releaseNotes || DEFAULT_WHATSNEW,
+      marketingUrl: info.marketingUrl,
+      promotionalText: info.promoText,
+      supportUrl: info.supportUrl,
+    };
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -1,0 +1,107 @@
+import {
+  AgeRatingDeclaration,
+  AppInfo,
+  AppInfoLocalization,
+  AppStoreVersion,
+  AppStoreVersionLocalization,
+  ReleaseType,
+} from '@expo/apple-utils';
+
+import { AttributesOf } from '../../utils/asc';
+import { AppleMetadata } from '../types';
+
+/**
+ * Serializes the Apple ASC entities into the metadata configuration schema.
+ * This uses version 0 of the config schema.
+ */
+export class AppleConfigWriter {
+  constructor(public readonly schema: Partial<AppleMetadata> = {}) {}
+
+  /** Get the schema result to write it to the config file */
+  toSchema(): { configVersion: number; apple: Partial<AppleMetadata> } {
+    return {
+      configVersion: 0,
+      apple: this.schema,
+    };
+  }
+
+  setAgeRating(attributes: AttributesOf<AgeRatingDeclaration>): void {
+    this.schema.advisory = attributes;
+  }
+
+  setInfoLocale(attributes: AttributesOf<AppInfoLocalization>): void {
+    this.schema.info = this.schema.info ?? {};
+    const existing = this.schema.info[attributes.locale] ?? {};
+
+    this.schema.info[attributes.locale] = {
+      ...existing,
+      title: attributes.name ?? 'no name provided',
+      subtitle: optional(attributes.subtitle),
+      privacyPolicyUrl: optional(attributes.privacyPolicyUrl),
+      privacyPolicyText: optional(attributes.privacyPolicyText),
+      privacyChoicesUrl: optional(attributes.privacyChoicesUrl),
+    };
+  }
+
+  setCategories({ primaryCategory, secondaryCategory }: AttributesOf<AppInfo>): void {
+    this.schema.categories = [];
+
+    // TODO: see why these types are conflicting
+    if (primaryCategory) {
+      this.schema.categories.push(primaryCategory.id as any);
+      if (secondaryCategory) {
+        this.schema.categories.push(secondaryCategory.id as any);
+      }
+    }
+  }
+
+  setVersion(
+    attributes: Omit<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
+  ): void {
+    this.schema.copyright = optional(attributes.copyright);
+  }
+
+  setVersionRelease(
+    attributes: Pick<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
+  ): void {
+    if (attributes.releaseType === ReleaseType.SCHEDULED) {
+      this.schema.release = {
+        autoReleaseDate: optional(attributes.earliestReleaseDate),
+      };
+    }
+
+    if (attributes.releaseType === ReleaseType.AFTER_APPROVAL) {
+      this.schema.release = {
+        automaticRelease: true,
+      };
+    }
+
+    if (attributes.releaseType === ReleaseType.MANUAL) {
+      this.schema.release = {
+        automaticRelease: false,
+      };
+    }
+  }
+
+  setVersionLocale(attributes: AttributesOf<AppStoreVersionLocalization>): void {
+    this.schema.info = this.schema.info ?? {};
+    const existing = this.schema.info[attributes.locale] ?? {};
+
+    this.schema.info[attributes.locale] = {
+      ...existing,
+      description: optional(attributes.description),
+      keywords: optional(attributes.keywords)
+        ?.split(',')
+        .map(keyword => keyword.trim()),
+      releaseNotes: optional(attributes.whatsNew),
+      marketingUrl: optional(attributes.marketingUrl),
+      promoText: optional(attributes.promotionalText),
+      supportUrl: optional(attributes.supportUrl),
+    };
+  }
+}
+
+/** Helper function to convert `T | null` to `T | undefined`, required for the entity properties */
+function optional<T>(value: T | null): T | undefined {
+  return value ?? undefined;
+}

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -1,0 +1,56 @@
+import type { AgeRatingDeclarationProps, AppCategoryId, AppSubcategoryId } from '@expo/apple-utils';
+
+export type AppleLocale = string;
+
+export interface AppleMetadata {
+  copyright?: string;
+  info?: Record<AppleLocale, AppleInfo>;
+  categories?: AppCategoryId[] | AppleCategory;
+  release?: AppleRelease;
+  advisory?: AppleAdvisory;
+  preview?: Record<string, string[]>;
+  review?: AppleReview;
+}
+
+export type AppleAdvisory = Partial<AgeRatingDeclarationProps>;
+
+export interface AppleCategory {
+  category: AppCategoryId;
+  subcategory?: AppSubcategoryId[];
+}
+
+export interface AppleRelease {
+  isPhasedReleaseEnabled?: boolean;
+  shouldResetRatings?: boolean;
+  autoReleaseDate?: number | string;
+  automaticRelease?: boolean;
+  usesThirdPartyContent?: boolean;
+  /** Alternative to setting `ITSAppUsesNonExemptEncryption` in the binary's `Info.plist`. */
+  usesNonExemptEncryption?: boolean;
+}
+
+export interface AppleInfo {
+  title: string;
+  subtitle?: string;
+  /** Does not effect ASO https://developer.apple.com/app-store/product-page/ */
+  promoText?: string;
+  description?: string;
+  keywords?: string[];
+  releaseNotes?: string;
+  marketingUrl?: string;
+  privacyPolicyUrl?: string;
+  privacyPolicyText?: string;
+  privacyChoicesUrl?: string;
+  supportUrl?: string;
+}
+
+export interface AppleReview {
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  email?: string;
+  demoUsername?: string;
+  demoPassword?: string;
+  notes?: string;
+  attachment?: string;
+}

--- a/packages/eas-cli/src/metadata/utils/array.ts
+++ b/packages/eas-cli/src/metadata/utils/array.ts
@@ -1,0 +1,4 @@
+export function unique<T = any>(items: T[]): T[] {
+  const set = new Set(items);
+  return [...set];
+}

--- a/packages/eas-cli/src/metadata/utils/asc.ts
+++ b/packages/eas-cli/src/metadata/utils/asc.ts
@@ -1,0 +1,4 @@
+import { ConnectModel } from '@expo/apple-utils';
+
+/** Get the properties of a single App Store Connect entity */
+export type AttributesOf<T extends ConnectModel> = T['attributes'];

--- a/packages/eas-cli/src/metadata/utils/date.ts
+++ b/packages/eas-cli/src/metadata/utils/date.ts
@@ -1,0 +1,23 @@
+/**
+ * Remove time precision from a date to avoid potential errors with the App Store.
+ *
+ * "status": "409",
+ * "code": "ENTITY_ERROR.ATTRIBUTE.INVALID",
+ * "title": "An attribute value is invalid.",
+ * "detail": "The attribute 'earliestReleaseDate' only allows hour precision",
+ * "source": {
+ *   "pointer": "/data/attributes/earliestReleaseDate"
+ * }
+ */
+export function removeDatePrecision(date: any): null | Date {
+  if (date) {
+    try {
+      const result = new Date(date);
+      result.setMinutes(0);
+      result.setSeconds(0);
+      result.setMilliseconds(0);
+      return result;
+    } catch {}
+  }
+  return null;
+}

--- a/packages/eas-cli/src/metadata/utils/log.ts
+++ b/packages/eas-cli/src/metadata/utils/log.ts
@@ -1,0 +1,34 @@
+import { Ora, ora } from '../../ora';
+
+type LogAsyncOptions = {
+  /** If the spinner representing the async action should be hidden, e.g. for JSON output */
+  hidden?: boolean;
+  /** The message to display when the action is pending */
+  pending: string;
+  /** The message to display when the action succeeded */
+  success: string;
+  /** The message to display when the action failed */
+  failure: string;
+};
+
+/**
+ * Log an asynchronous action using a spinner.
+ */
+export async function logAsync<T>(
+  action: (spinner?: Ora) => Promise<T>,
+  { hidden, ...message }: LogAsyncOptions
+): Promise<T> {
+  if (hidden) {
+    return action();
+  }
+
+  const spinner = ora(message.pending).start();
+  try {
+    const result = await action(spinner);
+    spinner.succeed(message.success);
+    return result;
+  } catch (error) {
+    spinner.fail(message.failure);
+    throw error;
+  }
+}

--- a/packages/eas-cli/src/metadata/utils/retry.ts
+++ b/packages/eas-cli/src/metadata/utils/retry.ts
@@ -1,0 +1,28 @@
+export async function waitAsync(duration: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, duration));
+}
+
+type WithRetryOptions = {
+  tries?: number;
+  delay?: number;
+  onRetry?: (triesLeft: number) => void;
+};
+
+export async function retryIfNullAsync<T>(
+  method: () => Promise<T | null>,
+  options: WithRetryOptions = {}
+): Promise<T | null> {
+  let { tries = 5, delay = 1000 } = options;
+
+  while (tries > 0) {
+    const value = await method();
+    if (value !== null) {
+      return value;
+    }
+    tries--;
+    options.onRetry?.(tries);
+    await waitAsync(delay);
+  }
+
+  return null;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Part of PR #1083

This adds the basic store config serializer to read and write the JSON file. It also includes [some utility methods](https://github.com/expo/eas-cli/tree/%40bycedric/metadata/draft/packages/eas-cli/src/metadata/utils) that we use throughout the metadata part.

# How

- The config reader should support multiple versions of the store config, mostly for when we add or change functionality in the future.
- The config writer can always be the latest version, we don't need to support older versions as we generate them on the fly.

# Test Plan

The config serializers are used before we download or upload the store configuration. The writer has some unit tests, I omitted the reader unit tests to focus on the functionality. Can add that later though!
