### PR TITLE
[eas-json] Increase max allowed profile extend chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Increase max number of chained "extends" in build profiles. ([#1208](https://github.com/expo/eas-cli/pull/1208) by [@wkozyra95](https://github.com/wkozyra95))
+
 ## [0.55.1](https://github.com/expo/eas-cli/releases/tag/v0.55.1) - 2022-07-12
 
 ### 🐛 Bug fixes

--- a/packages/eas-json/src/build/resolver.ts
+++ b/packages/eas-json/src/build/resolver.ts
@@ -34,7 +34,7 @@ function resolveProfile({
   profileName: string;
   depth?: number;
 }): EasJsonBuildProfileResolved {
-  if (depth >= 2) {
+  if (depth >= 5) {
     throw new Error(
       'Too long chain of profile extensions, make sure "extends" keys do not make a cycle'
     );


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

The current implementation allows only one base profile, but there is a lot of use cases where you might want to have more extends in a chain.

# How

Increase max number of build profiles in an extend chain to 5.

# Test Plan


