### PR TITLE
[eas-cli] Add js metadata config file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add metadata support for dynamic store.config.js files. ([#1270](https://github.com/expo/eas-cli/pull/1270) by [@byCedric](https://github.com/byCedric))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -51,11 +51,11 @@ export default class MetadataPull extends EasCommand {
       const relativePath = path.relative(process.cwd(), filePath);
 
       Log.addNewLineIfNone();
-      Log.log(`🎉 Your store configuration is ready.
+      Log.log(`🎉 Your store config is ready.
 
 - Update the ${chalk.bold(relativePath)} file to prepare the app information.
 - Run ${chalk.bold('eas submit')} or manually upload a new app version to the app stores.
-- Once the app is uploaded, run ${chalk.bold('eas metadata:push')} to sync the store configuration.
+- Once the app is uploaded, run ${chalk.bold('eas metadata:push')} to sync the store config.
 - ${learnMore('https://docs.expo.dev/eas-metadata/introduction/')}`);
     } catch (error: any) {
       handleMetadataError(error);

--- a/packages/eas-cli/src/metadata/__tests__/config.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/config.test.ts
@@ -41,9 +41,9 @@ describe(getStaticConfigFile, () => {
 describe(loadConfigAsync, () => {
   const projectDir = path.resolve(__dirname, 'fixtures');
 
-  it(`throws when file doesn't exists`, async () => {
+  it(`throws when file doesn't exist`, async () => {
     await expect(
-      loadConfigAsync({ projectDir, metadataPath: 'doesnt-exists.json' })
+      loadConfigAsync({ projectDir, metadataPath: 'doesnt-exist.json' })
     ).rejects.toThrow('file not found');
   });
 

--- a/packages/eas-cli/src/metadata/__tests__/config.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/config.test.ts
@@ -108,4 +108,30 @@ describe(loadConfigAsync, () => {
       loadConfigAsync({ projectDir, metadataPath: 'invalid.async.js' })
     ).resolves.toMatchObject({ configVersion: -1 });
   });
+
+  it(`throws invalid config type from "invalid-type.config.json"`, async () => {
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'invalid-type.config.json' })
+    ).rejects.toThrow(
+      `store config returned an unkown value, should be an object: "${[{ configVersion: -1 }]}"`
+    );
+  });
+
+  it(`throws invalid config type from "invalid-type.config.js"`, async () => {
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'invalid-type.config.js' })
+    ).rejects.toThrow(`store config returned an unkown value, should be an object: "${1337}"`);
+  });
+
+  it(`throws invalid config type from "invalid-type.function.js"`, async () => {
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'invalid-type.function.js' })
+    ).rejects.toThrow(`store config returned an unkown value, should be an object: "${true}"`);
+  });
+
+  it(`throws invalid config type from "invalid-type.async.js"`, async () => {
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'invalid-type.async.js' })
+    ).rejects.toThrow(`store config returned an unkown value, should be an object: "${null}"`);
+  });
 });

--- a/packages/eas-cli/src/metadata/__tests__/config.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/config.test.ts
@@ -54,30 +54,58 @@ describe(loadConfigAsync, () => {
     ).rejects.toThrow('errors found');
   });
 
-  it(`returns json config`, async () => {
+  it(`returns config from "store.config.json"`, async () => {
     await expect(
       loadConfigAsync({ projectDir, metadataPath: 'store.config.json' })
-    ).resolves.toHaveProperty('apple.copyright', '2022 ACME');
+    ).resolves.toHaveProperty('apple.copyright', 'ACME');
   });
 
-  it(`returns js config`, async () => {
+  it(`returns config from "store.config.js"`, async () => {
     const year = new Date().getFullYear();
     await expect(
       loadConfigAsync({ projectDir, metadataPath: 'store.config.js' })
     ).resolves.toHaveProperty('apple.copyright', `${year} ACME`);
   });
 
-  it(`returns json config when skipping validation`, async () => {
+  it(`returns config from "store.function.js"`, async () => {
+    const year = new Date().getFullYear();
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'store.function.js' })
+    ).resolves.toHaveProperty('apple.copyright', `${year} ACME`);
+  });
+
+  it(`returns config from "store.async.js"`, async () => {
+    const year = new Date().getFullYear();
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'store.async.js' })
+    ).resolves.toHaveProperty('apple.copyright', `${year} ACME`);
+  });
+
+  it(`returns invalid config from "invalid.config.json`, async () => {
     jest.mocked(confirmAsync).mockResolvedValue(true);
     await expect(
       loadConfigAsync({ projectDir, metadataPath: 'invalid.config.json' })
     ).resolves.toMatchObject({ configVersion: -1 });
   });
 
