### PR TITLE
[eas-cli] Polish the command output for release

### DIFF
--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -1,5 +1,7 @@
 import { getConfig } from '@expo/config';
 import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+import path from 'path';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { CredentialsContext } from '../../credentials/context';
@@ -42,13 +44,16 @@ export default class MetadataPull extends EasCommand {
     });
 
     try {
-      Log.addNewLineIfNone();
       const filePath = await downloadMetadataAsync(metadataCtx);
-      Log.addNewLineIfNone();
+      const relativePath = path.relative(process.cwd(), filePath);
 
-      Log.succeed('Your store configuration has been generated!');
-      Log.log(filePath);
-      Log.log(learnMore('https://docs.expo.dev/eas-metadata/introduction/'));
+      Log.addNewLineIfNone();
+      Log.log(`🎉 Your store configuration is ready.
+
+- Update the ${chalk.bold(relativePath)} file to prepare the app information.
+- Run ${chalk.bold('eas submit')} or manually upload a new app version to the app stores.
+- Once the app is uploaded, run ${chalk.bold('eas metadata')} to sync the store information.
+- ${learnMore('https://docs.expo.dev/eas-metadata/introduction/')}`);
     } catch (error: any) {
       handleMetadataError(error);
     }

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -44,10 +44,9 @@ export default class MetadataPush extends EasCommand {
     });
 
     try {
-      Log.addNewLineIfNone();
       await uploadMetadataAsync(metadataCtx);
       Log.addNewLineIfNone();
-      Log.succeed(`Store has been updated with your ${metadataCtx.metadataPath} configuration`);
+      Log.log(`🎉 Store configuration is synced with the app stores.`);
     } catch (error: any) {
       handleMetadataError(error);
     }

--- a/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-info.ts
@@ -74,9 +74,13 @@ export class AppInfoTask extends AppleTask {
               : await context.info.createLocalizationAsync({ ...attributes, locale });
           },
           {
-            pending: `${model ? 'Updating' : 'Creating'} localized info for ${locale}...`,
-            success: `${model ? 'Updated' : 'Created'} localized info for ${locale}`,
-            failure: `Failed ${model ? 'updating' : 'creating'} localized info for ${locale}`,
+            pending: `${model ? 'Updating' : 'Creating'} localized info for ${chalk.bold(
+              locale
+            )}...`,
+            success: `${model ? 'Updated' : 'Created'} localized info for ${chalk.bold(locale)}`,
+            failure: `Failed ${model ? 'updating' : 'creating'} localized info for ${chalk.bold(
+              locale
+            )}`,
           }
         );
       }

--- a/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
@@ -71,16 +71,17 @@ export class AppVersionTask extends AppleTask {
     if (!version && !release) {
       Log.log(chalk`{dim - Skipped version and release update, not configured}`);
     } else {
-      const description = [version && 'version info', release && 'release info']
+      const { versionString } = context.version.attributes;
+      const description = [version && 'version', release && 'release']
         .filter(Boolean)
         .join(' and ');
 
       context.version = await logAsync(
         () => context.version.updateAsync({ ...version, ...release }),
         {
-          pending: `Updating ${description}...`,
-          success: `Updated ${description}`,
-          failure: `Failed updating ${description}`,
+          pending: `Updating ${description} info for ${chalk.bold(versionString)}...`,
+          success: `Updated ${description} info for ${chalk.bold(versionString)}...`,
+          failure: `Failed updating ${description} info for ${chalk.bold(versionString)}...`,
         }
       );
     }

--- a/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
@@ -103,9 +103,15 @@ export class AppVersionTask extends AppleTask {
               : await context.version.createLocalizationAsync({ ...attributes, locale });
           },
           {
-            pending: `${oldModel ? 'Updating' : 'Creating'} localized version for ${locale}...`,
-            success: `${oldModel ? 'Updated' : 'Created'} localized version for ${locale}`,
-            failure: `Failed ${oldModel ? 'updating' : 'creating'} localized version for ${locale}`,
+            pending: `${oldModel ? 'Updating' : 'Creating'} localized version for ${chalk.bold(
+              locale
+            )}...`,
+            success: `${oldModel ? 'Updated' : 'Created'} localized version for ${chalk.bold(
+              locale
+            )}`,
+            failure: `Failed ${
+              oldModel ? 'updating' : 'creating'
+            } localized version for ${chalk.bold(locale)}`,
           }
         );
       }

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { MetadataEvent } from '../analytics/events';
+import Log from '../log';
 import { confirmAsync } from '../prompts';
 import { AppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
@@ -32,6 +33,9 @@ export async function downloadMetadataAsync(metadataCtx: MetadataContext): Promi
     MetadataEvent.APPLE_METADATA_DOWNLOAD,
     { app, auth }
   );
+
+  Log.addNewLineIfNone();
+  Log.log('Downloading App Store configuration...');
 
   const errors: Error[] = [];
   const config = createAppleWriter();

--- a/packages/eas-cli/src/metadata/errors.ts
+++ b/packages/eas-cli/src/metadata/errors.ts
@@ -8,7 +8,7 @@ import Log, { link } from '../log';
  * and should contain useful information for the user to solve before trying again.
  */
 export class MetadataValidationError extends Error {
-  public constructor(message?: string, public readonly errors?: ErrorObject[]) {
+  public constructor(message?: string, public readonly errors: ErrorObject[] = []) {
     super(message ?? 'Store configuration validation failed');
   }
 }
@@ -52,7 +52,9 @@ export class MetadataDownloadError extends Error {
 export function handleMetadataError(error: Error): void {
   if (error instanceof MetadataValidationError) {
     Log.error(error.message);
-    Log.log(error.errors?.map(err => `  - ${err.dataPath} ${err.message}`).join('\n'));
+    if (error.errors?.length > 0) {
+      Log.log(error.errors.map(err => `  - ${err.dataPath} ${err.message}`).join('\n'));
+    }
     return;
   }
 

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { MetadataEvent } from '../analytics/events';
+import Log from '../log';
 import { AppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
 import { createAppleReader, validateConfig } from './config';
@@ -30,6 +31,9 @@ export async function uploadMetadataAsync(metadataCtx: MetadataContext): Promise
   if (!valid) {
     throw new MetadataValidationError(`Store configuration errors found`, validationErrors);
   }
+
+  Log.addNewLineIfNone();
+  Log.log('Uploading App Store configuration...');
 
   const errors: Error[] = [];
   const config = createAppleReader(fileData);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This makes the output of the `eas metadata` commands more like `eas build`, showing the user how to use it.

# How

command | terminal UI
--- | ---
`eas metadata:pull` | <img alt="Screenshot 2022-06-14 at 14 55 58" src="https://user-images.githubusercontent.com/1203991/173584292-51efd19e-d48f-4205-81f6-61ca24335d11.png">
`eas metadata:push` | <img alt="Screenshot 2022-06-14 at 15 05 54" src="https://user-images.githubusercontent.com/1203991/173584229-2e3dc176-2691-4664-90a7-96bb5336e39e.png">

# Test Plan

- `$ eas metadata:pull`
- `$ eas metadata` or `$ eas metadata:push`
