### PR TITLE
[eas-cli] Make optional nonInteractive arguments non-optional in utility functions

### DIFF
--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -70,7 +70,11 @@ export async function commitPromptAsync({
     initial: initialCommitMessage,
     validate: (input: string) => input !== '',
   });
-  await getVcsClient().commitAsync({ commitAllFiles, commitMessage: message });
+  await getVcsClient().commitAsync({
+    commitAllFiles,
+    commitMessage: message,
+    nonInteractive: false,
+  });
 }
 
 export async function makeProjectTarballAsync(): Promise<{ path: string; size: number }> {

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -29,7 +29,7 @@ export class CredentialsContext {
     private options: {
       exp?: ExpoConfig;
       easJsonCliConfig?: EasJson['cli'];
-      nonInteractive?: boolean;
+      nonInteractive: boolean;
       projectDir: string;
       user: Actor;
       env?: Env;

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -60,6 +60,7 @@ export class ManageAndroid {
       // this command is interactive by design
       user: await ensureLoggedInAsync({ nonInteractive: false }),
       env: buildProfile?.env,
+      nonInteractive: false,
     });
     const accountName = ctx.hasProjectContext
       ? getProjectAccountName(ctx.exp, ctx.user)

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -67,6 +67,7 @@ export class ManageIos {
       // this command is interactive by design
       user: await ensureLoggedInAsync({ nonInteractive: false }),
       env: buildProfile?.env,
+      nonInteractive: false,
     });
     const buildCredentialsActions = getBuildCredentialsActions(ctx);
     const pushKeyActions = getPushKeyActions(ctx);

--- a/packages/eas-cli/src/project/ios/__tests__/scheme-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/scheme-test.ts
@@ -29,7 +29,7 @@ describe(selectSchemeAsync, () => {
         },
         projectDir
       );
-      const scheme = await selectSchemeAsync({ projectDir });
+      const scheme = await selectSchemeAsync({ projectDir, nonInteractive: true });
       expect(scheme).toBe('scheme1');
       expect(promptAsync).not.toHaveBeenCalled();
     });
@@ -61,7 +61,7 @@ describe(selectSchemeAsync, () => {
         selectedScheme: 'scheme3',
       }));
 
-      const scheme = await selectSchemeAsync({ projectDir });
+      const scheme = await selectSchemeAsync({ projectDir, nonInteractive: false });
       expect(scheme).toBe('scheme3');
       expect(promptAsync).toHaveBeenCalled();
     });

--- a/packages/eas-cli/src/project/ios/scheme.ts
+++ b/packages/eas-cli/src/project/ios/scheme.ts
@@ -59,7 +59,7 @@ export async function selectSchemeAsync({
   nonInteractive = false,
 }: {
   projectDir: string;
-  nonInteractive?: boolean;
+  nonInteractive: boolean;
 }): Promise<string> {
   const schemes = IOSConfig.BuildScheme.getSchemesFromXcodeproj(projectDir);
   if (schemes.length === 0) {

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -56,7 +56,7 @@ export default class GitClient extends Client {
       initial: 'Initial commit',
       validate: (input: string) => input !== '',
     });
-    await this.commitAsync({ commitAllFiles: true, commitMessage: message });
+    await this.commitAsync({ commitAllFiles: true, commitMessage: message, nonInteractive: false });
   }
 
   public override async commitAsync({
@@ -66,7 +66,7 @@ export default class GitClient extends Client {
   }: {
     commitMessage: string;
     commitAllFiles?: boolean;
-    nonInteractive?: boolean;
+    nonInteractive: boolean;
   }): Promise<void> {
     await ensureGitConfiguredAsync({ nonInteractive });
 

--- a/packages/eas-cli/src/vcs/vcs.ts
+++ b/packages/eas-cli/src/vcs/vcs.ts
@@ -37,7 +37,7 @@ export abstract class Client {
   public async commitAsync(_arg: {
     commitMessage: string;
     commitAllFiles?: boolean;
-    nonInteractive?: boolean;
+    nonInteractive: boolean;
   }): Promise<void> {
     // it should not be called unless hasUncommittedChangesAsync is implemented
     throw new Error('commitAsync is not implemented');


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Noticed while writing https://github.com/expo/eas-cli/pull/1356 that there were a few other methods that had `nonInteractive` as an optional arg. It's better to be explicit to avoid unintentionally missing cases where the flag is passed in by the user.

# How

Make these need to be specified explicitly.

# Test Plan

`yarn start` (typecheck) and run tests.