-  it(`returns js config when skipping validation`, async () => {
+  it(`returns invalid config from "invalid.config.js`, async () => {
     jest.mocked(confirmAsync).mockResolvedValue(true);
     await expect(
       loadConfigAsync({ projectDir, metadataPath: 'invalid.config.js' })
+    ).resolves.toMatchObject({ configVersion: -1 });
+  });
+
+  it(`returns invalid config from "invalid.function.js`, async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'invalid.function.js' })
+    ).resolves.toMatchObject({ configVersion: -1 });
+  });
+
+  it(`returns invalid config from "invalid.async.js`, async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'invalid.async.js' })
     ).resolves.toMatchObject({ configVersion: -1 });
   });
 });

--- a/packages/eas-cli/src/metadata/__tests__/config.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/config.test.ts
@@ -1,11 +1,42 @@
-import fs from 'fs';
 import path from 'path';
-import tempy from 'tempy';
 
 import { confirmAsync } from '../../prompts';
-import { loadConfigAsync, saveConfigAsync } from '../config';
+import { getStaticConfigFile, loadConfigAsync } from '../config';
 
 jest.mock('../../prompts', () => ({ confirmAsync: jest.fn(() => true) }));
+
+describe(getStaticConfigFile, () => {
+  const projectDir = '/app';
+
+  it(`returns same file for store.config.json`, () => {
+    const metadataPath = 'store.config.json';
+    const expectedFile = path.join(projectDir, metadataPath);
+
+    expect(getStaticConfigFile({ projectDir, metadataPath })).toBe(expectedFile);
+  });
+
+  it(`returns store.config.json for store.config.js`, () => {
+    const metadataPath = 'store.config.js';
+    const expectedFile = path.join(projectDir, 'store.config.json');
+
+    expect(getStaticConfigFile({ projectDir, metadataPath })).toBe(expectedFile);
+  });
+
+  it(`returns store.staging.json file for store.staging.js`, () => {
+    const metadataPath = 'store.staging.js';
+    const expectedFile = path.join(projectDir, 'store.staging.json');
+
+    expect(getStaticConfigFile({ projectDir, metadataPath })).toBe(expectedFile);
+  });
+
+  // This shouldn't be used IRL, but it tests if this function is working properly
+  it(`returns custom-name.json file for custom-name.js`, () => {
+    const metadataPath = 'custom-name.js';
+    const expectedFile = path.join(projectDir, 'custom-name.json');
+
+    expect(getStaticConfigFile({ projectDir, metadataPath })).toBe(expectedFile);
+  });
+});
 
 describe(loadConfigAsync, () => {
   const projectDir = path.resolve(__dirname, 'fixtures');
@@ -48,42 +79,5 @@ describe(loadConfigAsync, () => {
     await expect(
       loadConfigAsync({ projectDir, metadataPath: 'invalid.config.js' })
     ).resolves.toMatchObject({ configVersion: -1 });
-  });
-});
-
-describe(saveConfigAsync, () => {
-  const config = require('./fixtures/store.config');
-  let projectDir: string;
-
-  beforeAll(async () => {
-    // We can't use memfs in this case, because we are evaluating js modules.
-    // Instead, we will write the files to the temporary directory and use that instead.
-    projectDir = tempy.directory({ prefix: 'saveConfigAsync' });
-  });
-
-  afterAll(async () => {
-    await fs.promises.rm(projectDir, { recursive: true });
-  });
-
-  it(`throws for unknown extensions`, async () => {
-    await expect(
-      saveConfigAsync(config, { projectDir, metadataPath: 'not.supported.mjs' })
-    ).rejects.toThrow('Unkown store config extension');
-  });
-
-  it(`saves valid json config`, async () => {
-    await saveConfigAsync(config, { projectDir, metadataPath: 'store.config.json' });
-    const savedConfig = await fs.promises
-      .readFile(path.join(projectDir, 'store.config.json'))
-      .then(content => JSON.parse(content.toString()));
-
-    expect(savedConfig).toMatchObject(config);
-  });
-
-  it(`saves valid js config`, async () => {
-    await saveConfigAsync(config, { projectDir, metadataPath: 'store.config.js' });
-    const savedConfig = require(path.join(projectDir, 'store.config.js'));
-
-    expect(savedConfig).toMatchObject(config);
   });
 });

