### PR TITLE
[5/n][eas-cli] Remove getProjectFullNameAsync

### DIFF
--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -12,12 +12,12 @@ export const BUILDS_LIMIT = 50;
 
 export async function listAndRenderBuildsOnAppAsync({
   projectId,
-  projectName,
+  projectDisplayName,
   filter,
   paginatedQueryOptions,
 }: {
   projectId: string;
-  projectName: string;
+  projectDisplayName: string;
   filter?: BuildFilter;
   paginatedQueryOptions: PaginatedQueryOptions;
 }): Promise<void> {
@@ -28,7 +28,7 @@ export async function listAndRenderBuildsOnAppAsync({
       offset: paginatedQueryOptions.offset,
       filter,
     });
-    renderPageOfBuilds({ builds, projectName, paginatedQueryOptions });
+    renderPageOfBuilds({ builds, projectDisplayName, paginatedQueryOptions });
   } else {
     await paginatedQueryWithConfirmPromptAsync({
       limit: paginatedQueryOptions.limit ?? BUILDS_LIMIT,
@@ -43,7 +43,7 @@ export async function listAndRenderBuildsOnAppAsync({
       promptOptions: {
         title: 'Load more builds?',
         renderListItems: builds =>
-          renderPageOfBuilds({ builds, projectName, paginatedQueryOptions }),
+          renderPageOfBuilds({ builds, projectDisplayName, paginatedQueryOptions }),
       },
     });
   }
@@ -51,11 +51,11 @@ export async function listAndRenderBuildsOnAppAsync({
 
 function renderPageOfBuilds({
   builds,
-  projectName,
+  projectDisplayName,
   paginatedQueryOptions,
 }: {
   builds: BuildFragment[];
-  projectName: string;
+  projectDisplayName: string;
   paginatedQueryOptions: PaginatedQueryOptions;
 }): void {
   if (paginatedQueryOptions.json) {
@@ -64,7 +64,7 @@ function renderPageOfBuilds({
     const list = builds.map(build => formatGraphQLBuild(build)).join(`\n\n${chalk.dim('———')}\n\n`);
 
     Log.addNewLineIfNone();
-    Log.log(chalk.bold(`Builds for ${projectName}:`));
+    Log.log(chalk.bold(`Builds for ${projectDisplayName}:`));
     Log.log(`\n${list}`);
   }
 }

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -14,7 +14,7 @@ import Log from '../../log';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
-  getProjectFullNameAsync,
+  getDisplayNameForProjectIdAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
@@ -77,8 +77,8 @@ export default class BranchCreate extends EasCommand {
 
     const projectDir = await findProjectRootAsync();
     const exp = getExpoConfig(projectDir);
-    const fullName = await getProjectFullNameAsync(exp, { nonInteractive });
     const projectId = await getProjectIdAsync(exp, { nonInteractive });
+    const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
 
     if (!name) {
       const validationMessage = 'Branch name may not be empty.';
@@ -100,7 +100,9 @@ export default class BranchCreate extends EasCommand {
       printJsonOnlyOutput(newBranch);
     } else {
       Log.withTick(
-        `️Created a new branch: ${chalk.bold(newBranch.name)} on project ${chalk.bold(fullName)}.`
+        `️Created a new branch: ${chalk.bold(newBranch.name)} on project ${chalk.bold(
+          projectDisplayName
+        )}.`
       );
     }
   }

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -17,7 +17,7 @@ import Log from '../../log';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
-  getProjectFullNameAsync,
+  getDisplayNameForProjectIdAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { toggleConfirmAsync } from '../../prompts';
@@ -106,8 +106,8 @@ export default class BranchDelete extends EasCommand {
 
     const projectDir = await findProjectRootAsync();
     const exp = getExpoConfig(projectDir);
-    const fullName = await getProjectFullNameAsync(exp, { nonInteractive });
     const projectId = await getProjectIdAsync(exp, { nonInteractive });
+    const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
 
     if (!branchName) {
       const validationMessage = 'branch name may not be empty.';
@@ -125,7 +125,7 @@ export default class BranchDelete extends EasCommand {
     const data = await getBranchInfoAsync({ appId: projectId, name: branchName });
     const branchId = data.app?.byId.updateBranchByName?.id;
     if (!branchId) {
-      throw new Error(`Could not find branch ${branchName} on ${fullName}`);
+      throw new Error(`Could not find branch ${branchName} on ${projectDisplayName}`);
     }
 
     if (!nonInteractive) {
@@ -150,7 +150,9 @@ export default class BranchDelete extends EasCommand {
       printJsonOnlyOutput(deletionResult);
     } else {
       Log.withTick(
-        `️Deleted branch "${branchName}" and all of its updates on project ${chalk.bold(fullName)}.`
+        `️Deleted branch "${branchName}" and all of its updates on project ${chalk.bold(
+          projectDisplayName
+        )}.`
       );
     }
   }

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -15,7 +15,7 @@ import Log from '../../log';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
-  getProjectFullNameAsync,
+  getDisplayNameForProjectIdAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
@@ -77,8 +77,8 @@ export default class BranchRename extends EasCommand {
 
     const projectDir = await findProjectRootAsync();
     const exp = getExpoConfig(projectDir);
-    const fullName = await getProjectFullNameAsync(exp, { nonInteractive });
     const projectId = await getProjectIdAsync(exp, { nonInteractive });
+    const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
 
     if (!currentName) {
       const validationMessage = 'current name may not be empty.';
@@ -118,7 +118,7 @@ export default class BranchRename extends EasCommand {
       Log.withTick(
         `️Renamed branch from ${currentName} to ${chalk.bold(
           editedBranch.name
-        )} on project ${chalk.bold(fullName)}.`
+        )} on project ${chalk.bold(projectDisplayName)}.`
       );
     }
   }

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -17,7 +17,7 @@ import { appPlatformEmojis } from '../../platform';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
-  getProjectFullNameAsync,
+  getDisplayNameForProjectIdAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { confirmAsync, selectAsync } from '../../prompts';
@@ -62,7 +62,7 @@ function formatUnfinishedBuild(
 
 export async function selectBuildToCancelAsync(
   projectId: string,
-  projectFullName: string
+  projectDisplayName: string
 ): Promise<string | null> {
   const spinner = ora().start('Fetching the uncompleted builds…');
 
@@ -92,12 +92,12 @@ export async function selectBuildToCancelAsync(
     builds = [...newBuilds, ...inQueueBuilds, ...inProgressBuilds];
   } catch (error) {
     spinner.fail(
-      `Something went wrong and we couldn't fetch the builds for the project ${projectFullName}.`
+      `Something went wrong and we couldn't fetch the builds for the project ${projectDisplayName}.`
     );
     throw error;
   }
   if (builds.length === 0) {
-    Log.warn(`There aren't any uncompleted builds for the project ${projectFullName}.`);
+    Log.warn(`There aren't any uncompleted builds for the project ${projectDisplayName}.`);
     return null;
   } else {
     const buildId = await selectAsync<string>(
@@ -142,8 +142,7 @@ export default class BuildCancel extends EasCommand {
     const projectDir = await findProjectRootAsync();
     const exp = getExpoConfig(projectDir);
     const projectId = await getProjectIdAsync(exp, { nonInteractive });
-
-    const projectFullName = await getProjectFullNameAsync(exp, { nonInteractive });
+    const displayName = await getDisplayNameForProjectIdAsync(projectId);
 
     if (buildIdFromArg) {
       await ensureBuildExistsAsync(buildIdFromArg);
@@ -155,7 +154,7 @@ export default class BuildCancel extends EasCommand {
         throw new Error('BUILD_ID must not be empty in non-interactive mode');
       }
 
-      buildId = await selectBuildToCancelAsync(projectId, projectFullName);
+      buildId = await selectBuildToCancelAsync(projectId, displayName);
       if (!buildId) {
         return;
       }

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -18,7 +18,7 @@ import { RequestedPlatform } from '../../platform';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
-  getProjectFullNameAsync,
+  getDisplayNameForProjectIdAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { enableJsonOutput } from '../../utils/json';
@@ -81,11 +81,11 @@ export default class BuildList extends EasCommand {
     const projectDir = await findProjectRootAsync();
     const exp = getExpoConfig(projectDir);
     const projectId = await getProjectIdAsync(exp, { nonInteractive });
-    const projectName = await getProjectFullNameAsync(exp, { nonInteractive });
+    const displayName = await getDisplayNameForProjectIdAsync(projectId);
 
     await listAndRenderBuildsOnAppAsync({
       projectId,
-      projectName,
+      projectDisplayName: displayName,
       filter: {
         platform,
         status: graphqlBuildStatus,

--- a/packages/eas-cli/src/commands/build/version/set.ts
+++ b/packages/eas-cli/src/commands/build/version/set.ts
@@ -16,7 +16,7 @@ import { getExpoConfig } from '../../../project/expoConfig';
 import { BUILD_NUMBER_REQUIREMENTS, isValidBuildNumber } from '../../../project/ios/versions';
 import {
   findProjectRootAsync,
-  getProjectFullNameAsync,
+  getDisplayNameForProjectIdAsync,
   getProjectIdAsync,
 } from '../../../project/projectUtils';
 import {
@@ -60,8 +60,8 @@ export default class BuildVersionSetView extends EasCommand {
 
     // this command is always interactive (see prompt below)
     const projectId = await getProjectIdAsync(exp, { nonInteractive: false });
+    const displayName = await getDisplayNameForProjectIdAsync(projectId);
 
-    const projectFullName = await getProjectFullNameAsync(exp, { nonInteractive: false });
     validateAppConfigForRemoteVersionSource(exp, platform);
 
     const applicationIdentifier = await getApplicationIdentifierAsync(
@@ -76,12 +76,12 @@ export default class BuildVersionSetView extends EasCommand {
       applicationIdentifier
     );
     const currentStateMessage = remoteVersions?.buildVersion
-      ? `Project ${chalk.bold(projectFullName)} with ${getApplicationIdentifierName(
+      ? `Project ${chalk.bold(displayName)} with ${getApplicationIdentifierName(
           platform
         )} "${applicationIdentifier}" is configured with ${getBuildVersionName(platform)} ${
           remoteVersions.buildVersion
         }.`
-      : `Project ${chalk.bold(projectFullName)} with ${getApplicationIdentifierName(
+      : `Project ${chalk.bold(displayName)} with ${getApplicationIdentifierName(
           platform
         )} "${applicationIdentifier}" does not have any ${getBuildVersionName(
           platform

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -8,7 +8,7 @@ import { ora } from '../../ora';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
-  getProjectFullNameAsync,
+  getDisplayNameForProjectIdAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -36,7 +36,7 @@ export default class BuildView extends EasCommand {
 
     // this command is always non-interactive
     const projectId = await getProjectIdAsync(exp, { nonInteractive: true });
-    const projectName = await getProjectFullNameAsync(exp, { nonInteractive: true });
+    const displayName = await getDisplayNameForProjectIdAsync(projectId);
 
     const spinner = ora().start('Fetching the build…');
 
@@ -52,16 +52,16 @@ export default class BuildView extends EasCommand {
           limit: 1,
         });
         if (builds.length === 0) {
-          spinner.fail(`Couldn't find any builds for the project ${projectName}`);
+          spinner.fail(`Couldn't find any builds for the project ${displayName}`);
           return;
         }
         build = builds[0];
       }
 
       if (buildId) {
-        spinner.succeed(`Found a matching build for the project ${projectName}`);
+        spinner.succeed(`Found a matching build for the project ${displayName}`);
       } else {
-        spinner.succeed(`Showing the last build for the project ${projectName}`);
+        spinner.succeed(`Showing the last build for the project ${displayName}`);
       }
 
       if (flags.json) {
@@ -74,7 +74,7 @@ export default class BuildView extends EasCommand {
         spinner.fail(`Something went wrong and we couldn't fetch the build with id ${buildId}`);
       } else {
         spinner.fail(
-          `Something went wrong and we couldn't fetch the last build for the project ${projectName}`
+          `Something went wrong and we couldn't fetch the last build for the project ${displayName}`
         );
       }
 

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -14,7 +14,7 @@ import Log from '../../log';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
-  getProjectFullNameAsync,
+  getDisplayNameForProjectIdAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
@@ -144,7 +144,7 @@ export default class ChannelCreate extends EasCommand {
       Log.addNewLineIfNone();
       Log.withTick(
         `Created a new channel on project ${chalk.bold(
-          await getProjectFullNameAsync(exp, { nonInteractive })
+          await getDisplayNameForProjectIdAsync(projectId)
         )}`
       );
       Log.log(

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -11,7 +11,7 @@ import Log from '../../log';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
-  getProjectFullNameAsync,
+  getDisplayNameForProjectIdAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync, selectAsync } from '../../prompts';
@@ -64,7 +64,7 @@ async function startRolloutAsync({
   branchName,
   percent,
   projectId,
-  fullName,
+  displayName,
   currentBranchMapping,
   channel,
   nonInteractive,
@@ -73,7 +73,7 @@ async function startRolloutAsync({
   branchName: string;
   percent?: number;
   projectId: string;
-  fullName: string;
+  displayName: string;
   currentBranchMapping: BranchMapping;
   channel: UpdateChannelByNameObject;
   nonInteractive: boolean;
@@ -129,7 +129,7 @@ async function startRolloutAsync({
   const oldBranch = channel.updateBranches.filter(branch => branch.id === oldBranchId)[0];
   if (!oldBranch) {
     throw new Error(
-      `Branch mapping is missing its only branch for channel "${channelName}" on app "${fullName}"`
+      `Branch mapping is missing its only branch for channel "${channelName}" on app "${displayName}"`
     );
   }
 
@@ -333,8 +333,8 @@ export default class ChannelRollout extends EasCommand {
 
     const projectDir = await findProjectRootAsync();
     const exp = getExpoConfig(projectDir);
-    const fullName = await getProjectFullNameAsync(exp, { nonInteractive });
     const projectId = await getProjectIdAsync(exp, { nonInteractive });
+    const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
 
     const channel = await ChannelQuery.viewUpdateChannelAsync({
       appId: projectId,
@@ -387,7 +387,7 @@ export default class ChannelRollout extends EasCommand {
         percent,
         nonInteractive,
         projectId,
-        fullName,
+        displayName: projectDisplayName,
         currentBranchMapping,
         channel,
       });

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -19,8 +19,8 @@ import Log from '../../log';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
+  getDisplayNameForProjectIdAsync,
   getOwnerAccountForProjectIdAsync,
-  getProjectFullNameAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync, selectAsync } from '../../prompts';
@@ -66,8 +66,8 @@ export default class EnvironmentSecretCreate extends EasCommand {
 
     const projectDir = await findProjectRootAsync();
     const exp = getExpoConfig(projectDir);
-    const projectFullName = await getProjectFullNameAsync(exp, { nonInteractive });
     const projectId = await getProjectIdAsync(exp, { nonInteractive });
+    const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
     const ownerAccount = await getOwnerAccountForProjectIdAsync(projectId);
 
     if (!scope) {
@@ -182,7 +182,7 @@ export default class EnvironmentSecretCreate extends EasCommand {
           await EnvironmentSecretMutation.deleteAsync(existingSecret.id);
           Log.withTick(
             `Deleting existing secret ${chalk.bold(name)} on project ${chalk.bold(
-              projectFullName
+              projectDisplayName
             )}.`
           );
         }
@@ -202,13 +202,13 @@ export default class EnvironmentSecretCreate extends EasCommand {
         Log.withTick(
           `️Created a new secret ${chalk.bold(name)} with value ${chalk.bold(
             secretValue
-          )} on project ${chalk.bold(projectFullName)}.`
+          )} on project ${chalk.bold(projectDisplayName)}.`
         );
       } else {
         Log.withTick(
           `️Created a new secret ${chalk.bold(name)} from file ${chalk.bold(
             secretFilePath
-          )} on project ${chalk.bold(projectFullName)}.`
+          )} on project ${chalk.bold(projectDisplayName)}.`
         );
       }
     } else if (scope === EnvironmentSecretScope.ACCOUNT) {

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -9,7 +9,7 @@ import { ora } from '../../ora';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
-  getProjectFullNameAsync,
+  getDisplayNameForProjectIdAsync,
   getProjectIdAsync,
 } from '../../project/projectUtils';
 import { formatWebhook } from '../../webhooks/formatWebhook';
@@ -34,15 +34,15 @@ export default class WebhookList extends EasCommand {
 
     // this command is non-interactive by design
     const projectId = await getProjectIdAsync(exp, { nonInteractive: true });
-    const projectFullName = await getProjectFullNameAsync(exp, { nonInteractive: true });
+    const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
 
-    const spinner = ora(`Fetching the list of webhook on project ${projectFullName}`).start();
+    const spinner = ora(`Fetching the list of webhook on project ${projectDisplayName}`).start();
     try {
       const webhooks = await WebhookQuery.byAppIdAsync(projectId, event && { event });
       if (webhooks.length === 0) {
-        spinner.fail(`There are no webhooks on project ${projectFullName}`);
+        spinner.fail(`There are no webhooks on project ${projectDisplayName}`);
       } else {
-        spinner.succeed(`Found ${webhooks.length} webhooks on project ${projectFullName}`);
+        spinner.succeed(`Found ${webhooks.length} webhooks on project ${projectDisplayName}`);
         const list = webhooks
           .map(webhook => formatWebhook(webhook))
           .join(`\n\n${chalk.dim('———')}\n\n`);
@@ -50,7 +50,7 @@ export default class WebhookList extends EasCommand {
       }
     } catch (err) {
       spinner.fail(
-        `Something went wrong and we couldn't fetch the webhook list for the project ${projectFullName}`
+        `Something went wrong and we couldn't fetch the webhook list for the project ${projectDisplayName}`
       );
       throw err;
     }

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -185,15 +185,6 @@ const toAppPrivacy = (privacy: ExpoConfig['privacy']): AppPrivacy => {
   }
 };
 
-export async function getProjectFullNameAsync(
-  exp: ExpoConfig,
-  { nonInteractive }: { nonInteractive: boolean }
-): Promise<string> {
-  const user = await ensureLoggedInAsync({ nonInteractive });
-  const accountName = getProjectAccountName(exp, user);
-  return `@${accountName}/${exp.slug}`;
-}
-
 /**
  * Return a useful name describing the project config.
  * - dynamic: app.config.js
@@ -266,4 +257,9 @@ export async function getOwnerAccountForProjectIdAsync(
 ): Promise<AccountFragment> {
   const app = await AppQuery.byIdAsync(projectId);
   return app.ownerAccount;
+}
+
+export async function getDisplayNameForProjectIdAsync(projectId: string): Promise<string> {
+  const app = await AppQuery.byIdAsync(projectId);
+  return app.fullName;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Part 5 of https://github.com/expo/eas-cli/pull/1368.

# How

Remove function, replace with function that gets the display name (the only thing this function was used for) from GraphQL.

# Test Plan

`yarn start` (typecheck) and run tests.
