### PR TITLE
[ENG-5893] add runWithNoWaitFlag and runFromCI to build metadata

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -15705,6 +15705,12 @@
             "deprecationReason": null
           },
           {
+            "name": "UNIQUE_UPDATERS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "UNIQUE_USERS",
             "description": null,
             "isDeprecated": false,
@@ -25149,6 +25155,12 @@
           },
           {
             "name": "REQUEST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UPDATE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/config": "6.0.23",
     "@expo/config-plugins": "4.1.4",
     "@expo/config-types": "45.0.0",
-    "@expo/eas-build-job": "0.2.84",
+    "@expo/eas-build-job": "0.2.85",
     "@expo/eas-json": "0.57.0",
     "@expo/json-file": "8.2.36",
     "@expo/multipart-body-parser": "1.1.0",

--- a/packages/eas-cli/src/analytics/events.ts
+++ b/packages/eas-cli/src/analytics/events.ts
@@ -29,6 +29,8 @@ export enum BuildEvent {
   CONFIGURE_PROJECT_SUCCESS = 'build cli configure project success',
   CONFIGURE_PROJECT_FAIL = 'build cli configure project fail',
   BUILD_REQUEST_ATTEMPT = 'build cli build request attempt',
+  BUILD_REQUEST_CI = 'build cli build request ci',
+  BUILD_REQUEST_NO_WAIT = 'build cli build request no wait',
   BUILD_REQUEST_SUCCESS = 'build cli build request success',
   BUILD_REQUEST_FAIL = 'build cli build request fail',
 

--- a/packages/eas-cli/src/analytics/events.ts
+++ b/packages/eas-cli/src/analytics/events.ts
@@ -29,8 +29,6 @@ export enum BuildEvent {
   CONFIGURE_PROJECT_SUCCESS = 'build cli configure project success',
   CONFIGURE_PROJECT_FAIL = 'build cli configure project fail',
   BUILD_REQUEST_ATTEMPT = 'build cli build request attempt',
-  BUILD_REQUEST_CI = 'build cli build request ci',
-  BUILD_REQUEST_NO_WAIT = 'build cli build request no wait',
   BUILD_REQUEST_SUCCESS = 'build cli build request success',
   BUILD_REQUEST_FAIL = 'build cli build request fail',
 

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -36,6 +36,7 @@ export interface BuildContext<T extends Platform> {
   exp: ExpoConfig;
   localBuildOptions: LocalBuildOptions;
   nonInteractive: boolean;
+  noWait: boolean;
   platform: T;
   projectDir: string;
   projectId: string;

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -37,6 +37,7 @@ export interface BuildContext<T extends Platform> {
   localBuildOptions: LocalBuildOptions;
   nonInteractive: boolean;
   noWait: boolean;
+  runFromCI: boolean;
   platform: T;
   projectDir: string;
   projectId: string;

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -74,8 +74,8 @@ export async function createBuildContextAsync<T extends Platform>({
     project_id: projectId,
     project_type: workflow,
     ...devClientProperties,
-    noWait,
-    runFromCI,
+    no_wait: noWait,
+    run_from_ci: runFromCI,
   };
   Analytics.logEvent(BuildEvent.BUILD_COMMAND, trackingCtx);
 

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -24,7 +24,8 @@ export async function createBuildContextAsync<T extends Platform>({
   easJsonCliConfig,
   clearCache = false,
   localBuildOptions,
-  nonInteractive = false,
+  nonInteractive,
+  noWait,
   platform,
   projectDir,
   resourceClass,
@@ -36,6 +37,7 @@ export async function createBuildContextAsync<T extends Platform>({
   clearCache: boolean;
   localBuildOptions: LocalBuildOptions;
   nonInteractive: boolean;
+  noWait: boolean;
   platform: T;
   projectDir: string;
   resourceClass: BuildResourceClass;
@@ -84,6 +86,7 @@ export async function createBuildContextAsync<T extends Platform>({
     exp,
     localBuildOptions,
     nonInteractive,
+    noWait,
     platform,
     projectDir,
     projectId,

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -74,14 +74,10 @@ export async function createBuildContextAsync<T extends Platform>({
     project_id: projectId,
     project_type: workflow,
     ...devClientProperties,
+    noWait,
+    runFromCI,
   };
   Analytics.logEvent(BuildEvent.BUILD_COMMAND, trackingCtx);
-  if (noWait) {
-    Analytics.logEvent(BuildEvent.BUILD_REQUEST_NO_WAIT, trackingCtx);
-  }
-  if (runFromCI) {
-    Analytics.logEvent(BuildEvent.BUILD_REQUEST_CI, trackingCtx);
-  }
 
   const commonContext: CommonContext<T> = {
     accountName,

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -2,7 +2,6 @@ import { Updates } from '@expo/config-plugins';
 import { Metadata, Platform, sanitizeMetadata } from '@expo/eas-build-job';
 import { IosEnterpriseProvisioning } from '@expo/eas-json';
 import fs from 'fs-extra';
-import getenv from 'getenv';
 import resolveFrom from 'resolve-from';
 
 import Log from '../log';
@@ -58,7 +57,7 @@ export async function collectMetadataAsync<T extends Platform>(
       ),
     }),
     runWithNoWaitFlag: ctx.noWait,
-    runFromCI: getenv.boolish('CI', false),
+    runFromCI: ctx.runFromCI,
   };
   return sanitizeMetadata(metadata);
 }

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -2,6 +2,7 @@ import { Updates } from '@expo/config-plugins';
 import { Metadata, Platform, sanitizeMetadata } from '@expo/eas-build-job';
 import { IosEnterpriseProvisioning } from '@expo/eas-json';
 import fs from 'fs-extra';
+import getenv from 'getenv';
 import resolveFrom from 'resolve-from';
 
 import Log from '../log';
@@ -56,6 +57,8 @@ export async function collectMetadataAsync<T extends Platform>(
         ctx as BuildContext<Platform.IOS>
       ),
     }),
+    runWithNoWaitFlag: ctx.noWait,
+    runFromCI: getenv.boolish('CI', false),
   };
   return sanitizeMetadata(metadata);
 }

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -206,6 +206,7 @@ async function prepareAndStartBuildAsync({
     clearCache: flags.clearCache,
     buildProfile: buildProfile.profile,
     nonInteractive: flags.nonInteractive,
+    noWait: !flags.wait,
     platform: buildProfile.platform,
     projectDir,
     localBuildOptions: flags.localBuildOptions,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2289,6 +2289,7 @@ export enum EasServiceMetric {
   BandwidthUsage = 'BANDWIDTH_USAGE',
   Builds = 'BUILDS',
   ManifestRequests = 'MANIFEST_REQUESTS',
+  UniqueUpdaters = 'UNIQUE_UPDATERS',
   UniqueUsers = 'UNIQUE_USERS'
 }
 
@@ -3673,6 +3674,7 @@ export enum UsageMetricType {
   Bandwidth = 'BANDWIDTH',
   Build = 'BUILD',
   Request = 'REQUEST',
+  Update = 'UPDATE',
   User = 'USER'
 }
 

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.dev>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/eas-build-job": "0.2.84",
+    "@expo/eas-build-job": "0.2.85",
     "@expo/json-file": "8.2.36",
     "chalk": "4.1.2",
     "env-string": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,10 +1269,10 @@
     slugify "^1.3.4"
     sucrase "^3.20.0"
 
-"@expo/eas-build-job@0.2.84":
-  version "0.2.84"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.84.tgz#d5b423ee1ee828b21c9b6bee611dfd97728da5d4"
-  integrity sha512-e4OHxRUz2DeZWOsQkNWyAbJUGfOE6O2dH1/hEyzWeXew9kPrDr/u/aKAYicwOiZACiikBl+x7bOAIdoZuOz7uA==
+"@expo/eas-build-job@0.2.85":
+  version "0.2.85"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.85.tgz#b5dd12a23943b67139dc47322428b9e1958f6804"
+  integrity sha512-iPvj8ntlevBwaHw00Qj+36L1MDZk6GygjPcV8QldaWeDVjdypu9ZcX+UqYoFmQFiLZYEfwm2s89MDEwQJvNn+A==
   dependencies:
     joi "^17.4.2"
     semver "^7.3.5"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We want to track whether the build was run with the `--no-wait` flag and/or from CI environment.

# How

- Send new metadata to www.
- Send `BUILD_REQUEST_NO_WAIT` / `BUILD_REQUEST_CI` events.

# Test Plan

I ran 2 builds:
- `eas build`
- `CI=1 eas build --no-wait`

and checked the metadata was set correctly.