### PR TITLE
[eas-cli] Limit the number of SignedAssetUploadSpecifications fetched at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Rebind `console.info` correctly after `ora` instance stops. ([#1113](https://github.com/expo/eas-cli/pull/1113) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix initializing git repository in monorepo. ([#1279](https://github.com/expo/eas-cli/pull/1279) by [@dsokal](https://github.com/dsokal))
+- Limit the number of SignedAssetUploadSpecifications fetched at a time. ([#1287](https://github.com/expo/eas-cli/pull/1287) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Generating a ton of these at once on the server creates 1) requests that are huge and that have huge responses, and 2) a lot of load to google to generate the specs. Both of these issues were fixed on the server in https://github.com/expo/universe/pull/10394, but we still need to do batching on the client in order to not get timeouts. 

# How

I think doing 100 at a time is fine. For 3k assets, this took ~10 seconds or so to get all the specifications when I tested locally.

# Test Plan

For an app with 3k assets:
```
export EXPO_STAGING=1
~/expo/eas-cli/packages/eas-cli/bin/run update --branch preview --message "Updating the app"
```
See that it works!!
