### PR TITLE
[eas-cli] Show spinner instead of silently timing out during asset upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Show spinner instead of silently timing out during asset upload. ([#1206](https://github.com/expo/eas-cli/pull/1206) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 - Increase max number of chained "extends" in build profiles. ([#1208](https://github.com/expo/eas-cli/pull/1208) by [@wkozyra95](https://github.com/wkozyra95))

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -437,13 +437,17 @@ export default class UpdatePublish extends EasCommand {
         }
       }
 
-      const assetSpinner = ora().start('Uploading assets...');
+      const assetSpinner = ora({ isEnabled: true }).start('Uploading assets...');
       try {
         const platforms = platformFlag === 'all' ? defaultPublishPlatforms : [platformFlag];
         const assets = await collectAssetsAsync({ inputDir: inputDir!, platforms });
         const { uniqueUploadedAssetCount } = await uploadAssetsAsync(
           assets,
-          spinnerText => (assetSpinner.text = `Uploading assets... ${spinnerText}`)
+          (totalAssets, missingAssets) => {
+            assetSpinner.text = `Uploading assets. Finished (${
+              totalAssets - missingAssets
+            }/${totalAssets})`;
+          }
         );
         uploadedAssetCount = uniqueUploadedAssetCount;
         unsortedUpdateInfoGroups = await buildUnsortedUpdateInfoGroupAsync(assets, exp);

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -437,7 +437,7 @@ export default class UpdatePublish extends EasCommand {
         }
       }
 
-      const assetSpinner = ora({ isEnabled: true }).start('Uploading assets...');
+      const assetSpinner = ora().start('Uploading assets...');
       try {
         const platforms = platformFlag === 'all' ? defaultPublishPlatforms : [platformFlag];
         const assets = await collectAssetsAsync({ inputDir: inputDir!, platforms });

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -9,7 +9,6 @@ import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import { PublishQuery } from '../../graphql/queries/PublishQuery';
 import {
   MetadataJoi,
-  TIMEOUT_LIMIT,
   buildUnsortedUpdateInfoGroupAsync,
   collectAssetsAsync,
   convertAssetToUpdateInfoGroupFormatAsync,
@@ -412,38 +411,6 @@ describe(uploadAssetsAsync, () => {
     return { specifications: ['{}', '{}', '{}'] };
   });
 
-  // beforeEach(() => {
-  //   jest.useFakeTimers();
-  // });
-  it('throws an error if the upload exceeds TIMEOUT_LIMIT', async () => {
-    jest.spyOn(PublishQuery, 'getAssetMetadataAsync').mockImplementation(async () => {
-      const status = AssetMetadataStatus.DoesNotExist;
-      mockdate.set(Date.now() + TIMEOUT_LIMIT + 1);
-      jest.runAllTimers();
-      return [
-        {
-          storageKey: 'qbgckgkgfdjnNuf9dQd7FDTWUmlEEzg7l1m1sKzQaq0',
-          status,
-          __typename: 'AssetMetadataResult',
-        }, // userDefinedAsset
-        {
-          storageKey: 'bbjgXFSIXtjviGwkaPFY0HG4dVVIGiXHAboRFQEqVa4',
-          status,
-          __typename: 'AssetMetadataResult',
-        }, // android.code
-        {
-          storageKey: 'dP-nC8EJXKz42XKh_Rc9tYxiGAT-ilpkRltEi6HIKeQ',
-          status,
-          __typename: 'AssetMetadataResult',
-        }, // ios.code
-      ];
-    });
-
-    mockdate.set(0);
-    await expect(uploadAssetsAsync(assetsForUpdateInfoGroup)).rejects.toThrow(
-      'Asset upload timed out. Please try again.'
-    );
-  });
   it('resolves if the assets are already uploaded', async () => {
     jest.spyOn(PublishQuery, 'getAssetMetadataAsync').mockImplementation(async () => {
       const status = AssetMetadataStatus.Exists;
@@ -530,15 +497,15 @@ describe(uploadAssetsAsync, () => {
         }, // ios.code
       ];
     });
-    const updateSpinnerFn = jest.fn(_text => {});
+    const updateSpinnerFn = jest.fn((_totalAssets, _missingAssets) => {});
 
     mockdate.set(0);
     await uploadAssetsAsync(assetsForUpdateInfoGroup, updateSpinnerFn);
     const calls = updateSpinnerFn.mock.calls;
     expect(calls).toEqual([
-      ['6 assets present'],
-      ['3 unique assets found'],
-      ['2 new assets uploading'],
+      [3, 3],
+      [3, 2],
+      [3, 0],
     ]);
   });
 });

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -15,8 +15,6 @@ import { uploadWithPresignedPostAsync } from '../uploads';
 import { expoCommandAsync } from '../utils/expoCli';
 import uniqBy from '../utils/expodash/uniqBy';
 
-export const TIMEOUT_LIMIT = 60_000; // 1 minute
-
 export type PublishPlatform = Extract<'android' | 'ios', Platform>;
 type Metadata = {
   version: number;
@@ -255,7 +253,7 @@ type AssetUploadResult = {
 
 export async function uploadAssetsAsync(
   assetsForUpdateInfoGroup: CollectedAssets,
-  updateSpinnerText?: (updatedText: string) => void
+  updateSpinnerText?: (totalAssets: number, missingAssets: number) => void
 ): Promise<AssetUploadResult> {
   let assets: RawAsset[] = [];
   let platform: keyof CollectedAssets;
@@ -266,7 +264,6 @@ export async function uploadAssetsAsync(
       ...assetsForUpdateInfoGroup[platform]!.assets,
     ];
   }
-  updateSpinnerText?.(`${assets.length} ${assets.length === 1 ? 'asset' : 'assets'} present`);
 
   const assetsWithStorageKey = await Promise.all(
     assets.map(async asset => {
@@ -281,15 +278,18 @@ export async function uploadAssetsAsync(
       storageKey: string;
     }
   >(assetsWithStorageKey, asset => asset.storageKey);
-  updateSpinnerText?.(
-    `${uniqueAssets.length} unique ${uniqueAssets.length === 1 ? 'asset' : 'assets'} found`
-  );
+
+  const totalAssets = uniqueAssets.length;
+
+  updateSpinnerText?.(totalAssets, totalAssets);
 
   let missingAssets = await filterOutAssetsThatAlreadyExistAsync(uniqueAssets);
   const uniqueUploadedAssetCount = missingAssets.length;
   const { specifications } = await PublishMutation.getUploadURLsAsync(
     missingAssets.map(ma => ma.contentType)
   );
+
+  updateSpinnerText?.(totalAssets, missingAssets.length);
 
   const assetUploadPromiseLimit = promiseLimit(15);
 
@@ -302,21 +302,13 @@ export async function uploadAssetsAsync(
     })
   );
 
-  updateSpinnerText?.(
-    `${missingAssets.length} new ${missingAssets.length === 1 ? 'asset' : 'assets'} uploading`
-  );
-  // Wait up to TIMEOUT_LIMIT for assets to be uploaded and processed
-  const start = Date.now();
   let timeout = 1;
   while (missingAssets.length > 0) {
     const timeoutPromise = new Promise(resolve => setTimeout(resolve, timeout * 1000)); // linear backoff
     missingAssets = await filterOutAssetsThatAlreadyExistAsync(missingAssets);
     await timeoutPromise; // await after filterOutAssetsThatAlreadyExistAsync for easy mocking with jest.runAllTimers
     timeout += 1;
-
-    if (Date.now() - start > TIMEOUT_LIMIT) {
-      throw new Error('Asset upload timed out. Please try again.');
-    }
+    updateSpinnerText?.(totalAssets, missingAssets.length);
   }
   return {
     assetCount: assets.length,

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -304,7 +304,9 @@ export async function uploadAssetsAsync(
 
   let timeout = 1;
   while (missingAssets.length > 0) {
-    const timeoutPromise = new Promise(resolve => setTimeout(resolve, timeout * 1000)); // linear backoff
+    const timeoutPromise = new Promise(resolve =>
+      setTimeout(resolve, Math.min(timeout * 1000, 5000))
+    ); // linear backoff
     missingAssets = await filterOutAssetsThatAlreadyExistAsync(missingAssets);
     await timeoutPromise; // await after filterOutAssetsThatAlreadyExistAsync for easy mocking with jest.runAllTimers
     timeout += 1;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Now that we are allowing more assets to be uploaded, this timeout no longer makes sense. Instead, this PR shows a spinner (progress) to let people ctrl-c when they deem it to be stalled.

Closes ENG-5706.

# How

Add spinner.

<img width="280" alt="Screen Shot 2022-07-11 at 5 13 01 PM" src="https://user-images.githubusercontent.com/189568/178379546-cdaa384a-f0a9-493e-9562-39d6172c819c.png">

# Test Plan

```
$ EXPO_DEBUG=1 ~/expo/eas-cli/packages/eas-cli/bin/run update --branch preview --message "Updating the app"
```
with an app with ~700 assets.