### PR TITLE
[eas-cli] Use confirmation when canceling builds

### DIFF
--- a/packages/eas-cli/src/build/__tests__/cancel-test.ts
+++ b/packages/eas-cli/src/build/__tests__/cancel-test.ts
@@ -1,0 +1,83 @@
+import { v4 as uuid } from 'uuid';
+
+import { selectBuildToCancelAsync } from '../../commands/build/cancel';
+import { AppPlatform, BuildFragment, BuildPriority, BuildStatus } from '../../graphql/generated';
+import { BuildQuery } from '../../graphql/queries/BuildQuery';
+import { confirmAsync, selectAsync } from '../../prompts';
+
+jest.mock('../../ora', () => ({
+  ora: jest.fn().mockImplementation(() => ({
+    start: jest.fn().mockImplementation(() => ({
+      stop: jest.fn(),
+      fail: jest.fn(),
+    })),
+  })),
+}));
+jest.mock('../../prompts', () => {
+  return {
+    selectAsync: jest.fn(),
+    confirmAsync: jest.fn(),
+  };
+});
+
+jest.mock('../../graphql/queries/BuildQuery', () => {
+  const actual = jest.requireActual('../../graphql/queries/BuildQuery');
+  return {
+    BuildQuery: {
+      ...actual.BuildQuery,
+      viewBuildsOnAppAsync: jest.fn(),
+    },
+  };
+});
+
+describe(selectBuildToCancelAsync.name, () => {
+  const selectedBuildId = uuid();
+  const projectId = uuid();
+
+  beforeEach(() => {
+    jest
+      .mocked(BuildQuery.viewBuildsOnAppAsync)
+      .mockImplementation(async () => [
+        createMockBuildFragment({ projectId, buildId: selectedBuildId }),
+      ]);
+  });
+
+  it('does not return build id when confirmation is rejected', async () => {
+    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
+    expect(selectBuildToCancelAsync(projectId, 'blah')).resolves.toEqual(null);
+  });
+
+  it('returns build id when confirmation is confirmed', async () => {
+    jest.mocked(selectAsync).mockResolvedValueOnce(selectedBuildId);
+    jest.mocked(confirmAsync).mockResolvedValueOnce(true);
+    expect(selectBuildToCancelAsync(projectId, 'blah')).resolves.toEqual(selectedBuildId);
+  });
+});
+
+function createMockBuildFragment({
+  projectId,
+  buildId,
+}: {
+  projectId: string;
+  buildId?: string;
+}): BuildFragment {
+  return {
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    platform: AppPlatform.Android,
+    id: buildId ?? uuid(),
+    priority: BuildPriority.Normal,
+    project: {
+      __typename: 'App',
+      slug: 'test-project',
+      id: projectId,
+      name: 'test-project',
+      ownerAccount: {
+        __typename: 'Account',
+        id: uuid(),
+        name: 'test-account',
+      },
+    },
+    status: BuildStatus.InQueue,
+  };
+}

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -59,11 +59,12 @@ function formatUnfinishedBuild(
   return `${platform} Started at: ${startTime}, Status: ${status}, Id: ${build.id}`;
 }
 
-async function selectBuildToCancelAsync(
+export async function selectBuildToCancelAsync(
   projectId: string,
   projectFullName: string
 ): Promise<string | null> {
   const spinner = ora().start('Fetching the uncompleted builds…');
+
   let builds;
   try {
     const [newBuilds, inQueueBuilds, inProgressBuilds] = await Promise.all([
@@ -97,13 +98,6 @@ async function selectBuildToCancelAsync(
   if (builds.length === 0) {
     Log.warn(`There aren't any uncompleted builds for the project ${projectFullName}.`);
     return null;
-  } else if (builds.length === 1) {
-    Log.log('Found one build');
-    Log.log(formatUnfinishedBuild(builds[0]));
-    await confirmAsync({
-      message: 'Do you want to cancel it?',
-    });
-    return builds[0].id;
   } else {
     const buildId = await selectAsync<string>(
       'Which build do you want to cancel?',
@@ -112,7 +106,12 @@ async function selectBuildToCancelAsync(
         value: build.id,
       }))
     );
-    return buildId;
+
+    return (await confirmAsync({
+      message: 'Are you sure you want to cancel it?',
+    }))
+      ? buildId
+      : null;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

When running `build:cancel` for a single build, the results of the confirm prompt are ignored.

<img width="1099" alt="image" src="https://user-images.githubusercontent.com/15132641/190711112-587e2c46-12eb-4aa4-baab-1c760aa5a614.png">

# How

I changed the behavior slightly, to always have the user select from a list of builds (even if there is just one) and to always ask for confirmation that 'yes, we should delete the build'. Happy to change this back to how it was with just the bugfix, but this seemed better behavior to me because:
- it's more consistent across use-cases 
- it always asks for confirmation

# Test Plan

Ran the command locally