--- a/packages/eas-cli/src/metadata/__tests__/config.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/config.test.ts
@@ -1,32 +1,30 @@
 import path from 'path';
 
-import { confirmAsync } from '../../prompts';
-import { getStaticConfigFile, loadConfigAsync } from '../config';
+import { getStaticConfigFilePath, loadConfigAsync } from '../config';
+import { MetadataValidationError } from '../errors';
 
-jest.mock('../../prompts', () => ({ confirmAsync: jest.fn(() => true) }));
-
-describe(getStaticConfigFile, () => {
+describe(getStaticConfigFilePath, () => {
   const projectDir = '/app';
 
   it(`returns same file for store.config.json`, () => {
     const metadataPath = 'store.config.json';
     const expectedFile = path.join(projectDir, metadataPath);
 
-    expect(getStaticConfigFile({ projectDir, metadataPath })).toBe(expectedFile);
+    expect(getStaticConfigFilePath({ projectDir, metadataPath })).toBe(expectedFile);
   });
 
   it(`returns store.config.json for store.config.js`, () => {
     const metadataPath = 'store.config.js';
     const expectedFile = path.join(projectDir, 'store.config.json');
 
-    expect(getStaticConfigFile({ projectDir, metadataPath })).toBe(expectedFile);
+    expect(getStaticConfigFilePath({ projectDir, metadataPath })).toBe(expectedFile);
   });
 
   it(`returns store.staging.json file for store.staging.js`, () => {
     const metadataPath = 'store.staging.js';
     const expectedFile = path.join(projectDir, 'store.staging.json');
 
-    expect(getStaticConfigFile({ projectDir, metadataPath })).toBe(expectedFile);
+    expect(getStaticConfigFilePath({ projectDir, metadataPath })).toBe(expectedFile);
   });
 
   // This shouldn't be used IRL, but it tests if this function is working properly
@@ -34,7 +32,7 @@ describe(getStaticConfigFile, () => {
     const metadataPath = 'custom-name.js';
     const expectedFile = path.join(projectDir, 'custom-name.json');
 
-    expect(getStaticConfigFile({ projectDir, metadataPath })).toBe(expectedFile);
+    expect(getStaticConfigFilePath({ projectDir, metadataPath })).toBe(expectedFile);
   });
 });
 
@@ -47,8 +45,7 @@ describe(loadConfigAsync, () => {
     ).rejects.toThrow('file not found');
   });
 
-  it(`throws when validation errors are found without skipping`, async () => {
-    jest.mocked(confirmAsync).mockResolvedValue(false);
+  it(`throws when validation errors are found without skipping validation`, async () => {
     await expect(
       loadConfigAsync({ projectDir, metadataPath: 'invalid.config.json' })
     ).rejects.toThrow('errors found');
@@ -82,56 +79,50 @@ describe(loadConfigAsync, () => {
   });
 
   it(`returns invalid config from "invalid.config.json`, async () => {
-    jest.mocked(confirmAsync).mockResolvedValue(true);
     await expect(
-      loadConfigAsync({ projectDir, metadataPath: 'invalid.config.json' })
+      loadConfigAsync({ projectDir, metadataPath: 'invalid.config.json', skipValidation: true })
     ).resolves.toMatchObject({ configVersion: -1 });
   });
 
   it(`returns invalid config from "invalid.config.js`, async () => {
-    jest.mocked(confirmAsync).mockResolvedValue(true);
     await expect(
-      loadConfigAsync({ projectDir, metadataPath: 'invalid.config.js' })
+      loadConfigAsync({ projectDir, metadataPath: 'invalid.config.js', skipValidation: true })
     ).resolves.toMatchObject({ configVersion: -1 });
   });
 
   it(`returns invalid config from "invalid.function.js`, async () => {
-    jest.mocked(confirmAsync).mockResolvedValue(true);
     await expect(
-      loadConfigAsync({ projectDir, metadataPath: 'invalid.function.js' })
+      loadConfigAsync({ projectDir, metadataPath: 'invalid.function.js', skipValidation: true })
     ).resolves.toMatchObject({ configVersion: -1 });
   });
 
   it(`returns invalid config from "invalid.async.js`, async () => {
-    jest.mocked(confirmAsync).mockResolvedValue(true);
     await expect(
-      loadConfigAsync({ projectDir, metadataPath: 'invalid.async.js' })
+      loadConfigAsync({ projectDir, metadataPath: 'invalid.async.js', skipValidation: true })
     ).resolves.toMatchObject({ configVersion: -1 });
   });
 
   it(`throws invalid config type from "invalid-type.config.json"`, async () => {
     await expect(
       loadConfigAsync({ projectDir, metadataPath: 'invalid-type.config.json' })
-    ).rejects.toThrow(
-      `store config returned an unkown value, should be an object: "${[{ configVersion: -1 }]}"`
-    );
+    ).rejects.toThrow(MetadataValidationError);
   });
 
   it(`throws invalid config type from "invalid-type.config.js"`, async () => {
     await expect(
       loadConfigAsync({ projectDir, metadataPath: 'invalid-type.config.js' })
-    ).rejects.toThrow(`store config returned an unkown value, should be an object: "${1337}"`);
+    ).rejects.toThrow(MetadataValidationError);
   });
 
   it(`throws invalid config type from "invalid-type.function.js"`, async () => {
     await expect(
       loadConfigAsync({ projectDir, metadataPath: 'invalid-type.function.js' })
-    ).rejects.toThrow(`store config returned an unkown value, should be an object: "${true}"`);
+    ).rejects.toThrow(MetadataValidationError);
   });
 
   it(`throws invalid config type from "invalid-type.async.js"`, async () => {
     await expect(
       loadConfigAsync({ projectDir, metadataPath: 'invalid-type.async.js' })
-    ).rejects.toThrow(`store config returned an unkown value, should be an object: "${null}"`);
+    ).rejects.toThrow(MetadataValidationError);
   });
 });

