### PR TITLE
[eas-cli] Fix asset upload crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix asset upload crash. ([#1205](https://github.com/expo/eas-cli/pull/1205) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 ## [0.55.0](https://github.com/expo/eas-cli/releases/tag/v0.55.0) - 2022-07-11

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -297,7 +297,7 @@ export async function uploadAssetsAsync(
     missingAssets.map((missingAsset, i) => {
       assetUploadPromiseLimit(async () => {
         const presignedPost: PresignedPost = JSON.parse(specifications[i]);
-        return uploadWithPresignedPostAsync(missingAsset.path, presignedPost);
+        await uploadWithPresignedPostAsync(missingAsset.path, presignedPost);
       });
     })
   );

--- a/packages/eas-cli/src/submit/__tests__/ArchiveSource-test.ts
+++ b/packages/eas-cli/src/submit/__tests__/ArchiveSource-test.ts
@@ -1,6 +1,7 @@
 import { Platform } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 import { vol } from 'memfs';
+import { Headers, Response } from 'node-fetch';
 import { v4 as uuidv4 } from 'uuid';
 
 import { AppPlatform, BuildFragment, UploadSessionType } from '../../graphql/generated';
@@ -242,7 +243,9 @@ describe(getArchiveAsync, () => {
   it('handles path source', async () => {
     const path = '/archive.apk';
     await fs.writeFile(path, 'some content');
-    jest.mocked(uploadAsync).mockResolvedValueOnce({ url: ARCHIVE_URL, bucketKey: 'wat' });
+
+    const response = new Response(undefined, { headers: new Headers([['location', ARCHIVE_URL]]) });
+    jest.mocked(uploadAsync).mockResolvedValueOnce({ response, bucketKey: 'wat' });
 
     const archive = await getArchiveAsync({
       ...SOURCE_STUB_INPUT,

--- a/packages/eas-cli/src/submit/utils/__tests__/files-test.ts
+++ b/packages/eas-cli/src/submit/utils/__tests__/files-test.ts
@@ -1,4 +1,4 @@
-import { fixArchiveUrl } from '../uploads';
+import { fixArchiveUrl } from '../files';
 
 describe(fixArchiveUrl, () => {
   it('fixes broken links', () => {

--- a/packages/eas-cli/src/submit/utils/files.ts
+++ b/packages/eas-cli/src/submit/utils/files.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { URL } from 'url';
 
 import { UploadSessionType } from '../../graphql/generated';
 import { uploadAsync } from '../../uploads';
@@ -15,7 +16,7 @@ export async function isExistingFileAsync(filePath: string): Promise<boolean> {
 
 export async function uploadAppArchiveAsync(path: string): Promise<string> {
   const fileSize = (await fs.stat(path)).size;
-  const { url } = await uploadAsync(
+  const { response } = await uploadAsync(
     UploadSessionType.EasSubmitAppArchive,
     path,
     createProgressTracker({
@@ -24,5 +25,18 @@ export async function uploadAppArchiveAsync(path: string): Promise<string> {
       completedMessage: 'Uploaded to EAS Submit',
     })
   );
-  return url;
+
+  const url = response.headers.get('location');
+  return fixArchiveUrl(String(url));
+}
+
+/**
+ * S3 returns broken URLs, sth like:
+ * https://submission-service-archives.s3.amazonaws.com/production%2Fdc98ca84-1473-4cb3-ae81-8c7b291cb27e%2F4424aa95-b985-4e2f-8755-9507b1037c1c
+ * This function replaces %2F with /.
+ */
+export function fixArchiveUrl(archiveUrl: string): string {
+  const parsed = new URL(archiveUrl);
+  parsed.pathname = decodeURIComponent(parsed.pathname);
+  return parsed.toString();
 }

--- a/packages/eas-cli/src/uploads.ts
+++ b/packages/eas-cli/src/uploads.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import FormData from 'form-data';
 import fs from 'fs-extra';
-import { URL } from 'url';
+import { Response } from 'node-fetch';
 
 import fetch from './fetch';
 import { UploadSessionType } from './graphql/generated';
@@ -12,18 +12,19 @@ export async function uploadAsync(
   type: UploadSessionType,
   path: string,
   handleProgressEvent: ProgressHandler
-): Promise<{ url: string; bucketKey: string }> {
+): Promise<{ response: Response; bucketKey: string }> {
   const presignedPost = await UploadSessionMutation.createUploadSessionAsync(type);
-  const url = await uploadWithPresignedPostAsync(path, presignedPost, handleProgressEvent);
   assert(presignedPost.fields.key, 'key is not specified in in presigned post');
-  return { url, bucketKey: presignedPost.fields.key };
+
+  const response = await uploadWithPresignedPostAsync(path, presignedPost, handleProgressEvent);
+  return { response, bucketKey: presignedPost.fields.key };
 }
 
 export async function uploadWithPresignedPostAsync(
   file: string,
   presignedPost: PresignedPost,
   handleProgressEvent?: ProgressHandler
-): Promise<string> {
+): Promise<Response> {
   const fileStat = await fs.stat(file);
   const fileSize = fileStat.size;
   const form = new FormData();
@@ -55,24 +56,12 @@ export async function uploadWithPresignedPostAsync(
     try {
       const response = await uploadPromise;
       handleProgressEvent({ isComplete: true });
-      return fixArchiveUrl(String(response.headers.get('location')));
+      return response;
     } catch (error: any) {
       handleProgressEvent({ isComplete: true, error });
       throw error;
     }
   } else {
-    const response = await uploadPromise;
-    return fixArchiveUrl(String(response.headers.get('location')));
+    return await uploadPromise;
   }
-}
-
-/**
- * S3 returns broken URLs, sth like:
- * https://submission-service-archives.s3.amazonaws.com/production%2Fdc98ca84-1473-4cb3-ae81-8c7b291cb27e%2F4424aa95-b985-4e2f-8755-9507b1037c1c
- * This function replaces %2F with /.
- */
-export function fixArchiveUrl(archiveUrl: string): string {
-  const parsed = new URL(archiveUrl);
-  parsed.pathname = decodeURIComponent(parsed.pathname);
-  return parsed.toString();
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://github.com/expo/eas-cli/commit/3d5b77a2638f91705134846817dcc3053ce6427e looks correct from a type point of view, but due to the weirdness of the method signature and casting to string, it unfortunately is crashing.

What would happen is that the `location` headers is sometimes not present in the response. Therefore it would pass the string `"null"` to `fixArchiveUrl`, which would throw in the `URL` constructor.

# How

The fix here is to stop doing this header extraction and string coercion when not necessary. It seems like maybe all the submission requests have `location` and only the asset ones don't?

# Test Plan

```
$ EXPO_DEBUG=1 ~/expo/eas-cli/packages/eas-cli/bin/run update --branch preview --message "Updating the app"
```

(this would have been tough to catch in an integration test since it is external-dependency dependent)