### PR TITLE
[eas-cli] Standardize GQL Update type schema using Fragment 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Standardize the GQL 'Update' schema using UpdateFragmentNode. ([#1348](https://github.com/expo/eas-cli/pull/1348) by [@kgc00](https://github.com/kgc00))
+
 ## [2.1.0](https://github.com/expo/eas-cli/releases/tag/v2.1.0) - 2022-09-05
 
 ### 🎉 New features

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -17017,6 +17017,55 @@
         "description": "",
         "fields": [
           {
+            "name": "accessibleRepositories",
+            "description": "",
+            "args": [
+              {
+                "name": "page",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "1",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "perPage",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "50",
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GitHubAppInstallationAccessibleRepository",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "account",
             "description": "",
             "args": [],
@@ -17070,6 +17119,192 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubAppInstallationMetadata",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubAppInstallationAccessibleRepository",
+        "description": "",
+        "fields": [
+          {
+            "name": "defaultBranch",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubRepositoryOwner",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "private",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubAppInstallationMetadata",
+        "description": "",
+        "fields": [
+          {
+            "name": "githubAccountAvatarUrl",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubAccountName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "installationStatus",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "GitHubAppInstallationStatus",
                 "ofType": null
               }
             },
@@ -17160,6 +17395,35 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "GitHubAppInstallationStatus",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ACTIVE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_INSTALLED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUSPENDED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "GitHubAppQuery",
         "description": "",
@@ -17182,6 +17446,81 @@
           },
           {
             "name": "clientIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubRepositoryOwner",
+        "description": "",
+        "fields": [
+          {
+            "name": "avatarUrl",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "login",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
             "description": "",
             "args": [],
             "type": {

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -1,4 +1,5 @@
 import { Flags } from '@oclif/core';
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import EasCommand from '../../commandUtils/EasCommand';
@@ -7,6 +8,7 @@ import {
   GetAllChannelsForAppQuery,
   GetAllChannelsForAppQueryVariables,
 } from '../../graphql/generated';
+import { UpdateFragmentNode } from '../../graphql/types/Update';
 import Log from '../../log';
 import { getExpoConfig } from '../../project/expoConfig';
 import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
@@ -38,26 +40,14 @@ async function getAllUpdateChannelForAppAsync({
                     name
                     updates(offset: 0, limit: 10) {
                       id
-                      group
-                      message
-                      runtimeVersion
-                      createdAt
-                      platform
-                      actor {
-                        id
-                        ... on User {
-                          username
-                        }
-                        ... on Robot {
-                          firstName
-                        }
-                      }
+                      ...UpdateFragment
                     }
                   }
                 }
               }
             }
           }
+          ${print(UpdateFragmentNode)}
         `,
         { appId, offset: 0, limit: CHANNEL_LIMIT },
         { additionalTypenames: ['UpdateChannel', 'UpdateBranch', 'Update'] }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2468,10 +2468,36 @@ export type GetSignedAssetUploadSpecificationsResult = {
 
 export type GitHubAppInstallation = {
   __typename?: 'GitHubAppInstallation';
+  accessibleRepositories: Array<GitHubAppInstallationAccessibleRepository>;
   account: Account;
   actor?: Maybe<Actor>;
   id: Scalars['ID'];
   installationIdentifier: Scalars['Int'];
+  metadata: GitHubAppInstallationMetadata;
+};
+
+
+export type GitHubAppInstallationAccessibleRepositoriesArgs = {
+  page?: InputMaybe<Scalars['Int']>;
+  perPage?: InputMaybe<Scalars['Int']>;
+};
+
+export type GitHubAppInstallationAccessibleRepository = {
+  __typename?: 'GitHubAppInstallationAccessibleRepository';
+  defaultBranch: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  owner: GitHubRepositoryOwner;
+  private: Scalars['Boolean'];
+  url: Scalars['String'];
+};
+
+export type GitHubAppInstallationMetadata = {
+  __typename?: 'GitHubAppInstallationMetadata';
+  githubAccountAvatarUrl?: Maybe<Scalars['String']>;
+  githubAccountName?: Maybe<Scalars['String']>;
+  installationStatus: GitHubAppInstallationStatus;
 };
 
 export type GitHubAppInstallationMutation = {
@@ -2492,10 +2518,24 @@ export type GitHubAppInstallationMutationDeleteGitHubAppInstallationArgs = {
   githubAppInstallationId: Scalars['ID'];
 };
 
+export enum GitHubAppInstallationStatus {
+  Active = 'ACTIVE',
+  NotInstalled = 'NOT_INSTALLED',
+  Suspended = 'SUSPENDED'
+}
+
 export type GitHubAppQuery = {
   __typename?: 'GitHubAppQuery';
   appIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
+};
+
+export type GitHubRepositoryOwner = {
+  __typename?: 'GitHubRepositoryOwner';
+  avatarUrl: Scalars['String'];
+  id: Scalars['Int'];
+  login: Scalars['String'];
+  url: Scalars['String'];
 };
 
 export type GoogleServiceAccountKey = {
@@ -4376,7 +4416,7 @@ export type GetAllChannelsForAppQueryVariables = Exact<{
 }>;
 
 
-export type GetAllChannelsForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, runtimeVersion: string, createdAt: any, platform: string, actor?: { __typename?: 'Robot', firstName?: string | null, id: string } | { __typename?: 'User', username: string, id: string } | null }> }> }> } } };
+export type GetAllChannelsForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string } }> }> }> } } };
 
 export type AppInfoQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -4926,7 +4966,7 @@ export type BranchesByAppQueryVariables = Exact<{
 }>;
 
 
-export type BranchesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, createdAt: any, message?: string | null, runtimeVersion: string, group: string, platform: string, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null }> }> } } };
+export type BranchesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string } }> }> } } };
 
 export type BuildsByIdQueryVariables = Exact<{
   buildId: Scalars['ID'];
@@ -4958,7 +4998,7 @@ export type GetChannelByNameForAppQueryVariables = Exact<{
 }>;
 
 
-export type GetChannelByNameForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, runtimeVersion: string, createdAt: any, platform: string, actor?: { __typename?: 'Robot', firstName?: string | null, id: string } | { __typename?: 'User', username: string, id: string } | null }> }> } | null } } };
+export type GetChannelByNameForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string } }> }> } | null } } };
 
 export type EnvironmentSecretsByAccountNameQueryVariables = Exact<{
   accountName: Scalars['String'];
@@ -5018,7 +5058,7 @@ export type ViewUpdatesByGroupQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdatesByGroupQuery = { __typename?: 'RootQuery', updatesByGroup: Array<{ __typename?: 'Update', id: string, group: string, runtimeVersion: string, platform: string, message?: string | null, createdAt: any, manifestFragment: string, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string } }> };
+export type ViewUpdatesByGroupQuery = { __typename?: 'RootQuery', updatesByGroup: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string } }> };
 
 export type ViewUpdateGroupsOnBranchQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5073,7 +5113,9 @@ export type StatuspageServiceFragment = { __typename?: 'StatuspageService', id: 
 
 export type SubmissionFragment = { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null };
 
-export type UpdateBranchFragment = { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, createdAt: any, message?: string | null, runtimeVersion: string, group: string, platform: string, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null }> };
+export type UpdateFragment = { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string } };
+
+export type UpdateBranchFragment = { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string } }> };
 
 export type WebhookFragment = { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any };
 

--- a/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
@@ -1,7 +1,9 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import { GetChannelByNameForAppQuery, GetChannelByNameForAppQueryVariables } from '../generated';
+import { UpdateFragmentNode } from '../types/Update';
 
 export const ChannelQuery = {
   async getUpdateChannelByNameForAppAsync({
@@ -32,26 +34,14 @@ export const ChannelQuery = {
                       name
                       updates(offset: 0, limit: 10) {
                         id
-                        group
-                        message
-                        runtimeVersion
-                        createdAt
-                        platform
-                        actor {
-                          id
-                          ... on User {
-                            username
-                          }
-                          ... on Robot {
-                            firstName
-                          }
-                        }
+                        ...UpdateFragment
                       }
                     }
                   }
                 }
               }
             }
+            ${print(UpdateFragmentNode)}
           `,
           { appId, channelName },
           { additionalTypenames: ['UpdateChannel', 'UpdateBranch', 'Update'] }

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -1,8 +1,9 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { graphqlClient, withErrorHandlingAsync } from '../client';
 import {
-  UpdateBranchFragment,
+  UpdateFragment,
   ViewUpdateGroupsOnAppQuery,
   ViewUpdateGroupsOnAppQueryVariables,
   ViewUpdateGroupsOnBranchQuery,
@@ -10,31 +11,10 @@ import {
   ViewUpdatesByGroupQuery,
   ViewUpdatesByGroupQueryVariables,
 } from '../generated';
-
-export type BranchUpdateObject = UpdateBranchFragment['updates'][number];
-
-export type BranchUpdateGroupObject = Exclude<
-  ViewUpdateGroupsOnBranchQuery['app']['byId']['updateBranchByName'],
-  null | undefined
->['updateGroups'][number];
-
-export type AppUpdateGroupObject = Exclude<
-  ViewUpdateGroupsOnAppQuery['app']['byId'],
-  null | undefined
->['updateGroups'][number];
-
-export type UpdateByGroupObject = Exclude<
-  ViewUpdatesByGroupQuery['updatesByGroup'],
-  null | undefined
->;
-
-export type UpdateGroupObject =
-  | UpdateByGroupObject
-  | AppUpdateGroupObject
-  | BranchUpdateGroupObject;
+import { UpdateFragmentNode } from '../types/Update';
 
 export const UpdateQuery = {
-  async viewUpdateGroupAsync({ groupId }: { groupId: string }): Promise<UpdateByGroupObject> {
+  async viewUpdateGroupAsync({ groupId }: { groupId: string }): Promise<UpdateFragment[]> {
     const { updatesByGroup } = await withErrorHandlingAsync(
       graphqlClient
         .query<ViewUpdatesByGroupQuery, ViewUpdatesByGroupQueryVariables>(
@@ -42,28 +22,10 @@ export const UpdateQuery = {
             query ViewUpdatesByGroup($groupId: ID!) {
               updatesByGroup(group: $groupId) {
                 id
-                group
-                runtimeVersion
-                platform
-                message
-                createdAt
-                manifestFragment
-                actor {
-                  __typename
-                  id
-                  ... on User {
-                    username
-                  }
-                  ... on Robot {
-                    firstName
-                  }
-                }
-                branch {
-                  id
-                  name
-                }
+                ...UpdateFragment
               }
             }
+            ${print(UpdateFragmentNode)}
           `,
           {
             groupId,
@@ -85,7 +47,7 @@ export const UpdateQuery = {
     appId,
     branchName,
     filter,
-  }: ViewUpdateGroupsOnBranchQueryVariables): Promise<BranchUpdateGroupObject[]> {
+  }: ViewUpdateGroupsOnBranchQueryVariables): Promise<UpdateFragment[][]> {
     const response = await withErrorHandlingAsync(
       graphqlClient
         .query<ViewUpdateGroupsOnBranchQuery, ViewUpdateGroupsOnBranchQueryVariables>(
@@ -104,31 +66,13 @@ export const UpdateQuery = {
                     id
                     updateGroups(limit: $limit, offset: $offset, filter: $filter) {
                       id
-                      group
-                      message
-                      createdAt
-                      runtimeVersion
-                      platform
-                      manifestFragment
-                      actor {
-                        __typename
-                        id
-                        ... on User {
-                          username
-                        }
-                        ... on Robot {
-                          firstName
-                        }
-                      }
-                      branch {
-                        id
-                        name
-                      }
+                      ...UpdateFragment
                     }
                   }
                 }
               }
             }
+            ${print(UpdateFragmentNode)}
           `,
           {
             appId,
@@ -154,7 +98,7 @@ export const UpdateQuery = {
     offset,
     appId,
     filter,
-  }: ViewUpdateGroupsOnAppQueryVariables): Promise<AppUpdateGroupObject[]> {
+  }: ViewUpdateGroupsOnAppQueryVariables): Promise<UpdateFragment[][]> {
     const response = await withErrorHandlingAsync(
       graphqlClient
         .query<ViewUpdateGroupsOnAppQuery, ViewUpdateGroupsOnAppQueryVariables>(
@@ -170,30 +114,12 @@ export const UpdateQuery = {
                   id
                   updateGroups(limit: $limit, offset: $offset, filter: $filter) {
                     id
-                    group
-                    message
-                    createdAt
-                    runtimeVersion
-                    platform
-                    manifestFragment
-                    actor {
-                      __typename
-                      id
-                      ... on User {
-                        username
-                      }
-                      ... on Robot {
-                        firstName
-                      }
-                    }
-                    branch {
-                      id
-                      name
-                    }
+                    ...UpdateFragment
                   }
                 }
               }
             }
+            ${print(UpdateFragmentNode)}
           `,
           {
             appId,

--- a/packages/eas-cli/src/graphql/types/Update.ts
+++ b/packages/eas-cli/src/graphql/types/Update.ts
@@ -1,0 +1,27 @@
+import gql from 'graphql-tag';
+
+export const UpdateFragmentNode = gql`
+  fragment UpdateFragment on Update {
+    id
+    group
+    message
+    createdAt
+    runtimeVersion
+    platform
+    manifestFragment
+    actor {
+      __typename
+      id
+      ... on User {
+        username
+      }
+      ... on Robot {
+        firstName
+      }
+    }
+    branch {
+      id
+      name
+    }
+  }
+`;

--- a/packages/eas-cli/src/graphql/types/UpdateBranch.ts
+++ b/packages/eas-cli/src/graphql/types/UpdateBranch.ts
@@ -1,4 +1,7 @@
+import { print } from 'graphql';
 import gql from 'graphql-tag';
+
+import { UpdateFragmentNode } from './Update';
 
 export const UpdateBranchFragmentNode = gql`
   fragment UpdateBranchFragment on UpdateBranch {
@@ -6,21 +9,8 @@ export const UpdateBranchFragmentNode = gql`
     name
     updates(offset: 0, limit: 10) {
       id
-      actor {
-        __typename
-        id
-        ... on User {
-          username
-        }
-        ... on Robot {
-          firstName
-        }
-      }
-      createdAt
-      message
-      runtimeVersion
-      group
-      platform
+      ...UpdateFragment
     }
   }
+  ${print(UpdateFragmentNode)}
 `;

--- a/packages/eas-cli/src/update/queries.ts
+++ b/packages/eas-cli/src/update/queries.ts
@@ -4,14 +4,11 @@ import CliTable from 'cli-table3';
 
 import { PaginatedQueryOptions } from '../commandUtils/pagination';
 import {
+  UpdateFragment,
   ViewUpdateGroupsOnAppQueryVariables,
   ViewUpdateGroupsOnBranchQueryVariables,
 } from '../graphql/generated';
-import {
-  AppUpdateGroupObject,
-  BranchUpdateGroupObject,
-  UpdateQuery,
-} from '../graphql/queries/UpdateQuery';
+import { UpdateQuery } from '../graphql/queries/UpdateQuery';
 import Log from '../log';
 import formatFields from '../utils/formatFields';
 import { printJsonOnlyOutput } from '../utils/json';
@@ -99,7 +96,7 @@ export async function selectUpdateGroupOnBranchAsync({
   projectId: string;
   branchName: string;
   paginatedQueryOptions: PaginatedQueryOptions;
-}): Promise<BranchUpdateGroupObject> {
+}): Promise<UpdateFragment[]> {
   if (painatedQueryOptions.nonInteractive) {
     throw new Error('Unable to select an update in non-interactive mode.');
   }
@@ -125,13 +122,13 @@ export async function selectUpdateGroupOnBranchAsync({
 
 async function queryUpdateGroupsOnBranchAsync(
   args: ViewUpdateGroupsOnBranchQueryVariables
-): Promise<BranchUpdateGroupObject[]> {
+): Promise<UpdateFragment[][]> {
   return await UpdateQuery.viewUpdateGroupsOnBranchAsync(args);
 }
 
 async function queryUpdateGroupsOnAppAsync(
   args: ViewUpdateGroupsOnAppQueryVariables
-): Promise<AppUpdateGroupObject[]> {
+): Promise<UpdateFragment[][]> {
   return await UpdateQuery.viewUpdateGroupsOnAppAsync(args);
 }
 
@@ -140,7 +137,7 @@ function renderUpdateGroupsOnBranchAsTable({
   branchName,
   paginatedQueryOptions: { json },
 }: {
-  updateGroups: BranchUpdateGroupObject[];
+  updateGroups: UpdateFragment[][];
   branchName: string;
   paginatedQueryOptions: PaginatedQueryOptions;
 }): void {
@@ -185,7 +182,7 @@ function renderUpdateGroupsOnBranchAsTable({
 }
 
 function renderUpdateGroupsOnAppAsTable(
-  updateGroups: (BranchUpdateGroupObject | AppUpdateGroupObject)[],
+  updateGroups: UpdateFragment[][],
   { json }: PaginatedQueryOptions
 ): void {
   const updateGroupDescriptions = getUpdateGroupDescriptionsWithBranch(updateGroups);

--- a/packages/eas-cli/src/update/utils.ts
+++ b/packages/eas-cli/src/update/utils.ts
@@ -3,8 +3,7 @@ import { format } from '@expo/timeago.js';
 import chalk from 'chalk';
 import dateFormat from 'dateformat';
 
-import { Maybe, Robot, Update, User } from '../graphql/generated';
-import { BranchUpdateObject, UpdateGroupObject } from '../graphql/queries/UpdateQuery';
+import { Maybe, Robot, Update, UpdateFragment, User } from '../graphql/generated';
 import { learnMore } from '../log';
 import { RequestedPlatform } from '../platform';
 import { getActorDisplayName } from '../user/User';
@@ -114,7 +113,7 @@ export function ensureValidVersions(exp: ExpoConfig, platform: RequestedPlatform
   }
 }
 
-export function formatUpdateTitle(update: UpdateGroupObject[number] | BranchUpdateObject): string {
+export function formatUpdateTitle(update: UpdateFragment): string {
   const { message, createdAt, actor, runtimeVersion } = update;
 
   let actorName: string;
@@ -138,7 +137,7 @@ export function formatUpdateTitle(update: UpdateGroupObject[number] | BranchUpda
 }
 
 export function getUpdateGroupDescriptions(
-  updateGroups: UpdateGroupObject[]
+  updateGroups: UpdateFragment[][]
 ): FormattedUpdateGroupDescription[] {
   return updateGroups.map(updateGroup => ({
     message: formatUpdateMessage(updateGroup[0]),
@@ -149,7 +148,7 @@ export function getUpdateGroupDescriptions(
 }
 
 export function getUpdateGroupDescriptionsWithBranch(
-  updateGroups: UpdateGroupObject[]
+  updateGroups: UpdateFragment[][]
 ): FormattedUpdateGroupDescriptionWithBranch[] {
   return updateGroups.map(updateGroup => ({
     branch: updateGroup[0].branch.name,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

There are a lot of different queries that fetch `Updates`. When we then use that data elsewhere in the code-base we need to match sure that the typing in those functions matches the query type. This gets complicated and unnecessarily difficult to handle. We should simplify the typing so that every schema has the same format and we just use that one format when referring to updates in our typing.

# How

Most of the standardizing was already done in previous PRs. This PR introduces a standardized fragment and replaces in-line schemas with a spread of the fragment.

# Test Plan

Ran commands locally to confirm the GQL changes didn't break our fetches.
