### PR TITLE
[eas-cli] Validate only if using remote version source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix building Android projects locally that don't have execute permissions set for `gradlew`. ([82231](https://github.com/expo/eas-cli/commit/822313e90e94bd6ddd3872061a0c25a8aa4db7cd) by [@dsokal](https://github.com/dsokal))
+- Disable `nativeVersion` policy only for remote version source. ([#1261](https://github.com/expo/eas-cli/pull/1261) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -1,5 +1,5 @@
 import { Platform, Workflow } from '@expo/eas-build-job';
-import { BuildProfile, EasJson, EasJsonReader, SubmitProfile } from '@expo/eas-json';
+import { AppVersionSource, BuildProfile, EasJson, EasJsonReader, SubmitProfile } from '@expo/eas-json';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
@@ -249,8 +249,9 @@ async function prepareAndStartBuildAsync({
       )}`
     );
   }
-
-  validateAppConfigForRemoteVersionSource(buildCtx.exp, buildProfile.platform);
+  if (easJsonCliConfig?.appVersionSource === AppVersionSource.REMOTE) {
+    validateAppConfigForRemoteVersionSource(buildCtx.exp, buildProfile.platform);
+  }
   if (buildCtx.workflow === Workflow.MANAGED) {
     if (!sdkVersionChecked) {
       await checkExpoSdkIsSupportedAsync(buildCtx);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

nativeVersion should only be disable when remoteVersionSource is set to remote

# How



# Test Plan

Set nativeVersion policy and try run build.
