### PR TITLE
remove support for deprecated eas.json formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Remove fallback for legacy format in `eas.json`. ([#1158](https://github.com/expo/eas-cli/pull/1158) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🎉 New features
 
 - `eas update` now provides more information about the publish process including real-time feedback on asset uploads, update ids, and website links. ([#1152](https://github.com/expo/eas-cli/pull/1152) by [@kgc00](https://github.com/kgc00/))

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -1,5 +1,5 @@
 import { Platform, Workflow } from '@expo/eas-build-job';
-import { BuildProfile, SubmitProfile } from '@expo/eas-json';
+import { BuildProfile, EasJsonReader, SubmitProfile } from '@expo/eas-json';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
@@ -57,11 +57,12 @@ export async function runBuildAndSubmitAsync(projectDir: string, flags: BuildFla
     projectDir,
     nonInteractive: flags.nonInteractive,
   });
+  const easJsonReader = new EasJsonReader(projectDir);
 
   const platforms = toPlatforms(flags.requestedPlatform);
   const buildProfiles = await getProfilesAsync({
     type: 'build',
-    projectDir,
+    easJsonReader,
     platforms,
     profileName: flags.profile ?? undefined,
   });
@@ -102,7 +103,7 @@ export async function runBuildAndSubmitAsync(projectDir: string, flags: BuildFla
   const submissions: SubmissionFragment[] = [];
   if (flags.autoSubmit) {
     const submitProfiles = await getProfilesAsync({
-      projectDir,
+      easJsonReader,
       platforms,
       profileName: flags.submitProfile,
       type: 'submit',

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -11,7 +11,6 @@ import { appPlatformEmojis } from '../platform';
 import { getExpoConfig } from '../project/expoConfig';
 import { findProjectRootAsync } from '../project/projectUtils';
 import { selectAsync } from '../prompts';
-import { handleDeprecatedEasJsonAsync } from './build';
 
 export default class Config extends EasCommand {
   static description = 'display project configuration (app.json + eas.json)';
@@ -31,7 +30,6 @@ export default class Config extends EasCommand {
     };
 
     const projectDir = await findProjectRootAsync();
-    await handleDeprecatedEasJsonAsync(projectDir, false);
 
     const reader = new EasJsonReader(projectDir);
     const profileName =

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -1,3 +1,4 @@
+import { EasJsonReader } from '@expo/eas-json';
 import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
 
@@ -95,7 +96,7 @@ export default class Submit extends EasCommand {
     const platforms = toPlatforms(flags.requestedPlatform);
     const submissionProfiles = await getProfilesAsync({
       type: 'submit',
-      projectDir,
+      easJsonReader: new EasJsonReader(projectDir),
       platforms,
       profileName: flags.profile,
     });

--- a/packages/eas-cli/src/utils/profiles.ts
+++ b/packages/eas-cli/src/utils/profiles.ts
@@ -1,16 +1,5 @@
 import { Platform } from '@expo/eas-build-job';
-import {
-  BuildProfile,
-  EasJsonReader,
-  ProfileType,
-  SubmitProfile,
-  errors,
-  getDefaultSubmitProfile,
-} from '@expo/eas-json';
-import chalk from 'chalk';
-
-import Log from '../log';
-import { ExpoChoice, selectAsync } from '../prompts';
+import { BuildProfile, EasJsonReader, ProfileType, SubmitProfile } from '@expo/eas-json';
 
 type EasProfile<T extends ProfileType> = T extends 'build'
   ? BuildProfile<Platform>
@@ -23,109 +12,26 @@ export type ProfileData<T extends ProfileType> = {
 };
 
 export async function getProfilesAsync<T extends ProfileType>({
-  projectDir,
+  easJsonReader,
   platforms,
   profileName,
   type,
 }: {
-  projectDir: string;
+  easJsonReader: EasJsonReader;
   platforms: Platform[];
   profileName?: string;
   type: T;
 }): Promise<ProfileData<T>[]> {
   const results = platforms.map(async function (platform) {
-    if (profileName) {
-      const profile = await readProfileAsync({ projectDir, platform, type, profileName });
-      return {
-        profile,
-        profileName,
-        platform,
-      };
-    }
-
-    try {
-      const profile = await readProfileAsync({
-        projectDir,
-        platform,
-        type,
-        profileName: 'production',
-      });
-      return {
-        profile,
-        profileName: 'production',
-        platform,
-      };
-    } catch (error) {
-      if (!(error instanceof errors.MissingProfileError)) {
-        throw error;
-      }
-    }
-
-    try {
-      const profile = await readProfileAsync({
-        projectDir,
-        platform,
-        type,
-        profileName: 'release',
-      });
-      Log.warn(
-        `The default profile changed from ${chalk.bold('release')} to ${chalk.bold(
-          'production'
-        )}. We detected that you still have a ${chalk.bold(
-          'release'
-        )} build profile, so we are using it. Update eas.json to have a profile named ${chalk.bold(
-          'production'
-        )} under the ${chalk.bold(
-          'build'
-        )} key, or specify which profile you'd like to use with the ${chalk.bold(
-          '--profile'
-        )} flag. This fallback behavior will be removed in the next major version of EAS CLI.`
-      );
-      return {
-        profile,
-        profileName: 'release',
-        platform,
-      };
-    } catch (error) {
-      if (!(error instanceof errors.MissingProfileError)) {
-        throw error;
-      }
-    }
-    const defaultProfile = getDefaultProfile({ platform, type });
-    if (defaultProfile) {
-      return {
-        profile: defaultProfile,
-        profileName: '__default__',
-        platform,
-      };
-    }
-
-    const profileNames = await readProfileNamesAsync({
-      projectDir,
-      type,
-    });
-    if (profileNames.length === 0) {
-      throw new errors.MissingProfileError(
-        `Missing profile in eas.json: ${profileName ?? 'production'}`
-      );
-    }
-    const choices: ExpoChoice<string>[] = profileNames.map(profileName => ({
-      title: profileName,
-      value: profileName,
-    }));
-    const chosenProfileName = await selectAsync(
-      'The "production" profile is missing in eas.json. Pick another profile:',
-      choices
-    );
     const profile = await readProfileAsync({
-      projectDir,
+      easJsonReader,
       platform,
       type,
-      profileName: chosenProfileName,
+      profileName: profileName ?? 'production',
     });
     return {
       profile,
-      profileName: chosenProfileName,
+      profileName: profileName ?? 'production',
       platform,
     };
   });
@@ -134,49 +40,19 @@ export async function getProfilesAsync<T extends ProfileType>({
 }
 
 async function readProfileAsync<T extends ProfileType>({
-  projectDir,
+  easJsonReader,
   platform,
   type,
   profileName,
 }: {
-  projectDir: string;
+  easJsonReader: EasJsonReader;
   platform: Platform;
   type: T;
   profileName: string;
 }): Promise<EasProfile<T>> {
-  const easJsonReader = new EasJsonReader(projectDir);
   if (type === 'build') {
     return (await easJsonReader.getBuildProfileAsync(platform, profileName)) as EasProfile<T>;
   } else {
     return (await easJsonReader.getSubmitProfileAsync(platform, profileName)) as EasProfile<T>;
-  }
-}
-
-function getDefaultProfile<T extends ProfileType>({
-  platform,
-  type,
-}: {
-  platform: Platform;
-  type: T;
-}): EasProfile<T> | null {
-  if (type === 'build') {
-    return null;
-  } else {
-    return getDefaultSubmitProfile(platform) as EasProfile<T>;
-  }
-}
-
-async function readProfileNamesAsync({
-  projectDir,
-  type,
-}: {
-  projectDir: string;
-  type: ProfileType;
-}): Promise<string[]> {
-  const easJsonReader = new EasJsonReader(projectDir);
-  if (type === 'build') {
-    return await easJsonReader.getBuildProfileNamesAsync();
-  } else {
-    return await easJsonReader.getSubmitProfileNamesAsync();
   }
 }

--- a/packages/eas-json/src/submit/resolver.ts
+++ b/packages/eas-json/src/submit/resolver.ts
@@ -19,13 +19,21 @@ export function resolveSubmitProfile<T extends Platform>({
   platform: T;
   profileName: string;
 }): SubmitProfile<T> {
-  const submitProfile = resolveProfile({
-    easJson,
-    platform,
-    profileName,
-  });
-  const unevaluatedProfile = mergeProfiles(getDefaultProfile(platform), submitProfile);
-  return evaluateFields(platform, unevaluatedProfile);
+  try {
+    const submitProfile = resolveProfile({
+      easJson,
+      platform,
+      profileName,
+    });
+    const unevaluatedProfile = mergeProfiles(getDefaultProfile(platform), submitProfile);
+    return evaluateFields(platform, unevaluatedProfile);
+  } catch (err: any) {
+    if (err instanceof MissingProfileError) {
+      return getDefaultProfile(platform);
+    } else {
+      throw err;
+    }
+  }
 }
 
 function resolveProfile<T extends Platform>({


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We keep backward compatibility for some breaking changes in eas.json, this PR removes them:
- change from git workflow that required committing
- change from the default 'release' profile to 'production'


# How

- remove migration process for git workflow changes
- remove fallback to `release` profile
- remove prompt that asked what profile you want to use if default profile did not exist
- move default profile logic(submits only) to `eas-json` package

# Test Plan

tests + run build with different profiles

