### PR TITLE
[eas-cli] Improve store configuration defaults and schema configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Update validation rules for metadata info locales. ([#1174](https://github.com/expo/eas-cli/pull/1174) by [@byCedric](https://github.com/byCedric))
+- Improve store configuration defaults and schema documentation. ([#1183](https://github.com/expo/eas-cli/pull/1183) by [@byCedric](https://github.com/byCedric))
 
 ## [0.54.1](https://github.com/expo/eas-cli/releases/tag/v0.54.1) - 2022-06-15
 

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -273,7 +273,6 @@
                 "violenceCartoonOrFantasy": "NONE",
                 "violenceRealisticProlongedGraphicOrSadistic": "NONE",
                 "violenceRealistic": "NONE",
-                "gamblingAndContests":false,
                 "gambling": false,
                 "kidsAgeBand": null,
                 "seventeenPlus": false,
@@ -296,7 +295,6 @@
                 "violenceCartoonOrFantasy": "${10|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
                 "violenceRealisticProlongedGraphicOrSadistic": "${11|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
                 "violenceRealistic": "${12|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "gamblingAndContests":false,
                 "gambling": false,
                 "kidsAgeBand": null,
                 "seventeenPlus": false,
@@ -310,9 +308,6 @@
           },
           "contests": {
             "$ref": "#/definitions/apple/AppleRating"
-          },
-          "gamblingAndContests": {
-            "type": "boolean"
           },
           "gambling": {
             "type": "boolean"

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -142,7 +142,7 @@
               "subtitle": "${2:Subtitle for your app}",
               "description": "${3:A longer description of what your app does}",
               "keywords": ["${4:keyword}"],
-              "whatsNew": "${5:Bug fixes and improved stability}",
+              "releaseNotes": "${5:Bug fixes and improved stability}",
               "promoText": "${6:Short tagline for your app}",
               "marketingUrl": "https://${7:www.}",
               "supportUrl": "https://${8:www.}",
@@ -191,7 +191,7 @@
               "versioned": true
             }
           },
-          "whatsNew": {
+          "releaseNotes": {
             "type": "string",
             "description": "Changes since the last public version",
             "maxLength": 4000,

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -19,9 +19,11 @@
         ]
       },
       "AppleKidsAge": {
+        "type": "string",
         "enum": ["FIVE_AND_UNDER", "SIX_TO_EIGHT", "NINE_TO_ELEVEN"]
       },
       "AppleRating": {
+        "type": "string",
         "enum": ["NONE", "INFREQUENT_OR_MILD", "FREQUENT_OR_INTENSE"]
       },
       "AppleCategory": {
@@ -256,107 +258,139 @@
       "AppleAdvisory": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "alcoholTobaccoOrDrugUseOrReferences",
+          "contests",
+          "gamblingSimulated",
+          "horrorOrFearThemes",
+          "matureOrSuggestiveThemes",
+          "medicalOrTreatmentInformation",
+          "profanityOrCrudeHumor",
+          "sexualContentGraphicAndNudity",
+          "sexualContentOrNudity",
+          "violenceCartoonOrFantasy",
+          "violenceRealistic",
+          "violenceRealisticProlongedGraphicOrSadistic",
+          "gambling",
+          "unrestrictedWebAccess",
+          "kidsAgeBand",
+          "seventeenPlus"
+        ],
         "defaultSnippets": [
-            {
-              "label": "Minimum",
-              "description": "The bare minimum rating, your app does nothing",
-              "body": {
-                "alcoholTobaccoOrDrugUseOrReferences": "NONE",
-                "contests": "NONE",
-                "gamblingSimulated": "NONE",
-                "medicalOrTreatmentInformation": "NONE",
-                "profanityOrCrudeHumor": "NONE",
-                "sexualContentGraphicAndNudity": "NONE",
-                "sexualContentOrNudity": "NONE",
-                "horrorOrFearThemes": "NONE",
-                "matureOrSuggestiveThemes": "NONE",
-                "violenceCartoonOrFantasy": "NONE",
-                "violenceRealisticProlongedGraphicOrSadistic": "NONE",
-                "violenceRealistic": "NONE",
-                "gambling": false,
-                "kidsAgeBand": null,
-                "seventeenPlus": false,
-                "unrestrictedWebAccess": false
-              }
-            },
-            {
-              "label": "Interactive",
-              "description": "Step through options",
-              "body": {
-                "alcoholTobaccoOrDrugUseOrReferences": "${1|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "contests": "${2|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "gamblingSimulated": "${3|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "medicalOrTreatmentInformation": "${4|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "profanityOrCrudeHumor": "${5|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "sexualContentGraphicAndNudity": "${6|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "sexualContentOrNudity": "${7|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "horrorOrFearThemes": "${8|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "matureOrSuggestiveThemes": "${9|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "violenceCartoonOrFantasy": "${10|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "violenceRealisticProlongedGraphicOrSadistic": "${11|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "violenceRealistic": "${12|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
-                "gambling": false,
-                "kidsAgeBand": null,
-                "seventeenPlus": false,
-                "unrestrictedWebAccess": false
-              }
+          {
+            "label": "Basic",
+            "description": "Create an advisory that disables all age-rated properties, for when your app does nothing",
+            "body": {
+              "alcoholTobaccoOrDrugUseOrReferences": "NONE",
+              "contests": "NONE",
+              "gamblingSimulated": "NONE",
+              "horrorOrFearThemes": "NONE",
+              "matureOrSuggestiveThemes": "NONE",
+              "medicalOrTreatmentInformation": "NONE",
+              "profanityOrCrudeHumor": "NONE",
+              "sexualContentGraphicAndNudity": "NONE",
+              "sexualContentOrNudity": "NONE",
+              "violenceCartoonOrFantasy": "NONE",
+              "violenceRealistic": "NONE",
+              "violenceRealisticProlongedGraphicOrSadistic": "NONE",
+              "gambling": false,
+              "unrestrictedWebAccess": false,
+              "kidsAgeBand": null,
+              "seventeenPlus": false
             }
-          ],
+          },
+          {
+            "label": "Full",
+            "description": "Create an advisory that enables some of the age-rated properties",
+            "body": {
+              "alcoholTobaccoOrDrugUseOrReferences": "${1|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "contests": "${2|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "gamblingSimulated": "${3|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "horrorOrFearThemes": "${4|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "matureOrSuggestiveThemes": "${5|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "medicalOrTreatmentInformation": "${6|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "profanityOrCrudeHumor": "${7|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "sexualContentGraphicAndNudity": "${8|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "sexualContentOrNudity": "${9|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "violenceCartoonOrFantasy": "${10|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "violenceRealistic": "${11|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "violenceRealisticProlongedGraphicOrSadistic": "${12|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "unrestrictedWebAccess": false,
+              "gambling": false,
+              "kidsAgeBand": null,
+              "seventeenPlus": false
+            }
+          }
+        ],
         "properties": {
           "alcoholTobaccoOrDrugUseOrReferences": {
-            "$ref": "#/definitions/apple/AppleRating"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain alcohol, tobacco, or drug use or references?"
           },
           "contests": {
-            "$ref": "#/definitions/apple/AppleRating"
-          },
-          "gambling": {
-            "type": "boolean"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain contests?"
           },
           "gamblingSimulated": {
-            "$ref": "#/definitions/apple/AppleRating"
-          },
-          "kidsAgeBand": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/apple/AppleKidsAge"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain simulated gambling?"
           },
           "medicalOrTreatmentInformation": {
-            "$ref": "#/definitions/apple/AppleRating"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain medical or treatment information?"
           },
           "profanityOrCrudeHumor": {
-            "$ref": "#/definitions/apple/AppleRating"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain profanity or crude humor?"
           },
           "sexualContentGraphicAndNudity": {
-            "$ref": "#/definitions/apple/AppleRating"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain graphic sexual content and nudity?"
           },
           "sexualContentOrNudity": {
-            "$ref": "#/definitions/apple/AppleRating"
-          },
-          "seventeenPlus": {
-            "type": "boolean"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain sexual content or nudity?"
           },
           "horrorOrFearThemes": {
-            "$ref": "#/definitions/apple/AppleRating"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain horror or fear themes?"
           },
           "matureOrSuggestiveThemes": {
-            "$ref": "#/definitions/apple/AppleRating"
-          },
-          "unrestrictedWebAccess": {
-            "type": "boolean"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain mature or suggestive themes?"
           },
           "violenceCartoonOrFantasy": {
-            "$ref": "#/definitions/apple/AppleRating"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain cartoon or fantasy violence?"
           },
           "violenceRealisticProlongedGraphicOrSadistic": {
-            "$ref": "#/definitions/apple/AppleRating"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain prolonged graphic or sadistic realistic violence?"
           },
           "violenceRealistic": {
-            "$ref": "#/definitions/apple/AppleRating"
+            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "description": "Does the app contain realistic violence?"
+          },
+          "unrestrictedWebAccess": {
+            "type": "boolean",
+            "description": "Does your app contain unrestricted web access, such as with an embedded browser?"
+          },
+          "gambling": {
+            "type": "boolean",
+            "description": "Does your app contain gambling?"
+          },
+          "kidsAgeBand": {
+            "oneOf": [
+              { "type": "null" },
+              { "$ref": "#/definitions/apple/AppleKidsAge" }
+            ],
+            "description": "The Kids category is a great way for people to easily find apps that are designed for children. Keep in mind that once your Made for Kids app is approved by App Review, the app and all subsequent updates will need to follow the Kids category guidelines unless you create a new app in App Store Connect.\n@see https://developer.apple.com/news/?id=091202019a",
+            "markdownDescription": "The Kids category is a great way for people to easily find apps that are designed for children. Keep in mind that once your Made for Kids app is approved by App Review, the app and all subsequent updates will need to follow the Kids category guidelines unless you create a new app in App Store Connect.\n\n[Learn more](https://developer.apple.com/news/?id=091202019a)"
+          },
+          "seventeenPlus": {
+            "type": "boolean",
+            "description": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 17, you can manually set the age rating to 17+.\n@see https://help.apple.com/app-store-connect/#/dev599d50efb",
+            "markdownDescription": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 17, you can manually set the age rating to 17+.\n\n[Learn more](https://help.apple.com/app-store-connect/#/dev599d50efb)"
           }
         }
       },

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -19,10 +19,18 @@
         ]
       },
       "AppleKidsAge": {
-        "enum": ["FIVE_AND_UNDER", "SIX_TO_EIGHT", "NINE_TO_ELEVEN"]
+        "enum": [
+          "FIVE_AND_UNDER",
+          "SIX_TO_EIGHT",
+          "NINE_TO_ELEVEN"
+        ]
       },
       "AppleRating": {
-        "enum": ["NONE", "INFREQUENT_OR_MILD", "FREQUENT_OR_INTENSE"]
+        "enum": [
+          "NONE",
+          "INFREQUENT_OR_MILD",
+          "FREQUENT_OR_INTENSE"
+        ]
       },
       "AppleCategory": {
         "enum": [
@@ -94,15 +102,15 @@
         "type": "object",
         "additionalProperties": false,
         "defaultSnippets": [
-            {
-              "body": {
-                  "servesAds": false,
-                  "attributesAppInstallationToPreviousAd": false,
-                  "attributesActionWithPreviousAd": false,
-                  "honorsLimitedAdTracking": false
-              }
+          {
+            "body": {
+              "servesAds": false,
+              "attributesAppInstallationToPreviousAd": false,
+              "attributesActionWithPreviousAd": false,
+              "honorsLimitedAdTracking": false
             }
-          ],
+          }
+        ],
         "properties": {
           "servesAds": {
             "type": "boolean"
@@ -141,7 +149,9 @@
               "title": "${1:App title}",
               "subtitle": "${2:Subtitle for your app}",
               "description": "${3:A longer description of what your app does}",
-              "keywords": ["${4:keyword}"],
+              "keywords": [
+                "${4:keyword}"
+              ],
               "releaseNotes": "${5:Bug fixes and improved stability}",
               "promoText": "${6:Short tagline for your app}",
               "marketingUrl": "https://${7:www.}",
@@ -322,51 +332,51 @@
         ],
         "properties": {
           "alcoholTobaccoOrDrugUseOrReferences": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain alcohol, tobacco, or drug use or references?"
           },
           "contests": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain contests?"
           },
           "gamblingSimulated": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain simulated gambling?"
           },
           "medicalOrTreatmentInformation": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain medical or treatment information?"
           },
           "profanityOrCrudeHumor": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain profanity or crude humor?"
           },
           "sexualContentGraphicAndNudity": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain graphic sexual content and nudity?"
           },
           "sexualContentOrNudity": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain sexual content or nudity?"
           },
           "horrorOrFearThemes": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain horror or fear themes?"
           },
           "matureOrSuggestiveThemes": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain mature or suggestive themes?"
           },
           "violenceCartoonOrFantasy": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain cartoon or fantasy violence?"
           },
           "violenceRealisticProlongedGraphicOrSadistic": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain prolonged graphic or sadistic realistic violence?"
           },
           "violenceRealistic": {
-            "allOf": [{ "$ref": "#/definitions/apple/AppleRating" }],
+            "$ref": "#/definitions/apple/AppleRating",
             "description": "Does the app contain realistic violence?"
           },
           "unrestrictedWebAccess": {
@@ -379,8 +389,12 @@
           },
           "kidsAgeBand": {
             "oneOf": [
-              { "type": "null" },
-              { "$ref": "#/definitions/apple/AppleKidsAge" }
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/definitions/apple/AppleKidsAge"
+              }
             ],
             "description": "The Kids category is a great way for people to easily find apps that are designed for children. Keep in mind that once your Made for Kids app is approved by App Review, the app and all subsequent updates will need to follow the Kids category guidelines unless you create a new app in App Store Connect.\n@see https://developer.apple.com/news/?id=091202019a",
             "markdownDescription": "The Kids category is a great way for people to easily find apps that are designed for children. Keep in mind that once your Made for Kids app is approved by App Review, the app and all subsequent updates will need to follow the Kids category guidelines unless you create a new app in App Store Connect.\n\n[Learn more](https://developer.apple.com/news/?id=091202019a)"
@@ -434,8 +448,8 @@
             }
           },
           "shouldResetRatings": {
-            "description": "Should App Store ratings be reset for this version of the app.",
             "type": "boolean",
+            "description": "Should App Store ratings be reset for this version of the app.",
             "meta": {
               "storeInfo": "You can reset your app’s summary rating for all countries or regions when you release this version. Keep in mind that once this version is released, you won’t be able to restore the rating. Your app’s existing customer reviews will still appear on the App Store."
             }
@@ -444,19 +458,22 @@
             "type": "boolean"
           },
           "automaticRelease": {
-            "description": "Should the app automatically be released when approved by App Store review.",
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Should the app automatically be released when approved by App Store review."
           },
           "usesNonExemptEncryption": {
-            "description": "Alternative to setting `ITSAppUsesNonExemptEncryption` in the binary's `Info.plist`.",
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Alternative to setting `ITSAppUsesNonExemptEncryption` in the binary's `Info.plist`."
           }
         }
       },
       "AppleReview": {
         "type": "object",
         "description": "Info provided to the App Store review team to help them understand how to use your app.",
-        "required": ["firstName", "lastName"],
+        "required": [
+          "firstName",
+          "lastName"
+        ],
         "defaultSnippets": [
           {
             "body": {
@@ -467,44 +484,44 @@
         ],
         "properties": {
           "demoUsername": {
-            "description": "Optional username for testing the app.",
-            "type": "string"
+            "type": "string",
+            "description": "Optional username for testing the app."
           },
           "demoPassword": {
-            "description": "Optional password for testing the app.",
-            "type": "string"
+            "type": "string",
+            "description": "Optional password for testing the app."
           },
           "attachment": {
-            "description": "Local file path to upload to the review team.",
-            "type": "string"
+            "type": "string",
+            "description": "Local file path to upload to the review team."
           },
           "firstName": {
-            "description": "Developer first name for the reviewer to contact.",
-            "type": "string"
+            "type": "string",
+            "description": "Developer first name for the reviewer to contact."
           },
           "lastName": {
-            "description": "Developer last name (surname) for the reviewer to contact.",
-            "type": "string"
+            "type": "string",
+            "description": "Developer last name (surname) for the reviewer to contact."
           },
           "phone": {
-            "description": "Developer phone number for the reviewer to contact.",
-            "type": "string"
+            "type": "string",
+            "description": "Developer phone number for the reviewer to contact."
           },
           "email": {
-            "description": "Developer email address for the reviewer to contact.",
             "type": "string",
+            "description": "Developer email address for the reviewer to contact.",
             "format": "email"
           },
           "notes": {
-            "description": "Any additional notes for the App Store reviewer.",
-            "type": "string"
+            "type": "string",
+            "description": "Any additional notes for the App Store reviewer."
           }
         }
       }
     },
     "AppleConfig": {
-      "description": "Configuration that is specific to the Apple App Store.",
       "type": "object",
+      "description": "Configuration that is specific to the Apple App Store.",
       "additionalProperties": false,
       "properties": {
         "advisory": {
@@ -524,7 +541,9 @@
                 "maxItems": 2,
                 "items": [
                   {
-                    "enum": ["GAMES"]
+                    "enum": [
+                      "GAMES"
+                    ]
                   },
                   {
                     "enum": [
@@ -554,7 +573,9 @@
                 "maxItems": 2,
                 "items": [
                   {
-                    "enum": ["STICKERS"]
+                    "enum": [
+                      "STICKERS"
+                    ]
                   },
                   {
                     "enum": [
@@ -582,6 +603,8 @@
           }
         },
         "copyright": {
+          "type": "string",
+          "description": "The updated company copyright. Example: 2021 Evan Bacon",
           "defaultSnippets": [
             {
               "body": "$CURRENT_YEAR ${1:name}"
@@ -591,9 +614,7 @@
             "versioned": true,
             "liveEdits": true,
             "storeInfo": "The name of the person or entity that owns the exclusive rights to your app, preceded by the year the rights were obtained (for example, \"2008 Acme Inc.\"). Do not provide a URL."
-          },
-          "description": "The updated company copyright. Example: 2021 Evan Bacon",
-          "type": "string"
+          }
         },
         "idfa": {
           "$ref": "#/definitions/apple/AppleIdfa"
@@ -933,28 +954,32 @@
           ]
         },
         "release": {
-            "description": "Release strategy",
-          "$ref": "#/definitions/apple/AppleRelease"
+          "$ref": "#/definitions/apple/AppleRelease",
+          "description": "Release strategy"
         },
         "review": {
-            "description": "Info for the App Store reviewer",
-          "$ref": "#/definitions/apple/AppleReview"
+          "$ref": "#/definitions/apple/AppleReview",
+          "description": "Info for the App Store reviewer"
         },
         "priceTier": {
-            "description": "App price tier. 0 is Free.",
-          "type": "number"
+          "type": "number",
+          "description": "App price tier. 0 is Free."
         }
       }
     }
   },
   "properties": {
     "configVersion": {
-      "const": 0
+      "const": 0,
+      "description": "The EAS metadata store configuration version"
     },
     "apple": {
       "$ref": "#/definitions/AppleConfig"
     }
   },
   "additionalProperties": false,
-  "required": ["configVersion", "apple"]
+  "required": [
+    "configVersion",
+    "apple"
+  ]
 }

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -19,11 +19,9 @@
         ]
       },
       "AppleKidsAge": {
-        "type": "string",
         "enum": ["FIVE_AND_UNDER", "SIX_TO_EIGHT", "NINE_TO_ELEVEN"]
       },
       "AppleRating": {
-        "type": "string",
         "enum": ["NONE", "INFREQUENT_OR_MILD", "FREQUENT_OR_INTENSE"]
       },
       "AppleCategory": {

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -396,8 +396,8 @@
                 "$ref": "#/definitions/apple/AppleKidsAge"
               }
             ],
