### PR TITLE
[ENG-5836] use commit message as default build message

### DIFF
--- a/packages/eas-cli/src/build/__tests__/metadata-test.ts
+++ b/packages/eas-cli/src/build/__tests__/metadata-test.ts
@@ -1,0 +1,40 @@
+import { instance, mock, when } from 'ts-mockito';
+
+import { Client } from '../../vcs/vcs';
+import { getFormattedCommitMessageAsync } from '../metadata';
+
+describe(getFormattedCommitMessageAsync, () => {
+  it(`returns undefined if it's not a git project`, async () => {
+    const clientMock = mock<Client>();
+    when(clientMock.getLastCommitMessageAsync()).thenResolve(null);
+    const client = instance(clientMock);
+
+    await expect(getFormattedCommitMessageAsync(client)).resolves.toBe(undefined);
+  });
+
+  it('returns commit message', async () => {
+    const clientMock = mock<Client>();
+    when(clientMock.getLastCommitMessageAsync()).thenResolve('lorem ipsum');
+    const client = instance(clientMock);
+
+    await expect(getFormattedCommitMessageAsync(client)).resolves.toBe('lorem ipsum');
+  });
+
+  it('trims long commit messages', async () => {
+    const clientMock = mock<Client>();
+    when(clientMock.getLastCommitMessageAsync()).thenResolve('a'.repeat(1500));
+    const client = instance(clientMock);
+
+    await expect(getFormattedCommitMessageAsync(client)).resolves.toBe(`${'a'.repeat(1021)}...`);
+  });
+
+  it('replaces new lines with spaces', async () => {
+    const clientMock = mock<Client>();
+    when(clientMock.getLastCommitMessageAsync()).thenResolve(`Lorem\nipsum\ndolor\nsit\namet`);
+    const client = instance(clientMock);
+
+    await expect(getFormattedCommitMessageAsync(client)).resolves.toBe(
+      `Lorem ipsum dolor sit amet`
+    );
+  });
+});

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -29,6 +29,8 @@ export async function collectMetadataAsync<T extends Platform>(
     ('simulator' in ctx.buildProfile && ctx.buildProfile.simulator
       ? 'simulator'
       : ctx.buildProfile.distribution) ?? 'store';
+
+  const vcsClient = getVcsClient();
   const metadata: Metadata = {
     trackingContext: ctx.trackingCtx,
     ...(await maybeResolveVersionsAsync(ctx)),
@@ -43,10 +45,10 @@ export async function collectMetadataAsync<T extends Platform>(
     appName: ctx.exp.name,
     appIdentifier: resolveAppIdentifier(ctx),
     buildProfile: ctx.buildProfileName,
-    gitCommitHash: await getVcsClient().getCommitHashAsync(),
-    isGitWorkingTreeDirty: await getVcsClient().hasUncommittedChangesAsync(),
+    gitCommitHash: await vcsClient.getCommitHashAsync(),
+    isGitWorkingTreeDirty: await vcsClient.hasUncommittedChangesAsync(),
     username: getUsername(ctx.exp, await ensureLoggedInAsync()),
-    message: ctx.message,
+    message: ctx.message ?? (await vcsClient.getLastCommitMessageAsync())?.trim() ?? undefined,
     ...(ctx.platform === Platform.IOS && {
       iosEnterpriseProvisioning: resolveIosEnterpriseProvisioning(
         ctx as BuildContext<Platform.IOS>


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

@wkozyra95 had an idea about defaulting the build message to the commit message of the last commit. It seems EAS Update has the same logic.

# How

Use the latest commit message if the user does not provide their own with `--message`.

# Test Plan

I ran `eas build` (without `--message`) and saw that the metadata object had the commit message for `message`.