### PR TITLE
[eas-cli] Limit concurrent asset uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Match bundle identifier capabilities more accurately. ([#1112](https://github.com/expo/eas-cli/pull/1112) by [@EvanBacon](https://github.com/EvanBacon))
-- Limit concurrent asset uploads to google. ([#1153](https://github.com/expo/eas-cli/pull/1153) by [@wschurman](https://github.com/wschurman))
+- Limit concurrent asset uploads. ([#1153](https://github.com/expo/eas-cli/pull/1153) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Match bundle identifier capabilities more accurately. ([#1112](https://github.com/expo/eas-cli/pull/1112) by [@EvanBacon](https://github.com/EvanBacon))
+- Limit concurrent asset uploads to google. ([#1153](https://github.com/expo/eas-cli/pull/1153) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -60,6 +60,7 @@
     "nullthrows": "1.1.1",
     "ora": "5.1.0",
     "pkg-dir": "4.2.0",
+    "promise-limit": "2.7.0",
     "prompts": "2.4.2",
     "qrcode-terminal": "0.12.0",
     "resolve-from": "5.0.0",

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -276,7 +276,7 @@ export async function uploadAssetsAsync(assetsForUpdateInfoGroup: CollectedAsset
     missingAssets.map(ma => ma.contentType)
   );
 
-  const assetUploadPromiseLimit = promiseLimit(50);
+  const assetUploadPromiseLimit = promiseLimit(15);
 
   await Promise.all(
     missingAssets.map((missingAsset, i) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10535,6 +10535,11 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise-limit@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/promise-limit/-/promise-limit-2.7.0.tgz#eb5737c33342a030eaeaecea9b3d3a93cb592b26"
+  integrity sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==
+
 promise-retry@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Google gets overloaded when too many assets are uploaded at once. 

Closes ENG-5232.

# How

This limits it to 50 at a time. Previously there was no limit but we had another artificial limit of 400 on the server side, so the max concurrent uploads was 400. We could do 400 here, but I figure 50 is probably a bit more reliable.

# Test Plan

With eas-cli changes running locally and www changes running locally from https://github.com/expo/universe/pull/9852, with an app with 1600 assets (temporarily set MAX_ASSETS_PER_UPDATE to 2000 on local server)
```
export EXPO_LOCAL=1
EXPO_DEBUG=1 ~/expo/eas-cli/packages/eas-cli/bin/run update --branch preview --message "Updating the app"
```
see it finishes successfully.