### PR TITLE
[eas-cli] add fetching additional pages for update --republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Improved support for working on branches with many updates. ([#1144](https://github.com/expo/eas-cli/pull/1144)) by [@kgc00](https://github.com/kgc00/)
+- Improved support for working on branches with many updates. ([#1144](https://github.com/expo/eas-cli/pull/1144), [#1148](https://github.com/expo/eas-cli/pull/1148)) by [@kgc00](https://github.com/kgc00/)
 - `eas update` project links no longer contain a `)` on unsupported terminals. ([#1152](https://github.com/expo/eas-cli/pull/1152)) by [@kgc00](https://github.com/kgc00/)
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -607,13 +607,18 @@ export async function getUpdatesToRepublishInteractiveAsync(
     Exclude<ViewBranchUpdatesQuery['app'], null | undefined>['byId']['updateBranchByName'],
     null | undefined
   >['updates'] = []
-): Promise<any> {
+): Promise<
+  Exclude<
+    Exclude<ViewBranchUpdatesQuery['app'], null | undefined>['byId']['updateBranchByName'],
+    null | undefined
+  >['updates']
+> {
   const fetchMoreValue = '_fetchMore';
 
   const { updates } = await ensureBranchExistsAsync({
     appId: projectId,
     name: branchName,
-    limit: pageSize + 1, // fetch an extra item so we know if there are additional updates to fetch
+    limit: pageSize + 1, // fetch an extra item so we know if there are additional pages
     offset,
   });
   cumulativeUpdates = [
@@ -652,7 +657,7 @@ export async function getUpdatesToRepublishInteractiveAsync(
       branchName,
       platformFlag,
       pageSize,
-      (offset + 1) * pageSize,
+      offset + pageSize,
       cumulativeUpdates
     );
   }

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -25,7 +25,10 @@ import {
   ViewBranchUpdatesQuery,
 } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
-import { UpdateQuery, viewBranchUpdatesQueryUpdateLimit } from '../../graphql/queries/UpdateQuery';
+import {
+  UpdateQuery,
+  getViewBranchUpdatesQueryUpdateLimit,
+} from '../../graphql/queries/UpdateQuery';
 import Log, { link } from '../../log';
 import { ora } from '../../ora';
 import { getExpoConfig } from '../../project/expoConfig';
@@ -62,7 +65,7 @@ import { listBranchesAsync } from '../branch/list';
 import { createUpdateChannelOnAppAsync } from '../channel/create';
 
 export const defaultPublishPlatforms: PublishPlatform[] = ['android', 'ios'];
-type PlatformFlag = PublishPlatform | 'all';
+export type PlatformFlag = PublishPlatform | 'all';
 
 async function getUpdateGroupAsync({
   group,
@@ -629,7 +632,7 @@ export async function getUpdatesToRepublishInteractiveAsync(
     );
   }
 
-  if (updates.length && updates.length === viewBranchUpdatesQueryUpdateLimit) {
+  if (updates.length && updates.length === getViewBranchUpdatesQueryUpdateLimit()) {
     updateGroups.push({ title: 'Next page...', value: fetchMoreValue });
   }
 
@@ -643,7 +646,7 @@ export async function getUpdatesToRepublishInteractiveAsync(
       branchName,
       platformFlag,
       cumulativeUpdates,
-      offset + 1 * viewBranchUpdatesQueryUpdateLimit
+      (offset + 1) * getViewBranchUpdatesQueryUpdateLimit()
     );
   }
   return cumulativeUpdates.filter(update => update.group === selectedUpdateGroup);

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4523,6 +4523,7 @@ export type ViewBranchUpdatesQueryVariables = Exact<{
   appId: Scalars['String'];
   name: Scalars['String'];
   limit: Scalars['Int'];
+  offset: Scalars['Int'];
 }>;
 
 

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -8,8 +8,7 @@ import {
   ViewBranchUpdatesQueryVariables,
 } from '../generated';
 
-// used for changing the value during testing
-export const getViewBranchUpdatesQueryUpdateLimit = (): number => 300;
+export const viewBranchUpdatesQueryUpdateLimit = 300;
 
 type ViewBranchUpdatesQueryVariablesWithOptionalLimitAndOffset =
   Partial<ViewBranchUpdatesQueryVariables> &
@@ -52,7 +51,7 @@ export const UpdateQuery = {
           `,
           {
             appId,
-            limit: getViewBranchUpdatesQueryUpdateLimit(),
+            limit: viewBranchUpdatesQueryUpdateLimit,
           },
           { additionalTypenames: ['UpdateBranch', 'Update'] }
         )
@@ -62,7 +61,7 @@ export const UpdateQuery = {
   async viewBranchAsync({
     appId,
     name,
-    limit = getViewBranchUpdatesQueryUpdateLimit(),
+    limit = viewBranchUpdatesQueryUpdateLimit,
     offset = 0,
   }: ViewBranchUpdatesQueryVariablesWithOptionalLimitAndOffset) {
     return withErrorHandlingAsync<ViewBranchUpdatesQuery>(

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -10,8 +10,9 @@ import {
 
 export const viewBranchUpdatesQueryUpdateLimit = 300;
 
-type ViewBranchUpdatesQueryVariablesWithOptionalLimit = Partial<ViewBranchUpdatesQueryVariables> &
-  Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>;
+type ViewBranchUpdatesQueryVariablesWithOptionalLimitAndOffset =
+  Partial<ViewBranchUpdatesQueryVariables> &
+    Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>;
 
 export const UpdateQuery = {
   async viewAllAsync({ appId }: { appId: string }): Promise<ViewAllUpdatesQuery> {
@@ -61,19 +62,20 @@ export const UpdateQuery = {
     appId,
     name,
     limit = viewBranchUpdatesQueryUpdateLimit,
-  }: ViewBranchUpdatesQueryVariablesWithOptionalLimit) {
+    offset = 0,
+  }: ViewBranchUpdatesQueryVariablesWithOptionalLimitAndOffset) {
     return withErrorHandlingAsync<ViewBranchUpdatesQuery>(
       graphqlClient
         .query<ViewBranchUpdatesQuery, ViewBranchUpdatesQueryVariables>(
           gql`
-            query ViewBranchUpdates($appId: String!, $name: String!, $limit: Int!) {
+            query ViewBranchUpdates($appId: String!, $name: String!, $limit: Int!, $offset: Int!) {
               app {
                 byId(appId: $appId) {
                   id
                   updateBranchByName(name: $name) {
                     id
                     name
-                    updates(offset: 0, limit: $limit) {
+                    updates(offset: $offset, limit: $limit) {
                       id
                       group
                       message
@@ -100,6 +102,7 @@ export const UpdateQuery = {
             appId,
             name,
             limit,
+            offset,
           },
           { additionalTypenames: ['UpdateBranch', 'Update'] }
         )

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -8,7 +8,8 @@ import {
   ViewBranchUpdatesQueryVariables,
 } from '../generated';
 
-export const viewBranchUpdatesQueryUpdateLimit = 300;
+// used for changing the value during testing
+export const getViewBranchUpdatesQueryUpdateLimit = (): number => 300;
 
 type ViewBranchUpdatesQueryVariablesWithOptionalLimitAndOffset =
   Partial<ViewBranchUpdatesQueryVariables> &
@@ -51,7 +52,7 @@ export const UpdateQuery = {
           `,
           {
             appId,
-            limit: viewBranchUpdatesQueryUpdateLimit,
+            limit: getViewBranchUpdatesQueryUpdateLimit(),
           },
           { additionalTypenames: ['UpdateBranch', 'Update'] }
         )
@@ -61,7 +62,7 @@ export const UpdateQuery = {
   async viewBranchAsync({
     appId,
     name,
-    limit = viewBranchUpdatesQueryUpdateLimit,
+    limit = getViewBranchUpdatesQueryUpdateLimit(),
     offset = 0,
   }: ViewBranchUpdatesQueryVariablesWithOptionalLimitAndOffset) {
     return withErrorHandlingAsync<ViewBranchUpdatesQuery>(

--- a/packages/eas-cli/src/update/__tests__/update-test.ts
+++ b/packages/eas-cli/src/update/__tests__/update-test.ts
@@ -1,16 +1,44 @@
-import { ensureBranchExistsAsync } from '../../commands/update';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  PlatformFlag,
+  ensureBranchExistsAsync,
+  getUpdatesToRepublishInteractiveAsync,
+} from '../../commands/update';
 import { graphqlClient } from '../../graphql/client';
-import { viewBranchUpdatesQueryUpdateLimit } from '../../graphql/queries/UpdateQuery';
+import { ViewBranchUpdatesQuery } from '../../graphql/generated';
+import { getViewBranchUpdatesQueryUpdateLimit } from '../../graphql/queries/UpdateQuery';
+import { selectAsync } from '../../prompts';
 
 const appId = '6c94sxe6-37d2-4700-52fa-1b813204dad2';
 const branchId = '5e84e3cb-563e-4022-a65e-6e7a42fe4ed3';
 const appName = '@tester/test';
 const branchName = 'test-branch';
 
+jest.mock('../../graphql/queries/UpdateQuery', () => {
+  const actual = jest.requireActual('../../graphql/queries/UpdateQuery');
+  return {
+    ...actual,
+    getViewBranchUpdatesQueryUpdateLimit: jest.fn(actual.getViewBranchUpdatesQueryUpdateLimit),
+  };
+});
+jest.mock('../../prompts', () => ({
+  selectAsync: jest.fn(),
+}));
 jest.mock('../../commands/update', () => {
   const actual = jest.requireActual('../../commands/update');
-  return { ...actual, ensureBranchExistsAsync: jest.fn(actual.ensureBranchExistsAsync) };
+  return {
+    ...actual,
+    ensureBranchExistsAsync: jest.fn(actual.ensureBranchExistsAsync),
+    getUpdatesToRepublishInteractiveAsync: jest.fn(actual.getUpdatesToRepublishInteractiveAsync),
+  };
 });
+const updatesToResolve = jest.fn(
+  (): Exclude<
+    Exclude<ViewBranchUpdatesQuery['app'], null | undefined>['byId']['updateBranchByName'],
+    null | undefined
+  >['updates'] => []
+);
 jest.mock('../../graphql/client', () => ({
   ...jest.requireActual('../../graphql/client'),
   graphqlClient: {
@@ -28,7 +56,7 @@ jest.mock('../../graphql/client', () => ({
                   __typename: 'UpdateBranch',
                   id: branchId,
                   name: branchName,
-                  updates: [],
+                  updates: updatesToResolve(),
                 },
               },
             },
@@ -53,6 +81,49 @@ jest.mock('../../graphql/client', () => ({
   },
 }));
 
+function createMockUpdate(
+  {
+    platformFlag = 'all',
+    group = uuidv4(),
+  }: Partial<{
+    platformFlag: PlatformFlag;
+    group: string;
+  }> = {
+    platformFlag: 'all',
+    group: uuidv4(),
+  }
+): Exclude<
+  Exclude<ViewBranchUpdatesQuery['app'], null | undefined>['byId']['updateBranchByName'],
+  null | undefined
+>['updates'] {
+  const androidUpdate = {
+    id: uuidv4(),
+    group,
+    message: 'default test message',
+    createdAt: new Date(),
+    runtimeVersion: 'exposdk:44.0.0',
+    platform: 'ios',
+    manifestFragment: '',
+  };
+  const iosUpdate = {
+    id: uuidv4(),
+    group,
+    message: 'default test message',
+    createdAt: new Date(),
+    runtimeVersion: 'exposdk:44.0.0',
+    platform: 'android',
+    manifestFragment: '',
+  };
+  switch (platformFlag) {
+    case 'all':
+      return [androidUpdate, iosUpdate];
+    case 'android':
+      return [androidUpdate];
+    case 'ios':
+      return [iosUpdate];
+  }
+}
+
 describe('UpdatePublish', () => {
   describe('ensureBranchExistsAsync', () => {
     beforeEach(() => {
@@ -67,7 +138,7 @@ describe('UpdatePublish', () => {
       expect(bindings).toEqual({
         appId,
         name: appName,
-        limit: viewBranchUpdatesQueryUpdateLimit,
+        limit: getViewBranchUpdatesQueryUpdateLimit(),
         offset: 0,
       });
     });
@@ -87,6 +158,85 @@ describe('UpdatePublish', () => {
         limit,
         offset,
       });
+    });
+  });
+
+  describe('getUpdatesToRepublishInteractiveAsync', () => {
+    beforeEach(() => {
+      jest.mocked(graphqlClient.query).mockClear();
+      jest.mocked(graphqlClient.mutation).mockClear();
+      jest.mocked(getUpdatesToRepublishInteractiveAsync).mockClear();
+      jest.mocked(selectAsync).mockClear();
+      jest.mocked(getViewBranchUpdatesQueryUpdateLimit).mockReturnValue(2);
+    });
+
+    it('throws when there are no updates', async () => {
+      const platformFlag = 'all';
+      await expect(
+        async () =>
+          await getUpdatesToRepublishInteractiveAsync('test-project', branchName, platformFlag)
+      ).rejects.toThrow(
+        `There are no updates on branch "${branchName}" published on the platform(s) ${platformFlag}. Did you mean to publish a new update instead?`
+      );
+    });
+
+    it('fetches multiple pages of updates and can republish an update from the most recent page', async () => {
+      const mockSelectedGroupId = uuidv4();
+      updatesToResolve
+        .mockReturnValueOnce(createMockUpdate())
+        .mockReturnValueOnce(createMockUpdate({ group: mockSelectedGroupId }));
+      jest
+        .mocked(selectAsync)
+        .mockResolvedValueOnce('_fetchMore')
+        .mockResolvedValueOnce(mockSelectedGroupId);
+
+      const selectedUpdates: Exclude<
+        Exclude<ViewBranchUpdatesQuery['app'], null | undefined>['byId']['updateBranchByName'],
+        null | undefined
+      >['updates'] = await getUpdatesToRepublishInteractiveAsync('test-project', branchName, 'all');
+      expect(selectedUpdates.every(update => update.group === mockSelectedGroupId)).toBeTruthy();
+    });
+
+    it('fetches multiple pages of updates and can republish an update from the previous page', async () => {
+      const mockSelectedGroupId = uuidv4();
+
+      updatesToResolve
+        .mockReturnValueOnce(createMockUpdate({ group: mockSelectedGroupId }))
+        .mockReturnValueOnce(createMockUpdate());
+      jest
+        .mocked(selectAsync)
+        .mockResolvedValueOnce('_fetchMore')
+        .mockResolvedValueOnce(mockSelectedGroupId);
+
+      const selectedUpdates: Exclude<
+        Exclude<ViewBranchUpdatesQuery['app'], null | undefined>['byId']['updateBranchByName'],
+        null | undefined
+      >['updates'] = await getUpdatesToRepublishInteractiveAsync('test-project', branchName, 'all');
+      expect(selectedUpdates.every(update => update.group === mockSelectedGroupId)).toBeTruthy();
+    });
+
+    it('displays the option to fetch more as long as there are unfetched updates left', async () => {
+      const mockSelectedGroupId = uuidv4();
+      updatesToResolve
+        .mockReturnValueOnce(createMockUpdate({ group: mockSelectedGroupId }))
+        .mockReturnValueOnce(createMockUpdate())
+        .mockReturnValueOnce(createMockUpdate({ platformFlag: 'android' }));
+      jest
+        .mocked(selectAsync)
+        .mockResolvedValueOnce('_fetchMore')
+        .mockResolvedValueOnce('_fetchMore')
+        .mockResolvedValueOnce(mockSelectedGroupId);
+
+      await getUpdatesToRepublishInteractiveAsync('test-project', branchName, 'all');
+      const { calls } = jest.mocked(selectAsync).mock;
+      expect(calls.length).toEqual(3);
+      const [[, firstOptions], [, secondOptions], [, thirdOptions]] = calls;
+      const fetchMoreValue = '_fetchMore';
+      expect(firstOptions[firstOptions.length - 1].value).toEqual(fetchMoreValue);
+      expect(firstOptions.length).toEqual(2);
+      expect(secondOptions[secondOptions.length - 1].value).toEqual(fetchMoreValue);
+      expect(secondOptions.length).toEqual(3);
+      expect(thirdOptions.every(update => update.value !== fetchMoreValue)).toBeTruthy();
     });
   });
 });

--- a/packages/eas-cli/src/update/__tests__/update-test.ts
+++ b/packages/eas-cli/src/update/__tests__/update-test.ts
@@ -60,7 +60,7 @@ describe('UpdatePublish', () => {
       jest.mocked(graphqlClient.mutation).mockClear();
     });
 
-    it('defaults to the PAGE_LIMIT when no limit is provided', async () => {
+    it('defaults limit to PAGE_LIMIT and offset to 0 when none are provided', async () => {
       await ensureBranchExistsAsync({ appId, name: appName });
       const [[, bindings]] = jest.mocked(graphqlClient.query).mock.calls;
 
@@ -68,17 +68,24 @@ describe('UpdatePublish', () => {
         appId,
         name: appName,
         limit: viewBranchUpdatesQueryUpdateLimit,
+        offset: 0,
       });
     });
 
-    it.each([0, 10, 100, 1000])('sets the limit to %s when asked', async limit => {
-      await ensureBranchExistsAsync({ appId, name: appName, limit });
+    it.each([
+      [0, 0],
+      [10, 50],
+      [100, 3],
+      [1000, 77],
+    ])('sets the limit to %s and offset to %s when asked', async (limit, offset) => {
+      await ensureBranchExistsAsync({ appId, name: appName, limit, offset });
       const [[, bindings]] = jest.mocked(graphqlClient.query).mock.calls;
 
       expect(bindings).toEqual({
         appId,
         name: appName,
         limit,
+        offset,
       });
     });
   });

--- a/packages/eas-cli/src/update/__tests__/update-test.ts
+++ b/packages/eas-cli/src/update/__tests__/update-test.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import {
-  PlatformFlag,
+  PublishPlatformFlag,
   ensureBranchExistsAsync,
   getUpdatesToRepublishInteractiveAsync,
 } from '../../commands/update';
@@ -86,7 +86,7 @@ function createMockUpdate(
     platformFlag = 'all',
     group = uuidv4(),
   }: Partial<{
-    platformFlag: PlatformFlag;
+    platformFlag: PublishPlatformFlag;
     group: string;
   }> = {
     platformFlag: 'all',


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Follow up to #1119. This allows CLI users to `update --republish` any previously published update, even if it is beyond the initial page limit (n=300).

# How

I added the `getUpdatesToRepublishAsync` method which will recurse when the user asks for a new page updates. The updates are accumulated and presented to the user. Once a branch has been fully loaded, the option to fetch another page (`Next page...`) will disappear.

# Test Plan

Run locally (`edl update --republish`) with a low page limit (n=5) on a branch with few updates. Ensure that:
- the option to fetch new pages of updates is present
- updates fetched in both the current network request and previous network requests can be republished
- once all updates are fetched, the option to fetch another page disappears

Also, added some automated tests for above