### PR TITLE
[eas-cli] Add metadata telemetry to increase visibility in store errors

### DIFF
--- a/packages/eas-cli/src/analytics/events.ts
+++ b/packages/eas-cli/src/analytics/events.ts
@@ -1,5 +1,5 @@
 import { logEvent } from './rudderstackClient';
-export type Event = BuildEvent | SubmissionEvent;
+export type Event = BuildEvent | SubmissionEvent | MetadataEvent;
 
 export enum SubmissionEvent {
   SUBMIT_COMMAND = 'submit cli submit command',
@@ -43,6 +43,11 @@ export enum BuildEvent {
   CREDENTIALS_SYNC_UPDATE_REMOTE_FAIL = 'build cli credentials sync update remote fail',
 
   ANDROID_KEYSTORE_CREATE = 'build cli credentials keystore create',
+}
+
+export enum MetadataEvent {
+  APPLE_METADATA_DOWNLOAD = 'metadata cli download apple response',
+  APPLE_METADATA_UPLOAD = 'metadata cli upload apple response',
 }
 
 export class Analytics {

--- a/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
+++ b/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
@@ -1,0 +1,79 @@
+import { App } from '@expo/apple-utils';
+
+import { TelemetryContext, makeDataScrubber } from '../telemetry';
+
+describe(makeDataScrubber, () => {
+  const stub: TelemetryContext = {
+    // Only the App ID is considered to be sensitive
+    app: new App({} as any, 'SECRET_APP_ID', {} as any),
+    // Only the token properties and user credentials are considered to be sensitive
+    auth: {
+      username: 'SECRET_USERNAME',
+      password: 'SECRET_PASSWORD',
+      context: {
+        token: 'SECRET_TOKEN',
+        teamId: 'SECRET_TEAM_ID',
+        providerId: 1337,
+      },
+    } as any,
+  };
+
+  it('scrubs the app.id', () => {
+    expect(makeDataScrubber(stub)('some text SECRET_APP_ID')).toBe('some text {APPLE_APP_ID}');
+  });
+
+  it('scrubs the auth.username', () => {
+    expect(makeDataScrubber(stub)('some text SECRET_USERNAME')).toBe('some text {APPLE_USERNAME}');
+  });
+
+  it('scrubs the auth.password', () => {
+    expect(makeDataScrubber(stub)('SECRET_PASSWORD')).toBe('{APPLE_PASSWORD}');
+  });
+
+  it('scrubs the auth.context.token', () => {
+    expect(makeDataScrubber(stub)('some text SECRET_TOKEN')).toBe('some text {APPLE_TOKEN}');
+  });
+
+  it('scrubs the auth.context.token when using token instances', () => {
+    const token = { getToken: () => 'SECRET_TOKEN_INSTANCE' } as any;
+    const scrubber = makeDataScrubber({
+      ...stub,
+      auth: {
+        ...stub.auth,
+        context: {
+          ...stub.auth.context,
+          token,
+        },
+      },
+    });
+
+    expect(scrubber('some text SECRET_TOKEN_INSTANCE')).toBe('some text {APPLE_TOKEN}');
+  });
+
+  it('scrubs the auth.context.teamId', () => {
+    expect(makeDataScrubber(stub)('SECRET_TEAM_ID')).toBe('{APPLE_TEAM_ID}');
+  });
+
+  it('scrubs the auth.context.teamId', () => {
+    expect(makeDataScrubber(stub)('some provider 1337')).toBe('some provider {APPLE_PROVIDER_ID}');
+  });
+
+  it('scrubber returns string representation of falsy values', () => {
+    const scrubber = makeDataScrubber(stub);
+    expect(scrubber(null)).toBe('null');
+    expect(scrubber(undefined)).toBe('undefined');
+    expect(scrubber(false)).toBe('false');
+  });
+
+  it('scrubs multiple sensitive values at once', () => {
+    expect(makeDataScrubber(stub)('SECRET_TOKEN SECRET_USERNAME SECRET_PASSWORD')).toBe(
+      '{APPLE_TOKEN} {APPLE_USERNAME} {APPLE_PASSWORD}'
+    );
+  });
+
+  it('scrubs json and transforms it to string', () => {
+    const scrubber = makeDataScrubber(stub);
+    expect(scrubber({ foo: 'bar' })).toBe('{"foo":"bar"}');
+    expect(scrubber({ value: 'SECRET_APP_ID' })).toBe('{"value":"{APPLE_APP_ID}"}');
+  });
+});

--- a/packages/eas-cli/src/metadata/utils/telemetry.ts
+++ b/packages/eas-cli/src/metadata/utils/telemetry.ts
@@ -1,0 +1,110 @@
+import { App, Session, getRequestClient } from '@expo/apple-utils';
+import type { AxiosError } from 'axios';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Analytics, MetadataEvent } from '../../analytics/events';
+
+export type TelemetryContext = {
+  app: App;
+  auth: Partial<Session.AuthState>;
+};
+
+/**
+ * Subscribe the telemetry to the ongoing metadata requests and responses.
+ * When providing the app and auth info, we can scrub that data from the telemetry.
+ * Returns an execution ID to group all events of a single run together, and a unsubscribe function.
+ */
+export function subscribeTelemetry(
+  event: MetadataEvent,
+  options: TelemetryContext
+): {
+  /** Unsubscribe the telemetry from all apple-utils events */
+  unsubscribeTelemetry: () => void;
+  /** The unique id added to all telemetry events from a single execution */
+  executionId: string;
+} {
+  const executionId = uuidv4();
+  const scrubber = makeDataScrubber(options);
+  const { interceptors } = getRequestClient();
+
+  const responseInterceptorId = interceptors.response.use(
+    response => {
+      Analytics.logEvent(event, {
+        executionId,
+        type: 'response',
+        phase: 'resolved',
+        method: response.request.method.toUpperCase(),
+        url: scrubber(response.request.path),
+        status: String(response.status),
+        statusText: scrubber(response.statusText),
+      });
+
+      return response;
+    },
+    (error: AxiosError) => {
+      Analytics.logEvent(event, {
+        executionId,
+        type: 'response',
+        phase: 'rejected',
+        method: error.request.method.toUpperCase(),
+        url: scrubber(error.config.url),
+        error: scrubber(error.message),
+        status: String(error.response?.status),
+        statusText: scrubber(error.response?.statusText),
+        input: scrubber(error.config.data),
+        output: scrubber(error.response?.data),
+      });
+
+      throw error;
+    }
+  );
+
+  function unsubscribeTelemetry(): void {
+    interceptors.response.eject(responseInterceptorId);
+  }
+
+  return { unsubscribeTelemetry, executionId };
+}
+
+/** Exposed for testing */
+export function makeDataScrubber({ app, auth }: TelemetryContext): <T>(data: T) => string {
+  const token = getAuthTokenString(auth);
+  const patterns: Record<string, RegExp | null> = {
+    APPLE_APP_ID: new RegExp(app.id, 'gi'),
+    APPLE_USERNAME: auth.username ? new RegExp(auth.username, 'gi') : null,
+    APPLE_PASSWORD: auth.password ? new RegExp(auth.password, 'gi') : null,
+    APPLE_TOKEN: token ? new RegExp(token, 'gi') : null,
+    APPLE_TEAM_ID: auth.context?.teamId ? new RegExp(auth.context.teamId, 'gi') : null,
+    APPLE_PROVIDER_ID: auth.context?.providerId
+      ? new RegExp(String(auth.context.providerId), 'gi')
+      : null,
+  };
+
+  const iterator = Object.entries(patterns);
+
+  return function scrubber(data) {
+    if (!data) {
+      return String(data);
+    }
+
+    let value = typeof data === 'object' ? JSON.stringify(data) : String(data);
+    for (const [replacement, pattern] of iterator) {
+      if (pattern) {
+        value = value.replace(pattern, `{${replacement}}`);
+      }
+    }
+    return value;
+  };
+}
+
+function getAuthTokenString(auth: TelemetryContext['auth']): string | null {
+  if (!auth.context?.token) {
+    return null;
+  }
+
+  if (typeof auth.context.token === 'object') {
+    return auth.context.token.getToken();
+  }
+
+  return auth.context.token;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

- Part of PR #1083 
- [x] ~~Requires PR #1130~~

This adds customized telemetry to the App Store library, and gives us visibility on potential (new) issues or changes from the stores.

# How

- The telemetry can be directly bound to the App Store library and sends events based on the responses.
- In cases of failures, we send a bit more context to understand what is going wrong.
- When we send more context, we also make sure to never send sensitive data by scrubbing/replacing these values with placeholders.

# Test Plan

See unit tests
