### PR TITLE
[cli] Change wording on build warning for bundle id/package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Increase max number of chained "extends" in build profiles. ([#1208](https://github.com/expo/eas-cli/pull/1208) by [@wkozyra95](https://github.com/wkozyra95))
+- Change wording on build warning for bundle id/package name. ([#1211](https://github.com/expo/eas-cli/pull/1211) by [@kbrandwijk](https://github.com/kbrandwijk))
 
 ## [0.55.1](https://github.com/expo/eas-cli/releases/tag/v0.55.1) - 2022-07-12
 

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -161,7 +161,7 @@ export function warnIfAndroidPackageDefinedInAppConfigForBareWorkflowProject(
     Log.warn(
       `Specified value for "android.package" in ${getProjectConfigDescription(
         projectDir
-      )} is ignored if native project folders are detected.\n` +
+      )} is ignored because native project folders were detected.\n` +
         'EAS Build will use the value found in the native code.'
     );
     warnPrinted = true;

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -159,10 +159,10 @@ export function warnIfAndroidPackageDefinedInAppConfigForBareWorkflowProject(
 ): void {
   if (AndroidConfig.Package.getPackage(exp) && !warnPrinted) {
     Log.warn(
-      `Specifying "android.package" in ${getProjectConfigDescription(
+      `Specified value for "android.package" in ${getProjectConfigDescription(
         projectDir
-      )} is deprecated for bare workflow projects.\n` +
-        'EAS Build depends only on the value in the native code. Please remove the deprecated configuration.'
+      )} is ignored if native project folders are detected.\n` +
+        'EAS Build will use the value found in the native code.'
     );
     warnPrinted = true;
   }

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -161,7 +161,7 @@ export function warnIfAndroidPackageDefinedInAppConfigForBareWorkflowProject(
     Log.warn(
       `Specified value for "android.package" in ${getProjectConfigDescription(
         projectDir
-      )} is ignored because native project folders were detected.\n` +
+      )} is ignored because an ${chalk.bold('android')} directory was detected in the project.\n` +
         'EAS Build will use the value found in the native code.'
     );
     warnPrinted = true;

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -152,10 +152,10 @@ export function warnIfBundleIdentifierDefinedInAppConfigForBareWorkflowProject(
 ): void {
   if (IOSConfig.BundleIdentifier.getBundleIdentifier(exp) && !warnPrinted) {
     Log.warn(
-      `Specifying "ios.bundleIdentifier" in ${getProjectConfigDescription(
+      `Specified value for "ios.bundleIdentifier" in ${getProjectConfigDescription(
         projectDir
-      )} is deprecated for bare workflow projects.\n` +
-        'EAS Build depends only on the value in the native code. Please remove the deprecated configuration.'
+      )} is ignored if native project folders are detected.\n` +
+        'EAS Build will use the value found in the native code.'
     );
     warnPrinted = true;
   }

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -154,7 +154,7 @@ export function warnIfBundleIdentifierDefinedInAppConfigForBareWorkflowProject(
     Log.warn(
       `Specified value for "ios.bundleIdentifier" in ${getProjectConfigDescription(
         projectDir
-      )} is ignored if native project folders are detected.\n` +
+      )} is ignored because an ${chalk.bold('ios')} directory was detected in the project.\n` +
         'EAS Build will use the value found in the native code.'
     );
     warnPrinted = true;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

The warning about package name / bundle identifier also shows up after running `expo prebuild` or `expo run`, in which case it's expected that app.json contains these fields. The warning that it will be ignored once the native code exists is okay, but the deprecation notice should be removed.

# How

Old vs new:
![image](https://user-images.githubusercontent.com/852069/179119613-5bf628fd-fd76-4fc3-bf06-50d2a2fbbef2.png)

# Test Plan

Tested by running `expo prebuild` followed by `eas build`.
