### PR TITLE
[eas-cli] make viewBranchAsync updates limit configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ packages/eas-cli/tmp
 # Code editors
 .idea
 .history
+.vscode
 
 # macOS
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Improved support for working on branches with many updates. ([#1144](https://github.com/expo/eas-cli/pull/1144)) by [@kgc00](https://github.com/kgc00/)
+
 ### 🧹 Chores
 
 ## [0.53.1](https://github.com/expo/eas-cli/releases/tag/v0.53.1) - 2022-06-07
 
 ### 🐛 Bug fixes
 
-- No longer timeout on publishing updates for branches with many updates. ([#1119](https://github.com/expo/eas-cli/pull/1119) by [@kgc00](https://github.com/kgc00/))
+- No longer timeout on publishing updates for branches with many updates. ([#1119](https://github.com/expo/eas-cli/pull/1119)) by [@kgc00](https://github.com/kgc00/)
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -10524,6 +10524,22 @@
             "deprecationReason": null
           },
           {
+            "name": "canRetry",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cancelingActor",
             "description": null,
             "args": [],
@@ -10548,7 +10564,7 @@
             "deprecationReason": null
           },
           {
-            "name": "createdAt",
+            "name": "completedAt",
             "description": null,
             "args": [],
             "type": {
@@ -10560,12 +10576,40 @@
             "deprecationReason": null
           },
           {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "distribution",
             "description": null,
             "args": [],
             "type": {
               "kind": "ENUM",
               "name": "DistributionType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "enqueuedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "isDeprecated": false,
@@ -10732,6 +10776,18 @@
             "deprecationReason": null
           },
           {
+            "name": "parentBuild",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Build",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "platform",
             "description": null,
             "args": [],
@@ -10775,6 +10831,18 @@
                 "name": "Project",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "provisioningStartedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -10881,6 +10949,22 @@
           },
           {
             "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerStartedAt",
             "description": null,
             "args": [],
             "type": {
@@ -12301,6 +12385,39 @@
           {
             "name": "deleteBuild",
             "description": "Delete an EAS Build build",
+            "args": [
+              {
+                "name": "buildId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Build",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retryBuild",
+            "description": "Retry an EAS Build build",
             "args": [
               {
                 "name": "buildId",

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -120,9 +120,11 @@ async function ensureChannelExistsAsync({
 async function ensureBranchExistsAsync({
   appId,
   name: branchName,
+  limit,
 }: {
   appId: string;
   name: string;
+  limit?: number;
 }): Promise<{
   id: string;
   updates: Exclude<
@@ -133,6 +135,7 @@ async function ensureBranchExistsAsync({
   const { app } = await UpdateQuery.viewBranchAsync({
     appId,
     name: branchName,
+    limit,
   });
   const updateBranch = app?.byId.updateBranchByName;
   if (updateBranch) {
@@ -309,11 +312,6 @@ export default class UpdatePublish extends EasCommand {
       assert(branchName, 'Branch name must be specified.');
     }
 
-    const { id: branchId, updates } = await ensureBranchExistsAsync({
-      appId: projectId,
-      name: branchName,
-    });
-
     let unsortedUpdateInfoGroups: UpdateInfoGroup = {};
     let oldMessage: string, oldRuntimeVersion: string;
     if (republish) {
@@ -335,6 +333,10 @@ export default class UpdatePublish extends EasCommand {
           throw new Error('You must specify the update group to republish.');
         }
 
+        const { updates } = await ensureBranchExistsAsync({
+          appId: projectId,
+          name: branchName,
+        });
         const updateGroups = uniqBy(updates, u => u.group)
           .filter(update => {
             // Only show groups that have updates on the specified platform(s).
@@ -464,6 +466,12 @@ export default class UpdatePublish extends EasCommand {
         .filter(pair => pair[1] === runtime)
         .map(pair => pair[0]);
     }
+
+    const { id: branchId } = await ensureBranchExistsAsync({
+      appId: projectId,
+      name: branchName,
+      limit: 0,
+    });
 
     // Sort the updates into different groups based on their platform specific runtime versions
     const updateGroups: PublishUpdateGroupInput[] = Object.entries(runtimeToPlatformMapping).map(

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -117,7 +117,7 @@ async function ensureChannelExistsAsync({
   }
 }
 
-async function ensureBranchExistsAsync({
+export async function ensureBranchExistsAsync({
   appId,
   name: branchName,
   limit,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1564,10 +1564,13 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   appVersion?: Maybe<Scalars['String']>;
   artifacts?: Maybe<BuildArtifacts>;
   buildProfile?: Maybe<Scalars['String']>;
+  canRetry: Scalars['Boolean'];
   cancelingActor?: Maybe<Actor>;
   channel?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['DateTime']>;
+  completedAt?: Maybe<Scalars['DateTime']>;
+  createdAt: Scalars['DateTime'];
   distribution?: Maybe<DistributionType>;
+  enqueuedAt?: Maybe<Scalars['DateTime']>;
   error?: Maybe<BuildError>;
   estimatedWaitTimeLeftSeconds?: Maybe<Scalars['Int']>;
   expirationDate?: Maybe<Scalars['DateTime']>;
@@ -1582,9 +1585,11 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   isGitWorkingTreeDirty?: Maybe<Scalars['Boolean']>;
   logFiles: Array<Scalars['String']>;
   metrics?: Maybe<BuildMetrics>;
+  parentBuild?: Maybe<Build>;
   platform: AppPlatform;
   priority: BuildPriority;
   project: Project;
+  provisioningStartedAt?: Maybe<Scalars['DateTime']>;
   /** Queue position is 1-indexed */
   queuePosition?: Maybe<Scalars['Int']>;
   reactNativeVersion?: Maybe<Scalars['String']>;
@@ -1593,7 +1598,8 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   sdkVersion?: Maybe<Scalars['String']>;
   status: BuildStatus;
   submissions: Array<Submission>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
+  updatedAt: Scalars['DateTime'];
+  workerStartedAt?: Maybe<Scalars['DateTime']>;
 };
 
 export type BuildArtifact = {
@@ -1765,6 +1771,8 @@ export type BuildMutation = {
   createIosBuild: CreateBuildResult;
   /** Delete an EAS Build build */
   deleteBuild: Build;
+  /** Retry an EAS Build build */
+  retryBuild: Build;
 };
 
 
@@ -1788,6 +1796,11 @@ export type BuildMutationCreateIosBuildArgs = {
 
 
 export type BuildMutationDeleteBuildArgs = {
+  buildId: Scalars['ID'];
+};
+
+
+export type BuildMutationRetryBuildArgs = {
   buildId: Scalars['ID'];
 };
 
@@ -4309,7 +4322,7 @@ export type CreateAndroidBuildMutationVariables = Exact<{
 }>;
 
 
-export type CreateAndroidBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createAndroidBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt?: any | null, updatedAt?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }, deprecationInfo?: { __typename?: 'EASBuildDeprecationInfo', type: EasBuildDeprecationInfoType, message: string } | null } } };
+export type CreateAndroidBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createAndroidBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }, deprecationInfo?: { __typename?: 'EASBuildDeprecationInfo', type: EasBuildDeprecationInfoType, message: string } | null } } };
 
 export type CreateIosBuildMutationVariables = Exact<{
   appId: Scalars['ID'];
@@ -4318,7 +4331,7 @@ export type CreateIosBuildMutationVariables = Exact<{
 }>;
 
 
-export type CreateIosBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createIosBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt?: any | null, updatedAt?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }, deprecationInfo?: { __typename?: 'EASBuildDeprecationInfo', type: EasBuildDeprecationInfoType, message: string } | null } } };
+export type CreateIosBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createIosBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }, deprecationInfo?: { __typename?: 'EASBuildDeprecationInfo', type: EasBuildDeprecationInfoType, message: string } | null } } };
 
 export type CreateEnvironmentSecretForAccountMutationVariables = Exact<{
   input: CreateEnvironmentSecretInput;
@@ -4431,7 +4444,7 @@ export type BuildsByIdQueryVariables = Exact<{
 }>;
 
 
-export type BuildsByIdQuery = { __typename?: 'RootQuery', builds: { __typename?: 'BuildQuery', byId: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt?: any | null, updatedAt?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
+export type BuildsByIdQuery = { __typename?: 'RootQuery', builds: { __typename?: 'BuildQuery', byId: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
 
 export type GetAllBuildsForAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -4441,7 +4454,7 @@ export type GetAllBuildsForAppQueryVariables = Exact<{
 }>;
 
 
-export type GetAllBuildsForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, builds: Array<{ __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt?: any | null, updatedAt?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }> } } };
+export type GetAllBuildsForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, builds: Array<{ __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }> } } };
 
 export type GetChannelByNameForAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -4537,7 +4550,7 @@ export type WebhookByIdQuery = { __typename?: 'RootQuery', webhook: { __typename
 
 export type AppFragment = { __typename?: 'App', id: string, fullName: string, slug: string };
 
-export type BuildFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt?: any | null, updatedAt?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } };
+export type BuildFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } };
 
 export type EnvironmentSecretFragment = { __typename?: 'EnvironmentSecret', id: string, name: string, createdAt: any };
 

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -10,6 +10,9 @@ import {
 
 const PAGE_LIMIT = 300;
 
+type ViewBranchUpdatesQueryVariablesWithOptionalLimit = Partial<ViewBranchUpdatesQueryVariables> &
+  Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>;
+
 export const UpdateQuery = {
   async viewAllAsync({ appId }: { appId: string }): Promise<ViewAllUpdatesQuery> {
     return withErrorHandlingAsync(
@@ -54,7 +57,7 @@ export const UpdateQuery = {
         .toPromise()
     );
   },
-  async viewBranchAsync({ appId, name }: Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>) {
+  async viewBranchAsync({ appId, name, limit }: ViewBranchUpdatesQueryVariablesWithOptionalLimit) {
     return withErrorHandlingAsync<ViewBranchUpdatesQuery>(
       graphqlClient
         .query<ViewBranchUpdatesQuery, ViewBranchUpdatesQueryVariables>(
@@ -92,7 +95,7 @@ export const UpdateQuery = {
           {
             appId,
             name,
-            limit: PAGE_LIMIT,
+            limit: limit ?? PAGE_LIMIT,
           },
           { additionalTypenames: ['UpdateBranch', 'Update'] }
         )

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -57,7 +57,11 @@ export const UpdateQuery = {
         .toPromise()
     );
   },
-  async viewBranchAsync({ appId, name, limit }: ViewBranchUpdatesQueryVariablesWithOptionalLimit) {
+  async viewBranchAsync({
+    appId,
+    name,
+    limit = PAGE_LIMIT,
+  }: ViewBranchUpdatesQueryVariablesWithOptionalLimit) {
     return withErrorHandlingAsync<ViewBranchUpdatesQuery>(
       graphqlClient
         .query<ViewBranchUpdatesQuery, ViewBranchUpdatesQueryVariables>(
@@ -95,7 +99,7 @@ export const UpdateQuery = {
           {
             appId,
             name,
-            limit: limit ?? PAGE_LIMIT,
+            limit,
           },
           { additionalTypenames: ['UpdateBranch', 'Update'] }
         )

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -8,7 +8,7 @@ import {
   ViewBranchUpdatesQueryVariables,
 } from '../generated';
 
-export const PAGE_LIMIT = 300;
+export const viewBranchUpdatesQueryUpdateLimit = 300;
 
 type ViewBranchUpdatesQueryVariablesWithOptionalLimit = Partial<ViewBranchUpdatesQueryVariables> &
   Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>;
@@ -50,7 +50,7 @@ export const UpdateQuery = {
           `,
           {
             appId,
-            limit: PAGE_LIMIT,
+            limit: viewBranchUpdatesQueryUpdateLimit,
           },
           { additionalTypenames: ['UpdateBranch', 'Update'] }
         )
@@ -60,7 +60,7 @@ export const UpdateQuery = {
   async viewBranchAsync({
     appId,
     name,
-    limit = PAGE_LIMIT,
+    limit = viewBranchUpdatesQueryUpdateLimit,
   }: ViewBranchUpdatesQueryVariablesWithOptionalLimit) {
     return withErrorHandlingAsync<ViewBranchUpdatesQuery>(
       graphqlClient

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -8,7 +8,7 @@ import {
   ViewBranchUpdatesQueryVariables,
 } from '../generated';
 
-const PAGE_LIMIT = 300;
+export const PAGE_LIMIT = 300;
 
 type ViewBranchUpdatesQueryVariablesWithOptionalLimit = Partial<ViewBranchUpdatesQueryVariables> &
   Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>;

--- a/packages/eas-cli/src/update/__tests__/update-test.ts
+++ b/packages/eas-cli/src/update/__tests__/update-test.ts
@@ -1,0 +1,85 @@
+import { ensureBranchExistsAsync } from '../../commands/update';
+import { graphqlClient } from '../../graphql/client';
+import { PAGE_LIMIT } from '../../graphql/queries/UpdateQuery';
+
+const appId = '6c94sxe6-37d2-4700-52fa-1b813204dad2';
+const branchId = '5e84e3cb-563e-4022-a65e-6e7a42fe4ed3';
+const appName = '@tester/test';
+const branchName = 'test-branch';
+
+jest.mock('../../commands/update', () => {
+  const actual = jest.requireActual('../../commands/update');
+  return { ...actual, ensureBranchExistsAsync: jest.fn(actual.ensureBranchExistsAsync) };
+});
+jest.mock('../../graphql/client', () => ({
+  ...jest.requireActual('../../graphql/client'),
+  graphqlClient: {
+    query: jest.fn(() => ({
+      toPromise: () =>
+        Promise.resolve({
+          data: {
+            __typename: 'RootQuery',
+            app: {
+              __typename: 'AppQuery',
+              byId: {
+                __typename: 'App',
+                id: appId,
+                updateBranchByName: {
+                  __typename: 'UpdateBranch',
+                  id: branchId,
+                  name: branchName,
+                  updates: [],
+                },
+              },
+            },
+          },
+        }),
+    })),
+    mutation: jest.fn(() => ({
+      toPromise: () => ({
+        error: {
+          graphQLErrors: [
+            {
+              GraphQLError: `A channel already exists with (app_id, name) = (${appId}, ${appName})`,
+              extensions: {
+                code: 'INTERNAL_SERVER_ERROR',
+                errorCode: 'CHANNEL_ALREADY_EXISTS',
+              },
+            },
+          ],
+        },
+      }),
+    })),
+  },
+}));
+
+describe.only('UpdatePublish', () => {
+  describe('ensureBranchExistsAsync', () => {
+    beforeEach(() => {
+      jest.mocked(graphqlClient.query).mockClear();
+      jest.mocked(graphqlClient.mutation).mockClear();
+    });
+
+    it('defaults to the PAGE_LIMIT when no limit is provided', async () => {
+      await ensureBranchExistsAsync({ appId, name: appName });
+      const [[, bindings]] = jest.mocked(graphqlClient.query).mock.calls;
+
+      expect(bindings).toEqual({
+        appId,
+        name: appName,
+        limit: PAGE_LIMIT,
+      });
+    });
+
+    it.each([0, 10, 100, 1000])('sets the limit to %s when asked', async limit => {
+      await ensureBranchExistsAsync({ appId, name: appName, limit });
+      const [[, bindings]] = jest.mocked(graphqlClient.query).mock.calls;
+
+      expect(bindings).toEqual({
+        appId,
+        name: appName,
+        limit,
+      });
+    });
+  });
+});

--- a/packages/eas-cli/src/update/__tests__/update-test.ts
+++ b/packages/eas-cli/src/update/__tests__/update-test.ts
@@ -1,6 +1,6 @@
 import { ensureBranchExistsAsync } from '../../commands/update';
 import { graphqlClient } from '../../graphql/client';
-import { PAGE_LIMIT } from '../../graphql/queries/UpdateQuery';
+import { viewBranchUpdatesQueryUpdateLimit } from '../../graphql/queries/UpdateQuery';
 
 const appId = '6c94sxe6-37d2-4700-52fa-1b813204dad2';
 const branchId = '5e84e3cb-563e-4022-a65e-6e7a42fe4ed3';
@@ -53,7 +53,7 @@ jest.mock('../../graphql/client', () => ({
   },
 }));
 
-describe.only('UpdatePublish', () => {
+describe('UpdatePublish', () => {
   describe('ensureBranchExistsAsync', () => {
     beforeEach(() => {
       jest.mocked(graphqlClient.query).mockClear();
@@ -67,7 +67,7 @@ describe.only('UpdatePublish', () => {
       expect(bindings).toEqual({
         appId,
         name: appName,
-        limit: PAGE_LIMIT,
+        limit: viewBranchUpdatesQueryUpdateLimit,
       });
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Follow up to #1119. This will help avoid timeouts and network errors related to publishing updates by avoiding querying for large payloads of updates when it is not necessary.

# How

For the execution flow to publish a new update we just need to check the existence of the branch, and if it is not extant, create it. We can limit the updates returned in the GQL query in this case to 0 because we are not using them.

For the execution flow to republish an old update, we need to both check that a branch exists and get updates associated with it. We can limit the updates returned in the GQL query in this case to however many we need. We lowered the number of updates returned from 10k to 300 previously. We will need to add in some new functionality to paginate these results and re-query with an offset if the user did not find the update they'd like to re-publish on the first page. This will be done in a follow-up PR.

# Test Plan

Added automated tests to ensure the configurable update limit is working. Additionally, one can:
- run `yarn start`
- alias their local `yarn start` output to `edl` and run:
  - `edl update --republish`
  - `edl update`

to ensure that both flows work properly
