### PR TITLE
add eas.json option to skip push notifications setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Print warning when eas-cli is installed as project dependency. ([#1310](https://github.com/expo/eas-cli/pull/1310) by [@dsokal](https://github.com/dsokal))
+- Add eas.json to skip push notifications credentials setup. ([#1315](https://github.com/expo/eas-cli/pull/1315) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -60,6 +60,7 @@ export async function createBuildContextAsync<T extends Platform>({
     projectDir,
     user,
     env: buildProfile.env,
+    easJsonCliConfig,
   });
 
   const devClientProperties = getDevClientEventProperties({

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { Env } from '@expo/eas-build-job';
+import { EasJson } from '@expo/eas-json';
 import chalk from 'chalk';
 
 import Log from '../log';
@@ -19,6 +20,7 @@ export class CredentialsContext {
   public readonly nonInteractive: boolean;
   public readonly projectDir: string;
   public readonly user: Actor;
+  public readonly easJsonCliConfig?: EasJson['cli'];
 
   private shouldAskAuthenticateAppStore: boolean = true;
   private resolvedExp?: ExpoConfig;
@@ -26,12 +28,14 @@ export class CredentialsContext {
   constructor(
     private options: {
       exp?: ExpoConfig;
+      easJsonCliConfig?: EasJson['cli'];
       nonInteractive?: boolean;
       projectDir: string;
       user: Actor;
       env?: Env;
     }
   ) {
+    this.easJsonCliConfig = options.easJsonCliConfig;
     this.projectDir = options.projectDir;
     this.user = options.user;
     this.nonInteractive = options.nonInteractive ?? false;

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -101,7 +101,7 @@ export default class IosCredentialsProvider {
       return null;
     }
 
-    if (ctx.easJsonCliConfig?.setUpPushNotifications === false) {
+    if (ctx.easJsonCliConfig?.promptToConfigurePushNotfications === false) {
       return null;
     }
 
@@ -111,7 +111,7 @@ export default class IosCredentialsProvider {
         { title: 'Yes', value: PushNotificationSetupOption.YES },
         { title: 'No', value: PushNotificationSetupOption.NO },
         {
-          title: `No, don't ask again (updates eas.json)`,
+          title: `No, don't ask again (preference will be saved to eas.json)`,
           value: PushNotificationSetupOption.NO_DONT_ASK_AGAIN,
         },
       ]
@@ -131,7 +131,7 @@ export default class IosCredentialsProvider {
   ): Promise<void> {
     const easJsonPath = EasJsonReader.formatEasJsonPath(ctx.projectDir);
     const easJson = await fs.readJSON(easJsonPath);
-    easJson.cli = { ...easJson?.cli, setUpPushNotifications: false };
+    easJson.cli = { ...easJson?.cli, promptToConfigurePushNotfications: false };
     await fs.writeFile(easJsonPath, `${JSON.stringify(easJson, null, 2)}\n`);
     Log.withTick('Updated eas.json');
   }

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -37,6 +37,11 @@
             "When using local, the `autoIncrement` is based on your local project values.",
             "When using remote, the `autoIncrement` is based on the values stored on EAS servers."
           ]
+        },
+        "promptToConfigurePushNotfications" : {
+          "type": "boolean",
+          "description": "Specifies where EAS CLI should prompt to configure Push Notifications credentials. Defaults to true.",
+          "default": true
         }
       }
     },

--- a/packages/eas-json/src/schema.ts
+++ b/packages/eas-json/src/schema.ts
@@ -9,7 +9,7 @@ export const EasJsonSchema = Joi.object({
     version: Joi.string(),
     requireCommit: Joi.boolean(),
     appVersionSource: Joi.string().valid(...Object.values(AppVersionSource)),
-    setUpPushNotifications: Joi.boolean(),
+    promptToConfigurePushNotfications: Joi.boolean(),
   }),
   build: Joi.object().pattern(Joi.string(), BuildProfileSchema),
   submit: Joi.object().pattern(Joi.string(), SubmitProfileSchema),

--- a/packages/eas-json/src/schema.ts
+++ b/packages/eas-json/src/schema.ts
@@ -9,6 +9,7 @@ export const EasJsonSchema = Joi.object({
     version: Joi.string(),
     requireCommit: Joi.boolean(),
     appVersionSource: Joi.string().valid(...Object.values(AppVersionSource)),
+    setUpPushNotifications: Joi.boolean(),
   }),
   build: Joi.object().pattern(Joi.string(), BuildProfileSchema),
   submit: Joi.object().pattern(Joi.string(), SubmitProfileSchema),

--- a/packages/eas-json/src/types.ts
+++ b/packages/eas-json/src/types.ts
@@ -21,6 +21,7 @@ export interface EasJson {
     version?: string;
     requireCommit?: boolean;
     appVersionSource?: AppVersionSource;
+    setUpPushNotifications?: boolean;
   };
   build?: { [profileName: string]: EasJsonBuildProfile };
   submit?: { [profileName: string]: EasJsonSubmitProfile };

--- a/packages/eas-json/src/types.ts
+++ b/packages/eas-json/src/types.ts
@@ -21,7 +21,7 @@ export interface EasJson {
     version?: string;
     requireCommit?: boolean;
     appVersionSource?: AppVersionSource;
-    setUpPushNotifications?: boolean;
+    promptToConfigurePushNotfications?: boolean;
   };
   build?: { [profileName: string]: EasJsonBuildProfile };
   submit?: { [profileName: string]: EasJsonSubmitProfile };


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

When building a project that doesn't use push notifications, it's really annoying that EAS CLI keeps asking if you want to set up push notifications credentials for your project.
This PR introduces an option to permanently skip the question.

# How

Give the user an option to skip the push notifications credentials setup forever when we detect they don't have them set up. Persist this choice to eas.json - `"cli.setUpPushNotifications": false`.

# Test Plan

Tested manually.

The prompt looks like this:
<img width="733" alt="Screenshot 2022-08-25 at 12 24 58" src="https://user-images.githubusercontent.com/5256730/186641408-c0b96984-9bd3-423e-86ed-af244190d756.png">

