### PR TITLE
chore: add better message on how to self-upgrade eas-cli

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -166,7 +166,7 @@
     },
     "warn-if-update-available": {
       "timeoutInDays": 0.5,
-      "message": "<%= chalk.bold('★') %> <%= chalk.bold(config.name + '@' + latest) %> <%= chalk.bold('is now available.') %>\n<%= chalk('* To upgrade, run ') %><%= chalk.bold('npm install -g eas-cli') %><%= chalk('.') %>\n\n<%= chalk.dim('Proceeding with outdated version') %>"
+      "message": "<%= chalk('★') %> <%= chalk.bold(config.name + '@' + latest) %> <%= chalk.bold('is now available.') %>\n<%= chalk('* To upgrade, run ') %><%= chalk.bold('npm install -g eas-cli') %><%= chalk('.') %>\n\n<%= chalk.dim('Proceeding with outdated version') %>"
     },
     "update": {
       "node": {

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -166,7 +166,7 @@
     },
     "warn-if-update-available": {
       "timeoutInDays": 0.5,
-      "message": "<%= chalk.bold('★') %> <%= chalk.bold(config.name + '@' + latest) %> <%= chalk.bold('is now available, please upgrade.') %>\n<%= chalk.dim('Proceeding with outdated version') %>\n"
+      "message": "<%= chalk.bold('★') %> <%= chalk.bold(config.name + '@' + latest) %> <%= chalk.bold('is now available.') %>\n<%= chalk('* To upgrade, run ') %><%= chalk.bold('npm install -g eas-cli') %><%= chalk('.') %>\n\n<%= chalk.dim('Proceeding with outdated version') %>"
     },
     "update": {
       "node": {

--- a/packages/eas-cli/src/project/ensureProjectExists.ts
+++ b/packages/eas-cli/src/project/ensureProjectExists.ts
@@ -6,6 +6,7 @@ import { getProjectDashboardUrl } from '../build/utils/url';
 import { AppPrivacy } from '../graphql/generated';
 import { AppMutation } from '../graphql/mutations/AppMutation';
 import { ProjectQuery } from '../graphql/queries/ProjectQuery';
+import Log from '../log';
 import { ora } from '../ora';
 import { findAccountByName } from '../user/Account';
 import { ensureLoggedInAsync } from '../user/actions';
@@ -40,9 +41,11 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
     fallback: () => `${projectFullName} (${projectDashboardUrl})`,
   });
 
-  const spinner = ora(`Linking to project ${chalk.bold(projectFullName)}`).start();
+  Log.addNewLineIfNone();
 
+  const spinner = ora(`Linking to project ${chalk.bold(projectFullName)}`).start();
   const maybeId = await findProjectIdByAccountNameAndSlugNullableAsync(accountName, projectName);
+
   if (maybeId) {
     spinner.succeed(`Linked to project ${chalk.bold(projectLink)}`);
     projectCache[projectFullName] = maybeId;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

I always forget the command to upgrade CLIs. Some requires to run `brew`, other `npm`, some `yarn` or `curl`.

# How

- Add a one-line command on how to upgrade
- I specifically used `npm` to match expo-doc which also use `npm/npx` as default
- I also fixed the `addNewLineIfNone` usage. Looks like the new line added through package.json wasn't recognized by the util function that supposed to detect those. I instead removed it from package.json and added the `addNewLineIfNone` to the command coming after the upgrade message.

# Test Plan

~~Install an outdated eas-cli f.x. `npm install -g eas-cli@0.50.0`. Then run a command f.x. `eas build --profile development --platform ios`~~ (yeah well, not really, I had to manually change my global node_modules folder to preview the changes)

You will be prompt with the following message:
![Screenshot 2022-07-20 at 08 26 08](https://user-images.githubusercontent.com/937328/179936900-6eb34334-382e-4088-bc8b-1b2f0484472a.png)

/changelog-entry chore add better message on how to self-upgrade eas-cli