### PR TITLE
[eas-cli] Fix newlines in cli deprecation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Display build queue type when waiting. ([#1217](https://github.com/expo/eas-cli/pull/1217) by [@dsokal](https://github.com/dsokal))
-- Add better message on how to upgrade EAS CLI. ([#1222](https://github.com/expo/eas-cli/pull/1222) by [@jeremybarbet](https://github.com/jeremybarbet))
+- Add better message on how to upgrade EAS CLI. ([#1222](https://github.com/expo/eas-cli/pull/1222) by [@jeremybarbet](https://github.com/jeremybarbet), [#1231](https://github.com/expo/eas-cli/pull/1231) by [@wkozyra95](https://github.com/wkozyra95))
 - Invoke export with sourcemaps on update. ([#1228](https://github.com/expo/eas-cli/pull/1228) by [@kbrandwijk](https://github.com/kbrandwijk))
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -166,7 +166,7 @@
     },
     "warn-if-update-available": {
       "timeoutInDays": 0.5,
-      "message": "<%= chalk('★') %> <%= chalk.bold(config.name + '@' + latest) %> <%= chalk.bold('is now available.') %>\n<%= chalk('* To upgrade, run ') %><%= chalk.bold('npm install -g eas-cli') %><%= chalk('.') %>\n\n<%= chalk.dim('Proceeding with outdated version') %>"
+      "message": "<%= chalk('★') %> <%= chalk.bold(config.name + '@' + latest) %> <%= chalk.bold('is now available.') %>\n<%= chalk.dim('To upgrade, run ') %><%= chalk.dim(chalk.bold('npm install -g eas-cli')) %><%= chalk.dim('.') %>\n<%= chalk.dim('Proceeding with outdated version.') %>\n"
     },
     "update": {
       "node": {

--- a/packages/eas-cli/src/project/ensureProjectExists.ts
+++ b/packages/eas-cli/src/project/ensureProjectExists.ts
@@ -6,7 +6,6 @@ import { getProjectDashboardUrl } from '../build/utils/url';
 import { AppPrivacy } from '../graphql/generated';
 import { AppMutation } from '../graphql/mutations/AppMutation';
 import { ProjectQuery } from '../graphql/queries/ProjectQuery';
-import Log from '../log';
 import { ora } from '../ora';
 import { findAccountByName } from '../user/Account';
 import { ensureLoggedInAsync } from '../user/actions';
@@ -40,8 +39,6 @@ export async function ensureProjectExistsAsync(projectInfo: ProjectInfo): Promis
     // https://github.com/sindresorhus/terminal-link/issues/18#issuecomment-1068020361
     fallback: () => `${projectFullName} (${projectDashboardUrl})`,
   });
-
-  Log.addNewLineIfNone();
 
   const spinner = ora(`Linking to project ${chalk.bold(projectFullName)}`).start();
   const maybeId = await findProjectIdByAccountNameAndSlugNullableAsync(accountName, projectName);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Commit https://github.com/expo/eas-cli/commit/2bbf7f2b6d50db77127fa30e6f993da115f84c38 introduced newline before project is resolved which is adding a new line even if there was no output before it.
![20220725_11h03m01s_grim](https://user-images.githubusercontent.com/9753141/180743204-75c0eb09-10a1-4689-8bf6-6c3177209813.png)

Also, leading stars were using different symbol fo `*` which make it look inconsistent in different terminals

# How

![20220725_11h20m06s_grim](https://user-images.githubusercontent.com/9753141/180743411-58fb247a-7225-4fd6-90a0-e2cd89881a51.png)

# Test Plan


