### PR TITLE
[workspace] bump Node used by oclif

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -172,7 +172,7 @@
     },
     "update": {
       "node": {
-        "version": "12.13.0"
+        "version": "18.6.0"
       },
       "s3": {
         "templates": {


### PR DESCRIPTION
# Why

During the work on the Windows DX PR I have spotted that `oclif` uses old Node for generating tars.

# How

Update Node used by `oclif` to the same version as specified for Volta. 

# Test Plan

`build-for-size-check` command works as expected after the bump.

## Preview
<img width="779" alt="Screenshot 2022-08-12 at 14 51 15" src="https://user-images.githubusercontent.com/719641/184357570-1c0a7b03-13a5-4d3c-9f05-f0ef2af04601.png">
