### PR TITLE
[eas-cli] Add metadata app store task runner

### DIFF
--- a/packages/eas-cli/src/metadata/apple/data.ts
+++ b/packages/eas-cli/src/metadata/apple/data.ts
@@ -1,0 +1,18 @@
+import type { App } from '@expo/apple-utils';
+
+import type { AgeRatingData } from './tasks/age-rating';
+import type { AppInfoData } from './tasks/app-info';
+import type { AppVersionData } from './tasks/app-version';
+
+/**
+ * The fully prepared apple data, used within the `downloadAsync` or `uploadAsync` tasks.
+ * It contains references to each individual models, to either upload or download App Store data.
+ */
+export type AppleData = { app: App } & AppInfoData & AppVersionData & AgeRatingData;
+
+/**
+ * The unprepared partial apple data, used within the `prepareAsync` tasks.
+ * It contains a reference to the app, each task should populate the necessary data.
+ * If an entity fails to prepare the data, individual tasks should raise errors about the missing data.
+ */
+export type PartialAppleData = { app: App } & Partial<Omit<AppleData, 'app'>>;

--- a/packages/eas-cli/src/metadata/apple/task.ts
+++ b/packages/eas-cli/src/metadata/apple/task.ts
@@ -1,0 +1,31 @@
+import { AppleConfigReader } from './config/reader';
+import { AppleConfigWriter } from './config/writer';
+import { AppleData, PartialAppleData } from './data';
+
+export abstract class AppleTask {
+  /** Get a description from the task to use as section headings in the log */
+  abstract name(): string;
+
+  /** Prepare the data from the App Store to start syncing with the store configuration */
+  abstract prepareAsync(options: TaskPrepareOptions): Promise<void>;
+
+  /** Download all information from the App Store to generate the store configuration */
+  abstract downloadAsync(options: TaskDownloadOptions): Promise<void>;
+
+  /** Upload all information from the store configuration to the App Store */
+  abstract uploadAsync(options: TaskUploadOptions): Promise<void>;
+}
+
+export type TaskPrepareOptions = {
+  context: PartialAppleData;
+};
+
+export type TaskDownloadOptions = {
+  config: AppleConfigWriter;
+  context: AppleData;
+};
+
+export type TaskUploadOptions = {
+  config: AppleConfigReader;
+  context: AppleData;
+};

