### PR TITLE
[ENG-5262] fix URLs returned from AWS S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix submission archive URLs. ([#1179](https://github.com/expo/eas-cli/pull/1179) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 - Update validation rules for metadata info locales. ([#1174](https://github.com/expo/eas-cli/pull/1174) by [@byCedric](https://github.com/byCedric))

--- a/packages/eas-cli/src/__tests__/uploads-test.ts
+++ b/packages/eas-cli/src/__tests__/uploads-test.ts
@@ -1,0 +1,17 @@
+import { fixArchiveUrl } from '../uploads';
+
+describe(fixArchiveUrl, () => {
+  it('fixes broken links', () => {
+    const input =
+      'https://submission-service-archives.s3.amazonaws.com/production%2Fdc98ca84-1473-4cb3-ae81-8c7b291cb27e%2F4424aa95-b985-4e2f-8755-9507b1037c1c';
+    const expectedOutput =
+      'https://submission-service-archives.s3.amazonaws.com/production/dc98ca84-1473-4cb3-ae81-8c7b291cb27e/4424aa95-b985-4e2f-8755-9507b1037c1c';
+    expect(fixArchiveUrl(input)).toBe(expectedOutput);
+  });
+
+  it('does not change correct urls', () => {
+    const correctUrl =
+      'https://submission-service-archives.s3.amazonaws.com/production/dc98ca84-1473-4cb3-ae81-8c7b291cb27e/4424aa95-b985-4e2f-8755-9507b1037c1c';
+    expect(fixArchiveUrl(correctUrl)).toBe(correctUrl);
+  });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

I noticed that links to submission archives are broken (but they are still usable).

`https://submission-service-archives.s3.amazonaws.com/production%2Fdc98ca84-1473-4cb3-ae81-8c7b291cb27e%2F4424aa95-b985-4e2f-8755-9507b1037c1c`

See that the path is encoded - `%2F` instead of `/`. This is probably a bug in AWS S3.

# How

Fix links.

# Test Plan

Added test case.