### PR TITLE
[eas-cli] Add review details to metadata store configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Allow users to skip metadata validation. ([#1175](https://github.com/expo/eas-cli/pull/1175) by [@byCedric](https://github.com/byCedric))
 - Add experimental `--resource-class` flag for Build commands. ([#1138](https://github.com/expo/eas-cli/pull/1138) by [@christopherwalter](https://github.com/christopherwalter))
 - Truncate long messages for `eas update` command, rather than failing. ([#1178](https://github.com/expo/eas-cli/pull/1178) by [@kgc00](https://github.com/kgc00))
+- Add review details to metadata store configuration. ([#1184](https://github.com/expo/eas-cli/pull/1184) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -538,6 +538,7 @@
           "notes": {
             "type": "string",
             "description": "Additional information about your app that can help during the review process. Do not include demo account details.",
+            "markdownDescription": "Additional information about your app that can help during the review process.\n\n**Do not include demo account details.**",
             "minLength": 2,
             "maxLength": 4000
           }

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -472,49 +472,74 @@
         "description": "Info provided to the App Store review team to help them understand how to use your app.",
         "required": [
           "firstName",
-          "lastName"
+          "lastName",
+          "email",
+          "phone"
         ],
         "defaultSnippets": [
           {
+            "label": "Basic",
+            "description": "Only define the contact details in case communcation is needed with the App Store review team.",
             "body": {
               "firstName": "$1",
-              "lastName": "$2"
+              "lastName": "$2",
+              "email": "$3",
+              "phone": "+$4"
+            }
+          },
+          {
+            "label": "Full",
+            "description": "Define the demo account credentials, additional info, and contact details for the App Store review team.",
+            "body": {
+              "firstName": "$1",
+              "lastName": "$2",
+              "email": "$3",
+              "phone": "+$4",
+              "demoUsername": "$5",
+              "demoPassword": "$6",
+              "demoRequired": true,
+              "notes": "$7"
             }
           }
         ],
         "properties": {
-          "demoUsername": {
-            "type": "string",
-            "description": "Optional username for testing the app."
-          },
-          "demoPassword": {
-            "type": "string",
-            "description": "Optional password for testing the app."
-          },
-          "attachment": {
-            "type": "string",
-            "description": "Local file path to upload to the review team."
-          },
           "firstName": {
             "type": "string",
-            "description": "Developer first name for the reviewer to contact."
+            "description": "First name of contact in case communication is needed with the App Store review team.",
+            "minLength": 1
           },
           "lastName": {
             "type": "string",
-            "description": "Developer last name (surname) for the reviewer to contact."
-          },
-          "phone": {
-            "type": "string",
-            "description": "Developer phone number for the reviewer to contact."
+            "description": "Last name of contact in case communication is needed with the App Store review team.",
+            "minLength": 1
           },
           "email": {
             "type": "string",
-            "description": "Developer email address for the reviewer to contact.",
+            "description": "Email address of contact in case communication is needed with the App Store review team.",
             "format": "email"
+          },
+          "phone": {
+            "type": "string",
+            "description": "Phone number of contact in case communication is needed with the App Store review team. Preface the phone number with ‘+’ followed by the country code (for example, +44 844 209 0611)"
+          },
+          "demoUsername": {
+            "type": "string",
+            "description": "The user name to sign in to your app to review its features."
+          },
+          "demoPassword": {
+            "type": "string",
+            "description": "The password to sign in to your app to review its features."
+          },
+          "demoRequired": {
+            "type": "boolean",
+            "description": "A Boolean value that indicates if sign-in information is required to review all the features of your app. If users sign in using social media, provide information for an account for review. Credentials must be valid and active for duration of review.",
+            "markdownDescription": "A Boolean value that indicates if sign-in information is required to review all the features of your app. If users sign in using social media, provide information for an account for review.\n\n**Credentials must be valid and active for duration of review.**"
           },
           "notes": {
             "type": "string",
-            "description": "Any additional notes for the App Store reviewer."
+            "description": "Additional information about your app that can help during the review process. Do not include demo account details.",
+            "minLength": 2,
+            "maxLength": 4000
           }
         }
       }

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreReviewDetail.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreReviewDetail.ts
@@ -1,0 +1,25 @@
+import { AppStoreReviewDetail } from '@expo/apple-utils';
+
+import { AttributesOf } from '../../../../utils/asc';
+
+export const nameOnlyReviewDetails: AttributesOf<AppStoreReviewDetail> = {
+  contactFirstName: 'Evan',
+  contactLastName: 'Bacon',
+  contactEmail: null,
+  contactPhone: null,
+  demoAccountName: null,
+  demoAccountPassword: null,
+  demoAccountRequired: null,
+  notes: null,
+};
+
+export const nameAndDemoReviewDetails: AttributesOf<AppStoreReviewDetail> = {
+  contactFirstName: 'Evan',
+  contactLastName: 'Bacon',
+  contactEmail: null,
+  contactPhone: null,
+  demoAccountName: 'demo@apple.com',
+  demoAccountPassword: 'secretpassword',
+  demoAccountRequired: true,
+  notes: null,
+};

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreReviewDetail.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreReviewDetail.ts
@@ -5,8 +5,8 @@ import { AttributesOf } from '../../../../utils/asc';
 export const nameOnlyReviewDetails: AttributesOf<AppStoreReviewDetail> = {
   contactFirstName: 'Evan',
   contactLastName: 'Bacon',
-  contactEmail: null,
-  contactPhone: null,
+  contactEmail: 'apple@example.com',
+  contactPhone: '+1 (555) 555-5555',
   demoAccountName: null,
   demoAccountPassword: null,
   demoAccountRequired: null,
@@ -16,8 +16,8 @@ export const nameOnlyReviewDetails: AttributesOf<AppStoreReviewDetail> = {
 export const nameAndDemoReviewDetails: AttributesOf<AppStoreReviewDetail> = {
   contactFirstName: 'Evan',
   contactLastName: 'Bacon',
-  contactEmail: null,
-  contactPhone: null,
+  contactEmail: 'apple@example.com',
+  contactPhone: '+1 (555) 555-5555',
   demoAccountName: 'demo@apple.com',
   demoAccountPassword: 'secretpassword',
   demoAccountRequired: true,

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -7,6 +7,7 @@ import {
 } from './fixtures/ageRatingDeclaration';
 import { primaryAndSecondaryCategory, secondaryOnlyCategory } from './fixtures/appInfo';
 import { dutchInfo, englishInfo } from './fixtures/appInfoLocalization';
+import { nameAndDemoReviewDetails, nameOnlyReviewDetails } from './fixtures/appStoreReviewDetail';
 import { automaticRelease, manualRelease, scheduledRelease } from './fixtures/appStoreVersion';
 import { dutchVersion, englishVersion } from './fixtures/appStoreVersionLocalization';
 
@@ -161,6 +162,49 @@ describe('setVersionLocale', () => {
     expect(writer.schema.info?.[englishVersion.locale]).toMatchObject({
       description: 'This is now different',
       releaseNotes: undefined,
+    });
+  });
+});
+
+describe('setReviewDetails', () => {
+  it('modifies name only review details', () => {
+    const writer = new AppleConfigWriter();
+    writer.setReviewDetails(nameOnlyReviewDetails);
+    expect(writer.schema.review).toMatchObject({
+      firstName: nameOnlyReviewDetails.contactFirstName,
+      lastName: nameOnlyReviewDetails.contactLastName,
+      email: undefined,
+      phone: undefined,
+      demoUsername: undefined,
+      demoPassword: undefined,
+      demoRequired: undefined,
+      notes: undefined,
+    });
+  });
+
+  it('modifies name and demo review details', () => {
+    const writer = new AppleConfigWriter();
+    writer.setReviewDetails(nameAndDemoReviewDetails);
+    expect(writer.schema.review).toMatchObject({
+      firstName: nameAndDemoReviewDetails.contactFirstName,
+      lastName: nameAndDemoReviewDetails.contactLastName,
+      demoUsername: nameAndDemoReviewDetails.demoAccountName,
+      demoPassword: nameAndDemoReviewDetails.demoAccountPassword,
+      demoRequired: nameAndDemoReviewDetails.demoAccountRequired,
+      email: undefined,
+      phone: undefined,
+      notes: undefined,
+    });
+  });
+
+  it('replaces existing review details', () => {
+    const writer = new AppleConfigWriter();
+    writer.setReviewDetails(nameAndDemoReviewDetails);
+    writer.setReviewDetails(nameOnlyReviewDetails);
+    expect(writer.schema.review).toMatchObject({
+      demoUsername: undefined,
+      demoPassword: undefined,
+      demoRequired: undefined,
     });
   });
 });

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -173,8 +173,8 @@ describe('setReviewDetails', () => {
     expect(writer.schema.review).toMatchObject({
       firstName: nameOnlyReviewDetails.contactFirstName,
       lastName: nameOnlyReviewDetails.contactLastName,
-      email: undefined,
-      phone: undefined,
+      email: nameOnlyReviewDetails.contactEmail,
+      phone: nameOnlyReviewDetails.contactPhone,
       demoUsername: undefined,
       demoPassword: undefined,
       demoRequired: undefined,
@@ -188,11 +188,11 @@ describe('setReviewDetails', () => {
     expect(writer.schema.review).toMatchObject({
       firstName: nameAndDemoReviewDetails.contactFirstName,
       lastName: nameAndDemoReviewDetails.contactLastName,
+      email: nameAndDemoReviewDetails.contactEmail,
+      phone: nameAndDemoReviewDetails.contactPhone,
       demoUsername: nameAndDemoReviewDetails.demoAccountName,
       demoPassword: nameAndDemoReviewDetails.demoAccountPassword,
       demoRequired: nameAndDemoReviewDetails.demoAccountRequired,
-      email: undefined,
-      phone: undefined,
       notes: undefined,
     });
   });

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -1,6 +1,7 @@
 import {
   AgeRatingDeclaration,
   AppInfoLocalization,
+  AppStoreReviewDetail,
   AppStoreVersion,
   AppStoreVersionLocalization,
   CategoryIds,
@@ -142,6 +143,25 @@ export class AppleConfigReader {
       marketingUrl: info.marketingUrl,
       promotionalText: info.promoText,
       supportUrl: info.supportUrl,
+    };
+  }
+
+  public getReviewDetails(): Partial<AttributesOf<AppStoreReviewDetail>> | null {
+    const review = this.schema.review;
+    if (!review) {
+      return null;
+    }
+
+    return {
+      contactFirstName: review.firstName,
+      contactLastName: review.lastName,
+      contactEmail: review.email,
+      contactPhone: review.phone,
+      demoAccountName: review.demoUsername,
+      demoAccountPassword: review.demoPassword,
+      demoAccountRequired: review.demoRequired,
+      notes: review.notes,
+      // TODO: add attachment
     };
   }
 }

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -2,6 +2,7 @@ import {
   AgeRatingDeclaration,
   AppInfo,
   AppInfoLocalization,
+  AppStoreReviewDetail,
   AppStoreVersion,
   AppStoreVersionLocalization,
   Rating,
@@ -117,6 +118,20 @@ export class AppleConfigWriter {
       marketingUrl: optional(attributes.marketingUrl),
       promoText: optional(attributes.promotionalText),
       supportUrl: optional(attributes.supportUrl),
+    };
+  }
+
+  public setReviewDetails(attributes: AttributesOf<AppStoreReviewDetail>): void {
+    this.schema.review = {
+      firstName: attributes.contactFirstName ?? '',
+      lastName: attributes.contactLastName ?? '',
+      email: attributes.contactEmail ?? '',
+      phone: attributes.contactPhone ?? '',
+      demoUsername: optional(attributes.demoAccountName),
+      demoPassword: optional(attributes.demoAccountPassword),
+      demoRequired: optional(attributes.demoAccountRequired),
+      notes: optional(attributes.notes),
+      // TODO: add attachment
     };
   }
 }

--- a/packages/eas-cli/src/metadata/apple/data.ts
+++ b/packages/eas-cli/src/metadata/apple/data.ts
@@ -2,13 +2,14 @@ import type { App } from '@expo/apple-utils';
 
 import type { AgeRatingData } from './tasks/age-rating';
 import type { AppInfoData } from './tasks/app-info';
+import type { AppReviewData } from './tasks/app-review-detail';
 import type { AppVersionData } from './tasks/app-version';
 
 /**
  * The fully prepared apple data, used within the `downloadAsync` or `uploadAsync` tasks.
  * It contains references to each individual models, to either upload or download App Store data.
  */
-export type AppleData = { app: App } & AppInfoData & AppVersionData & AgeRatingData;
+export type AppleData = { app: App } & AppInfoData & AppVersionData & AgeRatingData & AppReviewData;
 
 /**
  * The unprepared partial apple data, used within the `prepareAsync` tasks.

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-review-detail.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-review-detail.test.ts
@@ -1,0 +1,151 @@
+import { AppStoreReviewAttachment, AppStoreReviewDetail, AppStoreVersion } from '@expo/apple-utils';
+import nock from 'nock';
+
+import { AppleConfigReader } from '../../config/reader';
+import { AppleConfigWriter } from '../../config/writer';
+import { AppReviewDetailTask } from '../app-review-detail';
+import { requestContext } from './fixtures/requestContext';
+
+jest.mock('../../../../ora');
+jest.mock('../../config/writer');
+
+describe(AppReviewDetailTask, () => {
+  describe('prepareAsync', () => {
+    it('aborts when version is not loaded', async () => {
+      const promise = new AppReviewDetailTask().prepareAsync({ context: {} as any });
+
+      await expect(promise).rejects.toThrow('version not init');
+    });
+
+    it('loads review details from app version', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .get(`/v1/${AppStoreVersion.type}/stub-id/appStoreReviewDetail`)
+        .query((params: any) => params['include'] === AppStoreReviewAttachment.type)
+        .reply(200, require('./fixtures/appStoreVersions/get-appStoreReviewDetail-200.json'));
+
+      const context: any = {
+        version: new AppStoreVersion(requestContext, 'stub-id', {} as any),
+      };
+
+      await new AppReviewDetailTask().prepareAsync({ context });
+
+      expect(context.reviewDetail).toBeInstanceOf(AppStoreReviewDetail);
+      expect(scope.isDone()).toBeTruthy();
+    });
+  });
+
+  describe('downloadAsync', () => {
+    it('sets review details when loaded', async () => {
+      const writer = jest.mocked(new AppleConfigWriter());
+      const reviewDetail = new AppStoreReviewDetail(requestContext, 'stub-id', {} as any);
+
+      await new AppReviewDetailTask().downloadAsync({
+        config: writer,
+        context: { reviewDetail } as any,
+      });
+
+      expect(writer.setReviewDetails).toBeCalledWith(reviewDetail.attributes);
+    });
+
+    it('skips when no review details are loaded', async () => {
+      const writer = jest.mocked(new AppleConfigWriter());
+
+      await new AppReviewDetailTask().downloadAsync({
+        config: writer,
+        context: {} as any,
+      });
+
+      expect(writer.setReviewDetails).not.toBeCalled();
+    });
+  });
+
+  describe('uploadAsync', () => {
+    it('skips when review details are not configured', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .post(`/v1/${AppStoreReviewDetail.type}`)
+        .reply(201, require('./fixtures/appStoreReviewDetails/post-201.json'));
+
+      await new AppReviewDetailTask().uploadAsync({
+        config: new AppleConfigReader({
+          review: undefined,
+        }),
+        context: {
+          version: new AppStoreVersion(requestContext, 'stub-id', {} as any),
+        } as any,
+      });
+
+      expect(scope.isDone()).toBeFalsy();
+      nock.cleanAll();
+    });
+
+    it('aborts when version is not loaded', async () => {
+      const promise = new AppReviewDetailTask().uploadAsync({
+        config: new AppleConfigReader({
+          review: {
+            firstName: 'Evan',
+            lastName: 'Bacon',
+            email: 'review@example.com',
+            phone: '+1 555 555 5555',
+          },
+        }),
+        context: {} as any,
+      });
+
+      await expect(promise).rejects.toThrow('version not init');
+    });
+
+    it('updates review details when loaded', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .patch(`/v1/${AppStoreReviewDetail.type}/APP_STORE_REVIEW_DETAILS_1`)
+        .reply(200, require('./fixtures/appStoreReviewDetails/patch-200.json'));
+
+      await new AppReviewDetailTask().uploadAsync({
+        config: new AppleConfigReader({
+          review: {
+            firstName: 'Evan',
+            lastName: 'Bacon',
+            email: 'review@example.com',
+            phone: '+1 555 555 5555',
+          },
+        }),
+        context: {
+          version: new AppStoreVersion(requestContext, 'stub-id', {} as any),
+          reviewDetail: new AppStoreReviewDetail(
+            requestContext,
+            'APP_STORE_REVIEW_DETAILS_1',
+            {} as any
+          ),
+        } as any,
+      });
+
+      expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('creates and updates review details when not loaded', async () => {
+      const createReviewDetailScope = nock('https://api.appstoreconnect.apple.com')
+        .post(`/v1/${AppStoreReviewDetail.type}`)
+        .reply(201, require('./fixtures/appStoreReviewDetails/post-201.json'));
+
+      const updateReviewDetailScope = nock('https://api.appstoreconnect.apple.com')
+        .patch(`/v1/${AppStoreReviewDetail.type}/APP_STORE_REVIEW_DETAILS_1`)
+        .reply(200, require('./fixtures/appStoreReviewDetails/patch-200.json'));
+
+      await new AppReviewDetailTask().uploadAsync({
+        config: new AppleConfigReader({
+          review: {
+            firstName: 'Evan',
+            lastName: 'Bacon',
+            email: 'review@example.com',
+            phone: '+1 555 555 5555',
+          },
+        }),
+        context: {
+          version: new AppStoreVersion(requestContext, 'stub-id', {} as any),
+        } as any,
+      });
+
+      expect(createReviewDetailScope.isDone()).toBeTruthy();
+      expect(updateReviewDetailScope.isDone()).toBeTruthy();
+    });
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreReviewDetails/patch-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreReviewDetails/patch-200.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "type": "appStoreReviewDetails",
+    "id": "APP_STORE_REVIEW_DETAILS_1",
+    "attributes": {
+      "contactFirstName": "Evan",
+      "contactLastName": "Bacon",
+      "contactPhone": "+1-555-555-5555",
+      "contactEmail": "review@myapp.com",
+      "demoAccountName": null,
+      "demoAccountPassword": null,
+      "demoAccountRequired": false,
+      "notes": ""
+    },
+    "relationships": {
+      "appStoreReviewAttachments": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/relationships/appStoreReviewAttachments",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/appStoreReviewAttachments"
+        }
+      },
+      "appSandboxEntitlementUsages": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/relationships/appSandboxEntitlementUsages",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/appSandboxEntitlementUsages"
+        }
+      }
+    },
+    "links": {
+      "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1"
+    }
+  },
+  "links": {
+    "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1"
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreReviewDetails/post-201.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreReviewDetails/post-201.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "type": "appStoreReviewDetails",
+    "id": "APP_STORE_REVIEW_DETAILS_1",
+    "attributes": {
+      "contactFirstName": "Evan",
+      "contactLastName": "Bacon",
+      "contactPhone": "+1-555-555-5555",
+      "contactEmail": "review@myapp.com",
+      "demoAccountName": null,
+      "demoAccountPassword": null,
+      "demoAccountRequired": false,
+      "notes": ""
+    },
+    "relationships": {
+      "appStoreReviewAttachments": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/relationships/appStoreReviewAttachments",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/appStoreReviewAttachments"
+        }
+      },
+      "appSandboxEntitlementUsages": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/relationships/appSandboxEntitlementUsages",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/appSandboxEntitlementUsages"
+        }
+      }
+    },
+    "links": {
+      "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1"
+    }
+  },
+  "links": {
+    "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails"
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-appStoreReviewDetail-200-empty.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-appStoreReviewDetail-200-empty.json
@@ -1,0 +1,6 @@
+{
+	"data": null,
+	"links": {
+		"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_1/appStoreReviewDetail?include=appStoreReviewAttachments"
+	}
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-appStoreReviewDetail-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-appStoreReviewDetail-200.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "type": "appStoreReviewDetails",
+    "id": "APP_STORE_REVIEW_DETAILS_1",
+    "attributes": {
+      "contactFirstName": "Evan",
+      "contactLastName": "Bacon",
+      "contactPhone": "+1-555-555-5555",
+      "contactEmail": "review@myapp.com",
+      "demoAccountName": null,
+      "demoAccountPassword": null,
+      "demoAccountRequired": false,
+      "notes": ""
+    },
+    "relationships": {
+      "appStoreReviewAttachments": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/relationships/appStoreReviewAttachments",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/appStoreReviewAttachments"
+        }
+      },
+      "appSandboxEntitlementUsages": {
+        "links": {
+          "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/relationships/appSandboxEntitlementUsages",
+          "related": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1/appSandboxEntitlementUsages"
+        }
+      }
+    },
+    "links": {
+      "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1"
+    }
+  },
+  "links": {
+    "self": "https://appstoreconnect.apple.com/iris/v1/appStoreReviewDetails/APP_STORE_REVIEW_DETAILS_1"
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/app-review-detail.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-review-detail.ts
@@ -11,6 +11,7 @@ export type AppReviewData = {
   reviewDetail: AppStoreReviewDetail;
 };
 
+/** Handle all contact, demo account, or instruction info that are required for the App Store review team. */
 export class AppReviewDetailTask extends AppleTask {
   public name = (): string => 'app review detail';
 

--- a/packages/eas-cli/src/metadata/apple/tasks/app-review-detail.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-review-detail.ts
@@ -1,0 +1,57 @@
+import { AppStoreReviewDetail } from '@expo/apple-utils';
+import assert from 'assert';
+import chalk from 'chalk';
+
+import Log from '../../../log';
+import { logAsync } from '../../utils/log';
+import { AppleTask, TaskDownloadOptions, TaskPrepareOptions, TaskUploadOptions } from '../task';
+
+export type AppReviewData = {
+  /** The current app info that should be edited */
+  reviewDetail: AppStoreReviewDetail;
+};
+
+export class AppReviewDetailTask extends AppleTask {
+  public name = (): string => 'app review detail';
+
+  public async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
+    assert(context.version, `App version not initialized, can't download store review details`);
+    context.reviewDetail = (await context.version.getAppStoreReviewDetailAsync()) ?? undefined;
+  }
+
+  public async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
+    if (context.reviewDetail) {
+      config.setReviewDetails(context.reviewDetail.attributes);
+    }
+  }
+
+  public async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
+    const reviewDetail = config.getReviewDetails();
+    if (!reviewDetail) {
+      return Log.log(chalk`{dim - Skipped store review details, not configured}`);
+    }
+
+    assert(context.version, `App version not initialized, can't upload store review details`);
+    const { versionString } = context.version.attributes;
+
+    if (!context.reviewDetail) {
+      // We can't set the demo required property when creating, omit it from the request
+      const { demoAccountRequired, ...reviewDetailsToCreate } = reviewDetail;
+
+      context.reviewDetail = await logAsync(
+        () => context.version.createReviewDetailAsync(reviewDetailsToCreate),
+        {
+          pending: `Creating store review details for ${chalk.bold(versionString)}...`,
+          success: `Created store review details for ${chalk.bold(versionString)}`,
+          failure: `Failed creating store review details for ${chalk.bold(versionString)}`,
+        }
+      );
+    }
+
+    context.reviewDetail = await logAsync(() => context.reviewDetail.updateAsync(reviewDetail), {
+      pending: `Updating store review details for ${chalk.bold(versionString)}...`,
+      success: `Updated store review details for ${chalk.bold(versionString)}`,
+      failure: `Failed updating store review details for ${chalk.bold(versionString)}`,
+    });
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
@@ -80,8 +80,8 @@ export class AppVersionTask extends AppleTask {
         () => context.version.updateAsync({ ...version, ...release }),
         {
           pending: `Updating ${description} info for ${chalk.bold(versionString)}...`,
-          success: `Updated ${description} info for ${chalk.bold(versionString)}...`,
-          failure: `Failed updating ${description} info for ${chalk.bold(versionString)}...`,
+          success: `Updated ${description} info for ${chalk.bold(versionString)}`,
+          failure: `Failed updating ${description} info for ${chalk.bold(versionString)}`,
         }
       );
     }

--- a/packages/eas-cli/src/metadata/apple/tasks/index.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/index.ts
@@ -2,11 +2,12 @@ import { MetadataContext } from '../../context';
 import { AppleTask } from '../task';
 import { AgeRatingTask } from './age-rating';
 import { AppInfoTask } from './app-info';
+import { AppReviewDetailTask } from './app-review-detail';
 import { AppVersionTask } from './app-version';
 
 /**
  * List of all eligible tasks to sync local store configuration to the App store.
  */
 export function createAppleTasks(_ctx: MetadataContext): AppleTask[] {
-  return [new AppVersionTask(), new AppInfoTask(), new AgeRatingTask()];
+  return [new AppVersionTask(), new AppInfoTask(), new AgeRatingTask(), new AppReviewDetailTask()];
 }

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -45,12 +45,13 @@ export interface AppleInfo {
 }
 
 export interface AppleReview {
-  firstName?: string;
-  lastName?: string;
-  phone?: string;
-  email?: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  email: string;
   demoUsername?: string;
   demoPassword?: string;
+  demoRequired?: boolean;
   notes?: string;
-  attachment?: string;
+  // attachment?: string;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Adds the review details to the metadata task runners.

# How

- Tested validation properties through force-feeding ASC API
- Added tests for `AppReviewDetailTask`, with actual ASC API responses
- Tweaked the store configuration scheme

# Test Plan

- See tests
- Set the `apple.review` property and run `eas metadata:push`

# Still TODO

- Add review detail attachments