### PR TITLE
[ENG-4730] support uploading files to EAS Secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add `-e` as a shortcut for `--profile` flag. ([#1342](https://github.com/expo/eas-cli/pull/1342) by [@szdziedzic](https://github.com/szdziedzic))
 - Support JSON5 in **eas.json**. ([#1350](https://github.com/expo/eas-cli/pull/1350) by [@dsokal](https://github.com/dsokal))
 - Add pagination and interactivity to update commands. ([#1323](https://github.com/expo/eas-cli/pull/1323) by [@kgc00](https://github.com/kgc00))
+- Add support for uploading files to EAS Secret. ([#1354](https://github.com/expo/eas-cli/pull/1354) by [@dsokal](https://github.com/dsokal))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -15431,6 +15431,18 @@
             "deprecationReason": null
           },
           {
+            "name": "type",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "EnvironmentSecretType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "value",
             "description": "",
             "type": {
@@ -16483,6 +16495,22 @@
             "deprecationReason": null
           },
           {
+            "name": "type",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EnvironmentSecretType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updatedAt",
             "description": "",
             "args": [],
@@ -16644,6 +16672,29 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EnvironmentSecretType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "FILE_BASE64",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STRING",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -6747,6 +6747,18 @@
             "deprecationReason": null
           },
           {
+            "name": "githubRepository",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GitHubRepository",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "githubUrl",
             "description": "githubUrl field from most recent classic update manifest",
             "args": [],
@@ -11758,8 +11770,8 @@
               "name": "PaymentDetails",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer used"
           },
           {
             "name": "subscription",
@@ -15508,6 +15520,65 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "CreateGitHubRepositoryInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubAppInstallationId",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubRepositoryIdentifier",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "CreateIosSubmissionInput",
         "description": "",
         "fields": null,
@@ -17505,6 +17576,289 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubRepository",
+        "description": "",
+        "fields": [
+          {
+            "name": "app",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubAppInstallation",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubAppInstallation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubRepositoryIdentifier",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GitHubRepositoryMetadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubRepositoryMetadata",
+        "description": "",
+        "fields": [
+          {
+            "name": "githubRepoDescription",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubRepoName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubRepoOwnerName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubRepoUrl",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastPushed",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastUpdated",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "private",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubRepositoryMutation",
+        "description": "",
+        "fields": [
+          {
+            "name": "createGitHubRepository",
+            "description": "Create a GitHub repository for an App",
+            "args": [
+              {
+                "name": "githubRepositoryData",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreateGitHubRepositoryInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubRepository",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteGitHubRepository",
+            "description": "Delete a GitHub repository by ID",
+            "args": [
+              {
+                "name": "githubRepositoryId",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubRepository",
                 "ofType": null
               }
             },
@@ -23013,6 +23367,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "GitHubAppInstallationMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubRepository",
+            "description": "Mutations for GitHub repositories",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubRepositoryMutation",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -128,8 +128,9 @@ export default class EnvironmentSecretCreate extends EasCommand {
 
     assert(secretValue);
 
+    let secretFilePath: string | undefined;
     if (type !== SecretType.STRING) {
-      const secretFilePath = path.resolve(secretValue);
+      secretFilePath = path.resolve(secretValue);
       if (!(await fs.pathExists(secretFilePath))) {
         if (type === SecretType.FILE) {
           throw new Error(`File "${secretValue}" does not exist`);
@@ -173,11 +174,19 @@ export default class EnvironmentSecretCreate extends EasCommand {
         );
       }
 
-      Log.withTick(
-        `️Created a new secret ${chalk.bold(name)} on project ${chalk.bold(
-          `@${accountName}/${slug}`
-        )}.`
-      );
+      if (type === SecretType.STRING) {
+        Log.withTick(
+          `️Created a new secret ${chalk.bold(name)} with value ${chalk.bold(
+            secretValue
+          )} on project ${chalk.bold(`@${accountName}/${slug}`)}.`
+        );
+      } else {
+        Log.withTick(
+          `️Created a new secret ${chalk.bold(name)} from file ${chalk.bold(
+            secretFilePath
+          )} on project ${chalk.bold(`@${accountName}/${slug}`)}.`
+        );
+      }
     } else if (scope === EnvironmentSecretScope.ACCOUNT) {
       const ownerAccount = findAccountByName(actor.accounts, accountName);
 
@@ -216,9 +225,19 @@ export default class EnvironmentSecretCreate extends EasCommand {
         );
       }
 
-      Log.withTick(
-        `️Created a new secret ${chalk.bold(name)} on account ${chalk.bold(ownerAccount.name)}.`
-      );
+      if (type === SecretType.STRING) {
+        Log.withTick(
+          `️Created a new secret ${chalk.bold(name)} with value ${chalk.bold(
+            secretValue
+          )} on account ${chalk.bold(ownerAccount.name)}.`
+        );
+      } else {
+        Log.withTick(
+          `️Created a new secret ${chalk.bold(name)} from file ${chalk.bold(
+            secretFilePath
+          )} on account ${chalk.bold(ownerAccount.name)}.`
+        );
+      }
     }
   }
 }

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -43,7 +43,7 @@ export default class EnvironmentSecretCreate extends EasCommand {
       description: 'Text value or path to a file to store in the secret',
     }),
     type: Flags.enum({
-      description: 'Type of the secret (use to force the type)',
+      description: 'The type of secret (string is the default type)',
       options: [SecretType.STRING, SecretType.FILE],
     }),
     force: Flags.boolean({

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -106,13 +106,13 @@ export default class EnvironmentSecretCreate extends EasCommand {
     }
 
     if (!secretType) {
-      secretType = await selectAsync('Select type', [
+      secretType = await selectAsync('Select secret type', [
         {
-          title: 'String',
+          title: 'string',
           value: SecretType.STRING,
         },
         {
-          title: 'File',
+          title: 'file',
           value: SecretType.FILE,
         },
       ]);
@@ -122,7 +122,7 @@ export default class EnvironmentSecretCreate extends EasCommand {
       ({ secretValue } = await promptAsync({
         type: 'text',
         name: 'secretValue',
-        message: 'Secret value (or local file path):',
+        message: secretType === SecretType.STRING ? 'Secret value:' : 'Local file path:',
         // eslint-disable-next-line async-protect/async-suffix
         validate: async secretValue => {
           if (!secretValue) {
@@ -131,7 +131,7 @@ export default class EnvironmentSecretCreate extends EasCommand {
           if (secretType === SecretType.FILE) {
             const secretFilePath = path.resolve(secretValue);
             if (!(await fs.pathExists(secretFilePath))) {
-              return 'Secret file does not exist.';
+              return `File "${secretValue}" does not exist.`;
             }
           }
           return true;

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -4,6 +4,7 @@ import dateFormat from 'dateformat';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { EnvironmentSecretsQuery } from '../../graphql/queries/EnvironmentSecretsQuery';
+import { EnvironmentSecretTypeToSecretType } from '../../graphql/types/EnvironmentSecret';
 import Log from '../../log';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
@@ -28,13 +29,19 @@ export default class EnvironmentSecretList extends EasCommand {
     const secrets = await EnvironmentSecretsQuery.allAsync(projectAccountName, projectId);
 
     const table = new Table({
-      head: ['Name', 'Scope', 'ID', 'Updated at'],
+      head: ['Name', 'Type', 'Scope', 'ID', 'Updated at'],
       wordWrap: true,
     });
 
     for (const secret of secrets) {
-      const { name, createdAt: updatedAt, scope, id } = secret;
-      table.push([name, scope, id, dateFormat(updatedAt, 'mmm dd HH:MM:ss')]);
+      const { name, createdAt: updatedAt, scope, id, type } = secret;
+      table.push([
+        name,
+        EnvironmentSecretTypeToSecretType[type],
+        scope,
+        id,
+        dateFormat(updatedAt, 'mmm dd HH:MM:ss'),
+      ]);
     }
 
     Log.log(chalk`{bold Secrets for this account and project:}`);

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2215,6 +2215,7 @@ export type CreateBuildResult = {
 
 export type CreateEnvironmentSecretInput = {
   name: Scalars['String'];
+  type?: InputMaybe<EnvironmentSecretType>;
   value: Scalars['String'];
 };
 
@@ -2385,6 +2386,7 @@ export type EnvironmentSecret = {
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
   name: Scalars['String'];
+  type: EnvironmentSecretType;
   updatedAt: Scalars['DateTime'];
 };
 
@@ -2414,6 +2416,11 @@ export type EnvironmentSecretMutationCreateEnvironmentSecretForAppArgs = {
 export type EnvironmentSecretMutationDeleteEnvironmentSecretArgs = {
   id: Scalars['String'];
 };
+
+export enum EnvironmentSecretType {
+  FileBase64 = 'FILE_BASE64',
+  String = 'STRING'
+}
 
 export type ExperimentationQuery = {
   __typename?: 'ExperimentationQuery';

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -930,6 +930,7 @@ export type App = Project & {
   /** Environment secrets for an app */
   environmentSecrets: Array<EnvironmentSecret>;
   fullName: Scalars['String'];
+  githubRepository?: Maybe<GitHubRepository>;
   /** githubUrl field from most recent classic update manifest */
   githubUrl?: Maybe<Scalars['String']>;
   /** Info about the icon specified in the most recent classic update manifest */
@@ -1724,6 +1725,7 @@ export type Billing = {
   /** History of invoices */
   charges?: Maybe<Array<Maybe<Charge>>>;
   id: Scalars['ID'];
+  /** @deprecated No longer used */
   payment?: Maybe<PaymentDetails>;
   subscription?: Maybe<SubscriptionDetails>;
 };
@@ -2224,6 +2226,12 @@ export type CreateGitHubAppInstallationInput = {
   installationIdentifier: Scalars['Int'];
 };
 
+export type CreateGitHubRepositoryInput = {
+  appId: Scalars['ID'];
+  githubAppInstallationId: Scalars['ID'];
+  githubRepositoryIdentifier: Scalars['Int'];
+};
+
 export type CreateIosSubmissionInput = {
   appId: Scalars['ID'];
   archiveUrl?: InputMaybe<Scalars['String']>;
@@ -2535,6 +2543,44 @@ export type GitHubAppQuery = {
   __typename?: 'GitHubAppQuery';
   appIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
+};
+
+export type GitHubRepository = {
+  __typename?: 'GitHubRepository';
+  app: App;
+  githubAppInstallation: GitHubAppInstallation;
+  githubRepositoryIdentifier: Scalars['Int'];
+  id: Scalars['ID'];
+  metadata?: Maybe<GitHubRepositoryMetadata>;
+};
+
+export type GitHubRepositoryMetadata = {
+  __typename?: 'GitHubRepositoryMetadata';
+  githubRepoDescription?: Maybe<Scalars['String']>;
+  githubRepoName: Scalars['String'];
+  githubRepoOwnerName: Scalars['String'];
+  githubRepoUrl: Scalars['String'];
+  lastPushed: Scalars['DateTime'];
+  lastUpdated: Scalars['DateTime'];
+  private: Scalars['Boolean'];
+};
+
+export type GitHubRepositoryMutation = {
+  __typename?: 'GitHubRepositoryMutation';
+  /** Create a GitHub repository for an App */
+  createGitHubRepository: GitHubRepository;
+  /** Delete a GitHub repository by ID */
+  deleteGitHubRepository: GitHubRepository;
+};
+
+
+export type GitHubRepositoryMutationCreateGitHubRepositoryArgs = {
+  githubRepositoryData: CreateGitHubRepositoryInput;
+};
+
+
+export type GitHubRepositoryMutationDeleteGitHubRepositoryArgs = {
+  githubRepositoryId: Scalars['ID'];
 };
 
 export type GitHubRepositoryOwner = {
@@ -3299,6 +3345,8 @@ export type RootMutation = {
   environmentSecret: EnvironmentSecretMutation;
   /** Mutations for GitHub App installations */
   githubAppInstallation: GitHubAppInstallationMutation;
+  /** Mutations for GitHub repositories */
+  githubRepository: GitHubRepositoryMutation;
   /** Mutations that modify a Google Service Account Key */
   googleServiceAccountKey: GoogleServiceAccountKeyMutation;
   /** Mutations that modify the build credentials for an iOS app */

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4850,7 +4850,7 @@ export type CreateEnvironmentSecretForAccountMutationVariables = Exact<{
 }>;
 
 
-export type CreateEnvironmentSecretForAccountMutation = { __typename?: 'RootMutation', environmentSecret: { __typename?: 'EnvironmentSecretMutation', createEnvironmentSecretForAccount: { __typename?: 'EnvironmentSecret', id: string, name: string, createdAt: any } } };
+export type CreateEnvironmentSecretForAccountMutation = { __typename?: 'RootMutation', environmentSecret: { __typename?: 'EnvironmentSecretMutation', createEnvironmentSecretForAccount: { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any } } };
 
 export type CreateEnvironmentSecretForAppMutationVariables = Exact<{
   input: CreateEnvironmentSecretInput;
@@ -4858,7 +4858,7 @@ export type CreateEnvironmentSecretForAppMutationVariables = Exact<{
 }>;
 
 
-export type CreateEnvironmentSecretForAppMutation = { __typename?: 'RootMutation', environmentSecret: { __typename?: 'EnvironmentSecretMutation', createEnvironmentSecretForApp: { __typename?: 'EnvironmentSecret', id: string, name: string, createdAt: any } } };
+export type CreateEnvironmentSecretForAppMutation = { __typename?: 'RootMutation', environmentSecret: { __typename?: 'EnvironmentSecretMutation', createEnvironmentSecretForApp: { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any } } };
 
 export type DeleteEnvironmentSecretMutationVariables = Exact<{
   id: Scalars['String'];
@@ -5012,14 +5012,14 @@ export type EnvironmentSecretsByAccountNameQueryVariables = Exact<{
 }>;
 
 
-export type EnvironmentSecretsByAccountNameQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, environmentSecrets: Array<{ __typename?: 'EnvironmentSecret', id: string, name: string, createdAt: any }> } } };
+export type EnvironmentSecretsByAccountNameQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, environmentSecrets: Array<{ __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any }> } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String'];
 }>;
 
 
-export type EnvironmentSecretsByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, environmentSecrets: Array<{ __typename?: 'EnvironmentSecret', id: string, name: string, createdAt: any }> } } };
+export type EnvironmentSecretsByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, environmentSecrets: Array<{ __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any }> } } };
 
 export type GetAssetMetadataQueryVariables = Exact<{
   storageKeys: Array<Scalars['String']> | Scalars['String'];
@@ -5114,7 +5114,7 @@ export type BuildFragment = { __typename?: 'Build', id: string, status: BuildSta
 
 export type BuildWithSubmissionsFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, submissions: Array<{ __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null }>, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } };
 
-export type EnvironmentSecretFragment = { __typename?: 'EnvironmentSecret', id: string, name: string, createdAt: any };
+export type EnvironmentSecretFragment = { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any };
 
 export type StatuspageServiceFragment = { __typename?: 'StatuspageService', id: string, name: StatuspageServiceName, status: StatuspageServiceStatus, incidents: Array<{ __typename?: 'StatuspageIncident', id: string, status: StatuspageIncidentStatus, name: string, impact: StatuspageIncidentImpact, shortlink: string }> };
 

--- a/packages/eas-cli/src/graphql/mutations/EnvironmentSecretMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/EnvironmentSecretMutation.ts
@@ -7,12 +7,13 @@ import {
   CreateEnvironmentSecretForAppMutation,
   DeleteEnvironmentSecretMutation,
   EnvironmentSecretFragment,
+  EnvironmentSecretType,
 } from '../generated';
 import { EnvironmentSecretFragmentNode } from '../types/EnvironmentSecret';
 
 export const EnvironmentSecretMutation = {
   async createForAccountAsync(
-    input: { name: string; value: string },
+    input: { name: string; value: string; type: EnvironmentSecretType },
     accountId: string
   ): Promise<EnvironmentSecretFragment> {
     const data = await withErrorHandlingAsync(
@@ -43,7 +44,7 @@ export const EnvironmentSecretMutation = {
     return data.environmentSecret.createEnvironmentSecretForAccount;
   },
   async createForAppAsync(
-    input: { name: string; value: string },
+    input: { name: string; value: string; type: EnvironmentSecretType },
     appId: string
   ): Promise<EnvironmentSecretFragment> {
     const data = await withErrorHandlingAsync(

--- a/packages/eas-cli/src/graphql/types/EnvironmentSecret.ts
+++ b/packages/eas-cli/src/graphql/types/EnvironmentSecret.ts
@@ -1,9 +1,27 @@
 import gql from 'graphql-tag';
 
+import { EnvironmentSecretType } from '../generated';
+
 export const EnvironmentSecretFragmentNode = gql`
   fragment EnvironmentSecretFragment on EnvironmentSecret {
     id
     name
+    type
     createdAt
   }
 `;
+
+export enum SecretType {
+  STRING = 'string',
+  FILE = 'file',
+}
+
+export const SecretTypeToEnvironmentSecretType: Record<SecretType, EnvironmentSecretType> = {
+  [SecretType.STRING]: EnvironmentSecretType.String,
+  [SecretType.FILE]: EnvironmentSecretType.FileBase64,
+};
+
+export const EnvironmentSecretTypeToSecretType: Record<EnvironmentSecretType, SecretType> = {
+  [EnvironmentSecretType.String]: SecretType.STRING,
+  [EnvironmentSecretType.FileBase64]: SecretType.FILE,
+};


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We want to allow users to upload files to EAS Secrets. The file will be recreated on EAS Build and the env var set to the ephemeral file path.

# How

- `secret:create`
  - add new option - `--type` that can be either `string` or `file`
  - If `--type` is not specified, assume the value is a file path and try to find it. If the file exists, ask the user if they want to upload the file contents. Otherwise, fall back to `string`.
- `secret:list`
  - add column with `type`

# Test Plan

Tested manually.