### PR TITLE
[eas-cli] Add version selector to store config for metadata

### DIFF
--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -572,11 +572,10 @@
       "description": "Configuration that is specific to the Apple App Store.",
       "additionalProperties": false,
       "properties": {
-        "advisory": {
-          "$ref": "#/definitions/apple/AppleAdvisory"
-        },
-        "categories": {
-          "$ref": "#/definitions/apple/AppleCategory"
+        "version": {
+          "type": "string",
+          "description": "The version string to edit, or create, if it doesn't exist.",
+          "minLength": 1
         },
         "copyright": {
           "type": "string",
@@ -591,6 +590,12 @@
             "liveEdits": true,
             "storeInfo": "The name of the person or entity that owns the exclusive rights to your app, preceded by the year the rights were obtained (for example, \"2008 Acme Inc.\"). Do not provide a URL."
           }
+        },
+        "advisory": {
+          "$ref": "#/definitions/apple/AppleAdvisory"
+        },
+        "categories": {
+          "$ref": "#/definitions/apple/AppleCategory"
         },
         "info": {
           "description": "Localized core app info",

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -574,8 +574,13 @@
       "properties": {
         "version": {
           "type": "string",
-          "description": "The version string to edit, or create, if it doesn't exist.",
-          "minLength": 1
+          "description": "The version string to edit, or create, if it doesn't exist. All the metadata will be stored on this app version.",
+          "minLength": 1,
+          "defaultSnippets": [
+            {
+              "body": "${1:1}.${2:0}"
+            }
+          ]
         },
         "copyright": {
           "type": "string",

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
@@ -158,3 +158,21 @@ describe('getVersionReleasePhased', () => {
     expect(reader.getVersionReleasePhased()).toBeNull();
   });
 });
+
+describe('getVersion', () => {
+  it('ignores version when not set', () => {
+    const reader = new AppleConfigReader({});
+    expect(reader.getVersion()).toBeNull();
+  });
+
+  it('returns version and copyright when set', () => {
+    const reader = new AppleConfigReader({
+      version: '2.0',
+      copyright: '2022 - ACME',
+    });
+    expect(reader.getVersion()).toMatchObject({
+      versionString: '2.0',
+      copyright: '2022 - ACME',
+    });
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -183,9 +183,10 @@ describe('setCategories', () => {
 });
 
 describe('setVersion', () => {
-  it('modifies the copyright', () => {
+  it('modifies the copyright and version string', () => {
     const writer = new AppleConfigWriter();
     writer.setVersion(manualRelease);
+    expect(writer.schema.version).toBe(manualRelease.versionString);
     expect(writer.schema.copyright).toBe(manualRelease.copyright);
   });
 });

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -113,7 +113,13 @@ export class AppleConfigReader {
   public getVersion(): Partial<
     Omit<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
   > | null {
-    return this.schema.copyright ? { copyright: this.schema.copyright } : null;
+    const attributes: Pick<AttributesOf<AppStoreVersion>, 'versionString' | 'copyright'> = {
+      versionString: this.schema.version ?? '',
+      copyright: this.schema.copyright ?? null,
+    };
+
+    const hasValues = Object.values(attributes).some(Boolean);
+    return hasValues ? attributes : null;
   }
 
   public getVersionReleaseType(): Partial<

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -109,6 +109,7 @@ export class AppleConfigWriter {
   public setVersion(
     attributes: Omit<AttributesOf<AppStoreVersion>, 'releaseType' | 'earliestReleaseDate'>
   ): void {
+    this.schema.version = optional(attributes.versionString);
     this.schema.copyright = optional(attributes.copyright);
   }
 

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-version.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-version.test.ts
@@ -176,7 +176,21 @@ describe(AppVersionTask, () => {
         .reply(
           200,
           require('./fixtures/appStoreVersions/get-appStoreVersionLocalizations-200.json')
-        );
+        )
+        // Respond to version.getPhasedReleaseAsync
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_2/appStoreVersionPhasedRelease`)
+        .reply(200, {
+          data: {
+            id: 'APP_STORE_VERSION_PHASED_RELEASE_1',
+            type: AppStoreVersionPhasedRelease.type,
+            attributes: {
+              phasedReleaseState: PhasedReleaseState.INACTIVE,
+              currentDayNumber: null,
+              startDate: null,
+              totalPauseDuration: null,
+            },
+          },
+        });
 
       const context: PartialAppleData = {
         app: new App(requestContext, 'stub-id', {} as any),
@@ -211,7 +225,21 @@ describe(AppVersionTask, () => {
         .reply(
           200,
           require('./fixtures/appStoreVersions/get-appStoreVersionLocalizations-200.json')
-        );
+        )
+        // Respond to version.getPhasedReleaseAsync (for version 3.0)
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_3/appStoreVersionPhasedRelease`)
+        .reply(200, {
+          data: {
+            id: 'APP_STORE_VERSION_PHASED_RELEASE_1',
+            type: AppStoreVersionPhasedRelease.type,
+            attributes: {
+              phasedReleaseState: PhasedReleaseState.INACTIVE,
+              currentDayNumber: null,
+              startDate: null,
+              totalPauseDuration: null,
+            },
+          },
+        });
 
       const context: PartialAppleData = {
         app: new App(requestContext, 'stub-id', {} as any),

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-version.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-version.test.ts
@@ -160,6 +160,69 @@ describe(AppVersionTask, () => {
       expect(context.versionIsFirst).toBeFalsy();
       expect(scope.isDone()).toBeTruthy();
     });
+
+    it('fetches the existing version from options', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        // Respond to app.getAppStoreVersionsAsync in findEditAppStoreVersionAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query(true)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-count-multiple-200'))
+        // Respond to app.getAppStoreVersionsAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-count-multiple-200.json'))
+        // Respond to version.getLocalizationsAsync (for version 2.0)
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_2/${AppStoreVersionLocalization.type}`)
+        .reply(
+          200,
+          require('./fixtures/appStoreVersions/get-appStoreVersionLocalizations-200.json')
+        );
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+      };
+
+      await new AppVersionTask({ version: '2.0' }).prepareAsync({ context });
+
+      expect(context.version).toBeInstanceOf(AppStoreVersion);
+      expect(context.version?.attributes).toHaveProperty('versionString', '2.0');
+      expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('creates the non-existing version from options', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        // Respond to app.getAppStoreVersionsAsync in findEditAppStoreVersionAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query(true)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-count-multiple-200.json'))
+        // Respond to app.getAppStoreVersionsAsync in createOrUpdateEditAppStoreVersionAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query(true)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-200-empty.json'))
+        // Respond to app.createVersionAsync in createOrUpdateEditAppStoreVersionAsync
+        .post(`/v1/${AppStoreVersion.type}`)
+        .reply(201, require('./fixtures/appStoreVersions/post-201.json'))
+        // Respond to app.getAppStoreVersionsAsync
+        .get(`/v1/${App.type}/stub-id/${AppStoreVersion.type}`)
+        .query((params: any) => params['filter[appStoreState]'] !== AppStoreState.READY_FOR_SALE)
+        .reply(200, require('./fixtures/apps/get-appStoreVersions-count-multiple-200.json'))
+        // Respond to version.getLocalizationsAsync (for version 3.0)
+        .get(`/v1/${AppStoreVersion.type}/APP_STORE_VERSION_3/${AppStoreVersionLocalization.type}`)
+        .reply(
+          200,
+          require('./fixtures/appStoreVersions/get-appStoreVersionLocalizations-200.json')
+        );
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+      };
+
+      await new AppVersionTask({ version: '3.0' }).prepareAsync({ context });
+
+      expect(context.version).toBeInstanceOf(AppStoreVersion);
+      expect(context.version?.attributes).toHaveProperty('versionString', '3.0');
+      expect(scope.isDone()).toBeTruthy();
+    });
   });
 
   describe('downloadAsync', () => {

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/post-201.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/appStoreVersions/post-201.json
@@ -1,0 +1,116 @@
+{
+  "data": [
+    {
+      "type": "appStoreVersions",
+      "id": "APP_STORE_VERSION_3",
+      "attributes": {
+        "platform": "IOS",
+        "versionString": "3.0",
+        "appStoreState": "PREPARE_FOR_SUBMISSION",
+        "storeIcon": null,
+        "watchStoreIcon": null,
+        "copyright": "2022 name",
+        "releaseType": "SCHEDULED",
+        "earliestReleaseDate": "2022-03-14T17:00:00-07:00",
+        "usesIdfa": null,
+        "isWatchOnly": false,
+        "downloadable": true,
+        "createdDate": "2022-02-21T09:26:24-08:00",
+        "promotedDate": null
+      },
+      "relationships": {
+        "ageRatingDeclaration": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/ageRatingDeclaration",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/ageRatingDeclaration"
+          }
+        },
+        "appStoreVersionLocalizations": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/appStoreVersionLocalizations",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/appStoreVersionLocalizations"
+          }
+        },
+        "build": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/build",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/build"
+          }
+        },
+        "appStoreVersionPhasedRelease": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/appStoreVersionPhasedRelease",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/appStoreVersionPhasedRelease"
+          }
+        },
+        "gameCenterConfiguration": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/gameCenterConfiguration",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/gameCenterConfiguration"
+          }
+        },
+        "routingAppCoverage": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/routingAppCoverage",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/routingAppCoverage"
+          }
+        },
+        "appStoreReviewDetail": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/appStoreReviewDetail",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/appStoreReviewDetail"
+          }
+        },
+        "appStoreVersionSubmission": {
+          "data": null,
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/appStoreVersionSubmission",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/appStoreVersionSubmission"
+          }
+        },
+        "resetRatingsRequest": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/resetRatingsRequest",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/resetRatingsRequest"
+          }
+        },
+        "idfaDeclaration": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/idfaDeclaration",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/idfaDeclaration"
+          }
+        },
+        "appClipDefaultExperience": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/appClipDefaultExperience",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/appClipDefaultExperience"
+          }
+        },
+        "appStoreVersionStateChanges": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/appStoreVersionStateChanges",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/appStoreVersionStateChanges"
+          }
+        },
+        "appStoreVersionExperiments": {
+          "links": {
+            "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/relationships/appStoreVersionExperiments",
+            "related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3/appStoreVersionExperiments"
+          }
+        }
+      },
+      "links": {
+        "self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_3"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://appstoreconnect.apple.com/iris/v1/apps/1611050397/appStoreVersions?include=appStoreVersionSubmission&filter%5Bplatform%5D=IOS&filter%5BappStoreState%5D=DEVELOPER_REJECTED%2CINVALID_BINARY%2CMETADATA_REJECTED%2CPREPARE_FOR_SUBMISSION%2CREJECTED%2CWAITING_FOR_REVIEW"
+  },
+  "meta": {
+    "paging": {
+      "total": 1,
+      "limit": 50
+    }
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appStoreVersions-200-empty.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appStoreVersions-200-empty.json
@@ -1,0 +1,12 @@
+{
+  "data": null,
+  "links": {
+    "self": "https://appstoreconnect.apple.com/iris/v1/apps/1611050397/appStoreVersions?include=appStoreVersionSubmission&filter%5Bplatform%5D=IOS&filter%5BappStoreState%5D=DEVELOPER_REJECTED%2CINVALID_BINARY%2CMETADATA_REJECTED%2CPREPARE_FOR_SUBMISSION%2CREJECTED%2CWAITING_FOR_REVIEW"
+  },
+  "meta": {
+    "paging": {
+      "total": 0,
+      "limit": 50
+    }
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appStoreVersions-count-multiple-200.json
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/fixtures/apps/get-appStoreVersions-count-multiple-200.json
@@ -105,10 +105,10 @@
 		},
 		{
 			"type": "appStoreVersions",
-			"id": "APP-STORE-VERSION-2",
+			"id": "APP_STORE_VERSION_2",
 			"attributes": {
 				"platform": "IOS",
-				"versionString": "1.1",
+				"versionString": "2.0",
 				"appStoreState": "PREPARE_FOR_SUBMISSION",
 				"storeIcon": null,
 				"watchStoreIcon": null,
@@ -124,86 +124,86 @@
 			"relationships": {
 				"ageRatingDeclaration": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/ageRatingDeclaration",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/ageRatingDeclaration"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/ageRatingDeclaration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/ageRatingDeclaration"
 					}
 				},
 				"appStoreVersionLocalizations": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreVersionLocalizations",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreVersionLocalizations"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/appStoreVersionLocalizations",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/appStoreVersionLocalizations"
 					}
 				},
 				"build": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/build",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/build"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/build",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/build"
 					}
 				},
 				"appStoreVersionPhasedRelease": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreVersionPhasedRelease",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreVersionPhasedRelease"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/appStoreVersionPhasedRelease",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/appStoreVersionPhasedRelease"
 					}
 				},
 				"gameCenterConfiguration": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/gameCenterConfiguration",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/gameCenterConfiguration"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/gameCenterConfiguration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/gameCenterConfiguration"
 					}
 				},
 				"routingAppCoverage": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/routingAppCoverage",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/routingAppCoverage"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/routingAppCoverage",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/routingAppCoverage"
 					}
 				},
 				"appStoreReviewDetail": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreReviewDetail",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreReviewDetail"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/appStoreReviewDetail",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/appStoreReviewDetail"
 					}
 				},
 				"appStoreVersionSubmission": {
 					"data": null,
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreVersionSubmission",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreVersionSubmission"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/appStoreVersionSubmission",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/appStoreVersionSubmission"
 					}
 				},
 				"resetRatingsRequest": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/resetRatingsRequest",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/resetRatingsRequest"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/resetRatingsRequest",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/resetRatingsRequest"
 					}
 				},
 				"idfaDeclaration": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/idfaDeclaration",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/idfaDeclaration"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/idfaDeclaration",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/idfaDeclaration"
 					}
 				},
 				"appClipDefaultExperience": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appClipDefaultExperience",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appClipDefaultExperience"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/appClipDefaultExperience",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/appClipDefaultExperience"
 					}
 				},
 				"appStoreVersionStateChanges": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreVersionStateChanges",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreVersionStateChanges"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/appStoreVersionStateChanges",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/appStoreVersionStateChanges"
 					}
 				},
 				"appStoreVersionExperiments": {
 					"links": {
-						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/relationships/appStoreVersionExperiments",
-						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2/appStoreVersionExperiments"
+						"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/relationships/appStoreVersionExperiments",
+						"related": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2/appStoreVersionExperiments"
 					}
 				}
 			},
 			"links": {
-				"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP-STORE-VERSION-2"
+				"self": "https://appstoreconnect.apple.com/iris/v1/appStoreVersions/APP_STORE_VERSION_2"
 			}
 		}
 	],

--- a/packages/eas-cli/src/metadata/apple/tasks/index.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/index.ts
@@ -3,11 +3,23 @@ import { AppleTask } from '../task';
 import { AgeRatingTask } from './age-rating';
 import { AppInfoTask } from './app-info';
 import { AppReviewDetailTask } from './app-review-detail';
-import { AppVersionTask } from './app-version';
+import { AppVersionOptions, AppVersionTask } from './app-version';
+
+type AppleTaskOptions = {
+  version?: AppVersionOptions['version'];
+};
 
 /**
  * List of all eligible tasks to sync local store configuration to the App store.
  */
-export function createAppleTasks(_ctx: MetadataContext): AppleTask[] {
-  return [new AppVersionTask(), new AppInfoTask(), new AgeRatingTask(), new AppReviewDetailTask()];
+export function createAppleTasks(
+  _ctx: MetadataContext,
+  { version }: AppleTaskOptions = {}
+): AppleTask[] {
+  return [
+    new AppVersionTask({ version }),
+    new AppInfoTask(),
+    new AgeRatingTask(),
+    new AppReviewDetailTask(),
+  ];
 }

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -3,6 +3,7 @@ import type { AgeRatingDeclarationProps } from '@expo/apple-utils';
 export type AppleLocale = string;
 
 export interface AppleMetadata {
+  version?: string;
   copyright?: string;
   info?: Record<AppleLocale, AppleInfo>;
   categories?: AppleCategory;

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -51,7 +51,12 @@ export async function uploadMetadataAsync(
 
   const errors: Error[] = [];
   const config = createAppleReader(fileData);
-  const tasks = createAppleTasks(metadataCtx);
+  const tasks = createAppleTasks(metadataCtx, {
+    // We need to resolve a different version as soon as possible.
+    // This version is the parent model of all changes we are going to push.
+    version: config.getVersion()?.versionString,
+  });
+
   const taskCtx = { app };
 
   for (const task of tasks) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes ENG-5286

This allows users to create or select an editable app version through the store config.

# How

- Added `apple.version` to store config schema
- Added find and update existing editable app version
- Added create new editable app version

# Test Plan

- See added tests
