### PR TITLE
[ENG-5622] allow importing devices from Apple Developer Portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Display build queue type when waiting. ([#1217](https://github.com/expo/eas-cli/pull/1217) by [@dsokal](https://github.com/dsokal))
 - Add better message on how to upgrade EAS CLI. ([#1222](https://github.com/expo/eas-cli/pull/1222) by [@jeremybarbet](https://github.com/jeremybarbet), [#1231](https://github.com/expo/eas-cli/pull/1231) by [@wkozyra95](https://github.com/wkozyra95))
 - Invoke export with sourcemaps on update. ([#1228](https://github.com/expo/eas-cli/pull/1228) by [@kbrandwijk](https://github.com/kbrandwijk))
+- Add new option to `eas device:create` - allow importing devices from Apple Developer Portal. ([#1236](https://github.com/expo/eas-cli/pull/1236) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -103,6 +103,7 @@
     "nock": "13.2.4",
     "tempy": "0.7.0",
     "ts-deepmerge": "2.0.1",
+    "ts-mockito": "2.6.1",
     "typescript": "4.7.4"
   },
   "engines": {

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
@@ -254,11 +254,11 @@ export class SetUpAdhocProvisioningProfile {
     ctx: CredentialsContext,
     appleTeam: AppleTeamFragment
   ): Promise<AppleDeviceFragment[]> {
-    const action = new DeviceCreateAction(this.app.account, appleTeam);
+    const action = new DeviceCreateAction(ctx.appStore, this.app.account, appleTeam);
     const method = await action.runAsync();
 
     while (true) {
-      if (method !== RegistrationMethod.INPUT) {
+      if (method === RegistrationMethod.WEBSITE) {
         Log.newLine();
         Log.log(chalk.bold("Press any key if you've already finished device registration."));
         await pressAnyKeyToContinueAsync();

--- a/packages/eas-cli/src/devices/actions/create/__mocks__/developerPortalMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/__mocks__/developerPortalMethod.ts
@@ -1,0 +1,1 @@
+export const runDeveloperPortalMethodAsync = jest.fn();

--- a/packages/eas-cli/src/devices/actions/create/__tests__/action-test.ts
+++ b/packages/eas-cli/src/devices/actions/create/__tests__/action-test.ts
@@ -1,13 +1,17 @@
 import prompts from 'prompts';
+import { instance, mock } from 'ts-mockito';
 
+import AppStoreApi from '../../../../credentials/ios/appstore/AppStoreApi';
 import { Account } from '../../../../user/Account';
 import DeviceCreateAction, { RegistrationMethod } from '../action';
+import { runDeveloperPortalMethodAsync } from '../developerPortalMethod';
 import { runInputMethodAsync } from '../inputMethod';
 import { runRegistrationUrlMethodAsync } from '../registrationUrlMethod';
 
 jest.mock('prompts');
-jest.mock('../registrationUrlMethod');
+jest.mock('../developerPortalMethod');
 jest.mock('../inputMethod');
+jest.mock('../registrationUrlMethod');
 
 beforeEach(() => {
   const promptsMock = jest.mocked(prompts);
@@ -25,6 +29,8 @@ describe(DeviceCreateAction, () => {
       jest.mocked(prompts).mockImplementationOnce(async () => ({
         method: RegistrationMethod.WEBSITE,
       }));
+      const appStoreApiMock = mock<AppStoreApi>();
+      const appStoreApi = instance(appStoreApiMock);
 
       const account: Account = {
         id: 'account_id',
@@ -35,7 +41,7 @@ describe(DeviceCreateAction, () => {
         appleTeamIdentifier: 'ABC123Y',
         appleTeamName: 'John Doe (Individual)',
       };
-      const action = new DeviceCreateAction(account, appleTeam);
+      const action = new DeviceCreateAction(appStoreApi, account, appleTeam);
       await action.runAsync();
 
       expect(runRegistrationUrlMethodAsync).toBeCalled();
@@ -45,6 +51,8 @@ describe(DeviceCreateAction, () => {
       jest.mocked(prompts).mockImplementationOnce(async () => ({
         method: RegistrationMethod.INPUT,
       }));
+      const appStoreApiMock = mock<AppStoreApi>();
+      const appStoreApi = instance(appStoreApiMock);
 
       const account: Account = {
         id: 'account_id',
@@ -55,10 +63,32 @@ describe(DeviceCreateAction, () => {
         appleTeamIdentifier: 'ABC123Y',
         appleTeamName: 'John Doe (Individual)',
       };
-      const action = new DeviceCreateAction(account, appleTeam);
+      const action = new DeviceCreateAction(appStoreApi, account, appleTeam);
       await action.runAsync();
 
       expect(runInputMethodAsync).toBeCalled();
+    });
+
+    it('calls runDeveloperPortalMethodAsync if user chooses the developer portal method', async () => {
+      jest.mocked(prompts).mockImplementationOnce(async () => ({
+        method: RegistrationMethod.DEVELOPER_PORTAL,
+      }));
+      const appStoreApiMock = mock<AppStoreApi>();
+      const appStoreApi = instance(appStoreApiMock);
+
+      const account: Account = {
+        id: 'account_id',
+        name: 'foobar',
+      };
+      const appleTeam = {
+        id: 'apple-team-id',
+        appleTeamIdentifier: 'ABC123Y',
+        appleTeamName: 'John Doe (Individual)',
+      };
+      const action = new DeviceCreateAction(appStoreApi, account, appleTeam);
+      await action.runAsync();
+
+      expect(runDeveloperPortalMethodAsync).toBeCalled();
     });
   });
 });

--- a/packages/eas-cli/src/devices/actions/create/developerPortalMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/developerPortalMethod.ts
@@ -1,0 +1,131 @@
+import { Device, DeviceClass } from '@expo/apple-utils';
+
+import { AppleDeviceMutation } from '../../../credentials/ios/api/graphql/mutations/AppleDeviceMutation';
+import {
+  AppleDeviceFragmentWithAppleTeam,
+  AppleDeviceQuery,
+} from '../../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
+import AppStoreApi from '../../../credentials/ios/appstore/AppStoreApi';
+import { getRequestContext } from '../../../credentials/ios/appstore/authenticate';
+import { AuthCtx } from '../../../credentials/ios/appstore/authenticateTypes';
+import { AppleDeviceClass, AppleTeam } from '../../../graphql/generated';
+import Log from '../../../log';
+import { ora } from '../../../ora';
+import { promptAsync } from '../../../prompts';
+import chunk from '../../../utils/expodash/chunk';
+
+const DEVICE_IMPORT_CHUNK_SIZE = 10;
+const DEVICE_CLASS_TO_GRAPHQL_TYPE: Partial<Record<DeviceClass, AppleDeviceClass>> = {
+  [DeviceClass.IPAD]: AppleDeviceClass.Ipad,
+  [DeviceClass.IPHONE]: AppleDeviceClass.Iphone,
+};
+
+export async function runDeveloperPortalMethodAsync(
+  appStoreApi: AppStoreApi,
+  accountId: string,
+  appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName' | 'id'>
+): Promise<void> {
+  const appleAuthCtx = await appStoreApi.ensureAuthenticatedAsync();
+  const unregisteredPortalDevices = await findUnregisteredPortalDevicesAsync(
+    appleAuthCtx,
+    accountId,
+    appleTeam
+  );
+  if (unregisteredPortalDevices.length === 0) {
+    Log.log('All your devices registered on Apple Developer Portal are already imported to EAS.');
+    return;
+  }
+  const devicesToImport = await chooseDevicesToImportAsync(unregisteredPortalDevices);
+  await importDevicesAsync(accountId, appleTeam, devicesToImport);
+}
+
+async function importDevicesAsync(
+  accountId: string,
+  appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName' | 'id'>,
+  devices: Device[]
+): Promise<void> {
+  const spinner = ora(
+    `Importing ${devices.length} Apple device${devices.length === 1 ? '' : 's'} to EAS`
+  ).start();
+  const deviceChunks = chunk(devices, DEVICE_IMPORT_CHUNK_SIZE);
+  try {
+    for (const deviceChunk of deviceChunks) {
+      await importDeviceChunkAsync(accountId, appleTeam, deviceChunk);
+    }
+  } catch (err) {
+    spinner.fail();
+    throw err;
+  }
+  spinner.succeed();
+}
+
+async function importDeviceChunkAsync(
+  accountId: string,
+  appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName' | 'id'>,
+  devices: Device[]
+): Promise<void> {
+  const promises = devices.map(device => {
+    return AppleDeviceMutation.createAppleDeviceAsync(
+      {
+        appleTeamId: appleTeam.id,
+        identifier: device.attributes.udid,
+        name: device.attributes.name,
+        deviceClass: DEVICE_CLASS_TO_GRAPHQL_TYPE[device.attributes.deviceClass] ?? undefined,
+      },
+      accountId
+    );
+  });
+  await Promise.all(promises);
+}
+
+async function findUnregisteredPortalDevicesAsync(
+  appleAuthCtx: AuthCtx,
+  accountId: string,
+  appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName' | 'id'>
+): Promise<Device[]> {
+  const expoRegisteredDevices = await AppleDeviceQuery.getAllByAppleTeamIdentifierAsync(
+    accountId,
+    appleTeam.appleTeamIdentifier,
+    { useCache: false }
+  );
+  const expoRegisteredDevicesByUdid = expoRegisteredDevices.reduce((acc, device) => {
+    acc[device.identifier] = device;
+    return acc;
+  }, {} as Record<string, AppleDeviceFragmentWithAppleTeam>);
+
+  const portalDevices = await Device.getAllIOSProfileDevicesAsync(getRequestContext(appleAuthCtx));
+  return portalDevices.filter(
+    portalDevice =>
+      !(portalDevice.attributes.udid in expoRegisteredDevicesByUdid) &&
+      [DeviceClass.IPAD, DeviceClass.IPHONE].includes(portalDevice.attributes.deviceClass)
+  );
+}
+
+async function chooseDevicesToImportAsync(devices: Device[]): Promise<Device[]> {
+  const { chosenDevices } = await promptAsync({
+    type: 'multiselect',
+    name: 'chosenDevices',
+    message: 'Which devices do you want to import to EAS?',
+    choices: devices.map(device => ({
+      value: device,
+      title: formatDeviceLabel(device),
+      selected: true,
+    })),
+  });
+  return chosenDevices;
+}
+
+export function formatDeviceLabel(device: Device): string {
+  const deviceDetails = formatDeviceDetails(device);
+  return `${device.attributes.name} - ${device.attributes.udid})${
+    deviceDetails !== '' ? ` - ${deviceDetails}` : ''
+  }`;
+}
+
+function formatDeviceDetails(device: Device): string {
+  let details: string = device.attributes.deviceClass;
+  if (device.attributes.model) {
+    details = device.attributes.model;
+  }
+  return details === '' ? details : `(${details})`;
+}

--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -29,12 +29,12 @@ export default class DeviceManager {
     Log.addNewLineIfNone();
 
     const account = await this.resolveAccountAsync();
-    const { team } = await this.ctx.appStore.ensureAuthenticatedAsync();
+    const appleAuthCtx = await this.ctx.appStore.ensureAuthenticatedAsync();
     const appleTeam = await ensureAppleTeamExistsAsync(account.id, {
-      appleTeamIdentifier: team.id,
-      appleTeamName: team.name,
+      appleTeamIdentifier: appleAuthCtx.team.id,
+      appleTeamName: appleAuthCtx.team.name,
     });
-    const action = new DeviceCreateAction(account, appleTeam);
+    const action = new DeviceCreateAction(this.ctx.appStore, account, appleTeam);
     await action.runAsync();
   }
 

--- a/packages/eas-cli/src/utils/expodash/__tests__/chunk-test.ts
+++ b/packages/eas-cli/src/utils/expodash/__tests__/chunk-test.ts
@@ -1,0 +1,19 @@
+import chunk from '../chunk';
+
+describe(chunk, () => {
+  it('works with an empty list', () => {
+    expect(chunk([])).toEqual([]);
+  });
+
+  it('works with list length undividable by chunk size', () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it('works with list length dividable by chunk size', () => {
+    expect(chunk([1, 2, 3, 4, 5, 6], 2)).toEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+});

--- a/packages/eas-cli/src/utils/expodash/chunk.ts
+++ b/packages/eas-cli/src/utils/expodash/chunk.ts
@@ -1,0 +1,12 @@
+export default function chunk<T>(list: T[], size = 1): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < list.length; i++) {
+    const isFirstElementInChunk = i % size === 0;
+    if (isFirstElementInChunk) {
+      result.push([list[i]]);
+    } else {
+      result[result.length - 1].push(list[i]);
+    }
+  }
+  return result;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8930,7 +8930,7 @@ lodash.without@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.21, lodash@^4.7.0, lodash@~4.17.0:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.7.0, lodash@~4.17.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -12131,6 +12131,13 @@ ts-log@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.3.tgz#4da5640fe25a9fb52642cd32391c886721318efb"
   integrity sha512-XvB+OdKSJ708Dmf9ore4Uf/q62AYDTzFcAdxc8KNML1mmAWywRFVt/dn1KYJH8Agt5UJNujfM3znU5PxgAzA2w==
+
+ts-mockito@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ts-mockito/-/ts-mockito-2.6.1.tgz#bc9ee2619033934e6fad1c4455aca5b5ace34e73"
+  integrity sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==
+  dependencies:
+    lodash "^4.17.5"
 
 ts-node@^9:
   version "9.0.0"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Adds a new option to `eas device:create`. It allows importing devices from Apple Developer Portal.

# How

Use `@expo/apple-utils` for fetching devices from Apple Developer Portal and display a multi-select for importing them to EAS.

# Test Plan


https://user-images.githubusercontent.com/5256730/181497915-9576425a-8f64-4b6f-a35d-216836bfa8b7.mov


https://user-images.githubusercontent.com/5256730/181497948-8cb76504-1d39-45d9-bc7c-b533d0038183.mov


