### PR TITLE
Small updates to the language of the Device Create command

### DIFF
--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -14,7 +14,7 @@ import DeviceCreateAction from './actions/create/action';
 import { DeviceManagerContext } from './context';
 
 const CREATE_COMMAND_DESCRIPTION = `This command lets you register your Apple devices (iPhones and iPads) for internal distribution of your app.
-Internal distribution means that you won't need upload your app archive to App Store / Testflight.
+Internal distribution means that you won't need to upload your app archive to App Store / Testflight.
 Your app archive (.ipa) will be installable on your equipment as long as you sign your application with an adhoc provisiong profile.
 The provisioning profile needs to contain the UDIDs (unique identifiers) of your iPhones and iPads.
 
@@ -72,7 +72,7 @@ export class AccountResolver {
     }
 
     const useProjectAccount = await confirmAsync({
-      message: `You're inside the project directory. Would you like to use ${chalk.underline(
+      message: `You're inside the project directory. Would you like to use the ${chalk.underline(
         projectAccountName
       )} account?`,
     });


### PR DESCRIPTION
Small language updates that I noticed while running the `eas device:create` command to add some iOS devices to our provisioning profile.