### PR TITLE
[eas-cli] Finalize the store config release properties

### DIFF
--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -464,62 +464,43 @@
       },
       "AppleRelease": {
         "type": "object",
+        "description": "Configure how the app is released in the app store.",
         "additionalProperties": false,
-        "defaultSnippets": [
-          {
-            "body": {
-              "automaticRelease": true,
-              "usesThirdPartyContent": false,
-              "usesNonExemptEncryption": false
-            }
-          }
-        ],
         "properties": {
-          "autoReleaseDate": {
-            "description": "ISO Date to release the app automatically. Leave undefined to manually release the app to the public.",
-            "defaultSnippets": [
-              {
-                "body": "$CURRENT_YEAR-${1:$CURRENT_MONTH}-${2:$CURRENT_DATE}"
-              }
-            ],
-            "anyOf": [
+          "automaticRelease": {
+            "description": "If and how the app should automatically be released when approved by App Store review.",
+            "markdownDescription": "If and how the app should automatically be released when approved by App Store review.\n- `false` - Manually release the app after store approval. (default behavior)\n- `true` - Automatically release after store approval.\n- `Date` - Automatically schedule release on this date, after store approval.\n\nApple does not guarantee that your app is available at the chosen scheduled release date.",
+            "oneOf": [
               {
                 "type": "string",
                 "format": "date-time"
               },
               {
-                "type": "string",
-                "format": "date"
+                "type": "boolean"
+              }
+            ],
+            "defaultSnippets": [
+              {
+                "label": "Manual release",
+                "description": "Manually release the app after store approval",
+                "body": false
               },
               {
-                "type": "number"
+                "label": "Automatic release",
+                "description": "Automatically release the app after store approval",
+                "body": true
+              },
+              {
+                "label": "Scheduled release",
+                "description": "Automatically release the app on this date, and store approval",
+                "body": "$CURRENT_YEAR-${1:$CURRENT_MONTH}-${2:$CURRENT_DATE}T${3:$CURRENT_HOUR}:00:00+00:00"
               }
             ]
           },
-          "isPhasedReleaseEnabled": {
+          "phasedRelease": {
             "type": "boolean",
-            "description": "Release update over 7-day period instead of instantly.",
-            "meta": {
-              "storeInfo": "Phased release for automatic updates lets you gradually release this update over a 7-day period to users who have turned on automatic updates. Keep in mind that this version will still be available to all users as a manual update from the App Store. You can pause the phased release for up to 30 days or release this update to all users at any time. [Learn More](https://help.apple.com/app-store-connect/#/dev3d65fcee1)."
-            }
-          },
-          "shouldResetRatings": {
-            "type": "boolean",
-            "description": "Should App Store ratings be reset for this version of the app.",
-            "meta": {
-              "storeInfo": "You can reset your app’s summary rating for all countries or regions when you release this version. Keep in mind that once this version is released, you won’t be able to restore the rating. Your app’s existing customer reviews will still appear on the App Store."
-            }
-          },
-          "usesThirdPartyContent": {
-            "type": "boolean"
-          },
-          "automaticRelease": {
-            "type": "boolean",
-            "description": "Should the app automatically be released when approved by App Store review."
-          },
-          "usesNonExemptEncryption": {
-            "type": "boolean",
-            "description": "Alternative to setting `ITSAppUsesNonExemptEncryption` in the binary's `Info.plist`."
+            "description": "Phased release for automatic updates lets you gradually release this update over a 7-day period to users who have turned on automatic updates. Keep in mind that this version will still be available to all users as a manual update from the App Store. You can pause the phased release for up to 30 days or release this update to all users at any time.\n@see https://help.apple.com/app-store-connect/#/dev3d65fcee1",
+            "markdownDescription": "Phased release for automatic updates lets you gradually release this update over a 7-day period to users who have turned on automatic updates.\n\nKeep in mind that this version will still be available to all users as a manual update from the App Store.\n\nYou can pause the phased release for up to 30 days or release this update to all users at any time.\n\n[Learn More](https://help.apple.com/app-store-connect/#/dev3d65fcee1)"
           }
         }
       },

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreVersionPhasedRelease.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreVersionPhasedRelease.ts
@@ -1,0 +1,10 @@
+import { AppStoreVersionPhasedRelease, PhasedReleaseState } from '@expo/apple-utils';
+
+import { AttributesOf } from '../../../../utils/asc';
+
+export const phasedRelease: AttributesOf<AppStoreVersionPhasedRelease> = {
+  phasedReleaseState: PhasedReleaseState.COMPLETE,
+  currentDayNumber: 7,
+  startDate: null,
+  totalPauseDuration: null,
+};

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
@@ -1,4 +1,4 @@
-import { AppCategoryId, AppSubcategoryId } from '@expo/apple-utils';
+import { AppCategoryId, AppSubcategoryId, ReleaseType } from '@expo/apple-utils';
 
 import { AppleConfigReader } from '../reader';
 import { leastRestrictiveAdvisory, mostRestrictiveAdvisory } from './fixtures/ageRatingDeclaration';
@@ -81,5 +81,57 @@ describe('getAgeRating', () => {
   it('returns most restrictive advisory', () => {
     const reader = new AppleConfigReader({ advisory: mostRestrictiveAdvisory });
     expect(reader.getAgeRating()).toMatchObject(mostRestrictiveAdvisory);
+  });
+});
+
+describe('getVersionReleaseType', () => {
+  it('ignores release when not set', () => {
+    const reader = new AppleConfigReader({ release: undefined });
+    expect(reader.getVersionReleaseType()).toBeNull();
+  });
+
+  it('ignores release when automaticRelease not set', () => {
+    const reader = new AppleConfigReader({ release: {} });
+    expect(reader.getVersionReleaseType()).toBeNull();
+  });
+
+  it('returns scheduled release date with iso string', () => {
+    const reader = new AppleConfigReader({
+      release: { automaticRelease: '2020-06-17T12:00:00-00:00' },
+    });
+    expect(reader.getVersionReleaseType()).toMatchObject({
+      releaseType: ReleaseType.SCHEDULED,
+      earliestReleaseDate: '2020-06-17T12:00:00.000Z',
+    });
+  });
+
+  it('returns scheduled release with unparsable date string', () => {
+    const reader = new AppleConfigReader({
+      release: { automaticRelease: '2020-06-17-12:00:00' },
+    });
+    expect(reader.getVersionReleaseType()).toMatchObject({
+      releaseType: ReleaseType.SCHEDULED,
+      earliestReleaseDate: '2020-06-17-12:00:00',
+    });
+  });
+
+  it('returns automatic release', () => {
+    const reader = new AppleConfigReader({
+      release: { automaticRelease: true },
+    });
+    expect(reader.getVersionReleaseType()).toMatchObject({
+      releaseType: ReleaseType.AFTER_APPROVAL,
+      earliestReleaseDate: null,
+    });
+  });
+
+  it('returns manual release', () => {
+    const reader = new AppleConfigReader({
+      release: { automaticRelease: false },
+    });
+    expect(reader.getVersionReleaseType()).toMatchObject({
+      releaseType: ReleaseType.MANUAL,
+      earliestReleaseDate: null,
+    });
   });
 });

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
@@ -1,4 +1,9 @@
-import { AppCategoryId, AppSubcategoryId, ReleaseType } from '@expo/apple-utils';
+import {
+  AppCategoryId,
+  AppSubcategoryId,
+  PhasedReleaseState,
+  ReleaseType,
+} from '@expo/apple-utils';
 
 import { AppleConfigReader } from '../reader';
 import { leastRestrictiveAdvisory, mostRestrictiveAdvisory } from './fixtures/ageRatingDeclaration';
@@ -85,12 +90,12 @@ describe('getAgeRating', () => {
 });
 
 describe('getVersionReleaseType', () => {
-  it('ignores release when not set', () => {
+  it('ignores automatic release when not set', () => {
     const reader = new AppleConfigReader({ release: undefined });
     expect(reader.getVersionReleaseType()).toBeNull();
   });
 
-  it('ignores release when automaticRelease not set', () => {
+  it('ignores automatic release when automaticRelease not set', () => {
     const reader = new AppleConfigReader({ release: {} });
     expect(reader.getVersionReleaseType()).toBeNull();
   });
@@ -106,9 +111,7 @@ describe('getVersionReleaseType', () => {
   });
 
   it('returns scheduled release with unparsable date string', () => {
-    const reader = new AppleConfigReader({
-      release: { automaticRelease: '2020-06-17-12:00:00' },
-    });
+    const reader = new AppleConfigReader({ release: { automaticRelease: '2020-06-17-12:00:00' } });
     expect(reader.getVersionReleaseType()).toMatchObject({
       releaseType: ReleaseType.SCHEDULED,
       earliestReleaseDate: '2020-06-17-12:00:00',
@@ -116,9 +119,7 @@ describe('getVersionReleaseType', () => {
   });
 
   it('returns automatic release', () => {
-    const reader = new AppleConfigReader({
-      release: { automaticRelease: true },
-    });
+    const reader = new AppleConfigReader({ release: { automaticRelease: true } });
     expect(reader.getVersionReleaseType()).toMatchObject({
       releaseType: ReleaseType.AFTER_APPROVAL,
       earliestReleaseDate: null,
@@ -126,12 +127,34 @@ describe('getVersionReleaseType', () => {
   });
 
   it('returns manual release', () => {
-    const reader = new AppleConfigReader({
-      release: { automaticRelease: false },
-    });
+    const reader = new AppleConfigReader({ release: { automaticRelease: false } });
     expect(reader.getVersionReleaseType()).toMatchObject({
       releaseType: ReleaseType.MANUAL,
       earliestReleaseDate: null,
     });
+  });
+});
+
+describe('getVersionReleasePhased', () => {
+  it('ignores phased release when not set', () => {
+    const reader = new AppleConfigReader({ release: undefined });
+    expect(reader.getVersionReleasePhased()).toBeNull();
+  });
+
+  it('ignores phased release when phasedRelease not set', () => {
+    const reader = new AppleConfigReader({ release: {} });
+    expect(reader.getVersionReleasePhased()).toBeNull();
+  });
+
+  it('returns phased release when enabled', () => {
+    const reader = new AppleConfigReader({ release: { phasedRelease: true } });
+    expect(reader.getVersionReleasePhased()).toMatchObject({
+      phasedReleaseState: PhasedReleaseState.ACTIVE,
+    });
+  });
+
+  it('ignores phased release when disabled', () => {
+    const reader = new AppleConfigReader({ release: { phasedRelease: false } });
+    expect(reader.getVersionReleasePhased()).toBeNull();
   });
 });

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -189,34 +189,29 @@ describe('setVersion', () => {
   });
 });
 
-describe('setVersionRelease', () => {
+describe('setVersionReleaseType', () => {
   it('modifies scheduled release', () => {
     const writer = new AppleConfigWriter();
-    writer.setVersionRelease(scheduledRelease);
+    writer.setVersionReleaseType(scheduledRelease);
     expect(writer.schema.release).toMatchObject({
-      autoReleaseDate: scheduledRelease.earliestReleaseDate,
+      automaticRelease: scheduledRelease.earliestReleaseDate,
     });
   });
 
   it('modifies automatic release', () => {
     const writer = new AppleConfigWriter();
-    writer.setVersionRelease(automaticRelease);
+    writer.setVersionReleaseType(automaticRelease);
     expect(writer.schema.release).toMatchObject({
       automaticRelease: true,
     });
   });
 
-  it('does not modify manual release', () => {
+  it('modifies manual release', () => {
     const writer = new AppleConfigWriter();
-    writer.setVersionRelease(manualRelease);
-    expect(writer.schema.release).toBeUndefined();
-  });
-
-  it('overwrites all release fields', () => {
-    const writer = new AppleConfigWriter();
-    writer.setVersionRelease(scheduledRelease);
-    writer.setVersionRelease(automaticRelease);
-    expect(writer.schema.release).not.toHaveProperty('autoReleaseDate');
+    writer.setVersionReleaseType(manualRelease);
+    expect(writer.schema.release).toMatchObject({
+      automaticRelease: false,
+    });
   });
 });
 

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -221,7 +221,7 @@ describe('setVersionReleaseType', () => {
     writer.setVersionReleaseType(manualRelease);
     expect(writer.schema.release).toMatchObject({
       automaticRelease: false,
-      phasedRelease: false,
+      phasedRelease: true,
     });
   });
 });
@@ -231,12 +231,6 @@ describe('setVersionReleasePhased', () => {
     const writer = new AppleConfigWriter();
     writer.setVersionReleasePhased(phasedRelease);
     expect(writer.schema.release).toHaveProperty('phasedRelease', true);
-  });
-
-  it('modifies disabled phased release', () => {
-    const writer = new AppleConfigWriter();
-    writer.setVersionReleasePhased(undefined);
-    expect(writer.schema.release).toHaveProperty('phasedRelease', false);
   });
 
   it('deletes phased release when undefined', () => {

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -12,6 +12,7 @@ import { dutchInfo, englishInfo } from './fixtures/appInfoLocalization';
 import { nameAndDemoReviewDetails, nameOnlyReviewDetails } from './fixtures/appStoreReviewDetail';
 import { automaticRelease, manualRelease, scheduledRelease } from './fixtures/appStoreVersion';
 import { dutchVersion, englishVersion } from './fixtures/appStoreVersionLocalization';
+import { phasedRelease } from './fixtures/appStoreVersionPhasedRelease';
 
 describe('toSchema', () => {
   it('returns object with apple schema', () => {
@@ -211,6 +212,47 @@ describe('setVersionReleaseType', () => {
     writer.setVersionReleaseType(manualRelease);
     expect(writer.schema.release).toMatchObject({
       automaticRelease: false,
+    });
+  });
+
+  it('does not overwrite phasedRelease', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionReleasePhased(phasedRelease);
+    writer.setVersionReleaseType(manualRelease);
+    expect(writer.schema.release).toMatchObject({
+      automaticRelease: false,
+      phasedRelease: false,
+    });
+  });
+});
+
+describe('setVersionReleasePhased', () => {
+  it('modifies enabled phased release', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionReleasePhased(phasedRelease);
+    expect(writer.schema.release).toHaveProperty('phasedRelease', true);
+  });
+
+  it('modifies disabled phased release', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionReleasePhased(undefined);
+    expect(writer.schema.release).toHaveProperty('phasedRelease', false);
+  });
+
+  it('deletes phased release when undefined', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionReleasePhased(phasedRelease);
+    writer.setVersionReleasePhased(undefined);
+    expect(writer.schema.release).not.toHaveProperty('phasedRelease');
+  });
+
+  it('does not overwrite automaticRelease', () => {
+    const writer = new AppleConfigWriter();
+    writer.setVersionReleaseType(automaticRelease);
+    writer.setVersionReleasePhased(phasedRelease);
+    expect(writer.schema.release).toMatchObject({
+      automaticRelease: true,
+      phasedRelease: true,
     });
   });
 });

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -114,16 +114,17 @@ export class AppleConfigReader {
     return this.schema.copyright ? { copyright: this.schema.copyright } : null;
   }
 
-  public getVersionRelease(): Partial<
+  public getVersionReleaseType(): Partial<
     Pick<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
   > | null {
     const { release } = this.schema;
 
-    if (release?.autoReleaseDate) {
+    if (typeof release?.automaticRelease === 'string') {
       return {
         releaseType: ReleaseType.SCHEDULED,
-        // Convert time format to 2020-06-17T12:00:00-07:00
-        earliestReleaseDate: removeDatePrecision(release.autoReleaseDate)?.toISOString() ?? null,
+        // Convert time format to 2020-06-17T12:00:00-07:00, if that fails, try the date anyways.
+        earliestReleaseDate:
+          removeDatePrecision(release.automaticRelease)?.toISOString() ?? release.automaticRelease,
       };
     }
 

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -4,7 +4,9 @@ import {
   AppStoreReviewDetail,
   AppStoreVersion,
   AppStoreVersionLocalization,
+  AppStoreVersionPhasedRelease,
   CategoryIds,
+  PhasedReleaseState,
   Rating,
   ReleaseType,
 } from '@expo/apple-utils';
@@ -142,6 +144,21 @@ export class AppleConfigReader {
       };
     }
 
+    return null;
+  }
+
+  public getVersionReleasePhased(): Pick<
+    AttributesOf<AppStoreVersionPhasedRelease>,
+    'phasedReleaseState'
+  > | null {
+    if (this.schema.release?.phasedRelease === true) {
+      return {
+        phasedReleaseState: PhasedReleaseState.ACTIVE,
+      };
+    }
+
+    // When phased release is turned off, we need to delete the phased release request.
+    // There is no concept (yet) of pausing the phased release through EAS metadata.
     return null;
   }
 

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -5,6 +5,7 @@ import {
   AppStoreReviewDetail,
   AppStoreVersion,
   AppStoreVersionLocalization,
+  AppStoreVersionPhasedRelease,
   Rating,
   ReleaseType,
 } from '@expo/apple-utils';
@@ -115,15 +116,38 @@ export class AppleConfigWriter {
     attributes: Pick<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
   ): void {
     if (attributes.releaseType === ReleaseType.SCHEDULED && attributes.earliestReleaseDate) {
-      this.schema.release = { automaticRelease: attributes.earliestReleaseDate };
+      this.schema.release = {
+        ...this.schema.release,
+        automaticRelease: attributes.earliestReleaseDate,
+      };
     }
 
     if (attributes.releaseType === ReleaseType.AFTER_APPROVAL) {
-      this.schema.release = { automaticRelease: true };
+      this.schema.release = {
+        ...this.schema.release,
+        automaticRelease: true,
+      };
     }
 
     if (attributes.releaseType === ReleaseType.MANUAL) {
-      this.schema.release = { automaticRelease: false };
+      this.schema.release = {
+        ...this.schema.release,
+        automaticRelease: false,
+      };
+    }
+  }
+
+  public setVersionReleasePhased(attributes?: AttributesOf<AppStoreVersionPhasedRelease>): void {
+    if (!attributes) {
+      this.schema.release = {
+        ...this.schema.release,
+        phasedRelease: false,
+      };
+    } else {
+      this.schema.release = {
+        ...this.schema.release,
+        phasedRelease: true,
+      };
     }
   }
 

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -139,10 +139,7 @@ export class AppleConfigWriter {
 
   public setVersionReleasePhased(attributes?: AttributesOf<AppStoreVersionPhasedRelease>): void {
     if (!attributes) {
-      this.schema.release = {
-        ...this.schema.release,
-        phasedRelease: false,
-      };
+      delete this.schema.release?.phasedRelease;
     } else {
       this.schema.release = {
         ...this.schema.release,

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -111,25 +111,19 @@ export class AppleConfigWriter {
     this.schema.copyright = optional(attributes.copyright);
   }
 
-  public setVersionRelease(
+  public setVersionReleaseType(
     attributes: Pick<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
   ): void {
-    if (attributes.releaseType === ReleaseType.SCHEDULED) {
-      this.schema.release = {
-        autoReleaseDate: optional(attributes.earliestReleaseDate),
-      };
+    if (attributes.releaseType === ReleaseType.SCHEDULED && attributes.earliestReleaseDate) {
+      this.schema.release = { automaticRelease: attributes.earliestReleaseDate };
     }
 
     if (attributes.releaseType === ReleaseType.AFTER_APPROVAL) {
-      this.schema.release = {
-        automaticRelease: true,
-      };
+      this.schema.release = { automaticRelease: true };
     }
 
     if (attributes.releaseType === ReleaseType.MANUAL) {
-      // ReleaseType.MANUAL is the default behavior, so we don't need to configure it.
-      // Setting `"automaticRelease": false` is a bit confusing for people who don't know what automaticRelease does.
-      this.schema.release = undefined;
+      this.schema.release = { automaticRelease: false };
     }
   }
 

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-version.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-version.test.ts
@@ -167,7 +167,7 @@ describe(AppVersionTask, () => {
         context: { version, versionLocales: [] } as any,
       });
 
-      expect(writer.setVersionRelease).toBeCalledWith(version.attributes);
+      expect(writer.setVersionReleaseType).toBeCalledWith(version.attributes);
     });
 
     it('skips when no locales are loaded', async () => {
@@ -220,7 +220,7 @@ describe(AppVersionTask, () => {
         release: { automaticRelease: true },
       });
 
-      const attributes = { ...config.getVersion(), ...config.getVersionRelease() };
+      const attributes = { ...config.getVersion(), ...config.getVersionReleaseType() };
       const scope = nock('https://api.appstoreconnect.apple.com')
         // Respond to version.updateAsync
         .patch(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1`)

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-version.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-version.test.ts
@@ -3,6 +3,8 @@ import {
   AppStoreState,
   AppStoreVersion,
   AppStoreVersionLocalization,
+  AppStoreVersionPhasedRelease,
+  PhasedReleaseState,
 } from '@expo/apple-utils';
 import nock from 'nock';
 
@@ -27,6 +29,12 @@ describe(AppVersionTask, () => {
         .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
         .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
         .reply(200, require('./fixtures/apps/get-appStoreVersions-count-200.json'))
+        // Respond to version.getPhasedReleaseAsync
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/appStoreVersionPhasedRelease`)
+        .reply(
+          200,
+          require('./fixtures/appStoreVersions/get-appStoreVersionPhasedRelease-200-empty.json')
+        )
         // Respond to version.getLocalizationsAsync
         .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/${AppStoreVersionLocalization.type}`)
         .reply(
@@ -60,6 +68,12 @@ describe(AppVersionTask, () => {
         .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
         .query(true)
         .reply(200, require('./fixtures/apps/get-appStoreVersions-count-200.json'))
+        // Respond to version.getPhasedReleaseAsync
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/appStoreVersionPhasedRelease`)
+        .reply(
+          200,
+          require('./fixtures/appStoreVersions/get-appStoreVersionPhasedRelease-200-empty.json')
+        )
         // Respond to version.getLocalizationsAsync
         .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/${AppStoreVersionLocalization.type}`)
         .reply(
@@ -89,6 +103,12 @@ describe(AppVersionTask, () => {
         .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
         .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
         .reply(200, require('./fixtures/apps/get-appStoreVersions-count-200.json'))
+        // Respond to version.getPhasedReleaseAsync
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/appStoreVersionPhasedRelease`)
+        .reply(
+          200,
+          require('./fixtures/appStoreVersions/get-appStoreVersionPhasedRelease-200-empty.json')
+        )
         // Respond to version.getLocalizationsAsync
         .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/${AppStoreVersionLocalization.type}`)
         .reply(
@@ -118,6 +138,12 @@ describe(AppVersionTask, () => {
         .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
         .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
         .reply(200, require('./fixtures/apps/get-appStoreVersions-count-multiple-200.json'))
+        // Respond to version.getPhasedReleaseAsync
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/appStoreVersionPhasedRelease`)
+        .reply(
+          200,
+          require('./fixtures/appStoreVersions/get-appStoreVersionPhasedRelease-200-empty.json')
+        )
         // Respond to version.getLocalizationsAsync
         .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_1/${AppStoreVersionLocalization.type}`)
         .reply(
@@ -158,7 +184,7 @@ describe(AppVersionTask, () => {
       expect(writer.setVersion).toBeCalledWith(version.attributes);
     });
 
-    it('sets version release when loaded', async () => {
+    it('sets version release type when loaded', async () => {
       const writer = new AppleConfigWriter();
       const version = new AppStoreVersion(requestContext, 'stub-id', {} as any);
 
@@ -168,6 +194,23 @@ describe(AppVersionTask, () => {
       });
 
       expect(writer.setVersionReleaseType).toBeCalledWith(version.attributes);
+    });
+
+    it('sets version phased release when loaded', async () => {
+      const writer = new AppleConfigWriter();
+      const version = new AppStoreVersion(requestContext, 'stub-id', {} as any);
+      const versionPhasedRelease = new AppStoreVersionPhasedRelease(
+        requestContext,
+        'stub-id',
+        {} as any
+      );
+
+      await new AppVersionTask().downloadAsync({
+        config: writer,
+        context: { version, versionPhasedRelease, versionLocales: [] } as any,
+      });
+
+      expect(writer.setVersionReleasePhased).toBeCalledWith(versionPhasedRelease.attributes);
     });
 
     it('skips when no locales are loaded', async () => {
@@ -241,6 +284,82 @@ describe(AppVersionTask, () => {
 
       expect(context.version?.attributes).toMatchObject(attributes);
       expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('creates phased release when enabled in config', async () => {
+      const config = new AppleConfigReader({ release: { phasedRelease: true } });
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .post(`/v1/${AppStoreVersionPhasedRelease.type}`)
+        .reply(201, {
+          data: {
+            id: 'APP_STORE_VERSION_PHASED_RELEASE_1',
+            type: AppStoreVersionPhasedRelease.type,
+            attributes: {
+              phasedReleaseState: PhasedReleaseState.ACTIVE,
+              currentDayNumber: null,
+              startDate: null,
+              totalPauseDuration: null,
+            },
+          },
+        });
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+        version: new AppStoreVersion(requestContext, 'APP_STORE_VERSION_1', {} as any),
+        versionPhasedRelease: null, // Not enabled yet
+      };
+
+      await new AppVersionTask().uploadAsync({ context: context as AppleData, config });
+
+      expect(context.versionPhasedRelease).toBeInstanceOf(AppStoreVersionPhasedRelease);
+      expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('deletes active phased release when disabled in config', async () => {
+      const config = new AppleConfigReader({ release: { phasedRelease: false } });
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .delete(`/v1/${AppStoreVersionPhasedRelease.type}/APP_STORE_VERSION_PHASED_RELEASE_1`)
+        .reply(204);
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+        version: new AppStoreVersion(requestContext, 'APP_STORE_VERSION_1', {} as any),
+        // Enabled, and not completed yet
+        versionPhasedRelease: new AppStoreVersionPhasedRelease(
+          requestContext,
+          'APP_STORE_VERSION_PHASED_RELEASE_1',
+          { phasedReleaseState: PhasedReleaseState.ACTIVE } as any
+        ),
+      };
+
+      await new AppVersionTask().uploadAsync({ context: context as AppleData, config });
+
+      expect(context.versionPhasedRelease).toBeNull();
+      expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('does not delete completed phased release when disabled in config', async () => {
+      const config = new AppleConfigReader({ release: { phasedRelease: false } });
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .delete(`/v1/${AppStoreVersionPhasedRelease.type}/APP_STORE_VERSION_PHASED_RELEASE_1`)
+        .reply(204);
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+        version: new AppStoreVersion(requestContext, 'APP_STORE_VERSION_1', {} as any),
+        // Enabled, and not completed yet
+        versionPhasedRelease: new AppStoreVersionPhasedRelease(
+          requestContext,
+          'APP_STORE_VERSION_PHASED_RELEASE_1',
+          { phasedReleaseState: PhasedReleaseState.COMPLETE } as any
+        ),
+      };
+
+      await new AppVersionTask().uploadAsync({ context: context as AppleData, config });
+
+      expect(context.versionPhasedRelease).toBe(context.versionPhasedRelease);
+      expect(scope.isDone()).toBeFalsy();
+      nock.cleanAll();
     });
   });
 });

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-appStoreVersionPhasedRelease-200-empty.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/get-appStoreVersionPhasedRelease-200-empty.json
@@ -1,0 +1,6 @@
+{
+  "data": null,
+  "links": {
+    "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_PHASED_RELEASE_1/appStoreVersionPhasedRelease"
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
@@ -1,4 +1,11 @@
-import { App, AppStoreVersion, AppStoreVersionLocalization, Platform } from '@expo/apple-utils';
+import {
+  App,
+  AppStoreVersion,
+  AppStoreVersionLocalization,
+  AppStoreVersionPhasedRelease,
+  PhasedReleaseState,
+  Platform,
+} from '@expo/apple-utils';
 import assert from 'assert';
 import chalk from 'chalk';
 
@@ -23,6 +30,8 @@ export type AppVersionData = {
   versionIsFirst: boolean;
   /** All version locales that should be, or are enabled */
   versionLocales: AppStoreVersionLocalization[];
+  /** The (existing) phased release configuration, when set */
+  versionPhasedRelease: AppStoreVersionPhasedRelease | null;
 };
 
 export class AppVersionTask extends AppleTask {
@@ -50,6 +59,7 @@ export class AppVersionTask extends AppleTask {
     context.versionIsFirst = versionIsFirst;
     context.versionIsLive = versionIsLive;
     context.versionLocales = await version.getLocalizationsAsync();
+    context.versionPhasedRelease = await version.getPhasedReleaseAsync();
   }
 
   public async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
@@ -57,6 +67,7 @@ export class AppVersionTask extends AppleTask {
 
     config.setVersion(context.version.attributes);
     config.setVersionReleaseType(context.version.attributes);
+    config.setVersionReleasePhased(context.versionPhasedRelease?.attributes);
 
     for (const locale of context.versionLocales) {
       config.setVersionLocale(locale.attributes);
@@ -66,12 +77,13 @@ export class AppVersionTask extends AppleTask {
   public async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
     assert(context.version, `App version not initialized, can't update version`);
 
+    const { versionString } = context.version.attributes;
+
     const version = config.getVersion();
     const release = config.getVersionReleaseType();
     if (!version && !release) {
       Log.log(chalk`{dim - Skipped version and release update, not configured}`);
     } else {
-      const { versionString } = context.version.attributes;
       const description = [version && 'version', release && 'release']
         .filter(Boolean)
         .join(' and ');
@@ -82,6 +94,27 @@ export class AppVersionTask extends AppleTask {
           pending: `Updating ${description} info for ${chalk.bold(versionString)}...`,
           success: `Updated ${description} info for ${chalk.bold(versionString)}`,
           failure: `Failed updating ${description} info for ${chalk.bold(versionString)}`,
+        }
+      );
+    }
+
+    const phasedRelease = config.getVersionReleasePhased();
+    if (!phasedRelease && shouldDeletePhasedRelease(context.versionPhasedRelease)) {
+      // if phased release was enabled, but now disabled, we need to remove it
+      await logAsync(() => context.versionPhasedRelease!.deleteAsync(), {
+        pending: `Disabling phased release for ${chalk.bold(versionString)}...`,
+        success: `Disabled phased release for ${chalk.bold(versionString)}`,
+        failure: `Failed disabling phased release for ${chalk.bold(versionString)}`,
+      });
+      context.versionPhasedRelease = null;
+    } else if (phasedRelease && !context.versionPhasedRelease) {
+      // if phased release was not yet set, but now enabled, we need to create it
+      context.versionPhasedRelease = await logAsync(
+        () => context.version.createPhasedReleaseAsync({ state: phasedRelease.phasedReleaseState }),
+        {
+          pending: `Enabling phased release for ${chalk.bold(versionString)}...`,
+          success: `Enabled phased release for ${chalk.bold(versionString)}`,
+          failure: `Failed enabling phased release for ${chalk.bold(versionString)}`,
         }
       );
     }
@@ -155,4 +188,22 @@ async function resolveVersionAsync(
     versionIsLive,
     versionIsFirst: versions.length === 1,
   };
+}
+
+/**
+ * Determine if we can, and should, delete the phased release instance.
+ * This returns true if the instance exist, and has one of the states below:
+ *   - PhasedReleaseState.INACTIVE
+ *   - PhasedReleaseState.ACTIVE
+ *   - PhasedReleaseState.PAUSED
+ */
+function shouldDeletePhasedRelease(phasedRelease: AppStoreVersionPhasedRelease | null): boolean {
+  if (
+    !phasedRelease ||
+    phasedRelease.attributes.phasedReleaseState === PhasedReleaseState.COMPLETE
+  ) {
+    return false;
+  }
+
+  return true;
 }

--- a/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-version.ts
@@ -56,7 +56,7 @@ export class AppVersionTask extends AppleTask {
     assert(context.version, `App version not initialized, can't download version`);
 
     config.setVersion(context.version.attributes);
-    config.setVersionRelease(context.version.attributes);
+    config.setVersionReleaseType(context.version.attributes);
 
     for (const locale of context.versionLocales) {
       config.setVersionLocale(locale.attributes);
@@ -67,7 +67,7 @@ export class AppVersionTask extends AppleTask {
     assert(context.version, `App version not initialized, can't update version`);
 
     const version = config.getVersion();
-    const release = config.getVersionRelease();
+    const release = config.getVersionReleaseType();
     if (!version && !release) {
       Log.log(chalk`{dim - Skipped version and release update, not configured}`);
     } else {

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -18,13 +18,8 @@ export type AppleAdvisory = Partial<AgeRatingDeclarationProps>;
 export type AppleCategory = (string | string[])[];
 
 export interface AppleRelease {
-  isPhasedReleaseEnabled?: boolean;
-  shouldResetRatings?: boolean;
-  autoReleaseDate?: number | string;
-  automaticRelease?: boolean;
-  usesThirdPartyContent?: boolean;
-  /** Alternative to setting `ITSAppUsesNonExemptEncryption` in the binary's `Info.plist`. */
-  usesNonExemptEncryption?: boolean;
+  automaticRelease?: boolean | string;
+  phasedRelease?: boolean;
 }
 
 export interface AppleInfo {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This cleans up a lot of the deprecated/unused `apple.release` properties. Right now, we support two:
- `automaticRelease`
- `phasedRelease`

# How

- Updated store config schema
- Added phased release config reader/writer
- Updated data handling
- Added and updated tests

# Test Plan

See tests
