### PR TITLE
[eas-cli] Configure EAS project ID in app config in all cases

### DIFF
--- a/packages/eas-cli/src/credentials/__tests__/fixtures-constants.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-constants.ts
@@ -18,6 +18,7 @@ export const jester2: Actor = {
 
 export const testUsername = jester.username;
 export const testSlug = 'testApp';
+export const testProjectId = '7ef93448-3bc7-4b57-be32-99326dcf24f0';
 export const testBundleIdentifier = 'test.com.app';
 export const testPackageName = 'test.com.app';
 export const testExperienceName = `@${testUsername}/${testSlug}`;
@@ -35,6 +36,11 @@ export const testAppJson = {
   sdkVersion: '38.0.0',
   ios: { bundleIdentifier: testBundleIdentifier },
   android: { package: testPackageName },
+  extra: {
+    eas: {
+      projectId: testProjectId,
+    },
+  },
 };
 
 export const testAppJsonWithDifferentOwner = {

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -129,7 +129,11 @@ export async function setProjectIdAsync(
 
 export async function getProjectIdAsync(
   exp: ExpoConfig,
-  options: { env?: Env } = {}
+  options: { env?: Env } = {},
+  findProjectRootOptions: {
+    cwd?: string;
+    defaultToProcessCwd?: boolean;
+  } = {}
 ): Promise<string> {
   const localProjectId = exp.extra?.eas?.projectId;
   if (localProjectId) {
@@ -137,7 +141,7 @@ export async function getProjectIdAsync(
   }
 
   // Set the project ID if it is missing.
-  const projectDir = await findProjectRootAsync();
+  const projectDir = await findProjectRootAsync(findProjectRootOptions);
   if (!projectDir) {
     throw new Error('Please run this command inside a project directory.');
   }

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -131,15 +131,6 @@ export async function getProjectIdAsync(
   exp: ExpoConfig,
   options: { env?: Env } = {}
 ): Promise<string> {
-  if (!process.env.EAS_ENABLE_PROJECT_ID) {
-    const privacy = toAppPrivacy(exp.privacy);
-    return await ensureProjectExistsAsync({
-      accountName: getProjectAccountName(exp, await ensureLoggedInAsync()),
-      projectName: exp.slug,
-      privacy,
-    });
-  }
-
   const localProjectId = exp.extra?.eas?.projectId;
   if (localProjectId) {
     return localProjectId;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Some background:
- We used to choose which type of manifest to serve in development based on the `extra.eas.projectId` field.
- At one point, code was added to configure the `extra.eas.projectId` field upon running commands that needed the project ID. https://github.com/expo/eas-cli/pull/402
- This caused those commands to change the manifest type used, and the new manifest type wasn't yet ready for prime time.
- https://github.com/expo/eas-cli/pull/412 was added to gate the auto-configuration-write temporarily.
- At some point shortly later, we changed the mechanism used to determine the type of manifest to use to either a flag or looking at the `updates.url` property of the config.
- We forgot to revert https://github.com/expo/eas-cli/pull/412

This PR reverts https://github.com/expo/eas-cli/pull/412.

Closes ENG-6076.

# How

Revert it.

# Test Plan

Run `~/expo/eas-cli/packages/eas-cli/bin/run update:configure` in a new project, ensure `extra.eas.projectId` is added to the app config.
