### PR TITLE
[ENG-6057][cli] api key creation: exponential backoff for slow apple propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Retry ASC Api Key Downloads if it has not fully propagated on Apple's infrastructure. ([#1302](https://github.com/expo/eas-cli/pull/1302) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🧹 Chores
 
 - Remove unused dependency and devDependency from the CLI. ([#1297](https://github.com/expo/eas-cli/pull/1297) by [@Simek](https://github.com/Simek))

--- a/packages/eas-cli/src/analytics/events.ts
+++ b/packages/eas-cli/src/analytics/events.ts
@@ -15,7 +15,9 @@ export enum SubmissionEvent {
   SUBMIT_REQUEST_ATTEMPT = 'submit cli request attempt',
   SUBMIT_REQUEST_SUCCESS = 'submit cli request success',
   SUBMIT_REQUEST_FAIL = 'submit cli request fail',
-  CREDENTIALS_API_KEY_DOWNLOAD = 'submit cli credentials api key download',
+  API_KEY_DOWNLOAD_FAIL = 'submit cli credentials api key download fail',
+  API_KEY_DOWNLOAD_RETRY = 'submit cli credentials api key download fail temporary',
+  API_KEY_DOWNLOAD_SUCCESS = 'submit cli credentials api key download succeed',
 }
 
 export enum BuildEvent {

--- a/packages/eas-cli/src/analytics/events.ts
+++ b/packages/eas-cli/src/analytics/events.ts
@@ -15,6 +15,7 @@ export enum SubmissionEvent {
   SUBMIT_REQUEST_ATTEMPT = 'submit cli request attempt',
   SUBMIT_REQUEST_SUCCESS = 'submit cli request success',
   SUBMIT_REQUEST_FAIL = 'submit cli request fail',
+  CREDENTIALS_API_KEY_DOWNLOAD = 'submit cli credentials api key download',
 }
 
 export enum BuildEvent {

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/ascApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/ascApiKey-test.ts
@@ -9,7 +9,6 @@ import {
 } from '../ascApiKey';
 import { getRequestContext } from '../authenticate';
 
-//jest.mock('@expo/apple-utils');
 jest.mock('../authenticate');
 jest.mock('../../../../ora');
 
@@ -112,7 +111,7 @@ test(`downloadWithRetryAsync`, async () => {
     downloadWithRetryAsync(mockApiKeyWithDownloadError, { minTimeout: 1 }) // stay within jest timeout window
   ).rejects.toThrowError(cacheFailureMessage);
   // expect to try once and retry 3 times = 4 total
-  expect(mockApiKeyWithDownloadError.downloadAsync as jest.Mock).toBeCalledTimes(4);
+  expect(mockApiKeyWithDownloadError.downloadAsync as jest.Mock).toBeCalledTimes(7);
 
   // one time failure
   const mockApiKeyWithOneTimeDownloadError = mockApiKey as unknown as ApiKey;

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/ascApiKey-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/ascApiKey-test.ts
@@ -1,14 +1,15 @@
-import { ApiKey, ApiKeyType, UserRole } from '@expo/apple-utils';
+import { ApiKey, ApiKeyType, UnexpectedResponse, UserRole } from '@expo/apple-utils';
 
 import {
   createAscApiKeyAsync,
+  downloadWithRetryAsync,
   getAscApiKeyAsync,
   listAscApiKeysAsync,
   revokeAscApiKeyAsync,
 } from '../ascApiKey';
 import { getRequestContext } from '../authenticate';
 
-jest.mock('@expo/apple-utils');
+//jest.mock('@expo/apple-utils');
 jest.mock('../authenticate');
 jest.mock('../../../../ora');
 
@@ -95,4 +96,39 @@ test(`revokeAscApiKeyAsync`, async () => {
   });
   expect(mockApiKey.revokeAsync).toBeCalled();
   expect(result).toEqual(mockAscApiKeyInfo);
+});
+
+test(`downloadWithRetryAsync`, async () => {
+  const cacheFailureMessage = `The specified resource does not exist - There is no resource of type 'apiKeys' with id 'TEST-ID'`;
+
+  // complete failure
+  const mockApiKeyWithDownloadError = {
+    ...mockApiKey,
+    downloadAsync: jest.fn(() => {
+      throw new UnexpectedResponse(cacheFailureMessage);
+    }),
+  } as unknown as ApiKey;
+  await expect(
+    downloadWithRetryAsync(mockApiKeyWithDownloadError, { minTimeout: 1 }) // stay within jest timeout window
+  ).rejects.toThrowError(cacheFailureMessage);
+  // expect to try once and retry 3 times = 4 total
+  expect(mockApiKeyWithDownloadError.downloadAsync as jest.Mock).toBeCalledTimes(4);
+
+  // one time failure
+  const mockApiKeyWithOneTimeDownloadError = mockApiKey as unknown as ApiKey;
+  (mockApiKeyWithOneTimeDownloadError.downloadAsync as jest.Mock).mockClear();
+  (mockApiKeyWithOneTimeDownloadError.downloadAsync as jest.Mock).mockImplementationOnce(() => {
+    throw new UnexpectedResponse(cacheFailureMessage);
+  });
+  const keyP8AfterOneFailure = await downloadWithRetryAsync(mockApiKeyWithOneTimeDownloadError, {
+    minTimeout: 1,
+  });
+  expect(keyP8AfterOneFailure).toBe('super secret');
+
+  // successful case
+  (mockApiKey.downloadAsync as jest.Mock).mockClear();
+  const keyP8NoFailure = await downloadWithRetryAsync(mockApiKeyWithOneTimeDownloadError, {
+    minTimeout: 1,
+  });
+  expect(keyP8NoFailure).toBe('super secret');
 });

--- a/packages/eas-cli/src/credentials/ios/appstore/ascApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ascApiKey.ts
@@ -51,6 +51,12 @@ export async function getAscApiKeyAsync(
   }
 }
 
+/**
+ * There is a bug in Apple's infrastructure that does not propagate newly created objects for a
+ * while. If the key has not propagated and you try to download it, Apple will error saying that
+ * the resource does not exist. We retry with exponential backoff until the key propagates and
+ * is available for download.
+ * */
 export async function downloadWithRetryAsync(
   key: ApiKey,
   options: { minTimeout?: number } = {}

--- a/packages/eas-cli/src/credentials/ios/appstore/ascApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ascApiKey.ts
@@ -1,6 +1,8 @@
 import { ApiKey, ApiKeyProps, ApiKeyType, UserRole } from '@expo/apple-utils';
+import promiseRetry from 'promise-retry';
 
-import Log from '../../../log';
+import { Analytics, SubmissionEvent } from '../../../analytics/events';
+import Log, { learnMore } from '../../../log';
 import { ora } from '../../../ora';
 import { AscApiKey, AscApiKeyInfo } from './Credentials.types';
 import { getRequestContext } from './authenticate';
@@ -49,6 +51,64 @@ export async function getAscApiKeyAsync(
   }
 }
 
+export async function downloadWithRetryAsync(
+  key: ApiKey,
+  options: { minTimeout?: number } = {}
+): Promise<string | null> {
+  const retries = 6;
+  const factor = 2;
+  const minTimeout = options.minTimeout ?? 1000;
+  const RESOURCE_DOES_NOT_EXIST_MESSAGE =
+    'The specified resource does not exist - There is no resource of type';
+  try {
+    return await promiseRetry(
+      async (retry, number) => {
+        try {
+          return await key.downloadAsync();
+        } catch (e: any) {
+          if (
+            e.name === 'UnexpectedAppleResponse' &&
+            e.message.includes(RESOURCE_DOES_NOT_EXIST_MESSAGE)
+          ) {
+            const secondsToRetry = Math.pow(factor, number);
+            Log.log(
+              `Received an unexpected response from Apple, retrying in ${secondsToRetry} seconds...`
+            );
+            Analytics.logEvent(SubmissionEvent.CREDENTIALS_API_KEY_DOWNLOAD, {
+              errorName: e.name,
+              reason: e.message,
+              retry: number,
+            });
+            return retry(e);
+          }
+          throw e;
+        }
+      },
+      {
+        retries,
+        factor,
+        minTimeout,
+      }
+    );
+  } catch (e: any) {
+    if (
+      e.name === 'UnexpectedAppleResponse' &&
+      e.message.includes(RESOURCE_DOES_NOT_EXIST_MESSAGE)
+    ) {
+      Log.warn(
+        `Unable to download Api Key from Apple at this time. Please create and upload your key manually by running 'eas credentials' ${learnMore(
+          'https://expo.fyi/creating-asc-api-key'
+        )}`
+      );
+    }
+    Analytics.logEvent(SubmissionEvent.CREDENTIALS_API_KEY_DOWNLOAD, {
+      errorName: e.name,
+      reason: e.message,
+    });
+    throw e;
+  }
+}
+
 /**
  * Create an App Store Connect API Key.
  * **Does not support App Store Connect API (CI).**
@@ -71,7 +131,7 @@ export async function createAscApiKeyAsync(
       roles: roles ?? [UserRole.ADMIN],
       keyType: keyType ?? ApiKeyType.PUBLIC_API,
     });
-    const keyP8 = await key.downloadAsync();
+    const keyP8 = await downloadWithRetryAsync(key);
     if (!keyP8) {
       const { nickname, roles } = key.attributes;
       const humanReadableKey = `App Store Connect Key '${nickname}' (${


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why
There is a [bug in Apple's infrastructure](https://developer.apple.com/forums/thread/684314) that does not propagate newly created objects for a long time (up to 14 seconds in my experiments!). This behaviour is non-deterministic, but the general chain of events is as follows:
1. cli creates Api Key through Apple API
2. cli receives response that key is created
3. cli attempts to download Api Key
4. Apple responds saying that resource does not exist 😿 

Fixes https://github.com/expo/expo-cli/issues/4521

# How
<img width="916" alt="Screen Shot 2022-08-22 at 9 38 40 PM" src="https://user-images.githubusercontent.com/6380927/186071130-277f43e0-3570-4083-b05b-318cb5e6baa8.png">


Retry, using exponential backoff. We will retry for up to 6 times, waiting 2, 4, 8, 16, 32 and 64 seconds between each retry. I tried creating an Api Key many times and when the bug occurred, the maximum time I ended up waiting was around 14 seconds. It is possible people might experience longer times, so I added more retries just in case (hopefully waiting 64 seconds in the worst case scenario is not too awful!). 

In the case where the key never propagates, I fail with a helpful error message showing people how to create their key manually. I've also added analytics to track the types of failures and the # of retries users experience - this propagation issue is new, and Apple's server side code may change to eventually fix this.

# Test Plan

- [x] new tests pass 
