### PR TITLE
[ENG-6125] print warning when eas-cli is installed as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Print warning when eas-cli is installed as project dependency. ([#1310](https://github.com/expo/eas-cli/pull/1310) by [@dsokal](https://github.com/dsokal))
+
 ### 🐛 Bug fixes
 
 - Replace promptToCreateProjectIfNotExistsAsync with getProjectIdAsync. ([#1303](https://github.com/expo/eas-cli/pull/1303) by [@wschurman](https://github.com/wschurman))

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -19,6 +19,28 @@ npm install -g eas-cli
 yarn global add eas-cli
 ```
 
+## Enforcing eas-cli version for your project
+
+If you want to enforce the **eas-cli** version for your project, use the `"cli.version"` field in eas.json. Installing **eas-cli** as your project dependency is strongly discouraged.
+
+An example of `eas.json` that enforces `eas-cli` in version `1.0.0` or newer:
+
+```json
+{
+  "cli": {
+    "version": ">=1.0.0"
+  },
+  "build": {
+    // build profiles
+  }
+  "submit": {
+    // submit profiles
+  }
+}
+```
+
+Learn more: https://docs.expo.dev/build-reference/eas-json/
+
 # Usage
 
 ```sh
@@ -33,61 +55,62 @@ eas --help COMMAND
 # Commands
 
 <!-- commands -->
-* [`eas account:login`](#eas-accountlogin)
-* [`eas account:logout`](#eas-accountlogout)
-* [`eas account:view`](#eas-accountview)
-* [`eas analytics [STATUS]`](#eas-analytics-status)
-* [`eas autocomplete [SHELL]`](#eas-autocomplete-shell)
-* [`eas branch:create [NAME]`](#eas-branchcreate-name)
-* [`eas branch:delete [NAME]`](#eas-branchdelete-name)
-* [`eas branch:list`](#eas-branchlist)
-* [`eas branch:rename`](#eas-branchrename)
-* [`eas branch:view [NAME]`](#eas-branchview-name)
-* [`eas build`](#eas-build)
-* [`eas build:cancel [BUILD_ID]`](#eas-buildcancel-build_id)
-* [`eas build:configure`](#eas-buildconfigure)
-* [`eas build:inspect`](#eas-buildinspect)
-* [`eas build:list`](#eas-buildlist)
-* [`eas build:submit`](#eas-buildsubmit)
-* [`eas build:version:set`](#eas-buildversionset)
-* [`eas build:version:sync`](#eas-buildversionsync)
-* [`eas build:view [BUILD_ID]`](#eas-buildview-build_id)
-* [`eas channel:create [NAME]`](#eas-channelcreate-name)
-* [`eas channel:edit [NAME]`](#eas-channeledit-name)
-* [`eas channel:list`](#eas-channellist)
-* [`eas channel:view [NAME]`](#eas-channelview-name)
-* [`eas config`](#eas-config)
-* [`eas credentials`](#eas-credentials)
-* [`eas database:create`](#eas-databasecreate)
-* [`eas device:create`](#eas-devicecreate)
-* [`eas device:delete`](#eas-devicedelete)
-* [`eas device:list`](#eas-devicelist)
-* [`eas device:view [UDID]`](#eas-deviceview-udid)
-* [`eas diagnostics`](#eas-diagnostics)
-* [`eas functions:start`](#eas-functionsstart)
-* [`eas help [COMMAND]`](#eas-help-command)
-* [`eas init`](#eas-init)
-* [`eas login`](#eas-login)
-* [`eas logout`](#eas-logout)
-* [`eas metadata:pull`](#eas-metadatapull)
-* [`eas metadata:push`](#eas-metadatapush)
-* [`eas project:info`](#eas-projectinfo)
-* [`eas project:init`](#eas-projectinit)
-* [`eas secret:create`](#eas-secretcreate)
-* [`eas secret:delete`](#eas-secretdelete)
-* [`eas secret:list`](#eas-secretlist)
-* [`eas submit`](#eas-submit)
-* [`eas update`](#eas-update)
-* [`eas update:configure`](#eas-updateconfigure)
-* [`eas update:delete GROUPID`](#eas-updatedelete-groupid)
-* [`eas update:list`](#eas-updatelist)
-* [`eas update:view GROUPID`](#eas-updateview-groupid)
-* [`eas webhook:create`](#eas-webhookcreate)
-* [`eas webhook:delete [ID]`](#eas-webhookdelete-id)
-* [`eas webhook:list`](#eas-webhooklist)
-* [`eas webhook:update`](#eas-webhookupdate)
-* [`eas webhook:view ID`](#eas-webhookview-id)
-* [`eas whoami`](#eas-whoami)
+
+- [`eas account:login`](#eas-accountlogin)
+- [`eas account:logout`](#eas-accountlogout)
+- [`eas account:view`](#eas-accountview)
+- [`eas analytics [STATUS]`](#eas-analytics-status)
+- [`eas autocomplete [SHELL]`](#eas-autocomplete-shell)
+- [`eas branch:create [NAME]`](#eas-branchcreate-name)
+- [`eas branch:delete [NAME]`](#eas-branchdelete-name)
+- [`eas branch:list`](#eas-branchlist)
+- [`eas branch:rename`](#eas-branchrename)
+- [`eas branch:view [NAME]`](#eas-branchview-name)
+- [`eas build`](#eas-build)
+- [`eas build:cancel [BUILD_ID]`](#eas-buildcancel-build_id)
+- [`eas build:configure`](#eas-buildconfigure)
+- [`eas build:inspect`](#eas-buildinspect)
+- [`eas build:list`](#eas-buildlist)
+- [`eas build:submit`](#eas-buildsubmit)
+- [`eas build:version:set`](#eas-buildversionset)
+- [`eas build:version:sync`](#eas-buildversionsync)
+- [`eas build:view [BUILD_ID]`](#eas-buildview-build_id)
+- [`eas channel:create [NAME]`](#eas-channelcreate-name)
+- [`eas channel:edit [NAME]`](#eas-channeledit-name)
+- [`eas channel:list`](#eas-channellist)
+- [`eas channel:view [NAME]`](#eas-channelview-name)
+- [`eas config`](#eas-config)
+- [`eas credentials`](#eas-credentials)
+- [`eas database:create`](#eas-databasecreate)
+- [`eas device:create`](#eas-devicecreate)
+- [`eas device:delete`](#eas-devicedelete)
+- [`eas device:list`](#eas-devicelist)
+- [`eas device:view [UDID]`](#eas-deviceview-udid)
+- [`eas diagnostics`](#eas-diagnostics)
+- [`eas functions:start`](#eas-functionsstart)
+- [`eas help [COMMAND]`](#eas-help-command)
+- [`eas init`](#eas-init)
+- [`eas login`](#eas-login)
+- [`eas logout`](#eas-logout)
+- [`eas metadata:pull`](#eas-metadatapull)
+- [`eas metadata:push`](#eas-metadatapush)
+- [`eas project:info`](#eas-projectinfo)
+- [`eas project:init`](#eas-projectinit)
+- [`eas secret:create`](#eas-secretcreate)
+- [`eas secret:delete`](#eas-secretdelete)
+- [`eas secret:list`](#eas-secretlist)
+- [`eas submit`](#eas-submit)
+- [`eas update`](#eas-update)
+- [`eas update:configure`](#eas-updateconfigure)
+- [`eas update:delete GROUPID`](#eas-updatedelete-groupid)
+- [`eas update:list`](#eas-updatelist)
+- [`eas update:view GROUPID`](#eas-updateview-groupid)
+- [`eas webhook:create`](#eas-webhookcreate)
+- [`eas webhook:delete [ID]`](#eas-webhookdelete-id)
+- [`eas webhook:list`](#eas-webhooklist)
+- [`eas webhook:update`](#eas-webhookupdate)
+- [`eas webhook:view ID`](#eas-webhookview-id)
+- [`eas whoami`](#eas-whoami)
 
 ## `eas account:login`
 
@@ -1140,4 +1163,5 @@ DESCRIPTION
 ALIASES
   $ eas whoami
 ```
+
 <!-- commandsstop -->

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -21,9 +21,9 @@ yarn global add eas-cli
 
 ## Enforcing eas-cli version for your project
 
-If you want to enforce the **eas-cli** version for your project, use the `"cli.version"` field in eas.json. Installing **eas-cli** as your project dependency is strongly discouraged.
+If you want to enforce the `eas-cli` version for your project, use the `"cli.version"` field in **eas.json**. Installing `eas-cli` to your project dependencies is strongly discouraged because it may cause dependency conflicts that are difficult to debug.
 
-An example of `eas.json` that enforces `eas-cli` in version `1.0.0` or newer:
+An example of **eas.json** that enforces `eas-cli` in version `1.0.0` or newer:
 
 ```json
 {

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -12,7 +12,7 @@ import {
   initAsync as initAnalyticsAsync,
   logEvent,
 } from '../analytics/rudderstackClient';
-import Log, { learnMore } from '../log';
+import { learnMore } from '../log';
 import { findProjectRootAsync } from '../project/projectUtils';
 import { getUserAsync } from '../user/User';
 import { ensureLoggedInAsync } from '../user/actions';
@@ -77,27 +77,37 @@ export default abstract class EasCommand extends Command {
   private async ensureEasCliIsNotInDependenciesAsync(projectDir: string): Promise<void> {
     let printCliVersionWarning = false;
 
+    const consoleWarn = (msg?: string): void => {
+      if (msg) {
+        // eslint-disable-next-line no-console
+        console.warn(chalk.yellow(msg));
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn();
+      }
+    };
+
     if (await this.isEasCliInDependenciesAsync(projectDir)) {
       printCliVersionWarning = true;
-      Log.warn(`${chalk.bold('eas-cli')} is added to the project dependencies.`);
+      consoleWarn(`${chalk.bold('eas-cli')} is added to the project dependencies.`);
     }
 
     const maybeRepoRoot = PackageManagerUtils.findWorkspaceRoot(projectDir) ?? projectDir;
     if (maybeRepoRoot !== projectDir && (await this.isEasCliInDependenciesAsync(maybeRepoRoot))) {
       printCliVersionWarning = true;
-      Log.warn(`${chalk.bold('eas-cli')} is added to the monorepo dependencies.`);
+      consoleWarn(`${chalk.bold('eas-cli')} is added to the monorepo dependencies.`);
     }
 
     if (printCliVersionWarning) {
-      Log.warn(
+      consoleWarn(
         `It's recommended to use the ${chalk.bold(
           '"cli.version"'
         )} field in eas.json instead. Use it to enforce the ${chalk.bold(
           'eas-cli'
         )} version for your project.`
       );
-      Log.warn(learnMore('https://docs.expo.dev/build-reference/eas-json/'));
-      Log.newLine();
+      consoleWarn(learnMore('https://docs.expo.dev/build-reference/eas-json/'));
+      consoleWarn();
     }
   }
 

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -102,11 +102,11 @@ export default abstract class EasCommand extends Command {
       consoleWarn(
         `It's recommended to use the ${chalk.bold(
           '"cli.version"'
-        )} field in eas.json to enforce the ${chalk.bold(
-          'eas-cli'
-        )} version for your project.`
+        )} field in eas.json to enforce the ${chalk.bold('eas-cli')} version for your project.`
       );
-      consoleWarn(learnMore('https://docs.expo.dev/build-reference/eas-json/'));
+      consoleWarn(
+        learnMore('https://github.com/expo/eas-cli#enforcing-eas-cli-version-for-your-project')
+      );
       consoleWarn();
     }
   }

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -89,20 +89,20 @@ export default abstract class EasCommand extends Command {
 
     if (await this.isEasCliInDependenciesAsync(projectDir)) {
       printCliVersionWarning = true;
-      consoleWarn(`${chalk.bold('eas-cli')} is added to the project dependencies.`);
+      consoleWarn(`Found ${chalk.bold('eas-cli')} in your project dependencies.`);
     }
 
     const maybeRepoRoot = PackageManagerUtils.findWorkspaceRoot(projectDir) ?? projectDir;
     if (maybeRepoRoot !== projectDir && (await this.isEasCliInDependenciesAsync(maybeRepoRoot))) {
       printCliVersionWarning = true;
-      consoleWarn(`${chalk.bold('eas-cli')} is added to the monorepo dependencies.`);
+      consoleWarn(`Found ${chalk.bold('eas-cli')} in your monorepo dependencies.`);
     }
 
     if (printCliVersionWarning) {
       consoleWarn(
         `It's recommended to use the ${chalk.bold(
           '"cli.version"'
-        )} field in eas.json instead. Use it to enforce the ${chalk.bold(
+        )} field in eas.json to enforce the ${chalk.bold(
           'eas-cli'
         )} version for your project.`
       );


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-6125/verify-that-eas-cli-isnt-installed-locally-to-the-project-dependencies

# How

Detect if eas-cli is installed as a dependency and print a warning.

# Test Plan

Installed in project:
<img width="964" alt="Screenshot 2022-08-24 at 12 20 03" src="https://user-images.githubusercontent.com/5256730/186395402-6f086874-32e1-4a65-8d09-9b1e11f25283.png">


Installed in monorepo root:
<img width="900" alt="Screenshot 2022-08-24 at 12 21 51" src="https://user-images.githubusercontent.com/5256730/186395397-b5c37fad-5ea8-4192-8463-c592893c2052.png">

Installed in project + monorepo root:
<img width="975" alt="Screenshot 2022-08-24 at 12 22 26" src="https://user-images.githubusercontent.com/5256730/186395390-5d683307-36af-4c75-ac36-8339c5bda4e9.png">