### PR TITLE
[eas-cli] allow applicationId override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Use `android/app/build.gradle` file to detect project workflow. ([#1203](https://github.com/expo/eas-cli/pull/1203) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🎉 New features
 
 - Show bundler output by default for eas update command. ([#1171](https://github.com/expo/eas-cli/pull/1171) by [@kgc00](https://github.com/kgc00/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add experimental `--resource-class` flag for Build commands. ([#1138](https://github.com/expo/eas-cli/pull/1138) by [@christopherwalter](https://github.com/christopherwalter))
 - Truncate long messages for `eas update` command, rather than failing. ([#1178](https://github.com/expo/eas-cli/pull/1178) by [@kgc00](https://github.com/kgc00))
 - Add review details to metadata store configuration. ([#1184](https://github.com/expo/eas-cli/pull/1184) by [@byCedric](https://github.com/byCedric))
+- Override applicationId via env. ([#1203](https://github.com/expo/eas-cli/pull/1203) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/env.ts
+++ b/packages/eas-cli/src/env.ts
@@ -4,8 +4,8 @@ export default {
    */
 
   /**
-   * Overrides applicationId read from android project, setting this option will also
-   * ignore failures when parsing build.gradle
+   * Overrides applicationId from Android project, setting this option will also
+   * ignore failures when parsing build.gradle.
    */
   overrideAndroidApplicationId: process.env.EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID,
 };

--- a/packages/eas-cli/src/env.ts
+++ b/packages/eas-cli/src/env.ts
@@ -1,0 +1,11 @@
+export default {
+  /**
+   * Dangerous overrides, use only if you know what you are doing
+   */
+
+  /**
+   * Overrides applicationId read from android project, setting this option will also
+   * ignore failures when parsing build.gradle
+   */
+  overrideAndroidApplicationId: process.env.EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID,
+};

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -7,6 +7,7 @@ import fs from 'fs-extra';
 import nullthrows from 'nullthrows';
 
 import { readAppJson } from '../../build/utils/appJson';
+import env from '../../env';
 import Log, { learnMore } from '../../log';
 import { getProjectConfigDescription, getUsername } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
@@ -43,6 +44,9 @@ export async function getApplicationIdFromBareAsync(
   projectDir: string,
   gradleContext?: GradleBuildContext
 ): Promise<string> {
+  if (env.overrideAndroidApplicationId) {
+    return env.overrideAndroidApplicationId;
+  }
   const errorMessage = 'Could not read applicationId from Android project.';
 
   if (gradleContext) {

--- a/packages/eas-cli/src/project/workflow.ts
+++ b/packages/eas-cli/src/project/workflow.ts
@@ -1,4 +1,4 @@
-import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
+import { IOSConfig } from '@expo/config-plugins';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 import path from 'path';
@@ -13,7 +13,7 @@ export async function resolveWorkflowAsync(
   try {
     platformWorkflowMarker =
       platform === Platform.ANDROID
-        ? await AndroidConfig.Paths.getAndroidManifestAsync(projectDir)
+        ? path.join(projectDir, 'android/app/build.gradle')
         : IOSConfig.Paths.getPBXProjectPath(projectDir);
   } catch {
     return Workflow.MANAGED;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Expo go build gradle is using more complicated logic that we can handle when parsing to extract applicationId.

# How

- Pass applicationId override via env.
- Change file that detects workflows to app/build.gradl.

# Test Plan


