### PR TITLE
[eas-cli] Add pagination to device:* commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 - Prompt before configuring EAS project. ([#1356](https://github.com/expo/eas-cli/pull/1356) by [@wschurman](https://github.com/wschurman))
+- Adds paginated support to device commands. Removes the ability to delete multiple devices at once. ([#1381](https://github.com/expo/eas-cli/pull/1381) by [@kgc00](https://github.com/kgc00))
 
 ### 🎉 New features
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -11200,7 +11200,32 @@
           {
             "name": "appleDevices",
             "description": "",
-            "args": [],
+            "args": [
+              {
+                "name": "limit",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14249,6 +14274,50 @@
         ]
       },
       {
+        "kind": "OBJECT",
+        "name": "BuildOrBuildJobQuery",
+        "description": "",
+        "fields": [
+          {
+            "name": "byId",
+            "description": "Look up EAS Build or Classic Build Job by ID",
+            "args": [
+              {
+                "name": "buildOrBuildJobId",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "EASBuildOrClassicBuildJob",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "BuildParamsInput",
         "description": "",
@@ -16462,6 +16531,27 @@
         "possibleTypes": null
       },
       {
+        "kind": "UNION",
+        "name": "EASBuildOrClassicBuildJob",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Build",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "BuildJob",
+            "ofType": null
+          }
+        ]
+      },
+      {
         "kind": "ENUM",
         "name": "EASServiceMetric",
         "description": "",
@@ -17680,6 +17770,87 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "searchRepositories",
+            "description": "",
+            "args": [
+              {
+                "name": "githubAppInstallationId",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "page",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "1",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "perPage",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "50",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "query",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GitHubAppInstallationAccessibleRepository",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -24164,6 +24335,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "BuildJobQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildOrBuildJob",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BuildOrBuildJobQuery",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/src/commands/device/delete.ts
+++ b/packages/eas-cli/src/commands/device/delete.ts
@@ -3,28 +3,38 @@ import { Flags } from '@oclif/core';
 import assert from 'assert';
 
 import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
-import { chooseDevicesToDeleteAsync } from '../../credentials/ios/actions/DeviceUtils';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import {
+  EasPaginatedQueryFlags,
+  PaginatedQueryOptions,
+  getPaginatedQueryOptions,
+} from '../../commandUtils/pagination';
 import { AppleDeviceMutation } from '../../credentials/ios/api/graphql/mutations/AppleDeviceMutation';
 import {
   AppleDeviceQuery,
   AppleDeviceQueryResult,
-  AppleDevicesByTeamIdentifierQueryResult,
 } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
-import { AppleTeamQuery } from '../../credentials/ios/api/graphql/queries/AppleTeamQuery';
 import { authenticateAsync, getRequestContext } from '../../credentials/ios/appstore/authenticate';
+import {
+  selectAppleDeviceOnAppleTeamAsync,
+  selectAppleTeamOnAccountAsync,
+} from '../../devices/queries';
 import formatDevice from '../../devices/utils/formatDevice';
 import { AppleDevice, Maybe } from '../../graphql/generated';
 import Log from '../../log';
 import { ora } from '../../ora';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
-import { promptAsync, toggleConfirmAsync } from '../../prompts';
+import { toggleConfirmAsync } from '../../prompts';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class DeviceDelete extends EasCommand {
   static override description = 'remove a registered device from your account';
 
   static override flags = {
     'apple-team-id': Flags.string(),
-    udid: Flags.string({ multiple: true }),
+    udid: Flags.string({ multiple: false, description: 'The device ID to disable' }),
+    ...EasPaginatedQueryFlags,
+    ...EasNonInteractiveAndJsonFlags,
   };
 
   static override contextDefinition = {
@@ -32,123 +42,126 @@ export default class DeviceDelete extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    let {
-      flags: { 'apple-team-id': appleTeamIdentifier, udid: udids },
-    } = await this.parse(DeviceDelete);
+    const { flags } = await this.parse(DeviceDelete);
+    const paginatedQueryOptions = getPaginatedQueryOptions(flags);
+    let { 'apple-team-id': appleTeamIdentifier, udid } = flags;
     const {
       projectConfig: { projectId },
     } = await this.getContextAsync(DeviceDelete, {
-      nonInteractive: false,
+      nonInteractive: paginatedQueryOptions.nonInteractive,
     });
-
     const account = await getOwnerAccountForProjectIdAsync(projectId);
+    let appleTeamName;
+
+    if (paginatedQueryOptions.json) {
+      enableJsonOutput();
+    }
 
     if (!appleTeamIdentifier) {
-      appleTeamIdentifier = await this.askForAppleTeamAsync(account.name);
+      const appleTeam = await selectAppleTeamOnAccountAsync({
+        accountName: account.name,
+        selectionPromptTitle: `What Apple Team would you like to list devices for?`,
+        paginatedQueryOptions,
+      });
+      appleTeamIdentifier = appleTeam.id;
+      appleTeamName = appleTeam.appleTeamName;
     }
 
     assert(appleTeamIdentifier, 'No team identifier is specified');
 
-    const appleDevicesResult = await this.getDevicesForTeamAsync(account.name, appleTeamIdentifier);
+    const chosenDevice = udid
+      ? await AppleDeviceQuery.getByDeviceIdentifierAsync(account.name, udid)
+      : await selectAppleDeviceOnAppleTeamAsync({
+          accountName: account.name,
+          appleTeamIdentifier,
+          selectionPromptTitle: `Which device would you like to disable?`,
+          paginatedQueryOptions,
+        });
 
-    if (!appleDevicesResult) {
+    this.logChosenDevice(chosenDevice, appleTeamName, appleTeamIdentifier, paginatedQueryOptions);
+
+    if (!(await this.shouldRemoveDeviceFromExpoAsync(paginatedQueryOptions))) {
       return;
     }
 
-    const { appleTeamName, appleDevices } = appleDevicesResult;
+    await this.removeDeviceFromExpoAsync(chosenDevice);
 
-    const chosenDevices = await this.chooseDevicesToDeleteAsync(appleDevices, udids);
-
-    if (chosenDevices.length === 0) {
-      Log.newLine();
-      Log.warn('No devices were chosen to be removed.');
-      return;
+    if (await this.shouldDisableDeviceOnAppleAsync(paginatedQueryOptions)) {
+      await this.disableDeviceOnAppleAsync(chosenDevice, appleTeamIdentifier);
     }
-
-    this.logChosenDevices(chosenDevices, appleTeamName, appleTeamIdentifier);
-
-    const hasRemoved = await this.askAndRemoveFromExpoAsync(chosenDevices);
-
-    if (!hasRemoved) {
-      return;
-    }
-
-    await this.askAndDisableOnAppleAsync(chosenDevices, appleTeamIdentifier);
   }
 
-  async askAndDisableOnAppleAsync(
-    chosenDevices: (AppleDevice | AppleDeviceQueryResult)[],
+  async shouldDisableDeviceOnAppleAsync({
+    nonInteractive,
+  }: PaginatedQueryOptions): Promise<boolean> {
+    if (!nonInteractive) {
+      Log.newLine();
+      return await toggleConfirmAsync({
+        message: 'Do you want to disable this device on your Apple account as well?',
+      });
+    }
+    return true;
+  }
+
+  async disableDeviceOnAppleAsync(
+    device: AppleDevice | AppleDeviceQueryResult,
     appleTeamIdentifier: string
   ): Promise<void> {
-    Log.newLine();
-    const deleteOnApple = await toggleConfirmAsync({
-      message: 'Do you want to disable these devices on your Apple account as well?',
-    });
-
-    if (!deleteOnApple) {
-      return;
-    }
-
     const ctx = await authenticateAsync({ teamId: appleTeamIdentifier });
     const context = getRequestContext(ctx);
 
     Log.addNewLineIfNone();
-    const removeAppleSpinner = ora('Disabling devices on Apple').start();
+    const removeAppleSpinner = ora('Disabling device on Apple').start();
     try {
-      const chosenDeviceIdentifiers = chosenDevices.map(cd => cd.identifier);
-      const allDevices = await Device.getAsync(context);
-      const realDevices = allDevices.filter(d =>
-        chosenDeviceIdentifiers.includes(d.attributes.udid)
-      );
-
-      for (const device of realDevices) {
-        await device.updateAsync({ status: DeviceStatus.DISABLED });
+      const appleValidatedDevices = await Device.getAsync(context);
+      const appleValidatedDevice = appleValidatedDevices.find(d => d.id === device.id);
+      if (appleValidatedDevice) {
+        await appleValidatedDevice.updateAsync({ status: DeviceStatus.DISABLED });
       }
-
-      removeAppleSpinner.succeed('Disabled devices on Apple');
+      removeAppleSpinner.succeed('Disabled device on Apple');
     } catch (err) {
       removeAppleSpinner.fail();
       throw err;
     }
   }
 
-  async askAndRemoveFromExpoAsync(
-    chosenDevices: (AppleDevice | AppleDeviceQueryResult)[]
-  ): Promise<boolean> {
-    Log.warn(
-      `You are about to remove the Apple device${
-        chosenDevices.length > 1 ? 's' : ''
-      } listed above from your Expo account.`
-    );
-    Log.newLine();
+  async shouldRemoveDeviceFromExpoAsync({
+    nonInteractive,
+  }: PaginatedQueryOptions): Promise<boolean> {
+    if (!nonInteractive) {
+      Log.warn(`You are about to remove the Apple device listed above from your Expo account.`);
+      Log.newLine();
 
-    const confirmed = await toggleConfirmAsync({
-      message: 'Are you sure you wish to proceed?',
-    });
-
-    if (confirmed) {
-      const removalSpinner = ora(`Removing Apple devices on Expo`).start();
-      try {
-        for (const chosenDevice of chosenDevices) {
-          await AppleDeviceMutation.deleteAppleDeviceAsync(chosenDevice.id);
-        }
-        removalSpinner.succeed('Removed Apple devices from Expo');
-      } catch (err) {
-        removalSpinner.fail();
-        throw err;
-      }
+      return await toggleConfirmAsync({
+        message: 'Are you sure you wish to proceed?',
+      });
     }
-
-    return confirmed;
+    return true;
   }
 
-  logChosenDevices(
-    chosenDevices: (AppleDevice | AppleDeviceQueryResult)[],
+  async removeDeviceFromExpoAsync(
+    chosenDevice: AppleDevice | AppleDeviceQueryResult
+  ): Promise<void> {
+    const removalSpinner = ora(`Removing Apple device on Expo`).start();
+    try {
+      await AppleDeviceMutation.deleteAppleDeviceAsync(chosenDevice.id);
+      removalSpinner.succeed('Removed Apple device from Expo');
+    } catch (err) {
+      removalSpinner.fail();
+      throw err;
+    }
+  }
+
+  logChosenDevice(
+    device: AppleDevice | AppleDeviceQueryResult,
     appleTeamName: Maybe<string> | undefined,
-    appleTeamIdentifier: string
+    appleTeamIdentifier: string,
+    { json }: PaginatedQueryOptions
   ): void {
-    Log.addNewLineIfNone();
-    chosenDevices.forEach(device => {
+    if (json) {
+      printJsonOnlyOutput(device);
+    } else {
+      Log.addNewLineIfNone();
       Log.log(
         formatDevice(device, {
           appleTeamName,
@@ -156,98 +169,6 @@ export default class DeviceDelete extends EasCommand {
         })
       );
       Log.newLine();
-    });
-  }
-
-  async chooseDevicesToDeleteAsync(
-    appleDevices: AppleDeviceQueryResult[],
-    udids: string[]
-  ): Promise<(AppleDevice | AppleDeviceQueryResult)[]> {
-    let chosenDevices: (AppleDeviceQueryResult | AppleDevice)[] = [];
-    Log.newLine();
-    if (udids) {
-      udids.forEach(udid => {
-        const foundDevice = appleDevices.find(device => device.identifier === udid);
-        if (foundDevice) {
-          chosenDevices.push(foundDevice);
-        } else {
-          Log.warn(`No device found with UDID ${udid}.`);
-        }
-      });
-    }
-
-    if (chosenDevices.length === 0) {
-      Log.addNewLineIfNone();
-      chosenDevices = await chooseDevicesToDeleteAsync(appleDevices);
-      Log.newLine();
-    }
-
-    return chosenDevices;
-  }
-
-  async getDevicesForTeamAsync(
-    accountName: string,
-    appleTeamIdentifier: string
-  ): Promise<AppleDevicesByTeamIdentifierQueryResult | undefined> {
-    const devicesSpinner = ora().start('Fetching the list of devices for the team…');
-
-    try {
-      const result = await AppleDeviceQuery.getAllForAppleTeamAsync(
-        accountName,
-        appleTeamIdentifier
-      );
-
-      if (result?.appleDevices.length) {
-        const { appleTeamName, appleDevices } = result;
-
-        devicesSpinner.succeed(
-          `Found ${appleDevices.length} devices for team ${appleTeamName ?? appleTeamIdentifier}`
-        );
-
-        return result;
-      } else {
-        devicesSpinner.fail(`Couldn't find any devices for the team ${appleTeamIdentifier}`);
-        return;
-      }
-    } catch (e) {
-      devicesSpinner.fail(`Something went wrong and we couldn't fetch the device list`);
-      throw e;
-    }
-  }
-
-  async askForAppleTeamAsync(accountName: string): Promise<string | undefined> {
-    const teamSpinner = ora().start('Fetching the list of teams for the project…');
-
-    try {
-      const teams = await AppleTeamQuery.getAllForAccountAsync(accountName);
-
-      if (teams.length > 0) {
-        teamSpinner.succeed('Fetched the list of teams for the project');
-
-        if (teams.length === 1) {
-          return teams[0].appleTeamIdentifier;
-        }
-
-        const result = await promptAsync({
-          type: 'select',
-          name: 'appleTeamIdentifier',
-          message: 'What Apple Team would you like to list devices for?',
-          choices: teams.map(team => ({
-            title: team.appleTeamName
-              ? `${team.appleTeamName} (ID: ${team.appleTeamIdentifier})`
-              : team.appleTeamIdentifier,
-            value: team.appleTeamIdentifier,
-          })),
-        });
-
-        return result.appleTeamIdentifier;
-      } else {
-        teamSpinner.fail(`Couldn't find any teams for the account ${accountName}`);
-        return;
-      }
-    } catch (e) {
-      teamSpinner.fail(`Something went wrong and we couldn't fetch the list of teams`);
-      throw e;
     }
   }
 }

--- a/packages/eas-cli/src/commands/device/delete.ts
+++ b/packages/eas-cli/src/commands/device/delete.ts
@@ -4,11 +4,7 @@ import assert from 'assert';
 
 import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import {
-  EasPaginatedQueryFlags,
-  PaginatedQueryOptions,
-  getPaginatedQueryOptions,
-} from '../../commandUtils/pagination';
+import { PaginatedQueryOptions, getPaginatedQueryOptions } from '../../commandUtils/pagination';
 import { AppleDeviceMutation } from '../../credentials/ios/api/graphql/mutations/AppleDeviceMutation';
 import {
   AppleDeviceQuery,
@@ -31,9 +27,8 @@ export default class DeviceDelete extends EasCommand {
   static override description = 'remove a registered device from your account';
 
   static override flags = {
-    'apple-team-id': Flags.string(),
-    udid: Flags.string({ multiple: false, description: 'The device ID to disable' }),
-    ...EasPaginatedQueryFlags,
+    'apple-team-id': Flags.string({ description: 'The Apple team ID on which to find the device' }),
+    udid: Flags.string({ description: 'The Apple device ID to disable' }),
     ...EasNonInteractiveAndJsonFlags,
   };
 
@@ -63,7 +58,7 @@ export default class DeviceDelete extends EasCommand {
         selectionPromptTitle: `What Apple Team would you like to list devices for?`,
         paginatedQueryOptions,
       });
-      appleTeamIdentifier = appleTeam.id;
+      appleTeamIdentifier = appleTeam.appleTeamIdentifier;
       appleTeamName = appleTeam.appleTeamName;
     }
 

--- a/packages/eas-cli/src/commands/device/delete.ts
+++ b/packages/eas-cli/src/commands/device/delete.ts
@@ -55,7 +55,7 @@ export default class DeviceDelete extends EasCommand {
     if (!appleTeamIdentifier) {
       const appleTeam = await selectAppleTeamOnAccountAsync({
         accountName: account.name,
-        selectionPromptTitle: `What Apple Team would you like to list devices for?`,
+        selectionPromptTitle: `What Apple team would you like to list devices for?`,
         paginatedQueryOptions,
       });
       appleTeamIdentifier = appleTeam.appleTeamIdentifier;

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -49,14 +49,13 @@ export default class BuildList extends EasCommand {
           offset: 0,
           limit: undefined,
         },
-        selectionPromptTitle: 'What Apple Team would you like to list devices for?',
+        selectionPromptTitle: 'What Apple team would you like to list devices for?',
       });
       appleTeamIdentifier = selectedAppleTeam.appleTeamIdentifier;
       appleTeamName = selectedAppleTeam.appleTeamName;
     }
 
     assert(appleTeamIdentifier, 'No team identifier is specified');
-
     await listAndRenderAppleDevicesOnAppleTeamAsync({
       accountName: account.name,
       appleTeam: {

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -1,21 +1,23 @@
 import { Flags } from '@oclif/core';
 import assert from 'assert';
-import chalk from 'chalk';
 
 import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
-import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
-import { AppleTeamQuery } from '../../credentials/ios/api/graphql/queries/AppleTeamQuery';
-import formatDevice from '../../devices/utils/formatDevice';
-import Log from '../../log';
-import { Ora, ora } from '../../ora';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { EasPaginatedQueryFlags, getPaginatedQueryOptions } from '../../commandUtils/pagination';
+import {
+  listAndRenderAppleDevicesOnAppleTeamAsync,
+  selectAppleTeamOnAccountAsync,
+} from '../../devices/queries';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
-import { promptAsync } from '../../prompts';
+import { enableJsonOutput } from '../../utils/json';
 
 export default class BuildList extends EasCommand {
   static override description = 'list all registered devices for your account';
 
   static override flags = {
     'apple-team-id': Flags.string(),
+    ...EasPaginatedQueryFlags,
+    ...EasNonInteractiveAndJsonFlags,
   };
 
   static override contextDefinition = {
@@ -23,82 +25,40 @@ export default class BuildList extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    let appleTeamIdentifier = (await this.parse(BuildList)).flags['apple-team-id'];
+    const { flags } = await this.parse(BuildList);
+    const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     const {
       projectConfig: { projectId },
     } = await this.getContextAsync(BuildList, {
-      nonInteractive: false,
+      nonInteractive: paginatedQueryOptions.nonInteractive,
     });
+    let appleTeamIdentifier = flags['apple-team-id'];
+    let appleTeamName;
+    if (paginatedQueryOptions.json) {
+      enableJsonOutput();
+    }
 
     const account = await getOwnerAccountForProjectIdAsync(projectId);
 
-    let spinner: Ora;
-
     if (!appleTeamIdentifier) {
-      spinner = ora().start('Fetching the list of teams for the project…');
-
-      try {
-        const teams = await AppleTeamQuery.getAllForAccountAsync(account.name);
-
-        if (teams.length > 0) {
-          spinner.succeed();
-
-          if (teams.length === 1) {
-            appleTeamIdentifier = teams[0].appleTeamIdentifier;
-          } else {
-            const result = await promptAsync({
-              type: 'select',
-              name: 'appleTeamIdentifier',
-              message: 'What Apple Team would you like to list devices for?',
-              choices: teams.map(team => ({
-                title: team.appleTeamName
-                  ? `${team.appleTeamName} (ID: ${team.appleTeamIdentifier})`
-                  : team.appleTeamIdentifier,
-                value: team.appleTeamIdentifier,
-              })),
-            });
-
-            appleTeamIdentifier = result.appleTeamIdentifier;
-          }
-        } else {
-          spinner.fail(`Couldn't find any teams for the account ${account.name}`);
-        }
-      } catch (e) {
-        spinner.fail(`Something went wrong and we couldn't fetch the list of teams`);
-        throw e;
-      }
+      const selectedAppleTeam = await selectAppleTeamOnAccountAsync({
+        accountName: account.name,
+        paginatedQueryOptions,
+        selectionPromptTitle: 'What Apple Team would you like to list devices for?',
+      });
+      appleTeamIdentifier = selectedAppleTeam.id;
+      appleTeamName = selectedAppleTeam.appleTeamName;
     }
 
     assert(appleTeamIdentifier, 'No team identifier is specified');
 
-    spinner = ora().start('Fetching the list of devices for the team…');
-
-    try {
-      const result = await AppleDeviceQuery.getAllForAppleTeamAsync(
-        account.name,
-        appleTeamIdentifier
-      );
-
-      if (result?.appleDevices.length) {
-        const { appleTeamName, appleDevices } = result;
-
-        spinner.succeed(
-          `Found ${appleDevices.length} devices for team ${appleTeamName ?? appleTeamIdentifier}`
-        );
-
-        const list = appleDevices
-          .map(device =>
-            formatDevice(device, { appleTeamName, appleTeamIdentifier: appleTeamIdentifier! })
-          )
-          .join(`\n\n${chalk.dim('———')}\n\n`);
-
-        Log.log(`\n${list}`);
-      } else {
-        spinner.fail(`Couldn't find any devices for the team ${appleTeamIdentifier}`);
-      }
-    } catch (e) {
-      spinner.fail(`Something went wrong and we couldn't fetch the device list`);
-      throw e;
-    }
+    await listAndRenderAppleDevicesOnAppleTeamAsync({
+      accountName: account.name,
+      appleTeam: {
+        appleTeamIdentifier,
+        appleTeamName,
+      },
+      paginatedQueryOptions,
+    });
   }
 }

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -40,13 +40,18 @@ export default class BuildList extends EasCommand {
 
     const account = await getOwnerAccountForProjectIdAsync(projectId);
 
+    // if they don't provide a team id, fetch devices on their account
     if (!appleTeamIdentifier) {
       const selectedAppleTeam = await selectAppleTeamOnAccountAsync({
         accountName: account.name,
-        paginatedQueryOptions,
+        paginatedQueryOptions: {
+          ...paginatedQueryOptions,
+          offset: 0,
+          limit: undefined,
+        },
         selectionPromptTitle: 'What Apple Team would you like to list devices for?',
       });
-      appleTeamIdentifier = selectedAppleTeam.id;
+      appleTeamIdentifier = selectedAppleTeam.appleTeamIdentifier;
       appleTeamName = selectedAppleTeam.appleTeamName;
     }
 

--- a/packages/eas-cli/src/credentials/ios/actions/AppleTeamFormatting.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AppleTeamFormatting.ts
@@ -1,5 +1,8 @@
 import { AppleTeamFragment } from '../../../graphql/generated';
 
-export function formatAppleTeam({ appleTeamIdentifier, appleTeamName }: AppleTeamFragment): string {
+export function formatAppleTeam({
+  appleTeamIdentifier,
+  appleTeamName,
+}: Pick<AppleTeamFragment, 'appleTeamIdentifier' | 'appleTeamName'>): string {
   return `Team ID: ${appleTeamIdentifier}${appleTeamName ? `, Team name: ${appleTeamName}` : ''}`;
 }

--- a/packages/eas-cli/src/credentials/ios/actions/AppleTeamFormatting.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AppleTeamFormatting.ts
@@ -1,0 +1,5 @@
+import { AppleTeamFragment } from '../../../graphql/generated';
+
+export function formatAppleTeam({ appleTeamIdentifier, appleTeamName }: AppleTeamFragment): string {
+  return `Team ID: ${appleTeamIdentifier}${appleTeamName ? `, Team name: ${appleTeamName}` : ''}`;
+}

--- a/packages/eas-cli/src/credentials/ios/actions/AppleTeamUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AppleTeamUtils.ts
@@ -14,7 +14,3 @@ export async function resolveAppleTeamIfAuthenticatedAsync(
     appleTeamName: ctx.appStore.authCtx.team.name,
   });
 }
-
-export function formatAppleTeam({ appleTeamIdentifier, appleTeamName }: AppleTeamFragment): string {
-  return `Team ID: ${appleTeamIdentifier}${appleTeamName ? `, Team name: ${appleTeamName}` : ''}`;
-}

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -20,7 +20,7 @@ import {
   ascApiKeyIssuerIdSchema,
 } from '../credentials';
 import { isAscApiKeyValidAndTrackedAsync } from '../validators/validateAscApiKey';
-import { formatAppleTeam } from './AppleTeamUtils';
+import { formatAppleTeam } from './AppleTeamFormatting';
 
 export enum AppStoreApiKeyPurpose {
   SUBMISSION_SERVICE = 'EAS Submit',

--- a/packages/eas-cli/src/credentials/ios/actions/DeviceUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DeviceUtils.ts
@@ -26,26 +26,11 @@ export async function chooseDevicesAsync(
   return devices;
 }
 
-export async function chooseDevicesToDeleteAsync(
-  allDevices: AppleDeviceFragment[]
-): Promise<AppleDevice[]> {
-  const { devices } = await promptAsync({
-    type: 'multiselect',
-    name: 'devices',
-    message: 'Which devices do you want to remove?',
-    choices: allDevices.map(device => ({
-      value: device,
-      title: formatDeviceLabel(device),
-      selected: false,
-    })),
-    instructions: false,
-  });
-  return devices;
-}
-
 export function formatDeviceLabel(device: AppleDeviceFragment): string {
   const deviceDetails = formatDeviceDetails(device);
-  return `${device.name ?? device.identifier}${deviceDetails !== '' ? ` ${deviceDetails}` : ''}`;
+  return `${device.identifier}${deviceDetails !== '' ? ` ${deviceDetails}` : ''}${
+    device.name ? ` (${device.name})` : ''
+  }`;
 }
 
 function formatDeviceDetails(device: AppleDeviceFragment): string {

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -17,7 +17,7 @@ import { filterRevokedDistributionCertsFromEasServers } from '../appstore/Creden
 import { AppleTooManyCertsError } from '../appstore/distributionCertificate';
 import { distributionCertificateSchema } from '../credentials';
 import { validateDistributionCertificateAsync } from '../validators/validateDistributionCertificate';
-import { formatAppleTeam } from './AppleTeamUtils';
+import { formatAppleTeam } from './AppleTeamFormatting';
 
 export function formatDistributionCertificate(
   distributionCertificate: AppleDistributionCertificateFragment,

--- a/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
@@ -11,7 +11,7 @@ import { filterRevokedAndUntrackedPushKeysFromEasServersAsync } from '../appstor
 import { APPLE_KEYS_TOO_MANY_GENERATED_ERROR } from '../appstore/pushKey';
 import { pushKeySchema } from '../credentials';
 import { isPushKeyValidAndTrackedAsync } from '../validators/validatePushKey';
-import { formatAppleTeam } from './AppleTeamUtils';
+import { formatAppleTeam } from './AppleTeamFormatting';
 
 export async function provideOrGeneratePushKeyAsync(ctx: CredentialsContext): Promise<PushKey> {
   if (!ctx.nonInteractive) {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../../../graphql/generated';
 import { AppleDeviceFragmentNode } from '../../../../../graphql/types/credentials/AppleDevice';
 import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
-import { formatAppleTeam } from '../../../actions/AppleTeamUtils';
+import { formatAppleTeam } from '../../../actions/AppleTeamFormatting';
 
 export type AppleDeviceFragmentWithAppleTeam = AppleDeviceFragment & {
   appleTeam: AppleTeamFragment;
@@ -112,6 +112,7 @@ export const AppleDeviceQuery = {
                       name
                       deviceClass
                       enabled
+                      model
                     }
                   }
                 }
@@ -128,7 +129,7 @@ export const AppleDeviceQuery = {
     const [appleTeam] = data.account.byName.appleTeams;
     const { appleDevices } = appleTeam;
     if (!appleDevices) {
-      throw new Error(`Could not find devices on apple team -- ${formatAppleTeam(appleTeam)}`);
+      throw new Error(`Could not find devices on Apple team -- ${formatAppleTeam(appleTeam)}`);
     }
     return appleDevices;
   },
@@ -147,6 +148,7 @@ export const AppleDeviceQuery = {
                   id
                   appleDevices(identifier: $identifier) {
                     id
+                    model
                     identifier
                     name
                     deviceClass
@@ -172,7 +174,7 @@ export const AppleDeviceQuery = {
     const device = data.account.byName.appleDevices[0];
     if (!device) {
       throw new DeviceNotFoundError(
-        `Device [${identifier}] not found on account [${accountName}].`
+        `Device with id ${identifier} was not found on account ${accountName}.`
       );
     }
     return device;

--- a/packages/eas-cli/src/devices/queries.ts
+++ b/packages/eas-cli/src/devices/queries.ts
@@ -1,0 +1,147 @@
+import chalk from 'chalk';
+
+import { PaginatedQueryOptions } from '../commandUtils/pagination';
+import { AppleDeviceQuery } from '../credentials/ios/api/graphql/queries/AppleDeviceQuery';
+import { AppleTeamQuery } from '../credentials/ios/api/graphql/queries/AppleTeamQuery';
+import { AppleDeviceFragment, AppleTeamFragment } from '../graphql/generated';
+import Log from '../log';
+import { printJsonOnlyOutput } from '../utils/json';
+import {
+  paginatedQueryWithConfirmPromptAsync,
+  paginatedQueryWithSelectPromptAsync,
+} from '../utils/queries';
+import formatDevice, { AppleTeamIdAndName } from './utils/formatDevice';
+
+export const TEAMS_LIMIT = 50;
+export const DEVICES_LIMIT = 50;
+
+export async function selectAppleTeamOnAccountAsync({
+  accountName,
+  selectionPromptTitle,
+  paginatedQueryOptions,
+}: {
+  accountName: string;
+  selectionPromptTitle: string;
+  paginatedQueryOptions: PaginatedQueryOptions;
+}): Promise<AppleTeamFragment> {
+  if (paginatedQueryOptions.nonInteractive) {
+    throw new Error('Unable to select an apple team in non-interactive mode.');
+  } else {
+    const selectedAppleTeam = await paginatedQueryWithSelectPromptAsync({
+      limit: paginatedQueryOptions.limit ?? TEAMS_LIMIT,
+      offset: paginatedQueryOptions.offset,
+      queryToPerform: (limit, offset) =>
+        AppleTeamQuery.getAllForAccountAsync({
+          accountName,
+          limit,
+          offset,
+        }),
+      promptOptions: {
+        title: selectionPromptTitle,
+        createDisplayTextForSelectionPromptListItem: appleTeam =>
+          appleTeam.appleTeamName
+            ? `${appleTeam.appleTeamName} (ID: ${appleTeam.appleTeamIdentifier})`
+            : appleTeam.appleTeamIdentifier,
+        getIdentifierForQueryItem: appleTeam => appleTeam.id,
+      },
+    });
+    if (!selectedAppleTeam) {
+      throw new Error(`Couldn't find any teams for the account ${accountName}`);
+    }
+    return selectedAppleTeam;
+  }
+}
+
+export async function selectAppleDeviceOnAppleTeamAsync({
+  accountName,
+  appleTeamIdentifier,
+  selectionPromptTitle,
+  paginatedQueryOptions,
+}: {
+  accountName: string;
+  appleTeamIdentifier: string;
+  selectionPromptTitle: string;
+  paginatedQueryOptions: PaginatedQueryOptions;
+}): Promise<AppleDeviceFragment> {
+  if (paginatedQueryOptions.nonInteractive) {
+    throw new Error('Unable to select an apple device in non-interactive mode.');
+  } else {
+    const selectedAppleDevice = await paginatedQueryWithSelectPromptAsync({
+      limit: paginatedQueryOptions.limit ?? DEVICES_LIMIT,
+      offset: paginatedQueryOptions.offset,
+      queryToPerform: (limit, offset) =>
+        AppleDeviceQuery.getAllForAppleTeamAsync({
+          accountName,
+          appleTeamIdentifier,
+          limit,
+          offset,
+        }),
+      promptOptions: {
+        title: selectionPromptTitle,
+        createDisplayTextForSelectionPromptListItem: appleDevice => formatDevice(appleDevice),
+        getIdentifierForQueryItem: appleTeam => appleTeam.id,
+      },
+    });
+    if (!selectedAppleDevice) {
+      throw new Error(
+        `Couldn't find any devices on the apple team with the id ${appleTeamIdentifier}`
+      );
+    }
+    return selectedAppleDevice;
+  }
+}
+
+export async function listAndRenderAppleDevicesOnAppleTeamAsync({
+  accountName,
+  appleTeam,
+  paginatedQueryOptions,
+}: {
+  accountName: string;
+  appleTeam: AppleTeamIdAndName;
+  paginatedQueryOptions: PaginatedQueryOptions;
+}): Promise<void> {
+  if (paginatedQueryOptions.nonInteractive) {
+    const devices = await AppleDeviceQuery.getAllForAppleTeamAsync({
+      accountName,
+      appleTeamIdentifier: appleTeam.appleTeamIdentifier,
+    });
+    renderPageOfAppleDevices({ devices, appleTeam, paginatedQueryOptions });
+  } else {
+    await paginatedQueryWithConfirmPromptAsync({
+      limit: paginatedQueryOptions.limit ?? DEVICES_LIMIT,
+      offset: paginatedQueryOptions.offset,
+      queryToPerform: (limit, offset) =>
+        AppleDeviceQuery.getAllForAppleTeamAsync({
+          accountName,
+          appleTeamIdentifier: appleTeam.appleTeamIdentifier,
+          limit,
+          offset,
+        }),
+      promptOptions: {
+        title: 'Load more devices?',
+        renderListItems: devices =>
+          renderPageOfAppleDevices({ devices, appleTeam, paginatedQueryOptions }),
+      },
+    });
+  }
+}
+
+function renderPageOfAppleDevices({
+  devices,
+  appleTeam,
+  paginatedQueryOptions,
+}: {
+  devices: AppleDeviceFragment[];
+  appleTeam?: AppleTeamIdAndName;
+  paginatedQueryOptions: PaginatedQueryOptions;
+}): void {
+  if (paginatedQueryOptions.json) {
+    printJsonOnlyOutput(devices);
+  } else {
+    const list = devices
+      .map(device => formatDevice(device, appleTeam))
+      .join(`\n\n${chalk.dim('———')}\n\n`);
+
+    Log.log(`\n${list}`);
+  }
+}

--- a/packages/eas-cli/src/devices/queries.ts
+++ b/packages/eas-cli/src/devices/queries.ts
@@ -25,7 +25,7 @@ export async function selectAppleTeamOnAccountAsync({
   paginatedQueryOptions: PaginatedQueryOptions;
 }): Promise<AppleTeamFragment> {
   if (paginatedQueryOptions.nonInteractive) {
-    throw new Error('Unable to select an apple team in non-interactive mode.');
+    throw new Error('Unable to select an Apple team in non-interactive mode.');
   } else {
     const selectedAppleTeam = await paginatedQueryWithSelectPromptAsync({
       limit: paginatedQueryOptions.limit ?? TEAMS_LIMIT,
@@ -64,7 +64,7 @@ export async function selectAppleDeviceOnAppleTeamAsync({
   paginatedQueryOptions: PaginatedQueryOptions;
 }): Promise<AppleDeviceFragment> {
   if (paginatedQueryOptions.nonInteractive) {
-    throw new Error('Unable to select an apple device in non-interactive mode.');
+    throw new Error('Unable to select an Apple device in non-interactive mode.');
   } else {
     const selectedAppleDevice = await paginatedQueryWithSelectPromptAsync({
       limit: paginatedQueryOptions.limit ?? DEVICES_LIMIT,
@@ -84,7 +84,7 @@ export async function selectAppleDeviceOnAppleTeamAsync({
     });
     if (!selectedAppleDevice) {
       throw new Error(
-        `Couldn't find any devices on the apple team with the id ${appleTeamIdentifier}`
+        `Couldn't find any devices on the Apple team with the id ${appleTeamIdentifier}`
       );
     }
     return selectedAppleDevice;
@@ -104,6 +104,8 @@ export async function listAndRenderAppleDevicesOnAppleTeamAsync({
     const devices = await AppleDeviceQuery.getAllForAppleTeamAsync({
       accountName,
       appleTeamIdentifier: appleTeam.appleTeamIdentifier,
+      offset: paginatedQueryOptions.offset,
+      limit: paginatedQueryOptions.limit,
     });
     renderPageOfAppleDevices({ devices, appleTeam, paginatedQueryOptions });
   } else {

--- a/packages/eas-cli/src/devices/queries.ts
+++ b/packages/eas-cli/src/devices/queries.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk';
 
 import { PaginatedQueryOptions } from '../commandUtils/pagination';
+import { formatAppleTeam } from '../credentials/ios/actions/AppleTeamFormatting';
+import { formatDeviceLabel } from '../credentials/ios/actions/DeviceUtils';
 import { AppleDeviceQuery } from '../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import { AppleTeamQuery } from '../credentials/ios/api/graphql/queries/AppleTeamQuery';
 import { AppleDeviceFragment, AppleTeamFragment } from '../graphql/generated';
@@ -78,7 +80,7 @@ export async function selectAppleDeviceOnAppleTeamAsync({
         }),
       promptOptions: {
         title: selectionPromptTitle,
-        createDisplayTextForSelectionPromptListItem: appleDevice => formatDevice(appleDevice),
+        createDisplayTextForSelectionPromptListItem: appleDevice => formatDeviceLabel(appleDevice),
         getIdentifierForQueryItem: appleTeam => appleTeam.id,
       },
     });
@@ -134,16 +136,26 @@ function renderPageOfAppleDevices({
   paginatedQueryOptions,
 }: {
   devices: AppleDeviceFragment[];
-  appleTeam?: AppleTeamIdAndName;
+  appleTeam: AppleTeamIdAndName;
   paginatedQueryOptions: PaginatedQueryOptions;
 }): void {
   if (paginatedQueryOptions.json) {
     printJsonOnlyOutput(devices);
   } else {
-    const list = devices
-      .map(device => formatDevice(device, appleTeam))
-      .join(`\n\n${chalk.dim('———')}\n\n`);
+    if (devices.length === 0) {
+      Log.log(
+        `Could not find devices on Apple team -- ${formatAppleTeam({
+          appleTeamIdentifier: appleTeam.appleTeamIdentifier,
+          appleTeamName: appleTeam.appleTeamName,
+        })}`
+      );
+    } else {
+      const list = devices
+        .map(device => formatDevice(device, appleTeam))
+        .join(`\n\n${chalk.dim('———')}\n\n`);
 
-    Log.log(`\n${list}`);
+      Log.log(`\n${list}`);
+      Log.addNewLineIfNone();
+    }
   }
 }

--- a/packages/eas-cli/src/devices/utils/errors.ts
+++ b/packages/eas-cli/src/devices/utils/errors.ts
@@ -1,0 +1,5 @@
+export class DeviceNotFoundError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Device not found.');
+  }
+}

--- a/packages/eas-cli/src/devices/utils/formatDevice.ts
+++ b/packages/eas-cli/src/devices/utils/formatDevice.ts
@@ -3,9 +3,9 @@ import formatFields from '../../utils/formatFields';
 
 type Device = Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'deviceClass' | 'enabled'>;
 
-type Team = Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName'>;
+export type AppleTeamIdAndName = Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName'>;
 
-export default function formatDevice(device: Device, team?: Team): string {
+export default function formatDevice(device: Device, team?: AppleTeamIdAndName): string {
   const fields = [
     { label: 'ID', value: device.id },
     { label: 'Name', value: device.name ?? 'Unknown' },

--- a/packages/eas-cli/src/devices/utils/formatDevice.ts
+++ b/packages/eas-cli/src/devices/utils/formatDevice.ts
@@ -1,7 +1,7 @@
 import { AppleDevice, AppleTeam } from '../../graphql/generated';
 import formatFields from '../../utils/formatFields';
 
-type Device = Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'deviceClass' | 'enabled'>;
+type Device = Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'deviceClass' | 'enabled' | 'model'>;
 
 export type AppleTeamIdAndName = Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName'>;
 
@@ -9,7 +9,12 @@ export default function formatDevice(device: Device, team?: AppleTeamIdAndName):
   const fields = [
     { label: 'ID', value: device.id },
     { label: 'Name', value: device.name ?? 'Unknown' },
-    { label: 'Class', value: device.deviceClass ?? 'Unknown' },
+    {
+      label: 'Class',
+      value: device.deviceClass
+        ? `${device.deviceClass}${device.model ? ` ${device.model}` : ''}`
+        : 'Unknown',
+    },
     { label: 'UDID', value: device.identifier },
   ];
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1639,6 +1639,12 @@ export type AppleTeamAppleAppIdentifiersArgs = {
 };
 
 
+export type AppleTeamAppleDevicesArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+};
+
+
 export type AppleTeamAppleProvisioningProfilesArgs = {
   appleAppIdentifierId?: InputMaybe<Scalars['ID']>;
 };
@@ -2030,6 +2036,17 @@ export type BuildOrBuildJob = {
   id: Scalars['ID'];
 };
 
+export type BuildOrBuildJobQuery = {
+  __typename?: 'BuildOrBuildJobQuery';
+  /** Look up EAS Build or Classic Build Job by ID */
+  byId: EasBuildOrClassicBuildJob;
+};
+
+
+export type BuildOrBuildJobQueryByIdArgs = {
+  buildOrBuildJobId: Scalars['ID'];
+};
+
 export type BuildParamsInput = {
   resourceClass: BuildResourceClass;
 };
@@ -2374,6 +2391,8 @@ export enum EasBuildDeprecationInfoType {
   UserFacing = 'USER_FACING'
 }
 
+export type EasBuildOrClassicBuildJob = Build | BuildJob;
+
 export enum EasServiceMetric {
   AssetsRequests = 'ASSETS_REQUESTS',
   BandwidthUsage = 'BANDWIDTH_USAGE',
@@ -2554,6 +2573,15 @@ export type GitHubAppQuery = {
   __typename?: 'GitHubAppQuery';
   appIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
+  searchRepositories: Array<GitHubAppInstallationAccessibleRepository>;
+};
+
+
+export type GitHubAppQuerySearchRepositoriesArgs = {
+  githubAppInstallationId: Scalars['ID'];
+  page?: InputMaybe<Scalars['Int']>;
+  perPage?: InputMaybe<Scalars['Int']>;
+  query: Scalars['String'];
 };
 
 export type GitHubRepository = {
@@ -3467,6 +3495,7 @@ export type RootQuery = {
   appleTeam: AppleTeamQuery;
   asset: AssetQuery;
   buildJobs: BuildJobQuery;
+  buildOrBuildJob: BuildOrBuildJobQuery;
   /** Top-level query object for querying BuildPublicData publicly. */
   buildPublicData: BuildPublicDataQuery;
   builds: BuildQuery;
@@ -4797,6 +4826,8 @@ export type AppleDevicesByAppleTeamQuery = { __typename?: 'RootQuery', appleTeam
 export type AppleDevicesByTeamIdentifierQueryVariables = Exact<{
   accountName: Scalars['String'];
   appleTeamIdentifier: Scalars['String'];
+  offset?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
 }>;
 
 
@@ -4844,10 +4875,12 @@ export type ApplePushKeyByAccountQuery = { __typename?: 'RootQuery', account: { 
 
 export type AppleTeamsByAccountNameQueryVariables = Exact<{
   accountName: Scalars['String'];
+  offset?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
 }>;
 
 
-export type AppleTeamsByAccountNameQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleTeams: Array<{ __typename?: 'AppleTeam', id: string, appleTeamName?: string | null, appleTeamIdentifier: string }> } } };
+export type AppleTeamsByAccountNameQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleTeams: Array<{ __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null }> } } };
 
 export type AppleTeamByIdentifierQueryVariables = Exact<{
   accountId: Scalars['ID'];

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4831,7 +4831,7 @@ export type AppleDevicesByTeamIdentifierQueryVariables = Exact<{
 }>;
 
 
-export type AppleDevicesByTeamIdentifierQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleTeams: Array<{ __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, deviceClass?: AppleDeviceClass | null, enabled?: boolean | null }> }> } } };
+export type AppleDevicesByTeamIdentifierQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleTeams: Array<{ __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, deviceClass?: AppleDeviceClass | null, enabled?: boolean | null, model?: string | null }> }> } } };
 
 export type AppleDevicesByIdentifierQueryVariables = Exact<{
   accountName: Scalars['String'];
@@ -4839,7 +4839,7 @@ export type AppleDevicesByIdentifierQueryVariables = Exact<{
 }>;
 
 
-export type AppleDevicesByIdentifierQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, deviceClass?: AppleDeviceClass | null, enabled?: boolean | null, appleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } }> } } };
+export type AppleDevicesByIdentifierQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, model?: string | null, identifier: string, name?: string | null, deviceClass?: AppleDeviceClass | null, enabled?: boolean | null, appleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } }> } } };
 
 export type AppleDistributionCertificateByAppQueryVariables = Exact<{
   projectFullName: Scalars['String'];


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This PR finishes adding support for paginated queries to the EAS CLI.

# How

Following in the steps of previous PRs I 
- introduced helper methods to query for items
- updated the gql schema for relevant queries
- did some light rewriting/refactoring

As a part of this PR, I removed support for deleting multiple devices from an Apple team in a single `delete` command. That requires multi-select pagination and we are choosing to hold off an adding that functionality due to UX concerns.

# Test Plan

Ran the affected commands (using Brent's account 🙏 ). Confirmed each combination of flags and command was working properly.

### device:list

https://user-images.githubusercontent.com/15132641/192421718-948410c7-bd39-4c17-ae46-e89ca1763a88.mov

### device:delete

https://user-images.githubusercontent.com/15132641/192421879-4a12f915-62fa-417d-ba2e-681f0a456ecb.mov

(non-interactive not shown)