-            "description": "The Kids category is a great way for people to easily find apps that are designed for children. Keep in mind that once your Made for Kids app is approved by App Review, the app and all subsequent updates will need to follow the Kids category guidelines unless you create a new app in App Store Connect.\n@see https://developer.apple.com/news/?id=091202019a",
-            "markdownDescription": "The Kids category is a great way for people to easily find apps that are designed for children. Keep in mind that once your Made for Kids app is approved by App Review, the app and all subsequent updates will need to follow the Kids category guidelines unless you create a new app in App Store Connect.\n\n[Learn more](https://developer.apple.com/news/?id=091202019a)"
+            "description": "When parents visit the Kids category on the App Store, they expect the apps they find will protect their children’s data, provide only age-appropriate content, and require a parental gate in order to link out of the app, request permissions, or present purchasing opportunities. It’s critical that no personally identifiable information or device information be transmitted to third parties, and that advertisements are human-reviewed for age appropriateness in order to be displayed.\n@see https://developer.apple.com/news/?id=091202019a",
+            "markdownDescription": "When parents visit the Kids category on the App Store, they expect the apps they find will protect their children’s data, provide only age-appropriate content, and require a parental gate in order to link out of the app, request permissions, or present purchasing opportunities. It’s critical that no personally identifiable information or device information be transmitted to third parties, and that advertisements are human-reviewed for age appropriateness in order to be displayed.\n\n[Learn more](https://developer.apple.com/news/?id=091202019a)"
           },
           "seventeenPlus": {
             "type": "boolean",

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/ageRatingDeclaration.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/ageRatingDeclaration.ts
@@ -1,23 +1,84 @@
-import { AgeRatingDeclaration, KidsAge } from '@expo/apple-utils';
+import { AgeRatingDeclaration, KidsAge, Rating } from '@expo/apple-utils';
 
 import { AttributesOf } from '../../../../utils/asc';
 
-export const kidsSixToEightAdvisory: AttributesOf<AgeRatingDeclaration> = {
+// @ts-expect-error: Deprecated property `gamblingAndContests` needs to be deleted from the types
+// These attributes is what we get from the API when no questions are answered
+export const emptyAdvisory: AttributesOf<AgeRatingDeclaration> = {
   alcoholTobaccoOrDrugUseOrReferences: null,
-  gamblingSimulated: null,
-  gambling: null,
   contests: null,
+  gamblingSimulated: null,
+  horrorOrFearThemes: null,
+  matureOrSuggestiveThemes: null,
   medicalOrTreatmentInformation: null,
   profanityOrCrudeHumor: null,
   sexualContentGraphicAndNudity: null,
   sexualContentOrNudity: null,
-  horrorOrFearThemes: null,
-  matureOrSuggestiveThemes: null,
   violenceCartoonOrFantasy: null,
-  violenceRealisticProlongedGraphicOrSadistic: null,
   violenceRealistic: null,
+  violenceRealisticProlongedGraphicOrSadistic: null,
+  gambling: false,
   unrestrictedWebAccess: false,
+  kidsAgeBand: null,
   seventeenPlus: false,
+};
+
+// @ts-expect-error: Deprecated property `gamblingAndContests` needs to be deleted from the types
+export const leastRestrictiveAdvisory: AttributesOf<AgeRatingDeclaration> = {
+  alcoholTobaccoOrDrugUseOrReferences: Rating.NONE,
+  contests: Rating.NONE,
+  gamblingSimulated: Rating.NONE,
+  horrorOrFearThemes: Rating.NONE,
+  matureOrSuggestiveThemes: Rating.NONE,
+  medicalOrTreatmentInformation: Rating.NONE,
+  profanityOrCrudeHumor: Rating.NONE,
+  sexualContentGraphicAndNudity: Rating.NONE,
+  sexualContentOrNudity: Rating.NONE,
+  violenceCartoonOrFantasy: Rating.NONE,
+  violenceRealistic: Rating.NONE,
+  violenceRealisticProlongedGraphicOrSadistic: Rating.NONE,
+  gambling: false,
+  unrestrictedWebAccess: false,
+  kidsAgeBand: null,
+  seventeenPlus: false,
+};
+
+// @ts-expect-error: Deprecated property `gamblingAndContests` needs to be deleted from the types
+export const mostRestrictiveAdvisory: AttributesOf<AgeRatingDeclaration> = {
+  alcoholTobaccoOrDrugUseOrReferences: Rating.FREQUENT_OR_INTENSE,
+  contests: Rating.FREQUENT_OR_INTENSE,
+  gamblingSimulated: Rating.FREQUENT_OR_INTENSE,
+  horrorOrFearThemes: Rating.FREQUENT_OR_INTENSE,
+  matureOrSuggestiveThemes: Rating.FREQUENT_OR_INTENSE,
+  medicalOrTreatmentInformation: Rating.FREQUENT_OR_INTENSE,
+  profanityOrCrudeHumor: Rating.FREQUENT_OR_INTENSE,
+  sexualContentGraphicAndNudity: Rating.FREQUENT_OR_INTENSE,
+  sexualContentOrNudity: Rating.FREQUENT_OR_INTENSE,
+  violenceCartoonOrFantasy: Rating.FREQUENT_OR_INTENSE,
+  violenceRealistic: Rating.FREQUENT_OR_INTENSE,
+  violenceRealisticProlongedGraphicOrSadistic: Rating.FREQUENT_OR_INTENSE,
+  gambling: true,
+  unrestrictedWebAccess: true,
+  kidsAgeBand: null,
+  seventeenPlus: true,
+};
+
+// @ts-expect-error: Deprecated property `gamblingAndContests` needs to be deleted from the types
+export const kidsSixToEightAdvisory: AttributesOf<AgeRatingDeclaration> = {
+  alcoholTobaccoOrDrugUseOrReferences: Rating.NONE,
+  contests: Rating.NONE,
+  gamblingSimulated: Rating.NONE,
+  horrorOrFearThemes: Rating.NONE,
+  matureOrSuggestiveThemes: Rating.NONE,
+  medicalOrTreatmentInformation: Rating.NONE,
+  profanityOrCrudeHumor: Rating.NONE,
+  sexualContentGraphicAndNudity: Rating.NONE,
+  sexualContentOrNudity: Rating.NONE,
+  violenceCartoonOrFantasy: Rating.NONE,
+  violenceRealistic: Rating.NONE,
+  violenceRealisticProlongedGraphicOrSadistic: Rating.NONE,
+  gambling: false,
+  unrestrictedWebAccess: false,
   kidsAgeBand: KidsAge.SIX_TO_EIGHT,
-  gamblingAndContests: false,
+  seventeenPlus: false,
 };

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
@@ -5,7 +5,7 @@ describe('setAgeRating', () => {
   it('ignores advisory when not set', () => {
     const reader = new AppleConfigReader({ advisory: undefined });
     expect(reader.getAgeRating()).toBeNull();
-  })
+  });
 
   it('auto-fills least restrictive advisory', () => {
     const reader = new AppleConfigReader({ advisory: {} });

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
@@ -1,0 +1,19 @@
+import { AppleConfigReader } from '../reader';
+import { leastRestrictiveAdvisory, mostRestrictiveAdvisory } from './fixtures/ageRatingDeclaration';
+
+describe('setAgeRating', () => {
+  it('ignores advisory when not set', () => {
+    const reader = new AppleConfigReader({ advisory: undefined });
+    expect(reader.getAgeRating()).toBeNull();
+  })
+
+  it('auto-fills least restrictive advisory', () => {
+    const reader = new AppleConfigReader({ advisory: {} });
+    expect(reader.getAgeRating()).toMatchObject(leastRestrictiveAdvisory);
+  });
+
+  it('returns most restrictive advisory', () => {
+    const reader = new AppleConfigReader({ advisory: mostRestrictiveAdvisory });
+    expect(reader.getAgeRating()).toMatchObject(mostRestrictiveAdvisory);
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -99,18 +99,16 @@ describe('setVersionRelease', () => {
     });
   });
 
-  it('modifies manual release', () => {
+  it('does not modify manual release', () => {
     const writer = new AppleConfigWriter();
     writer.setVersionRelease(manualRelease);
-    expect(writer.schema.release).toMatchObject({
-      automaticRelease: false,
-    });
+    expect(writer.schema.release).toBeUndefined();
   });
 
   it('overwrites all release fields', () => {
     const writer = new AppleConfigWriter();
     writer.setVersionRelease(scheduledRelease);
-    writer.setVersionRelease(manualRelease);
+    writer.setVersionRelease(automaticRelease);
     expect(writer.schema.release).not.toHaveProperty('autoReleaseDate');
   });
 });

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -1,5 +1,10 @@
 import { AppleConfigWriter } from '../writer';
-import { kidsSixToEightAdvisory } from './fixtures/ageRatingDeclaration';
+import {
+  emptyAdvisory,
+  kidsSixToEightAdvisory,
+  leastRestrictiveAdvisory,
+  mostRestrictiveAdvisory,
+} from './fixtures/ageRatingDeclaration';
 import { primaryAndSecondaryCategory, secondaryOnlyCategory } from './fixtures/appInfo';
 import { dutchInfo, englishInfo } from './fixtures/appInfoLocalization';
 import { automaticRelease, manualRelease, scheduledRelease } from './fixtures/appStoreVersion';
@@ -16,10 +21,22 @@ describe('toSchema', () => {
 });
 
 describe('setAgeRating', () => {
-  it('modifies the advisory', () => {
+  it('auto-fills least restrictive advisory', () => {
+    const writer = new AppleConfigWriter();
+    writer.setAgeRating(emptyAdvisory);
+    expect(writer.schema.advisory).toMatchObject(leastRestrictiveAdvisory);
+  });
+
+  it('modifies kids band rating', () => {
     const writer = new AppleConfigWriter();
     writer.setAgeRating(kidsSixToEightAdvisory);
     expect(writer.schema.advisory).toMatchObject(kidsSixToEightAdvisory);
+  });
+
+  it('modifies most restrictive advisory', () => {
+    const writer = new AppleConfigWriter();
+    writer.setAgeRating(mostRestrictiveAdvisory);
+    expect(writer.schema.advisory).toMatchObject(mostRestrictiveAdvisory);
   });
 });
 

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -43,7 +43,7 @@ export class AppleConfigReader {
 
     return {
       locale,
-      name: info.title ?? 'no name provided',
+      name: info.title ?? 'App title', // see schema #/definitions/apple/AppleInfo/defaultSnippets
       subtitle: info.subtitle,
       privacyChoicesUrl: info.privacyChoicesUrl,
       privacyPolicyText: info.privacyPolicyText,

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -68,7 +68,7 @@ export class AppleConfigReader {
 
     return {
       locale,
-      name: info.title ?? 'App title', // see schema #/definitions/apple/AppleInfo/defaultSnippets
+      name: info.title,
       subtitle: info.subtitle,
       privacyChoicesUrl: info.privacyChoicesUrl,
       privacyPolicyText: info.privacyPolicyText,

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -4,6 +4,7 @@ import {
   AppStoreVersion,
   AppStoreVersionLocalization,
   CategoryIds,
+  Rating,
   ReleaseType,
 } from '@expo/apple-utils';
 
@@ -25,7 +26,31 @@ export class AppleConfigReader {
   public constructor(public readonly schema: AppleMetadata) {}
 
   public getAgeRating(): Partial<AttributesOf<AgeRatingDeclaration>> | null {
-    return this.schema.advisory || null;
+    const attributes = this.schema.advisory;
+    if (!attributes) {
+      return null;
+    }
+
+    return {
+      alcoholTobaccoOrDrugUseOrReferences:
+        attributes.alcoholTobaccoOrDrugUseOrReferences ?? Rating.NONE,
+      contests: attributes.contests ?? Rating.NONE,
+      gamblingSimulated: attributes.gamblingSimulated ?? Rating.NONE,
+      horrorOrFearThemes: attributes.horrorOrFearThemes ?? Rating.NONE,
+      matureOrSuggestiveThemes: attributes.matureOrSuggestiveThemes ?? Rating.NONE,
+      medicalOrTreatmentInformation: attributes.medicalOrTreatmentInformation ?? Rating.NONE,
+      profanityOrCrudeHumor: attributes.profanityOrCrudeHumor ?? Rating.NONE,
+      sexualContentGraphicAndNudity: attributes.sexualContentGraphicAndNudity ?? Rating.NONE,
+      sexualContentOrNudity: attributes.sexualContentOrNudity ?? Rating.NONE,
+      violenceCartoonOrFantasy: attributes.violenceCartoonOrFantasy ?? Rating.NONE,
+      violenceRealistic: attributes.violenceRealistic ?? Rating.NONE,
+      violenceRealisticProlongedGraphicOrSadistic:
+        attributes.violenceRealisticProlongedGraphicOrSadistic ?? Rating.NONE,
+      gambling: attributes.gambling ?? false,
+      unrestrictedWebAccess: attributes.unrestrictedWebAccess ?? false,
+      kidsAgeBand: attributes.kidsAgeBand ?? null,
+      seventeenPlus: attributes.seventeenPlus ?? false,
+    };
   }
 
   public getLocales(): string[] {

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -77,9 +77,9 @@ export class AppleConfigWriter {
     }
 
     if (attributes.releaseType === ReleaseType.MANUAL) {
-      this.schema.release = {
-        automaticRelease: false,
-      };
+      // ReleaseType.MANUAL is the default behavior, so we don't need to configure it.
+      // Setting `"automaticRelease": false` is a bit confusing for people who don't know what automaticRelease does.
+      this.schema.release = undefined;
     }
   }
 

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -35,7 +35,7 @@ export class AppleConfigWriter {
 
     this.schema.info[attributes.locale] = {
       ...existing,
-      title: attributes.name ?? 'no name provided',
+      title: attributes.name ?? 'App title', // see schema #/definitions/apple/AppleInfo/defaultSnippets
       subtitle: optional(attributes.subtitle),
       privacyPolicyUrl: optional(attributes.privacyPolicyUrl),
       privacyPolicyText: optional(attributes.privacyPolicyText),

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -4,6 +4,7 @@ import {
   AppInfoLocalization,
   AppStoreVersion,
   AppStoreVersionLocalization,
+  Rating,
   ReleaseType,
 } from '@expo/apple-utils';
 
@@ -26,7 +27,26 @@ export class AppleConfigWriter {
   }
 
   public setAgeRating(attributes: AttributesOf<AgeRatingDeclaration>): void {
-    this.schema.advisory = attributes;
+    this.schema.advisory = {
+      alcoholTobaccoOrDrugUseOrReferences:
+        attributes.alcoholTobaccoOrDrugUseOrReferences ?? Rating.NONE,
+      contests: attributes.contests ?? Rating.NONE,
+      gamblingSimulated: attributes.gamblingSimulated ?? Rating.NONE,
+      horrorOrFearThemes: attributes.horrorOrFearThemes ?? Rating.NONE,
+      matureOrSuggestiveThemes: attributes.matureOrSuggestiveThemes ?? Rating.NONE,
+      medicalOrTreatmentInformation: attributes.medicalOrTreatmentInformation ?? Rating.NONE,
+      profanityOrCrudeHumor: attributes.profanityOrCrudeHumor ?? Rating.NONE,
+      sexualContentGraphicAndNudity: attributes.sexualContentGraphicAndNudity ?? Rating.NONE,
+      sexualContentOrNudity: attributes.sexualContentOrNudity ?? Rating.NONE,
+      violenceCartoonOrFantasy: attributes.violenceCartoonOrFantasy ?? Rating.NONE,
+      violenceRealistic: attributes.violenceRealistic ?? Rating.NONE,
+      violenceRealisticProlongedGraphicOrSadistic:
+        attributes.violenceRealisticProlongedGraphicOrSadistic ?? Rating.NONE,
+      gambling: attributes.gambling ?? false,
+      unrestrictedWebAccess: attributes.unrestrictedWebAccess ?? false,
+      kidsAgeBand: attributes.kidsAgeBand ?? null,
+      seventeenPlus: attributes.seventeenPlus ?? false,
+    };
   }
 
   public setInfoLocale(attributes: AttributesOf<AppInfoLocalization>): void {

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -55,7 +55,7 @@ export class AppleConfigWriter {
 
     this.schema.info[attributes.locale] = {
       ...existing,
-      title: attributes.name ?? 'App title', // see schema #/definitions/apple/AppleInfo/defaultSnippets
+      title: attributes.name ?? '',
       subtitle: optional(attributes.subtitle),
       privacyPolicyUrl: optional(attributes.privacyPolicyUrl),
       privacyPolicyText: optional(attributes.privacyPolicyText),


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This includes improved schema configuration and default store config values for:
- `apple.info`
- `apple.release`
- `apple.advisory`

# How

- Updated metadata schema
- Updated tests

# Test Plan

- See tests