### PR TITLE
[ENG-6070][cli] generate tvOS credentials for adhoc and prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add tvOS credentials compatibility for Adhoc and App store builds. ([#1325](https://github.com/expo/eas-cli/pull/1325) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/device/delete.ts
+++ b/packages/eas-cli/src/commands/device/delete.ts
@@ -90,8 +90,10 @@ export default class DeviceDelete extends EasCommand {
     const removeAppleSpinner = ora('Disabling devices on Apple').start();
     try {
       const chosenDeviceIdentifiers = chosenDevices.map(cd => cd.identifier);
-      let realDevices = await Device.getAsync(context);
-      realDevices = realDevices.filter(d => chosenDeviceIdentifiers.includes(d.attributes.udid));
+      const allDevices = await Device.getAsync(context);
+      const realDevices = allDevices.filter(d =>
+        chosenDeviceIdentifiers.includes(d.attributes.udid)
+      );
 
       for (const device of realDevices) {
         await device.updateAsync({ status: DeviceStatus.DISABLED });

--- a/packages/eas-cli/src/commands/device/delete.ts
+++ b/packages/eas-cli/src/commands/device/delete.ts
@@ -89,10 +89,9 @@ export default class DeviceDelete extends EasCommand {
     Log.addNewLineIfNone();
     const removeAppleSpinner = ora('Disabling devices on Apple').start();
     try {
-      let realDevices = await Device.getAllIOSProfileDevicesAsync(context);
-      realDevices = realDevices.filter(d =>
-        chosenDevices.map(cd => cd.identifier).includes(d.attributes.udid)
-      );
+      const chosenDeviceIdentifiers = chosenDevices.map(cd => cd.identifier);
+      let realDevices = await Device.getAsync(context);
+      realDevices = realDevices.filter(d => chosenDeviceIdentifiers.includes(d.attributes.udid));
 
       for (const device of realDevices) {
         await device.updateAsync({ status: DeviceStatus.DISABLED });

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
@@ -1,12 +1,12 @@
 import merge from 'ts-deepmerge';
 
-import { CredentialsContext } from '../context';
+import { TargetCredentialsContext } from '../context';
 import { getNewAndroidApiMock } from './fixtures-android';
 import { getAppstoreMock } from './fixtures-appstore';
 import { testAppJson, testUsername } from './fixtures-constants';
-import { getNewIosApiMock } from './fixtures-ios';
+import { getNewIosApiMock, testTarget } from './fixtures-ios';
 
-export function createCtxMock(mockOverride: Record<string, any> = {}): CredentialsContext {
+export function createCtxMock(mockOverride: Record<string, any> = {}): TargetCredentialsContext {
   const defaultMock = {
     ios: getNewIosApiMock(),
     android: getNewAndroidApiMock(),
@@ -23,6 +23,8 @@ export function createCtxMock(mockOverride: Record<string, any> = {}): Credentia
     hasProjectContext: true,
     exp: testAppJson,
     projectDir: '.',
+    createTargetContext: jest.fn(() => createCtxMock(mockOverride)),
+    target: testTarget,
   };
   return merge(defaultMock, mockOverride) as any;
 }

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
@@ -1,12 +1,12 @@
 import merge from 'ts-deepmerge';
 
-import { TargetCredentialsContext } from '../context';
+import { CredentialsContext } from '../context';
 import { getNewAndroidApiMock } from './fixtures-android';
 import { getAppstoreMock } from './fixtures-appstore';
 import { testAppJson, testUsername } from './fixtures-constants';
-import { getNewIosApiMock, testTarget } from './fixtures-ios';
+import { getNewIosApiMock } from './fixtures-ios';
 
-export function createCtxMock(mockOverride: Record<string, any> = {}): TargetCredentialsContext {
+export function createCtxMock(mockOverride: Record<string, any> = {}): CredentialsContext {
   const defaultMock = {
     ios: getNewIosApiMock(),
     android: getNewAndroidApiMock(),
@@ -23,8 +23,6 @@ export function createCtxMock(mockOverride: Record<string, any> = {}): TargetCre
     hasProjectContext: true,
     exp: testAppJson,
     projectDir: '.',
-    createTargetContext: jest.fn(() => createCtxMock(mockOverride)),
-    target: testTarget,
   };
   return merge(defaultMock, mockOverride) as any;
 }

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-ios.ts
@@ -76,9 +76,13 @@ export const testPushKey: ApplePushKeyFragment = {
   iosAppCredentialsList: [],
 };
 
-export const testTargets: Target[] = [
-  { targetName: 'testapp', bundleIdentifier: 'foo.bar.com', entitlements: {} },
-];
+export const testTarget = {
+  targetName: 'testapp',
+  bundleIdentifier: 'foo.bar.com',
+  entitlements: {},
+};
+
+export const testTargets: Target[] = [testTarget];
 
 export const testProvisioningProfileFragment: AppleProvisioningProfileFragment = {
   id: 'test-prov-prof-id-1',

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -12,6 +12,16 @@ import * as AndroidGraphqlClient from './android/api/GraphqlClient';
 import * as IosGraphqlClient from './ios/api/GraphqlClient';
 import AppStoreApi from './ios/appstore/AppStoreApi';
 import { AuthenticationMode } from './ios/appstore/authenticateTypes';
+import { Target } from './ios/types';
+
+type CredentialsContextOptions = {
+  exp?: ExpoConfig;
+  easJsonCliConfig?: EasJson['cli'];
+  nonInteractive?: boolean;
+  projectDir: string;
+  user: Actor;
+  env?: Env;
+};
 
 export class CredentialsContext {
   public readonly android = AndroidGraphqlClient;
@@ -25,16 +35,7 @@ export class CredentialsContext {
   private shouldAskAuthenticateAppStore: boolean = true;
   private resolvedExp?: ExpoConfig;
 
-  constructor(
-    private options: {
-      exp?: ExpoConfig;
-      easJsonCliConfig?: EasJson['cli'];
-      nonInteractive?: boolean;
-      projectDir: string;
-      user: Actor;
-      env?: Env;
-    }
-  ) {
+  constructor(private options: CredentialsContextOptions) {
     this.easJsonCliConfig = options.easJsonCliConfig;
     this.projectDir = options.projectDir;
     this.user = options.user;
@@ -94,6 +95,10 @@ export class CredentialsContext {
     }
   }
 
+  public createTargetContext(target: Target): TargetCredentialsContext {
+    return new TargetCredentialsContext(target, this.options);
+  }
+
   async bestEffortAppStoreAuthenticateAsync(): Promise<void> {
     if (this.appStore.authCtx || !this.shouldAskAuthenticateAppStore) {
       // skip prompts if already have apple ctx or already asked about it
@@ -132,5 +137,14 @@ export class CredentialsContext {
       );
     }
     this.shouldAskAuthenticateAppStore = false;
+  }
+}
+
+/**
+ * Credentials context for a specific XCode target.
+ * */
+export class TargetCredentialsContext extends CredentialsContext {
+  constructor(public target: Target, options: CredentialsContextOptions) {
+    super(options);
   }
 }

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -12,16 +12,6 @@ import * as AndroidGraphqlClient from './android/api/GraphqlClient';
 import * as IosGraphqlClient from './ios/api/GraphqlClient';
 import AppStoreApi from './ios/appstore/AppStoreApi';
 import { AuthenticationMode } from './ios/appstore/authenticateTypes';
-import { Target } from './ios/types';
-
-type CredentialsContextOptions = {
-  exp?: ExpoConfig;
-  easJsonCliConfig?: EasJson['cli'];
-  nonInteractive?: boolean;
-  projectDir: string;
-  user: Actor;
-  env?: Env;
-};
 
 export class CredentialsContext {
   public readonly android = AndroidGraphqlClient;
@@ -35,7 +25,16 @@ export class CredentialsContext {
   private shouldAskAuthenticateAppStore: boolean = true;
   private resolvedExp?: ExpoConfig;
 
-  constructor(private options: CredentialsContextOptions) {
+  constructor(
+    private options: {
+      exp?: ExpoConfig;
+      easJsonCliConfig?: EasJson['cli'];
+      nonInteractive?: boolean;
+      projectDir: string;
+      user: Actor;
+      env?: Env;
+    }
+  ) {
     this.easJsonCliConfig = options.easJsonCliConfig;
     this.projectDir = options.projectDir;
     this.user = options.user;
@@ -95,10 +94,6 @@ export class CredentialsContext {
     }
   }
 
-  public createTargetContext(target: Target): TargetCredentialsContext {
-    return new TargetCredentialsContext(target, this.options);
-  }
-
   async bestEffortAppStoreAuthenticateAsync(): Promise<void> {
     if (this.appStore.authCtx || !this.shouldAskAuthenticateAppStore) {
       // skip prompts if already have apple ctx or already asked about it
@@ -137,14 +132,5 @@ export class CredentialsContext {
       );
     }
     this.shouldAskAuthenticateAppStore = false;
-  }
-}
-
-/**
- * Credentials context for a specific XCode target.
- * */
-export class TargetCredentialsContext extends CredentialsContext {
-  constructor(public target: Target, options: CredentialsContextOptions) {
-    super(options);
   }
 }

--- a/packages/eas-cli/src/credentials/ios/__tests__/IosCredentialsProvider-test.ts
+++ b/packages/eas-cli/src/credentials/ios/__tests__/IosCredentialsProvider-test.ts
@@ -17,6 +17,7 @@ jest.mock('fs');
 jest.mock('../validators/validateProvisioningProfile', () => ({
   validateProvisioningProfileAsync: async (
     _ctx: any,
+    _target: any,
     _app: any,
     buildCredentials: Partial<IosAppBuildCredentialsFragment> | null
   ): Promise<boolean> => {

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -1,4 +1,3 @@
-import { Platform as ApplePlatform } from '@expo/apple-utils';
 import assert from 'assert';
 import chalk from 'chalk';
 
@@ -15,6 +14,7 @@ import { AppLookupParams } from '../api/GraphqlClient';
 import { AppleProvisioningProfileMutationResult } from '../api/graphql/mutations/AppleProvisioningProfileMutation';
 import { ProvisioningProfileStoreInfo } from '../appstore/Credentials.types';
 import { AuthCtx } from '../appstore/authenticateTypes';
+import { ApplePlatform } from '../appstore/constants';
 
 export class ConfigureProvisioningProfile {
   constructor(
@@ -45,7 +45,7 @@ export class ConfigureProvisioningProfile {
       return null;
     }
 
-    const applePlatform = (await getApplePlatformFromSdkRoot(ctx.target)) ?? ApplePlatform.IOS;
+    const applePlatform = await getApplePlatformFromSdkRoot(ctx.target);
     const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
       this.app.bundleIdentifier,
       applePlatform

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -1,3 +1,4 @@
+import { Platform as ApplePlatform } from '@expo/apple-utils';
 import assert from 'assert';
 import chalk from 'chalk';
 
@@ -7,7 +8,8 @@ import {
 } from '../../../graphql/generated';
 import Log from '../../../log';
 import { ora } from '../../../ora';
-import { CredentialsContext } from '../../context';
+import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
+import { CredentialsContext, TargetCredentialsContext } from '../../context';
 import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
 import { AppleProvisioningProfileMutationResult } from '../api/graphql/mutations/AppleProvisioningProfileMutation';
@@ -22,7 +24,7 @@ export class ConfigureProvisioningProfile {
   ) {}
 
   public async runAsync(
-    ctx: CredentialsContext
+    ctx: TargetCredentialsContext
   ): Promise<AppleProvisioningProfileMutationResult | null> {
     if (ctx.nonInteractive) {
       throw new MissingCredentialsNonInteractiveError(
@@ -43,8 +45,10 @@ export class ConfigureProvisioningProfile {
       return null;
     }
 
+    const applePlatform = (await getApplePlatformFromSdkRoot(ctx.target)) ?? ApplePlatform.IOS;
     const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
-      this.app.bundleIdentifier
+      this.app.bundleIdentifier,
+      applePlatform
     );
     const [matchingProfile] = profilesFromApple.filter(appleInfo =>
       developerPortalIdentifier

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -8,23 +8,24 @@ import {
 import Log from '../../../log';
 import { ora } from '../../../ora';
 import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
-import { CredentialsContext, TargetCredentialsContext } from '../../context';
+import { CredentialsContext } from '../../context';
 import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
 import { AppleProvisioningProfileMutationResult } from '../api/graphql/mutations/AppleProvisioningProfileMutation';
 import { ProvisioningProfileStoreInfo } from '../appstore/Credentials.types';
 import { AuthCtx } from '../appstore/authenticateTypes';
-import { ApplePlatform } from '../appstore/constants';
+import { Target } from '../types';
 
 export class ConfigureProvisioningProfile {
   constructor(
     private app: AppLookupParams,
+    private target: Target,
     private distributionCertificate: AppleDistributionCertificateFragment,
     private originalProvisioningProfile: AppleProvisioningProfileFragment
   ) {}
 
   public async runAsync(
-    ctx: TargetCredentialsContext
+    ctx: CredentialsContext
   ): Promise<AppleProvisioningProfileMutationResult | null> {
     if (ctx.nonInteractive) {
       throw new MissingCredentialsNonInteractiveError(
@@ -45,7 +46,7 @@ export class ConfigureProvisioningProfile {
       return null;
     }
 
-    const applePlatform = await getApplePlatformFromSdkRoot(ctx.target);
+    const applePlatform = await getApplePlatformFromSdkRoot(this.target);
     const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
       this.app.bundleIdentifier,
       applePlatform

--- a/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
@@ -3,7 +3,7 @@ import nullthrows from 'nullthrows';
 
 import { AppleDistributionCertificateFragment } from '../../../graphql/generated';
 import Log from '../../../log';
-import { CredentialsContext } from '../../context';
+import { TargetCredentialsContext } from '../../context';
 import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { askForUserProvidedAsync } from '../../utils/promptForCredentials';
 import { AppLookupParams } from '../api/GraphqlClient';
@@ -20,7 +20,7 @@ export class CreateProvisioningProfile {
     private distributionCertificate: AppleDistributionCertificateFragment
   ) {}
 
-  async runAsync(ctx: CredentialsContext): Promise<AppleProvisioningProfileMutationResult> {
+  async runAsync(ctx: TargetCredentialsContext): Promise<AppleProvisioningProfileMutationResult> {
     if (ctx.nonInteractive) {
       throw new MissingCredentialsNonInteractiveError(
         'Creating Provisioning Profiles is only supported in interactive mode.'
@@ -46,7 +46,7 @@ export class CreateProvisioningProfile {
   }
 
   private async provideOrGenerateAsync(
-    ctx: CredentialsContext,
+    ctx: TargetCredentialsContext,
     appleAuthCtx: AuthCtx
   ): Promise<ProvisioningProfile> {
     const userProvided = await askForUserProvidedAsync(provisioningProfileSchema);

--- a/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
@@ -1,13 +1,13 @@
 import chalk from 'chalk';
 
 import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
-import { TargetCredentialsContext } from '../../context';
+import { CredentialsContext } from '../../context';
 import {
   DistributionCertificate,
   ProvisioningProfile,
   ProvisioningProfileStoreInfo,
 } from '../appstore/Credentials.types';
-import { ApplePlatform } from '../appstore/constants';
+import { Target } from '../types';
 
 export function formatProvisioningProfileFromApple(
   appleInfo: ProvisioningProfileStoreInfo
@@ -21,14 +21,15 @@ export function formatProvisioningProfileFromApple(
 }
 
 export async function generateProvisioningProfileAsync(
-  ctx: TargetCredentialsContext,
+  ctx: CredentialsContext,
+  target: Target,
   bundleIdentifier: string,
   distCert: DistributionCertificate
 ): Promise<ProvisioningProfile> {
   const appleAuthCtx = await ctx.appStore.ensureAuthenticatedAsync();
   const type = appleAuthCtx.team.inHouse ? 'Enterprise ' : 'AppStore';
   const profileName = `*[expo] ${bundleIdentifier} ${type} ${new Date().toISOString()}`; // Apple drops [ if its the first char (!!)
-  const applePlatform = await getApplePlatformFromSdkRoot(ctx.target);
+  const applePlatform = await getApplePlatformFromSdkRoot(target);
   return await ctx.appStore.createProvisioningProfileAsync(
     bundleIdentifier,
     distCert,

--- a/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
@@ -1,4 +1,3 @@
-import { Platform as ApplePlatform } from '@expo/apple-utils';
 import chalk from 'chalk';
 
 import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
@@ -8,6 +7,7 @@ import {
   ProvisioningProfile,
   ProvisioningProfileStoreInfo,
 } from '../appstore/Credentials.types';
+import { ApplePlatform } from '../appstore/constants';
 
 export function formatProvisioningProfileFromApple(
   appleInfo: ProvisioningProfileStoreInfo
@@ -28,7 +28,7 @@ export async function generateProvisioningProfileAsync(
   const appleAuthCtx = await ctx.appStore.ensureAuthenticatedAsync();
   const type = appleAuthCtx.team.inHouse ? 'Enterprise ' : 'AppStore';
   const profileName = `*[expo] ${bundleIdentifier} ${type} ${new Date().toISOString()}`; // Apple drops [ if its the first char (!!)
-  const applePlatform = (await getApplePlatformFromSdkRoot(ctx.target)) ?? ApplePlatform.IOS;
+  const applePlatform = await getApplePlatformFromSdkRoot(ctx.target);
   return await ctx.appStore.createProvisioningProfileAsync(
     bundleIdentifier,
     distCert,

--- a/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
@@ -1,6 +1,8 @@
+import { Platform as ApplePlatform } from '@expo/apple-utils';
 import chalk from 'chalk';
 
-import { CredentialsContext } from '../../context';
+import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
+import { TargetCredentialsContext } from '../../context';
 import {
   DistributionCertificate,
   ProvisioningProfile,
@@ -19,12 +21,18 @@ export function formatProvisioningProfileFromApple(
 }
 
 export async function generateProvisioningProfileAsync(
-  ctx: CredentialsContext,
+  ctx: TargetCredentialsContext,
   bundleIdentifier: string,
   distCert: DistributionCertificate
 ): Promise<ProvisioningProfile> {
   const appleAuthCtx = await ctx.appStore.ensureAuthenticatedAsync();
   const type = appleAuthCtx.team.inHouse ? 'Enterprise ' : 'AppStore';
   const profileName = `*[expo] ${bundleIdentifier} ${type} ${new Date().toISOString()}`; // Apple drops [ if its the first char (!!)
-  return await ctx.appStore.createProvisioningProfileAsync(bundleIdentifier, distCert, profileName);
+  const applePlatform = (await getApplePlatformFromSdkRoot(ctx.target)) ?? ApplePlatform.IOS;
+  return await ctx.appStore.createProvisioningProfileAsync(
+    bundleIdentifier,
+    distCert,
+    profileName,
+    applePlatform
+  );
 }

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
@@ -1,4 +1,4 @@
-import { Platform as ApplePlatform, ProfileType } from '@expo/apple-utils';
+import { ProfileType } from '@expo/apple-utils';
 import assert from 'assert';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
@@ -19,6 +19,7 @@ import differenceBy from '../../../utils/expodash/differenceBy';
 import { CredentialsContext, TargetCredentialsContext } from '../../context';
 import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
+import { ApplePlatform } from '../appstore/constants';
 import { validateProvisioningProfileAsync } from '../validators/validateProvisioningProfile';
 import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
 import { assignBuildCredentialsAsync, getBuildCredentialsAsync } from './BuildCredentialsUtils';

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpBuildCredentials.ts
@@ -47,17 +47,17 @@ export class SetUpBuildCredentials {
       } else {
         Log.newLine();
       }
+      const targetCtx = ctx.createTargetContext(target);
       const action = new SetUpTargetBuildCredentials({
         enterpriseProvisioning: this.options.enterpriseProvisioning,
         distribution: this.options.distribution,
-        entitlements: target.entitlements,
         app: {
           ...this.options.app,
           bundleIdentifier: target.bundleIdentifier,
           parentBundleIdentifier: target.parentBundleIdentifier,
         },
       });
-      iosAppBuildCredentialsMap[target.targetName] = await action.runAsync(ctx);
+      iosAppBuildCredentialsMap[target.targetName] = await action.runAsync(targetCtx);
     }
 
     const appInfo = formatAppInfo(this.options.app, this.options.targets);

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpBuildCredentials.ts
@@ -47,17 +47,18 @@ export class SetUpBuildCredentials {
       } else {
         Log.newLine();
       }
-      const targetCtx = ctx.createTargetContext(target);
       const action = new SetUpTargetBuildCredentials({
         enterpriseProvisioning: this.options.enterpriseProvisioning,
         distribution: this.options.distribution,
+        entitlements: target.entitlements,
+        target,
         app: {
           ...this.options.app,
           bundleIdentifier: target.bundleIdentifier,
           parentBundleIdentifier: target.parentBundleIdentifier,
         },
       });
-      iosAppBuildCredentialsMap[target.targetName] = await action.runAsync(targetCtx);
+      iosAppBuildCredentialsMap[target.targetName] = await action.runAsync(ctx);
     }
 
     const appInfo = formatAppInfo(this.options.app, this.options.targets);

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpInternalProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpInternalProvisioningProfile.ts
@@ -1,7 +1,7 @@
 import { IosAppBuildCredentialsFragment, IosDistributionType } from '../../../graphql/generated';
 import Log, { learnMore } from '../../../log';
 import { promptAsync } from '../../../prompts';
-import { CredentialsContext } from '../../context';
+import { TargetCredentialsContext } from '../../context';
 import { AppLookupParams } from '../api/GraphqlClient';
 import { getAllBuildCredentialsAsync } from './BuildCredentialsUtils';
 import { SetUpAdhocProvisioningProfile } from './SetUpAdhocProvisioningProfile';
@@ -17,7 +17,7 @@ import { SetUpProvisioningProfile } from './SetUpProvisioningProfile';
 export class SetUpInternalProvisioningProfile {
   constructor(private app: AppLookupParams) {}
 
-  async runAsync(ctx: CredentialsContext): Promise<IosAppBuildCredentialsFragment> {
+  async runAsync(ctx: TargetCredentialsContext): Promise<IosAppBuildCredentialsFragment> {
     const buildCredentials = await getAllBuildCredentialsAsync(ctx, this.app);
 
     const adhocBuildCredentialsExist =
@@ -85,13 +85,13 @@ export class SetUpInternalProvisioningProfile {
   }
 
   private async setupAdhocProvisioningProfileAsync(
-    ctx: CredentialsContext
+    ctx: TargetCredentialsContext
   ): Promise<IosAppBuildCredentialsFragment> {
     return await new SetUpAdhocProvisioningProfile(this.app).runAsync(ctx);
   }
 
   private async setupUniversalProvisioningProfileAsync(
-    ctx: CredentialsContext
+    ctx: TargetCredentialsContext
   ): Promise<IosAppBuildCredentialsFragment> {
     return await new SetUpProvisioningProfile(this.app, IosDistributionType.Enterprise).runAsync(
       ctx
@@ -99,7 +99,7 @@ export class SetUpInternalProvisioningProfile {
   }
 
   private async askForDistributionTypeAndSetupAsync(
-    ctx: CredentialsContext,
+    ctx: TargetCredentialsContext,
     message: string
   ): Promise<IosAppBuildCredentialsFragment> {
     const { distributionType } = await promptAsync({

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
@@ -1,4 +1,3 @@
-import { Platform as ApplePlatform } from '@expo/apple-utils';
 import nullthrows from 'nullthrows';
 
 import {
@@ -13,6 +12,7 @@ import { TargetCredentialsContext } from '../../context';
 import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
 import { ProvisioningProfileStoreInfo } from '../appstore/Credentials.types';
+import { ApplePlatform } from '../appstore/constants';
 import { validateProvisioningProfileAsync } from '../validators/validateProvisioningProfile';
 import {
   assignBuildCredentialsAsync,
@@ -107,7 +107,7 @@ export class SetUpProvisioningProfile {
     }
 
     // See if the profile we have exists on the Apple Servers
-    const applePlatform = (await getApplePlatformFromSdkRoot(ctx.target)) ?? ApplePlatform.IOS;
+    const applePlatform = await getApplePlatformFromSdkRoot(ctx.target);
     const existingProfiles = await ctx.appStore.listProvisioningProfilesAsync(
       this.app.bundleIdentifier,
       applePlatform

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpTargetBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpTargetBuildCredentials.ts
@@ -1,12 +1,11 @@
 import { DistributionType, IosEnterpriseProvisioning } from '@expo/eas-json';
-import { JSONObject } from '@expo/json-file';
 
 import {
   IosDistributionType as GraphQLIosDistributionType,
   IosAppBuildCredentialsFragment,
 } from '../../../graphql/generated';
 import Log from '../../../log';
-import { CredentialsContext } from '../../context';
+import { TargetCredentialsContext } from '../../context';
 import { AppLookupParams as GraphQLAppLookupParams } from '../api/GraphqlClient';
 import { SetUpAdhocProvisioningProfile } from './SetUpAdhocProvisioningProfile';
 import { SetUpInternalProvisioningProfile } from './SetUpInternalProvisioningProfile';
@@ -16,13 +15,12 @@ interface Options {
   app: GraphQLAppLookupParams;
   distribution: DistributionType;
   enterpriseProvisioning?: IosEnterpriseProvisioning;
-  entitlements: JSONObject;
 }
 export class SetUpTargetBuildCredentials {
   constructor(private options: Options) {}
 
-  async runAsync(ctx: CredentialsContext): Promise<IosAppBuildCredentialsFragment> {
-    const { app, entitlements } = this.options;
+  async runAsync(ctx: TargetCredentialsContext): Promise<IosAppBuildCredentialsFragment> {
+    const { app } = this.options;
 
     await ctx.bestEffortAppStoreAuthenticateAsync();
 
@@ -33,7 +31,7 @@ export class SetUpTargetBuildCredentials {
           bundleIdentifier: app.bundleIdentifier,
           projectName: app.projectName,
         },
-        { entitlements }
+        { entitlements: ctx.target.entitlements }
       );
     }
     try {
@@ -45,7 +43,7 @@ export class SetUpTargetBuildCredentials {
   }
 
   async setupBuildCredentialsAsync(
-    ctx: CredentialsContext
+    ctx: TargetCredentialsContext
   ): Promise<IosAppBuildCredentialsFragment> {
     const { app, distribution, enterpriseProvisioning } = this.options;
     if (distribution === 'internal') {

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/ConfigureProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/ConfigureProvisioningProfile-test.ts
@@ -6,6 +6,7 @@ import {
   testDistCertFragmentNoDependencies,
   testProvisioningProfile,
   testProvisioningProfileFragment,
+  testTarget,
   testTargets,
 } from '../../../__tests__/fixtures-ios';
 import { MissingCredentialsNonInteractiveError } from '../../../errors';
@@ -36,6 +37,7 @@ describe('ConfigureProvisioningProfile', () => {
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const provProfConfigurator = new ConfigureProvisioningProfile(
       appLookupParams,
+      testTarget,
       testDistCertFragmentNoDependencies,
       testProvisioningProfileFragment
     );
@@ -53,6 +55,7 @@ describe('ConfigureProvisioningProfile', () => {
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const provProfConfigurator = new ConfigureProvisioningProfile(
       appLookupParams,
+      testTarget,
       testDistCertFragmentNoDependencies,
       testProvisioningProfileFragment
     );

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateProvisioningProfile-test.ts
@@ -5,6 +5,7 @@ import { createCtxMock } from '../../../__tests__/fixtures-context';
 import {
   testDistCertFragmentNoDependencies,
   testProvisioningProfile,
+  testTarget,
   testTargets,
 } from '../../../__tests__/fixtures-ios';
 import { MissingCredentialsNonInteractiveError } from '../../../errors';
@@ -28,6 +29,7 @@ describe('CreateProvisioningProfile', () => {
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const createProvProfAction = new CreateProvisioningProfile(
       appLookupParams,
+      testTarget,
       testDistCertFragmentNoDependencies
     );
     await createProvProfAction.runAsync(ctx);
@@ -44,6 +46,7 @@ describe('CreateProvisioningProfile', () => {
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const createProvProfAction = new CreateProvisioningProfile(
       appLookupParams,
+      testTarget,
       testDistCertFragmentNoDependencies
     );
     await expect(createProvProfAction.runAsync(ctx)).rejects.toThrowError(

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpInternalProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpInternalProvisioningProfile-test.ts
@@ -2,6 +2,7 @@ import { IosAppBuildCredentialsFragment, IosDistributionType } from '../../../..
 import { promptAsync } from '../../../../prompts';
 import { getAppstoreMock, testAuthCtx } from '../../../__tests__/fixtures-appstore';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
+import { testTarget } from '../../../__tests__/fixtures-ios';
 import { getAllBuildCredentialsAsync } from '../BuildCredentialsUtils';
 import { SetUpAdhocProvisioningProfile } from '../SetUpAdhocProvisioningProfile';
 import { SetUpInternalProvisioningProfile } from '../SetUpInternalProvisioningProfile';
@@ -41,9 +42,12 @@ describe(SetUpInternalProvisioningProfile, () => {
           return buildCredentials;
         });
         const action = new SetUpInternalProvisioningProfile({
-          account: { id: 'account-id', name: 'account-name' },
-          bundleIdentifier: 'com.expo.test',
-          projectName: 'testproject',
+          app: {
+            account: { id: 'account-id', name: 'account-name' },
+            bundleIdentifier: 'com.expo.test',
+            projectName: 'testproject',
+          },
+          target: testTarget,
         });
         const ctx = createCtxMock({
           nonInteractive: false,
@@ -72,9 +76,12 @@ describe(SetUpInternalProvisioningProfile, () => {
         });
 
         const action = new SetUpInternalProvisioningProfile({
-          account: { id: 'account-id', name: 'account-name' },
-          bundleIdentifier: 'com.expo.test',
-          projectName: 'testproject',
+          app: {
+            account: { id: 'account-id', name: 'account-name' },
+            bundleIdentifier: 'com.expo.test',
+            projectName: 'testproject',
+          },
+          target: testTarget,
         });
         const ctx = createCtxMock({
           nonInteractive: false,
@@ -110,9 +117,12 @@ describe(SetUpInternalProvisioningProfile, () => {
         });
 
         const action = new SetUpInternalProvisioningProfile({
-          account: { id: 'account-id', name: 'account-name' },
-          bundleIdentifier: 'com.expo.test',
-          projectName: 'testproject',
+          app: {
+            account: { id: 'account-id', name: 'account-name' },
+            bundleIdentifier: 'com.expo.test',
+            projectName: 'testproject',
+          },
+          target: testTarget,
         });
         const ctx = createCtxMock({
           nonInteractive: false,
@@ -141,9 +151,12 @@ describe(SetUpInternalProvisioningProfile, () => {
         });
 
         const action = new SetUpInternalProvisioningProfile({
-          account: { id: 'account-id', name: 'account-name' },
-          bundleIdentifier: 'com.expo.test',
-          projectName: 'testproject',
+          app: {
+            account: { id: 'account-id', name: 'account-name' },
+            bundleIdentifier: 'com.expo.test',
+            projectName: 'testproject',
+          },
+          target: testTarget,
         });
         const ctx = createCtxMock({
           nonInteractive: false,
@@ -174,9 +187,12 @@ describe(SetUpInternalProvisioningProfile, () => {
         });
 
         const action = new SetUpInternalProvisioningProfile({
-          account: { id: 'account-id', name: 'account-name' },
-          bundleIdentifier: 'com.expo.test',
-          projectName: 'testproject',
+          app: {
+            account: { id: 'account-id', name: 'account-name' },
+            bundleIdentifier: 'com.expo.test',
+            projectName: 'testproject',
+          },
+          target: testTarget,
         });
         const ctx = createCtxMock({
           nonInteractive: false,
@@ -205,9 +221,12 @@ describe(SetUpInternalProvisioningProfile, () => {
         });
 
         const action = new SetUpInternalProvisioningProfile({
-          account: { id: 'account-id', name: 'account-name' },
-          bundleIdentifier: 'com.expo.test',
-          projectName: 'testproject',
+          app: {
+            account: { id: 'account-id', name: 'account-name' },
+            bundleIdentifier: 'com.expo.test',
+            projectName: 'testproject',
+          },
+          target: testTarget,
         });
         const ctx = createCtxMock({
           nonInteractive: false,
@@ -235,9 +254,12 @@ describe(SetUpInternalProvisioningProfile, () => {
         return buildCredentials;
       });
       const action = new SetUpInternalProvisioningProfile({
-        account: { id: 'account-id', name: 'account-name' },
-        bundleIdentifier: 'com.expo.test',
-        projectName: 'testproject',
+        app: {
+          account: { id: 'account-id', name: 'account-name' },
+          bundleIdentifier: 'com.expo.test',
+          projectName: 'testproject',
+        },
+        target: testTarget,
       });
       const ctx = createCtxMock({
         nonInteractive: true,
@@ -253,9 +275,12 @@ describe(SetUpInternalProvisioningProfile, () => {
         return buildCredentials;
       });
       const action = new SetUpInternalProvisioningProfile({
-        account: { id: 'account-id', name: 'account-name' },
-        bundleIdentifier: 'com.expo.test',
-        projectName: 'testproject',
+        app: {
+          account: { id: 'account-id', name: 'account-name' },
+          bundleIdentifier: 'com.expo.test',
+          projectName: 'testproject',
+        },
+        target: testTarget,
       });
       const ctx = createCtxMock({
         nonInteractive: true,
@@ -269,9 +294,12 @@ describe(SetUpInternalProvisioningProfile, () => {
         return buildCredentials;
       });
       const action = new SetUpInternalProvisioningProfile({
-        account: { id: 'account-id', name: 'account-name' },
-        bundleIdentifier: 'com.expo.test',
-        projectName: 'testproject',
+        app: {
+          account: { id: 'account-id', name: 'account-name' },
+          bundleIdentifier: 'com.expo.test',
+          projectName: 'testproject',
+        },
+        target: testTarget,
       });
       const ctx = createCtxMock({
         nonInteractive: true,
@@ -291,9 +319,12 @@ describe(SetUpInternalProvisioningProfile, () => {
         return buildCredentials;
       });
       const action = new SetUpInternalProvisioningProfile({
-        account: { id: 'account-id', name: 'account-name' },
-        bundleIdentifier: 'com.expo.test',
-        projectName: 'testproject',
+        app: {
+          account: { id: 'account-id', name: 'account-name' },
+          bundleIdentifier: 'com.expo.test',
+          projectName: 'testproject',
+        },
+        target: testTarget,
       });
       const ctx = createCtxMock({
         nonInteractive: true,

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpProvisioningProfile-test.ts
@@ -10,6 +10,7 @@ import {
   testAppleAppIdentifierFragment,
   testCommonIosAppCredentialsFragment,
   testIosAppBuildCredentialsFragment,
+  testTarget,
   testTargets,
 } from '../../../__tests__/fixtures-ios';
 import { MissingCredentialsNonInteractiveError } from '../../../errors';
@@ -55,6 +56,7 @@ describe('SetUpProvisioningProfile', () => {
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const setupProvisioningProfileAction = new SetUpProvisioningProfile(
       appLookupParams,
+      testTarget,
       IosDistributionType.AppStore
     );
     await setupProvisioningProfileAction.runAsync(ctx);
@@ -87,6 +89,7 @@ describe('SetUpProvisioningProfile', () => {
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const setupProvisioningProfileAction = new SetUpProvisioningProfile(
       appLookupParams,
+      testTarget,
       IosDistributionType.AppStore
     );
     await setupProvisioningProfileAction.runAsync(ctx);
@@ -119,6 +122,7 @@ describe('SetUpProvisioningProfile', () => {
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const setupProvisioningProfileAction = new SetUpProvisioningProfile(
       appLookupParams,
+      testTarget,
       IosDistributionType.AppStore
     );
     await setupProvisioningProfileAction.runAsync(ctx);
@@ -147,6 +151,7 @@ describe('SetUpProvisioningProfile', () => {
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const setupProvisioningProfileAction = new SetUpProvisioningProfile(
       appLookupParams,
+      testTarget,
       IosDistributionType.AppStore
     );
     await setupProvisioningProfileAction.runAsync(ctx);
@@ -166,6 +171,7 @@ describe('SetUpProvisioningProfile', () => {
     const appLookupParams = getAppLookupParamsFromContext(ctx, findApplicationTarget(testTargets));
     const setupProvisioningProfileAction = new SetUpProvisioningProfile(
       appLookupParams,
+      testTarget,
       IosDistributionType.AppStore
     );
     await expect(setupProvisioningProfileAction.runAsync(ctx)).rejects.toThrowError(

--- a/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
@@ -1,5 +1,4 @@
 import { ProfileType } from '@expo/app-store';
-import { Platform as ApplePlatform } from '@expo/apple-utils';
 
 import Log from '../../../log';
 import {
@@ -25,6 +24,7 @@ import {
   isUserAuthCtx,
 } from './authenticate';
 import { AuthCtx, AuthenticationMode, UserAuthCtx } from './authenticateTypes';
+import { ApplePlatform } from './constants';
 import {
   createDistributionCertificateAsync,
   listDistributionCertificatesAsync,

--- a/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
@@ -1,3 +1,6 @@
+import { ProfileType } from '@expo/app-store';
+import { Platform as ApplePlatform } from '@expo/apple-utils';
+
 import Log from '../../../log';
 import {
   AscApiKey,
@@ -129,16 +132,18 @@ export default class AppStoreApi {
 
   public async listProvisioningProfilesAsync(
     bundleIdentifier: string,
+    applePlatform: ApplePlatform,
     profileClass?: ProfileClass
   ): Promise<ProvisioningProfileStoreInfo[]> {
     const ctx = await this.ensureAuthenticatedAsync();
-    return await listProvisioningProfilesAsync(ctx, bundleIdentifier, profileClass);
+    return await listProvisioningProfilesAsync(ctx, bundleIdentifier, applePlatform, profileClass);
   }
 
   public async createProvisioningProfileAsync(
     bundleIdentifier: string,
     distCert: DistributionCertificate,
     profileName: string,
+    applePlatform: ApplePlatform,
     profileClass?: ProfileClass
   ): Promise<ProvisioningProfile> {
     const ctx = await this.ensureAuthenticatedAsync();
@@ -147,29 +152,33 @@ export default class AppStoreApi {
       bundleIdentifier,
       distCert,
       profileName,
+      applePlatform,
       profileClass
     );
   }
 
   public async revokeProvisioningProfileAsync(
     bundleIdentifier: string,
+    applePlatform: ApplePlatform,
     profileClass?: ProfileClass
   ): Promise<void> {
     const ctx = await this.ensureAuthenticatedAsync();
-    return await revokeProvisioningProfileAsync(ctx, bundleIdentifier, profileClass);
+    return await revokeProvisioningProfileAsync(ctx, bundleIdentifier, applePlatform, profileClass);
   }
 
   public async createOrReuseAdhocProvisioningProfileAsync(
     udids: string[],
     bundleIdentifier: string,
-    distCertSerialNumber: string
+    distCertSerialNumber: string,
+    profileType: ProfileType
   ): Promise<ProvisioningProfile> {
     const ctx = await this.ensureAuthenticatedAsync();
     return await createOrReuseAdhocProvisioningProfileAsync(
       ctx,
       udids,
       bundleIdentifier,
-      distCertSerialNumber
+      distCertSerialNumber,
+      profileType
     );
   }
 

--- a/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/Credentials.types.ts
@@ -1,21 +1,5 @@
 import { UserRole } from '@expo/apple-utils';
 
-export interface Device {
-  id: string;
-  teamId: string;
-  identifier: string;
-  name?: string;
-  model?: string;
-  deviceClass?: DeviceClass;
-  softwareVersion?: string;
-  enabled: boolean;
-}
-
-export enum DeviceClass {
-  IPHONE = 'iphone',
-  IPAD = 'ipad',
-}
-
 export interface DistributionCertificateStoreInfo {
   id: string;
   name: string;

--- a/packages/eas-cli/src/credentials/ios/appstore/constants.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/constants.ts
@@ -1,0 +1,2 @@
+// Renamed to avoid conflation with Android/iOS/Web Platform constants
+export { Platform as ApplePlatform } from '@expo/apple-utils';

--- a/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/distributionCertificate.ts
@@ -33,7 +33,7 @@ export async function getDistributionCertificateAsync(
   const certificates = await Certificate.getAsync(context, {
     query: {
       filter: {
-        certificateType: CertificateType.IOS_DISTRIBUTION,
+        certificateType: [CertificateType.IOS_DISTRIBUTION, CertificateType.DISTRIBUTION],
       },
     },
   });

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
@@ -1,4 +1,4 @@
-import { Platform as ApplePlatform, Profile, ProfileType, RequestContext } from '@expo/apple-utils';
+import { Profile, ProfileType, RequestContext } from '@expo/apple-utils';
 
 import { ora } from '../../../ora';
 import { isAppStoreConnectTokenOnlyContext } from '../utils/authType';
@@ -11,6 +11,7 @@ import {
 import { getRequestContext } from './authenticate';
 import { AuthCtx } from './authenticateTypes';
 import { getBundleIdForIdentifierAsync, getProfilesForBundleIdAsync } from './bundleId';
+import { ApplePlatform } from './constants';
 import { getCertificateBySerialNumberAsync, transformCertificate } from './distributionCertificate';
 
 export enum ProfileClass {

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfileAdhoc.ts
@@ -44,11 +44,13 @@ async function registerMissingDevicesAsync(
   return alreadyAdded;
 }
 
-async function findProfileByBundleIdAsync(
+async function findProfileAsync(
   context: RequestContext,
-  bundleId: string,
-  certSerialNumber: string,
-  profileType: ProfileType
+  {
+    bundleId,
+    certSerialNumber,
+    profileType,
+  }: { bundleId: string; certSerialNumber: string; profileType: ProfileType }
 ): Promise<{
   profile: Profile | null;
   didUpdate: boolean;
@@ -156,12 +158,7 @@ async function manageAdHocProfilesAsync(
     }
   } else {
     // If no profile id is passed, try to find a suitable provisioning profile for the App ID.
-    const results = await findProfileByBundleIdAsync(
-      context,
-      bundleId,
-      certSerialNumber,
-      profileType
-    );
+    const results = await findProfileAsync(context, { bundleId, certSerialNumber, profileType });
     existingProfile = results.profile;
     didUpdate = results.didUpdate;
   }
@@ -199,7 +196,7 @@ async function manageAdHocProfilesAsync(
     }
 
     const updatedProfile = (
-      await findProfileByBundleIdAsync(context, bundleId, certSerialNumber, profileType)
+      await findProfileAsync(context, { bundleId, certSerialNumber, profileType })
     ).profile;
     if (!updatedProfile) {
       throw new Error(

--- a/packages/eas-cli/src/credentials/ios/validators/validateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validateProvisioningProfile.ts
@@ -7,15 +7,16 @@ import nullthrows from 'nullthrows';
 import { IosAppBuildCredentialsFragment, IosDistributionType } from '../../../graphql/generated';
 import Log from '../../../log';
 import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
-import { TargetCredentialsContext } from '../../context';
+import { CredentialsContext } from '../../context';
 import { AppLookupParams } from '../api/GraphqlClient';
-import { ApplePlatform } from '../appstore/constants';
 import { ProfileClass } from '../appstore/provisioningProfile';
+import { Target } from '../types';
 import { getP12CertFingerprint } from '../utils/p12Certificate';
 import { parse as parseProvisioningProfile } from '../utils/provisioningProfile';
 
 export async function validateProvisioningProfileAsync(
-  ctx: TargetCredentialsContext,
+  ctx: CredentialsContext,
+  target: Target,
   app: AppLookupParams,
   buildCredentials: Partial<IosAppBuildCredentialsFragment> | null
 ): Promise<boolean> {
@@ -39,7 +40,7 @@ export async function validateProvisioningProfileAsync(
     return true;
   }
 
-  return await validateProvisioningProfileWithAppleAsync(ctx, app, buildCredentials);
+  return await validateProvisioningProfileWithAppleAsync(ctx, target, app, buildCredentials);
 }
 
 function validateProvisioningProfileWithoutApple(
@@ -85,14 +86,15 @@ function validateProvisioningProfileWithoutApple(
 }
 
 async function validateProvisioningProfileWithAppleAsync(
-  ctx: TargetCredentialsContext,
+  ctx: CredentialsContext,
+  target: Target,
   app: AppLookupParams,
   buildCredentials: Partial<IosAppBuildCredentialsFragment>
 ): Promise<boolean> {
   assert(buildCredentials.provisioningProfile, 'Provisioning Profile must be defined');
   const { developerPortalIdentifier, provisioningProfile } = buildCredentials.provisioningProfile;
 
-  const applePlatform = await getApplePlatformFromSdkRoot(ctx.target);
+  const applePlatform = await getApplePlatformFromSdkRoot(target);
   const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
     app.bundleIdentifier,
     applePlatform,

--- a/packages/eas-cli/src/credentials/ios/validators/validateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validateProvisioningProfile.ts
@@ -1,4 +1,3 @@
-import { Platform as ApplePlatform } from '@expo/apple-utils';
 import { PlistArray, PlistObject } from '@expo/plist';
 import assert from 'assert';
 import crypto from 'crypto';
@@ -10,6 +9,7 @@ import Log from '../../../log';
 import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
 import { TargetCredentialsContext } from '../../context';
 import { AppLookupParams } from '../api/GraphqlClient';
+import { ApplePlatform } from '../appstore/constants';
 import { ProfileClass } from '../appstore/provisioningProfile';
 import { getP12CertFingerprint } from '../utils/p12Certificate';
 import { parse as parseProvisioningProfile } from '../utils/provisioningProfile';
@@ -92,7 +92,7 @@ async function validateProvisioningProfileWithAppleAsync(
   assert(buildCredentials.provisioningProfile, 'Provisioning Profile must be defined');
   const { developerPortalIdentifier, provisioningProfile } = buildCredentials.provisioningProfile;
 
-  const applePlatform = (await getApplePlatformFromSdkRoot(ctx.target)) ?? ApplePlatform.IOS;
+  const applePlatform = await getApplePlatformFromSdkRoot(ctx.target);
   const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
     app.bundleIdentifier,
     applePlatform,

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -15,7 +15,7 @@ import { getProjectAccountName, getProjectIdAsync } from '../../project/projectU
 import { confirmAsync, promptAsync, selectAsync } from '../../prompts';
 import { Account, findAccountByName } from '../../user/Account';
 import { ensureActorHasUsername, ensureLoggedInAsync } from '../../user/actions';
-import { CredentialsContext } from '../context';
+import { CredentialsContext, TargetCredentialsContext } from '../context';
 import {
   AppStoreApiKeyPurpose,
   selectAscApiKeysFromAccountAsync,
@@ -250,6 +250,7 @@ export class ManageIos {
 
     const target = await this.selectTargetAsync(targets);
     const appLookupParams = getAppLookupParamsFromContext(ctx, target);
+    const targetCtx = ctx.createTargetContext(target);
     switch (action) {
       case IosActionType.UseExistingDistributionCertificate: {
         const distCert = await selectValidDistributionCertificateAsync(ctx, appLookupParams);
@@ -257,7 +258,7 @@ export class ManageIos {
           return;
         }
         await this.setupProvisioningProfileWithSpecificDistCertAsync(
-          ctx,
+          targetCtx,
           appLookupParams,
           distCert,
           distributionType
@@ -273,7 +274,7 @@ export class ManageIos {
         });
         if (confirm) {
           await this.setupProvisioningProfileWithSpecificDistCertAsync(
-            ctx,
+            targetCtx,
             appLookupParams,
             distCert,
             distributionType
@@ -376,7 +377,7 @@ export class ManageIos {
   }
 
   private async setupProvisioningProfileWithSpecificDistCertAsync(
-    ctx: CredentialsContext,
+    ctx: TargetCredentialsContext,
     appLookupParams: AppLookupParams,
     distCert: AppleDistributionCertificateFragment,
     distributionType: IosDistributionTypeGraphql

--- a/packages/eas-cli/src/devices/actions/create/developerPortalMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/developerPortalMethod.ts
@@ -93,11 +93,13 @@ async function findUnregisteredPortalDevicesAsync(
     return acc;
   }, {} as Record<string, AppleDeviceFragmentWithAppleTeam>);
 
-  const portalDevices = await Device.getAllIOSProfileDevicesAsync(getRequestContext(appleAuthCtx));
+  const portalDevices = await Device.getAsync(getRequestContext(appleAuthCtx));
   return portalDevices.filter(
     portalDevice =>
       !(portalDevice.attributes.udid in expoRegisteredDevicesByUdid) &&
-      [DeviceClass.IPAD, DeviceClass.IPHONE].includes(portalDevice.attributes.deviceClass)
+      [DeviceClass.IPAD, DeviceClass.IPHONE, DeviceClass.APPLE_TV].includes(
+        portalDevice.attributes.deviceClass
+      )
   );
 }
 

--- a/packages/eas-cli/src/project/ios/__tests__/target-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/target-test.ts
@@ -1,9 +1,8 @@
-import { Platform as ApplePlatform } from '@expo/apple-utils';
-
 import { testTarget } from '../../../credentials/__tests__/fixtures-ios';
+import { ApplePlatform } from '../../../credentials/ios/appstore/constants';
 import { getApplePlatformFromSdkRoot } from '../target';
 
-function getApplePlatform(sdkRoot: string): ApplePlatform | null {
+function getApplePlatform(sdkRoot: string): ApplePlatform {
   const target = {
     ...testTarget,
     buildSettings: {
@@ -14,27 +13,21 @@ function getApplePlatform(sdkRoot: string): ApplePlatform | null {
 }
 
 describe(getApplePlatformFromSdkRoot, () => {
+  // Update `getApplePlatformFromSdkRoot` to be compatible with new Apple Platforms
   test('all enumerations work with the function', () => {
-    for (const platform of Object.values(ApplePlatform)) {
-      switch (platform) {
-        case ApplePlatform.IOS:
-        case ApplePlatform.TV_OS:
-        case ApplePlatform.MAC_OS:
-          break;
-        default:
-          throw new Error(`Update the function to work with ${platform}`);
-      }
-    }
+    expect(Object.values(ApplePlatform).sort()).toEqual(
+      [ApplePlatform.IOS, ApplePlatform.TV_OS, ApplePlatform.MAC_OS].sort()
+    );
   });
   test('existing SDKs work with the function', () => {
     // sdks from `xcodebuild -showsdks`
     expect(getApplePlatform('iphoneos14.4')).toBe(ApplePlatform.IOS);
-    expect(getApplePlatform('iphonesimulator14.4')).toBe(null);
+    expect(getApplePlatform('iphonesimulator14.4')).toBe(ApplePlatform.IOS);
     expect(getApplePlatform('driverkit.macosx20.2 ')).toBe(ApplePlatform.MAC_OS);
     expect(getApplePlatform('macosx11.1')).toBe(ApplePlatform.MAC_OS);
     expect(getApplePlatform('appletvos14.3')).toBe(ApplePlatform.TV_OS);
-    expect(getApplePlatform('appletvsimulator14.3')).toBe(null);
-    expect(getApplePlatform('watchos7.2')).toBe(null);
-    expect(getApplePlatform('watchsimulator7.2')).toBe(null);
+    expect(getApplePlatform('appletvsimulator14.3')).toBe(ApplePlatform.IOS);
+    expect(getApplePlatform('watchos7.2')).toBe(ApplePlatform.IOS);
+    expect(getApplePlatform('watchsimulator7.2')).toBe(ApplePlatform.IOS);
   });
 });

--- a/packages/eas-cli/src/project/ios/__tests__/target-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/target-test.ts
@@ -1,0 +1,40 @@
+import { Platform as ApplePlatform } from '@expo/apple-utils';
+
+import { testTarget } from '../../../credentials/__tests__/fixtures-ios';
+import { getApplePlatformFromSdkRoot } from '../target';
+
+function getApplePlatform(sdkRoot: string): ApplePlatform | null {
+  const target = {
+    ...testTarget,
+    buildSettings: {
+      SDKROOT: sdkRoot,
+    },
+  };
+  return getApplePlatformFromSdkRoot(target);
+}
+
+describe(getApplePlatformFromSdkRoot, () => {
+  test('all enumerations work with the function', () => {
+    for (const platform of Object.values(ApplePlatform)) {
+      switch (platform) {
+        case ApplePlatform.IOS:
+        case ApplePlatform.TV_OS:
+        case ApplePlatform.MAC_OS:
+          break;
+        default:
+          throw new Error(`Update the function to work with ${platform}`);
+      }
+    }
+  });
+  test('existing SDKs work with the function', () => {
+    // sdks from `xcodebuild -showsdks`
+    expect(getApplePlatform('iphoneos14.4')).toBe(ApplePlatform.IOS);
+    expect(getApplePlatform('iphonesimulator14.4')).toBe(null);
+    expect(getApplePlatform('driverkit.macosx20.2 ')).toBe(ApplePlatform.MAC_OS);
+    expect(getApplePlatform('macosx11.1')).toBe(ApplePlatform.MAC_OS);
+    expect(getApplePlatform('appletvos14.3')).toBe(ApplePlatform.TV_OS);
+    expect(getApplePlatform('appletvsimulator14.3')).toBe(null);
+    expect(getApplePlatform('watchos7.2')).toBe(null);
+    expect(getApplePlatform('watchsimulator7.2')).toBe(null);
+  });
+});

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -1,4 +1,3 @@
-import { Platform as ApplePlatform } from '@expo/apple-utils';
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig, XcodeProject } from '@expo/config-plugins';
 import { Platform, Workflow } from '@expo/eas-build-job';
@@ -6,6 +5,7 @@ import { JSONObject } from '@expo/json-file';
 import Joi from 'joi';
 import type { XCBuildConfiguration } from 'xcode';
 
+import { ApplePlatform } from '../../credentials/ios/appstore/constants';
 import { Target } from '../../credentials/ios/types';
 import { resolveWorkflowAsync } from '../workflow';
 import { getBundleIdentifierAsync } from './bundleIdentifier';
@@ -230,12 +230,12 @@ function resolveBareProjectBuildSettings(
 
 /**
  * Get Apple Platform from the Xcode SDKROOT where possible.
- * @returns - Apple Platform when known, otherwise null
+ * @returns - Apple Platform when known, defaults to IOS when unknown
  */
-export function getApplePlatformFromSdkRoot(target: Target): ApplePlatform | null {
+export function getApplePlatformFromSdkRoot(target: Target): ApplePlatform {
   const sdkRoot = target.buildSettings?.SDKROOT;
   if (!sdkRoot) {
-    return null;
+    return ApplePlatform.IOS;
   }
   if (sdkRoot.includes('iphoneos')) {
     return ApplePlatform.IOS;
@@ -244,6 +244,6 @@ export function getApplePlatformFromSdkRoot(target: Target): ApplePlatform | nul
   } else if (sdkRoot.includes('macosx')) {
     return ApplePlatform.MAC_OS;
   } else {
-    return null;
+    return ApplePlatform.IOS;
   }
 }

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -1,3 +1,4 @@
+import { Platform as ApplePlatform } from '@expo/apple-utils';
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig, XcodeProject } from '@expo/config-plugins';
 import { Platform, Workflow } from '@expo/eas-build-job';
@@ -225,4 +226,24 @@ function resolveBareProjectBuildSettings(
     buildConfiguration,
   });
   return xcBuildConfiguration?.buildSettings ?? {};
+}
+
+/**
+ * Get Apple Platform from the Xcode SDKROOT where possible.
+ * @returns - Apple Platform when known, otherwise null
+ */
+export function getApplePlatformFromSdkRoot(target: Target): ApplePlatform | null {
+  const sdkRoot = target.buildSettings?.SDKROOT;
+  if (!sdkRoot) {
+    return null;
+  }
+  if (sdkRoot.includes('iphoneos')) {
+    return ApplePlatform.IOS;
+  } else if (sdkRoot.includes('tvos')) {
+    return ApplePlatform.TV_OS;
+  } else if (sdkRoot.includes('macosx')) {
+    return ApplePlatform.MAC_OS;
+  } else {
+    return null;
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why
- Ensure tvOS projects play nice for adhoc, enterprise and app store builds. 
- Generate the proper credentials for tvOS in the case where the user wants Expo to manage them

# Test Plan

- [x] new tests pass

# Manual sanity check
Since this PR touches many files

- [x] tvOS Adhoc build works
- [x] tvOS App store build works
- [x] iOS App store build works
- [x] iOS Adhoc build works