### PR TITLE
[eas-cli] Improve EAS metadata categories configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Update validation rules for metadata info locales. ([#1174](https://github.com/expo/eas-cli/pull/1174) by [@byCedric](https://github.com/byCedric))
 - Improve store configuration defaults and schema documentation. ([#1183](https://github.com/expo/eas-cli/pull/1183) by [@byCedric](https://github.com/byCedric))
+- Improve store config categories configuration. ([#1187](https://github.com/expo/eas-cli/pull/1187) by [@byCedric](https://github.com/byCedric))
 
 ## [0.54.1](https://github.com/expo/eas-cli/releases/tag/v0.54.1) - 2022-06-15
 

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -35,7 +35,7 @@
       "AppleCategory": {
         "type": "array",
         "description": "App Store categories for the app, can add up to two categories. The first item in this list is the primary category, the second is the secondary and optional category. `STICKERS` and `GAMES` categories can add up to two additional subcategories, written as nested array.",
-        "markdownDescription": "App Store categories for the app, can add up to two categories. The first item in this list is the primary category, the second is the secondary and optional category. `STICKERS` and `GAMES` categories can add up to two additional subcategories, written as nested array. E.g.\n\n- `[\"SPORTS\"]`\n- `[\"SPORTS\", \"LIFESTYLE\"]`\n- `[[\"GAMES\", \"GAMES_CARD\"], \"ENTERTAINMENT\"]`\n- `[[\"STICKERS\"], \"WEATHER\"]`",
+        "markdownDescription": "App Store categories for the app, can add up to two categories. The first item in this list is the primary category, the second is the secondary and optional category. `STICKERS` and `GAMES` categories can add up to two additional subcategories, written as nested array. E.g.\n\n- `[\"SPORTS\"]`\n- `[\"SPORTS\", \"LIFESTYLE\"]`\n- `[[\"GAMES\", \"GAMES_CARD\"], \"ENTERTAINMENT\"]`\n- `[\"GAMES\", \"WEATHER\"]`",
         "minItems": 1,
         "maxItems": 2,
         "uniqueItems": true,
@@ -64,6 +64,9 @@
           "oneOf": [
             {
               "$ref": "#/definitions/apple/AppleCategory/categories/root"
+            },
+            {
+              "$ref": "#/definitions/apple/AppleCategory/categories/parent"
             },
             {
               "type": "array",
@@ -130,6 +133,12 @@
               "NEWS",
               "PHOTO_AND_VIDEO",
               "NAVIGATION"
+            ]
+          },
+          "parent": {
+            "enum": [
+              "GAMES",
+              "STICKERS"
             ]
           },
           "games": {

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -33,69 +33,145 @@
         ]
       },
       "AppleCategory": {
-        "enum": [
-          "FOOD_AND_DRINK",
-          "BUSINESS",
-          "EDUCATION",
-          "SOCIAL_NETWORKING",
-          "BOOKS",
-          "SPORTS",
-          "FINANCE",
-          "REFERENCE",
-          "GRAPHICS_AND_DESIGN",
-          "DEVELOPER_TOOLS",
-          "HEALTH_AND_FITNESS",
-          "MUSIC",
-          "WEATHER",
-          "TRAVEL",
-          "ENTERTAINMENT",
-          "STICKERS",
-          "GAMES",
-          "LIFESTYLE",
-          "MEDICAL",
-          "MAGAZINES_AND_NEWSPAPERS",
-          "UTILITIES",
-          "SHOPPING",
-          "PRODUCTIVITY",
-          "NEWS",
-          "PHOTO_AND_VIDEO",
-          "NAVIGATION"
-        ]
-      },
-      "AppleSubcategory": {
-        "enum": [
-          "STICKERS_PLACES_AND_OBJECTS",
-          "STICKERS_EMOJI_AND_EXPRESSIONS",
-          "STICKERS_CELEBRATIONS",
-          "STICKERS_CELEBRITIES",
-          "STICKERS_MOVIES_AND_TV",
-          "STICKERS_SPORTS_AND_ACTIVITIES",
-          "STICKERS_EATING_AND_DRINKING",
-          "STICKERS_CHARACTERS",
-          "STICKERS_ANIMALS",
-          "STICKERS_FASHION",
-          "STICKERS_ART",
-          "STICKERS_GAMING",
-          "STICKERS_KIDS_AND_FAMILY",
-          "STICKERS_PEOPLE",
-          "STICKERS_MUSIC",
-          "GAMES_SPORTS",
-          "GAMES_WORD",
-          "GAMES_MUSIC",
-          "GAMES_ADVENTURE",
-          "GAMES_ACTION",
-          "GAMES_ROLE_PLAYING",
-          "GAMES_CASUAL",
-          "GAMES_BOARD",
-          "GAMES_TRIVIA",
-          "GAMES_CARD",
-          "GAMES_PUZZLE",
-          "GAMES_CASINO",
-          "GAMES_STRATEGY",
-          "GAMES_SIMULATION",
-          "GAMES_RACING",
-          "GAMES_FAMILY"
-        ]
+        "type": "array",
+        "description": "App Store categories for the app, can add up to two categories. The first item in this list is the primary category, the second is the secondary and optional category. `STICKERS` and `GAMES` categories can add up to two additional subcategories, written as nested array.",
+        "markdownDescription": "App Store categories for the app, can add up to two categories. The first item in this list is the primary category, the second is the secondary and optional category. `STICKERS` and `GAMES` categories can add up to two additional subcategories, written as nested array. E.g.\n\n- `[\"SPORTS\"]`\n- `[\"SPORTS\", \"LIFESTYLE\"]`\n- `[[\"GAMES\", \"GAMES_CARD\"], \"ENTERTAINMENT\"]`\n- `[[\"STICKERS\"], \"WEATHER\"]`",
+        "minItems": 1,
+        "maxItems": 2,
+        "uniqueItems": true,
+        "defaultSnippets": [
+          {
+            "label": "Basic categories",
+            "description": "Add two simple categories",
+            "body": [
+              "$1",
+              "$2"
+            ]
+          },
+          {
+            "label": "Category with subcategories",
+            "description": "Add a category containing subcategories",
+            "body": [
+              [
+                "${1|GAMES,STICKERS|}",
+                "$3",
+                "$4"
+              ]
+            ]
+          }
+        ],
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/apple/AppleCategory/categories/root"
+            },
+            {
+              "type": "array",
+              "description": "The GAMES category can have additional subcategories",
+              "minItems": 1,
+              "maxItems": 3,
+              "uniqueItems": true,
+              "items": [
+                {
+                  "const": "GAMES"
+                },
+                {
+                  "$ref": "#/definitions/apple/AppleCategory/categories/games"
+                },
+                {
+                  "$ref": "#/definitions/apple/AppleCategory/categories/games"
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "description": "The STICKERS category can have additional subcategories",
+              "minItems": 1,
+              "maxItems": 3,
+              "uniqueItems": true,
+              "items": [
+                {
+                  "const": "STICKERS"
+                },
+                {
+                  "$ref": "#/definitions/apple/AppleCategory/categories/stickers"
+                },
+                {
+                  "$ref": "#/definitions/apple/AppleCategory/categories/stickers"
+                }
+              ]
+            }
+          ]
+        },
+        "categories": {
+          "root": {
+            "enum": [
+              "BUSINESS",
+              "SOCIAL_NETWORKING",
+              "MEDICAL",
+              "FOOD_AND_DRINK",
+              "EDUCATION",
+              "BOOKS",
+              "SPORTS",
+              "FINANCE",
+              "REFERENCE",
+              "GRAPHICS_AND_DESIGN",
+              "DEVELOPER_TOOLS",
+              "HEALTH_AND_FITNESS",
+              "MUSIC",
+              "WEATHER",
+              "TRAVEL",
+              "ENTERTAINMENT",
+              "LIFESTYLE",
+              "MAGAZINES_AND_NEWSPAPERS",
+              "UTILITIES",
+              "SHOPPING",
+              "PRODUCTIVITY",
+              "NEWS",
+              "PHOTO_AND_VIDEO",
+              "NAVIGATION"
+            ]
+          },
+          "games": {
+            "enum": [
+              "GAMES_SPORTS",
+              "GAMES_WORD",
+              "GAMES_MUSIC",
+              "GAMES_ADVENTURE",
+              "GAMES_ACTION",
+              "GAMES_ROLE_PLAYING",
+              "GAMES_CASUAL",
+              "GAMES_BOARD",
+              "GAMES_TRIVIA",
+              "GAMES_CARD",
+              "GAMES_PUZZLE",
+              "GAMES_CASINO",
+              "GAMES_STRATEGY",
+              "GAMES_SIMULATION",
+              "GAMES_RACING",
+              "GAMES_FAMILY"
+            ]
+          },
+          "stickers": {
+            "enum": [
+              "STICKERS_PLACES_AND_OBJECTS",
+              "STICKERS_EMOJI_AND_EXPRESSIONS",
+              "STICKERS_CELEBRATIONS",
+              "STICKERS_CELEBRITIES",
+              "STICKERS_MOVIES_AND_TV",
+              "STICKERS_SPORTS_AND_ACTIVITIES",
+              "STICKERS_EATING_AND_DRINKING",
+              "STICKERS_CHARACTERS",
+              "STICKERS_ANIMALS",
+              "STICKERS_FASHION",
+              "STICKERS_ART",
+              "STICKERS_GAMING",
+              "STICKERS_KIDS_AND_FAMILY",
+              "STICKERS_PEOPLE",
+              "STICKERS_MUSIC"
+            ]
+          }
+        }
       },
       "AppleIdfa": {
         "description": "Identifier for Advertisers",
@@ -554,79 +630,7 @@
           "$ref": "#/definitions/apple/AppleAdvisory"
         },
         "categories": {
-          "type": "array",
-          "maxItems": 2,
-          "description": "App Store categories for the app. Can add up to two categories. STICKERS and GAMES categories can add an additional subcategory.",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/apple/AppleCategory"
-              },
-              {
-                "type": "array",
-                "maxItems": 2,
-                "items": [
-                  {
-                    "enum": [
-                      "GAMES"
-                    ]
-                  },
-                  {
-                    "enum": [
-                      "GAMES_SPORTS",
-                      "GAMES_WORD",
-                      "GAMES_MUSIC",
-                      "GAMES_ADVENTURE",
-                      "GAMES_ACTION",
-                      "GAMES_ROLE_PLAYING",
-                      "GAMES_CASUAL",
-                      "GAMES_BOARD",
-                      "GAMES_TRIVIA",
-                      "GAMES_CARD",
-                      "GAMES_PUZZLE",
-                      "GAMES_CASINO",
-                      "GAMES_STRATEGY",
-                      "GAMES_SIMULATION",
-                      "GAMES_RACING",
-                      "GAMES_FAMILY"
-                    ]
-                  }
-                ],
-                "additionalItems": false
-              },
-              {
-                "type": "array",
-                "maxItems": 2,
-                "items": [
-                  {
-                    "enum": [
-                      "STICKERS"
-                    ]
-                  },
-                  {
-                    "enum": [
-                      "STICKERS_PLACES_AND_OBJECTS",
-                      "STICKERS_EMOJI_AND_EXPRESSIONS",
-                      "STICKERS_CELEBRATIONS",
-                      "STICKERS_CELEBRITIES",
-                      "STICKERS_MOVIES_AND_TV",
-                      "STICKERS_SPORTS_AND_ACTIVITIES",
-                      "STICKERS_EATING_AND_DRINKING",
-                      "STICKERS_CHARACTERS",
-                      "STICKERS_ANIMALS",
-                      "STICKERS_FASHION",
-                      "STICKERS_ART",
-                      "STICKERS_GAMING",
-                      "STICKERS_KIDS_AND_FAMILY",
-                      "STICKERS_PEOPLE",
-                      "STICKERS_MUSIC"
-                    ]
-                  }
-                ],
-                "additionalItems": false
-              }
-            ]
-          }
+          "$ref": "#/definitions/apple/AppleCategory"
         },
         "copyright": {
           "type": "string",

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appInfo.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appInfo.ts
@@ -1,23 +1,37 @@
-import { AppCategory, AppInfo, BundleIdPlatform } from '@expo/apple-utils';
+import { AppCategory, AppCategoryId, AppSubcategoryId, BundleIdPlatform } from '@expo/apple-utils';
 
-import { AttributesOf } from '../../../../utils/asc';
+import { AppleConfigWriter } from '../../writer';
 
-export const primaryOnlyCategory: Pick<AttributesOf<AppInfo>, 'primaryCategory'> = {
-  primaryCategory: new AppCategory({} as any, 'ENTERTAINMENT', {
+/** Infered type of the AppleConfigWriter.setCategories attributes */
+type CategoryInfoProps = Parameters<typeof AppleConfigWriter.prototype.setCategories>[0];
+
+/**
+ * Export a factory method instead of fixed categories.
+ * In the tests, we need to create a couple of different categories,
+ * adding them here as fixed objects won't be readable.
+ */
+export function makeCategory(id?: AppCategoryId | AppSubcategoryId): AppCategory | undefined {
+  if (!id) {
+    return undefined;
+  }
+
+  return new AppCategory({} as any, id, {
     platforms: [BundleIdPlatform.IOS, BundleIdPlatform.MAC_OS],
-  }),
-};
+  });
+}
 
-export const secondaryOnlyCategory: Pick<AttributesOf<AppInfo>, 'secondaryCategory'> = {
-  secondaryCategory: new AppCategory({} as any, 'GAMES', {
-    platforms: [BundleIdPlatform.IOS, BundleIdPlatform.MAC_OS],
-  }),
-};
-
-export const primaryAndSecondaryCategory: Pick<
-  AttributesOf<AppInfo>,
-  'primaryCategory' | 'secondaryCategory'
-> = {
-  ...primaryOnlyCategory,
-  ...secondaryOnlyCategory,
-};
+/**
+ * Export a helper method to create the AppInfo object, using only AppCategoryIds or AppSubcategoryId.
+ */
+export function makeCategoryInfo(
+  attributes: Partial<Record<keyof CategoryInfoProps, AppCategoryId | AppSubcategoryId>>
+): CategoryInfoProps {
+  return {
+    primaryCategory: makeCategory(attributes.primaryCategory),
+    primarySubcategoryOne: makeCategory(attributes.primarySubcategoryOne),
+    primarySubcategoryTwo: makeCategory(attributes.primarySubcategoryTwo),
+    secondaryCategory: makeCategory(attributes.secondaryCategory),
+    secondarySubcategoryOne: makeCategory(attributes.secondarySubcategoryOne),
+    secondarySubcategoryTwo: makeCategory(attributes.secondarySubcategoryTwo),
+  };
+}

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
@@ -1,7 +1,73 @@
+import { AppCategoryId, AppSubcategoryId } from '@expo/apple-utils';
+
 import { AppleConfigReader } from '../reader';
 import { leastRestrictiveAdvisory, mostRestrictiveAdvisory } from './fixtures/ageRatingDeclaration';
 
-describe('setAgeRating', () => {
+describe('getCategories', () => {
+  it('ignores categories when not set', () => {
+    const reader = new AppleConfigReader({ categories: undefined });
+    expect(reader.getCategories()).toBeNull();
+  });
+
+  it('returns primary category only', () => {
+    const reader = new AppleConfigReader({ categories: [AppCategoryId.ENTERTAINMENT] });
+    expect(reader.getCategories()).toMatchObject({
+      primaryCategory: AppCategoryId.ENTERTAINMENT,
+      secondaryCategory: undefined,
+    });
+  });
+
+  it('returns primary and secondary categories', () => {
+    const reader = new AppleConfigReader({
+      categories: [AppCategoryId.ENTERTAINMENT, AppCategoryId.FOOD_AND_DRINK],
+    });
+    expect(reader.getCategories()).toMatchObject({
+      primaryCategory: AppCategoryId.ENTERTAINMENT,
+      secondaryCategory: AppCategoryId.FOOD_AND_DRINK,
+    });
+  });
+
+  it('returns primary category without subcategory', () => {
+    const reader = new AppleConfigReader({ categories: [[AppCategoryId.GAMES]] });
+    expect(reader.getCategories()).toMatchObject({
+      primaryCategory: AppCategoryId.GAMES,
+      secondaryCategory: undefined,
+    });
+  });
+
+  it('returns primary category with two subcategories', () => {
+    const reader = new AppleConfigReader({
+      categories: [
+        [AppCategoryId.GAMES, AppSubcategoryId.GAMES_CARD, AppSubcategoryId.GAMES_ADVENTURE],
+      ],
+    });
+    expect(reader.getCategories()).toMatchObject({
+      primaryCategory: AppCategoryId.GAMES,
+      primarySubcategoryOne: AppSubcategoryId.GAMES_CARD,
+      primarySubcategoryTwo: AppSubcategoryId.GAMES_ADVENTURE,
+      secondaryCategory: undefined,
+    });
+  });
+
+  it('returns primary and secondary categories with two subcategories', () => {
+    const reader = new AppleConfigReader({
+      categories: [
+        AppCategoryId.ENTERTAINMENT,
+        [AppCategoryId.GAMES, AppSubcategoryId.GAMES_CARD, AppSubcategoryId.GAMES_ADVENTURE],
+      ],
+    });
+    expect(reader.getCategories()).toMatchObject({
+      primaryCategory: AppCategoryId.ENTERTAINMENT,
+      secondaryCategory: AppCategoryId.GAMES,
+      secondarySubcategoryOne: AppSubcategoryId.GAMES_CARD,
+      secondarySubcategoryTwo: AppSubcategoryId.GAMES_ADVENTURE,
+    });
+    expect(reader.getCategories()).not.toHaveProperty('primarySubcategoryOne');
+    expect(reader.getCategories()).not.toHaveProperty('primarySubcategoryTwo');
+  });
+});
+
+describe('getAgeRating', () => {
   it('ignores advisory when not set', () => {
     const reader = new AppleConfigReader({ advisory: undefined });
     expect(reader.getAgeRating()).toBeNull();

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
@@ -28,7 +28,7 @@ describe('getCategories', () => {
   });
 
   it('returns primary category without subcategory', () => {
-    const reader = new AppleConfigReader({ categories: [[AppCategoryId.GAMES]] });
+    const reader = new AppleConfigReader({ categories: [AppCategoryId.GAMES] });
     expect(reader.getCategories()).toMatchObject({
       primaryCategory: AppCategoryId.GAMES,
       secondaryCategory: undefined,

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -114,6 +114,19 @@ describe('setCategories', () => {
     expect(writer.schema.categories).toEqual([AppCategoryId.GAMES]);
   });
 
+  it('modifies primary category with one subcategories', () => {
+    const writer = new AppleConfigWriter();
+    writer.setCategories(
+      makeCategoryInfo({
+        primaryCategory: AppCategoryId.GAMES,
+        primarySubcategoryOne: AppSubcategoryId.GAMES_CARD,
+      })
+    );
+    expect(writer.schema.categories).toEqual([[AppCategoryId.GAMES, AppSubcategoryId.GAMES_CARD]]);
+    // We need to filter the lists to avoid writing `[GAMES, GAMES_CARD, null]`
+    expect(writer.schema.categories![0]).toHaveLength(2);
+  });
+
   it('modifies primary category with two subcategories', () => {
     const writer = new AppleConfigWriter();
     writer.setCategories(
@@ -126,6 +139,23 @@ describe('setCategories', () => {
     expect(writer.schema.categories).toEqual([
       [AppCategoryId.GAMES, AppSubcategoryId.GAMES_CARD, AppSubcategoryId.GAMES_ADVENTURE],
     ]);
+  });
+
+  it('modifies primary and secondary categories with one subcategories', () => {
+    const writer = new AppleConfigWriter();
+    writer.setCategories(
+      makeCategoryInfo({
+        primaryCategory: AppCategoryId.ENTERTAINMENT,
+        secondaryCategory: AppCategoryId.GAMES,
+        secondarySubcategoryOne: AppSubcategoryId.GAMES_CARD,
+      })
+    );
+    expect(writer.schema.categories).toEqual([
+      AppCategoryId.ENTERTAINMENT,
+      [AppCategoryId.GAMES, AppSubcategoryId.GAMES_CARD],
+    ]);
+    // We need to filter the lists to avoid writing `[GAMES, GAMES_CARD, null]`
+    expect(writer.schema.categories![1]).toHaveLength(2);
   });
 
   it('modifies primary and secondary categories with two subcategories', () => {

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -111,7 +111,7 @@ describe('setCategories', () => {
   it('modifies primary category without subcategories', () => {
     const writer = new AppleConfigWriter();
     writer.setCategories(makeCategoryInfo({ primaryCategory: AppCategoryId.GAMES }));
-    expect(writer.schema.categories).toEqual([[AppCategoryId.GAMES]]);
+    expect(writer.schema.categories).toEqual([AppCategoryId.GAMES]);
   });
 
   it('modifies primary category with two subcategories', () => {

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -173,6 +173,12 @@ describe('setCategories', () => {
       [AppCategoryId.GAMES, AppSubcategoryId.GAMES_CARD, AppSubcategoryId.GAMES_ADVENTURE],
     ]);
   });
+
+  it('modifies secondary category without primary', () => {
+    const writer = new AppleConfigWriter();
+    writer.setCategories(makeCategoryInfo({ secondaryCategory: AppCategoryId.GAMES }));
+    expect(writer.schema.categories).toEqual(['', AppCategoryId.GAMES]);
+  });
 });
 
 describe('setVersion', () => {

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -83,7 +83,7 @@ export class AppleConfigReader {
       return null;
     }
 
-    const categoryIds: CategoryIds = {};
+    const categoryIds: Partial<Record<keyof CategoryIds, string>> = {};
 
     // If primary category is an array and has subcategories
     if (Array.isArray(categories[0])) {
@@ -103,7 +103,9 @@ export class AppleConfigReader {
       categoryIds.secondaryCategory = categories[1];
     }
 
-    return categoryIds;
+    // Because we handle categories as normal strings,
+    // the type doesn't match with the actual CategoryIds types.
+    return categoryIds as CategoryIds;
   }
 
   /** Get the `AppStoreVersion` object. */

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -83,9 +83,9 @@ export class AppleConfigReader {
       return null;
     }
 
+    // We validate the categories based on enums, but they will still be strings here.
     const categoryIds: Partial<Record<keyof CategoryIds, string>> = {};
 
-    // If primary category is an array and has subcategories
     if (Array.isArray(categories[0])) {
       categoryIds.primaryCategory = categories[0][0];
       categoryIds.primarySubcategoryOne = categories[0][1];
@@ -94,7 +94,6 @@ export class AppleConfigReader {
       categoryIds.primaryCategory = categories[0];
     }
 
-    // If secondary category is an array and has subcategories
     if (Array.isArray(categories[1])) {
       categoryIds.secondaryCategory = categories[1][0];
       categoryIds.secondarySubcategoryOne = categories[1][1];

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -78,14 +78,32 @@ export class AppleConfigReader {
   }
 
   public getCategories(): CategoryIds | null {
-    if (Array.isArray(this.schema.categories) && this.schema.categories.length > 0) {
-      return {
-        primaryCategory: this.schema.categories[0],
-        secondaryCategory: this.schema.categories[1],
-      };
+    const { categories } = this.schema;
+    if (!categories || categories.length <= 0) {
+      return null;
     }
 
-    return null;
+    const categoryIds: CategoryIds = {};
+
+    // If primary category is an array and has subcategories
+    if (Array.isArray(categories[0])) {
+      categoryIds.primaryCategory = categories[0][0];
+      categoryIds.primarySubcategoryOne = categories[0][1];
+      categoryIds.primarySubcategoryTwo = categories[0][2];
+    } else {
+      categoryIds.primaryCategory = categories[0];
+    }
+
+    // If secondary category is an array and has subcategories
+    if (Array.isArray(categories[1])) {
+      categoryIds.secondaryCategory = categories[1][0];
+      categoryIds.secondarySubcategoryOne = categories[1][1];
+      categoryIds.secondarySubcategoryTwo = categories[1][2];
+    } else {
+      categoryIds.secondaryCategory = categories[1];
+    }
+
+    return categoryIds;
   }
 
   /** Get the `AppStoreVersion` object. */

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -82,13 +82,7 @@ export class AppleConfigWriter {
       return;
     }
 
-    const PARENT_CATEGORIES = [AppCategoryId.GAMES, AppCategoryId.STICKERS];
-
-    // If primary category is a parent category, or has subcategories, store it in a nested array
-    if (
-      PARENT_CATEGORIES.includes(attributes.primaryCategory.id as AppCategoryId) ||
-      attributes.primarySubcategoryOne
-    ) {
+    if (attributes.primarySubcategoryOne) {
       this.schema.categories = [
         [
           attributes.primaryCategory.id as AppCategoryId,
@@ -100,21 +94,13 @@ export class AppleConfigWriter {
       this.schema.categories = [attributes.primaryCategory.id as AppCategoryId];
     }
 
-    if (!attributes.secondaryCategory) {
-      return;
-    }
-
-    // If secondary category is a parent category, or has subcategories, store it in a nested array
-    if (
-      PARENT_CATEGORIES.includes(attributes.primaryCategory.id as AppCategoryId) ||
-      attributes.secondarySubcategoryOne
-    ) {
+    if (attributes.secondaryCategory && attributes.secondarySubcategoryOne) {
       this.schema.categories.push([
         attributes.secondaryCategory.id as AppCategoryId,
         attributes.secondarySubcategoryOne?.id as AppSubcategoryId | undefined,
         attributes.secondarySubcategoryTwo?.id as AppSubcategoryId | undefined,
       ]);
-    } else {
+    } else if (attributes.secondaryCategory) {
       this.schema.categories.push(attributes.secondaryCategory.id as AppCategoryId);
     }
   }

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -14,7 +14,7 @@ export interface AppleMetadata {
 
 export type AppleAdvisory = Partial<AgeRatingDeclarationProps>;
 
-/** Apps can define up to two categories, or category with subcategories */
+/** Apps can define up to two categories, or categories with subcategories */
 export type AppleCategory = [
   AppCategoryId | AppleCategoryWithSubcategory,
   (AppCategoryId | AppleCategoryWithSubcategory)?

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -1,4 +1,4 @@
-import type { AgeRatingDeclarationProps, AppCategoryId, AppSubcategoryId } from '@expo/apple-utils';
+import type { AgeRatingDeclarationProps } from '@expo/apple-utils';
 
 export type AppleLocale = string;
 
@@ -14,14 +14,8 @@ export interface AppleMetadata {
 
 export type AppleAdvisory = Partial<AgeRatingDeclarationProps>;
 
-/** Apps can define up to two categories, or categories with subcategories */
-export type AppleCategory = [
-  AppCategoryId | AppleCategoryWithSubcategory,
-  (AppCategoryId | AppleCategoryWithSubcategory)?
-];
-
-/** Categories with subcategories can define up to two subcategories */
-export type AppleCategoryWithSubcategory = [AppCategoryId, AppSubcategoryId?, AppSubcategoryId?];
+/** Apps can define up to two categories, or categories with up to two subcategories */
+export type AppleCategory = (string | string[])[];
 
 export interface AppleRelease {
   isPhasedReleaseEnabled?: boolean;

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -5,7 +5,7 @@ export type AppleLocale = string;
 export interface AppleMetadata {
   copyright?: string;
   info?: Record<AppleLocale, AppleInfo>;
-  categories?: AppCategoryId[] | AppleCategory;
+  categories?: AppleCategory;
   release?: AppleRelease;
   advisory?: AppleAdvisory;
   preview?: Record<string, string[]>;
@@ -14,10 +14,14 @@ export interface AppleMetadata {
 
 export type AppleAdvisory = Partial<AgeRatingDeclarationProps>;
 
-export interface AppleCategory {
-  category: AppCategoryId;
-  subcategory?: AppSubcategoryId[];
-}
+/** Apps can define up to two categories, or category with subcategories */
+export type AppleCategory = [
+  AppCategoryId | AppleCategoryWithSubcategory,
+  (AppCategoryId | AppleCategoryWithSubcategory)?
+];
+
+/** Categories with subcategories can define up to two subcategories */
+export type AppleCategoryWithSubcategory = [AppCategoryId, AppSubcategoryId?, AppSubcategoryId?];
 
 export interface AppleRelease {
   isPhasedReleaseEnabled?: boolean;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This improves/finalizes the `apple.categories` in the EAS metadata store configuration.

> See the `metadata-0.json` schema for examples

# How

- Updated schema documentation and validation
- Updated the schema typescript types
- Updated the store configuration reader and writer

# Test Plan

- See added tests
