### PR TITLE
add default code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
+* @dsokal @wkozyra95
+
 packages/eas-cli/src/build @dsokal @wkozyra95
 packages/eas-cli/src/commands/build @dsokal @wkozyra95
 


### PR DESCRIPTION

# Why

add default code owners

ownership that is already defined in the CODEOWNERS file take precedence over what I'm adding in this PR


