### PR TITLE
[eas-cli] Add metadata commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - `eas update` now provides more information about the publish process including real-time feedback on asset uploads, update ids, and website links. ([#1152](https://github.com/expo/eas-cli/pull/1152) by [@kgc00](https://github.com/kgc00/))
+- Added first beta of `eas metadata` to sync store information using store configuration files ([#1136])(https://github.com/expo/eas-cli/pull/1136) by [@bycedric](https://github.com/bycedric))
 
 ### 🐛 Bug fixes
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,7 @@ packages/eas-cli/src/commands/build @dsokal @wkozyra95
 packages/eas-cli/src/submit @barthap @dsokal
 packages/eas-cli/src/commands/submit.ts @barthap @dsokal
 
+packages/eas-cli/src/metadata @bycedric
+packages/eas-cli/src/commands/metadata @bycedric
+
 packages/eas-json @dsokal @wkozyra95

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -143,6 +143,9 @@
       "device": {
         "description": "manage Apple devices for Internal Distribution"
       },
+      "metadata": {
+        "description": "manage store configuration"
+      },
       "project": {
         "description": "manage project"
       },

--- a/packages/eas-cli/src/commands/metadata/configure.ts
+++ b/packages/eas-cli/src/commands/metadata/configure.ts
@@ -36,8 +36,6 @@ export default class MetadataConfigure extends EasCommand {
     }),
   };
 
-  static args = [];
-
   async runAsync(): Promise<void> {
     const { flags: rawFlags } = await this.parse(MetadataConfigure);
     const flags = await this.sanitizeFlagsAsync(rawFlags);

--- a/packages/eas-cli/src/commands/metadata/configure.ts
+++ b/packages/eas-cli/src/commands/metadata/configure.ts
@@ -23,7 +23,7 @@ type CommandFlags = {
 
 export default class MetadataConfigure extends EasCommand {
   static hidden = true;
-  static description = 'upload metadata configuration to the app stores';
+  static description = 'configure the store configuration file in your project';
 
   static flags = {
     platform: Flags.enum({

--- a/packages/eas-cli/src/commands/metadata/configure.ts
+++ b/packages/eas-cli/src/commands/metadata/configure.ts
@@ -1,0 +1,86 @@
+import { getConfig } from '@expo/config';
+import { Errors, Flags } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import Log, { learnMore } from '../../log';
+import { createMetadataContextAsync } from '../../metadata/context';
+import { downloadMetadataAsync } from '../../metadata/download';
+import { handleMetadataError } from '../../metadata/errors';
+import { RequestedPlatform } from '../../platform';
+import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
+
+type RawCommandFlags = {
+  platform?: string;
+  profile?: string;
+  'non-interactive': boolean;
+};
+
+type CommandFlags = {
+  requestedPlatforms: RequestedPlatform;
+  profile?: string;
+  nonInteractive: boolean;
+};
+
+export default class MetadataConfigure extends EasCommand {
+  static description = 'upload metadata configuration to the app stores';
+
+  static flags = {
+    platform: Flags.enum({
+      char: 'p',
+      options: ['ios'],
+    }),
+    profile: Flags.string({
+      description:
+        'Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.',
+    }),
+    'non-interactive': Flags.boolean({
+      default: false,
+      description: 'Run command in non-interactive mode',
+    }),
+  };
+
+  static args = [];
+
+  async runAsync(): Promise<void> {
+    const { flags: rawFlags } = await this.parse(MetadataConfigure);
+    const flags = await this.sanitizeFlagsAsync(rawFlags);
+
+    const projectDir = await findProjectRootAsync();
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    await getProjectIdAsync(exp);
+
+    const metadataContext = await createMetadataContextAsync({
+      projectDir,
+      exp,
+      profileName: flags.profile,
+      nonInteractive: flags.nonInteractive,
+    });
+
+    try {
+      Log.addNewLineIfNone();
+      const filePath = await downloadMetadataAsync(metadataContext);
+      Log.addNewLineIfNone();
+
+      Log.succeed('Your store configuration has been generated!');
+      Log.log(filePath);
+      Log.log(learnMore('https://docs.expo.dev/eas-metadata/introduction/'));
+    } catch (error: any) {
+      handleMetadataError(error);
+    }
+  }
+
+  private async sanitizeFlagsAsync(flags: RawCommandFlags): Promise<CommandFlags> {
+    const { platform, profile, 'non-interactive': nonInteractive } = flags;
+
+    if (!platform && nonInteractive) {
+      Errors.error('--platform is required when building in non-interactive mode', { exit: 1 });
+    }
+
+    return {
+      // TODO: add support for multiple platforms, right now we only support ios
+      requestedPlatforms: RequestedPlatform.Ios, // enforced by the flag options
+      profile,
+      nonInteractive,
+    };
+  }
+}

--- a/packages/eas-cli/src/commands/metadata/configure.ts
+++ b/packages/eas-cli/src/commands/metadata/configure.ts
@@ -22,6 +22,7 @@ type CommandFlags = {
 };
 
 export default class MetadataConfigure extends EasCommand {
+  static hidden = true;
   static description = 'upload metadata configuration to the app stores';
 
   static flags = {

--- a/packages/eas-cli/src/commands/metadata/configure.ts
+++ b/packages/eas-cli/src/commands/metadata/configure.ts
@@ -1,5 +1,5 @@
 import { getConfig } from '@expo/config';
-import { Errors, Flags } from '@oclif/core';
+import { Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import Log, { learnMore } from '../../log';
@@ -12,13 +12,11 @@ import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUt
 type RawCommandFlags = {
   platform?: string;
   profile?: string;
-  'non-interactive': boolean;
 };
 
 type CommandFlags = {
   requestedPlatforms: RequestedPlatform;
   profile?: string;
-  nonInteractive: boolean;
 };
 
 export default class MetadataConfigure extends EasCommand {
@@ -33,10 +31,6 @@ export default class MetadataConfigure extends EasCommand {
     profile: Flags.string({
       description:
         'Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.',
-    }),
-    'non-interactive': Flags.boolean({
-      default: false,
-      description: 'Run command in non-interactive mode',
     }),
   };
 
@@ -54,7 +48,6 @@ export default class MetadataConfigure extends EasCommand {
       projectDir,
       exp,
       profileName: flags.profile,
-      nonInteractive: flags.nonInteractive,
     });
 
     try {
@@ -71,17 +64,12 @@ export default class MetadataConfigure extends EasCommand {
   }
 
   private async sanitizeFlagsAsync(flags: RawCommandFlags): Promise<CommandFlags> {
-    const { platform, profile, 'non-interactive': nonInteractive } = flags;
-
-    if (!platform && nonInteractive) {
-      Errors.error('--platform is required when building in non-interactive mode', { exit: 1 });
-    }
+    const { profile } = flags;
 
     return {
       // TODO: add support for multiple platforms, right now we only support ios
       requestedPlatforms: RequestedPlatform.Ios, // enforced by the flag options
       profile,
-      nonInteractive,
     };
   }
 }

--- a/packages/eas-cli/src/commands/metadata/index.ts
+++ b/packages/eas-cli/src/commands/metadata/index.ts
@@ -34,10 +34,6 @@ export default class Metadata extends EasCommand {
       description:
         'Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.',
     }),
-    'non-interactive': Flags.boolean({
-      default: false,
-      description: 'Run command in non-interactive mode',
-    }),
   };
 
   static args = [];

--- a/packages/eas-cli/src/commands/metadata/index.ts
+++ b/packages/eas-cli/src/commands/metadata/index.ts
@@ -12,13 +12,11 @@ import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUt
 type RawCommandFlags = {
   platform?: string;
   profile?: string;
-  'non-interactive': boolean;
 };
 
 type CommandFlags = {
   requestedPlatforms: RequestedPlatform;
   profile?: string;
-  nonInteractive: boolean;
 };
 
 export default class Metadata extends EasCommand {
@@ -54,7 +52,6 @@ export default class Metadata extends EasCommand {
       projectDir,
       exp,
       profileName: flags.profile,
-      nonInteractive: flags.nonInteractive,
     });
 
     try {
@@ -68,17 +65,12 @@ export default class Metadata extends EasCommand {
   }
 
   private async sanitizeFlagsAsync(flags: RawCommandFlags): Promise<CommandFlags> {
-    const { platform, profile, 'non-interactive': nonInteractive } = flags;
-
-    if (!platform && nonInteractive) {
-      Errors.error('--platform is required when building in non-interactive mode', { exit: 1 });
-    }
+    const { profile } = flags;
 
     return {
       // TODO: add support for multiple platforms, right now we only support ios
       requestedPlatforms: RequestedPlatform.Ios, // enforced by the flag options
       profile,
-      nonInteractive,
     };
   }
 }

--- a/packages/eas-cli/src/commands/metadata/index.ts
+++ b/packages/eas-cli/src/commands/metadata/index.ts
@@ -1,0 +1,83 @@
+import { getConfig } from '@expo/config';
+import { Errors, Flags } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import Log from '../../log';
+import { createMetadataContextAsync } from '../../metadata/context';
+import { handleMetadataError } from '../../metadata/errors';
+import { uploadMetadataAsync } from '../../metadata/upload';
+import { RequestedPlatform } from '../../platform';
+import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
+
+type RawCommandFlags = {
+  platform?: string;
+  profile?: string;
+  'non-interactive': boolean;
+};
+
+type CommandFlags = {
+  requestedPlatforms: RequestedPlatform;
+  profile?: string;
+  nonInteractive: boolean;
+};
+
+export default class Metadata extends EasCommand {
+  static description = 'upload metadata configuration to the app stores';
+
+  static flags = {
+    platform: Flags.enum({
+      char: 'p',
+      options: ['ios'],
+    }),
+    profile: Flags.string({
+      description:
+        'Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.',
+    }),
+    'non-interactive': Flags.boolean({
+      default: false,
+      description: 'Run command in non-interactive mode',
+    }),
+  };
+
+  static args = [];
+
+  async runAsync(): Promise<void> {
+    const { flags: rawFlags } = await this.parse(Metadata);
+    const flags = await this.sanitizeFlagsAsync(rawFlags);
+
+    const projectDir = await findProjectRootAsync();
+    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    await getProjectIdAsync(exp);
+
+    const metadataContext = await createMetadataContextAsync({
+      projectDir,
+      exp,
+      profileName: flags.profile,
+      nonInteractive: flags.nonInteractive,
+    });
+
+    try {
+      Log.addNewLineIfNone();
+      await uploadMetadataAsync(metadataContext);
+      Log.addNewLineIfNone();
+      Log.succeed(`Store has been updated with your ${metadataContext.metadataFile} configuration`);
+    } catch (error: any) {
+      handleMetadataError(error);
+    }
+  }
+
+  private async sanitizeFlagsAsync(flags: RawCommandFlags): Promise<CommandFlags> {
+    const { platform, profile, 'non-interactive': nonInteractive } = flags;
+
+    if (!platform && nonInteractive) {
+      Errors.error('--platform is required when building in non-interactive mode', { exit: 1 });
+    }
+
+    return {
+      // TODO: add support for multiple platforms, right now we only support ios
+      requestedPlatforms: RequestedPlatform.Ios, // enforced by the flag options
+      profile,
+      nonInteractive,
+    };
+  }
+}

--- a/packages/eas-cli/src/commands/metadata/index.ts
+++ b/packages/eas-cli/src/commands/metadata/index.ts
@@ -22,6 +22,7 @@ type CommandFlags = {
 };
 
 export default class Metadata extends EasCommand {
+  static hidden = true;
   static description = 'upload metadata configuration to the app stores';
 
   static flags = {

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -7,29 +7,14 @@ import Log, { learnMore } from '../../log';
 import { createMetadataContextAsync } from '../../metadata/context';
 import { downloadMetadataAsync } from '../../metadata/download';
 import { handleMetadataError } from '../../metadata/errors';
-import { RequestedPlatform } from '../../platform';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
-
-type RawCommandFlags = {
-  platform?: string;
-  profile?: string;
-};
-
-type CommandFlags = {
-  requestedPlatforms: RequestedPlatform;
-  profile?: string;
-};
 
 export default class MetadataPull extends EasCommand {
   static hidden = true;
   static description = 'configure the store configuration file in your project';
 
   static flags = {
-    platform: Flags.enum({
-      char: 'p',
-      options: ['ios'],
-    }),
     profile: Flags.string({
       description:
         'Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.',
@@ -37,9 +22,7 @@ export default class MetadataPull extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    const { flags: rawFlags } = await this.parse(MetadataPull);
-    const flags = await this.sanitizeFlagsAsync(rawFlags);
-
+    const { flags } = await this.parse(MetadataPull);
     const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     await getProjectIdAsync(exp);
@@ -69,15 +52,5 @@ export default class MetadataPull extends EasCommand {
     } catch (error: any) {
       handleMetadataError(error);
     }
-  }
-
-  private async sanitizeFlagsAsync(flags: RawCommandFlags): Promise<CommandFlags> {
-    const { profile } = flags;
-
-    return {
-      // TODO: add support for multiple platforms, right now we only support ios
-      requestedPlatforms: RequestedPlatform.Ios, // enforced by the flag options
-      profile,
-    };
   }
 }

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -25,6 +25,8 @@ export default class MetadataPull extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
+    Log.warn('EAS Metadata is in beta and subject to breaking changes.');
+
     const { flags } = await this.parse(MetadataPull);
     const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -12,7 +12,7 @@ import { ensureLoggedInAsync } from '../../user/actions';
 
 export default class MetadataPull extends EasCommand {
   static hidden = true;
-  static description = 'configure the store configuration file in your project';
+  static description = 'generate the local store configuration from the app stores';
 
   static flags = {
     profile: Flags.string({

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -14,7 +14,6 @@ import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUt
 import { ensureLoggedInAsync } from '../../user/actions';
 
 export default class MetadataPull extends EasCommand {
-  static hidden = true;
   static description = 'generate the local store configuration from the app stores';
 
   static flags = {

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -1,5 +1,7 @@
 import { getConfig } from '@expo/config';
 import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+import path from 'path';
 
 import { ensureProjectConfiguredAsync } from '../../build/configure';
 import EasCommand from '../../commandUtils/EasCommand';
@@ -44,13 +46,16 @@ export default class MetadataPull extends EasCommand {
     });
 
     try {
-      Log.addNewLineIfNone();
       const filePath = await downloadMetadataAsync(metadataCtx);
-      Log.addNewLineIfNone();
+      const relativePath = path.relative(process.cwd(), filePath);
 
-      Log.succeed('Your store configuration has been generated!');
-      Log.log(filePath);
-      Log.log(learnMore('https://docs.expo.dev/eas-metadata/introduction/'));
+      Log.addNewLineIfNone();
+      Log.log(`🎉 Your store configuration is ready.
+
+- Update the ${chalk.bold(relativePath)} file to prepare the app information.
+- Run ${chalk.bold('eas submit')} or manually upload a new app version to the app stores.
+- Once the app is uploaded, run ${chalk.bold('eas metadata')} to sync the store information.
+- ${learnMore('https://docs.expo.dev/eas-metadata/introduction/')}`);
     } catch (error: any) {
       handleMetadataError(error);
     }

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@expo/config';
 import { Flags } from '@oclif/core';
 
+import { ensureProjectConfiguredAsync } from '../../build/configure';
 import EasCommand from '../../commandUtils/EasCommand';
 import { CredentialsContext } from '../../credentials/context';
 import Log, { learnMore } from '../../log';
@@ -26,6 +27,7 @@ export default class MetadataPull extends EasCommand {
     const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     await getProjectIdAsync(exp);
+    await ensureProjectConfiguredAsync({ projectDir, nonInteractive: false });
 
     const credentialsCtx = new CredentialsContext({
       exp,

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -55,7 +55,7 @@ export default class MetadataPull extends EasCommand {
 
 - Update the ${chalk.bold(relativePath)} file to prepare the app information.
 - Run ${chalk.bold('eas submit')} or manually upload a new app version to the app stores.
-- Once the app is uploaded, run ${chalk.bold('eas metadata')} to sync the store information.
+- Once the app is uploaded, run ${chalk.bold('eas metadata:push')} to sync the store configuration.
 - ${learnMore('https://docs.expo.dev/eas-metadata/introduction/')}`);
     } catch (error: any) {
       handleMetadataError(error);

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -3,10 +3,10 @@ import { Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { CredentialsContext } from '../../credentials/context';
-import Log from '../../log';
+import Log, { learnMore } from '../../log';
 import { createMetadataContextAsync } from '../../metadata/context';
+import { downloadMetadataAsync } from '../../metadata/download';
 import { handleMetadataError } from '../../metadata/errors';
-import { uploadMetadataAsync } from '../../metadata/upload';
 import { RequestedPlatform } from '../../platform';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
@@ -21,9 +21,9 @@ type CommandFlags = {
   profile?: string;
 };
 
-export default class Metadata extends EasCommand {
+export default class MetadataPull extends EasCommand {
   static hidden = true;
-  static description = 'upload metadata configuration to the app stores';
+  static description = 'configure the store configuration file in your project';
 
   static flags = {
     platform: Flags.enum({
@@ -36,10 +36,8 @@ export default class Metadata extends EasCommand {
     }),
   };
 
-  static args = [];
-
   async runAsync(): Promise<void> {
-    const { flags: rawFlags } = await this.parse(Metadata);
+    const { flags: rawFlags } = await this.parse(MetadataPull);
     const flags = await this.sanitizeFlagsAsync(rawFlags);
 
     const projectDir = await findProjectRootAsync();
@@ -62,9 +60,12 @@ export default class Metadata extends EasCommand {
 
     try {
       Log.addNewLineIfNone();
-      await uploadMetadataAsync(metadataCtx);
+      const filePath = await downloadMetadataAsync(metadataCtx);
       Log.addNewLineIfNone();
-      Log.succeed(`Store has been updated with your ${metadataCtx.metadataPath} configuration`);
+
+      Log.succeed('Your store configuration has been generated!');
+      Log.log(filePath);
+      Log.log(learnMore('https://docs.expo.dev/eas-metadata/introduction/'));
     } catch (error: any) {
       handleMetadataError(error);
     }

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -46,10 +46,9 @@ export default class MetadataPush extends EasCommand {
     });
 
     try {
-      Log.addNewLineIfNone();
       await uploadMetadataAsync(metadataCtx);
       Log.addNewLineIfNone();
-      Log.succeed(`Store has been updated with your ${metadataCtx.metadataPath} configuration`);
+      Log.log(`🎉 Store configuration is synced with the app stores.`);
     } catch (error: any) {
       handleMetadataError(error);
     }

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -12,8 +12,7 @@ import { ensureLoggedInAsync } from '../../user/actions';
 
 export default class MetadataPush extends EasCommand {
   static hidden = true;
-  static description = 'upload metadata configuration to the app stores';
-  static aliases = ['metadata'];
+  static description = 'sync the local store configuration to the app stores';
 
   static flags = {
     profile: Flags.string({

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -7,19 +7,8 @@ import Log from '../../log';
 import { createMetadataContextAsync } from '../../metadata/context';
 import { handleMetadataError } from '../../metadata/errors';
 import { uploadMetadataAsync } from '../../metadata/upload';
-import { RequestedPlatform } from '../../platform';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
-
-type RawCommandFlags = {
-  platform?: string;
-  profile?: string;
-};
-
-type CommandFlags = {
-  requestedPlatforms: RequestedPlatform;
-  profile?: string;
-};
 
 export default class MetadataPush extends EasCommand {
   static hidden = true;
@@ -27,10 +16,6 @@ export default class MetadataPush extends EasCommand {
   static aliases = ['metadata'];
 
   static flags = {
-    platform: Flags.enum({
-      char: 'p',
-      options: ['ios'],
-    }),
     profile: Flags.string({
       description:
         'Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.',
@@ -40,9 +25,7 @@ export default class MetadataPush extends EasCommand {
   static args = [];
 
   async runAsync(): Promise<void> {
-    const { flags: rawFlags } = await this.parse(MetadataPush);
-    const flags = await this.sanitizeFlagsAsync(rawFlags);
-
+    const { flags } = await this.parse(MetadataPush);
     const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     await getProjectIdAsync(exp);
@@ -69,15 +52,5 @@ export default class MetadataPush extends EasCommand {
     } catch (error: any) {
       handleMetadataError(error);
     }
-  }
-
-  private async sanitizeFlagsAsync(flags: RawCommandFlags): Promise<CommandFlags> {
-    const { profile } = flags;
-
-    return {
-      // TODO: add support for multiple platforms, right now we only support ios
-      requestedPlatforms: RequestedPlatform.Ios, // enforced by the flag options
-      profile,
-    };
   }
 }

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -25,6 +25,8 @@ export default class MetadataPush extends EasCommand {
   static args = [];
 
   async runAsync(): Promise<void> {
+    Log.warn('EAS Metadata is in beta and subject to breaking changes.');
+
     const { flags } = await this.parse(MetadataPush);
     const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -3,10 +3,10 @@ import { Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { CredentialsContext } from '../../credentials/context';
-import Log, { learnMore } from '../../log';
+import Log from '../../log';
 import { createMetadataContextAsync } from '../../metadata/context';
-import { downloadMetadataAsync } from '../../metadata/download';
 import { handleMetadataError } from '../../metadata/errors';
+import { uploadMetadataAsync } from '../../metadata/upload';
 import { RequestedPlatform } from '../../platform';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
@@ -21,9 +21,10 @@ type CommandFlags = {
   profile?: string;
 };
 
-export default class MetadataConfigure extends EasCommand {
+export default class MetadataPush extends EasCommand {
   static hidden = true;
-  static description = 'configure the store configuration file in your project';
+  static description = 'upload metadata configuration to the app stores';
+  static aliases = ['metadata'];
 
   static flags = {
     platform: Flags.enum({
@@ -36,8 +37,10 @@ export default class MetadataConfigure extends EasCommand {
     }),
   };
 
+  static args = [];
+
   async runAsync(): Promise<void> {
-    const { flags: rawFlags } = await this.parse(MetadataConfigure);
+    const { flags: rawFlags } = await this.parse(MetadataPush);
     const flags = await this.sanitizeFlagsAsync(rawFlags);
 
     const projectDir = await findProjectRootAsync();
@@ -60,12 +63,9 @@ export default class MetadataConfigure extends EasCommand {
 
     try {
       Log.addNewLineIfNone();
-      const filePath = await downloadMetadataAsync(metadataCtx);
+      await uploadMetadataAsync(metadataCtx);
       Log.addNewLineIfNone();
-
-      Log.succeed('Your store configuration has been generated!');
-      Log.log(filePath);
-      Log.log(learnMore('https://docs.expo.dev/eas-metadata/introduction/'));
+      Log.succeed(`Store has been updated with your ${metadataCtx.metadataPath} configuration`);
     } catch (error: any) {
       handleMetadataError(error);
     }

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -12,7 +12,6 @@ import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUt
 import { ensureLoggedInAsync } from '../../user/actions';
 
 export default class MetadataPush extends EasCommand {
-  static hidden = true;
   static description = 'sync the local store configuration to the app stores';
 
   static flags = {

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -21,8 +21,6 @@ export default class MetadataPush extends EasCommand {
     }),
   };
 
-  static args = [];
-
   async runAsync(): Promise<void> {
     Log.warn('EAS Metadata is in beta and subject to breaking changes.');
 

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@expo/config';
 import { Flags } from '@oclif/core';
 
+import { ensureProjectConfiguredAsync } from '../../build/configure';
 import EasCommand from '../../commandUtils/EasCommand';
 import { CredentialsContext } from '../../credentials/context';
 import Log from '../../log';
@@ -28,6 +29,7 @@ export default class MetadataPush extends EasCommand {
     const projectDir = await findProjectRootAsync();
     const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
     await getProjectIdAsync(exp);
+    await ensureProjectConfiguredAsync({ projectDir, nonInteractive: false });
 
     const credentialsCtx = new CredentialsContext({
       exp,

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -7,7 +7,7 @@ import {
   ReleaseType,
 } from '@expo/apple-utils';
 
-import { unique } from '../../utils/array';
+import uniq from '../../../utils/expodash/uniq';
 import { AttributesOf } from '../../utils/asc';
 import { removeDatePrecision } from '../../utils/date';
 import { AppleMetadata } from '../types';
@@ -22,18 +22,18 @@ export const DEFAULT_WHATSNEW = 'Bug fixes and improved stability';
  * This uses version 0 of the config schema.
  */
 export class AppleConfigReader {
-  constructor(public readonly schema: AppleMetadata) {}
+  public constructor(public readonly schema: AppleMetadata) {}
 
-  getAgeRating(): Partial<AttributesOf<AgeRatingDeclaration>> | null {
+  public getAgeRating(): Partial<AttributesOf<AgeRatingDeclaration>> | null {
     return this.schema.advisory || null;
   }
 
-  getLocales(): string[] {
+  public getLocales(): string[] {
     // TODO: filter "default" locales, add option to add non-localized info to the config
-    return unique(Object.keys(this.schema.info || {}));
+    return uniq(Object.keys(this.schema.info || {}));
   }
 
-  getInfoLocale(
+  public getInfoLocale(
     locale: string
   ): PartialExcept<AttributesOf<AppInfoLocalization>, 'locale' | 'name'> | null {
     const info = this.schema.info?.[locale];
@@ -43,7 +43,7 @@ export class AppleConfigReader {
 
     return {
       locale,
-      name: info.title || 'no name provided',
+      name: info.title ?? 'no name provided',
       subtitle: info.subtitle,
       privacyChoicesUrl: info.privacyChoicesUrl,
       privacyPolicyText: info.privacyPolicyText,
@@ -51,7 +51,7 @@ export class AppleConfigReader {
     };
   }
 
-  getCategories(): CategoryIds | null {
+  public getCategories(): CategoryIds | null {
     if (Array.isArray(this.schema.categories) && this.schema.categories.length > 0) {
       return {
         primaryCategory: this.schema.categories[0],
@@ -63,13 +63,13 @@ export class AppleConfigReader {
   }
 
   /** Get the `AppStoreVersion` object. */
-  getVersion(): Partial<
+  public getVersion(): Partial<
     Omit<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
   > | null {
     return this.schema.copyright ? { copyright: this.schema.copyright } : null;
   }
 
-  getVersionRelease(): Partial<
+  public getVersionRelease(): Partial<
     Pick<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
   > | null {
     const { release } = this.schema;
@@ -99,7 +99,7 @@ export class AppleConfigReader {
     return null;
   }
 
-  getVersionLocale(
+  public getVersionLocale(
     locale: string,
     context: { versionIsFirst: boolean }
   ): Partial<AttributesOf<AppStoreVersionLocalization>> | null {

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -18,18 +18,18 @@ export class AppleConfigWriter {
   constructor(public readonly schema: Partial<AppleMetadata> = {}) {}
 
   /** Get the schema result to write it to the config file */
-  toSchema(): { configVersion: number; apple: Partial<AppleMetadata> } {
+  public toSchema(): { configVersion: number; apple: Partial<AppleMetadata> } {
     return {
       configVersion: 0,
       apple: this.schema,
     };
   }
 
-  setAgeRating(attributes: AttributesOf<AgeRatingDeclaration>): void {
+  public setAgeRating(attributes: AttributesOf<AgeRatingDeclaration>): void {
     this.schema.advisory = attributes;
   }
 
-  setInfoLocale(attributes: AttributesOf<AppInfoLocalization>): void {
+  public setInfoLocale(attributes: AttributesOf<AppInfoLocalization>): void {
     this.schema.info = this.schema.info ?? {};
     const existing = this.schema.info[attributes.locale] ?? {};
 
@@ -43,7 +43,7 @@ export class AppleConfigWriter {
     };
   }
 
-  setCategories({ primaryCategory, secondaryCategory }: AttributesOf<AppInfo>): void {
+  public setCategories({ primaryCategory, secondaryCategory }: AttributesOf<AppInfo>): void {
     this.schema.categories = [];
 
     // TODO: see why these types are conflicting
@@ -55,13 +55,13 @@ export class AppleConfigWriter {
     }
   }
 
-  setVersion(
+  public setVersion(
     attributes: Omit<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
   ): void {
     this.schema.copyright = optional(attributes.copyright);
   }
 
-  setVersionRelease(
+  public setVersionRelease(
     attributes: Pick<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
   ): void {
     if (attributes.releaseType === ReleaseType.SCHEDULED) {
@@ -83,7 +83,7 @@ export class AppleConfigWriter {
     }
   }
 
-  setVersionLocale(attributes: AttributesOf<AppStoreVersionLocalization>): void {
+  public setVersionLocale(attributes: AttributesOf<AppStoreVersionLocalization>): void {
     this.schema.info = this.schema.info ?? {};
     const existing = this.schema.info[attributes.locale] ?? {};
 

--- a/packages/eas-cli/src/metadata/apple/task.ts
+++ b/packages/eas-cli/src/metadata/apple/task.ts
@@ -4,16 +4,16 @@ import { AppleData, PartialAppleData } from './data';
 
 export abstract class AppleTask {
   /** Get a description from the task to use as section headings in the log */
-  abstract name(): string;
+  public abstract name(): string;
 
   /** Prepare the data from the App Store to start syncing with the store configuration */
-  abstract prepareAsync(options: TaskPrepareOptions): Promise<void>;
+  public abstract prepareAsync(options: TaskPrepareOptions): Promise<void>;
 
   /** Download all information from the App Store to generate the store configuration */
-  abstract downloadAsync(options: TaskDownloadOptions): Promise<void>;
+  public abstract downloadAsync(options: TaskDownloadOptions): Promise<void>;
 
   /** Upload all information from the store configuration to the App Store */
-  abstract uploadAsync(options: TaskUploadOptions): Promise<void>;
+  public abstract uploadAsync(options: TaskUploadOptions): Promise<void>;
 }
 
 export type TaskPrepareOptions = {

--- a/packages/eas-cli/src/metadata/apple/tasks/age-rating.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/age-rating.ts
@@ -12,20 +12,20 @@ export type AgeRatingData = {
 };
 
 export class AgeRatingTask extends AppleTask {
-  name = (): string => 'age rating declarations';
+  public name = (): string => 'age rating declarations';
 
-  async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
+  public async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
     assert(context.version, `App version information is not prepared, can't update age rating`);
     context.ageRating = (await context.version.getAgeRatingDeclarationAsync()) || undefined;
   }
 
-  async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
+  public async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
     if (context.ageRating) {
       config.setAgeRating(context.ageRating.attributes);
     }
   }
 
-  async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
+  public async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
     assert(context.ageRating, `Age rating not initialized, can't update age rating`);
 
     const ageRating = config.getAgeRating();

--- a/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
@@ -15,9 +15,9 @@ export type AppInfoData = {
 };
 
 export class AppInfoTask extends AppleTask {
-  name = (): string => 'app information';
+  public name = (): string => 'app information';
 
-  async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
+  public async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
     const info = await retryIfNullAsync(() => context.app.getEditAppInfoAsync());
     assert(info, 'Could not resolve the editable app info to update');
 
@@ -25,7 +25,7 @@ export class AppInfoTask extends AppleTask {
     context.infoLocales = await info.getLocalizationsAsync();
   }
 
-  async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
+  public async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
     assert(context.info, `App info not initialized, can't download info`);
 
     config.setCategories(context.info.attributes);
@@ -35,7 +35,7 @@ export class AppInfoTask extends AppleTask {
     }
   }
 
-  async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
+  public async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
     assert(context.info, `App info not initialized, can't update info`);
 
     const categories = config.getCategories();
@@ -68,10 +68,11 @@ export class AppInfoTask extends AppleTask {
 
         const model = context.infoLocales.find(model => model.attributes.locale === locale);
         await logAsync(
-          () =>
-            model
-              ? model.updateAsync(attributes)
-              : context.info.createLocalizationAsync({ ...attributes, locale }),
+          async () => {
+            return model
+              ? await model.updateAsync(attributes)
+              : await context.info.createLocalizationAsync({ ...attributes, locale });
+          },
           {
             pending: `${model ? 'Updating' : 'Creating'} localized info for ${locale}...`,
             success: `${model ? 'Updated' : 'Created'} localized info for ${locale}`,

--- a/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
@@ -74,9 +74,13 @@ export class AppInfoTask extends AppleTask {
               : await context.info.createLocalizationAsync({ ...attributes, locale });
           },
           {
-            pending: `${model ? 'Updating' : 'Creating'} localized info for ${locale}...`,
-            success: `${model ? 'Updated' : 'Created'} localized info for ${locale}`,
-            failure: `Failed ${model ? 'updating' : 'creating'} localized info for ${locale}`,
+            pending: `${model ? 'Updating' : 'Creating'} localized info for ${chalk.bold(
+              locale
+            )}...`,
+            success: `${model ? 'Updated' : 'Created'} localized info for ${chalk.bold(locale)}`,
+            failure: `Failed ${model ? 'updating' : 'creating'} localized info for ${chalk.bold(
+              locale
+            )}`,
           }
         );
       }

--- a/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
@@ -71,16 +71,17 @@ export class AppVersionTask extends AppleTask {
     if (!version && !release) {
       Log.log(chalk`{dim - Skipped version and release update, not configured}`);
     } else {
-      const description = [version && 'version info', release && 'release info']
+      const { versionString } = context.version.attributes;
+      const description = [version && 'version', release && 'release']
         .filter(Boolean)
         .join(' and ');
 
       context.version = await logAsync(
         () => context.version.updateAsync({ ...version, ...release }),
         {
-          pending: `Updating ${description}...`,
-          success: `Updated ${description}`,
-          failure: `Failed updating ${description}`,
+          pending: `Updating ${description} info for ${chalk.bold(versionString)}...`,
+          success: `Updated ${description} info for ${chalk.bold(versionString)}...`,
+          failure: `Failed updating ${description} info for ${chalk.bold(versionString)}...`,
         }
       );
     }
@@ -103,9 +104,15 @@ export class AppVersionTask extends AppleTask {
               : await context.version.createLocalizationAsync({ ...attributes, locale });
           },
           {
-            pending: `${oldModel ? 'Updating' : 'Creating'} localized version for ${locale}...`,
-            success: `${oldModel ? 'Updated' : 'Created'} localized version for ${locale}`,
-            failure: `Failed ${oldModel ? 'updating' : 'creating'} localized version for ${locale}`,
+            pending: `${oldModel ? 'Updating' : 'Creating'} localized version for ${chalk.bold(
+              locale
+            )}...`,
+            success: `${oldModel ? 'Updated' : 'Created'} localized version for ${chalk.bold(
+              locale
+            )}`,
+            failure: `Failed ${
+              oldModel ? 'updating' : 'creating'
+            } localized version for ${chalk.bold(locale)}`,
           }
         );
       }

--- a/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
@@ -28,17 +28,17 @@ export type AppVersionData = {
 export class AppVersionTask extends AppleTask {
   private options: AppVersionOptions;
 
-  constructor(options: Partial<AppVersionOptions> = {}) {
+  public constructor(options: Partial<AppVersionOptions> = {}) {
     super();
     this.options = {
-      platform: options.platform || Platform.IOS,
-      editLive: options.editLive || false,
+      platform: options.platform ?? Platform.IOS,
+      editLive: options.editLive ?? false,
     };
   }
 
-  name = (): string => (this.options.editLive ? 'live app version' : 'editable app version');
+  public name = (): string => (this.options.editLive ? 'live app version' : 'editable app version');
 
-  async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
+  public async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
     const { version, versionIsFirst, versionIsLive } = await resolveVersionAsync(
       context.app,
       this.options
@@ -52,7 +52,7 @@ export class AppVersionTask extends AppleTask {
     context.versionLocales = await version.getLocalizationsAsync();
   }
 
-  async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
+  public async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
     assert(context.version, `App version not initialized, can't download version`);
 
     config.setVersion(context.version.attributes);
@@ -63,7 +63,7 @@ export class AppVersionTask extends AppleTask {
     }
   }
 
-  async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
+  public async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
     assert(context.version, `App version not initialized, can't update version`);
 
     const version = config.getVersion();
@@ -97,10 +97,11 @@ export class AppVersionTask extends AppleTask {
 
         const oldModel = context.versionLocales.find(model => model.attributes.locale === locale);
         await logAsync(
-          () =>
-            oldModel
-              ? oldModel.updateAsync(attributes)
-              : context.version.createLocalizationAsync({ ...attributes, locale }),
+          async () => {
+            return oldModel
+              ? await oldModel.updateAsync(attributes)
+              : await context.version.createLocalizationAsync({ ...attributes, locale });
+          },
           {
             pending: `${oldModel ? 'Updating' : 'Creating'} localized version for ${locale}...`,
             success: `${oldModel ? 'Updated' : 'Created'} localized version for ${locale}`,

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -64,7 +64,9 @@ export async function createMetadataContextAsync(params: {
 
   const exp = params.exp ?? getExpoConfig(params.projectDir);
   const user = await ensureLoggedInAsync();
-  const bundleIdentifier = await getBundleIdentifierAsync(params.projectDir, exp);
+  const bundleIdentifier =
+    iosSubmissionProfile.bundleIdentifier ??
+    (await getBundleIdentifierAsync(params.projectDir, exp));
 
   return {
     platform: Platform.IOS,

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -54,8 +54,11 @@ export async function downloadMetadataAsync(metadataCtx: MetadataContext): Promi
     }
   }
 
-  await fs.writeJson(filePath, config.toSchema(), { spaces: 2 });
-  unsubscribeTelemetry();
+  try {
+    await fs.writeJson(filePath, config.toSchema(), { spaces: 2 });
+  } finally {
+    unsubscribeTelemetry();
+  }
 
   if (errors.length > 0) {
     throw new MetadataDownloadError(errors, executionId);

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { MetadataEvent } from '../analytics/events';
+import Log from '../log';
 import { confirmAsync } from '../prompts';
 import { AppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
@@ -32,6 +33,9 @@ export async function downloadMetadataAsync(metadataCtx: MetadataContext): Promi
     MetadataEvent.APPLE_METADATA_DOWNLOAD,
     { app, auth }
   );
+
+  Log.addNewLineIfNone();
+  Log.log('Downloading App Store configuration...');
 
   const errors: Error[] = [];
   const config = createAppleWriter();

--- a/packages/eas-cli/src/metadata/errors.ts
+++ b/packages/eas-cli/src/metadata/errors.ts
@@ -8,7 +8,7 @@ import Log, { link } from '../log';
  * and should contain useful information for the user to solve before trying again.
  */
 export class MetadataValidationError extends Error {
-  public constructor(message?: string, public readonly errors?: ErrorObject[]) {
+  public constructor(message?: string, public readonly errors: ErrorObject[] = []) {
     super(message ?? 'Store configuration validation failed');
   }
 }
@@ -52,7 +52,9 @@ export class MetadataDownloadError extends Error {
 export function handleMetadataError(error: Error): void {
   if (error instanceof MetadataValidationError) {
     Log.error(error.message);
-    Log.log(error.errors?.map(err => `  - ${err.dataPath} ${err.message}`).join('\n'));
+    if (error.errors?.length > 0) {
+      Log.log(error.errors.map(err => `  - ${err.dataPath} ${err.message}`).join('\n'));
+    }
     return;
   }
 

--- a/packages/eas-cli/src/metadata/errors.ts
+++ b/packages/eas-cli/src/metadata/errors.ts
@@ -8,7 +8,7 @@ import Log, { link } from '../log';
  * and should contain useful information for the user to solve before trying again.
  */
 export class MetadataValidationError extends Error {
-  constructor(message?: string, public readonly errors?: ErrorObject[]) {
+  public constructor(message?: string, public readonly errors?: ErrorObject[]) {
     super(message ?? 'Store configuration validation failed');
   }
 }
@@ -20,7 +20,7 @@ export class MetadataValidationError extends Error {
  * It contains that list of encountered errors to present to the user.
  */
 export class MetadataUploadError extends Error {
-  constructor(public readonly errors: Error[], public readonly executionId: string) {
+  public constructor(public readonly errors: Error[], public readonly executionId: string) {
     super(
       `Store configuration upload encountered ${
         errors.length === 1 ? 'an error' : `${errors.length} errors`
@@ -36,7 +36,7 @@ export class MetadataUploadError extends Error {
  * It contains that list of encountered errors to present to the user.
  */
 export class MetadataDownloadError extends Error {
-  constructor(public readonly errors: Error[], public readonly executionId: string) {
+  public constructor(public readonly errors: Error[], public readonly executionId: string) {
     super(
       `Store configuration download encountered ${
         errors.length === 1 ? 'an error' : `${errors.length} errors`

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { MetadataEvent } from '../analytics/events';
+import Log from '../log';
 import { AppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
 import { createAppleReader, validateConfig } from './config';
@@ -30,6 +31,9 @@ export async function uploadMetadataAsync(metadataCtx: MetadataContext): Promise
   if (!valid) {
     throw new MetadataValidationError(`Store configuration errors found`, validationErrors);
   }
+
+  Log.addNewLineIfNone();
+  Log.log('Uploading App Store configuration...');
 
   const errors: Error[] = [];
   const config = createAppleReader(fileData);

--- a/packages/eas-cli/src/metadata/utils/__tests__/date.test.ts
+++ b/packages/eas-cli/src/metadata/utils/__tests__/date.test.ts
@@ -4,7 +4,6 @@ describe(removeDatePrecision, () => {
   it('returns null for falsy values', () => {
     expect(removeDatePrecision(null)).toBeNull();
     expect(removeDatePrecision(undefined)).toBeNull();
-    expect(removeDatePrecision(false)).toBeNull();
   });
 
   it('returns null for invalid dates', () => {

--- a/packages/eas-cli/src/metadata/utils/array.ts
+++ b/packages/eas-cli/src/metadata/utils/array.ts
@@ -1,4 +1,0 @@
-export function unique<T = any>(items: T[]): T[] {
-  const set = new Set(items);
-  return [...set];
-}

--- a/packages/eas-cli/src/metadata/utils/date.ts
+++ b/packages/eas-cli/src/metadata/utils/date.ts
@@ -9,7 +9,7 @@
  *   "pointer": "/data/attributes/earliestReleaseDate"
  * }
  */
-export function removeDatePrecision(date: any): null | Date {
+export function removeDatePrecision(date: null | undefined | string | number | Date): null | Date {
   if (date) {
     try {
       const result = new Date(date);

--- a/packages/eas-cli/src/utils/expodash/__tests__/uniq-test.ts
+++ b/packages/eas-cli/src/utils/expodash/__tests__/uniq-test.ts
@@ -1,0 +1,15 @@
+import uniq from '../uniq';
+
+describe(uniq, () => {
+  it('returns unique numbers from a list', () => {
+    expect(uniq([1, 2, 2, 3, 4, 2, 3])).toEqual([1, 2, 3, 4]);
+  });
+
+  it('returns unique strings from a list', () => {
+    expect(uniq(['hi', 'hello', 'hello', 'ola'])).toEqual(['hi', 'hello', 'ola']);
+  });
+
+  it('returns unique mixed types from a list', () => {
+    expect(uniq([1, 2, 2, 'hi', 'hi', 'hello', 3])).toEqual([1, 2, 'hi', 'hello', 3]);
+  });
+});

--- a/packages/eas-cli/src/utils/expodash/uniq.ts
+++ b/packages/eas-cli/src/utils/expodash/uniq.ts
@@ -1,0 +1,4 @@
+export default function uniq<T = any>(items: T[]): T[] {
+  const set = new Set(items);
+  return [...set];
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

**Part of PR #1083**
- [x] ~~Requires PR #1130~~
- [x] ~~Requires PR #1131~~
- [x] ~~Requires PR #1132~~
- [x] ~~Requires PR #1133~~
- [x] ~~Requires PR #1134~~
- [x] ~~Requires PR #1135~~


**Additional PRs merged**
- [x] PR #1159
- [x] PR #1156

This adds the EAS CLI commands to let users interact with the metadata features.

# How

Originally we wanted to include it in the submission commands, but that workflow does not work well.
- We have to wait until the binary is shipped and processed, else we might be editing a wrong version
- There is no good way to wait until the binary is processed
- It's not that great to ask the user to wait until that's all done

As a temporary solution, the metadata is split into its own commands.

# Test Plan

After all PRs are merged and ready:
- `$ eas metadata`
- `$ eas metadata:pull`
- _Edit the store configuration_
- `$ eas metadata:push`
