### PR TITLE
[eas-cli] Fix dynamic config update warning for update:configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix dynamic config update warning. ([#1322](https://github.com/expo/eas-cli/pull/1322) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 ## [1.2.0](https://github.com/expo/eas-cli/releases/tag/v1.2.0) - 2022-08-29

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -166,7 +166,7 @@ async function configureAppJSONForEASUpdateAsync({
         newConfigOnlyAddedValues = {
           ...('runtimeVersion' in exp
             ? {
-                runtimeVersion: undefined, // top level runtime is redundant if it is specified in both android and ios
+                runtimeVersion: '<remove this key>', // top level runtime is redundant if it is specified in both android and ios
               }
             : {}),
           android: {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

The output message for this call to `modifyConfigAsync` contains all the existing keys. This PR manually curates that message just for added/removed keys.

Fixes ENG-6174.

# How

Manually curate object to include in message.

# Test Plan

```
$ ~/expo/eas-cli/packages/eas-cli/bin/run update:configure
💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.

It looks like you are using a dynamic configuration! Learn more
In order to finish configuring your project for EAS Update, you are going to need manually add the following to your app.config.js:
Learn more

{
  "runtimeVersion": {
    "policy": "sdkVersion"
  },
  "updates": {
    "url": "https://staging-u.expo.dev/a26c0832-1d8e-4154-8ed0-9ec11cc66986"
  }
}

    Error: Cannot automatically write to dynamic config at: app.config.js
```
