### PR TITLE
[eas-cli] disallow .only from being commited

### DIFF
--- a/packages/eas-cli/.eslintrc.js
+++ b/packages/eas-cli/.eslintrc.js
@@ -2,6 +2,24 @@ const rootEslintrc = require('../../.eslintrc.js');
 
 module.exports = {
   rules: {
+    'no-restricted-properties': [
+      'warn',
+      {
+        object: 'it',
+        property: 'only',
+        message: 'it.only should not be committed to main.',
+      },
+      {
+        object: 'test',
+        property: 'only',
+        message: 'test.only should not be committed to main.',
+      },
+      {
+        object: 'describe',
+        property: 'only',
+        message: 'describe.only should not be committed to main.',
+      },
+    ],
     'no-restricted-imports': [
       'error',
       {

--- a/packages/eas-cli/src/utils/__tests__/queries-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/queries-test.ts
@@ -89,7 +89,7 @@ describe(paginatedQueryWithSelectPromptAsync.name, () => {
     jest.mocked(selectAsync).mockClear();
   });
 
-  it.each([
+  it.only.each([
     [10, 50],
     [77, 30],
   ])(

--- a/packages/eas-cli/src/utils/__tests__/queries-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/queries-test.ts
@@ -89,7 +89,7 @@ describe(paginatedQueryWithSelectPromptAsync.name, () => {
     jest.mocked(selectAsync).mockClear();
   });
 
-  it.only.each([
+  it.each([
     [10, 50],
     [77, 30],
   ])(


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Closes https://linear.app/expo/issue/ENG-5230/add-linter-error-if-only-is-present-on-eas-cli

# How

Updated the eslint config

# Test Plan

My first commit on this pr had a `.only` and the tests failed.
