### PR TITLE
[eas-cli] truncates long messages for eas update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Show bundler output by default for eas update command. ([#1171](https://github.com/expo/eas-cli/pull/1171) by [@kgc00](https://github.com/kgc00/))
 - Allow users to skip metadata validation. ([#1175](https://github.com/expo/eas-cli/pull/1175) by [@byCedric](https://github.com/byCedric))
 - Add experimental `--resource-class` flag for Build commands. ([#1138](https://github.com/expo/eas-cli/pull/1138) by [@christopherwalter](https://github.com/christopherwalter))
+- Truncate long messages for `eas update` command, rather than failing. ([#1178](https://github.com/expo/eas-cli/pull/1178) by [@kgc00](https://github.com/kgc00))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -457,6 +457,8 @@ export default class UpdatePublish extends EasCommand {
       }
     }
 
+    const truncatedMessage = truncatePublishUpdateMessage(message!);
+
     const runtimeToPlatformMapping: Record<string, string[]> = {};
     for (const runtime of new Set(Object.values(runtimeVersions))) {
       runtimeToPlatformMapping[runtime] = Object.entries(runtimeVersions)
@@ -489,7 +491,7 @@ export default class UpdatePublish extends EasCommand {
           branchId,
           updateInfoGroup: localUpdateInfoGroup,
           runtimeVersion: republish ? oldRuntimeVersion : runtime,
-          message,
+          message: truncatedMessage,
           awaitingCodeSigningInfo: !!codeSigningInfo,
         };
       }
@@ -587,7 +589,7 @@ export default class UpdatePublish extends EasCommand {
               ? [{ label: 'Android update ID', value: newAndroidUpdate.id }]
               : []),
             ...(newIosUpdate ? [{ label: 'iOS update ID', value: newIosUpdate.id }] : []),
-            { label: 'Message', value: message! },
+            { label: 'Message', value: truncatedMessage },
             { label: 'Website link', value: updateGroupLink },
           ])
         );
@@ -733,3 +735,11 @@ async function checkEASUpdateURLIsSetAsync(exp: ExpoConfig): Promise<void> {
     );
   }
 }
+
+export const truncatePublishUpdateMessage = (originalMessage: string): string => {
+  if (originalMessage.length > 1024) {
+    Log.warn('Update message exceeds the allowed 1024 character limit. Truncating message...');
+    return originalMessage.substring(0, 1021) + '...';
+  }
+  return originalMessage;
+};


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Closes [5234](https://linear.app/expo/issue/ENG-5234/truncate-eas-update-message-in-eas-cli)

# How

Added a short truncate function and ran the user input through it. The function will warn the user if truncation has occurred.

# Test Plan

Added some automated tests to check:
- truncates long messages
- does not truncate short messages
- warns the user that truncation has occurred

## Truncation flow

https://user-images.githubusercontent.com/15132641/175425347-d8f401d6-b54b-4349-afcf-c4f914ae742c.mov

## Non-truncatiow flow

https://user-images.githubusercontent.com/15132641/175425365-47f88cb3-d295-4349-97c4-536363b9b258.mov


