### PR TITLE
[eas-cli] Allow users to skip metadata validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Show bundler output by default for eas update command. ([#1171](https://github.com/expo/eas-cli/pull/1171) by [@kgc00](https://github.com/kgc00/))
+- Allow users to skip metadata validation. ([#1175](https://github.com/expo/eas-cli/pull/1175) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/metadata/errors.ts
+++ b/packages/eas-cli/src/metadata/errors.ts
@@ -47,17 +47,25 @@ export class MetadataDownloadError extends Error {
 }
 
 /**
+ * Log the encountered metadata validation error in detail for the user.
+ * This should help communicate any possible configuration error and help the user resolve it.
+ */
+export function logMetadataValidationError(error: MetadataValidationError): void {
+  Log.newLine();
+  Log.error(chalk.bold(error.message));
+  if (error.errors?.length > 0) {
+    // TODO(cedric): group errors by property to make multiple errors for same property more readable
+    Log.log(error.errors.map(err => `  - ${chalk.bold(err.dataPath)} ${err.message}`).join('\n'));
+  }
+}
+
+/**
  * Handle a thrown metadata error by informing the user what went wrong.
  * If a normal error is thrown, this method will re-throw that error to avoid consuming it.
  */
 export function handleMetadataError(error: Error): void {
   if (error instanceof MetadataValidationError) {
-    Log.newLine();
-    Log.error(chalk.bold(error.message));
-    if (error.errors?.length > 0) {
-      Log.log(error.errors.map(err => `  - ${err.dataPath} ${err.message}`).join('\n'));
-    }
-    return;
+    return logMetadataValidationError(error);
   }
 
   if (error instanceof MetadataDownloadError || error instanceof MetadataUploadError) {

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -3,11 +3,12 @@ import path from 'path';
 
 import { MetadataEvent } from '../analytics/events';
 import Log from '../log';
+import { confirmAsync } from '../prompts';
 import { AppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
 import { createAppleReader, validateConfig } from './config';
 import { MetadataContext, ensureMetadataAppStoreAuthenticatedAsync } from './context';
-import { MetadataUploadError, MetadataValidationError } from './errors';
+import { MetadataUploadError, MetadataValidationError, logMetadataValidationError } from './errors';
 import { subscribeTelemetry } from './utils/telemetry';
 
 /**
@@ -22,17 +23,28 @@ export async function uploadMetadataAsync(
     throw new MetadataValidationError(`Store configuration file not found "${filePath}"`);
   }
 
+  const fileData = await fs.readJson(filePath);
+  const { valid, errors: validationErrors } = validateConfig(fileData);
+  if (!valid) {
+    const error = new MetadataValidationError(`Store configuration errors found`, validationErrors);
+    logMetadataValidationError(error);
+    Log.newLine();
+
+    const attempt = await confirmAsync({
+      message: 'Do you want to still want to attempt syncing the store configuration?',
+      instructions:
+        'This might fail or could cause a review rejection when submitted without additional changes.',
+    });
+    if (!attempt) {
+      throw error;
+    }
+  }
+
   const { app, auth } = await ensureMetadataAppStoreAuthenticatedAsync(metadataCtx);
   const { unsubscribeTelemetry, executionId } = subscribeTelemetry(
     MetadataEvent.APPLE_METADATA_UPLOAD,
     { app, auth }
   );
-
-  const fileData = await fs.readJson(filePath);
-  const { valid, errors: validationErrors } = validateConfig(fileData);
-  if (!valid) {
-    throw new MetadataValidationError(`Store configuration errors found`, validationErrors);
-  }
 
   Log.addNewLineIfNone();
   Log.log('Uploading App Store configuration...');

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -34,7 +34,6 @@ export async function uploadMetadataAsync(
     );
     const attempt = await confirmAsync({
       message: 'Do you want to still want to attempt syncing the store configuration?',
-      instructions: '',
     });
     if (!attempt) {
       throw error;

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -33,7 +33,7 @@ export async function uploadMetadataAsync(
       'The current store configuration might fail during syncing or could fail review when submitted without additional changes.'
     );
     const attempt = await confirmAsync({
-      message: 'Do you want to still want to attempt syncing the store configuration?',
+      message: 'Do you still want to attempt syncing the store configuration?',
     });
     if (!attempt) {
       throw error;

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -29,11 +29,12 @@ export async function uploadMetadataAsync(
     const error = new MetadataValidationError(`Store configuration errors found`, validationErrors);
     logMetadataValidationError(error);
     Log.newLine();
-
+    Log.warn(
+      'The current store configuration might fail during syncing or could fail review when submitted without additional changes.'
+    );
     const attempt = await confirmAsync({
       message: 'Do you want to still want to attempt syncing the store configuration?',
-      instructions:
-        'This might fail or could cause a review rejection when submitted without additional changes.',
+      instructions: '',
     });
     if (!attempt) {
       throw error;

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -33,7 +33,7 @@ export async function uploadMetadataAsync(
       'Without further updates, the current store configuration may fail to be synchronized with the App Store or pass App Store review.'
     );
     const attempt = await confirmAsync({
-      message: 'Do you still want to attempt syncing the store configuration?',
+      message: 'Do you still want to push the store configuration?',
     });
     if (!attempt) {
       throw error;

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -30,7 +30,7 @@ export async function uploadMetadataAsync(
     logMetadataValidationError(error);
     Log.newLine();
     Log.warn(
-      'The current store configuration might fail during syncing or could fail review when submitted without additional changes.'
+      'Without further updates, the current store configuration may fail to be synchronized with the App Store or pass App Store review.'
     );
     const attempt = await confirmAsync({
       message: 'Do you still want to attempt syncing the store configuration?',


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

If we have a potential issue in the metadata validation, we still want users to be able and try it anyways. The user should be "informed" that the current config state might cause issues later on.

# How

![image](https://user-images.githubusercontent.com/1203991/175052144-5e91264a-510f-4dc8-ad01-fa2e7b83740b.png)

> `want ... want` typo is fixed

# Test Plan

- Create a `store.config.json`
- Add `apple.info[en-CA]` with only `title`
- `$ eas metadata:push`