### PR TITLE
[10/n][eas-cli] Add new on-demand context concept for commands

### DIFF
--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -2,7 +2,7 @@ import { flushAsync, initAsync, logEvent } from '../../analytics/rudderstackClie
 import { jester as mockJester } from '../../credentials/__tests__/fixtures-constants';
 import { getUserAsync } from '../../user/User';
 import { ensureLoggedInAsync } from '../../user/actions';
-import EasCommand from '../EasCommand';
+import EasCommand, { CommandConfiguration } from '../EasCommand';
 
 jest.mock('../../user/User');
 jest.mock('../../user/actions', () => ({ ensureLoggedInAsync: jest.fn() }));
@@ -43,7 +43,9 @@ beforeEach(() => {
 
 const createTestEasCommand = (authValue: boolean): typeof EasCommand => {
   class TestEasCommand extends EasCommand {
-    override requiresAuthentication = authValue;
+    protected override commandConfiguration: CommandConfiguration = {
+      allowUnauthenticated: !authValue,
+    };
 
     async runAsync(): Promise<void> {}
   }

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -1,4 +1,4 @@
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { CommandConfiguration } from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import { showLoginPromptAsync } from '../../user/actions';
 
@@ -6,8 +6,10 @@ export default class AccountLogin extends EasCommand {
   static override description = 'log in with your Expo account';
   static override aliases = ['login'];
 
-  protected override mustBeRunInsideProject = false;
-  protected override requiresAuthentication = false;
+  protected override commandConfiguration: CommandConfiguration = {
+    allowUnauthenticated: true,
+    canRunOutsideProject: true,
+  };
 
   async runAsync(): Promise<void> {
     await showLoginPromptAsync();

--- a/packages/eas-cli/src/commands/account/logout.ts
+++ b/packages/eas-cli/src/commands/account/logout.ts
@@ -1,4 +1,4 @@
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { CommandConfiguration } from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import { logoutAsync } from '../../user/User';
 
@@ -6,8 +6,10 @@ export default class AccountLogout extends EasCommand {
   static override description = 'log out';
   static override aliases = ['logout'];
 
-  protected override mustBeRunInsideProject = false;
-  protected override requiresAuthentication = false;
+  protected override commandConfiguration: CommandConfiguration = {
+    allowUnauthenticated: true,
+    canRunOutsideProject: true,
+  };
 
   async runAsync(): Promise<void> {
     await logoutAsync();

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { CommandConfiguration } from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import { getActorDisplayName, getUserAsync } from '../../user/User';
 
@@ -8,8 +8,10 @@ export default class AccountView extends EasCommand {
   static override description = 'show the username you are logged in as';
   static override aliases = ['whoami'];
 
-  protected override mustBeRunInsideProject = false;
-  protected override requiresAuthentication = false;
+  protected override commandConfiguration: CommandConfiguration = {
+    allowUnauthenticated: true,
+    canRunOutsideProject: true,
+  };
 
   async runAsync(): Promise<void> {
     const user = await getUserAsync();

--- a/packages/eas-cli/src/commands/analytics.ts
+++ b/packages/eas-cli/src/commands/analytics.ts
@@ -1,4 +1,4 @@
-import EasCommand from '../commandUtils/EasCommand';
+import EasCommand, { CommandConfiguration } from '../commandUtils/EasCommand';
 import Log from '../log';
 import UserSettings from '../user/UserSettings';
 
@@ -7,7 +7,9 @@ export default class AnalyticsView extends EasCommand {
 
   static override args = [{ name: 'STATUS', options: ['on', 'off'] }];
 
-  protected override requiresAuthentication = false;
+  protected override commandConfiguration: CommandConfiguration = {
+    allowUnauthenticated: true,
+  };
 
   async runAsync(): Promise<void> {
     const { STATUS: status } = (await this.parse(AnalyticsView)).args;

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -1,9 +1,7 @@
 import { listAndRenderBranchesOnAppAsync } from '../../branch/queries';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { EasPaginatedQueryFlags, getPaginatedQueryOptions } from '../../commandUtils/pagination';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { enableJsonOutput } from '../../utils/json';
 
 export default class BranchList extends EasCommand {
@@ -14,19 +12,21 @@ export default class BranchList extends EasCommand {
     ...EasNonInteractiveAndJsonFlags,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BranchList);
+    const { projectId } = await this.getContextAsync(BranchList, {
+      nonInteractive: flags['non-interactive'],
+    });
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
 
     if (paginatedQueryOptions.json) {
       enableJsonOutput();
     }
 
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, {
-      nonInteractive: flags['non-interactive'],
-    });
     await listAndRenderBranchesOnAppAsync({ projectId, paginatedQueryOptions });
   }
 }

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -4,7 +4,7 @@ import { EasJsonAccessor, EasJsonUtils } from '@expo/eas-json';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
-import EasCommand from '../commandUtils/EasCommand';
+import EasCommand, { CommandConfiguration } from '../commandUtils/EasCommand';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log from '../log';
 import { appPlatformEmojis } from '../platform';
@@ -25,7 +25,9 @@ export default class Config extends EasCommand {
     }),
   };
 
-  protected override requiresAuthentication = false;
+  protected override commandConfiguration: CommandConfiguration = {
+    allowUnauthenticated: true,
+  };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(Config);

--- a/packages/eas-cli/src/commands/diagnostics.ts
+++ b/packages/eas-cli/src/commands/diagnostics.ts
@@ -1,7 +1,7 @@
 import { Platform } from '@expo/eas-build-job';
 import envinfo from 'envinfo';
 
-import EasCommand from '../commandUtils/EasCommand';
+import EasCommand, { CommandConfiguration } from '../commandUtils/EasCommand';
 import Log from '../log';
 import { findProjectRootAsync } from '../project/projectUtils';
 import { resolveWorkflowAsync } from '../project/workflow';
@@ -10,7 +10,9 @@ import { easCliVersion } from '../utils/easCli';
 export default class Diagnostics extends EasCommand {
   static override description = 'display environment info';
 
-  protected override requiresAuthentication = false;
+  protected override commandConfiguration: CommandConfiguration = {
+    allowUnauthenticated: true,
+  };
 
   async runAsync(): Promise<void> {
     const info = await envinfo.run(


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

The main idea is that we need a better way to declaratively specify dependencies/requirements for commands in a type-safe way. This PR creates a new concept similar in typesystem pattern to flags/parse, but for things like projectId, authenticated actor, project directory, etc.

It is the evolution of https://github.com/expo/eas-cli/pull/1360 but allows commands to be more fine-grained in what they specify/require.

# How

Create new Context concept following the patten used by flags/parse (pass the class constructor to the `getContextAsync` method to infer types).

This allows classes to specify what they need. The idea is that we'll remove `getProjectIdAsync` (in the next PR) and make it so that all commands that need the `projectId` must get it through this new context concept. This will work similarly with things like requiring project directory, etc.

This allows us to do things like validate the project setup (see linked task) on all commands that require it.

# Test Plan

Run tests.

```
$ ~/expo/eas-cli/packages/eas-cli/bin/run branch:list

Branches:
...
```

Run the other commands modified (especially the ones that can be run outside a project folder).
