### PR TITLE
[eas-cli] Drop deprecated idfa and price tier from store config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Update validation rules for metadata info locales. ([#1174](https://github.com/expo/eas-cli/pull/1174) by [@byCedric](https://github.com/byCedric))
 - Improve store configuration defaults and schema documentation. ([#1183](https://github.com/expo/eas-cli/pull/1183) by [@byCedric](https://github.com/byCedric))
 - Improve store config categories configuration. ([#1187](https://github.com/expo/eas-cli/pull/1187) by [@byCedric](https://github.com/byCedric))
+- Remove deprecated idfa and price tier from store config. ([#1193](https://github.com/expo/eas-cli/pull/1193) by [@byCedric](https://github.com/byCedric))
 
 ## [0.54.1](https://github.com/expo/eas-cli/releases/tag/v0.54.1) - 2022-06-15
 

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -967,10 +967,6 @@
         "review": {
           "$ref": "#/definitions/apple/AppleReview",
           "description": "Info for the App Store reviewer"
-        },
-        "priceTier": {
-          "type": "number",
-          "description": "App price tier. 0 is Free."
         }
       }
     }

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -182,35 +182,6 @@
           }
         }
       },
-      "AppleIdfa": {
-        "description": "Identifier for Advertisers",
-        "type": "object",
-        "additionalProperties": false,
-        "defaultSnippets": [
-          {
-            "body": {
-              "servesAds": false,
-              "attributesAppInstallationToPreviousAd": false,
-              "attributesActionWithPreviousAd": false,
-              "honorsLimitedAdTracking": false
-            }
-          }
-        ],
-        "properties": {
-          "servesAds": {
-            "type": "boolean"
-          },
-          "attributesAppInstallationToPreviousAd": {
-            "type": "boolean"
-          },
-          "attributesActionWithPreviousAd": {
-            "type": "boolean"
-          },
-          "honorsLimitedAdTracking": {
-            "type": "boolean"
-          }
-        }
-      },
       "AppleInfo": {
         "type": "object",
         "additionalProperties": false,
@@ -654,9 +625,6 @@
             "liveEdits": true,
             "storeInfo": "The name of the person or entity that owns the exclusive rights to your app, preceded by the year the rights were obtained (for example, \"2008 Acme Inc.\"). Do not provide a URL."
           }
-        },
-        "idfa": {
-          "$ref": "#/definitions/apple/AppleIdfa"
         },
         "info": {
           "description": "Localized core app info",


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This drops both `apple.idfa` and `apple.priceTier`.
- For IDFA, that's because it has been fully deprecated in ASC in favor of [AppTrackTransparency](https://developer.apple.com/documentation/apptrackingtransparency)
- For price tier, that's because there is a v2 that is completely different and needs to be re-implemented.

# How

Dropped both configuration options from store config schema

# Test Plan

Only a change in the store config schema
