### PR TITLE
[eas-cli] Fix regression for default submit profile

### DIFF
--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -48,10 +48,7 @@ export async function createMetadataContextAsync(params: {
   profileName?: string;
 }): Promise<MetadataContext> {
   const easJsonReader = new EasJsonReader(params.projectDir);
-  const submitProfile = await easJsonReader.getSubmitProfileAsync(
-    Platform.IOS,
-    params.profileName ?? 'production'
-  );
+  const submitProfile = await easJsonReader.getSubmitProfileAsync(Platform.IOS, params.profileName);
 
   const exp = params.exp ?? getExpoConfig(params.projectDir);
   const user = await ensureLoggedInAsync();

--- a/packages/eas-cli/src/utils/__tests__/profiles-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/profiles-test.ts
@@ -39,8 +39,8 @@ describe(getProfilesAsync, () => {
 
     expect(result[0].profileName).toBe('production');
     expect(result[1].profileName).toBe('production');
-    expect(getBuildProfileAsync).toBeCalledWith(Platform.ANDROID, 'production');
-    expect(getBuildProfileAsync).toBeCalledWith(Platform.IOS, 'production');
+    expect(getBuildProfileAsync).toBeCalledWith(Platform.ANDROID, undefined);
+    expect(getBuildProfileAsync).toBeCalledWith(Platform.IOS, undefined);
   });
 
   it('throws an error if there are no profiles in eas.json', async () => {

--- a/packages/eas-cli/src/utils/profiles.ts
+++ b/packages/eas-cli/src/utils/profiles.ts
@@ -27,7 +27,7 @@ export async function getProfilesAsync<T extends ProfileType>({
       easJsonReader,
       platform,
       type,
-      profileName: profileName ?? 'production',
+      profileName,
     });
     return {
       profile,
@@ -48,7 +48,7 @@ async function readProfileAsync<T extends ProfileType>({
   easJsonReader: EasJsonReader;
   platform: Platform;
   type: T;
-  profileName: string;
+  profileName?: string;
 }): Promise<EasProfile<T>> {
   if (type === 'build') {
     return (await easJsonReader.getBuildProfileAsync(platform, profileName)) as EasProfile<T>;

--- a/packages/eas-json/src/build/resolver.ts
+++ b/packages/eas-json/src/build/resolver.ts
@@ -14,11 +14,11 @@ export function resolveBuildProfile<T extends Platform>({
 }: {
   easJson: EasJson;
   platform: T;
-  profileName: string;
+  profileName?: string;
 }): BuildProfile<T> {
   const easJsonProfile = resolveProfile({
     easJson,
-    profileName,
+    profileName: profileName ?? 'production',
   });
   const { android, ios, ...base } = easJsonProfile;
   const withoutDefaults = mergeProfiles(base, easJsonProfile[platform] ?? {});

--- a/packages/eas-json/src/reader.ts
+++ b/packages/eas-json/src/reader.ts
@@ -59,7 +59,7 @@ export class EasJsonReader {
 
   public async getBuildProfileAsync<T extends Platform>(
     platform: T,
-    profileName: string
+    profileName?: string
   ): Promise<BuildProfile<T>> {
     const easJson = await this.readAsync();
     return resolveBuildProfile({ easJson, platform, profileName });
@@ -84,7 +84,7 @@ export class EasJsonReader {
 
   public async getSubmitProfileAsync<T extends Platform>(
     platform: T,
-    profileName: string
+    profileName?: string
   ): Promise<SubmitProfile<T>> {
     const easJson = await this.readAsync();
     return resolveSubmitProfile({ easJson, platform, profileName });

--- a/packages/eas-json/src/submit/resolver.ts
+++ b/packages/eas-json/src/submit/resolver.ts
@@ -17,18 +17,18 @@ export function resolveSubmitProfile<T extends Platform>({
 }: {
   easJson: EasJson;
   platform: T;
-  profileName: string;
+  profileName?: string;
 }): SubmitProfile<T> {
   try {
     const submitProfile = resolveProfile({
       easJson,
       platform,
-      profileName,
+      profileName: profileName ?? 'production',
     });
     const unevaluatedProfile = mergeProfiles(getDefaultProfile(platform), submitProfile);
     return evaluateFields(platform, unevaluatedProfile);
   } catch (err: any) {
-    if (err instanceof MissingProfileError) {
+    if (err instanceof MissingProfileError && !profileName) {
       return getDefaultProfile(platform);
     } else {
       throw err;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fix regression introduced in https://github.com/expo/eas-cli/pull/1158

# How

Submit profile should have a default value only when submit profile does not exist and the command did not specify the profile name explicitly. Regression changed this behavior to always provide a default profile if selected one did not exist

# Test Plan

run submit and metadata
