### PR TITLE
[eas-cli] Handle trailing backslash in gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Handle trailing backslash in `.gitignore`. ([#1306](https://github.com/expo/eas-cli/pull/1306) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [1.1.0](https://github.com/expo/eas-cli/releases/tag/v1.1.0) - 2022-08-23

--- a/packages/eas-cli/src/vcs/__tests__/local-test.ts
+++ b/packages/eas-cli/src/vcs/__tests__/local-test.ts
@@ -84,4 +84,17 @@ describe(Ignore, () => {
     await ignore.initIgnoreAsync();
     expect(ignore.ignores('.git')).toBe(true);
   });
+
+  it('does not throw an error if there is a trailing backslash in the gitignore', async () => {
+    vol.fromJSON(
+      {
+        '.gitignore': 'dir\\',
+      },
+      '/root'
+    );
+
+    const ignore = new Ignore('/root');
+    await ignore.initIgnoreAsync();
+    expect(() => ignore.ignores('dir/test')).not.toThrowError();
+  });
 });

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -39,7 +39,7 @@ export class Ignore {
     if (await fs.pathExists(easIgnorePath)) {
       this.ignoreMapping = [
         ['', createIgnore().add(DEFAULT_IGNORE)],
-        ['', createIgnore().add(await fs.readFile(easIgnorePath, 'utf8'))],
+        ['', createIgnore().add(await this.readIgnoreFileAsync(easIgnorePath))],
       ];
       return;
     }
@@ -57,7 +57,7 @@ export class Ignore {
       ignoreFilePaths.map(async filePath => {
         return [
           filePath.slice(0, filePath.length - GITIGNORE_FILENAME.length),
-          createIgnore().add(await fs.readFile(path.join(this.rootDir, filePath), 'utf8')),
+          createIgnore().add(await this.readIgnoreFileAsync(path.join(this.rootDir, filePath))),
         ] as const;
       })
     );
@@ -71,6 +71,16 @@ export class Ignore {
       }
     }
     return false;
+  }
+
+  private async readIgnoreFileAsync(filePath: string): Promise<string> {
+    const fileContents = await fs.readFile(filePath, 'utf-8');
+    const lines = fileContents.split('\n');
+    // Strip trailing '\'. This logic can be removed after fix upstream is released.
+    // https://github.com/kaelzhang/node-ignore/issues/81
+    return lines
+      .map((line: string) => (line.slice(-1) === '\\' ? line.slice(0, -1) : line))
+      .join('\n');
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Adding trailing backslash in gitignore, is causing a syntax error when packaging a build archive.

# How

Remove all trailing backslashes from gitignore before passing them to the ignore library.

# Test Plan

add test + tested manually
