### PR TITLE
[eas-cli] add asset limit warning on publish flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Managed app versions support. ([#1209](https://github.com/expo/eas-cli/pull/1209), [#1219](https://github.com/expo/eas-cli/pull/1219), [#1232](https://github.com/expo/eas-cli/pull/1232) by [@wkozyra95](https://github.com/wkozyra95))
+- Add a warning when publishing an update with too many assets. ([#1243](https://github.com/expo/eas-cli/pull/1243) by [@kgc00](https://github.com/kgc00))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -15082,6 +15082,49 @@
       },
       {
         "kind": "OBJECT",
+        "name": "CreateServerlessFunctionUploadUrlResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "formDataFields",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "CreateSubmissionResult",
         "description": null,
         "fields": [
@@ -21713,6 +21756,22 @@
             "deprecationReason": null
           },
           {
+            "name": "serverlessFunction",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ServerlessFunctionMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "submission",
             "description": "Mutations that modify an EAS Submit submission",
             "args": [],
@@ -22657,6 +22716,93 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ServerlessFunctionIdentifierInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "gitCommitSHA1",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ServerlessFunctionMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "createUploadPresignedUrl",
+            "description": null,
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "serverlessFunctionIdentifierInput",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ServerlessFunctionIdentifierInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CreateServerlessFunctionUploadUrlResult",
+                "ofType": null
               }
             },
             "isDeprecated": false,

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -6046,6 +6046,22 @@
             "deprecationReason": null
           },
           {
+            "name": "assetLimitPerUpdateGroup",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildJobs",
             "description": null,
             "args": [
@@ -11253,22 +11269,6 @@
         "description": null,
         "fields": [
           {
-            "name": "assetLimitPerUpdateGroup",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "getSignedAssetUploadSpecifications",
             "description": "Returns an array of specifications for upload. Each URL is valid for an hour.\nThe content type of the asset you wish to upload must be specified.",
             "args": [
@@ -12040,6 +12040,18 @@
             "type": {
               "kind": "ENUM",
               "name": "BuildResourceClass",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "runFromCI",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "isDeprecated": false,
@@ -13274,6 +13286,30 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "runFromCI",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "runWithNoWaitFlag",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -11253,6 +11253,22 @@
         "description": null,
         "fields": [
           {
+            "name": "assetLimitPerUpdateGroup",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "getSignedAssetUploadSpecifications",
             "description": "Returns an array of specifications for upload. Each URL is valid for an hour.\nThe content type of the asset you wish to upload must be specified.",
             "args": [

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -448,11 +448,15 @@ export default class UpdatePublish extends EasCommand {
       try {
         const platforms = platformFlag === 'all' ? defaultPublishPlatforms : [platformFlag];
         const assets = await collectAssetsAsync({ inputDir: inputDir!, platforms });
-        const uploadResults = await uploadAssetsAsync(assets, (totalAssets, missingAssets) => {
-          assetSpinner.text = `Uploading assets. Finished (${
-            totalAssets - missingAssets
-          }/${totalAssets})`;
-        });
+        const uploadResults = await uploadAssetsAsync(
+          assets,
+          projectId,
+          (totalAssets, missingAssets) => {
+            assetSpinner.text = `Uploading assets. Finished (${
+              totalAssets - missingAssets
+            }/${totalAssets})`;
+          }
+        );
         uploadedAssetCount = uploadResults.uniqueUploadedAssetCount;
         assetLimitPerUpdateGroup = uploadResults.assetLimitPerUpdateGroup;
         unsortedUpdateInfoGroups = await buildUnsortedUpdateInfoGroupAsync(assets, exp);

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -43,8 +43,8 @@ import {
   buildBundlesAsync,
   buildUnsortedUpdateInfoGroupAsync,
   collectAssetsAsync,
+  isUploadedAssetCountAboveWarningThreshold,
   uploadAssetsAsync,
-  uploadedAssetCountIsAboveWarningThreshold,
 } from '../../project/publish';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { confirmAsync, promptAsync, selectAsync } from '../../prompts';
@@ -605,14 +605,14 @@ export default class UpdatePublish extends EasCommand {
         );
         Log.addNewLineIfNone();
         if (
-          uploadedAssetCountIsAboveWarningThreshold(uploadedAssetCount, assetLimitPerUpdateGroup)
+          isUploadedAssetCountAboveWarningThreshold(uploadedAssetCount, assetLimitPerUpdateGroup)
         ) {
           Log.warn(
-            `This update group contains ${uploadedAssetCount} assets and is nearing or beyond the server cap of ${assetLimitPerUpdateGroup}\n` +
+            `This update group contains ${uploadedAssetCount} assets and is nearing or beyond the server cap of ${assetLimitPerUpdateGroup}.\n` +
               `${learnMore('https://docs.expo.dev/eas-update/optimize-assets/', {
                 learnMoreMessage: 'Consider optimizing your usage of assets',
                 dim: false,
-              })}`
+              })}.`
           );
           Log.addNewLineIfNone();
         }

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -612,7 +612,7 @@ export default class UpdatePublish extends EasCommand {
           isUploadedAssetCountAboveWarningThreshold(uploadedAssetCount, assetLimitPerUpdateGroup)
         ) {
           Log.warn(
-            `This update group contains ${uploadedAssetCount} assets and is nearing or beyond the server cap of ${assetLimitPerUpdateGroup}.\n` +
+            `This update group contains ${uploadedAssetCount} assets and is nearing the server cap of ${assetLimitPerUpdateGroup}.\n` +
               `${learnMore('https://docs.expo.dev/eas-update/optimize-assets/', {
                 learnMoreMessage: 'Consider optimizing your usage of assets',
                 dim: false,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1661,6 +1661,7 @@ export enum AssetMetadataStatus {
 
 export type AssetMutation = {
   __typename?: 'AssetMutation';
+  assetLimitPerUpdateGroup: Scalars['Int'];
   /**
    * Returns an array of specifications for upload. Each URL is valid for an hour.
    * The content type of the asset you wish to upload must be specified.
@@ -4581,7 +4582,7 @@ export type GetSignedUploadMutationVariables = Exact<{
 }>;
 
 
-export type GetSignedUploadMutation = { __typename?: 'RootMutation', asset: { __typename?: 'AssetMutation', getSignedAssetUploadSpecifications: { __typename?: 'GetSignedAssetUploadSpecificationsResult', specifications: Array<string> } } };
+export type GetSignedUploadMutation = { __typename?: 'RootMutation', asset: { __typename?: 'AssetMutation', assetLimitPerUpdateGroup: number, getSignedAssetUploadSpecifications: { __typename?: 'GetSignedAssetUploadSpecificationsResult', specifications: Array<string> } } };
 
 export type UpdatePublishMutationVariables = Exact<{
   publishUpdateGroupsInput: Array<PublishUpdateGroupInput> | PublishUpdateGroupInput;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2175,6 +2175,12 @@ export type CreateIosSubmissionInput = {
   submittedBuildId?: InputMaybe<Scalars['ID']>;
 };
 
+export type CreateServerlessFunctionUploadUrlResult = {
+  __typename?: 'CreateServerlessFunctionUploadUrlResult';
+  formDataFields: Scalars['JSONObject'];
+  url: Scalars['String'];
+};
+
 export type CreateSubmissionResult = {
   __typename?: 'CreateSubmissionResult';
   /** Created submission */
@@ -3137,6 +3143,7 @@ export type RootMutation = {
   me: MeMutation;
   /** Mutations that create, update, and delete Robots */
   robot: RobotMutation;
+  serverlessFunction: ServerlessFunctionMutation;
   /** Mutations that modify an EAS Submit submission */
   submission: SubmissionMutation;
   update: UpdateMutation;
@@ -3302,6 +3309,21 @@ export enum SecondFactorMethod {
 export type SecondFactorRegenerateBackupCodesResult = {
   __typename?: 'SecondFactorRegenerateBackupCodesResult';
   plaintextBackupCodes: Array<Scalars['String']>;
+};
+
+export type ServerlessFunctionIdentifierInput = {
+  gitCommitSHA1: Scalars['String'];
+};
+
+export type ServerlessFunctionMutation = {
+  __typename?: 'ServerlessFunctionMutation';
+  createUploadPresignedUrl: CreateServerlessFunctionUploadUrlResult;
+};
+
+
+export type ServerlessFunctionMutationCreateUploadPresignedUrlArgs = {
+  appId: Scalars['ID'];
+  serverlessFunctionIdentifierInput: ServerlessFunctionIdentifierInput;
 };
 
 export type Snack = Project & {
@@ -4730,12 +4752,12 @@ export type GetAssetMetadataQueryVariables = Exact<{
 
 export type GetAssetMetadataQuery = { __typename?: 'RootQuery', asset: { __typename?: 'AssetQuery', metadata: Array<{ __typename?: 'AssetMetadataResult', storageKey: string, status: AssetMetadataStatus }> } };
 
-export type GetAssetLimitForAppQueryVariables = Exact<{
+export type GetAssetLimitPerUpdateGroupForAppQueryVariables = Exact<{
   appId: Scalars['String'];
 }>;
 
 
-export type GetAssetLimitForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, assetLimitPerUpdateGroup: number } } };
+export type GetAssetLimitPerUpdateGroupForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, assetLimitPerUpdateGroup: number } } };
 
 export type SubmissionsByIdQueryVariables = Exact<{
   submissionId: Scalars['ID'];

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -894,6 +894,7 @@ export type App = Project & {
   androidAppCredentials: Array<AndroidAppCredentials>;
   /** ios.appStoreUrl field from most recent classic update manifest */
   appStoreUrl?: Maybe<Scalars['String']>;
+  assetLimitPerUpdateGroup: Scalars['Int'];
   buildJobs: Array<BuildJob>;
   /**
    * Coalesced Build (EAS) or BuildJob (Classic) items for this app.
@@ -1661,7 +1662,6 @@ export enum AssetMetadataStatus {
 
 export type AssetMutation = {
   __typename?: 'AssetMutation';
-  assetLimitPerUpdateGroup: Scalars['Int'];
   /**
    * Returns an array of specifications for upload. Each URL is valid for an hour.
    * The content type of the asset you wish to upload must be specified.
@@ -1752,6 +1752,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   reactNativeVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
   resourceClass?: Maybe<BuildResourceClass>;
+  runFromCI?: Maybe<Scalars['Boolean']>;
   runtimeVersion?: Maybe<Scalars['String']>;
   sdkVersion?: Maybe<Scalars['String']>;
   status: BuildStatus;
@@ -1902,6 +1903,8 @@ export type BuildMetadataInput = {
   message?: InputMaybe<Scalars['String']>;
   reactNativeVersion?: InputMaybe<Scalars['String']>;
   releaseChannel?: InputMaybe<Scalars['String']>;
+  runFromCI?: InputMaybe<Scalars['Boolean']>;
+  runWithNoWaitFlag?: InputMaybe<Scalars['Boolean']>;
   runtimeVersion?: InputMaybe<Scalars['String']>;
   sdkVersion?: InputMaybe<Scalars['String']>;
   trackingContext?: InputMaybe<Scalars['JSONObject']>;
@@ -4582,7 +4585,7 @@ export type GetSignedUploadMutationVariables = Exact<{
 }>;
 
 
-export type GetSignedUploadMutation = { __typename?: 'RootMutation', asset: { __typename?: 'AssetMutation', assetLimitPerUpdateGroup: number, getSignedAssetUploadSpecifications: { __typename?: 'GetSignedAssetUploadSpecificationsResult', specifications: Array<string> } } };
+export type GetSignedUploadMutation = { __typename?: 'RootMutation', asset: { __typename?: 'AssetMutation', getSignedAssetUploadSpecifications: { __typename?: 'GetSignedAssetUploadSpecificationsResult', specifications: Array<string> } } };
 
 export type UpdatePublishMutationVariables = Exact<{
   publishUpdateGroupsInput: Array<PublishUpdateGroupInput> | PublishUpdateGroupInput;
@@ -4726,6 +4729,13 @@ export type GetAssetMetadataQueryVariables = Exact<{
 
 
 export type GetAssetMetadataQuery = { __typename?: 'RootQuery', asset: { __typename?: 'AssetQuery', metadata: Array<{ __typename?: 'AssetMetadataResult', storageKey: string, status: AssetMetadataStatus }> } };
+
+export type GetAssetLimitForAppQueryVariables = Exact<{
+  appId: Scalars['String'];
+}>;
+
+
+export type GetAssetLimitForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, assetLimitPerUpdateGroup: number } } };
 
 export type SubmissionsByIdQueryVariables = Exact<{
   submissionId: Scalars['ID'];

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -3,25 +3,25 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import {
   CodeSigningInfoInput,
+  GetSignedUploadMutation,
+  GetSignedUploadMutationVariables,
   PublishUpdateGroupInput,
   SetCodeSigningInfoMutation,
   UpdatePublishMutation,
 } from '../generated';
 
 export const PublishMutation = {
-  async getUploadURLsAsync(contentTypes: string[]): Promise<{ specifications: string[] }> {
+  async getUploadURLsAsync(contentTypes: string[]): Promise<GetSignedUploadMutation['asset']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .mutation<
-          { asset: { getSignedAssetUploadSpecifications: { specifications: string[] } } },
-          { contentTypes: string[] }
-        >(
+        .mutation<GetSignedUploadMutation, GetSignedUploadMutationVariables>(
           gql`
             mutation GetSignedUploadMutation($contentTypes: [String!]!) {
               asset {
                 getSignedAssetUploadSpecifications(assetContentTypes: $contentTypes) {
                   specifications
                 }
+                assetLimitPerUpdateGroup
               }
             }
           `,
@@ -31,7 +31,7 @@ export const PublishMutation = {
         )
         .toPromise()
     );
-    return data.asset.getSignedAssetUploadSpecifications;
+    return data.asset;
   },
 
   async publishUpdateGroupAsync(

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -11,7 +11,9 @@ import {
 } from '../generated';
 
 export const PublishMutation = {
-  async getUploadURLsAsync(contentTypes: string[]): Promise<GetSignedUploadMutation['asset']> {
+  async getUploadURLsAsync(
+    contentTypes: string[]
+  ): Promise<GetSignedUploadMutation['asset']['getSignedAssetUploadSpecifications']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<GetSignedUploadMutation, GetSignedUploadMutationVariables>(
@@ -21,7 +23,6 @@ export const PublishMutation = {
                 getSignedAssetUploadSpecifications(assetContentTypes: $contentTypes) {
                   specifications
                 }
-                assetLimitPerUpdateGroup
               }
             }
           `,
@@ -31,9 +32,8 @@ export const PublishMutation = {
         )
         .toPromise()
     );
-    return data.asset;
+    return data.asset.getSignedAssetUploadSpecifications;
   },
-
   async publishUpdateGroupAsync(
     publishUpdateGroupsInput: PublishUpdateGroupInput[]
   ): Promise<UpdatePublishMutation['updateBranch']['publishUpdateGroups']> {

--- a/packages/eas-cli/src/graphql/queries/PublishQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/PublishQuery.ts
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import {
   AssetMetadataResult,
-  GetAssetLimitForAppQuery,
-  GetAssetLimitForAppQueryVariables,
+  GetAssetLimitPerUpdateGroupForAppQuery,
+  GetAssetLimitPerUpdateGroupForAppQueryVariables,
   GetAssetMetadataQuery,
 } from '../generated';
 
@@ -35,14 +35,17 @@ export const PublishQuery = {
     );
     return data.asset.metadata;
   },
-  async getAssetLimitAsync(
+  async getAssetLimitPerUpdateGroupAsync(
     appId: string
-  ): Promise<GetAssetLimitForAppQuery['app']['byId']['assetLimitPerUpdateGroup']> {
+  ): Promise<GetAssetLimitPerUpdateGroupForAppQuery['app']['byId']['assetLimitPerUpdateGroup']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<GetAssetLimitForAppQuery, GetAssetLimitForAppQueryVariables>(
+        .query<
+          GetAssetLimitPerUpdateGroupForAppQuery,
+          GetAssetLimitPerUpdateGroupForAppQueryVariables
+        >(
           gql`
-            query GetAssetLimitForApp($appId: String!) {
+            query GetAssetLimitPerUpdateGroupForApp($appId: String!) {
               app {
                 byId(appId: $appId) {
                   id
@@ -52,7 +55,7 @@ export const PublishQuery = {
             }
           `,
           { appId },
-          { additionalTypenames: [] }
+          { additionalTypenames: [] } // required arg
         )
         .toPromise()
     );

--- a/packages/eas-cli/src/graphql/queries/PublishQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/PublishQuery.ts
@@ -1,7 +1,12 @@
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
-import { AssetMetadataResult, GetAssetMetadataQuery } from '../generated';
+import {
+  AssetMetadataResult,
+  GetAssetLimitForAppQuery,
+  GetAssetLimitForAppQueryVariables,
+  GetAssetMetadataQuery,
+} from '../generated';
 
 export const PublishQuery = {
   async getAssetMetadataAsync(storageKeys: string[]): Promise<AssetMetadataResult[]> {
@@ -29,5 +34,28 @@ export const PublishQuery = {
         .toPromise()
     );
     return data.asset.metadata;
+  },
+  async getAssetLimitAsync(
+    appId: string
+  ): Promise<GetAssetLimitForAppQuery['app']['byId']['assetLimitPerUpdateGroup']> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<GetAssetLimitForAppQuery, GetAssetLimitForAppQueryVariables>(
+          gql`
+            query GetAssetLimitForApp($appId: String!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  assetLimitPerUpdateGroup
+                }
+              }
+            }
+          `,
+          { appId },
+          { additionalTypenames: [] }
+        )
+        .toPromise()
+    );
+    return data.app.byId.assetLimitPerUpdateGroup;
   },
 };

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -415,7 +415,9 @@ describe(uploadAssetsAsync, () => {
     return { specifications: ['{}', '{}', '{}'] };
   });
 
-  jest.spyOn(PublishQuery, 'getAssetLimitAsync').mockImplementation(async () => expectedAssetLimit);
+  jest
+    .spyOn(PublishQuery, 'getAssetLimitPerUpdateGroupAsync')
+    .mockImplementation(async () => expectedAssetLimit);
 
   it('resolves if the assets are already uploaded', async () => {
     jest.spyOn(PublishQuery, 'getAssetMetadataAsync').mockImplementation(async () => {

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -325,8 +325,8 @@ export async function uploadAssetsAsync(
 
 export function isUploadedAssetCountAboveWarningThreshold(
   uploadedAssetCount: number,
-  maxAssetsPerUpdate: number
+  assetLimitPerUpdateGroup: number
 ): boolean {
-  const warningThreshold = Math.floor(maxAssetsPerUpdate * 0.75);
+  const warningThreshold = Math.floor(assetLimitPerUpdateGroup * 0.75);
   return uploadedAssetCount > warningThreshold;
 }

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -296,7 +296,7 @@ export async function uploadAssetsAsync(
   const assetUploadPromiseLimit = promiseLimit(15);
 
   const [assetLimitPerUpdateGroup] = await Promise.all([
-    PublishQuery.getAssetLimitAsync(projectId),
+    PublishQuery.getAssetLimitPerUpdateGroupAsync(projectId),
     missingAssets.map((missingAsset, i) => {
       assetUploadPromiseLimit(async () => {
         const presignedPost: PresignedPost = JSON.parse(specifications[i]);

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -7,7 +7,7 @@ import mime from 'mime';
 import path from 'path';
 import promiseLimit from 'promise-limit';
 
-import { AppPlatform, AssetMetadataStatus, PartialManifestAsset } from '../graphql/generated';
+import { AssetMetadataStatus, PartialManifestAsset } from '../graphql/generated';
 import { PublishMutation } from '../graphql/mutations/PublishMutation';
 import { PresignedPost } from '../graphql/mutations/UploadSessionMutation';
 import { PublishQuery } from '../graphql/queries/PublishQuery';
@@ -322,7 +322,7 @@ export async function uploadAssetsAsync(
   };
 }
 
-export function uploadedAssetCountIsAboveWarningThreshold(
+export function isUploadedAssetCountAboveWarningThreshold(
   uploadedAssetCount: number,
   maxAssetsPerUpdate: number
 ): boolean {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Closes https://linear.app/expo/issue/ENG-5245/show-a-warning-when-publishing-updates-with-too-many-assets

# How

Uploading assets during a publish now returns the `assetLimitPerUpdateGroup` field. We use it to determine if we should render a warning message. 

# Test Plan

Ran locally with a hardcoded value to see the warning message.