--- a/packages/eas-cli/src/metadata/__tests__/config.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/config.test.ts
@@ -1,0 +1,50 @@
+import path from 'path';
+
+import { confirmAsync } from '../../prompts';
+import { loadConfigAsync } from '../config';
+
+jest.mock('../../prompts', () => ({ confirmAsync: jest.fn(() => true) }));
+
+describe(loadConfigAsync, () => {
+  const projectDir = path.resolve(__dirname, 'fixtures');
+
+  it(`throws when file doesn't exists`, async () => {
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'doesnt-exists.json' })
+    ).rejects.toThrow('file not found');
+  });
+
+  it(`throws when validation errors are found without skipping`, async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'invalid.config.json' })
+    ).rejects.toThrow('errors found');
+  });
+
+  it(`returns json config`, async () => {
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'store.config.json' })
+    ).resolves.toHaveProperty('apple.copyright', '2022 ACME');
+  });
+
+  it(`returns js config`, async () => {
+    const year = new Date().getFullYear();
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'store.config.js' })
+    ).resolves.toHaveProperty('apple.copyright', `${year} ACME`);
+  });
+
+  it(`returns json config when skipping validation`, async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'invalid.config.json' })
+    ).resolves.toMatchObject({ configVersion: -1 });
+  });
+
+  it(`returns js config when skipping validation`, async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+    await expect(
+      loadConfigAsync({ projectDir, metadataPath: 'invalid.config.js' })
+    ).resolves.toMatchObject({ configVersion: -1 });
+  });
+});

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/invalid-type.async.js
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/invalid-type.async.js
@@ -1,0 +1,3 @@
+module.exports = async function () {
+  return await Promise.resolve(null);
+};

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/invalid-type.config.js
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/invalid-type.config.js
@@ -1,0 +1,1 @@
+module.exports = 1337;

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/invalid-type.config.json
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/invalid-type.config.json
@@ -1,0 +1,5 @@
+[
+  {
+    "configVersion": -1
+  }
+]

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/invalid-type.function.js
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/invalid-type.function.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+  return true;
+};

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/invalid.async.js
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/invalid.async.js
@@ -1,0 +1,3 @@
+module.exports = async function () {
+  return await Promise.resolve({ configVersion: -1 });
+};

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/invalid.config.js
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/invalid.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  configVersion: -1,
+};

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/invalid.config.json
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/invalid.config.json
@@ -1,0 +1,3 @@
+{
+  "configVersion": -1
+}

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/invalid.function.js
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/invalid.function.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+  return { configVersion: -1 };
+};

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/store.async.js
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/store.async.js
@@ -1,0 +1,5 @@
+module.exports = async function () {
+  const config = require('./store.config.json');
+  config.apple.copyright = `${new Date().getFullYear()} ACME`;
+  return await Promise.resolve(config);
+};

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/store.config.js
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/store.config.js
@@ -1,20 +1,5 @@
-module.exports = {
-  configVersion: 0,
-  apple: {
-    copyright: `${new Date().getFullYear()} ACME`,
-    info: {
-      'en-US': {
-        title: 'App title',
-        subtitle: 'Subtitle for your app',
-        description: 'A longer description of what your app does',
-        keywords: ['keyword'],
-        releaseNotes: 'Bug fixes and improved stability',
-        promoText: 'Short tagline for your app',
-        marketingUrl: 'https://example.com/en/marketing',
-        supportUrl: 'https://example.com/en/support',
-        privacyPolicyUrl: 'https://example.com/en/privacy',
-        privacyChoicesUrl: 'https://example.com/en/choices',
-      },
-    },
-  },
-};
+const config = require('./store.config.json');
+
+config.apple.copyright = `${new Date().getFullYear()} ACME`;
+
+module.exports = config;

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/store.config.js
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/store.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  configVersion: 0,
+  apple: {
+    copyright: `${new Date().getFullYear()} ACME`,
+    info: {
+      'en-US': {
+        title: 'App title',
+        subtitle: 'Subtitle for your app',
+        description: 'A longer description of what your app does',
+        keywords: ['keyword'],
+        releaseNotes: 'Bug fixes and improved stability',
+        promoText: 'Short tagline for your app',
+        marketingUrl: 'https://example.com/en/marketing',
+        supportUrl: 'https://example.com/en/support',
+        privacyPolicyUrl: 'https://example.com/en/privacy',
+        privacyChoicesUrl: 'https://example.com/en/choices',
+      },
+    },
+  },
+};

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/store.config.json
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/store.config.json
@@ -1,7 +1,7 @@
 {
   "configVersion": 0,
   "apple": {
-    "copyright": "2022 ACME",
+    "copyright": "ACME",
     "info": {
       "en-US": {
         "title": "App title",

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/store.config.json
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/store.config.json
@@ -1,0 +1,22 @@
+{
+  "configVersion": 0,
+  "apple": {
+    "copyright": "2022 ACME",
+    "info": {
+      "en-US": {
+        "title": "App title",
+        "subtitle": "Subtitle for your app",
+        "description": "A longer description of what your app does",
+        "keywords": [
+          "keyword"
+        ],
+        "releaseNotes": "Bug fixes and improved stability",
+        "promoText": "Short tagline for your app",
+        "marketingUrl": "https://example.com/en/marketing",
+        "supportUrl": "https://example.com/en/support",
+        "privacyPolicyUrl": "https://example.com/en/privacy",
+        "privacyChoicesUrl": "https://example.com/en/choices"
+      }
+    }
+  }
+}

--- a/packages/eas-cli/src/metadata/__tests__/fixtures/store.function.js
+++ b/packages/eas-cli/src/metadata/__tests__/fixtures/store.function.js
@@ -1,0 +1,5 @@
+module.exports = function () {
+  const config = require('./store.config.json');
+  config.apple.copyright = `${new Date().getFullYear()} ACME`;
+  return config;
+};

--- a/packages/eas-cli/src/metadata/config.ts
+++ b/packages/eas-cli/src/metadata/config.ts
@@ -24,7 +24,7 @@ export interface MetadataConfig {
  */
 async function resolveDynamicConfigAsync(configFile: string): Promise<unknown> {
   const userConfigContent = await import(configFile);
-  let userConfig = userConfigContent.default || userConfigContent;
+  let userConfig = userConfigContent.default ?? userConfigContent;
 
   if (typeof userConfig === 'function') {
     userConfig = await userConfig();
@@ -43,10 +43,10 @@ async function resolveDynamicConfigAsync(configFile: string): Promise<unknown> {
  * Get the static configuration file path, based on the metadata context.
  * This uses any custom name provided, but swaps out the extension for `.json`.
  */
-export function getStaticConfigFile({
+export function getStaticConfigFilePath({
   projectDir,
   metadataPath,
-}: Pick<MetadataContext, 'projectDir' | 'metadataPath'>): string {
+}: { projectDir: string, metadataPath: string }): string {
   const configFile = path.join(projectDir, metadataPath);
   const configExtension = path.extname(configFile);
 

--- a/packages/eas-cli/src/metadata/config.ts
+++ b/packages/eas-cli/src/metadata/config.ts
@@ -2,7 +2,6 @@ import Ajv from 'ajv';
 import assert from 'assert';
 import fs from 'fs-extra';
 import path from 'path';
-import util from 'util';
 
 import Log from '../log';
 import { confirmAsync } from '../prompts';
@@ -60,31 +59,17 @@ export async function loadConfigAsync({
 }
 
 /**
- * Save the store config file, based on the file type extension.
- * It supports both `.js` and `.json` files, where:
- *   - JSON files are stringified
- *   - JS files have a `module.exports = {inspect(config)};` template
+ * Get the static configuration file path, based on the metadata context.
+ * This uses any custom name provided, but swaps out the extension for `.json`.
  */
-export async function saveConfigAsync(
-  config: MetadataConfig,
-  { projectDir, metadataPath }: Pick<MetadataContext, 'projectDir' | 'metadataPath'>
-): Promise<void> {
+export function getStaticConfigFile({
+  projectDir,
+  metadataPath,
+}: Pick<MetadataContext, 'projectDir' | 'metadataPath'>): string {
   const configFile = path.join(projectDir, metadataPath);
   const configExtension = path.extname(configFile);
 
-  switch (configExtension) {
-    case '.json':
-      return await fs.writeJson(configFile, config, { spaces: 2 });
-    case '.js':
-      return await fs.writeFile(
-        configFile,
-        `module.exports = ${util.inspect(config, { depth: null })};\n`
-      );
-    default:
-      throw new MetadataValidationError(
-        `Unkown store config extension: "${configExtension}" for "${metadataPath}". Use ".json" or ".js" instead.`
-      );
-  }
+  return path.join(projectDir, `${path.basename(configFile, configExtension)}.json`);
 }
 
 /**

--- a/packages/eas-cli/src/metadata/config.ts
+++ b/packages/eas-cli/src/metadata/config.ts
@@ -24,16 +24,18 @@ export interface MetadataConfig {
  */
 async function resolveDynamicConfigAsync(configFile: string): Promise<unknown> {
   const userConfigContent = await import(configFile);
-  const userConfig = userConfigContent.default || userConfigContent;
+  let userConfig = userConfigContent.default || userConfigContent;
 
   if (typeof userConfig === 'function') {
-    return await userConfig();
-  } else if (typeof userConfig === 'object') {
+    userConfig = await userConfig();
+  }
+
+  if (typeof userConfig === 'object' && userConfig !== null && !Array.isArray(userConfig)) {
     return userConfig;
   }
 
   throw new MetadataValidationError(
-    `Metadata store config returned an unkown object: "${typeof userConfig}"`
+    `Metadata store config returned an unkown value, should be an object: "${userConfig}"`
   );
 }
 

--- a/packages/eas-cli/src/metadata/config.ts
+++ b/packages/eas-cli/src/metadata/config.ts
@@ -35,7 +35,7 @@ async function resolveDynamicConfigAsync(configFile: string): Promise<unknown> {
   }
 
   throw new MetadataValidationError(
-    `Metadata store config returned an unkown value, should be an object: "${userConfig}"`
+    `Metadata store config returned an unknown value, should be an object: "${userConfig}"`
   );
 }
 
@@ -80,7 +80,7 @@ export async function loadConfigAsync({
     logMetadataValidationError(error);
     Log.newLine();
     Log.warn(
-      'Without further updates, the current store configuration may fail to be synchronized with the App Store or pass App Store review.'
+      'Without further updates, the current store configuration can fail to be synchronized with the App Store or pass App Store review.'
     );
 
     if (await confirmAsync({ message: 'Do you still want to push the store configuration?' })) {

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import path from 'path';
 
 import { MetadataEvent } from '../analytics/events';
 import Log from '../log';
@@ -19,11 +20,12 @@ export async function downloadMetadataAsync(metadataCtx: MetadataContext): Promi
   const fileExists = await fs.pathExists(filePath);
 
   if (fileExists) {
+    const filePathRelative = path.relative(metadataCtx.projectDir, filePath);
     const overwrite = await confirmAsync({
-      message: `Do you want to overwrite the existing store configuration "${metadataCtx.metadataPath}"?`,
+      message: `Do you want to overwrite the existing "${filePathRelative}"?`,
     });
     if (!overwrite) {
-      throw new MetadataValidationError(`Store configuration already exists at "${filePath}"`);
+      throw new MetadataValidationError(`Store config already exists at "${filePath}"`);
     }
   }
 
@@ -34,7 +36,7 @@ export async function downloadMetadataAsync(metadataCtx: MetadataContext): Promi
   );
 
   Log.addNewLineIfNone();
-  Log.log('Downloading App Store configuration...');
+  Log.log('Downloading App Store config...');
 
   const errors: Error[] = [];
   const config = createAppleWriter();

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -1,12 +1,11 @@
 import fs from 'fs-extra';
-import path from 'path';
 
 import { MetadataEvent } from '../analytics/events';
 import Log from '../log';
 import { confirmAsync } from '../prompts';
 import { AppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
-import { createAppleWriter, saveConfigAsync } from './config';
+import { createAppleWriter, getStaticConfigFile } from './config';
 import { MetadataContext, ensureMetadataAppStoreAuthenticatedAsync } from './context';
 import { MetadataDownloadError, MetadataValidationError } from './errors';
 import { subscribeTelemetry } from './utils/telemetry';
@@ -16,7 +15,7 @@ import { subscribeTelemetry } from './utils/telemetry';
  * Note, only App Store is supported at this time.
  */
 export async function downloadMetadataAsync(metadataCtx: MetadataContext): Promise<string> {
-  const filePath = path.resolve(metadataCtx.projectDir, metadataCtx.metadataPath);
+  const filePath = getStaticConfigFile(metadataCtx);
   const fileExists = await fs.pathExists(filePath);
 
   if (fileExists) {
@@ -59,7 +58,7 @@ export async function downloadMetadataAsync(metadataCtx: MetadataContext): Promi
   }
 
   try {
-    await saveConfigAsync(config.toSchema(), metadataCtx);
+    await fs.writeJSON(filePath, config.toSchema(), { spaces: 2 });
   } finally {
     unsubscribeTelemetry();
   }

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -6,7 +6,7 @@ import Log from '../log';
 import { confirmAsync } from '../prompts';
 import { AppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
-import { createAppleWriter } from './config';
+import { createAppleWriter, saveConfigAsync } from './config';
 import { MetadataContext, ensureMetadataAppStoreAuthenticatedAsync } from './context';
 import { MetadataDownloadError, MetadataValidationError } from './errors';
 import { subscribeTelemetry } from './utils/telemetry';
@@ -59,7 +59,7 @@ export async function downloadMetadataAsync(metadataCtx: MetadataContext): Promi
   }
 
   try {
-    await fs.writeJson(filePath, config.toSchema(), { spaces: 2 });
+    await saveConfigAsync(config.toSchema(), metadataCtx);
   } finally {
     unsubscribeTelemetry();
   }

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -6,7 +6,7 @@ import Log from '../log';
 import { confirmAsync } from '../prompts';
 import { AppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
-import { createAppleWriter, getStaticConfigFile } from './config';
+import { createAppleWriter, getStaticConfigFilePath } from './config';
 import { MetadataContext, ensureMetadataAppStoreAuthenticatedAsync } from './context';
 import { MetadataDownloadError, MetadataValidationError } from './errors';
 import { subscribeTelemetry } from './utils/telemetry';
@@ -16,7 +16,7 @@ import { subscribeTelemetry } from './utils/telemetry';
  * Note, only App Store is supported at this time.
  */
 export async function downloadMetadataAsync(metadataCtx: MetadataContext): Promise<string> {
-  const filePath = getStaticConfigFile(metadataCtx);
+  const filePath = getStaticConfigFilePath(metadataCtx);
   const fileExists = await fs.pathExists(filePath);
 
   if (fileExists) {

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -1,14 +1,10 @@
-import fs from 'fs-extra';
-import path from 'path';
-
 import { MetadataEvent } from '../analytics/events';
 import Log from '../log';
-import { confirmAsync } from '../prompts';
 import { AppleData } from './apple/data';
 import { createAppleTasks } from './apple/tasks';
-import { createAppleReader, validateConfig } from './config';
+import { createAppleReader, loadConfigAsync } from './config';
 import { MetadataContext, ensureMetadataAppStoreAuthenticatedAsync } from './context';
-import { MetadataUploadError, MetadataValidationError, logMetadataValidationError } from './errors';
+import { MetadataUploadError } from './errors';
 import { subscribeTelemetry } from './utils/telemetry';
 
 /**
@@ -18,28 +14,7 @@ import { subscribeTelemetry } from './utils/telemetry';
 export async function uploadMetadataAsync(
   metadataCtx: MetadataContext
 ): Promise<{ appleLink: string }> {
-  const filePath = path.resolve(metadataCtx.projectDir, metadataCtx.metadataPath);
-  if (!(await fs.pathExists(filePath))) {
-    throw new MetadataValidationError(`Store configuration file not found "${filePath}"`);
-  }
-
-  const fileData = await fs.readJson(filePath);
-  const { valid, errors: validationErrors } = validateConfig(fileData);
-  if (!valid) {
-    const error = new MetadataValidationError(`Store configuration errors found`, validationErrors);
-    logMetadataValidationError(error);
-    Log.newLine();
-    Log.warn(
-      'Without further updates, the current store configuration may fail to be synchronized with the App Store or pass App Store review.'
-    );
-    const attempt = await confirmAsync({
-      message: 'Do you still want to push the store configuration?',
-    });
-    if (!attempt) {
-      throw error;
-    }
-  }
-
+  const storeConfig = await loadConfigAsync(metadataCtx);
   const { app, auth } = await ensureMetadataAppStoreAuthenticatedAsync(metadataCtx);
   const { unsubscribeTelemetry, executionId } = subscribeTelemetry(
     MetadataEvent.APPLE_METADATA_UPLOAD,
@@ -50,7 +25,7 @@ export async function uploadMetadataAsync(
   Log.log('Uploading App Store configuration...');
 
   const errors: Error[] = [];
-  const config = createAppleReader(fileData);
+  const config = createAppleReader(storeConfig);
   const tasks = createAppleTasks(metadataCtx, {
     // We need to resolve a different version as soon as possible.
     // This version is the parent model of all changes we are going to push.


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This adds support for `store.config.js` files support, for `eas metadata:push`. It supports returned `object`, `function` or `async function`.

# How

Added `loadConfigAsync` and `saveConfigAsync` that handles language specific things, like reading/writing JSON or JavaScript content.

# Test Plan

See added tests