### PR TITLE
[ENG-6186] add "eas open" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add tvOS credentials compatibility for Adhoc and App store builds. ([#1325](https://github.com/expo/eas-cli/pull/1325) by [@quinlanj](https://github.com/quinlanj))
+- Add `eas open` command for opening project page in web browser. ([#1337](https://github.com/expo/eas-cli/pull/1337) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -32,6 +32,7 @@
     "@urql/core": "2.6.1",
     "@urql/exchange-retry": "0.3.3",
     "ajv": "^6.12.6",
+    "better-opn": "3.0.2",
     "chalk": "4.1.2",
     "cli-progress": "3.11.2",
     "cli-table3": "0.6.2",

--- a/packages/eas-cli/src/commands/open.ts
+++ b/packages/eas-cli/src/commands/open.ts
@@ -1,0 +1,45 @@
+import openBrowserAsync from 'better-opn';
+
+import { getProjectDashboardUrl } from '../build/utils/url';
+import EasCommand from '../commandUtils/EasCommand';
+import { ora } from '../ora';
+import { getExpoConfig } from '../project/expoConfig';
+import {
+  fetchProjectIdFromServerAsync,
+  findProjectRootAsync,
+  getProjectAccountName,
+} from '../project/projectUtils';
+import { ensureLoggedInAsync } from '../user/actions';
+
+export default class Open extends EasCommand {
+  static override description = 'open the project page in a web browser';
+
+  async runAsync(): Promise<void> {
+    const projectDir = await findProjectRootAsync();
+    const exp = getExpoConfig(projectDir);
+
+    // this ensures the project exists
+    await fetchProjectIdFromServerAsync(exp);
+
+    const user = await ensureLoggedInAsync();
+    const accountName = getProjectAccountName(exp, user);
+    const projectName = exp.slug;
+
+    const projectDashboardUrl = getProjectDashboardUrl(accountName, projectName);
+    const failedMessage = `Unable to open a web browser. Project page is available at: ${projectDashboardUrl}`;
+    const spinner = ora(`Opening ${projectDashboardUrl}`).start();
+    try {
+      const opened = await openBrowserAsync(projectDashboardUrl);
+
+      if (opened) {
+        spinner.succeed(`Opened ${projectDashboardUrl}`);
+      } else {
+        spinner.fail(failedMessage);
+      }
+      return;
+    } catch (error) {
+      spinner.fail(failedMessage);
+      throw error;
+    }
+  }
+}

--- a/ts-declarations/better-opn/index.d.ts
+++ b/ts-declarations/better-opn/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'better-opn' {
+  function open(
+    target: string,
+    options?: any
+  ): Promise<import('child_process').ChildProcess | false>;
+  export = open;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4642,6 +4642,13 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
+better-opn@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/better-opn/-/better-opn-3.0.2.tgz#f96f35deaaf8f34144a4102651babcf00d1d8817"
+  integrity sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==
+  dependencies:
+    open "^8.0.4"
+
 big-integer@1.6.x:
   version "1.6.51"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
@@ -5739,6 +5746,11 @@ defaults@^1.0.3:
   integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
   dependencies:
     clone "^1.0.2"
+
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
 define-properties@^1.1.3:
   version "1.1.3"
@@ -7788,6 +7800,11 @@ is-docker@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
   integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+
+is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -10090,6 +10107,15 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@^8.0.4:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 optionator@^0.9.1:
   version "0.9.1"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-6186/add-eas-open-command-to-open-the-project-on-the-website

# How

Adds `eas open` command that opens the project page in a web browser.

# Test Plan

I tested 3 scenarios:
1. Already existing project.
2. Freshly generated project (create-expo-app).
3. Outside project directory.