### PR TITLE
fix S3 upload URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Show spinner instead of silently timing out during asset upload. ([#1206](https://github.com/expo/eas-cli/pull/1206) by [@wschurman](https://github.com/wschurman))
+- Fix build archive S3 URLs. ([#1207](https://github.com/expo/eas-cli/pull/1207) by [@dsokal](https://github.com/dsokal))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/__tests__/uploads-test.ts
+++ b/packages/eas-cli/src/__tests__/uploads-test.ts
@@ -1,17 +1,17 @@
-import { fixArchiveUrl } from '../files';
+import { fixS3Url } from '../uploads';
 
-describe(fixArchiveUrl, () => {
+describe(fixS3Url, () => {
   it('fixes broken links', () => {
     const input =
       'https://submission-service-archives.s3.amazonaws.com/production%2Fdc98ca84-1473-4cb3-ae81-8c7b291cb27e%2F4424aa95-b985-4e2f-8755-9507b1037c1c';
     const expectedOutput =
       'https://submission-service-archives.s3.amazonaws.com/production/dc98ca84-1473-4cb3-ae81-8c7b291cb27e/4424aa95-b985-4e2f-8755-9507b1037c1c';
-    expect(fixArchiveUrl(input)).toBe(expectedOutput);
+    expect(fixS3Url(input)).toBe(expectedOutput);
   });
 
   it('does not change correct urls', () => {
     const correctUrl =
       'https://submission-service-archives.s3.amazonaws.com/production/dc98ca84-1473-4cb3-ae81-8c7b291cb27e/4424aa95-b985-4e2f-8755-9507b1037c1c';
-    expect(fixArchiveUrl(correctUrl)).toBe(correctUrl);
+    expect(fixS3Url(correctUrl)).toBe(correctUrl);
   });
 });

--- a/packages/eas-cli/src/submit/__tests__/ArchiveSource-test.ts
+++ b/packages/eas-cli/src/submit/__tests__/ArchiveSource-test.ts
@@ -1,7 +1,6 @@
 import { Platform } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 import { vol } from 'memfs';
-import { Headers, Response } from 'node-fetch';
 import { v4 as uuidv4 } from 'uuid';
 
 import { AppPlatform, BuildFragment, UploadSessionType } from '../../graphql/generated';
@@ -244,8 +243,7 @@ describe(getArchiveAsync, () => {
     const path = '/archive.apk';
     await fs.writeFile(path, 'some content');
 
-    const response = new Response(undefined, { headers: new Headers([['location', ARCHIVE_URL]]) });
-    jest.mocked(uploadAsync).mockResolvedValueOnce({ response, bucketKey: 'wat' });
+    jest.mocked(uploadAsync).mockResolvedValueOnce({ url: ARCHIVE_URL, bucketKey: 'wat' });
 
     const archive = await getArchiveAsync({
       ...SOURCE_STUB_INPUT,

--- a/packages/eas-cli/src/submit/utils/files.ts
+++ b/packages/eas-cli/src/submit/utils/files.ts
@@ -1,5 +1,4 @@
 import fs from 'fs-extra';
-import { URL } from 'url';
 
 import { UploadSessionType } from '../../graphql/generated';
 import { uploadAsync } from '../../uploads';
@@ -16,7 +15,7 @@ export async function isExistingFileAsync(filePath: string): Promise<boolean> {
 
 export async function uploadAppArchiveAsync(path: string): Promise<string> {
   const fileSize = (await fs.stat(path)).size;
-  const { response } = await uploadAsync(
+  const { url } = await uploadAsync(
     UploadSessionType.EasSubmitAppArchive,
     path,
     createProgressTracker({
@@ -25,18 +24,5 @@ export async function uploadAppArchiveAsync(path: string): Promise<string> {
       completedMessage: 'Uploaded to EAS Submit',
     })
   );
-
-  const url = response.headers.get('location');
-  return fixArchiveUrl(String(url));
-}
-
-/**
- * S3 returns broken URLs, sth like:
- * https://submission-service-archives.s3.amazonaws.com/production%2Fdc98ca84-1473-4cb3-ae81-8c7b291cb27e%2F4424aa95-b985-4e2f-8755-9507b1037c1c
- * This function replaces %2F with /.
- */
-export function fixArchiveUrl(archiveUrl: string): string {
-  const parsed = new URL(archiveUrl);
-  parsed.pathname = decodeURIComponent(parsed.pathname);
-  return parsed.toString();
+  return url;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

- In https://github.com/expo/eas-cli/pull/1179 I broke uploading assets with `eas update`.
- In https://github.com/expo/eas-cli/pull/1205 Will broke my fix for build archive URLs.

# How

`uploadAsync` is meant for handling AWS S3 uploads (used for EAS Build and Submit). Moved fixing the upload location to the function. 

# Test Plan

I made sure three code paths for uploading files work fine:
- `eas build`
- `eas submit`
- `eas update`
