### PR TITLE
[eas-cli] Use discriminated union type for BuildContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Use discriminated union type for BuildContext. ([#1330](https://github.com/expo/eas-cli/pull/1330) by [@wschurman](https://github.com/wschurman))
+
 ## [1.2.0](https://github.com/expo/eas-cli/releases/tag/v1.2.0) - 2022-08-29
 
 ### 🎉 New features

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -22,7 +22,7 @@ import {
   JobData,
   prepareBuildRequestForPlatformAsync,
 } from '../build';
-import { AndroidBuildContext, BuildContext, CommonContext } from '../context';
+import { AndroidBuildContext, AndroidCommonContext, BuildContextAndroid } from '../context';
 import { transformMetadata } from '../graphql';
 import { logCredentialsSource } from '../utils/credentials';
 import { checkGoogleServicesFileAsync, checkNodeEnvVariable } from '../validate';
@@ -32,7 +32,7 @@ import { syncProjectConfigurationAsync } from './syncProjectConfiguration';
 import { resolveRemoteVersionCodeAsync } from './version';
 
 export async function createAndroidContextAsync(
-  ctx: CommonContext<Platform.ANDROID>
+  ctx: AndroidCommonContext
 ): Promise<AndroidBuildContext> {
   const { buildProfile } = ctx;
 
@@ -77,11 +77,11 @@ This means that it will most likely produce an AAB and you will not be able to i
 }
 
 export async function prepareAndroidBuildAsync(
-  ctx: BuildContext<Platform.ANDROID>
+  ctx: BuildContextAndroid
 ): Promise<BuildRequestSender> {
   return await prepareBuildRequestForPlatformAsync({
     ctx,
-    ensureCredentialsAsync: async (ctx: BuildContext<Platform.ANDROID>) => {
+    ensureCredentialsAsync: async (ctx: BuildContextAndroid) => {
       return await ensureAndroidCredentialsAsync(ctx);
     },
     syncProjectConfigurationAsync: async () => {
@@ -95,7 +95,7 @@ export async function prepareAndroidBuildAsync(
       });
     },
     prepareJobAsync: async (
-      ctx: BuildContext<Platform.ANDROID>,
+      ctx: BuildContextAndroid,
       jobData: JobData<AndroidCredentials>
     ): Promise<Job> => {
       return await prepareJobAsync(ctx, jobData);
@@ -118,12 +118,12 @@ export async function prepareAndroidBuildAsync(
   });
 }
 
-function shouldProvideCredentials(ctx: BuildContext<Platform.ANDROID>): boolean {
+function shouldProvideCredentials(ctx: BuildContextAndroid): boolean {
   return !ctx.buildProfile.withoutCredentials;
 }
 
 async function ensureAndroidCredentialsAsync(
-  ctx: BuildContext<Platform.ANDROID>
+  ctx: BuildContextAndroid
 ): Promise<CredentialsResult<AndroidCredentials> | undefined> {
   if (!shouldProvideCredentials(ctx)) {
     return;

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -7,7 +7,7 @@ import { AndroidCredentials } from '../../credentials/android/AndroidCredentials
 import { getUsername } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
 import { getVcsClient } from '../../vcs';
-import { BuildContext } from '../context';
+import { BuildContextAndroid } from '../context';
 
 interface JobData {
   projectArchive: ArchiveSource;
@@ -20,10 +20,7 @@ const cacheDefaults = {
   cacheDefaultPaths: true,
 };
 
-export async function prepareJobAsync(
-  ctx: BuildContext<Platform.ANDROID>,
-  jobData: JobData
-): Promise<Job> {
+export async function prepareJobAsync(ctx: BuildContextAndroid, jobData: JobData): Promise<Job> {
   const username = getUsername(ctx.exp, await ensureLoggedInAsync());
   const buildProfile: BuildProfile<Platform.ANDROID> = ctx.buildProfile;
   const projectRootDirectory =

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -11,7 +11,9 @@ import { XcodeBuildContext } from '../project/ios/scheme';
 import { Actor } from '../user/User';
 import { LocalBuildOptions } from './local';
 
-export type CommonContext<T extends Platform> = Omit<BuildContext<T>, 'android' | 'ios'>;
+export type AndroidCommonContext = Omit<BuildContextAndroid, 'android'>;
+export type IosCommonContext = Omit<BuildContextIos, 'ios'>;
+export type CommonContext = AndroidCommonContext | IosCommonContext;
 
 export interface AndroidBuildContext {
   applicationId: string;
@@ -27,10 +29,9 @@ export interface IosBuildContext {
   buildNumberOverride?: string;
 }
 
-export interface BuildContext<T extends Platform> {
+interface BuildContextBase {
   accountName: string;
   easJsonCliConfig: EasJson['cli'];
-  buildProfile: BuildProfile<T>;
   buildProfileName: string;
   resourceClass: BuildResourceClass;
   clearCache: boolean;
@@ -40,7 +41,6 @@ export interface BuildContext<T extends Platform> {
   nonInteractive: boolean;
   noWait: boolean;
   runFromCI: boolean;
-  platform: T;
   projectDir: string;
   projectId: string;
   projectName: string;
@@ -48,6 +48,18 @@ export interface BuildContext<T extends Platform> {
   trackingCtx: TrackingContext;
   user: Actor;
   workflow: Workflow;
-  android: T extends Platform.ANDROID ? AndroidBuildContext : undefined;
-  ios: T extends Platform.IOS ? IosBuildContext : undefined;
 }
+
+export interface BuildContextAndroid extends BuildContextBase {
+  buildProfile: BuildProfile<Platform.ANDROID>;
+  platform: Platform.ANDROID;
+  android: AndroidBuildContext;
+}
+
+export interface BuildContextIos extends BuildContextBase {
+  buildProfile: BuildProfile<Platform.IOS>;
+  platform: Platform.IOS;
+  ios: IosBuildContext;
+}
+
+export type BuildContext = BuildContextAndroid | BuildContextIos;

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -15,7 +15,7 @@ import { resolveWorkflowAsync } from '../project/workflow';
 import { findAccountByName } from '../user/Account';
 import { ensureLoggedInAsync } from '../user/actions';
 import { createAndroidContextAsync } from './android/build';
-import { BuildContext, CommonContext } from './context';
+import { AndroidCommonContext, BuildContext, IosCommonContext } from './context';
 import { createIosContextAsync } from './ios/build';
 import { LocalBuildOptions } from './local';
 
@@ -43,7 +43,7 @@ export async function createBuildContextAsync<T extends Platform>({
   projectDir: string;
   resourceClass: BuildResourceClass;
   message?: string;
-}): Promise<BuildContext<T>> {
+}): Promise<BuildContext> {
   const exp = getExpoConfig(projectDir, { env: buildProfile.env });
 
   const user = await ensureLoggedInAsync();
@@ -80,7 +80,7 @@ export async function createBuildContextAsync<T extends Platform>({
   };
   Analytics.logEvent(BuildEvent.BUILD_COMMAND, trackingCtx);
 
-  const commonContext: CommonContext<T> = {
+  const commonContext = {
     accountName,
     buildProfile,
     buildProfileName,
@@ -103,17 +103,17 @@ export async function createBuildContextAsync<T extends Platform>({
     runFromCI,
   };
   if (platform === Platform.ANDROID) {
-    const common = commonContext as CommonContext<Platform.ANDROID>;
+    const common = commonContext as AndroidCommonContext;
     return {
       ...common,
       android: await createAndroidContextAsync(common),
-    } as BuildContext<T>;
+    };
   } else {
-    const common = commonContext as CommonContext<Platform.IOS>;
+    const common = commonContext as IosCommonContext;
     return {
       ...common,
       ios: await createIosContextAsync(common),
-    } as BuildContext<T>;
+    };
   }
 }
 

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -1,4 +1,4 @@
-import { Ios, Job, Metadata, Platform, Workflow } from '@expo/eas-build-job';
+import { Ios, Job, Metadata, Workflow } from '@expo/eas-build-job';
 import { AppVersionSource } from '@expo/eas-json';
 
 import { IosCredentials } from '../../credentials/ios/types';
@@ -8,7 +8,7 @@ import { ensureBundleIdentifierIsDefinedForManagedProjectAsync } from '../../pro
 import { resolveXcodeBuildContextAsync } from '../../project/ios/scheme';
 import { findApplicationTarget, resolveTargetsAsync } from '../../project/ios/target';
 import { BuildRequestSender, JobData, prepareBuildRequestForPlatformAsync } from '../build';
-import { BuildContext, CommonContext, IosBuildContext } from '../context';
+import { BuildContextIos, IosBuildContext, IosCommonContext } from '../context';
 import { transformMetadata } from '../graphql';
 import { checkGoogleServicesFileAsync, checkNodeEnvVariable } from '../validate';
 import { ensureIosCredentialsAsync } from './credentials';
@@ -17,9 +17,7 @@ import { prepareJobAsync } from './prepareJob';
 import { syncProjectConfigurationAsync } from './syncProjectConfiguration';
 import { resolveRemoteBuildNumberAsync } from './version';
 
-export async function createIosContextAsync(
-  ctx: CommonContext<Platform.IOS>
-): Promise<IosBuildContext> {
+export async function createIosContextAsync(ctx: IosCommonContext): Promise<IosBuildContext> {
   const { buildProfile } = ctx;
 
   if (ctx.workflow === Workflow.MANAGED) {
@@ -63,12 +61,10 @@ export async function createIosContextAsync(
   };
 }
 
-export async function prepareIosBuildAsync(
-  ctx: BuildContext<Platform.IOS>
-): Promise<BuildRequestSender> {
+export async function prepareIosBuildAsync(ctx: BuildContextIos): Promise<BuildRequestSender> {
   return await prepareBuildRequestForPlatformAsync({
     ctx,
-    ensureCredentialsAsync: async (ctx: BuildContext<Platform.IOS>) => {
+    ensureCredentialsAsync: async (ctx: BuildContextIos) => {
       return ensureIosCredentialsAsync(ctx, ctx.ios.targets);
     },
     syncProjectConfigurationAsync: async () => {
@@ -83,7 +79,7 @@ export async function prepareIosBuildAsync(
       });
     },
     prepareJobAsync: async (
-      ctx: BuildContext<Platform.IOS>,
+      ctx: BuildContextIos,
       jobData: JobData<IosCredentials>
     ): Promise<Job> => {
       return await prepareJobAsync(ctx, {

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -4,11 +4,11 @@ import IosCredentialsProvider from '../../credentials/ios/IosCredentialsProvider
 import { getAppFromContext } from '../../credentials/ios/actions/BuildCredentialsUtils';
 import { IosCredentials, Target } from '../../credentials/ios/types';
 import { CredentialsResult } from '../build';
-import { BuildContext } from '../context';
+import { BuildContextIos } from '../context';
 import { logCredentialsSource } from '../utils/credentials';
 
 export async function ensureIosCredentialsAsync(
-  buildCtx: BuildContext<Platform.IOS>,
+  buildCtx: BuildContextIos,
   targets: Target[]
 ): Promise<CredentialsResult<IosCredentials> | undefined> {
   if (!shouldProvideCredentials(buildCtx)) {
@@ -31,6 +31,6 @@ export async function ensureIosCredentialsAsync(
   };
 }
 
-function shouldProvideCredentials(buildCtx: BuildContext<Platform.IOS>): boolean {
+function shouldProvideCredentials(buildCtx: BuildContextIos): boolean {
   return !buildCtx.buildProfile.simulator;
 }

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -6,7 +6,7 @@ import { IosCredentials, TargetCredentials } from '../../credentials/ios/types';
 import { getUsername } from '../../project/projectUtils';
 import { ensureLoggedInAsync } from '../../user/actions';
 import { getVcsClient } from '../../vcs';
-import { BuildContext } from '../context';
+import { BuildContextIos } from '../context';
 
 interface JobData {
   projectArchive: ArchiveSource;
@@ -20,10 +20,7 @@ const cacheDefaults = {
   cacheDefaultPaths: true,
 };
 
-export async function prepareJobAsync(
-  ctx: BuildContext<Platform.IOS>,
-  jobData: JobData
-): Promise<Job> {
+export async function prepareJobAsync(ctx: BuildContextIos, jobData: JobData): Promise<Job> {
   const projectRootDirectory =
     slash(path.relative(await getVcsClient().getRootPathAsync(), ctx.projectDir)) || '.';
   const username = getUsername(ctx.exp, await ensureLoggedInAsync());

--- a/packages/eas-cli/src/build/validate.ts
+++ b/packages/eas-cli/src/build/validate.ts
@@ -1,4 +1,4 @@
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Workflow } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -6,7 +6,7 @@ import Log, { learnMore } from '../log';
 import { getVcsClient } from '../vcs';
 import { CommonContext } from './context';
 
-export function checkNodeEnvVariable(ctx: CommonContext<Platform>): void {
+export function checkNodeEnvVariable(ctx: CommonContext): void {
   if (ctx.buildProfile.env?.NODE_ENV === 'production') {
     Log.warn(
       'You set NODE_ENV=production in the build profile. Remember that it will be available during the entire build process. In particular, it will make yarn/npm install only production packages.'
@@ -15,9 +15,7 @@ export function checkNodeEnvVariable(ctx: CommonContext<Platform>): void {
   }
 }
 
-export async function checkGoogleServicesFileAsync<T extends Platform>(
-  ctx: CommonContext<T>
-): Promise<void> {
+export async function checkGoogleServicesFileAsync(ctx: CommonContext): Promise<void> {
   if (ctx.workflow === Workflow.GENERIC || ctx.buildProfile?.env?.GOOGLE_SERVICES_FILE) {
     return;
   }

--- a/packages/eas-cli/src/project/expoSdk.ts
+++ b/packages/eas-cli/src/project/expoSdk.ts
@@ -1,4 +1,4 @@
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Workflow } from '@expo/eas-build-job';
 import { Errors } from '@oclif/core';
 import assert from 'assert';
 import semver from 'semver';
@@ -10,7 +10,7 @@ import { confirmAsync } from '../prompts';
 const SUPPORTED_EXPO_SDK_VERSIONS = '>= 41.0.0';
 assert(semver.validRange(SUPPORTED_EXPO_SDK_VERSIONS), 'Must be a valid version range');
 
-export async function checkExpoSdkIsSupportedAsync(ctx: BuildContext<Platform>): Promise<void> {
+export async function checkExpoSdkIsSupportedAsync(ctx: BuildContext): Promise<void> {
   assert(ctx.workflow === Workflow.MANAGED, 'Must be a managed workflow project');
 
   if (ctx.exp.sdkVersion && semver.satisfies(ctx.exp.sdkVersion, SUPPORTED_EXPO_SDK_VERSIONS)) {

--- a/packages/eas-cli/src/project/metroConfig.ts
+++ b/packages/eas-cli/src/project/metroConfig.ts
@@ -1,4 +1,3 @@
-import { Platform } from '@expo/eas-build-job';
 import { Errors } from '@oclif/core';
 import chalk from 'chalk';
 import type MetroConfig from 'metro-config';
@@ -8,9 +7,7 @@ import { BuildContext } from '../build/context';
 import Log, { learnMore } from '../log';
 import { confirmAsync } from '../prompts';
 
-export async function validateMetroConfigForManagedWorkflowAsync(
-  ctx: BuildContext<Platform>
-): Promise<void> {
+export async function validateMetroConfigForManagedWorkflowAsync(ctx: BuildContext): Promise<void> {
   if (!(await configExistsAsync(ctx.projectDir))) {
     return;
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#discriminating-unions

This reduces the amount of casting we do of the context type.

i.e. we no longer need the `as` cast in:
```typescript
if (ctx.platform === Platform.IOS) {
    const iosContext = ctx as BuildContext<Platform.IOS>;
```

# How

Update types in `context.ts`, run tsc, fix errors.

# Test Plan

`yarn start` (runs tsc)
