### PR TITLE
[eas-cli] Surface metadata cause errors in logging output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Surface ASC errors in metadata for normal API rejections. ([#1167](https://github.com/expo/eas-cli/pull/1167) by [@byCedric](https://github.com/byCedric))
+
 ### 🧹 Chores
 
 ## [0.54.0](https://github.com/expo/eas-cli/releases/tag/v0.54.0) - 2022-06-15

--- a/packages/eas-cli/src/metadata/errors.ts
+++ b/packages/eas-cli/src/metadata/errors.ts
@@ -1,4 +1,5 @@
 import type { ErrorObject } from 'ajv';
+import chalk from 'chalk';
 
 import Log, { link } from '../log';
 
@@ -51,7 +52,8 @@ export class MetadataDownloadError extends Error {
  */
 export function handleMetadataError(error: Error): void {
   if (error instanceof MetadataValidationError) {
-    Log.error(error.message);
+    Log.newLine();
+    Log.error(chalk.bold(error.message));
     if (error.errors?.length > 0) {
       Log.log(error.errors.map(err => `  - ${err.dataPath} ${err.message}`).join('\n'));
     }
@@ -59,7 +61,13 @@ export function handleMetadataError(error: Error): void {
   }
 
   if (error instanceof MetadataDownloadError || error instanceof MetadataUploadError) {
-    Log.error(error.message);
+    Log.newLine();
+    Log.error(chalk.bold(error.message));
+    if (error.errors?.length > 0) {
+      Log.newLine();
+      Log.error(error.errors.map(err => err.message).join('\n\n'));
+    }
+    Log.newLine();
     Log.log('Please check the logs for any configuration issues.');
     Log.log('If this issue persists, please open a new issue at:');
     // TODO: add execution ID to the issue template link


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes ENG-5280

We keep track of these errors, but the user should also understand if something is configured wrongly.

# How

![173927511-bc94b8d2-75a2-4068-a84c-c75fd1fd1ef8](https://user-images.githubusercontent.com/1203991/173929459-0f815d1e-e31c-4669-a1fb-937f073e6c77.png)


# Test Plan

- Create an app
- Initialize metadata `eas metadata:pull`
- Change the `apple.info.[locale].title` to `My App`
- Check if the error above is surfaced