### PR TITLE
[ENG-5017] display queue type when waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Display build queue type when waiting. ([#1217](https://github.com/expo/eas-cli/pull/1217) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 - Show spinner instead of silently timing out during asset upload. ([#1206](https://github.com/expo/eas-cli/pull/1206) by [@wschurman](https://github.com/wschurman))

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -352,7 +352,7 @@ async function handleSingleBuildProgressAsync(
           );
         }
         Log.newLine();
-        Log.log('Waiting in queue');
+        Log.log(`Waiting in ${priorityToQueueDisplayName[build.priority]}`);
         queueProgressBar.start(
           build.initialQueuePosition + 1,
           build.initialQueuePosition - build.queuePosition + 1,
@@ -384,6 +384,12 @@ async function handleSingleBuildProgressAsync(
   }
   return { refetch: true };
 }
+
+const priorityToQueueDisplayName: Record<BuildPriority, string> = {
+  [BuildPriority.Normal]: 'Low Priority Queue',
+  [BuildPriority.NormalPlus]: 'High Priority Queue (free upgrade)',
+  [BuildPriority.High]: 'High Priority Queue',
+};
 
 const statusToDisplayName: Record<BuildStatus, string> = {
   [BuildStatus.New]: 'waiting to enter the queue (concurrency limit reached)',

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -386,9 +386,9 @@ async function handleSingleBuildProgressAsync(
 }
 
 const priorityToQueueDisplayName: Record<BuildPriority, string> = {
-  [BuildPriority.Normal]: 'Low Priority Queue',
-  [BuildPriority.NormalPlus]: 'High Priority Queue (free upgrade)',
-  [BuildPriority.High]: 'High Priority Queue',
+  [BuildPriority.Normal]: 'queue',
+  [BuildPriority.NormalPlus]: 'queue',
+  [BuildPriority.High]: 'priority queue',
 };
 
 const statusToDisplayName: Record<BuildStatus, string> = {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-5017/suggestion-display-queue-type-in-cli-when-waiting

# How

Display queue type when waiting.

# Test Plan
<img width="994" alt="Screenshot 2022-07-18 at 13 55 41" src="https://user-images.githubusercontent.com/5256730/179506352-9a8473bb-1fc6-4ea2-8c9e-e638ab40f4e4.png">