### PR TITLE
[eas-cli] Replace promptToCreateProjectIfNotExistsAsync with getProjectIdAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Prevent throwing dynamic app config write error when configuring project ID. ([#1301](https://github.com/expo/eas-cli/pull/1301) by [@wschurman](https://github.com/wschurman))
+- Replace promptToCreateProjectIfNotExistsAsync with getProjectIdAsync. ([#1303](https://github.com/expo/eas-cli/pull/1303) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -11,10 +11,7 @@ import {
 import Log, { learnMore } from '../../log';
 import { resolveXcodeBuildContextAsync } from '../../project/ios/scheme';
 import { resolveTargetsAsync } from '../../project/ios/target';
-import {
-  getProjectAccountName,
-  promptToCreateProjectIfNotExistsAsync,
-} from '../../project/projectUtils';
+import { getProjectAccountName, getProjectIdAsync } from '../../project/projectUtils';
 import { confirmAsync, promptAsync, selectAsync } from '../../prompts';
 import { Account, findAccountByName } from '../../user/Account';
 import { ensureActorHasUsername, ensureLoggedInAsync } from '../../user/actions';
@@ -175,12 +172,9 @@ export class ManageIos {
     targets: Target[];
   }> {
     assert(ctx.hasProjectContext, 'createProjectContextAsync: must have project context.');
-    const maybeProjectId = await promptToCreateProjectIfNotExistsAsync(ctx.exp);
-    if (!maybeProjectId) {
-      throw new Error(
-        'Your project must be registered with EAS in order to use the credentials manager.'
-      );
-    }
+
+    // ensure the project exists on the EAS server
+    await getProjectIdAsync(ctx.exp);
 
     const app = { account, projectName: ctx.exp.slug };
     const xcodeBuildContext = await resolveXcodeBuildContextAsync(

--- a/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
@@ -1,18 +1,13 @@
 import { getConfig, modifyConfigAsync } from '@expo/config';
 import { vol } from 'memfs';
 
-import { confirmAsync } from '../../prompts';
 import { Actor, getUserAsync } from '../../user/User';
-import {
-  ensureProjectExistsAsync,
-  findProjectIdByAccountNameAndSlugNullableAsync,
-} from '../ensureProjectExists';
+import { ensureProjectExistsAsync } from '../ensureProjectExists';
 import {
   findProjectRootAsync,
   getProjectAccountName,
   getProjectAccountNameAsync,
   getProjectIdAsync,
-  promptToCreateProjectIfNotExistsAsync,
 } from '../projectUtils';
 
 jest.mock('@expo/config');
@@ -183,75 +178,6 @@ describe(getProjectAccountNameAsync, () => {
     await expect(getProjectAccountNameAsync(expWithoutOwner)).rejects.toThrow(
       'manifest property is required'
     );
-  });
-});
-
-describe(promptToCreateProjectIfNotExistsAsync, () => {
-  beforeEach(() => {
-    jest.mocked(getUserAsync).mockReset();
-    jest.mocked(findProjectIdByAccountNameAndSlugNullableAsync).mockReset();
-  });
-
-  it('returns the existing project', async () => {
-    jest.mocked(getUserAsync).mockImplementation(
-      async (): Promise<Actor> => ({
-        __typename: 'User',
-        id: 'user_id',
-        username: 'quin',
-        accounts: [{ id: 'account_id_1', name: 'quin' }],
-        isExpoAdmin: false,
-      })
-    );
-    jest
-      .mocked(findProjectIdByAccountNameAndSlugNullableAsync)
-      .mockImplementation(async () => 'already-existing-project-id');
-    const exp: any = {};
-    const projectId = await promptToCreateProjectIfNotExistsAsync(exp);
-    expect(projectId).toBe('already-existing-project-id');
-  });
-  it('makes a new project if none exists', async () => {
-    jest.mock('../../prompts');
-    jest.mocked(getUserAsync).mockImplementation(
-      async (): Promise<Actor> => ({
-        __typename: 'User',
-        id: 'user_id',
-        username: 'quin',
-        accounts: [{ id: 'account_id_1', name: 'quin' }],
-        isExpoAdmin: false,
-      })
-    );
-    jest
-      .mocked(findProjectIdByAccountNameAndSlugNullableAsync)
-      .mockImplementation(async () => null);
-    jest.mocked(ensureProjectExistsAsync).mockImplementation(async () => 'new-project-id');
-
-    // user agrees to make new project
-    jest.mocked(confirmAsync).mockImplementation(async () => true);
-    const exp: any = {};
-    const projectId = await promptToCreateProjectIfNotExistsAsync(exp);
-    expect(projectId).toBe('new-project-id');
-  });
-  it('aborts making a new project if the user declines', async () => {
-    jest.mock('../../prompts');
-    jest.mocked(getUserAsync).mockImplementation(
-      async (): Promise<Actor> => ({
-        __typename: 'User',
-        id: 'user_id',
-        username: 'quin',
-        accounts: [{ id: 'account_id_1', name: 'quin' }],
-        isExpoAdmin: false,
-      })
-    );
-    jest
-      .mocked(findProjectIdByAccountNameAndSlugNullableAsync)
-      .mockImplementation(async () => null);
-    jest.mocked(ensureProjectExistsAsync).mockImplementation(async () => 'new-project-id');
-
-    // user doesnt agree to make new project
-    jest.mocked(confirmAsync).mockImplementation(async () => false);
-    const exp: any = {};
-    const projectId = await promptToCreateProjectIfNotExistsAsync(exp);
-    expect(projectId).toBe(null);
   });
 });
 

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -9,15 +9,11 @@ import semver from 'semver';
 
 import { AppPrivacy } from '../graphql/generated';
 import Log from '../log';
-import { confirmAsync } from '../prompts';
 import { Actor } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
 import { expoCommandAsync } from '../utils/expoCli';
 import { getVcsClient } from '../vcs';
-import {
-  ensureProjectExistsAsync,
-  findProjectIdByAccountNameAndSlugNullableAsync,
-} from './ensureProjectExists';
+import { ensureProjectExistsAsync } from './ensureProjectExists';
 import { getExpoConfig } from './expoConfig';
 
 export function getProjectAccountName(exp: ExpoConfig, user: Actor): string {
@@ -205,33 +201,6 @@ export function getProjectConfigDescription(projectDir: string): string {
     return path.relative(projectDir, paths.staticConfigPath);
   }
   return 'app.config.js/app.json';
-}
-
-// return project id of existing/newly created project, or null if user declines
-export async function promptToCreateProjectIfNotExistsAsync(
-  exp: ExpoConfig
-): Promise<string | null> {
-  const accountName = getProjectAccountName(exp, await ensureLoggedInAsync());
-  const maybeProjectId = await findProjectIdByAccountNameAndSlugNullableAsync(
-    accountName,
-    exp.slug
-  );
-  if (maybeProjectId) {
-    return maybeProjectId;
-  }
-  const fullName = await getProjectFullNameAsync(exp);
-  const shouldCreateProject = await confirmAsync({
-    message: `Looks like ${fullName} is new. Register it with EAS?`,
-  });
-  if (!shouldCreateProject) {
-    return null;
-  }
-  const privacy = toAppPrivacy(exp.privacy);
-  return await ensureProjectExistsAsync({
-    accountName,
-    projectName: exp.slug,
-    privacy,
-  });
 }
 
 export function isExpoUpdatesInstalled(projectDir: string): boolean {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This is inconsistent with the rest of the CLI commands which just create the project automatically.

# How

Remove code and replace with equivalent code. All cases here used to throw if the user declined. Now they throw only if the user is not logged-in or on the internet.

# Test Plan

In a project that is not yet linked, run `~/expo/eas-cli/packages/eas-cli/bin/run credentials`, generate android keystore and see that it is created on the server and linked.