--- a/packages/eas-cli/src/metadata/apple/tasks/__mocks__/nock.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__mocks__/nock.ts
@@ -1,0 +1,8 @@
+import { getRequestClient } from '@expo/apple-utils';
+
+export { default } from 'nock';
+
+// Axios from apple-utils needs to be patched when we use Nock.
+// Instead of the default adapter, we need to use `axios/lib/adapters/http`
+// see: https://github.com/nock/nock#axios
+getRequestClient().defaults.adapter = require('axios/lib/adapters/http');

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/age-rating.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/age-rating.test.ts
@@ -1,0 +1,84 @@
+import { AgeRatingDeclaration, AppStoreVersion, Rating } from '@expo/apple-utils';
+import nock from 'nock';
+
+import { AppleConfigReader } from '../../config/reader';
+import { AppleData } from '../../data';
+import { AgeRatingTask } from '../age-rating';
+import { requestContext } from './fixtures/requestContext';
+
+jest.mock('../../../../ora');
+
+describe(AgeRatingTask, () => {
+  describe('preuploadAsync', () => {
+    it('aborts when version is not loaded', async () => {
+      const promise = new AgeRatingTask().prepareAsync({ context: {} as any });
+
+      await expect(promise).rejects.toThrow('not prepared');
+    });
+
+    it('loads age rating from app version', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .get(`/v1/${AppStoreVersion.type}/stub-id/ageRatingDeclaration`)
+        .reply(200, require('./fixtures/appStoreVersions/get-ageRatingDeclaration-200.json'));
+
+      const context: any = {
+        version: new AppStoreVersion(requestContext, 'stub-id', {} as any),
+      };
+
+      await new AgeRatingTask().prepareAsync({ context });
+
+      expect(context.ageRating).toBeInstanceOf(AgeRatingDeclaration);
+      expect(scope.isDone()).toBeTruthy();
+    });
+  });
+
+  describe('uploadAsync', () => {
+    it('aborts when age rating is not loaded', async () => {
+      const promise = new AgeRatingTask().uploadAsync({
+        config: new AppleConfigReader({}),
+        context: { ageRating: undefined } as any,
+      });
+
+      await expect(promise).rejects.toThrow('rating not initialized');
+    });
+
+    it('skips updating age rating when not configured', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .patch(`/v1/${AgeRatingDeclaration.type}/stub-id`)
+        .reply(200, require('./fixtures/ageRatingDeclarations/patch-200.json'));
+
+      await new AgeRatingTask().uploadAsync({
+        config: new AppleConfigReader({ advisory: undefined }),
+        context: {
+          ageRating: new AgeRatingDeclaration(requestContext, 'stub-id', {} as any),
+        } as AppleData,
+      });
+
+      expect(scope.isDone()).toBeFalsy();
+      nock.cleanAll();
+    });
+
+    it('updates age rating from config when configured', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .patch(`/v1/${AgeRatingDeclaration.type}/stub-id`)
+        .reply(200, require('./fixtures/ageRatingDeclarations/patch-200.json'));
+
+      const context = {
+        ageRating: new AgeRatingDeclaration(requestContext, 'stub-id', {} as any),
+      };
+
+      await new AgeRatingTask().uploadAsync({
+        config: new AppleConfigReader({
+          advisory: {
+            // See fixture value for horrorOrFearThemes
+            horrorOrFearThemes: Rating.INFREQUENT_OR_MILD,
+          },
+        }),
+        context: context as AppleData,
+      });
+
+      expect(context.ageRating.id).not.toMatch('stub-id');
+      expect(scope.isDone()).toBeTruthy();
+    });
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-info.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-info.test.ts
@@ -1,0 +1,114 @@
+import { App, AppCategoryId, AppInfo, AppInfoLocalization } from '@expo/apple-utils';
+import nock from 'nock';
+
+import { AppleConfigReader } from '../../config/reader';
+import { AppleData, PartialAppleData } from '../../data';
+import { AppInfoTask } from '../app-info';
+import { requestContext } from './fixtures/requestContext';
+
+jest.mock('../../../../ora');
+
+describe(AppInfoTask, () => {
+  describe('preuploadAsync', () => {
+    it('loads editable app info and locales from app instance', async () => {
+      const scopeInfo = nock('https://api.appstoreconnect.apple.com')
+        .get(uri => uri.startsWith(`/v1/${App.type}/stub-id/${AppInfo.type}`)) // allow any query params
+        .reply(200, require('./fixtures/apps/get-appInfos-200.json'));
+
+      const scopeLocales = nock('https://api.appstoreconnect.apple.com')
+        .get(/\/v1\/appInfos\/.*\/appInfoLocalizations/) // allow any id from fixture
+        .reply(200, require('./fixtures/appInfos/get-appInfoLocalizations-200.json'));
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+      };
+
+      await new AppInfoTask().prepareAsync({ context });
+
+      expect(context.info).toBeInstanceOf(AppInfo);
+      expect(context.infoLocales).toBeInstanceOf(Array);
+      expect(scopeInfo.isDone()).toBeTruthy();
+      expect(scopeLocales.isDone()).toBeTruthy();
+    });
+  });
+
+  describe('uploadAsync', () => {
+    it('aborts when app info is not loaded', async () => {
+      const promise = new AppInfoTask().uploadAsync({
+        config: new AppleConfigReader({}),
+        context: { info: undefined } as any,
+      });
+
+      await expect(promise).rejects.toThrow('info not initialized');
+    });
+
+    it('skips updating categories when not configured', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .patch(`/v1/${AppInfo.type}/stub-id`)
+        .reply(200, require('./fixtures/appInfos/patch-200.json'));
+
+      await new AppInfoTask().uploadAsync({
+        config: new AppleConfigReader({ categories: undefined }),
+        context: {
+          info: new AppInfo(requestContext, 'stub-id', {} as any),
+        } as AppleData,
+      });
+
+      expect(scope.isDone()).toBeFalsy();
+      nock.cleanAll();
+    });
+
+    it('skips updating localized info when not configured', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .patch(`/v1/${AppInfoLocalization.type}/stub-id`)
+        .reply(200, require('./fixtures/appInfos/patch-200.json'));
+
+      await new AppInfoTask().uploadAsync({
+        config: new AppleConfigReader({ info: undefined }),
+        context: {
+          info: new AppInfo(requestContext, 'stub-id', {} as any),
+        } as AppleData,
+      });
+
+      expect(scope.isDone()).toBeFalsy();
+      nock.cleanAll();
+    });
+
+    it('updates categories and localized info', async () => {
+      const updateCategoryScope = nock('https://api.appstoreconnect.apple.com')
+        .patch(`/v1/${AppInfo.type}/stub-id`)
+        .reply(200, require('./fixtures/appInfos/patch-200.json'));
+
+      const updateENInfoScope = nock('https://api.appstoreconnect.apple.com')
+        .patch(`/v1/${AppInfoLocalization.type}/APP_INFO_LOCALE_1`) // see fixture ID
+        .reply(200, require('./fixtures/appInfoLocalizations/patch-200.json'));
+
+      const updateNLInfoScope = nock('https://api.appstoreconnect.apple.com')
+        .patch(`/v1/${AppInfoLocalization.type}/APP_INFO_LOCALE_2`) // see fixture ID
+        .reply(200, require('./fixtures/appInfoLocalizations/patch-200.json'));
+
+      const fetchLocalizedInfoScope = nock('https://api.appstoreconnect.apple.com')
+        .get(`/v1/${AppInfo.type}/APP_INFO_1/${AppInfoLocalization.type}`) // see fixture ID
+        .twice()
+        .reply(200, require('./fixtures/appInfos/get-appInfoLocalizations-200.json'));
+
+      await new AppInfoTask().uploadAsync({
+        config: new AppleConfigReader({
+          categories: [AppCategoryId.ENTERTAINMENT],
+          info: {
+            'en-US': { title: 'Hello' },
+            'nl-NL': { title: 'Hallo' },
+          },
+        }),
+        context: {
+          info: new AppInfo(requestContext, 'stub-id', {} as any),
+        } as AppleData,
+      });
+
+      expect(updateCategoryScope.isDone()).toBeTruthy();
+      expect(fetchLocalizedInfoScope.isDone()).toBeTruthy();
+      expect(updateENInfoScope.isDone()).toBeTruthy();
+      expect(updateNLInfoScope.isDone()).toBeTruthy();
+    });
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-version.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-version.test.ts
@@ -1,0 +1,176 @@
+import {
+  App,
+  AppStoreState,
+  AppStoreVersion,
+  AppStoreVersionLocalization,
+} from '@expo/apple-utils';
+import nock from 'nock';
+
+import { AppleConfigReader } from '../../config/reader';
+import { AppleData, PartialAppleData } from '../../data';
+import { AppVersionTask } from '../app-version';
+import { requestContext } from './fixtures/requestContext';
+
+jest.mock('../../../../ora');
+
+describe(AppVersionTask, () => {
+  describe('preuploadAsync', () => {
+    it('loads live version', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        // Respond to app.getLiveAppStoreVersionAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query((params: any) => params['filter[appStoreState]'] === AppStoreState.READY_FOR_SALE)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-200.json'))
+        // Respond to app.getAppStoreVersionsAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-count-200.json'))
+        // Respond to version.getLocalizationsAsync
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/${AppStoreVersionLocalization.type}`)
+        .reply(
+          200,
+          require('./fixtures/appStoreVersions/get-appStoreVersionLocalizations-200.json')
+        );
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+      };
+
+      await new AppVersionTask({ editLive: true }).prepareAsync({ context });
+
+      expect(context.version).toBeInstanceOf(AppStoreVersion);
+      expect(context.versionIsLive).toBeTruthy();
+      expect(context.versionIsFirst).toBeTruthy();
+      expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('falls back to editable version if live version is not found', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        // Respond to app.getLiveAppStoreVersionAsync, failing with 404
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query((params: any) => params['filter[appStoreState]'] === AppStoreState.READY_FOR_SALE)
+        .reply(404, {})
+        // Respond to app.getEditAppStoreVersionAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-count-200.json'))
+        // Respond to app.getAppStoreVersionsAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query(true)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-count-200.json'))
+        // Respond to version.getLocalizationsAsync
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/${AppStoreVersionLocalization.type}`)
+        .reply(
+          200,
+          require('./fixtures/appStoreVersions/get-appStoreVersionLocalizations-200.json')
+        );
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+      };
+
+      await new AppVersionTask({ editLive: true }).prepareAsync({ context });
+
+      expect(context.version).toBeInstanceOf(AppStoreVersion);
+      expect(context.versionIsLive).toBeFalsy();
+      expect(context.versionIsFirst).toBeTruthy();
+      expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('loads last editable version', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        // Respond to app.getEditAppStoreVersionAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-200.json'))
+        // Respond to app.getAppStoreVersionsAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-count-200.json'))
+        // Respond to version.getLocalizationsAsync
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/${AppStoreVersionLocalization.type}`)
+        .reply(
+          200,
+          require('./fixtures/appStoreVersions/get-appStoreVersionLocalizations-200.json')
+        );
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+      };
+
+      await new AppVersionTask().prepareAsync({ context });
+
+      expect(context.version).toBeInstanceOf(AppStoreVersion);
+      expect(context.versionIsLive).toBeFalsy();
+      expect(context.versionIsFirst).toBeTruthy();
+      expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('sets first version property for multiple versions', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        // Respond to app.getEditAppStoreVersionAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-200.json'))
+        // Respond to app.getAppStoreVersionsAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-count-multiple-200.json'))
+        // Respond to version.getLocalizationsAsync
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/${AppStoreVersionLocalization.type}`)
+        .reply(
+          200,
+          require('./fixtures/appStoreVersions/get-appStoreVersionLocalizations-200.json')
+        );
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+      };
+
+      await new AppVersionTask().prepareAsync({ context });
+
+      expect(context.versionIsFirst).toBeFalsy();
+      expect(scope.isDone()).toBeTruthy();
+    });
+  });
+
+  describe('upload', () => {
+    it('aborts when version is not loaded', async () => {
+      const promise = new AppVersionTask().uploadAsync({
+        context: {} as any,
+        config: new AppleConfigReader({}),
+      });
+
+      await expect(promise).rejects.toThrow('not initialized');
+    });
+
+    it('updates version and release from config', async () => {
+      const config = new AppleConfigReader({
+        copyright: '2022 ACME',
+        release: { automaticRelease: true },
+      });
+
+      const attributes = { ...config.getVersion(), ...config.getVersionRelease() };
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        // Respond to version.updateAsync
+        .patch(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1`)
+        .reply(200, {
+          data: {
+            id: 'APP_STORE_VERSION_1',
+            type: AppStoreVersion.type,
+            attributes,
+          },
+        });
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+        version: new AppStoreVersion(requestContext, 'APP_STORE_VERSION_1', {} as any),
+      };
+
+      await new AppVersionTask().uploadAsync({ context: context as AppleData, config });
+
+      expect(context.version?.attributes).toMatchObject(attributes);
+      expect(scope.isDone()).toBeTruthy();
+    });
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/ageRatingDeclarations/patch-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/ageRatingDeclarations/patch-200.json
@@ -1,0 +1,31 @@
+{
+	"data": {
+		"type": "ageRatingDeclarations",
+		"id": "AGE_RATING_1",
+		"attributes": {
+			"alcoholTobaccoOrDrugUseOrReferences": "NONE",
+			"contests": "NONE",
+			"gamblingAndContests": false,
+			"gambling": false,
+			"gamblingSimulated": "NONE",
+			"kidsAgeBand": null,
+			"medicalOrTreatmentInformation": "NONE",
+			"profanityOrCrudeHumor": "NONE",
+			"sexualContentGraphicAndNudity": "NONE",
+			"sexualContentOrNudity": "NONE",
+			"seventeenPlus": false,
+			"horrorOrFearThemes": "INFREQUENT_OR_MILD",
+			"matureOrSuggestiveThemes": "NONE",
+			"unrestrictedWebAccess": false,
+			"violenceCartoonOrFantasy": "NONE",
+			"violenceRealisticProlongedGraphicOrSadistic": "NONE",
+			"violenceRealistic": "NONE"
+		},
+		"links": {
+			"self": "https://appstoreconnect.apple.com/iris/v1/ageRatingDeclarations/AGE_RATING_1"
+		}
+	},
+	"links": {
+		"self": "https://appstoreconnect.apple.com/iris/v1/ageRatingDeclarations/AGE_RATING_1"
+	}
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appInfoLocalizations/patch-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appInfoLocalizations/patch-200.json
@@ -1,0 +1,20 @@
+{
+	"data": {
+		"type": "appInfoLocalizations",
+		"id": "APP_INFO_LOCALE_1",
+		"attributes": {
+			"locale": "en-US",
+			"name": "Rexpo Square App",
+			"subtitle": "144 fps red squares",
+			"privacyPolicyUrl": "https://github.com/bycedric/red-square-app",
+			"privacyChoicesUrl": null,
+			"privacyPolicyText": null
+		},
+		"links": {
+			"self": "https://appstoreconnect.apple.com/iris/v1/appInfoLocalizations/APP_INFO_LOCALE_1"
+		}
+	},
+	"links": {
+		"self": "https://appstoreconnect.apple.com/iris/v1/appInfoLocalizations/APP_INFO_LOCALE_1"
+	}
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appInfos/get-appInfoLocalizations-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appInfos/get-appInfoLocalizations-200.json
@@ -1,0 +1,43 @@
+{
+	"data": [
+		{
+			"type": "appInfoLocalizations",
+			"id": "APP_INFO_LOCALE_1",
+			"attributes": {
+				"locale": "en-US",
+				"name": "Rexpo Square App",
+				"subtitle": "144 fps red squares",
+				"privacyPolicyUrl": "https://github.com/bycedric/red-square-app",
+				"privacyChoicesUrl": null,
+				"privacyPolicyText": null
+			},
+			"links": {
+				"self": "https://appstoreconnect.apple.com/iris/v1/appInfoLocalizations/APP_INFO_LOCALE_1"
+			}
+		},
+		{
+			"type": "appInfoLocalizations",
+			"id": "APP_INFO_LOCALE_2",
+			"attributes": {
+				"locale": "nl-NL",
+				"name": "Rexpo Vierkant App",
+				"subtitle": "144 fps red vierkant",
+				"privacyPolicyUrl": "https://github.com/bycedric/red-square-app",
+				"privacyChoicesUrl": null,
+				"privacyPolicyText": null
+			},
+			"links": {
+				"self": "https://appstoreconnect.apple.com/iris/v1/appInfoLocalizations/APP_INFO_LOCALE_2"
+			}
+		}
+	],
+	"links": {
+		"self": "https://appstoreconnect.apple.com/iris/v1/appInfos/a9c2ad6a-182f-4021-9456-6b609ebc5eab/appInfoLocalizations"
+	},
+	"meta": {
+		"paging": {
+			"total": 2,
+			"limit": 50
+		}
+	}
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appInfos/patch-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appInfos/patch-200.json
@@ -1,0 +1,68 @@
+{
+  "data": {
+    "type": "appInfos",
+    "id": "APP_INFO_1",
+    "attributes": {
+      "appStoreState": "PREPARE_FOR_SUBMISSION",
+      "appStoreAgeRating": "NINE_PLUS",
+      "brazilAgeRating": "TEN",
+      "kidsAgeBand": null
+    },
+    "relationships": {
+      "ageRatingDeclaration": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/ageRatingDeclaration",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/ageRatingDeclaration"
+        }
+      },
+      "appInfoLocalizations": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/appInfoLocalizations",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/appInfoLocalizations"
+        }
+      },
+      "primaryCategory": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/primaryCategory",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/primaryCategory"
+        }
+      },
+      "primarySubcategoryOne": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/primarySubcategoryOne",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/primarySubcategoryOne"
+        }
+      },
+      "primarySubcategoryTwo": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/primarySubcategoryTwo",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/primarySubcategoryTwo"
+        }
+      },
+      "secondaryCategory": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/secondaryCategory",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/secondaryCategory"
+        }
+      },
+      "secondarySubcategoryOne": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/secondarySubcategoryOne",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/secondarySubcategoryOne"
+        }
+      },
+      "secondarySubcategoryTwo": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/secondarySubcategoryTwo",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/secondarySubcategoryTwo"
+        }
+      }
+    },
+    "links": {
+      "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1"
+    }
+  },
+  "links": {
+    "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1"
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-ageRatingDeclaration-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-ageRatingDeclaration-200.json
@@ -1,0 +1,31 @@
+{
+	"data": {
+		"type": "ageRatingDeclarations",
+		"id": "a9c2ad6a-182f-4021-9456-6b609ebc5eab",
+		"attributes": {
+			"alcoholTobaccoOrDrugUseOrReferences": "NONE",
+			"contests": "NONE",
+			"gamblingAndContests": false,
+			"gambling": false,
+			"gamblingSimulated": "NONE",
+			"kidsAgeBand": null,
+			"medicalOrTreatmentInformation": "NONE",
+			"profanityOrCrudeHumor": "NONE",
+			"sexualContentGraphicAndNudity": "NONE",
+			"sexualContentOrNudity": "NONE",
+			"seventeenPlus": false,
+			"horrorOrFearThemes": "NONE",
+			"matureOrSuggestiveThemes": "NONE",
+			"unrestrictedWebAccess": false,
+			"violenceCartoonOrFantasy": "NONE",
+			"violenceRealisticProlongedGraphicOrSadistic": "NONE",
+			"violenceRealistic": "NONE"
+		},
+		"links": {
+			"self": "https://appstoreconnect.apple.com/iris/v1/ageRatingDeclarations/a9c2ad6a-182f-4021-9456-6b609ebc5eab"
+		}
+	},
+	"links": {
+		"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/949768f6-58e5-46b4-b046-23861f61831a/ageRatingDeclaration"
+	}
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-ageRatingDeclaration-404.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-ageRatingDeclaration-404.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "id": "9901eeb2-81e7-4562-9beb-c5f72010ab71",
+      "status": "404",
+      "code": "NOT_FOUND",
+      "title": "The specified resource does not exist",
+      "detail": "There is no resource of type 'appStoreVersions' with id 'non-existing'"
+    }
+  ]
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-appStoreVersionLocalizations-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-appStoreVersionLocalizations-200.json
@@ -1,0 +1,70 @@
+{
+	"data": [{
+		"type": "appStoreVersionLocalizations",
+		"id": "4bad54bc-3810-401a-a7f4-b02ef8206c41",
+		"attributes": {
+			"description": "Some of the best apps",
+			"locale": "nl-NL",
+			"keywords": "meme, red, square, x2",
+			"marketingUrl": "https://github.com/bycedric/red-square-app",
+			"promotionalText": null,
+			"supportUrl": "https://github.com/bycedric/red-square-app/issues",
+			"whatsNew": null
+		},
+		"relationships": {
+			"appScreenshotSets": {
+				"links": {
+					"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersionLocalizations/4bad54bc-3810-401a-a7f4-b02ef8206c41/relationships/appScreenshotSets",
+					"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersionLocalizations/4bad54bc-3810-401a-a7f4-b02ef8206c41/appScreenshotSets"
+				}
+			},
+			"appPreviewSets": {
+				"links": {
+					"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersionLocalizations/4bad54bc-3810-401a-a7f4-b02ef8206c41/relationships/appPreviewSets",
+					"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersionLocalizations/4bad54bc-3810-401a-a7f4-b02ef8206c41/appPreviewSets"
+				}
+			}
+		},
+		"links": {
+			"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersionLocalizations/4bad54bc-3810-401a-a7f4-b02ef8206c41"
+		}
+	}, {
+		"type": "appStoreVersionLocalizations",
+		"id": "61153520-c5df-40a1-bb2b-e09cbfc33fe9",
+		"attributes": {
+			"description": "Some of the best apps",
+			"locale": "en-US",
+			"keywords": "meme, red, square, x2",
+			"marketingUrl": "https://github.com/bycedric/red-square-app",
+			"promotionalText": null,
+			"supportUrl": "https://github.com/bycedric/red-square-app/issues",
+			"whatsNew": null
+		},
+		"relationships": {
+			"appScreenshotSets": {
+				"links": {
+					"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersionLocalizations/61153520-c5df-40a1-bb2b-e09cbfc33fe9/relationships/appScreenshotSets",
+					"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersionLocalizations/61153520-c5df-40a1-bb2b-e09cbfc33fe9/appScreenshotSets"
+				}
+			},
+			"appPreviewSets": {
+				"links": {
+					"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersionLocalizations/61153520-c5df-40a1-bb2b-e09cbfc33fe9/relationships/appPreviewSets",
+					"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersionLocalizations/61153520-c5df-40a1-bb2b-e09cbfc33fe9/appPreviewSets"
+				}
+			}
+		},
+		"links": {
+			"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersionLocalizations/61153520-c5df-40a1-bb2b-e09cbfc33fe9"
+		}
+	}],
+	"links": {
+		"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/949768f6-58e5-46b4-b046-23861f61831a/appStoreVersionLocalizations"
+	},
+	"meta": {
+		"paging": {
+			"total": 2,
+			"limit": 50
+		}
+	}
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appInfos-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appInfos-200.json
@@ -1,0 +1,115 @@
+{
+  "data": [
+    {
+      "type": "appInfos",
+      "id": "APP_INFO_1",
+      "attributes": {
+        "appStoreState": "PREPARE_FOR_SUBMISSION",
+        "appStoreAgeRating": "NINE_PLUS",
+        "brazilAgeRating": "TEN",
+        "kidsAgeBand": null
+      },
+      "relationships": {
+        "ageRatingDeclaration": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/ageRatingDeclaration",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/ageRatingDeclaration"
+          }
+        },
+        "appInfoLocalizations": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/appInfoLocalizations",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/appInfoLocalizations"
+          }
+        },
+        "primaryCategory": {
+          "data": {
+            "type": "appCategories",
+            "id": "ENTERTAINMENT"
+          },
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/primaryCategory",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/primaryCategory"
+          }
+        },
+        "primarySubcategoryOne": {
+          "data": null,
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/primarySubcategoryOne",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/primarySubcategoryOne"
+          }
+        },
+        "primarySubcategoryTwo": {
+          "data": null,
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/primarySubcategoryTwo",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/primarySubcategoryTwo"
+          }
+        },
+        "secondaryCategory": {
+          "data": null,
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/secondaryCategory",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/secondaryCategory"
+          }
+        },
+        "secondarySubcategoryOne": {
+          "data": null,
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/secondarySubcategoryOne",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/secondarySubcategoryOne"
+          }
+        },
+        "secondarySubcategoryTwo": {
+          "data": null,
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/relationships/secondarySubcategoryTwo",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1/secondarySubcategoryTwo"
+          }
+        }
+      },
+      "links": {
+        "self": "https://appstoreconnect.apple.com/iris/v1/appInfos/APP_INFO_1"
+      }
+    }
+  ],
+  "included": [
+    {
+      "type": "appCategories",
+      "id": "ENTERTAINMENT",
+      "attributes": {
+        "platforms": [
+          "IOS",
+          "MAC_OS",
+          "TV_OS"
+        ]
+      },
+      "relationships": {
+        "subcategories": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appCategories/ENTERTAINMENT/relationships/subcategories",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appCategories/ENTERTAINMENT/subcategories"
+          }
+        },
+        "parent": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appCategories/ENTERTAINMENT/relationships/parent",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appCategories/ENTERTAINMENT/parent"
+          }
+        }
+      },
+      "links": {
+        "self": "https://appstoreconnect.apple.com/iris/v1/appCategories/ENTERTAINMENT"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://appstoreconnect.apple.com/iris/v1/apps/1611050397/appInfos?include=secondaryCategory%2CprimaryCategory%2CsecondarySubcategoryOne%2CprimarySubcategoryTwo%2CsecondarySubcategoryTwo%2CprimarySubcategoryOne"
+  },
+  "meta": {
+    "paging": {
+      "total": 1,
+      "limit": 50
+    }
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appInfos-404.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appInfos-404.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "id": "APP_INFO_0",
+      "status": "404",
+      "code": "NOT_FOUND",
+      "title": "The specified resource does not exist",
+      "detail": "There is no resource of type 'appInfo' with id 'non-existing'"
+    }
+  ]
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appStoreVersions-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appStoreVersions-200.json
@@ -1,0 +1,116 @@
+{
+  "data": [
+    {
+      "type": "appStoreVersions",
+      "id": "APP_STORE_VERSION_1",
+      "attributes": {
+        "platform": "IOS",
+        "versionString": "1.0",
+        "appStoreState": "PREPARE_FOR_SUBMISSION",
+        "storeIcon": null,
+        "watchStoreIcon": null,
+        "copyright": "2022 name",
+        "releaseType": "SCHEDULED",
+        "earliestReleaseDate": "2022-03-14T17:00:00-07:00",
+        "usesIdfa": null,
+        "isWatchOnly": false,
+        "downloadable": true,
+        "createdDate": "2022-02-21T09:26:24-08:00",
+        "promotedDate": null
+      },
+      "relationships": {
+        "ageRatingDeclaration": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/ageRatingDeclaration",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/ageRatingDeclaration"
+          }
+        },
+        "appStoreVersionLocalizations": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionLocalizations",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionLocalizations"
+          }
+        },
+        "build": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/build",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/build"
+          }
+        },
+        "appStoreVersionPhasedRelease": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionPhasedRelease",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionPhasedRelease"
+          }
+        },
+        "gameCenterConfiguration": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/gameCenterConfiguration",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/gameCenterConfiguration"
+          }
+        },
+        "routingAppCoverage": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/routingAppCoverage",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/routingAppCoverage"
+          }
+        },
+        "appStoreReviewDetail": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreReviewDetail",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreReviewDetail"
+          }
+        },
+        "appStoreVersionSubmission": {
+          "data": null,
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionSubmission",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionSubmission"
+          }
+        },
+        "resetRatingsRequest": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/resetRatingsRequest",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/resetRatingsRequest"
+          }
+        },
+        "idfaDeclaration": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/idfaDeclaration",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/idfaDeclaration"
+          }
+        },
+        "appClipDefaultExperience": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appClipDefaultExperience",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appClipDefaultExperience"
+          }
+        },
+        "appStoreVersionStateChanges": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionStateChanges",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionStateChanges"
+          }
+        },
+        "appStoreVersionExperiments": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionExperiments",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionExperiments"
+          }
+        }
+      },
+      "links": {
+        "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://appstoreconnect.apple.com/iris/v1/apps/1611050397/appStoreVersions?include=appStoreVersionSubmission&filter%5Bplatform%5D=IOS&filter%5BappStoreState%5D=DEVELOPER_REJECTED%2CINVALID_BINARY%2CMETADATA_REJECTED%2CPREPARE_FOR_SUBMISSION%2CREJECTED%2CWAITING_FOR_REVIEW"
+  },
+  "meta": {
+    "paging": {
+      "total": 1,
+      "limit": 50
+    }
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appStoreVersions-count-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appStoreVersions-count-200.json
@@ -1,0 +1,116 @@
+{
+	"data": [
+		{
+			"type": "appStoreVersions",
+			"id": "APP_STORE_VERSION_1",
+			"attributes": {
+				"platform": "IOS",
+				"versionString": "1.0",
+				"appStoreState": "PREPARE_FOR_SUBMISSION",
+				"storeIcon": null,
+				"watchStoreIcon": null,
+				"copyright": "2022 name",
+				"releaseType": "SCHEDULED",
+				"earliestReleaseDate": "2022-03-14T17:00:00-07:00",
+				"usesIdfa": null,
+				"isWatchOnly": false,
+				"downloadable": true,
+				"createdDate": "2022-02-21T09:26:24-08:00",
+				"promotedDate": null
+			},
+			"relationships": {
+				"ageRatingDeclaration": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/ageRatingDeclaration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/ageRatingDeclaration"
+					}
+				},
+				"appStoreVersionLocalizations": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionLocalizations",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionLocalizations"
+					}
+				},
+				"build": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/build",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/build"
+					}
+				},
+				"appStoreVersionPhasedRelease": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionPhasedRelease",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionPhasedRelease"
+					}
+				},
+				"gameCenterConfiguration": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/gameCenterConfiguration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/gameCenterConfiguration"
+					}
+				},
+				"routingAppCoverage": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/routingAppCoverage",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/routingAppCoverage"
+					}
+				},
+				"appStoreReviewDetail": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreReviewDetail",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreReviewDetail"
+					}
+				},
+				"appStoreVersionSubmission": {
+					"data": null,
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionSubmission",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionSubmission"
+					}
+				},
+				"resetRatingsRequest": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/resetRatingsRequest",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/resetRatingsRequest"
+					}
+				},
+				"idfaDeclaration": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/idfaDeclaration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/idfaDeclaration"
+					}
+				},
+				"appClipDefaultExperience": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appClipDefaultExperience",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appClipDefaultExperience"
+					}
+				},
+				"appStoreVersionStateChanges": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionStateChanges",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionStateChanges"
+					}
+				},
+				"appStoreVersionExperiments": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionExperiments",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionExperiments"
+					}
+				}
+			},
+			"links": {
+				"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1"
+			}
+		}
+	],
+	"links": {
+		"self": "https://appstoreconnect.apple.com/iris/v1/apps/1611050397/appStoreVersions?include=appStoreVersionSubmission&filter%5Bplatform%5D=IOS&limit=2"
+	},
+	"meta": {
+		"paging": {
+			"total": 1,
+			"limit": 2
+		}
+	}
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appStoreVersions-count-multiple-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appStoreVersions-count-multiple-200.json
@@ -1,0 +1,219 @@
+{
+	"data": [
+		{
+			"type": "appStoreVersions",
+			"id": "APP_STORE_VERSION_1",
+			"attributes": {
+				"platform": "IOS",
+				"versionString": "1.0",
+				"appStoreState": "PREPARE_FOR_SUBMISSION",
+				"storeIcon": null,
+				"watchStoreIcon": null,
+				"copyright": "2022 name",
+				"releaseType": "SCHEDULED",
+				"earliestReleaseDate": "2022-03-14T17:00:00-07:00",
+				"usesIdfa": null,
+				"isWatchOnly": false,
+				"downloadable": true,
+				"createdDate": "2022-02-21T09:26:24-08:00",
+				"promotedDate": null
+			},
+			"relationships": {
+				"ageRatingDeclaration": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/ageRatingDeclaration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/ageRatingDeclaration"
+					}
+				},
+				"appStoreVersionLocalizations": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionLocalizations",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionLocalizations"
+					}
+				},
+				"build": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/build",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/build"
+					}
+				},
+				"appStoreVersionPhasedRelease": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionPhasedRelease",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionPhasedRelease"
+					}
+				},
+				"gameCenterConfiguration": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/gameCenterConfiguration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/gameCenterConfiguration"
+					}
+				},
+				"routingAppCoverage": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/routingAppCoverage",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/routingAppCoverage"
+					}
+				},
+				"appStoreReviewDetail": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreReviewDetail",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreReviewDetail"
+					}
+				},
+				"appStoreVersionSubmission": {
+					"data": null,
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionSubmission",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionSubmission"
+					}
+				},
+				"resetRatingsRequest": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/resetRatingsRequest",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/resetRatingsRequest"
+					}
+				},
+				"idfaDeclaration": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/idfaDeclaration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/idfaDeclaration"
+					}
+				},
+				"appClipDefaultExperience": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appClipDefaultExperience",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appClipDefaultExperience"
+					}
+				},
+				"appStoreVersionStateChanges": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionStateChanges",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionStateChanges"
+					}
+				},
+				"appStoreVersionExperiments": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/relationships/appStoreVersionExperiments",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreVersionExperiments"
+					}
+				}
+			},
+			"links": {
+				"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1"
+			}
+		},
+		{
+			"type": "appStoreVersions",
+			"id": "APP-STORE-VERSION-2",
+			"attributes": {
+				"platform": "IOS",
+				"versionString": "1.1",
+				"appStoreState": "PREPARE_FOR_SUBMISSION",
+				"storeIcon": null,
+				"watchStoreIcon": null,
+				"copyright": "2022 name",
+				"releaseType": "SCHEDULED",
+				"earliestReleaseDate": "2022-03-14T17:00:00-07:00",
+				"usesIdfa": null,
+				"isWatchOnly": false,
+				"downloadable": true,
+				"createdDate": "2022-02-21T09:26:24-08:00",
+				"promotedDate": null
+			},
+			"relationships": {
+				"ageRatingDeclaration": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/ageRatingDeclaration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/ageRatingDeclaration"
+					}
+				},
+				"appStoreVersionLocalizations": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreVersionLocalizations",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreVersionLocalizations"
+					}
+				},
+				"build": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/build",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/build"
+					}
+				},
+				"appStoreVersionPhasedRelease": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreVersionPhasedRelease",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreVersionPhasedRelease"
+					}
+				},
+				"gameCenterConfiguration": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/gameCenterConfiguration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/gameCenterConfiguration"
+					}
+				},
+				"routingAppCoverage": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/routingAppCoverage",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/routingAppCoverage"
+					}
+				},
+				"appStoreReviewDetail": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreReviewDetail",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreReviewDetail"
+					}
+				},
+				"appStoreVersionSubmission": {
+					"data": null,
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreVersionSubmission",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreVersionSubmission"
+					}
+				},
+				"resetRatingsRequest": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/resetRatingsRequest",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/resetRatingsRequest"
+					}
+				},
+				"idfaDeclaration": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/idfaDeclaration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/idfaDeclaration"
+					}
+				},
+				"appClipDefaultExperience": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appClipDefaultExperience",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appClipDefaultExperience"
+					}
+				},
+				"appStoreVersionStateChanges": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreVersionStateChanges",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreVersionStateChanges"
+					}
+				},
+				"appStoreVersionExperiments": {
+					"links": {
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreVersionExperiments",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreVersionExperiments"
+					}
+				}
+			},
+			"links": {
+				"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2"
+			}
+		}
+	],
+	"links": {
+		"self": "https://appstoreconnect.apple.com/iris/v1/apps/1611050397/appStoreVersions?include=appStoreVersionSubmission&filter%5Bplatform%5D=IOS&limit=2"
+	},
+	"meta": {
+		"paging": {
+			"total": 1,
+			"limit": 2
+		}
+	}
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/requestContext.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/requestContext.ts
@@ -1,0 +1,6 @@
+/** A stubbed request context for the ASC API library */
+export const requestContext = {
+  providerId: 1337,
+  teamId: 'test-team-id',
+  token: 'test-token',
+};

--- a/packages/eas-cli/src/metadata/apple/tasks/age-rating.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/age-rating.ts
@@ -1,0 +1,42 @@
+import { AgeRatingDeclaration } from '@expo/apple-utils';
+import assert from 'assert';
+import chalk from 'chalk';
+
+import Log from '../../../log';
+import { logAsync } from '../../utils/log';
+import { AppleTask, TaskDownloadOptions, TaskPrepareOptions, TaskUploadOptions } from '../task';
+
+export type AgeRatingData = {
+  /** The app age rating declaration for the app version */
+  ageRating: AgeRatingDeclaration;
+};
+
+export class AgeRatingTask extends AppleTask {
+  name = (): string => 'age rating declarations';
+
+  async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
+    assert(context.version, `App version information is not prepared, can't update age rating`);
+    context.ageRating = (await context.version.getAgeRatingDeclarationAsync()) || undefined;
+  }
+
+  async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
+    if (context.ageRating) {
+      config.setAgeRating(context.ageRating.attributes);
+    }
+  }
+
+  async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
+    assert(context.ageRating, `Age rating not initialized, can't update age rating`);
+
+    const ageRating = config.getAgeRating();
+    if (!ageRating) {
+      Log.log(chalk`{dim - Skipped age rating update, no advisory configured}`);
+    } else {
+      context.ageRating = await logAsync(() => context.ageRating.updateAsync(ageRating), {
+        pending: 'Updating age rating declaration...',
+        success: 'Updated age rating declaration',
+        failure: 'Failed to update age rating declaration',
+      });
+    }
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
@@ -1,0 +1,88 @@
+import { AppInfo, AppInfoLocalization } from '@expo/apple-utils';
+import assert from 'assert';
+import chalk from 'chalk';
+
+import Log from '../../../log';
+import { logAsync } from '../../utils/log';
+import { retryIfNullAsync } from '../../utils/retry';
+import { AppleTask, TaskDownloadOptions, TaskPrepareOptions, TaskUploadOptions } from '../task';
+
+export type AppInfoData = {
+  /** The current app info that should be edited */
+  info: AppInfo;
+  /** All info locales that are enabled */
+  infoLocales: AppInfoLocalization[];
+};
+
+export class AppInfoTask extends AppleTask {
+  name = (): string => 'app information';
+
+  async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
+    const info = await retryIfNullAsync(() => context.app.getEditAppInfoAsync());
+    assert(info, 'Could not resolve the editable app info to update');
+
+    context.info = info;
+    context.infoLocales = await info.getLocalizationsAsync();
+  }
+
+  async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
+    assert(context.info, `App info not initialized, can't download info`);
+
+    // TODO: see why this type mismatch occurs
+    // @ts-ignore
+    config.setCategories(context.info.attributes);
+
+    for (const locale of context.infoLocales) {
+      config.setInfoLocale(locale.attributes);
+    }
+  }
+
+  async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
+    assert(context.info, `App info not initialized, can't update info`);
+
+    const categories = config.getCategories();
+    if (!categories) {
+      Log.log(chalk`{dim - Skipped app category update, not configured}`);
+    } else {
+      context.info = await logAsync(() => context.info.updateCategoriesAsync(categories), {
+        pending: 'Updating app categories...',
+        success: 'Updated app categories',
+        failure: 'Failed updating app categories',
+      });
+    }
+
+    const locales = config.getLocales();
+    if (locales.length <= 0) {
+      Log.log(chalk`{dim - Skipped localized info update, no locales configured}`);
+    } else {
+      // BUG: new issue introduced in ASC 1.8.0, when creating version locales, info locales are also generated
+      context.infoLocales = await logAsync(() => context.info.getLocalizationsAsync(), {
+        pending: 'Reloading localized info...',
+        success: 'Reloaded localized info',
+        failure: 'Failed reloading localized info',
+      });
+
+      for (const locale of locales) {
+        const attributes = config.getInfoLocale(locale);
+        if (!attributes) {
+          continue;
+        }
+
+        const model = context.infoLocales.find(model => model.attributes.locale === locale);
+        await logAsync(
+          () =>
+            model
+              ? model.updateAsync(attributes)
+              : context.info.createLocalizationAsync({ ...attributes, locale }),
+          {
+            pending: `${model ? 'Updating' : 'Creating'} localized info for ${locale}...`,
+            success: `${model ? 'Updated' : 'Created'} localized info for ${locale}`,
+            failure: `Failed ${model ? 'updating' : 'creating'} localized info for ${locale}`,
+          }
+        );
+      }
+
+      context.infoLocales = await context.info.getLocalizationsAsync();
+    }
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
@@ -28,8 +28,6 @@ export class AppInfoTask extends AppleTask {
   async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
     assert(context.info, `App info not initialized, can't download info`);
 
-    // TODO: see why this type mismatch occurs
-    // @ts-expect-error
     config.setCategories(context.info.attributes);
 
     for (const locale of context.infoLocales) {

--- a/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
@@ -29,7 +29,7 @@ export class AppInfoTask extends AppleTask {
     assert(context.info, `App info not initialized, can't download info`);
 
     // TODO: see why this type mismatch occurs
-    // @ts-ignore
+    // @ts-expect-error
     config.setCategories(context.info.attributes);
 
     for (const locale of context.infoLocales) {

--- a/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
@@ -1,0 +1,150 @@
+import { App, AppStoreVersion, AppStoreVersionLocalization, Platform } from '@expo/apple-utils';
+import assert from 'assert';
+import chalk from 'chalk';
+
+import Log from '../../../log';
+import { logAsync } from '../../utils/log';
+import { retryIfNullAsync } from '../../utils/retry';
+import { AppleTask, TaskDownloadOptions, TaskPrepareOptions, TaskUploadOptions } from '../task';
+
+export type AppVersionOptions = {
+  /** If we should use the live version of the app (if available - defaults to false) */
+  editLive: boolean;
+  /** The platform to use (defaults to IOS) */
+  platform: Platform;
+};
+
+export type AppVersionData = {
+  /** The current selected app store version to update */
+  version: AppStoreVersion;
+  /** If the current selected version is a live version, where not all properties are editable */
+  versionIsLive: boolean;
+  /** If the current selected version is the first version to be created */
+  versionIsFirst: boolean;
+  /** All version locales that should be, or are enabled */
+  versionLocales: AppStoreVersionLocalization[];
+};
+
+export class AppVersionTask extends AppleTask {
+  private options: AppVersionOptions;
+
+  constructor(options: Partial<AppVersionOptions> = {}) {
+    super();
+    this.options = {
+      platform: options.platform || Platform.IOS,
+      editLive: options.editLive || false,
+    };
+  }
+
+  name = (): string => (this.options.editLive ? 'live app version' : 'editable app version');
+
+  async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
+    const { version, versionIsFirst, versionIsLive } = await resolveVersionAsync(
+      context.app,
+      this.options
+    );
+
+    assert(version, 'Could not resolve a live or editable app version');
+
+    context.version = version;
+    context.versionIsFirst = versionIsFirst;
+    context.versionIsLive = versionIsLive;
+    context.versionLocales = await version.getLocalizationsAsync();
+  }
+
+  async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
+    assert(context.version, `App version not initialized, can't download version`);
+
+    config.setVersion(context.version.attributes);
+    config.setVersionRelease(context.version.attributes);
+
+    for (const locale of context.versionLocales) {
+      config.setVersionLocale(locale.attributes);
+    }
+  }
+
+  async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
+    assert(context.version, `App version not initialized, can't update version`);
+
+    const version = config.getVersion();
+    const release = config.getVersionRelease();
+    if (!version && !release) {
+      Log.log(chalk`{dim - Skipped version and release update, not configured}`);
+    } else {
+      const description = [version && 'version info', release && 'release info']
+        .filter(Boolean)
+        .join(' and ');
+
+      context.version = await logAsync(
+        () => context.version.updateAsync({ ...version, ...release }),
+        {
+          pending: `Updating ${description}...`,
+          success: `Updated ${description}`,
+          failure: `Failed updating ${description}`,
+        }
+      );
+    }
+
+    const locales = config.getLocales();
+    if (locales.length <= 0) {
+      Log.log(chalk`{dim - Skipped localized version update, no locales configured}`);
+    } else {
+      for (const locale of locales) {
+        const attributes = config.getVersionLocale(locale, context);
+        if (!attributes) {
+          continue;
+        }
+
+        const oldModel = context.versionLocales.find(model => model.attributes.locale === locale);
+        await logAsync(
+          () =>
+            oldModel
+              ? oldModel.updateAsync(attributes)
+              : context.version.createLocalizationAsync({ ...attributes, locale }),
+          {
+            pending: `${oldModel ? 'Updating' : 'Creating'} localized version for ${locale}...`,
+            success: `${oldModel ? 'Updated' : 'Created'} localized version for ${locale}`,
+            failure: `Failed ${oldModel ? 'updating' : 'creating'} localized version for ${locale}`,
+          }
+        );
+      }
+
+      context.versionLocales = await context.version.getLocalizationsAsync();
+    }
+  }
+}
+
+/**
+ * Resolve the AppStoreVersion instance, either from live or editable version.
+ * This also checks if this is the first version, which disallow release notes.
+ */
+async function resolveVersionAsync(
+  app: App,
+  { editLive, platform }: AppVersionOptions
+): Promise<{
+  version: AppStoreVersion | null;
+  versionIsLive: boolean;
+  versionIsFirst: boolean;
+}> {
+  let version: AppStoreVersion | null = null;
+  let versionIsLive = false;
+
+  if (editLive) {
+    version = await app.getLiveAppStoreVersionAsync({ platform });
+    versionIsLive = !!version;
+  }
+
+  if (!version) {
+    version = await retryIfNullAsync(() => app.getEditAppStoreVersionAsync({ platform }));
+  }
+
+  const versions = await app.getAppStoreVersionsAsync({
+    query: { limit: 2, filter: { platform } },
+  });
+
+  return {
+    version,
+    versionIsLive,
+    versionIsFirst: versions.length === 1,
+  };
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/index.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/index.ts
@@ -1,0 +1,12 @@
+import { MetadataContext } from '../../context';
+import { AppleTask } from '../task';
+import { AgeRatingTask } from './age-rating';
+import { AppInfoTask } from './app-info';
+import { AppVersionTask } from './app-version';
+
+/**
+ * List of all eligible tasks to sync local store configuration to the App store.
+ */
+export function createAppleTasks(_ctx: MetadataContext): AppleTask[] {
+  return [new AppVersionTask(), new AppInfoTask(), new AgeRatingTask()];
+}

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -32,7 +32,7 @@ export type MetadataContext = {
 };
 
 export type MetadataAppStoreAuthentication = {
-  /** The root entity of the App store  */
+  /** The root entity of the App store */
   app: App;
   /** The authentication state we used to fetch the root entity */
   auth: Partial<Session.AuthState>;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

- Part of PR #1083
- [x] ~~Requires PR #1130~~
- [x] ~~Requires PR #1134~~

This adds the task-runner based entity actions to perform the download/upload actions, see Notion for more info.

# How

- Every task runner works independently from another task
- Every task can have data-dependencies that have to be asserted
- When a task fails, the other tasks should still be executed to try and send/get as much data as possible
- When the command is finished, the exit status is determined by "encountered any issue or not" and should log helpful context to the user

# Test Plan

See tests with fixtures from the ASC
