### PR TITLE
[eas-cli] Add metadata context based on submission contexts

### DIFF
--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -1,7 +1,7 @@
 import { App, Session } from '@expo/apple-utils';
 import { ExpoConfig } from '@expo/config';
 import { Platform } from '@expo/eas-build-job';
-import { IosSubmitProfile } from '@expo/eas-json/build/submit/types';
+import { SubmitProfile } from '@expo/eas-json';
 import assert from 'assert';
 
 import { CredentialsContext } from '../credentials/context';
@@ -16,7 +16,7 @@ export type MetadataContext = {
   /** Submission profile platform to use */
   platform: Platform.IOS;
   /** Resolved submission profile configuration */
-  profile: IosSubmitProfile;
+  profile: SubmitProfile<Platform.IOS>;
   /** Configured store configuration file name (defaults to store.config.json) */
   metadataFile: string;
   /** Authenticated Expo account */
@@ -65,7 +65,7 @@ export async function createMetadataContextAsync(params: {
     submissionProfile,
     'Could not resolve the iOS submission profile, only iOS is supported for metadata'
   );
-  const iosSubmissionProfile = submissionProfile.profile as IosSubmitProfile;
+  const iosSubmissionProfile = submissionProfile.profile as SubmitProfile<Platform.IOS>;
 
   const exp = params.exp ?? getExpoConfig(params.projectDir);
   const user = await ensureLoggedInAsync({ nonInteractive: params.nonInteractive });

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -86,7 +86,7 @@ export async function createMetadataContextAsync(params: {
     credentialsCtx,
     bundleIdentifier,
     projectDir: params.projectDir,
-    exp: params.exp,
+    exp,
     nonInteractive: params.nonInteractive ?? false,
   };
 }

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -23,7 +23,7 @@ export type MetadataContext = {
   user: Actor;
   /** The store credentials manager */
   credentialsCtx: CredentialsContext;
-  /** The app bundle identifier to use for the stores */
+  /** The app bundle identifier to use for the store */
   bundleIdentifier: string;
   /** Root of the Expo project directory */
   projectDir: string;

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -29,11 +29,6 @@ export type MetadataContext = {
   projectDir: string;
   /** Resolved Expo app configuration */
   exp: ExpoConfig;
-  /**
-   * If we should run in non-interactive mode, as much as we can.
-   * The store authentication requires a fully configured ASC environment, or interactive mode.
-   */
-  nonInteractive: boolean;
 };
 
 export type MetadataAppStoreAuthentication = {
@@ -52,7 +47,6 @@ export async function createMetadataContextAsync(params: {
   credentialsCtx: CredentialsContext;
   exp?: ExpoConfig;
   profileName?: string;
-  nonInteractive?: boolean;
 }): Promise<MetadataContext> {
   const submissionProfiles = await getProfilesAsync({
     type: 'submit',
@@ -69,7 +63,7 @@ export async function createMetadataContextAsync(params: {
   const iosSubmissionProfile = submissionProfile.profile as SubmitProfile<Platform.IOS>;
 
   const exp = params.exp ?? getExpoConfig(params.projectDir);
-  const user = await ensureLoggedInAsync({ nonInteractive: params.nonInteractive });
+  const user = await ensureLoggedInAsync();
   const bundleIdentifier = await getBundleIdentifierAsync(params.projectDir, exp);
 
   return {
@@ -81,7 +75,6 @@ export async function createMetadataContextAsync(params: {
     bundleIdentifier,
     projectDir: params.projectDir,
     exp,
-    nonInteractive: params.nonInteractive ?? false,
   };
 }
 

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -18,7 +18,7 @@ export type MetadataContext = {
   /** Resolved submission profile configuration */
   profile: SubmitProfile<Platform.IOS>;
   /** Configured store configuration file name (defaults to store.config.json) */
-  metadataFile: string;
+  metadataFilename: string;
   /** Authenticated Expo account */
   user: Actor;
   /** The store credentials manager */
@@ -81,7 +81,7 @@ export async function createMetadataContextAsync(params: {
   return {
     platform: Platform.IOS,
     profile: iosSubmissionProfile,
-    metadataFile: iosSubmissionProfile.meta ?? 'store.config.json',
+    metadataFilename: iosSubmissionProfile.meta ?? 'store.config.json',
     user,
     credentialsCtx,
     bundleIdentifier,

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -1,0 +1,110 @@
+import { App, Session } from '@expo/apple-utils';
+import { ExpoConfig } from '@expo/config';
+import { Platform } from '@expo/eas-build-job';
+import { IosSubmitProfile } from '@expo/eas-json/build/submit/types';
+import assert from 'assert';
+
+import { CredentialsContext } from '../credentials/context';
+import { getRequestContext } from '../credentials/ios/appstore/authenticate';
+import { getExpoConfig } from '../project/expoConfig';
+import { getBundleIdentifierAsync } from '../project/ios/bundleIdentifier';
+import { Actor } from '../user/User';
+import { ensureLoggedInAsync } from '../user/actions';
+import { getProfilesAsync } from '../utils/profiles';
+
+export type MetadataContext = {
+  /** Submission profile platform to use */
+  platform: Platform.IOS;
+  /** Submission profile name to use */
+  profile: IosSubmitProfile;
+  /** Configured store configuration file name (defaults to store.config.json) */
+  metadataFile: string;
+  /** Authenticated Expo account */
+  user: Actor;
+  /** The store credentials manager */
+  credentialsCtx: CredentialsContext;
+  /** The app bundle identifier to use for the stores */
+  bundleIdentifier: string;
+  /** Root of the Expo project directory */
+  projectDir: string;
+  /** Resolved Expo app configuration */
+  exp: ExpoConfig;
+  /**
+   * If we should run in non-interactive mode, as much as we can.
+   * The store authentication requires a fully configured ASC environment, or interactive mode.
+   */
+  nonInteractive: boolean;
+};
+
+export type MetadataAppStoreAuthentication = {
+  /** The root entity of the App store  */
+  app: App;
+  /** The authentication state we used to fetch the root entity */
+  auth: Partial<Session.AuthState>;
+};
+
+/**
+ * Metadata uses the submission profile to find the configured metadata filename.
+ * Note, only iOS is supported for metadata right now.
+ */
+export async function createMetadataContextAsync(params: {
+  projectDir: string;
+  exp: ExpoConfig;
+  profileName?: string;
+  nonInteractive?: boolean;
+}): Promise<MetadataContext> {
+  const submissionProfiles = await getProfilesAsync({
+    type: 'submit',
+    platforms: [Platform.IOS],
+    projectDir: params.projectDir,
+    profileName: params.profileName,
+  });
+
+  const submissionProfile = submissionProfiles.find(profile => profile.platform === Platform.IOS);
+  assert(
+    submissionProfile,
+    'Could not resolve the iOS submission profile, only iOS is supported for metadata'
+  );
+  const iosSubmissionProfile = submissionProfile.profile as IosSubmitProfile;
+
+  const exp = params.exp ?? getExpoConfig(params.projectDir);
+  const user = await ensureLoggedInAsync({ nonInteractive: params.nonInteractive });
+  const bundleIdentifier = await getBundleIdentifierAsync(params.projectDir, exp);
+
+  const credentialsCtx = new CredentialsContext({
+    user,
+    exp: params.exp,
+    nonInteractive: params.nonInteractive,
+    projectDir: params.projectDir,
+  });
+
+  return {
+    platform: Platform.IOS,
+    profile: iosSubmissionProfile,
+    metadataFile: iosSubmissionProfile.meta ?? 'store.config.json',
+    user,
+    credentialsCtx,
+    bundleIdentifier,
+    projectDir: params.projectDir,
+    exp: params.exp,
+    nonInteractive: params.nonInteractive ?? false,
+  };
+}
+
+/**
+ * To start syncing ASC entities, we need access to the apple utils App instance.
+ * This ensures we are authenticated and have the app instance ready to use.
+ */
+export async function ensureMetadataAppStoreAuthenticatedAsync({
+  credentialsCtx,
+  bundleIdentifier,
+}: MetadataContext): Promise<MetadataAppStoreAuthentication> {
+  const authCtx = await credentialsCtx.appStore.ensureAuthenticatedAsync();
+  assert(authCtx.authState, 'Failed to authenticate with App Store Connect');
+
+  // TODO: improve error handling by mentioning possible configuration errors
+  const app = await App.findAsync(getRequestContext(authCtx), { bundleId: bundleIdentifier });
+  assert(app, `Failed to load app "${bundleIdentifier}" from App Store Connect`);
+
+  return { app, auth: authCtx.authState };
+}

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -49,6 +49,7 @@ export type MetadataAppStoreAuthentication = {
  */
 export async function createMetadataContextAsync(params: {
   projectDir: string;
+  credentialsCtx: CredentialsContext;
   exp?: ExpoConfig;
   profileName?: string;
   nonInteractive?: boolean;
@@ -71,19 +72,12 @@ export async function createMetadataContextAsync(params: {
   const user = await ensureLoggedInAsync({ nonInteractive: params.nonInteractive });
   const bundleIdentifier = await getBundleIdentifierAsync(params.projectDir, exp);
 
-  const credentialsCtx = new CredentialsContext({
-    user,
-    exp: params.exp,
-    nonInteractive: params.nonInteractive,
-    projectDir: params.projectDir,
-  });
-
   return {
     platform: Platform.IOS,
     profile: iosSubmissionProfile,
     metadataFilename: iosSubmissionProfile.meta ?? 'store.config.json',
     user,
-    credentialsCtx,
+    credentialsCtx: params.credentialsCtx,
     bundleIdentifier,
     projectDir: params.projectDir,
     exp,

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -49,7 +49,7 @@ export type MetadataAppStoreAuthentication = {
  */
 export async function createMetadataContextAsync(params: {
   projectDir: string;
-  exp: ExpoConfig;
+  exp?: ExpoConfig;
   profileName?: string;
   nonInteractive?: boolean;
 }): Promise<MetadataContext> {

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -15,7 +15,7 @@ import { getProfilesAsync } from '../utils/profiles';
 export type MetadataContext = {
   /** Submission profile platform to use */
   platform: Platform.IOS;
-  /** Submission profile name to use */
+  /** Resolved submission profile configuration */
   profile: IosSubmitProfile;
   /** Configured store configuration file name (defaults to store.config.json) */
   metadataFile: string;

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -17,8 +17,8 @@ export type MetadataContext = {
   platform: Platform.IOS;
   /** Resolved submission profile configuration */
   profile: SubmitProfile<Platform.IOS>;
-  /** Configured store configuration file name (defaults to store.config.json) */
-  metadataFilename: string;
+  /** Configured store config path, relative from projectDir (defaults to store.config.json) */
+  metadataPath: string;
   /** Authenticated Expo account */
   user: Actor;
   /** The store credentials manager */
@@ -75,7 +75,7 @@ export async function createMetadataContextAsync(params: {
   return {
     platform: Platform.IOS,
     profile: iosSubmissionProfile,
-    metadataFilename: iosSubmissionProfile.meta ?? 'store.config.json',
+    metadataPath: iosSubmissionProfile.metadataPath ?? 'store.config.json',
     user,
     credentialsCtx: params.credentialsCtx,
     bundleIdentifier,

--- a/packages/eas-json/src/submit/schema.ts
+++ b/packages/eas-json/src/submit/schema.ts
@@ -26,6 +26,7 @@ export const IosSubmitProfileSchema = Joi.object({
   companyName: Joi.string(),
   appName: Joi.string(),
   bundleIdentifier: Joi.string(),
+  meta: Joi.string(),
 });
 
 export const SubmitProfileSchema = Joi.object({

--- a/packages/eas-json/src/submit/schema.ts
+++ b/packages/eas-json/src/submit/schema.ts
@@ -26,7 +26,7 @@ export const IosSubmitProfileSchema = Joi.object({
   companyName: Joi.string(),
   appName: Joi.string(),
   bundleIdentifier: Joi.string(),
-  meta: Joi.string(),
+  metadataPath: Joi.string(),
 });
 
 export const SubmitProfileSchema = Joi.object({

--- a/packages/eas-json/src/submit/types.ts
+++ b/packages/eas-json/src/submit/types.ts
@@ -38,6 +38,7 @@ export interface IosSubmitProfile {
   companyName?: string;
   appName?: string;
   bundleIdentifier?: string;
+  meta?: string;
 }
 
 export const IosSubmitProfileFieldsToEvaluate: (keyof IosSubmitProfile)[] = [

--- a/packages/eas-json/src/submit/types.ts
+++ b/packages/eas-json/src/submit/types.ts
@@ -38,7 +38,7 @@ export interface IosSubmitProfile {
   companyName?: string;
   appName?: string;
   bundleIdentifier?: string;
-  meta?: string;
+  metadataPath?: string;
 }
 
 export const IosSubmitProfileFieldsToEvaluate: (keyof IosSubmitProfile)[] = [


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Part of PR #1083

This adds a new context around the metadata, based on the submission contexts. It is used to initialize and authenticate the user to interact with the metadata stuff.

# How

- Metadata is configured through `eas.json`'s submission profiles, that's why we read those profiles in the context.
- If it's not configured, we assume the store configuration file.
- When the store configuration file is set in the profile, we use that to read/write the data.

# TODO

- Add the submission property `meta` with default value whenever users configure it.

# Test Plan

I need to add some tests for this, can add them later.
