### PR TITLE
Copy changes to EAS Submit output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Improve instructions on setting `extra.eas.projectId` in app configuration. ([#1316](https://github.com/expo/eas-cli/pull/1316) by [@dsokal](https://github.com/dsokal))
+- Improve copy in EAS Submit - "e-mail" -> email, and make the link to app on App Store go directly to the TestFlight tab. ([#1318](https://github.com/expo/eas-cli/pull/1318) by [@brentvatne](https://github.com/brentvatne))
 
 ## [1.1.1](https://github.com/expo/eas-cli/releases/tag/v1.1.1) - 2022-08-23
 

--- a/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
@@ -164,7 +164,7 @@ function formatServiceAccountSummary({ summary }: ServiceAccountKeyResult): stri
       value: serviceAccountKeyPath,
     },
     {
-      label: 'Account E-mail',
+      label: 'Account Email',
       value: serviceAccountEmail,
     },
   ];

--- a/packages/eas-cli/src/submit/submit.ts
+++ b/packages/eas-cli/src/submit/submit.ts
@@ -74,7 +74,7 @@ function printInstructionsForIosSubmission(submission: SubmissionFragment): void
   if (submission.status === SubmissionStatus.Finished) {
     const logMsg = [
       chalk.bold('Your binary has been successfully uploaded to App Store Connect!'),
-      '- It is now being processed by Apple - you will receive an e-mail when the processing finishes.',
+      '- It is now being processed by Apple - you will receive an email when the processing finishes.',
       '- It usually takes about 5-10 minutes depending on how busy Apple servers are.',
       // ascAppIdentifier should be always available for ios submissions but check it anyway
       submission.iosConfig?.ascAppIdentifier &&

--- a/packages/eas-cli/src/submit/submit.ts
+++ b/packages/eas-cli/src/submit/submit.ts
@@ -79,7 +79,7 @@ function printInstructionsForIosSubmission(submission: SubmissionFragment): void
       // ascAppIdentifier should be always available for ios submissions but check it anyway
       submission.iosConfig?.ascAppIdentifier &&
         `- When it's done, you can see your build here: ${link(
-          `https://appstoreconnect.apple.com/apps/${submission.iosConfig?.ascAppIdentifier}/appstore/ios`
+          `https://appstoreconnect.apple.com/apps/${submission.iosConfig?.ascAppIdentifier}/testflight/ios`
         )}`,
     ].join('\n');
     Log.addNewLineIfNone();


### PR DESCRIPTION
Fixes ENG-6163 and ENG-6164

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

- Consistency with our usage of the word "email"
- After uploading the iOS app, developers will typically want to go to the TestFlight page
