### PR TITLE
fix typo in promptToConfigurePushNotifications

### DIFF
--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -101,7 +101,7 @@ export default class IosCredentialsProvider {
       return null;
     }
 
-    if (ctx.easJsonCliConfig?.promptToConfigurePushNotfications === false) {
+    if (ctx.easJsonCliConfig?.promptToConfigurePushNotifications === false) {
       return null;
     }
 
@@ -131,7 +131,7 @@ export default class IosCredentialsProvider {
   ): Promise<void> {
     const easJsonPath = EasJsonReader.formatEasJsonPath(ctx.projectDir);
     const easJson = await fs.readJSON(easJsonPath);
-    easJson.cli = { ...easJson?.cli, promptToConfigurePushNotfications: false };
+    easJson.cli = { ...easJson?.cli, promptToConfigurePushNotifications: false };
     await fs.writeFile(easJsonPath, `${JSON.stringify(easJson, null, 2)}\n`);
     Log.withTick('Updated eas.json');
   }

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -38,7 +38,7 @@
             "When using remote, the `autoIncrement` is based on the values stored on EAS servers."
           ]
         },
-        "promptToConfigurePushNotfications" : {
+        "promptToConfigurePushNotifications" : {
           "type": "boolean",
           "description": "Specifies where EAS CLI should prompt to configure Push Notifications credentials. Defaults to true.",
           "default": true

--- a/packages/eas-json/src/schema.ts
+++ b/packages/eas-json/src/schema.ts
@@ -10,7 +10,7 @@ export const EasJsonSchema = Joi.object({
     requireCommit: Joi.boolean(),
     appVersionSource: Joi.string().valid(...Object.values(AppVersionSource)),
     promptToConfigurePushNotifications: Joi.boolean(),
-  }).rename('promptToConfigurePushNotfications', 'promptToConfigurePushNotifications'),
+  }),
   build: Joi.object().pattern(Joi.string(), BuildProfileSchema),
   submit: Joi.object().pattern(Joi.string(), SubmitProfileSchema),
 });

--- a/packages/eas-json/src/schema.ts
+++ b/packages/eas-json/src/schema.ts
@@ -9,8 +9,8 @@ export const EasJsonSchema = Joi.object({
     version: Joi.string(),
     requireCommit: Joi.boolean(),
     appVersionSource: Joi.string().valid(...Object.values(AppVersionSource)),
-    promptToConfigurePushNotfications: Joi.boolean(),
-  }),
+    promptToConfigurePushNotifications: Joi.boolean(),
+  }).rename('promptToConfigurePushNotfications', 'promptToConfigurePushNotifications'),
   build: Joi.object().pattern(Joi.string(), BuildProfileSchema),
   submit: Joi.object().pattern(Joi.string(), SubmitProfileSchema),
 });

--- a/packages/eas-json/src/types.ts
+++ b/packages/eas-json/src/types.ts
@@ -21,7 +21,7 @@ export interface EasJson {
     version?: string;
     requireCommit?: boolean;
     appVersionSource?: AppVersionSource;
-    promptToConfigurePushNotfications?: boolean;
+    promptToConfigurePushNotifications?: boolean;
   };
   build?: { [profileName: string]: EasJsonBuildProfile };
   submit?: { [profileName: string]: EasJsonSubmitProfile };


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes typo in `promptToConfigurePushNotifications`.

# How

- I don't think many people started using this.
- Let's release this as soon as possible.
- I think that adding code that fixes the typo in eas.json is a bit of overkill. 

# Test Plan

Tested manually.
