### PR TITLE
[eas-cli] bump oclif help plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix viewing branch list when a branch has no associated platforms. ([#1326](https://github.com/expo/eas-cli/pull/1326) by [@hbiede](https://github.com/hbiede))
+- Fix entry for the help command in the help prompt.
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Fix viewing branch list when a branch has no associated platforms. ([#1326](https://github.com/expo/eas-cli/pull/1326) by [@hbiede](https://github.com/hbiede))
 - Fix entry for the help command in the help prompt.
+- Fix description of `help` command in help prompt. ([#1341](https://github.com/expo/eas-cli/pull/1341) by [@Simek](https://github.com/Simek))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix viewing branch list when a branch has no associated platforms. ([#1326](https://github.com/expo/eas-cli/pull/1326) by [@hbiede](https://github.com/hbiede))
-- Fix entry for the help command in the help prompt.
 - Fix description of `help` command in help prompt. ([#1341](https://github.com/expo/eas-cli/pull/1341) by [@Simek](https://github.com/Simek))
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -21,7 +21,7 @@
     "@expo/pkcs12": "0.0.8",
     "@expo/plist": "0.0.18",
     "@expo/plugin-autocomplete": "1.4.0",
-    "@expo/plugin-help": "5.2.0",
+    "@expo/plugin-help": "5.3.0",
     "@expo/plugin-warn-if-update-available": "2.3.0",
     "@expo/prebuild-config": "5.0.3",
     "@expo/results": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,10 +1428,10 @@
     debug "^4.3.4"
     fs-extra "^10.1.0"
 
-"@expo/plugin-help@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@expo/plugin-help/-/plugin-help-5.2.0.tgz#c73dab76c7e95f82efc0ed8055c6ad1c291f82a2"
-  integrity sha512-YOI+D93hqAQHxOhlbGXXeQZX8FwWE338vk22GQNmVdVEBafrBHqvCWm0uEQKorf1mNwl8p0hcb/9NrGov5p5Lw==
+"@expo/plugin-help@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@expo/plugin-help/-/plugin-help-5.3.0.tgz#e6ca5acc63c7fb5248c3a74bf70c50efd9a3d69f"
+  integrity sha512-dgh5zo2E2hOQ+5vCRWdrPRDp/omnDdTWpMcxFmco5CkCaRX21FRzMFEZdJVhoLlEeavDgX98VyzqWslJxXHn3w==
   dependencies:
     "@oclif/core" "^1.9.0"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [X] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Refs ENG-6204

# How

This PR bumps our fork of the oclif help plugin, which includes corrected description for the `help` command in the help prompt

# Test Plan

The change has been tested locally by running `yarn eas`.

## Preview
<img width="561" alt="Screenshot 2022-09-05 at 12 47 38" src="https://user-images.githubusercontent.com/719641/188431878-5a23c9df-2f7c-4562-8264-a4c0b8ed6e51.png">
