### PR TITLE
[eas-cli] improve update terminal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- `eas update` now provides more information about the publish results include # of assets uploaded, update ids, website links, and warnings. ([#1152](https://github.com/expo/eas-cli/pull/1152)) by [@kgc00](https://github.com/kgc00/)
+- `eas update` now provides more information about the publish process including real-time feedback on asset uploads, update ids, and website links. ([#1152](https://github.com/expo/eas-cli/pull/1152)) by [@kgc00](https://github.com/kgc00/)
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- `eas update` now provides more information about the publish results include # of assets uploaded, update ids, website links, and warnings. ([#1152](https://github.com/expo/eas-cli/pull/1152)) by [@kgc00](https://github.com/kgc00/)
+
 ### 🐛 Bug fixes
 
 - Improved support for working on branches with many updates. ([#1144](https://github.com/expo/eas-cli/pull/1144)) by [@kgc00](https://github.com/kgc00/)
+- `eas update` project links no longer contain a `)` on unsupported terminals. ([#1152](https://github.com/expo/eas-cli/pull/1152)) by [@kgc00](https://github.com/kgc00/)
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -35,3 +35,14 @@ export function getInternalDistributionInstallUrl(build: BuildFragment): string 
 
   return build.artifacts.buildUrl;
 }
+
+export function getUpdateGroupUrl(
+  accountName: string,
+  projectName: string,
+  updateGroupId: string
+): string {
+  return new URL(
+    `/accounts/${accountName}/projects/${projectName}/updates/${updateGroupId}`,
+    getExpoWebsiteBaseUrl()
+  ).toString();
+}

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -42,7 +42,9 @@ export function getUpdateGroupUrl(
   updateGroupId: string
 ): string {
   return new URL(
-    `/accounts/${accountName}/projects/${projectName}/updates/${updateGroupId}`,
+    `/accounts/${encodeURIComponent(accountName)}/projects/${encodeURIComponent(
+      projectName
+    )}/updates/${encodeURIComponent(updateGroupId)}`,
     getExpoWebsiteBaseUrl()
   ).toString();
 }

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -454,11 +454,15 @@ export default class UpdatePublish extends EasCommand {
         }
       }
 
-      const assetSpinner = ora().start('Uploading assets...');
+      const assetSpinner = ora().start();
       try {
         const platforms = platformFlag === 'all' ? defaultPublishPlatforms : [platformFlag];
         const assets = await collectAssetsAsync({ inputDir: inputDir!, platforms });
-        uploadedAssetCount = await uploadAssetsAsync(assets);
+        const { uniqueUploadedAssetCount } = await uploadAssetsAsync(
+          assets,
+          spinnerText => (assetSpinner.text = `Uploading assets... ${spinnerText}`)
+        );
+        uploadedAssetCount = uniqueUploadedAssetCount;
         unsortedUpdateInfoGroups = await buildUnsortedUpdateInfoGroupAsync(assets, exp);
         const uploadAssetSuccessMessage = uploadedAssetCount
           ? `Uploaded ${uploadedAssetCount} assets!`

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -9,6 +9,7 @@ import gql from 'graphql-tag';
 import nullthrows from 'nullthrows';
 
 import { getEASUpdateURL } from '../../api';
+import { getUpdateGroupUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
 import fetch from '../../fetch';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
@@ -25,25 +26,29 @@ import {
 } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
-import Log from '../../log';
+import Log, { learnMore, link } from '../../log';
 import { ora } from '../../ora';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
+  getProjectAccountName,
   getProjectIdAsync,
   installExpoUpdatesAsync,
   isExpoUpdatesInstalledOrAvailable,
 } from '../../project/projectUtils';
 import {
+  MAX_ASSETS_PER_UPLOAD,
   PublishPlatform,
   buildBundlesAsync,
   buildUnsortedUpdateInfoGroupAsync,
   collectAssetsAsync,
   uploadAssetsAsync,
+  uploadedAssetCountIsAboveWarningThreshold,
 } from '../../project/publish';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { confirmAsync, promptAsync, selectAsync } from '../../prompts';
 import { formatUpdate } from '../../update/utils';
+import { ensureLoggedInAsync } from '../../user/actions';
 import {
   checkManifestBodyAgainstUpdateInfoGroup,
   getCodeSigningInfoAsync,
@@ -314,6 +319,8 @@ export default class UpdatePublish extends EasCommand {
 
     let unsortedUpdateInfoGroups: UpdateInfoGroup = {};
     let oldMessage: string, oldRuntimeVersion: string;
+    let uploadedAssetCount = 0;
+
     if (republish) {
       // If we are republishing, we don't need to worry about building the bundle or uploading the assets.
       // Instead we get the `updateInfoGroup` from the update we wish to republish.
@@ -451,9 +458,12 @@ export default class UpdatePublish extends EasCommand {
       try {
         const platforms = platformFlag === 'all' ? defaultPublishPlatforms : [platformFlag];
         const assets = await collectAssetsAsync({ inputDir: inputDir!, platforms });
-        await uploadAssetsAsync(assets);
+        uploadedAssetCount = await uploadAssetsAsync(assets);
         unsortedUpdateInfoGroups = await buildUnsortedUpdateInfoGroupAsync(assets, exp);
-        assetSpinner.succeed('Uploaded assets!');
+        const uploadAssetSuccessMessage = uploadedAssetCount
+          ? `Uploaded ${uploadedAssetCount} assets!`
+          : `Uploading assets skipped -- no new assets were found!`;
+        assetSpinner.succeed(uploadAssetSuccessMessage);
       } catch (e) {
         assetSpinner.fail('Failed to upload assets');
         throw e;
@@ -562,23 +572,49 @@ export default class UpdatePublish extends EasCommand {
 
       Log.addNewLineIfNone();
       for (const runtime of new Set(Object.values(runtimeVersions))) {
-        const platforms = newUpdates
-          .filter(update => update.runtimeVersion === runtime)
-          .map(update => update.platform);
-        const newUpdate = newUpdates.find(update => update.runtimeVersion === runtime);
-        if (!newUpdate) {
+        const newUpdatesForRuntimeVersion = newUpdates.filter(
+          update => update.runtimeVersion === runtime
+        );
+        if (!newUpdatesForRuntimeVersion.length) {
           throw new Error(`Publish response is missing updates with runtime ${runtime}.`);
         }
+        const platforms = newUpdatesForRuntimeVersion.map(update => update.platform);
+        const newAndroidUpdate = newUpdatesForRuntimeVersion.find(
+          update => update.platform === 'android'
+        );
+        const newIosUpdate = newUpdatesForRuntimeVersion.find(update => update.platform === 'ios');
+        const updateGroupId = newUpdatesForRuntimeVersion[0].group;
+
+        const projectName = exp.slug;
+        const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
+        const updateGroupUrl = getUpdateGroupUrl(accountName, projectName, updateGroupId);
+        const updateGroupLink = link(updateGroupUrl, { dim: false });
+
         Log.log(
           formatFields([
-            { label: 'branch', value: branchName },
-            { label: 'runtime version', value: runtime },
-            { label: 'platform', value: platforms.join(', ') },
-            { label: 'update group ID', value: newUpdate.group },
-            { label: 'message', value: message! },
+            { label: 'Branch', value: branchName },
+            { label: 'Runtime version', value: runtime },
+            { label: 'Platform', value: platforms.join(', ') },
+            { label: 'Update group ID', value: updateGroupId },
+            ...(newAndroidUpdate
+              ? [{ label: 'Android update ID', value: newAndroidUpdate.id }]
+              : []),
+            ...(newIosUpdate ? [{ label: 'iOS update ID', value: newIosUpdate.id }] : []),
+            { label: 'Message', value: message! },
+            { label: 'Website link', value: updateGroupLink },
           ])
         );
         Log.addNewLineIfNone();
+        if (uploadedAssetCountIsAboveWarningThreshold(uploadedAssetCount)) {
+          Log.warn(
+            `This update group contains ${uploadedAssetCount} assets and is nearing the server cap of ${MAX_ASSETS_PER_UPLOAD}\n` +
+              `${learnMore('https://docs.expo.dev/eas-update/optimize-assets/', {
+                learnMoreMessage: 'Consider optimizing your usage of assets',
+                dim: false,
+              })}`
+          );
+          Log.addNewLineIfNone();
+        }
       }
     }
   }

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -468,7 +468,7 @@ describe(uploadAssetsAsync, () => {
     });
 
     mockdate.set(0);
-    await expect(uploadAssetsAsync(assetsForUpdateInfoGroup)).resolves.toBe(undefined);
+    await expect(uploadAssetsAsync(assetsForUpdateInfoGroup)).resolves.toBe(0);
   });
   it('resolves if the assets are eventually uploaded', async () => {
     jest.spyOn(PublishQuery, 'getAssetMetadataAsync').mockImplementation(async () => {
@@ -496,6 +496,6 @@ describe(uploadAssetsAsync, () => {
     });
 
     mockdate.set(0);
-    await expect(uploadAssetsAsync(assetsForUpdateInfoGroup)).resolves.toBe(undefined);
+    await expect(uploadAssetsAsync(assetsForUpdateInfoGroup)).resolves.toBe(2);
   });
 });

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -536,9 +536,9 @@ describe(uploadAssetsAsync, () => {
     await uploadAssetsAsync(assetsForUpdateInfoGroup, updateSpinnerFn);
     const calls = updateSpinnerFn.mock.calls;
     expect(calls).toEqual([
-      ['6 present'],
+      ['6 assets present'],
       ['3 unique assets found'],
-      ['2 missing assets being uploaded'],
+      ['2 new assets uploading'],
     ]);
   });
 });

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -468,7 +468,11 @@ describe(uploadAssetsAsync, () => {
     });
 
     mockdate.set(0);
-    await expect(uploadAssetsAsync(assetsForUpdateInfoGroup)).resolves.toBe(0);
+    await expect(uploadAssetsAsync(assetsForUpdateInfoGroup)).resolves.toEqual({
+      assetCount: 6,
+      uniqueAssetCount: 3,
+      uniqueUploadedAssetCount: 0,
+    });
   });
   it('resolves if the assets are eventually uploaded', async () => {
     jest.spyOn(PublishQuery, 'getAssetMetadataAsync').mockImplementation(async () => {
@@ -496,6 +500,45 @@ describe(uploadAssetsAsync, () => {
     });
 
     mockdate.set(0);
-    await expect(uploadAssetsAsync(assetsForUpdateInfoGroup)).resolves.toBe(2);
+    await expect(uploadAssetsAsync(assetsForUpdateInfoGroup)).resolves.toEqual({
+      assetCount: 6,
+      uniqueAssetCount: 3,
+      uniqueUploadedAssetCount: 2,
+    });
+  });
+  it('updates spinner text throughout execution', async () => {
+    jest.spyOn(PublishQuery, 'getAssetMetadataAsync').mockImplementation(async () => {
+      const status =
+        Date.now() === 0 ? AssetMetadataStatus.DoesNotExist : AssetMetadataStatus.Exists;
+      mockdate.set(Date.now() + 1);
+      jest.runAllTimers();
+      return [
+        {
+          storageKey: 'qbgckgkgfdjnNuf9dQd7FDTWUmlEEzg7l1m1sKzQaq0',
+          status,
+          __typename: 'AssetMetadataResult',
+        }, // userDefinedAsset
+        {
+          storageKey: 'bbjgXFSIXtjviGwkaPFY0HG4dVVIGiXHAboRFQEqVa4',
+          status,
+          __typename: 'AssetMetadataResult',
+        }, // android.code
+        {
+          storageKey: 'dP-nC8EJXKz42XKh_Rc9tYxiGAT-ilpkRltEi6HIKeQ',
+          status,
+          __typename: 'AssetMetadataResult',
+        }, // ios.code
+      ];
+    });
+    const updateSpinnerFn = jest.fn(_text => {});
+
+    mockdate.set(0);
+    await uploadAssetsAsync(assetsForUpdateInfoGroup, updateSpinnerFn);
+    const calls = updateSpinnerFn.mock.calls;
+    expect(calls).toEqual([
+      ['6 present'],
+      ['3 unique assets found'],
+      ['2 missing assets being uploaded'],
+    ]);
   });
 });

--- a/packages/eas-cli/src/project/ensureProjectExists.ts
+++ b/packages/eas-cli/src/project/ensureProjectExists.ts
@@ -35,7 +35,10 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
   assert(account, `You must have access to the ${accountName} account to run this command`);
 
   const projectDashboardUrl = getProjectDashboardUrl(accountName, projectName);
-  const projectLink = terminalLink(projectFullName, projectDashboardUrl);
+  const projectLink = terminalLink(projectFullName, projectDashboardUrl, {
+    // https://github.com/sindresorhus/terminal-link/issues/18#issuecomment-1068020361
+    fallback: () => `${projectFullName} (${projectDashboardUrl})`,
+  });
 
   const spinner = ora(`Linking to project ${chalk.bold(projectFullName)}`).start();
 

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -16,10 +16,6 @@ import { expoCommandAsync } from '../utils/expoCli';
 import uniqBy from '../utils/expodash/uniqBy';
 
 export const TIMEOUT_LIMIT = 60_000; // 1 minute
-export const MAX_ASSETS_PER_UPLOAD = 600; // https://github.com/expo/universe/blob/main/server/www/src/graphql/mutations/AssetMutation.ts#L14
-const MAX_ASSETS_PER_UPLOAD_WARNING_THRESHOLD = Math.floor(MAX_ASSETS_PER_UPLOAD * 0.75);
-export const uploadedAssetCountIsAboveWarningThreshold = (uploadedAssetCount: number): boolean =>
-  uploadedAssetCount > MAX_ASSETS_PER_UPLOAD_WARNING_THRESHOLD;
 
 export type PublishPlatform = Extract<'android' | 'ios', Platform>;
 type Metadata = {
@@ -268,7 +264,7 @@ export async function uploadAssetsAsync(
       ...assetsForUpdateInfoGroup[platform]!.assets,
     ];
   }
-  updateSpinnerText?.(`${assets.length} present`);
+  updateSpinnerText?.(`${assets.length} ${assets.length === 1 ? 'asset' : 'assets'} present`);
 
   const assetsWithStorageKey = await Promise.all(
     assets.map(async asset => {
@@ -283,7 +279,9 @@ export async function uploadAssetsAsync(
       storageKey: string;
     }
   >(assetsWithStorageKey, asset => asset.storageKey);
-  updateSpinnerText?.(`${uniqueAssets.length} unique assets found`);
+  updateSpinnerText?.(
+    `${uniqueAssets.length} unique ${uniqueAssets.length === 1 ? 'asset' : 'assets'} found`
+  );
 
   let missingAssets = await filterOutAssetsThatAlreadyExistAsync(uniqueAssets);
   const uniqueUploadedAssetCount = missingAssets.length;
@@ -298,7 +296,9 @@ export async function uploadAssetsAsync(
     })
   );
 
-  updateSpinnerText?.(`${missingAssets.length} missing assets being uploaded`);
+  updateSpinnerText?.(
+    `${missingAssets.length} new ${missingAssets.length === 1 ? 'asset' : 'assets'} uploading`
+  );
   // Wait up to TIMEOUT_LIMIT for assets to be uploaded and processed
   const start = Date.now();
   let timeout = 1;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We'd like to ensure our users have a better experience using `eas-cli`. Contains various UX improvements listed in  https://linear.app/expo/issue/ENG-4589/improve-publish-command

# How

- Updated `uploadAssetsAsync` to now return the # of unique assets uploaded and use that value to inform the user of the CLI run status
- Added a bunch of info to the log output
- Added a 'fallback' behavior for unsupported terminals for the `ensureProjectExistsAsync` console output

# Test Plan

I've updated the automated tests for `uploadAssetsAsync` to include the new return value.

You should be able to run the CLI as normal but now:
- in an unsupported terminal by [terminal link](https://www.npmjs.com/package/terminal-link), URLs should not contain `)`
- Console output should capitalize all the outputs (branch => Branch)
- Console output should contain Android and iOS specific update IDs
- Console output should contain a link to the website
- Console output should show how many assets we uploaded
- ~Console output should show a warning when assets uploaded near the server limit~

### No assets to upload
![image](https://user-images.githubusercontent.com/15132641/172956586-72879030-2872-4bc0-9370-11ae09a6c0b6.png)

### Some new assets
![image](https://user-images.githubusercontent.com/15132641/172956805-0b311e20-cb33-441d-9e3f-f381068d5232.png)

### Videos

https://user-images.githubusercontent.com/15132641/173119112-aac4c950-1f53-44b7-9129-4abbb553933d.mov

https://user-images.githubusercontent.com/15132641/173119131-7c56b6c1-534e-4d99-8570-bbaf964bf1f4.mov


