### PR TITLE
[eas-cli] Temporarily increase coverage memory to stabilize CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,10 @@ jobs:
         if: ${{ !matrix.coverage }}
       - run: yarn test --coverage
         if: ${{ matrix.coverage }}
+        env:
+          # Oclif seems to cause OOM errors when testing with coverage enabled.
+          # Remove this whenever we solved those OOM errors.
+          NODE_OPTIONS: --max-old-space-size=4096
       - run: yarn lint --max-warnings=0
       - run: shellcheck bin/*.sh
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

CI's coverage tests seem to fail due to OOM errors caused by OCLIF. This (temporarily) increases the memory limit to stabilize CI more. But, eventually, we have to address these OOM errors ([see this notion doc](https://www.notion.so/expo/Jest-Memory-Leak-EAS-CLI-854656c357064c08803d70e6466f9cc8))

# How

Added `NODE_OPTIONS` envvar to the `yarn test --coverage` command.

# Test Plan

[See if CI is more stable than it currently is](https://github.com/expo/eas-cli/actions/workflows/test.yml).
