### PR TITLE
[eas-cli] Add pagination to supported GQL queries

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -10209,7 +10209,7 @@
             "args": [
               {
                 "name": "assetContentTypes",
-                "description": "max 600",
+                "description": "max 1400",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -10758,6 +10758,22 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maxBuildTimeSeconds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -12571,6 +12587,12 @@
           },
           {
             "name": "NORMAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NORMAL_PLUS",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 
 import EasCommand from '../../commandUtils/EasCommand';
+import { ViewBranchUpdatesQuery } from '../../graphql/generated';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import Log from '../../log';
 import { getExpoConfig } from '../../project/expoConfig';
@@ -12,6 +13,7 @@ import { UPDATE_COLUMNS, formatUpdate, getPlatformsForGroup } from '../../update
 import groupBy from '../../utils/expodash/groupBy';
 import formatFields from '../../utils/formatFields';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+import { PaginatedQueryResponse, performPaginatedQueryAsync } from '../../utils/queries';
 
 export default class BranchView extends EasCommand {
   static description = 'view a branch';
@@ -57,50 +59,97 @@ export default class BranchView extends EasCommand {
       }));
     }
 
+    await queryForPaginatedBranchesAsync(projectId, name, { json: jsonFlag });
+  }
+}
+
+type BranchUpdateObject = Exclude<
+  ViewBranchUpdatesQuery['app']['byId']['updateBranchByName'],
+  null | undefined
+>['updates'][0];
+
+async function queryForPaginatedBranchesAsync(
+  projectId: string,
+  name: string,
+  flags: { json: boolean } & { json: boolean | undefined }
+): Promise<void> {
+  const queryAdditionalBranchesAsync = async (
+    pageSize: number,
+    offset: number
+  ): Promise<PaginatedQueryResponse<BranchUpdateObject>> => {
     const { app } = await UpdateQuery.viewBranchAsync({
       appId: projectId,
       name,
+      limit: pageSize,
+      offset,
     });
     const UpdateBranch = app?.byId.updateBranchByName;
     if (!UpdateBranch) {
       throw new Error(`Could not find branch "${name}"`);
     }
 
-    const updates = Object.values(groupBy(UpdateBranch.updates, u => u.group)).map(
-      group => group[0]
+    const updateGroups = Object.values(groupBy(UpdateBranch.updates, u => u.group)).map(
+      updateGroup => ({
+        ...updateGroup[0],
+        platform: getPlatformsForGroup({
+          updates: updateGroup,
+          group: updateGroup[0].group,
+        }),
+      })
     );
 
-    if (jsonFlag) {
-      printJsonOnlyOutput({ ...UpdateBranch, updates });
+    return {
+      queryResponse: updateGroups,
+      queryResponseRawLength: UpdateBranch.updates.length,
+    };
+  };
+
+  const renderPageOfBranches = (currentPage: BranchUpdateObject[]): void => {
+    if (flags.json) {
+      printJsonOnlyOutput(currentPage);
     } else {
-      const groupTable = new Table({
-        head: UPDATE_COLUMNS,
-        wordWrap: true,
-      });
+      if (flags.json) {
+        printJsonOnlyOutput({ currentPage });
+      } else {
+        const groupTable = new Table({
+          head: UPDATE_COLUMNS,
+          wordWrap: true,
+        });
 
-      for (const update of updates) {
-        groupTable.push([
-          formatUpdate(update),
-          update.runtimeVersion,
-          update.group,
-          getPlatformsForGroup({
-            updates: UpdateBranch.updates,
-            group: update.group,
-          }),
-        ]);
+        for (const update of currentPage) {
+          groupTable.push([
+            formatUpdate(update),
+            update.runtimeVersion,
+            update.group,
+            getPlatformsForGroup({
+              updates: currentPage,
+              group: update.group,
+            }),
+          ]);
+        }
+
+        Log.addNewLineIfNone();
+        Log.log(chalk.bold('Branch:'));
+        Log.log(
+          formatFields([
+            { label: 'Name', value: currentPage[0]['branch']['name'] },
+            { label: 'ID', value: currentPage[0]['branch']['id'] },
+          ])
+        );
+        Log.addNewLineIfNone();
+        Log.log(groupTable.toString());
       }
-
-      Log.addNewLineIfNone();
-      Log.log(chalk.bold('Branch:'));
-      Log.log(
-        formatFields([
-          { label: 'Name', value: UpdateBranch.name },
-          { label: 'ID', value: UpdateBranch.id },
-        ])
-      );
-      Log.addNewLineIfNone();
-      Log.log(chalk.bold('Recently published update groups:'));
-      Log.log(groupTable.toString());
     }
-  }
+  };
+
+  await performPaginatedQueryAsync({
+    pageSize: 50,
+    offset: 0,
+    queryToPerform: queryAdditionalBranchesAsync,
+    promptOptions: {
+      type: 'confirm',
+      title: 'Fetch next page of branches?',
+      renderListItems: renderPageOfBranches,
+    },
+  });
 }

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -351,6 +351,8 @@ export default class ChannelRollout extends EasCommand {
     const channel = await ChannelQuery.getUpdateChannelByNameForAppAsync({
       appId: projectId,
       channelName: channelName!,
+      offset: 0,
+      limit: 50,
     });
     if (!channel) {
       throw new Error(

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -111,7 +111,7 @@ export function logChannelDetails(channel: {
     }
 
     const { branchId } = branchMapping.data[index];
-    const branch = channel.updateBranches.filter(branch => branch.id === branchId)[0];
+    const branch = channel.updateBranches.find(branch => branch.id === branchId);
     if (!branch) {
       throw new Error('Branch mapping is pointing at a missing branch.');
     }
@@ -184,6 +184,8 @@ export default class ChannelView extends EasCommand {
     const channel = await ChannelQuery.getUpdateChannelByNameForAppAsync({
       appId: projectId,
       channelName,
+      offset: 0,
+      limit: 50,
     });
     if (!channel) {
       throw new Error(`Could not find a channel with name: ${channelName}`);

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1584,6 +1584,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   iosEnterpriseProvisioning?: Maybe<BuildIosEnterpriseProvisioning>;
   isGitWorkingTreeDirty?: Maybe<Scalars['Boolean']>;
   logFiles: Array<Scalars['String']>;
+  maxBuildTimeSeconds: Scalars['Int'];
   metrics?: Maybe<BuildMetrics>;
   parentBuild?: Maybe<Build>;
   platform: AppPlatform;
@@ -1817,7 +1818,8 @@ export type BuildParamsInput = {
 
 export enum BuildPriority {
   High = 'HIGH',
-  Normal = 'NORMAL'
+  Normal = 'NORMAL',
+  NormalPlus = 'NORMAL_PLUS'
 }
 
 /** Publicly visible data for a Build. */
@@ -3849,6 +3851,7 @@ export type DeleteUpdateBranchMutation = { __typename?: 'RootMutation', updateBr
 export type BranchesByAppQueryVariables = Exact<{
   appId: Scalars['String'];
   limit: Scalars['Int'];
+  offset: Scalars['Int'];
 }>;
 
 
@@ -3910,8 +3913,10 @@ export type UpdateChannelBranchMappingMutation = { __typename?: 'RootMutation', 
 
 export type GetAllChannelsForAppQueryVariables = Exact<{
   appId: Scalars['String'];
-  offset: Scalars['Int'];
-  limit: Scalars['Int'];
+  channelOffset: Scalars['Int'];
+  channelLimit: Scalars['Int'];
+  branchLimit: Scalars['Int'];
+  branchOffset: Scalars['Int'];
 }>;
 
 
@@ -4476,6 +4481,8 @@ export type GetAllBuildsForAppQuery = { __typename?: 'RootQuery', app: { __typen
 export type GetChannelByNameForAppQueryVariables = Exact<{
   appId: Scalars['String'];
   channelName: Scalars['String'];
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
 }>;
 
 
@@ -4531,10 +4538,11 @@ export type GetAllSubmissionsForAppQuery = { __typename?: 'RootQuery', app: { __
 export type ViewAllUpdatesQueryVariables = Exact<{
   appId: Scalars['String'];
   limit: Scalars['Int'];
+  offset: Scalars['Int'];
 }>;
 
 
-export type ViewAllUpdatesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, actor?: { __typename?: 'Robot', firstName?: string | null, id: string } | { __typename?: 'User', username: string, id: string } | null }> }> } } };
+export type ViewAllUpdatesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, actor?: { __typename?: 'Robot', firstName?: string | null, id: string } | { __typename?: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string } }> } } };
 
 export type ViewBranchUpdatesQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -4544,7 +4552,7 @@ export type ViewBranchUpdatesQueryVariables = Exact<{
 }>;
 
 
-export type ViewBranchUpdatesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, actor?: { __typename?: 'Robot', firstName?: string | null, id: string } | { __typename?: 'User', username: string, id: string } | null }> } | null } } };
+export type ViewBranchUpdatesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, actor?: { __typename?: 'Robot', firstName?: string | null, id: string } | { __typename?: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string } }> } | null } } };
 
 export type CurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/eas-cli/src/graphql/queries/BuildQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BuildQuery.ts
