### PR TITLE
Set Kirby and Will as codeowners for EAS Update CLI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,9 @@ packages/eas-cli/src/commands/build @dsokal @wkozyra95
 packages/eas-cli/src/submit @barthap @dsokal
 packages/eas-cli/src/commands/submit.ts @barthap @dsokal
 
+packages/eas-cli/src/update @kgc00 @wschurman
+packages/eas-cli/src/commands/update @kgc00 @wschurman
+
 packages/eas-cli/schema @bycedric
 packages/eas-cli/src/metadata @bycedric
 packages/eas-cli/src/commands/metadata @bycedric


### PR DESCRIPTION
Why
---
They have been working on EAS CLI for EAS Update the most. Set them as codeowners.
