### PR TITLE
[eas-cli] Use wrapper instead of telemetry subscriber for metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Refactor metadata telemetry with opt-out. ([#1169](https://github.com/expo/eas-cli/pull/1169) by [@byCedric](https://github.com/byCedric))
+
 ## [0.54.1](https://github.com/expo/eas-cli/releases/tag/v0.54.1) - 2022-06-15
 
 ### 🎉 New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Refactor metadata telemetry with opt-out. ([#1169](https://github.com/expo/eas-cli/pull/1169) by [@byCedric](https://github.com/byCedric))
+- Refactor metadata telemetry to handle errors better. ([#1169](https://github.com/expo/eas-cli/pull/1169) by [@byCedric](https://github.com/byCedric))
 
 ## [0.54.1](https://github.com/expo/eas-cli/releases/tag/v0.54.1) - 2022-06-15
 

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { MetadataEvent } from '../analytics/events';
 import Log from '../log';
 import { confirmAsync } from '../prompts';
-import { AppleData } from './apple/data';
+import { AppleData, PartialAppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
 import { createAppleWriter } from './config';
 import { MetadataContext, ensureMetadataAppStoreAuthenticatedAsync } from './context';
@@ -37,7 +37,7 @@ export async function downloadMetadataAsync(metadataCtx: MetadataContext): Promi
     const errors: Error[] = [];
     const config = createAppleWriter();
     const tasks = createAppleTasks(metadataCtx);
-    const taskCtx = { app };
+    const taskCtx: PartialAppleData = { app };
 
     for (const task of tasks) {
       try {

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -8,7 +8,7 @@ import { createAppleTasks } from './apple/tasks';
 import { createAppleReader, validateConfig } from './config';
 import { MetadataContext, ensureMetadataAppStoreAuthenticatedAsync } from './context';
 import { MetadataUploadError, MetadataValidationError } from './errors';
-import { subscribeTelemetry } from './utils/telemetry';
+import { withTelemetryAsync } from './utils/telemetry';
 
 /**
  * Sync a local store configuration with the stores.
@@ -23,11 +23,6 @@ export async function uploadMetadataAsync(
   }
 
   const { app, auth } = await ensureMetadataAppStoreAuthenticatedAsync(metadataCtx);
-  const { unsubscribeTelemetry, executionId } = subscribeTelemetry(
-    MetadataEvent.APPLE_METADATA_UPLOAD,
-    { app, auth }
-  );
-
   const fileData = await fs.readJson(filePath);
   const { valid, errors: validationErrors } = validateConfig(fileData);
   if (!valid) {
@@ -37,32 +32,32 @@ export async function uploadMetadataAsync(
   Log.addNewLineIfNone();
   Log.log('Uploading App Store configuration...');
 
-  const errors: Error[] = [];
-  const config = createAppleReader(fileData);
-  const tasks = createAppleTasks(metadataCtx);
-  const taskCtx = { app };
+  await withTelemetryAsync(MetadataEvent.APPLE_METADATA_UPLOAD, { app, auth }, async () => {
+    const errors: Error[] = [];
+    const config = createAppleReader(fileData);
+    const tasks = createAppleTasks(metadataCtx);
+    const taskCtx = { app };
 
-  for (const task of tasks) {
-    try {
-      await task.prepareAsync({ context: taskCtx });
-    } catch (error: any) {
-      errors.push(error);
+    for (const task of tasks) {
+      try {
+        await task.prepareAsync({ context: taskCtx });
+      } catch (error: any) {
+        errors.push(error);
+      }
     }
-  }
 
-  for (const task of tasks) {
-    try {
-      await task.uploadAsync({ config, context: taskCtx as AppleData });
-    } catch (error: any) {
-      errors.push(error);
+    for (const task of tasks) {
+      try {
+        await task.uploadAsync({ config, context: taskCtx as AppleData });
+      } catch (error: any) {
+        errors.push(error);
+      }
     }
-  }
 
-  unsubscribeTelemetry();
-
-  if (errors.length > 0) {
-    throw new MetadataUploadError(errors, executionId);
-  }
+    if (errors.length > 0) {
+      throw new MetadataUploadError(errors);
+    }
+  });
 
   return { appleLink: `https://appstoreconnect.apple.com/apps/${app.id}/appstore` };
 }

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { MetadataEvent } from '../analytics/events';
 import Log from '../log';
-import { AppleData } from './apple/data';
+import { AppleData, PartialAppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
 import { createAppleReader, validateConfig } from './config';
 import { MetadataContext, ensureMetadataAppStoreAuthenticatedAsync } from './context';
@@ -36,7 +36,7 @@ export async function uploadMetadataAsync(
     const errors: Error[] = [];
     const config = createAppleReader(fileData);
     const tasks = createAppleTasks(metadataCtx);
-    const taskCtx = { app };
+    const taskCtx: PartialAppleData = { app };
 
     for (const task of tasks) {
       try {

--- a/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
+++ b/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
@@ -1,23 +1,100 @@
-import { App } from '@expo/apple-utils';
+import { App, getRequestClient } from '@expo/apple-utils';
 
-import { TelemetryContext, makeDataScrubber } from '../telemetry';
+import { MetadataEvent } from '../../../analytics/events';
+import { TelemetryContext, makeDataScrubber, withTelemetryAsync } from '../telemetry';
+
+const stub: TelemetryContext = {
+  // Only the App ID is considered to be sensitive
+  app: new App({} as any, 'SECRET_APP_ID', {} as any),
+  // Only the token properties and user credentials are considered to be sensitive
+  auth: {
+    username: 'SECRET_USERNAME',
+    password: 'SECRET_PASSWORD',
+    context: {
+      token: 'SECRET_TOKEN',
+      teamId: 'SECRET_TEAM_ID',
+      providerId: 1337,
+    },
+  } as any,
+};
+
+describe(withTelemetryAsync, () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  it('disables telemetry when EXPO_NO_TELEMETRY is true', async () => {
+    const { interceptors } = getRequestClient();
+    const useInterceptor = jest.spyOn(interceptors.response, 'use');
+
+    process.env['EXPO_NO_TELEMETRY'] = 'true';
+
+    await withTelemetryAsync(MetadataEvent.APPLE_METADATA_UPLOAD, stub, async () => {
+      return 'testing telemetry';
+    });
+
+    expect(useInterceptor).not.toBeCalled();
+  });
+
+  it('enables telemetry when EXPO_NO_TELEMETRY is undefined', async () => {
+    const { interceptors } = getRequestClient();
+    const useInterceptor = jest.spyOn(interceptors.response, 'use');
+
+    process.env['EXPO_NO_TELEMETRY'] = undefined;
+
+    await withTelemetryAsync(MetadataEvent.APPLE_METADATA_DOWNLOAD, stub, async () => {
+      return 'testing telemetry';
+    });
+
+    expect(useInterceptor).toBeCalled();
+  });
+
+  it('detaches interceptors after action resolved', async () => {
+    const { interceptors } = getRequestClient();
+    const ejectInterceptor = jest.spyOn(interceptors.response, 'eject');
+
+    await withTelemetryAsync(MetadataEvent.APPLE_METADATA_DOWNLOAD, stub, async () => {
+      return 'testing resolved telemetry action';
+    });
+
+    expect(ejectInterceptor).toBeCalledWith(expect.any(Number));
+  });
+
+  it('detaches interceptors after action rejected', async () => {
+    const { interceptors } = getRequestClient();
+    const ejectInterceptor = jest.spyOn(interceptors.response, 'eject');
+
+    try {
+      await withTelemetryAsync(MetadataEvent.APPLE_METADATA_DOWNLOAD, stub, async () => {
+        throw new Error('testing rejected telemetry action');
+      });
+    } catch {
+      // intentional failure
+    }
+
+    expect(ejectInterceptor).toBeCalledWith(expect.any(Number));
+  });
+
+  it('adds executionId to thrown errors', async () => {
+    let caughtError: null | Error = null;
+
+    try {
+      await withTelemetryAsync(MetadataEvent.APPLE_METADATA_DOWNLOAD, stub, async () => {
+        throw new Error('testing exectution ID');
+      });
+    } catch (error: any) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toBeInstanceOf(Error);
+    expect(caughtError).toHaveProperty('executionId', expect.any(String));
+  });
+});
 
 describe(makeDataScrubber, () => {
-  const stub: TelemetryContext = {
-    // Only the App ID is considered to be sensitive
-    app: new App({} as any, 'SECRET_APP_ID', {} as any),
-    // Only the token properties and user credentials are considered to be sensitive
-    auth: {
-      username: 'SECRET_USERNAME',
-      password: 'SECRET_PASSWORD',
-      context: {
-        token: 'SECRET_TOKEN',
-        teamId: 'SECRET_TEAM_ID',
-        providerId: 1337,
-      },
-    } as any,
-  };
-
   it('scrubs the app.id', () => {
     expect(makeDataScrubber(stub)('some text SECRET_APP_ID')).toBe('some text {APPLE_APP_ID}');
   });

--- a/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
+++ b/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
@@ -20,37 +20,8 @@ const stub: TelemetryContext = {
 };
 
 describe(withTelemetryAsync, () => {
-  const originalEnv = { ...process.env };
-
   afterEach(() => {
-    process.env = originalEnv;
     jest.clearAllMocks();
-  });
-
-  it('disables telemetry when EXPO_NO_TELEMETRY is true', async () => {
-    const { interceptors } = getRequestClient();
-    const useInterceptor = jest.spyOn(interceptors.response, 'use');
-
-    process.env['EXPO_NO_TELEMETRY'] = 'true';
-
-    await withTelemetryAsync(MetadataEvent.APPLE_METADATA_UPLOAD, stub, async () => {
-      return 'testing telemetry';
-    });
-
-    expect(useInterceptor).not.toBeCalled();
-  });
-
-  it('enables telemetry when EXPO_NO_TELEMETRY is undefined', async () => {
-    const { interceptors } = getRequestClient();
-    const useInterceptor = jest.spyOn(interceptors.response, 'use');
-
-    process.env['EXPO_NO_TELEMETRY'] = undefined;
-
-    await withTelemetryAsync(MetadataEvent.APPLE_METADATA_DOWNLOAD, stub, async () => {
-      return 'testing telemetry';
-    });
-
-    expect(useInterceptor).toBeCalled();
   });
 
   it('detaches interceptors after action resolved', async () => {

--- a/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
+++ b/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
@@ -1,6 +1,7 @@
 import { App, getRequestClient } from '@expo/apple-utils';
 
 import { MetadataEvent } from '../../../analytics/events';
+import { MetadataTelemetryError } from '../../errors';
 import { TelemetryContext, makeDataScrubber, withTelemetryAsync } from '../telemetry';
 
 const stub: TelemetryContext = {
@@ -89,8 +90,9 @@ describe(withTelemetryAsync, () => {
       caughtError = error;
     }
 
-    expect(caughtError).toBeInstanceOf(Error);
+    expect(caughtError).toBeInstanceOf(MetadataTelemetryError);
     expect(caughtError).toHaveProperty('executionId', expect.any(String));
+    expect(caughtError).toHaveProperty('originalError', expect.any(Error));
   });
 });
 

--- a/packages/eas-cli/src/metadata/utils/telemetry.ts
+++ b/packages/eas-cli/src/metadata/utils/telemetry.ts
@@ -4,6 +4,7 @@ import getenv from 'getenv';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Analytics, MetadataEvent } from '../../analytics/events';
+import { MetadataTelemetryError } from '../errors';
 
 export type TelemetryContext = {
   app: App;
@@ -58,8 +59,7 @@ export async function withTelemetryAsync<T>(
   try {
     return await action();
   } catch (error: any) {
-    error.executionId = executionId;
-    throw error;
+    throw new MetadataTelemetryError(error, executionId);
   } finally {
     interceptors.response.eject(responseInterceptorId);
   }

--- a/packages/eas-cli/src/metadata/utils/telemetry.ts
+++ b/packages/eas-cli/src/metadata/utils/telemetry.ts
@@ -1,6 +1,5 @@
 import { App, Session, getRequestClient } from '@expo/apple-utils';
 import type { AxiosError } from 'axios';
-import getenv from 'getenv';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Analytics, MetadataEvent } from '../../analytics/events';
@@ -16,10 +15,6 @@ export async function withTelemetryAsync<T>(
   options: TelemetryContext,
   action: () => Promise<T>
 ): Promise<T> {
-  if (getenv.boolish('EXPO_NO_TELEMETRY', false)) {
-    return await action();
-  }
-
   const executionId = uuidv4();
   const scrubber = makeDataScrubber(options);
   const { interceptors } = getRequestClient();


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes ENG-5291

See discussion in https://github.com/expo/eas-cli/pull/1147#discussion_r892037938

# How

- Added `EXPO_NO_TELEMETRY` for `eas metadata`
- Refactored `subscribeTelemetry` to `withTelemetryAsync`
- Added more tests for `withTelemetryAsync`
- Added Error container to safely wrap `executionId` with the thrown error
- Updated shared error handler to use the Error container

# Test Plan

- `$ yarn test telemetry`