@@ -14,7 +14,7 @@ import {
 } from '../generated';
 import { BuildFragmentNode } from '../types/Build';
 
-type BuildsQuery = {
+export type BuildsQuery = {
   offset?: number;
   limit?: number;
   filter?: {

--- a/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
@@ -3,10 +3,14 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import { GetChannelByNameForAppQuery, GetChannelByNameForAppQueryVariables } from '../generated';
 
+const BRANCHES_LIMIT = 50;
+
 export const ChannelQuery = {
   async getUpdateChannelByNameForAppAsync({
     appId,
     channelName,
+    offset = 0,
+    limit = BRANCHES_LIMIT,
   }: GetChannelByNameForAppQueryVariables): Promise<
     GetChannelByNameForAppQuery['app']['byId']['updateChannelByName']
   > {
@@ -18,7 +22,12 @@ export const ChannelQuery = {
       graphqlClient
         .query<GetChannelByNameForAppQuery, GetChannelByNameForAppQueryVariables>(
           gql`
-            query GetChannelByNameForApp($appId: String!, $channelName: String!) {
+            query GetChannelByNameForApp(
+              $appId: String!
+              $channelName: String!
+              $limit: Int!
+              $offset: Int!
+            ) {
               app {
                 byId(appId: $appId) {
                   id
@@ -27,10 +36,10 @@ export const ChannelQuery = {
                     name
                     createdAt
                     branchMapping
-                    updateBranches(offset: 0, limit: 1000) {
+                    updateBranches(offset: $offset, limit: $limit) {
                       id
                       name
-                      updates(offset: 0, limit: 10) {
+                      updates(offset: 0, limit: 1) {
                         id
                         group
                         message
@@ -53,7 +62,7 @@ export const ChannelQuery = {
               }
             }
           `,
-          { appId, channelName },
+          { appId, channelName, offset, limit },
           { additionalTypenames: ['UpdateChannel', 'UpdateBranch', 'Update'] }
         )
         .toPromise()

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -8,41 +8,41 @@ import {
   ViewBranchUpdatesQueryVariables,
 } from '../generated';
 
-export const viewBranchUpdatesQueryUpdateLimit = 300;
-
-type ViewBranchUpdatesQueryVariablesWithOptionalLimitAndOffset =
-  Partial<ViewBranchUpdatesQueryVariables> &
-    Pick<ViewBranchUpdatesQueryVariables, 'appId' | 'name'>;
+const UPDATE_LIMIT = 50;
 
 export const UpdateQuery = {
-  async viewAllAsync({ appId }: { appId: string }): Promise<ViewAllUpdatesQuery> {
+  async viewAllAsync({
+    appId,
+    limit = UPDATE_LIMIT,
+    offset = 0,
+  }: ViewAllUpdatesQueryVariables): Promise<ViewAllUpdatesQuery> {
     return withErrorHandlingAsync(
       graphqlClient
         .query<ViewAllUpdatesQuery, ViewAllUpdatesQueryVariables>(
           gql`
-            query ViewAllUpdates($appId: String!, $limit: Int!) {
+            query ViewAllUpdates($appId: String!, $limit: Int!, $offset: Int!) {
               app {
                 byId(appId: $appId) {
                   id
-                  updateBranches(offset: 0, limit: $limit) {
+                  updates(offset: $offset, limit: $limit) {
                     id
-                    name
-                    updates(offset: 0, limit: $limit) {
+                    group
+                    message
+                    createdAt
+                    runtimeVersion
+                    platform
+                    actor {
                       id
-                      group
-                      message
-                      createdAt
-                      runtimeVersion
-                      platform
-                      actor {
-                        id
-                        ... on User {
-                          username
-                        }
-                        ... on Robot {
-                          firstName
-                        }
+                      ... on User {
+                        username
                       }
+                      ... on Robot {
+                        firstName
+                      }
+                    }
+                    branch {
+                      id
+                      name
                     }
                   }
                 }
@@ -51,7 +51,8 @@ export const UpdateQuery = {
           `,
           {
             appId,
-            limit: viewBranchUpdatesQueryUpdateLimit,
+            limit,
+            offset,
           },
           { additionalTypenames: ['UpdateBranch', 'Update'] }
         )
@@ -61,9 +62,9 @@ export const UpdateQuery = {
   async viewBranchAsync({
     appId,
     name,
-    limit = viewBranchUpdatesQueryUpdateLimit,
+    limit = UPDATE_LIMIT,
     offset = 0,
-  }: ViewBranchUpdatesQueryVariablesWithOptionalLimitAndOffset) {
+  }: ViewBranchUpdatesQueryVariables) {
     return withErrorHandlingAsync<ViewBranchUpdatesQuery>(
       graphqlClient
         .query<ViewBranchUpdatesQuery, ViewBranchUpdatesQueryVariables>(
@@ -91,6 +92,10 @@ export const UpdateQuery = {
                         ... on Robot {
                           firstName
                         }
+                      }
+                      branch {
+                        id
+                        name
                       }
                     }
                   }

--- a/packages/eas-cli/src/graphql/types/UpdateBranch.ts
+++ b/packages/eas-cli/src/graphql/types/UpdateBranch.ts
@@ -4,7 +4,7 @@ export const UpdateBranchFragmentNode = gql`
   fragment UpdateBranchFragment on UpdateBranch {
     id
     name
-    updates(offset: 0, limit: 10) {
+    updates(offset: 0, limit: 1) {
       id
       actor {
         __typename

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -49,6 +49,10 @@ export default class Log {
     Log.log(`${chalk.green(logSymbols.success)} ${message}`);
   }
 
+  public static withCross(...args: any[]): void {
+    Log.consoleLog(chalk.red(figures.cross), ...args);
+  }
+
   public static withTick(...args: any[]): void {
     Log.consoleLog(chalk.green(figures.tick), ...args);
   }

--- a/packages/eas-cli/src/update/utils.ts
+++ b/packages/eas-cli/src/update/utils.ts
@@ -36,11 +36,18 @@ export function getPlatformsForGroup({
     .join(', ');
 }
 
+export const truncateUpdateMessage = (originalMessage: string, length: number = 512): string => {
+  if (originalMessage.length > length) {
+    return originalMessage.substring(0, length - 3) + '...';
+  }
+  return originalMessage;
+};
+
 export function formatUpdate(update: FormatUpdateParameter): string {
   if (!update) {
     return 'N/A';
   }
-  const message = update.message ? `"${update.message}" ` : '';
+  const message = update.message ? `"${truncateUpdateMessage(update.message)}" ` : '';
   return `${message}(${format(update.createdAt, 'en_US')} by ${getActorDisplayName(
     update.actor as any
   )})`;

--- a/packages/eas-cli/src/utils/queries.ts
+++ b/packages/eas-cli/src/utils/queries.ts
@@ -1,0 +1,107 @@
+import { confirmAsync, selectAsync } from '../prompts';
+import uniqBy from './expodash/uniqBy';
+
+export type PaginatedQueryResponse<QueryReturnType extends Record<string, any>> = {
+  queryResponse: QueryReturnType[];
+  queryResponseRawLength: number;
+};
+
+export type PromptSelectionListItem = {
+  title: string;
+  value: string;
+};
+
+export type PaginatedQueryArguments<QueryReturnType extends Record<string, any>> = {
+  pageSize: number;
+  offset: number;
+  queryToPerform: (
+    pageSize: number,
+    offset: number
+  ) => Promise<PaginatedQueryResponse<QueryReturnType>>;
+  promptOptions: PaginatedQueryPromptOptions<QueryReturnType>;
+};
+
+export interface PaginatedQuerySelectPrompt<QueryReturnType extends Record<string, any>> {
+  readonly title: string;
+  readonly type: 'select';
+  createDisplayTextForSelectionPromptListItem: (queryItem: QueryReturnType) => string;
+  getIdentifierForQueryItem: (queryItem: QueryReturnType) => string;
+}
+
+export interface PaginatedQueryConfirmPrompt<QueryReturnType extends Record<string, any>> {
+  readonly type: 'confirm';
+  readonly title: string;
+  renderListItems: (currentPage: QueryReturnType[]) => void;
+}
+
+type PaginatedQueryPromptOptions<QueryReturnType extends Record<string, any>> =
+  | PaginatedQueryConfirmPrompt<QueryReturnType>
+  | PaginatedQuerySelectPrompt<QueryReturnType>;
+
+/**
+ * Return an empty array when the promptOptions type is PaginatedQueryConfirmPrompt
+ * Returns an array of the selected items when the promptOptions type is PaginatedQuerySelectPrompt
+ */
+export async function performPaginatedQueryAsync<QueryReturnType extends Record<string, any>>(
+  { pageSize, offset, queryToPerform, promptOptions }: PaginatedQueryArguments<QueryReturnType>,
+  accumulator?: QueryReturnType[]
+): Promise<QueryReturnType[]> {
+  const fetchMoreValue = '_fetchMore';
+
+  // query an extra item to determine if there are more pages left
+  const { queryResponse: items, queryResponseRawLength } = await queryToPerform(
+    pageSize + 1,
+    offset
+  );
+  const areMorePagesAvailable = queryResponseRawLength > pageSize;
+  // drop that extra item used for pagination from our render logic when extra pages are available
+  const currentPage = items.slice(0, areMorePagesAvailable ? items.length - 1 : undefined);
+  accumulator = [...(accumulator ?? []), ...currentPage];
+
+  let valueOfUserSelectedListItem = '';
+
+  if (promptOptions.type === 'confirm') {
+    promptOptions.renderListItems(currentPage);
+    if (areMorePagesAvailable) {
+      valueOfUserSelectedListItem = (await confirmAsync({ message: promptOptions.title }))
+        ? fetchMoreValue
+        : '';
+    }
+  } else {
+    const selectionPromptListItems = uniqBy(accumulator, queryItem =>
+      promptOptions.getIdentifierForQueryItem(queryItem)
+    ).map(queryItem => ({
+      title: promptOptions.createDisplayTextForSelectionPromptListItem(queryItem),
+      value: promptOptions.getIdentifierForQueryItem(queryItem),
+    }));
+    if (areMorePagesAvailable) {
+      selectionPromptListItems.push({ title: 'Next page...', value: fetchMoreValue });
+    }
+    if (selectionPromptListItems.length) {
+      valueOfUserSelectedListItem = await selectAsync<string>(
+        promptOptions.title,
+        selectionPromptListItems
+      );
+    }
+  }
+
+  if (valueOfUserSelectedListItem === fetchMoreValue) {
+    return await performPaginatedQueryAsync(
+      {
+        pageSize,
+        offset: offset + pageSize,
+        queryToPerform,
+        promptOptions,
+      },
+      accumulator
+    );
+  }
+
+  if (promptOptions.type === 'select') {
+    return accumulator.filter(
+      update => promptOptions.getIdentifierForQueryItem(update) === valueOfUserSelectedListItem
+    );
+  }
+
+  return [];
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Closes [ENG-5322](https://linear.app/expo/issue/ENG-5322/add-pagination-to-eas-cli-for-eas-update)

# How

Unfortunately, this is a pretty beefy PR 🐮 

IMO, we had two options to add pagination to our CLI. The first option was to copy something like the [aws-cli pagination options](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-pagination.html) and add flags for each command that control that logic (e.g. `--offset` and `--pageSize`). The second option was to create an interactive selector for each command, where users could select whether they wanted to fetch more pages.

The pros of the first option are its simplicity, and that it lends itself well to automation. The pros of the second option are that it's a nicer experience for humans, especially newer users, and that it doesn't force me to change the flags on a bunch of commands.

I ended up going with the second option.

I created a generic-ish function `performPaginatedQuery` that will operate on and return whatever `T` the caller provides (think GQL types like `BuildFragment` or `Update`). The function will recursively call itself while incrementing its offset until no more items are returned. I provided a callback where users can define how the specific query should be executed and what results should be saved from it.

`performPaginatedQuery` is accepts an arg `promptOptions` that is of type `confirm` or `select`. This controls how the user interacts with the CLI. `select` prompts require a user to select a list item and `performPaginatedQuery` return that value when the function finishes execution. `confirm` prompts require a user to approve querying for an additional page of items if there are more pages left, and return always an empty array of `QueryReturnType`. 

Shoutouts to @FiberJW who paired with me on some of this 👍 

# Test Plan

I manually tested each flow for each command that was affected. There's quite a bit here, so I may have missed some flow somewhere. Commands affected:
- branch/list.ts
- branch/view.ts
- build/cancel.ts
- build/list.ts
- channel/list.ts
- channel/rollout.ts
- channel/view.ts
- update/index.ts
- update/list.ts

+ `--non-interactive` + `--json` if those flags are applicable to those commands. (Assuming that prompting the user for input when `--json` is present will not break anything.)

## Preview Videos

### Confirm (list and view commands)

https://user-images.githubusercontent.com/15132641/177445637-91c35951-85a8-4597-b116-76d4767ef711.mov

### Select 

https://user-images.githubusercontent.com/15132641/177616248-3c8fdb7b-2a49-4f1c-a8e7-d56031511445.mov



