### PR TITLE
[ci] Add run in band for coverage testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - run: yarn typecheck
       - run: yarn test
         if: ${{ !matrix.coverage }}
-      - run: yarn test --coverage
+      - run: yarn test --coverage --runInBand
         if: ${{ matrix.coverage }}
       - run: yarn lint --max-warnings=0
       - run: shellcheck bin/*.sh


### PR DESCRIPTION

<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This should limit the maximum memory used in different workers. Doing so should make CI a bit more stable

# How

- `--runInBand` on Node 18 coverage tests

# Test Plan

See CI
