### PR TITLE
[eas-cli] Prevent throwing dynamic app config write error when configuring project id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Prevent throwing dynamic app config write error when configuring project ID. ([#1301](https://github.com/expo/eas-cli/pull/1301) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 - Remove unused dependency and devDependency from the CLI. ([#1297](https://github.com/expo/eas-cli/pull/1297) by [@Simek](https://github.com/Simek))

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -3,7 +3,11 @@ import chalk from 'chalk';
 import EasCommand from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, setProjectIdAsync } from '../../project/projectUtils';
+import {
+  fetchProjectIdFromServerAsync,
+  findProjectRootAsync,
+  saveProjectIdToAppConfigAsync,
+} from '../../project/projectUtils';
 
 export default class ProjectInit extends EasCommand {
   static description = 'create or link an EAS project';
@@ -20,6 +24,9 @@ export default class ProjectInit extends EasCommand {
       return;
     }
 
-    await setProjectIdAsync(projectDir);
+    const projectId = await fetchProjectIdFromServerAsync(exp);
+    await saveProjectIdToAppConfigAsync(projectDir, projectId);
+
+    Log.withTick(`Linked app.json to project with ID ${chalk.bold(projectId)}`);
   }
 }

--- a/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
@@ -22,6 +22,10 @@ jest.mock('../../prompts');
 jest.mock('../../user/User');
 jest.mock('../ensureProjectExists');
 
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
 describe(findProjectRootAsync, () => {
   beforeEach(() => {
     vol.reset();
@@ -252,6 +256,21 @@ describe(promptToCreateProjectIfNotExistsAsync, () => {
 });
 
 describe(getProjectIdAsync, () => {
+  beforeEach(() => {
+    jest.mocked(getUserAsync).mockImplementation(
+      async (): Promise<Actor> => ({
+        __typename: 'User',
+        id: 'user_id',
+        username: 'notnotbrent',
+        accounts: [
+          { id: 'account_id_1', name: 'notnotbrent' },
+          { id: 'account_id_2', name: 'dominik' },
+        ],
+        isExpoAdmin: false,
+      })
+    );
+  });
+
   it('gets the project ID from app config if exists', async () => {
     await expect(
       getProjectIdAsync({ name: 'test', slug: 'test', extra: { eas: { projectId: '1234' } } })
@@ -273,5 +292,17 @@ describe(getProjectIdAsync, () => {
     expect(modifyConfigAsync).toHaveBeenCalledWith('/app', {
       extra: { eas: { projectId: '2345' } },
     });
+  });
+
+  it('does not throw if writing the ID back to the config fails', async () => {
+    jest.mocked(getConfig).mockReturnValue({ exp: { name: 'test', slug: 'test' } } as any);
+    jest.mocked(modifyConfigAsync).mockResolvedValue({
+      type: 'fail',
+      config: null,
+    });
+    jest.mocked(ensureProjectExistsAsync).mockImplementation(async () => '4567');
+
+    const projectId = await getProjectIdAsync({ name: 'test', slug: 'test' }, {}, { cwd: '/app' });
+    expect(projectId).toBe('4567');
   });
 });

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -83,19 +83,15 @@ export async function findProjectRootAsync({
   }
 }
 
-export async function setProjectIdAsync(
+/**
+ * Save an EAS project ID to the appropriate field in the app config.
+ */
+export async function saveProjectIdToAppConfigAsync(
   projectDir: string,
+  projectId: string,
   options: { env?: Env } = {}
-): Promise<ExpoConfig | undefined> {
+): Promise<void> {
   const exp = getExpoConfig(projectDir, options);
-
-  const privacy = toAppPrivacy(exp.privacy);
-  const projectId = await ensureProjectExistsAsync({
-    accountName: getProjectAccountName(exp, await ensureLoggedInAsync()),
-    projectName: exp.slug,
-    privacy,
-  });
-
   const result = await modifyConfigAsync(projectDir, {
     extra: { ...exp.extra, eas: { ...exp.extra?.eas, projectId } },
   });
@@ -122,11 +118,27 @@ export async function setProjectIdAsync(
     default:
       throw new Error('Unexpected result type from modifyConfigAsync');
   }
-
-  Log.withTick(`Linked app.json to project with ID ${chalk.bold(projectId)}`);
-  return result.config?.expo;
 }
 
+/**
+ * Use the owner/slug to identify an EAS project on the server.
+ *
+ * @returns the EAS project ID from the server
+ */
+export async function fetchProjectIdFromServerAsync(exp: ExpoConfig): Promise<string> {
+  const privacy = toAppPrivacy(exp.privacy);
+  return await ensureProjectExistsAsync({
+    accountName: getProjectAccountName(exp, await ensureLoggedInAsync()),
+    projectName: exp.slug,
+    privacy,
+  });
+}
+
+/**
+ * Get the EAS project ID from the app config. If the project ID is not set in the config.
+ * use the owner/slug to identify an EAS project on the server, and attempt to save the
+ * EAS project ID to the appropriate field in the app config.
+ */
 export async function getProjectIdAsync(
   exp: ExpoConfig,
   options: { env?: Env } = {},
@@ -140,19 +152,20 @@ export async function getProjectIdAsync(
     return localProjectId;
   }
 
-  // Set the project ID if it is missing.
   const projectDir = await findProjectRootAsync(findProjectRootOptions);
   if (!projectDir) {
     throw new Error('Run this command inside a project directory.');
   }
-  const newExp = await setProjectIdAsync(projectDir, options);
 
-  const newLocalProjectId = newExp?.extra?.eas?.projectId;
-  if (!newLocalProjectId) {
-    // throw if we still can't locate the projectId
-    throw new Error('Could not retrieve project ID from app.json');
+  const projectId = await fetchProjectIdFromServerAsync(exp);
+
+  try {
+    await saveProjectIdToAppConfigAsync(projectDir, projectId, options);
+  } catch (e: any) {
+    Log.warn(`Failed to save EAS project ID to app config: ${e.message}`);
   }
-  return newLocalProjectId;
+
+  return projectId;
 }
 
 const toAppPrivacy = (privacy: ExpoConfig['privacy']): AppPrivacy => {

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -162,7 +162,10 @@ export async function getProjectIdAsync(
   try {
     await saveProjectIdToAppConfigAsync(projectDir, projectId, options);
   } catch (e: any) {
-    Log.warn(`Failed to save EAS project ID to app config: ${e.message}`);
+    // saveProjectIdToAppConfigAsync already printed out a set of detailed errors and
+    // instructions on how to fix it. To mimic throwing the error but not halting
+    // execution, just warn here with the error message.
+    Log.warn(e.message);
   }
 
   return projectId;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Blame: https://github.com/expo/eas-cli/pull/1282

- This PR made it so that whenever the project ID is created/fetched from the server, it is put in the app config (app.json). Automatically adding this to a dynamic app config (app.config.js) doesn't work, so an error was thrown.
- While some commands require an explicit project ID (the reason for the blame PR), most do not; instead, most commands just call this method to get the project ID and don't need it to be configured in the manifest for later in their process.
- This caused CI breakage for projects that use dynamic app config and don't synchronize their project ID locally.

In the future, we may require explicitly setting up the project ID before any command can be run, or may make all commands run the setup and throw if they can't set the project ID in the dynamic config case. The benefits of synchronizing the project ID locally are:
    - Less network
    - More explicit behavior. Less prone to error when server is switched, app is transferred to a new account, or account is renamed. This one is important. `owner`/`slug` as a unique identifier is deprecated as it is less reliable.

https://github.com/expo/expo/pull/18744#issuecomment-1222879919

Fixes https://github.com/expo/eas-cli/issues/1296. Fixes 

# How

Separate out the methods, and surround the setting of the field with a try/catch to just warn in the case that it can't be set.

# Test Plan

Run tests.

In local project, `~/expo/eas-cli/packages/eas-cli/bin/run build -p android` (see that it no longer throws)