### PR TITLE
[2/n][eas-cli] Remove rest of getProjectAccountNameAsync callsites

### DIFF
--- a/packages/eas-cli/src/commands/device/delete.ts
+++ b/packages/eas-cli/src/commands/device/delete.ts
@@ -17,7 +17,11 @@ import { AppleDevice, Maybe } from '../../graphql/generated';
 import Log from '../../log';
 import { ora } from '../../ora';
 import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+import {
+  findProjectRootAsync,
+  getOwnerAccountForProjectIdAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
 
 export default class DeviceDelete extends EasCommand {
@@ -36,15 +40,16 @@ export default class DeviceDelete extends EasCommand {
     const projectDir = await findProjectRootAsync();
     const exp = getExpoConfig(projectDir);
     // this command is interactive by design
-    const accountName = await getProjectAccountNameAsync(exp, { nonInteractive: false });
+    const projectId = await getProjectIdAsync(exp, { nonInteractive: false });
+    const account = await getOwnerAccountForProjectIdAsync(projectId);
 
     if (!appleTeamIdentifier) {
-      appleTeamIdentifier = await this.askForAppleTeamAsync(accountName);
+      appleTeamIdentifier = await this.askForAppleTeamAsync(account.name);
     }
 
     assert(appleTeamIdentifier, 'No team identifier is specified');
 
-    const appleDevicesResult = await this.getDevicesForTeamAsync(accountName, appleTeamIdentifier);
+    const appleDevicesResult = await this.getDevicesForTeamAsync(account.name, appleTeamIdentifier);
 
     if (!appleDevicesResult) {
       return;

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -4,7 +4,11 @@ import formatDevice from '../../devices/utils/formatDevice';
 import Log from '../../log';
 import { ora } from '../../ora';
 import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectAccountNameAsync } from '../../project/projectUtils';
+import {
+  findProjectRootAsync,
+  getOwnerAccountForProjectIdAsync,
+  getProjectIdAsync,
+} from '../../project/projectUtils';
 
 export default class DeviceView extends EasCommand {
   static override description = 'view a device for your project';
@@ -32,12 +36,13 @@ If you are not sure what is the UDID of the device you are looking for, run:
     const exp = getExpoConfig(projectDir);
 
     // this command is non-interactive by design
-    const accountName = await getProjectAccountNameAsync(exp, { nonInteractive: true });
+    const projectId = await getProjectIdAsync(exp, { nonInteractive: true });
+    const account = await getOwnerAccountForProjectIdAsync(projectId);
 
     const spinner = ora().start(`Fetching device details for ${UDID}…`);
 
     try {
-      const device = await AppleDeviceQuery.getByDeviceIdentifierAsync(accountName, UDID);
+      const device = await AppleDeviceQuery.getByDeviceIdentifierAsync(account.name, UDID);
 
       if (device) {
         spinner.succeed('Fetched device details');

--- a/packages/eas-cli/src/devices/__tests__/manager-test.ts
+++ b/packages/eas-cli/src/devices/__tests__/manager-test.ts
@@ -1,17 +1,13 @@
 import prompts from 'prompts';
 
-import Log from '../../log';
+import { AppQuery } from '../../graphql/queries/AppQuery';
 import { Actor } from '../../user/User';
 import { AccountResolver } from '../manager';
 
 jest.mock('prompts');
 
-jest.mock('../../project/projectUtils', () => {
-  return {
-    getProjectAccountNameAsync: () => 'foo',
-  };
-});
 jest.mock('../../credentials/ios/api/graphql/queries/AppleTeamQuery');
+jest.mock('../../graphql/queries/AppQuery');
 
 beforeEach(() => {
   jest.mocked(prompts).mockReset();
@@ -34,7 +30,24 @@ describe(AccountResolver, () => {
     };
 
     describe('when inside project dir', () => {
-      const exp = {} as any;
+      const exp = {
+        name: 'wat',
+        slug: 'wat',
+        extra: {
+          eas: {
+            projectId: '1234',
+          },
+        },
+      };
+
+      beforeEach(() => {
+        jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
+          id: 'test-project-id',
+          fullName: '@foo/wat',
+          slug: 'wat',
+          ownerAccount: { id: 'account_id_888', name: 'foo' },
+        });
+      });
 
       it('returns the account defined in app.json/app.config.js if user confirms', async () => {
         jest.mocked(prompts).mockImplementationOnce(async () => ({
@@ -57,23 +70,6 @@ describe(AccountResolver, () => {
         const resolver = new AccountResolver(exp, user);
         const account = await resolver.resolveAccountAsync();
         expect(account).toEqual(user.accounts[0]);
-      });
-
-      it(`asks the user to choose the account from his account list if he doesn't have access to the account defined in app.json / app.config.js`, async () => {
-        jest.mocked(prompts).mockImplementationOnce(async () => ({
-          account: user.accounts[0],
-        }));
-
-        const userWithAccessToProjectAccount: Actor = {
-          ...user,
-          accounts: [user.accounts[0]],
-        };
-
-        jest.spyOn(Log, 'warn');
-        const resolver = new AccountResolver(exp, userWithAccessToProjectAccount);
-        const account = await resolver.resolveAccountAsync();
-        expect(account).toEqual(user.accounts[0]);
-        expect(Log.warn).toBeCalledWith(expect.stringMatching(/doesn't have access to the/));
       });
     });
 

--- a/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils-test.ts
@@ -3,12 +3,7 @@ import { vol } from 'memfs';
 
 import { Actor, getUserAsync } from '../../user/User';
 import { fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync } from '../fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
-import {
-  findProjectRootAsync,
-  getProjectAccountName,
-  getProjectAccountNameAsync,
-  getProjectIdAsync,
-} from '../projectUtils';
+import { findProjectRootAsync, getProjectAccountName, getProjectIdAsync } from '../projectUtils';
 
 jest.mock('@expo/config');
 jest.mock('fs');
@@ -120,75 +115,6 @@ describe(getProjectAccountName, () => {
         isExpoAdmin: false,
       });
     expect(resolveProjectAccountName).toThrow('manifest property is required');
-  });
-});
-
-describe(getProjectAccountNameAsync, () => {
-  const expWithOwner: any = { owner: 'dominik' };
-  const expWithoutOwner: any = {};
-
-  beforeEach(() => {
-    jest.mocked(getUserAsync).mockReset();
-  });
-
-  it(`returns the owner field's value from app.json / app.config.js`, async () => {
-    jest.mocked(getUserAsync).mockImplementation(
-      async (): Promise<Actor> => ({
-        __typename: 'User',
-        id: 'user_id',
-        username: 'notnotbrent',
-        accounts: [
-          { id: 'account_id_1', name: 'notnotbrent' },
-          { id: 'account_id_2', name: 'dominik' },
-        ],
-        isExpoAdmin: false,
-      })
-    );
-
-    const projectAccountName = await getProjectAccountNameAsync(expWithOwner, {
-      nonInteractive: true,
-    });
-    expect(projectAccountName).toBe('dominik');
-  });
-
-  it(`returns the username if owner field is not set in app.json / app.config.js`, async () => {
-    jest.mocked(getUserAsync).mockImplementation(
-      async (): Promise<Actor> => ({
-        __typename: 'User',
-        id: 'user_id',
-        username: 'notnotbrent',
-        accounts: [
-          { id: 'account_id_1', name: 'notnotbrent' },
-          { id: 'account_id_2', name: 'dominik' },
-        ],
-        isExpoAdmin: false,
-      })
-    );
-
-    const projectAccountName = await getProjectAccountNameAsync(expWithoutOwner, {
-      nonInteractive: true,
-    });
-    expect(projectAccountName).toBe('notnotbrent');
-  });
-
-  it(`throws when project owner is undefined for robot actors`, async () => {
-    jest.mocked(getUserAsync).mockImplementation(
-      async (): Promise<Actor> => ({
-        __typename: 'Robot',
-        id: 'user_id',
-        firstName: 'GLaDOS',
-        accounts: [
-          { id: 'account_id_1', name: 'notnotbrent' },
-          { id: 'account_id_2', name: 'dominik' },
-        ],
-        isExpoAdmin: false,
-      })
-    );
-    await expect(
-      getProjectAccountNameAsync(expWithoutOwner, {
-        nonInteractive: true,
-      })
-    ).rejects.toThrow('manifest property is required');
   });
 });
 

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -52,18 +52,6 @@ export function getUsername(exp: ExpoConfig, user: Actor): string | undefined {
   }
 }
 
-/**
- * @deprecated - prefer using the account that definitively owns the project by
- *               fetching it via the App.ownerAccount GraphQL field.
- */
-export async function getProjectAccountNameAsync(
-  exp: ExpoConfig,
-  { nonInteractive }: { nonInteractive: boolean }
-): Promise<string> {
-  const user = await ensureLoggedInAsync({ nonInteractive });
-  return getProjectAccountName(exp, user);
-}
-
 export async function findProjectRootAsync({
   cwd,
   defaultToProcessCwd = false,
@@ -202,7 +190,8 @@ export async function getProjectFullNameAsync(
   exp: ExpoConfig,
   { nonInteractive }: { nonInteractive: boolean }
 ): Promise<string> {
-  const accountName = await getProjectAccountNameAsync(exp, { nonInteractive });
+  const user = await ensureLoggedInAsync({ nonInteractive });
+  const accountName = getProjectAccountName(exp, user);
   return `@${accountName}/${exp.slug}`;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Part 2 of https://github.com/expo/eas-cli/pull/1368.

This removes the rest of the callsites.

# How

Get account from GraphQL by using project ID.

# Test Plan

Run tests.

```
$ ~/expo/eas-cli/packages/eas-cli/bin/run device:create
This command lets you register your Apple devices (iPhones and iPads) for internal distribution of your app.
Internal distribution means that you won't need to upload your app archive to App Store / Testflight.
Your app archive (.ipa) will be installable on your equipment as long as you sign your application with an adhoc provisiong profile.
The provisioning profile needs to contain the UDIDs (unique identifiers) of your iPhones and iPads.

First of all, choose the Expo account under which you want to register your devices.
Later, authenticate with Apple and choose your desired Apple Team (if your Apple ID has access to multiple teams).

✔ You're inside the project directory. Would you like to use the wschurman141 account? … yes
› Log in to your Apple Developer account to continue
? Apple ID: › ...
```
