### PR TITLE
[eas-cli] Add link to ASC after successful metadata sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add App Store Connect link after `eas metadata:push`. ([#1168](https://github.com/expo/eas-cli/pull/1168) by [@byCedric](https://github.com/byCedric))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -4,7 +4,7 @@ import { Flags } from '@oclif/core';
 import { ensureProjectConfiguredAsync } from '../../build/configure';
 import EasCommand from '../../commandUtils/EasCommand';
 import { CredentialsContext } from '../../credentials/context';
-import Log from '../../log';
+import Log, { learnMore } from '../../log';
 import { createMetadataContextAsync } from '../../metadata/context';
 import { handleMetadataError } from '../../metadata/errors';
 import { uploadMetadataAsync } from '../../metadata/upload';
@@ -45,9 +45,11 @@ export default class MetadataPush extends EasCommand {
     });
 
     try {
-      await uploadMetadataAsync(metadataCtx);
+      const { appleLink } = await uploadMetadataAsync(metadataCtx);
       Log.addNewLineIfNone();
-      Log.log(`🎉 Store configuration is synced with the app stores.`);
+      Log.log(`🎉 Store configuration is synced with the app stores.
+
+${learnMore(appleLink, { learnMoreMessage: 'See the changes in App Store Connect' })}`);
     } catch (error: any) {
       handleMetadataError(error);
     }

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -14,7 +14,9 @@ import { subscribeTelemetry } from './utils/telemetry';
  * Sync a local store configuration with the stores.
  * Note, only App Store is supported at this time.
  */
-export async function uploadMetadataAsync(metadataCtx: MetadataContext): Promise<void> {
+export async function uploadMetadataAsync(
+  metadataCtx: MetadataContext
+): Promise<{ appleLink: string }> {
   const filePath = path.resolve(metadataCtx.projectDir, metadataCtx.metadataPath);
   if (!(await fs.pathExists(filePath))) {
     throw new MetadataValidationError(`Store configuration file not found "${filePath}"`);
@@ -61,4 +63,6 @@ export async function uploadMetadataAsync(metadataCtx: MetadataContext): Promise
   if (errors.length > 0) {
     throw new MetadataUploadError(errors, executionId);
   }
+
+  return { appleLink: `https://appstoreconnect.apple.com/apps/${app.id}/appstore` };
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes ENG-5282

# How

- Generated a link in **src/metadata/upload.ts**
- Outputted the link in **src/commands/metadata/push.ts**

![Screenshot 2022-06-15 at 23 23 20](https://user-images.githubusercontent.com/1203991/173932434-b60edc1d-b4d9-49b6-832d-a9e83cc4760f.png)

# Test Plan

- Run `eas metadata:push`