### PR TITLE
[eas-json] move eas.json schema to eas-cli repo

### DIFF
--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -1,0 +1,478 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema",
+  "type": "object",
+  "description": "The EAS config (eas.json) validation and documentation.",
+  "meta": {
+    "updatedAt": "2022-07-18T15:00:00.000Z"
+  },
+  "properties": {
+    "cli": {
+      "$ref": "#/definitions/Cli"
+    },
+    "build": {
+      "$ref": "#/definitions/Build"
+    },
+    "submit": {
+      "$ref": "#/definitions/Submit"
+    }
+  },
+  "definitions": {
+    "Cli": {
+      "type": "object",
+      "description": "Configure the basic behavior of your project with the EAS CLI",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The compatible versions of EAS CLI with this config",
+          "examples": [
+            ">=0.54.1"
+          ]
+        },
+        "requireCommit": {
+          "type": "boolean",
+          "description": "If all changes required to be committed before building or submitting"
+        },
+        "appVersionSource": {
+          "enum": [
+            "local",
+            "remote"
+          ],
+          "markdownDescription": "Version policy defines whether version of your app should be based on your local project or values stored on EAS servers (remote).\n\nThis is the configuration required for `eas build:version:set` and works with the `autoIncrement` options per platform.",
+          "markdownEnumDescriptions": [
+            "When using local, the `autoIncrement` is based on your local project values.",
+            "When using remote, the `autoIncrement` is based on the values stored on EAS servers."
+          ]
+        }
+      }
+    },
+    "Build": {
+      "type": "object",
+      "description": "EAS Build configuration. Learn more: https://docs.expo.dev/build-reference/eas-json/",
+      "markdownDescription": "EAS Build configuration. [Learn more](https://docs.expo.dev/build-reference/eas-json/)",
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/BuildProfile"
+        }
+      }
+    },
+    "BuildCache": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "description": "Disables caching. Defaults to false."
+        },
+        "key": {
+          "type": "string",
+          "description": "Cache key. You can invalidate the cache by changing this value."
+        },
+        "customPaths": {
+          "type": "array",
+          "description": "List of the paths that will be saved after a successful build and restored at the beginning of the next one.",
+          "markdownDescription": "List of the paths that will be saved after a successful build and restored at the beginning of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with `eas.json`.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "cacheDefaultPaths": {
+          "type": "boolean",
+          "description": "Specifies whether to cache the recommended set of files, currently only Podfile.lock is cached by default for iOS build and nothing is cached for Android.",
+          "default": true
+        }
+      }
+    },
+    "BuildProfile": {
+      "type": "object",
+      "description": "The build profile configuration.",
+      "properties": {
+        "extends": {
+          "type": "string",
+          "description": "The name of the build profile that the current one should inherit values from. This value can't be specified per platform."
+        },
+        "credentialsSource": {
+          "enum": [
+            "remote",
+            "local"
+          ],
+          "description": "The source of credentials used to sign build artifacts. Learn more: https://docs.expo.dev/app-signing/local-credentials/",
+          "markdownDescription": "The source of credentials used to sign build artifacts.\n\n- `remote` - if you want to use the credentials managed by EAS.\n- `local` - if you want to provide your own `credentials.json` file. [learn more](https://docs.expo.dev/app-signing/local-credentials/)",
+          "default": "remote",
+          "markdownEnumDescriptions": [
+            "Use the credentials managed by EAS.",
+            "Provide your own `credentials.json` file. [learn more](https://docs.expo.dev/app-signing/local-credentials/)"
+          ]
+        },
+        "releaseChannel": {
+          "type": "string",
+          "description": "Name of the release channel for the `expo-updates` package. Learn more: https://docs.expo.dev/distribution/release-channels/",
+          "markdownDescription": "Name of the release channel for the `expo-updates` package. [Learn more](https://docs.expo.dev/distribution/release-channels/)\n\nIf you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.\n\n**This field only applies to the Classic Update service**; if you use EAS Update, use the [channel](https://docs.expo.dev/build-reference/eas-json/#channel) field instead.",
+          "pattern": "^[a-z0-9._-]+$",
+          "patternErrorMessage": "Release channel names can only contain lowercase letters, numbers and special characters `.`, `_` and `-`."
+        },
+        "channel": {
+          "type": "string",
+          "description": "The channel is a name we can give to multiple builds to identify them easily. Learn more: https://docs.expo.dev/eas-update/how-eas-update-works/",
+          "markdownDescription": "The channel is a name we can give to multiple builds to identify them easily. [Learn more](https://docs.expo.dev/eas-update/how-eas-update-works/)\n\n**This field only applies to the EAS Update service**, if your project still uses Classic Updates then use the [releaseChannel](https://docs.expo.dev/build-reference/eas-json/#releasechannel) field instead."
+        },
+        "distribution": {
+          "enum": [
+            "store",
+            "internal"
+          ],
+          "description": "The method of distributing your app. Learn more: https://docs.expo.dev/build/internal-distribution/",
+          "markdownDescription": "The method of distributing your app.\n\n- `internal` - with this option you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK or IPA file. Otherwise, the shareable URL will be useless. [Learn more](https://docs.expo.dev/build/internal-distribution/)\n- `store` - produces builds for store uploads, your build URLs won't be shareable.",
+          "markdownEnumDescriptions": [
+            "With this option you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK or IPA file. Otherwise, the shareable URL will be useless. [Learn more](https://docs.expo.dev/build/internal-distribution/)",
+            "Produces builds for store uploads, your build URLs won't be shareable."
+          ]
+        },
+        "developmentClient": {
+          "type": "boolean",
+          "description": "If set to true, this field expresses the intent to produce a development client build. Learn more: https://docs.expo.dev/development/introduction/",
+          "markdownDescription": "If set to true, this field expresses the intent to produce a development client build.\n\nFor the build to be successful, the project must have `expo-dev-client` installed and configured.\n> This field is sugar for setting the iOS `buildConfiguration` to `Debug` and Android `gradleCommand` to `:app:assembleDebug`. Those fields, if provided for the same build profile, will take precedence.\n\n[Learn more](https://docs.expo.dev/development/introduction/)",
+          "default": false
+        },
+        "prebuildCommand": {
+          "type": "string",
+          "description": "Optional override of the prebuild command used by EAS. Learn more: https://docs.expo.dev/workflow/expo-cli/#expo-prebuild",
+          "markdownDescription": "Optional override of the prebuild command used by EAS.\n\nFor example, you can specify `prebuild --template example-template` to use a custom template.\n>`--platform` and `--non-interactive` will be added automatically by the build engine, so you do not need to specify them manually.\n\n[Learn more](https://docs.expo.dev/workflow/expo-cli/#expo-prebuild)"
+        },
+        "node": {
+          "type": "string",
+          "description": "The version of Node.js to use for the build. See: https://nodejs.org/en/about/releases/",
+          "markdownDescription": "The exact version of [Node.js](https://nodejs.org/en/about/releases/) to use for the build."
+        },
+        "yarn": {
+          "type": "string",
+          "description": "The version of Yarn to use for the build. See: https://www.npmjs.com/package/yarn",
+          "markdownDescription": "The exact version of [Yarn](https://www.npmjs.com/package/yarn) to use for the build."
+        },
+        "expoCli": {
+          "type": "string",
+          "description": "The version of `expo-cli` used to `prebuild` your app.",
+          "markdownDescription": "Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](https://docs.expo.dev/workflow/expo-cli/#expo-prebuild) your app. It does not have any effect on bare projects."
+        },
+        "env": {
+          "type": "object",
+          "description": "Environment variables that should be set during the build process.\n\nShould only be used for values that you would commit to your git repository, i.e. not passwords or secrets.",
+          "patternProperties": {
+            ".*": {
+              "type": "string",
+              "description": "This environment variable will be set during the build process."
+            }
+          }
+        },
+        "cache": {
+          "$ref": "#/definitions/BuildCache",
+          "description": "The cache configuration.",
+          "markdownDescription": "Cache configuration. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn't work well for `node_modules` because the cache is not local to the machine, so the download speed is similar to downloading from the npm registry."
+        },
+        "android": {
+          "$ref": "#/definitions/BuildProfileAndroid"
+        },
+        "ios": {
+          "$ref": "#/definitions/BuildProfileIos"
+        }
+      }
+    },
+    "BuildProfileAndroid": {
+      "type": "object",
+      "description": "The Android-specific build profile configuration.",
+      "properties": {
+        "withoutCredentials": {
+          "type": "boolean",
+          "description": "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository.",
+          "markdownDescription": "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository.",
+          "default": false
+        },
+        "image": {
+          "description": "Image with build environment. Learn more: https://docs.expo.dev/build-reference/infrastructure/",
+          "markdownDescription": "Image with build environment. [Learn more](https://docs.expo.dev/build-reference/infrastructure/)",
+          "default": "default",
+          "anyOf": [
+            {
+              "enum": [
+                "default",
+                "latest",
+                "stable",
+                "ubuntu-22.04-jdk-11-ndk-r21e",
+                "ubuntu-22.04-jdk-8-ndk-r21e",
+                "ubuntu-20.04-jdk-11-ndk-r21e",
+                "ubuntu-20.04-jdk-8-ndk-r21e",
+                "ubuntu-18.04-jdk-11-ndk-r19c",
+                "ubuntu-18.04-jdk-8-ndk-r19c"
+              ],
+              "markdownEnumDescriptions": [
+                "- React Native `>=0.68.0` - `ubuntu-20.04-jdk-11-ndk-r21e`\n- React Native `<0.68.0` - `ubuntu-18.04-jdk-8-ndk-r19c`",
+                "`ubuntu-22.04-jdk-11-ndk-r21e`",
+                "`ubuntu-20.04-jdk-11-ndk-r21e`"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "ndk": {
+          "type": "string",
+          "description": "The version of Android NDK."
+        },
+        "autoIncrement": {
+          "enum": [
+            false,
+            true,
+            "versionCode",
+            "version"
+          ],
+          "description": "Controls how EAS CLI bumps your application build version.",
+          "markdownDescription": "Controls how EAS CLI bumps your application build version.\n\nAllowed values:\n- `\"version\"` - the patch of `expo.version` is bumped (e.g. `1.2.3` -> `1.2.4`).\n- `\"versionCode\"` (or `true`) - `expo.android.versionCode` is bumped (e.g. `3` -> `4`).\n- `false` - versions won't be bumped automatically (default)\n\nIn the case of a bare project, it also updates versions in native code. `expo.version` corresponds to `versionName` and `expo.android.versionCode` to `versionCode` in the `build.gradle`. Google Play uses these values to identify the app build, `versionName` is the version visible to users, whereas `versionCode` defines the version number. The combination of those needs to be unique, so you can bump either of them.\n\nThis feature is not intended for use with dynamic configuration (app.config.js). EAS CLI will throw an error if you don't use app.json.",
+          "default": false,
+          "markdownEnumDescriptions": [
+            "Versions won't be bumped automatically (default).",
+            "`expo.android.versionCode` is bumped (e.g. `3` -> `4`).",
+            "`expo.android.versionCode` is bumped (e.g. `3` -> `4`).",
+            "The patch of `expo.version` is bumped (e.g. `1.2.3` -> `1.2.4`)."
+          ]
+        },
+        "buildType": {
+          "enum": ["app-bundle", "apk"],
+          "description": "Type of the artifact you want to build.",
+          "markdownDescription": "Type of the artifact you want to build. It controls what Gradle task will be used, can be overridden by `gradleCommand` or `developmentClient: true` option.\n- `app-bundle` - `:app:bundleRelease`\n- `apk` - `:app:assembleRelease`",
+          "markdownEnumDescriptions": [
+            "Gradle task `:app:bundleRelease` is used",
+            "Gradle task `:app:assembleRelease` is used"
+          ]
+        },
+        "gradleCommand": {
+          "type": "string",
+          "description": "Gradle task that will be used to build your project, e.g. `:app:assembleDebug` to build a debug binary.",
+          "markdownDescription": "Gradle task that will be used to build your project, e.g. `:app:assembleDebug` to build a debug binary.\n\nIt's not recommended unless you need to run a task that `buildType` does not support, it takes priority over `buildType` and `developmentClient`."
+        },
+        "artifactPath": {
+          "type": "string",
+          "description": "Path (or pattern) where EAS Build is going to look for the build artifacts. See: https://github.com/mrmlnc/fast-glob#pattern-syntax",
+          "markdownDescription": "Path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)).",
+          "default": "android/app/build/outputs/**/*.{apk,aab}"
+        }
+      }
+    },
+    "BuildProfileIos": {
+      "type": "object",
+      "description": "The iOS-specific build profile configuration.",
+      "properties": {
+        "simulator": {
+          "type": "boolean",
+          "description": "If set to true, creates build for simulator.",
+          "default": false
+        },
+        "enterpriseProvisioning": {
+          "enum": ["universal", "adhoc"],
+          "markdownDescription": "Provisioning method used for `\"distribution\": \"internal\"` when you have an Apple account with Apple Developer Enterprise Program membership.\n\nYou can choose if you want to use `adhoc` or `universal` provisioning. The latter is recommended as it does not require you to register each individual device. If you don't provide this option and you still authenticate with an enterprise team, you'll be prompted which provisioning method to use.",
+          "markdownEnumDescriptions": [
+            "Recommended as it does not require you to register each individual device"
+          ]
+        },
+        "autoIncrement": {
+          "enum": [
+            false,
+            true,
+            "buildNumber",
+            "version"
+          ],
+          "description": "Controls how EAS CLI bumps your application build version.",
+          "markdownDescription": "Controls how EAS CLI bumps your application build version.\n\nAllowed values:\n\n- `\"version\"` - the patch of `expo.version` is bumped (e.g. `1.2.3` -> `1.2.4`).\n- `\"buildNumber\"` (or `true`) - the last component of `expo.ios.buildNumber` is bumped (e.g. `1.2.3.39` -> `1.2.3.40`).\n- `false` - versions won't be bumped automatically (default)\n\nIn the case of a bare project, it also updates versions in native code. `expo.version` corresponds to `CFBundleShortVersionString` and `expo.ios.buildNumber` to `CFBundleVersion` in the `Info.plist`. The App Store is using those values to identify the app build, `CFBundleShortVersionString` is the version visible to users, whereas `CFBundleVersion` defines the build number. The combination of those needs to be unique, so you can bump either of them.\n\nThis feature is not intended for use with dynamic configuration (app.config.js). EAS CLI will throw an error if you don't use app.json.",
+          "default": false,
+          "markdownEnumDescriptions": [
+            "Versions won't be bumped automatically (default)",
+            "The last component of `expo.ios.buildNumber` is bumped (e.g. `1.2.3.39` -> `1.2.3.40`)",
+            "The last component of `expo.ios.buildNumber` is bumped (e.g. `1.2.3.39` -> `1.2.3.40`)",
+            "The patch of `expo.version` is bumped (e.g. `1.2.3` -> `1.2.4`)"
+          ]
+        },
+        "image": {
+          "description": "Image with build environment. Learn more: https://docs.expo.dev/build-reference/infrastructure/",
+          "markdownDescription": "Image with build environment. [Learn more](https://docs.expo.dev/build-reference/infrastructure/)",
+          "default": "default",
+          "anyOf": [
+            {
+              "enum": [
+                "default",
+                "latest",
+                "stable",
+                "macos-monterey-12.4-xcode-13.4",
+                "macos-monterey-12.3-xcode-13.3",
+                "macos-monterey-12.1-xcode-13.2",
+                "macos-big-sur-11.4-xcode-13.0",
+                "macos-big-sur-11.4-xcode-12.5"
+              ],
+              "markdownEnumDescriptions": [
+                "- Expo SDK `>=45` - `macos-monterey-12.3-xcode-13.3`\n- Expo SDK `<45` - `macos-big-sur-11.4-xcode-13.0`",
+                "`macos-monterey-12.4-xcode-13.4`",
+                "`macos-monterey-12.3-xcode-13.3`"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "bundler": {
+          "type": "string",
+          "description": "The version of bundler to use for the build. See: https://bundler.io/.",
+          "markdownDescription": "The version of [bundler](https://bundler.io/) to use for the build."
+        },
+        "fastlane": {
+          "type": "string",
+          "description": "The version of fastlane to use for the build. See: https://fastlane.tools/",
+          "markdownDescription": "The version of [fastlane](https://fastlane.tools/) to use for the build."
+        },
+        "cocoapods": {
+          "type": "string",
+          "description": "The version of CocoaPods to use for the build. See: https://cocoapods.org/",
+          "markdownDescription": "The version of [CocoaPods](https://cocoapods.org/) to use for the build."
+        },
+        "scheme": {
+          "type": "string",
+          "description": "Xcode project's scheme.",
+          "markdownDescription": "Xcode project's scheme.\n- managed project: does not have any effect\n- bare project\n  - If your project has multiple schemes, you should set this value.\n  - If the project has only one scheme, it will be detected automatically.\n  - If multiple schemes exist and this value is **not** set, EAS CLI will prompt you to select one of them."
+        },
+        "buildConfiguration": {
+          "type": "string",
+          "description": "Xcode project's Build Configuration.",
+          "markdownDescription": "Xcode project's Build Configuration.\n- managed project: \"Release\" or \"Debug\", defaults to \"Release\"\n- bare project: defaults to the value specified in the scheme\n\nIt takes priority over `developmentClient` field."
+        },
+        "artifactPath": {
+          "type": "string",
+          "description": "Path (or pattern) where EAS Build is going to look for the build artifacts. See: https://github.com/mrmlnc/fast-glob#pattern-syntax",
+          "markdownDescription": "Path (or pattern) where EAS Build is going to look for the build artifacts.\n\nEAS Build uses the `fast-glob` npm package for pattern matching, ([See their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)).\n\nYou should modify that path only if you are using a custom `Gymfile`.\n\nThe default is `ios/build/Build/Products/*-iphonesimulator/*.app` when building for simulator and `ios/build/*.ipa` in other cases."
+        }
+      }
+    },
+    "Submit": {
+      "type": "object",
+      "description": "EAS Submit configuration. Learn more: https://docs.expo.dev/submit/eas-json/",
+      "markdownDescription": "EAS Submit configuration. [Learn more](https://docs.expo.dev/submit/eas-json/)",
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/SubmitProfile",
+          "description": "The submit profile name with the configuration."
+        }
+      }
+    },
+    "SubmitProfile": {
+      "type": "object",
+      "properties": {
+        "extends": {
+          "type": "string",
+          "description": "The name of the submit profile that the current one should inherit values from."
+        },
+        "android": {
+          "$ref": "#/definitions/SubmitProfileAndroid"
+        },
+        "ios": {
+          "$ref": "#/definitions/SubmitProfileIos"
+        }
+      }
+    },
+    "SubmitProfileAndroid": {
+      "type": "object",
+      "description": "The Android-specific submit profile configuration.",
+      "properties": {
+        "serviceAccountKeyPath": {
+          "type": "string",
+          "description": "Path to the JSON file with service account key used to authenticate with Google Play. Learn more: https://expo.fyi/creating-google-service-account",
+          "markdownDescription": "Path to the JSON file with service account key used to authenticate with Google Play. [Learn more](https://expo.fyi/creating-google-service-account)"
+        },
+        "track": {
+          "enum": ["beta", "alpha", "internal", "production"],
+          "description": "The track of the application to use. Learn more: https://support.google.com/googleplay/android-developer/answer/9859348?hl=en",
+          "markdownDescription": "The [track of the application](https://support.google.com/googleplay/android-developer/answer/9859348?hl=en) to use.",
+          "markdownEnumDescriptions": [
+            "**Open testing** releases are available to testers on Google Play. Users can join tests from your store listing.",
+            "**Closed testing** releases are available to a limited number of testers that you choose, who can test a pre-release version of your app and submit feedback.",
+            "**Internal testing** releases are available to up to 100 testers that you choose.",
+            "**Production releases** are available to all Google Play users in your chosen countries."
+          ]
+        },
+        "releaseStatus": {
+          "enum": ["draft", "inProgress", "halted", "completed"],
+          "description": "The status of a release. Learn more: https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks",
+          "markdownDescription": "The status of a release. [Learn more](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks)",
+          "enumDescriptions": [
+            "The release's APKs are not being served to users.",
+            "The release's APKs are being served to a fraction of users, if set.",
+            "The release's APKs will no longer be served to users. Users who already have these APKs are unaffected.",
+            "The release will have no further changes. Its APKs are being served to all users, unless they are eligible to APKs of a more recent release."
+          ]
+        },
+        "changesNotSentForReview": {
+          "type": "boolean",
+          "description": "Indicates that the changes sent with this submission will not be reviewed until they are explicitly sent for review from the Google Play Console UI. Defaults to false.",
+          "default": false
+        },
+        "applicationId": {
+          "type": "string",
+          "description": "The application id that will be used when accessing Service Account Keys managed by Expo, it does not have any effect if you are using local credentials. In most cases this value will be autodetected, but if you have multiple product flavors, this value might be necessary."
+        }
+      }
+    },
+    "SubmitProfileIos": {
+      "type": "object",
+      "description": "The iOS-specific submit profile configuration.",
+      "properties": {
+        "appleId": {
+          "type": "string",
+          "description": "Your Apple ID username (you can also set the `EXPO_APPLE_ID` env variable).",
+          "markdownDescription": "Your Apple ID username (you can also set the `EXPO_APPLE_ID` env variable)."
+        },
+        "ascAppId": {
+          "type": "string",
+          "description": "App Store Connect unique application Apple ID number. When set, results in skipping the app creation step. Learn more: https://expo.fyi/asc-app-id",
+          "markdownDescription": "App Store Connect unique application Apple ID number. When set, results in skipping the app creation step. [Learn more](https://expo.fyi/asc-app-id)"
+        },
+        "appleTeamId": {
+          "type": "string",
+          "description": "Your Apple Developer Team ID."
+        },
+        "sku": {
+          "type": "string",
+          "description": "An unique ID for your app that is not visible on the App Store, will be generated unless provided."
+        },
+        "language": {
+          "type": "string",
+          "description": "Primary language. Defaults to `en-US`.",
+          "markdownDescription": "Primary language. Defaults to `en-US`."
+        },
+        "companyName": {
+          "type": "string",
+          "description": "The name of your company, needed only for the first submission of any app to the App Store."
+        },
+        "appName": {
+          "type": "string",
+          "description": "The name of your app as it will appear on the App Store. Defaults to `expo.name` from the app config.",
+          "markdownDescription": "The name of your app as it will appear on the App Store. Defaults to `expo.name` from the app config."
+        },
+        "ascApiKeyPath": {
+          "type": "string",
+          "description": "The path to your App Store Connect Api Key .p8 file. Learn more: https://expo.fyi/creating-asc-api-key",
+          "markdownDescription": "The path to your App Store Connect Api Key .p8 file. [Learn more](https://expo.fyi/creating-asc-api-key)"
+        },
+        "ascApiKeyIssuerId": {
+          "type": "string",
+          "description": "The Issuer ID of your App Store Connect Api Key. Learn more: https://expo.fyi/creating-asc-api-key",
+          "markdownDescription": "The Issuer ID of your App Store Connect Api Key. [Learn more](https://expo.fyi/creating-asc-api-key)"
+        },
+        "ascApiKeyId": {
+          "type": "string",
+          "description": "The Key ID of your App Store Connect Api Key. Learn more: https://expo.fyi/creating-asc-api-key",
+          "markdownDescription": "The Key ID of your App Store Connect Api Key. [Learn more](https://expo.fyi/creating-asc-api-key)"
+        },
+        "bundleIdentifier": {
+          "type": "string",
+          "description": "The Bundle identifier that will be used when accessing submit credentials managed by Expo, it does not have any effect if you are using local credentials. In most cases this value will be autodetected, but if you have multiple Xcode schemes and targets, this value might be necessary."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Moving schema to the eas-cli will minimize the maintenance, and potentially in the future, we can use it directly for validation and docs generation.

# How

- copy schema from vscode extension
- Cedric already prepared workflow that will pull this file from our repo https://github.com/expo/vscode-expo/pull/126

# Test Plan


