### PR TITLE
[eas-json] Add metadata path to ios submit profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add JSON Schema `metadataPath` to iOS submission profile. ([#1269](https://github.com/expo/eas-cli/pull/1269) by [@byCedric](https://github.com/byCedric))
+
 ## [0.59.0](https://github.com/expo/eas-cli/releases/tag/v0.59.0) - 2022-08-10
 
 ### 🐛 Bug fixes

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -471,6 +471,11 @@
         "bundleIdentifier": {
           "type": "string",
           "description": "The Bundle identifier that will be used when accessing submit credentials managed by Expo, it does not have any effect if you are using local credentials. In most cases this value will be autodetected, but if you have multiple Xcode schemes and targets, this value might be necessary."
+        },
+        "metadataPath": {
+          "type": "string",
+          "description": "The path to your store configuration file. Learn more: https://docs.expo.dev/eas-metadata/introduction/",
+          "markdownDescription": "The path to your store configuration file. [Learn more](https://docs.expo.dev/eas-metadata/introduction/)"
         }
       }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This was missing from the JSON Schema, used in the vscode plugin.

# How

- Added `metadataPath` to the iOS submit profiles, [as documented here](https://docs.expo.dev/submit/eas-json/#metadatapath).

# Test Plan

JSON schema change only.
