### PR TITLE
[11/n][eas-cli] Use new context for logged-in actor

### DIFF
--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -57,7 +57,7 @@ This means that it will most likely produce an AAB and you will not be able to i
   const gradleContext = await resolveGradleBuildContextAsync(ctx.projectDir, buildProfile);
 
   if (ctx.workflow === Workflow.MANAGED) {
-    await ensureApplicationIdIsDefinedForManagedProjectAsync(ctx.projectDir, ctx.exp);
+    await ensureApplicationIdIsDefinedForManagedProjectAsync(ctx.projectDir, ctx.exp, ctx.user);
   }
 
   const applicationId = await getApplicationIdAsync(ctx.projectDir, ctx.exp, gradleContext);

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -5,7 +5,6 @@ import slash from 'slash';
 
 import { AndroidCredentials } from '../../credentials/android/AndroidCredentialsProvider';
 import { getUsername } from '../../project/projectUtils';
-import { ensureLoggedInAsync } from '../../user/actions';
 import { getVcsClient } from '../../vcs';
 import { BuildContext } from '../context';
 
@@ -24,10 +23,7 @@ export async function prepareJobAsync(
   ctx: BuildContext<Platform.ANDROID>,
   jobData: JobData
 ): Promise<Job> {
-  const username = getUsername(
-    ctx.exp,
-    await ensureLoggedInAsync({ nonInteractive: ctx.nonInteractive })
-  );
+  const username = getUsername(ctx.exp, ctx.user);
   const buildProfile: BuildProfile<Platform.ANDROID> = ctx.buildProfile;
   const projectRootDirectory =
     slash(path.relative(await getVcsClient().getRootPathAsync(), ctx.projectDir)) || '.';

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -12,7 +12,7 @@ import { BuildResourceClass } from '../graphql/generated';
 import { getExpoConfig } from '../project/expoConfig';
 import { getOwnerAccountForProjectIdAsync, getProjectIdAsync } from '../project/projectUtils';
 import { resolveWorkflowAsync } from '../project/workflow';
-import { ensureLoggedInAsync } from '../user/actions';
+import { Actor } from '../user/User';
 import { createAndroidContextAsync } from './android/build';
 import { BuildContext, CommonContext } from './context';
 import { createIosContextAsync } from './ios/build';
@@ -30,6 +30,7 @@ export async function createBuildContextAsync<T extends Platform>({
   projectDir,
   resourceClass,
   message,
+  actor,
 }: {
   buildProfileName: string;
   buildProfile: BuildProfile<T>;
@@ -42,10 +43,10 @@ export async function createBuildContextAsync<T extends Platform>({
   projectDir: string;
   resourceClass: BuildResourceClass;
   message?: string;
+  actor: Actor;
 }): Promise<BuildContext<T>> {
   const exp = getExpoConfig(projectDir, { env: buildProfile.env });
 
-  const user = await ensureLoggedInAsync({ nonInteractive });
   const projectName = exp.slug;
   const projectId = await getProjectIdAsync(exp, {
     env: buildProfile.env,
@@ -60,7 +61,7 @@ export async function createBuildContextAsync<T extends Platform>({
     exp,
     nonInteractive,
     projectDir,
-    user,
+    user: actor,
     env: buildProfile.env,
     easJsonCliConfig,
   });
@@ -99,7 +100,7 @@ export async function createBuildContextAsync<T extends Platform>({
     projectId,
     projectName,
     trackingCtx,
-    user,
+    user: actor,
     workflow,
     message,
     runFromCI,

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -23,7 +23,7 @@ export async function createIosContextAsync(
   const { buildProfile } = ctx;
 
   if (ctx.workflow === Workflow.MANAGED) {
-    await ensureBundleIdentifierIsDefinedForManagedProjectAsync(ctx.projectDir, ctx.exp);
+    await ensureBundleIdentifierIsDefinedForManagedProjectAsync(ctx.projectDir, ctx.exp, ctx.user);
   }
 
   checkNodeEnvVariable(ctx);

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -4,7 +4,6 @@ import slash from 'slash';
 
 import { IosCredentials, TargetCredentials } from '../../credentials/ios/types';
 import { getUsername } from '../../project/projectUtils';
-import { ensureLoggedInAsync } from '../../user/actions';
 import { getVcsClient } from '../../vcs';
 import { BuildContext } from '../context';
 
@@ -26,10 +25,7 @@ export async function prepareJobAsync(
 ): Promise<Job> {
   const projectRootDirectory =
     slash(path.relative(await getVcsClient().getRootPathAsync(), ctx.projectDir)) || '.';
-  const username = getUsername(
-    ctx.exp,
-    await ensureLoggedInAsync({ nonInteractive: ctx.nonInteractive })
-  );
+  const username = getUsername(ctx.exp, ctx.user);
   const buildCredentials: Ios.Job['secrets']['buildCredentials'] = {};
   if (jobData.credentials) {
     const targetNames = Object.keys(jobData.credentials);

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -14,7 +14,6 @@ import {
   readChannelSafelyAsync as readIosChannelSafelyAsync,
   readReleaseChannelSafelyAsync as readIosReleaseChannelSafelyAsync,
 } from '../update/ios/UpdatesModule';
-import { ensureLoggedInAsync } from '../user/actions';
 import { easCliVersion } from '../utils/easCli';
 import { getVcsClient } from '../vcs';
 import { maybeResolveVersionsAsync as maybeResolveAndroidVersionsAsync } from './android/version';
@@ -49,10 +48,7 @@ export async function collectMetadataAsync<T extends Platform>(
       (await vcsClient.getLastCommitMessageAsync()) ?? undefined
     ),
     isGitWorkingTreeDirty: await vcsClient.hasUncommittedChangesAsync(),
-    username: getUsername(
-      ctx.exp,
-      await ensureLoggedInAsync({ nonInteractive: ctx.nonInteractive })
-    ),
+    username: getUsername(ctx.exp, ctx.user),
     message: ctx.message,
     ...(ctx.platform === Platform.IOS && {
       iosEnterpriseProvisioning: resolveIosEnterpriseProvisioning(

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -42,6 +42,7 @@ import {
 } from '../submit/submit';
 import { printSubmissionDetailsUrls } from '../submit/utils/urls';
 import { validateBuildProfileConfigMatchesProjectConfigAsync } from '../update/utils';
+import { Actor } from '../user/User';
 import { printJsonOnlyOutput } from '../utils/json';
 import { ProfileData, getProfilesAsync } from '../utils/profiles';
 import { getVcsClient } from '../vcs';
@@ -88,7 +89,11 @@ const platformToGraphQLResourceClassMapping: Record<
   },
 };
 
-export async function runBuildAndSubmitAsync(projectDir: string, flags: BuildFlags): Promise<void> {
+export async function runBuildAndSubmitAsync(
+  projectDir: string,
+  flags: BuildFlags,
+  actor: Actor
+): Promise<void> {
   await getVcsClient().ensureRepoExistsAsync();
   await ensureRepoIsCleanAsync(flags.nonInteractive);
 
@@ -135,6 +140,7 @@ export async function runBuildAndSubmitAsync(projectDir: string, flags: BuildFla
           flags.userInputResourceClass ?? UserInputResourceClass.DEFAULT
         ],
       easJsonCliConfig,
+      actor,
     });
     if (maybeBuild) {
       startedBuilds.push({ build: maybeBuild, buildProfile });
@@ -228,6 +234,7 @@ async function prepareAndStartBuildAsync({
   buildProfile,
   resourceClass,
   easJsonCliConfig,
+  actor,
 }: {
   projectDir: string;
   flags: BuildFlags;
@@ -235,6 +242,7 @@ async function prepareAndStartBuildAsync({
   buildProfile: ProfileData<'build'>;
   resourceClass: BuildResourceClass;
   easJsonCliConfig: EasJson['cli'];
+  actor: Actor;
 }): Promise<{ build: BuildFragment | undefined; buildCtx: BuildContext<Platform> }> {
   const buildCtx = await createBuildContextAsync({
     buildProfileName: buildProfile.profileName,
@@ -248,6 +256,7 @@ async function prepareAndStartBuildAsync({
     localBuildOptions: flags.localBuildOptions,
     easJsonCliConfig,
     message: flags.message,
+    actor,
   });
 
   if (moreBuilds) {
@@ -327,6 +336,7 @@ async function prepareAndStartSubmissionAsync({
     env: buildProfile.env,
     credentialsCtx: buildCtx.credentialsCtx,
     applicationIdentifier: buildCtx.android?.applicationId ?? buildCtx.ios?.bundleIdentifier,
+    actor: buildCtx.user,
   });
 
   if (moreBuilds) {

--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core';
 
-import EasCommand from '../commandUtils/EasCommand';
+import EasCommand, { EASCommandLoggedInContext } from '../commandUtils/EasCommand';
 import { SelectPlatform } from '../credentials/manager/SelectPlatform';
 
 export default class Credentials extends EasCommand {
@@ -10,8 +10,14 @@ export default class Credentials extends EasCommand {
     platform: Flags.enum({ char: 'p', options: ['android', 'ios'] }),
   };
 
+  static override contextDefinition = {
+    ...EASCommandLoggedInContext,
+  };
+
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(Credentials);
-    await new SelectPlatform(flags.platform).runAsync();
+    const { actor } = await this.getContextAsync(Credentials, { nonInteractive: false });
+
+    await new SelectPlatform(actor, flags.platform).runAsync();
   }
 }

--- a/packages/eas-cli/src/commands/device/create.ts
+++ b/packages/eas-cli/src/commands/device/create.ts
@@ -1,17 +1,20 @@
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandLoggedInContext } from '../../commandUtils/EasCommand';
 import AppStoreApi from '../../credentials/ios/appstore/AppStoreApi';
 import { createContextAsync } from '../../devices/context';
 import DeviceManager from '../../devices/manager';
-import { ensureLoggedInAsync } from '../../user/actions';
 
 export default class DeviceCreate extends EasCommand {
   static override description = 'register new Apple Devices to use for internal distribution';
 
+  static override contextDefinition = {
+    ...EASCommandLoggedInContext,
+  };
+
   async runAsync(): Promise<void> {
     // this command is interactive by design
-    const user = await ensureLoggedInAsync({ nonInteractive: false });
+    const { actor } = await this.getContextAsync(DeviceCreate, { nonInteractive: false });
 
-    const ctx = await createContextAsync({ appStore: new AppStoreApi(), user });
+    const ctx = await createContextAsync({ appStore: new AppStoreApi(), user: actor });
     const manager = new DeviceManager(ctx);
     await manager.createAsync();
   }

--- a/packages/eas-cli/src/credentials/manager/HelperActions.ts
+++ b/packages/eas-cli/src/credentials/manager/HelperActions.ts
@@ -1,8 +1,10 @@
 import Log from '../../log';
 import { pressAnyKeyToContinueAsync } from '../../prompts';
+import { Actor } from '../../user/User';
 import { CredentialsContext } from '../context';
 
 export interface Action<T = void> {
+  actor: Actor;
   runAsync(ctx: CredentialsContext): Promise<T>;
 }
 

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -6,7 +6,6 @@ import Log, { learnMore } from '../../log';
 import { GradleBuildContext, resolveGradleBuildContextAsync } from '../../project/android/gradle';
 import { getProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import { ensureLoggedInAsync } from '../../user/actions';
 import { AssignFcm } from '../android/actions/AssignFcm';
 import { AssignGoogleServiceAccountKey } from '../android/actions/AssignGoogleServiceAccountKey';
 import {
@@ -57,7 +56,7 @@ export class ManageAndroid {
     const ctx = new CredentialsContext({
       projectDir: process.cwd(),
       // this command is interactive by design
-      user: await ensureLoggedInAsync({ nonInteractive: false }),
+      user: this.callingAction.actor,
       env: buildProfile?.env,
       nonInteractive: false,
     });

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -14,7 +14,7 @@ import { resolveXcodeBuildContextAsync } from '../../project/ios/scheme';
 import { resolveTargetsAsync } from '../../project/ios/target';
 import { getOwnerAccountForProjectIdAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { confirmAsync, promptAsync, selectAsync } from '../../prompts';
-import { ensureActorHasPrimaryAccount, ensureLoggedInAsync } from '../../user/actions';
+import { ensureActorHasPrimaryAccount } from '../../user/actions';
 import { CredentialsContext } from '../context';
 import {
   AppStoreApiKeyPurpose,
@@ -64,8 +64,7 @@ export class ManageIos {
       : null;
     const ctx = new CredentialsContext({
       projectDir: process.cwd(),
-      // this command is interactive by design
-      user: await ensureLoggedInAsync({ nonInteractive: false }),
+      user: this.callingAction.actor,
       env: buildProfile?.env,
       nonInteractive: false,
     });

--- a/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
@@ -1,16 +1,17 @@
 import { selectPlatformAsync } from '../../platform';
+import { Actor } from '../../user/User';
 import { ManageAndroid } from './ManageAndroid';
 import { ManageIos } from './ManageIos';
 
 export class SelectPlatform {
-  constructor(private readonly flagPlatform?: string) {}
+  constructor(public readonly actor: Actor, private readonly flagPlatform?: string) {}
 
   async runAsync(): Promise<void> {
     const platform = await selectPlatformAsync(this.flagPlatform);
 
     if (platform === 'ios') {
-      return await new ManageIos(new SelectPlatform(platform), process.cwd()).runAsync();
+      return await new ManageIos(this, process.cwd()).runAsync();
     }
-    return await new ManageAndroid(new SelectPlatform(platform), process.cwd()).runAsync();
+    return await new ManageAndroid(this, process.cwd()).runAsync();
   }
 }

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -9,7 +9,6 @@ import { getRequestContext } from '../credentials/ios/appstore/authenticate';
 import { getExpoConfig } from '../project/expoConfig';
 import { getBundleIdentifierAsync } from '../project/ios/bundleIdentifier';
 import { Actor } from '../user/User';
-import { ensureLoggedInAsync } from '../user/actions';
 
 export type MetadataContext = {
   /** Submission profile platform to use */
@@ -55,7 +54,7 @@ export async function createMetadataContextAsync(params: {
   );
 
   const exp = params.exp ?? getExpoConfig(params.projectDir);
-  const user = await ensureLoggedInAsync({ nonInteractive: params.credentialsCtx.nonInteractive });
+  const user = params.credentialsCtx.user;
   const bundleIdentifier =
     submitProfile.bundleIdentifier ?? (await getBundleIdentifierAsync(params.projectDir, exp));
 

--- a/packages/eas-cli/src/project/__tests__/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync-test.ts
+++ b/packages/eas-cli/src/project/__tests__/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync-test.ts
@@ -1,3 +1,4 @@
+import { jester } from '../../credentials/__tests__/fixtures-constants';
 import { fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync } from '../fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 
 describe(fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync, () => {
@@ -5,7 +6,8 @@ describe(fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync, () => {
     await expect(
       fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync(
         { accountName: 'fake', projectName: 'fake' },
-        { nonInteractive: true }
+        { nonInteractive: true },
+        jester
       )
     ).rejects.toThrow(
       `Must configure EAS project by running 'eas init' before this command can be run in non-interactive mode.`

--- a/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
@@ -110,7 +110,7 @@ describe(ensureApplicationIdIsDefinedForManagedProjectAsync, () => {
         '/app'
       );
       await expect(
-        ensureApplicationIdIsDefinedForManagedProjectAsync('/app', {} as any)
+        ensureApplicationIdIsDefinedForManagedProjectAsync('/app', {} as any, mockJester)
       ).rejects.toThrowError(/we can't update this file programmatically/);
     });
     it('prompts for the Android package if using app.json', async () => {
@@ -126,7 +126,7 @@ describe(ensureApplicationIdIsDefinedForManagedProjectAsync, () => {
       }));
 
       await expect(
-        ensureApplicationIdIsDefinedForManagedProjectAsync('/app', {} as any)
+        ensureApplicationIdIsDefinedForManagedProjectAsync('/app', {} as any, mockJester)
       ).resolves.toBe('com.expo.notdominik');
       expect(promptAsync).toHaveBeenCalled();
     });
@@ -143,7 +143,7 @@ describe(ensureApplicationIdIsDefinedForManagedProjectAsync, () => {
       }));
 
       await expect(
-        ensureApplicationIdIsDefinedForManagedProjectAsync('/app', {} as any)
+        ensureApplicationIdIsDefinedForManagedProjectAsync('/app', {} as any, mockJester)
       ).resolves.toBe('com.expo.notdominik');
       const appJson = JSON.parse(await fs.readFile('/app/app.json', 'utf-8'));
       expect(appJson).toMatchObject({

--- a/packages/eas-cli/src/project/applicationIdentifier.ts
+++ b/packages/eas-cli/src/project/applicationIdentifier.ts
@@ -2,6 +2,7 @@ import { ExpoConfig } from '@expo/config';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { BuildProfile } from '@expo/eas-json';
 
+import { Actor } from '../user/User';
 import {
   ensureApplicationIdIsDefinedForManagedProjectAsync,
   getApplicationIdAsync,
@@ -16,7 +17,8 @@ export async function getApplicationIdentifierAsync(
   projectDir: string,
   exp: ExpoConfig,
   buildProfile: BuildProfile,
-  platform: Platform
+  platform: Platform,
+  actor: Actor
 ): Promise<string> {
   if (platform === Platform.ANDROID) {
     const profile = buildProfile as BuildProfile<Platform.ANDROID>;
@@ -24,7 +26,7 @@ export async function getApplicationIdentifierAsync(
     const gradleContext = await resolveGradleBuildContextAsync(projectDir, profile);
 
     if (workflow === Workflow.MANAGED) {
-      await ensureApplicationIdIsDefinedForManagedProjectAsync(projectDir, exp);
+      await ensureApplicationIdIsDefinedForManagedProjectAsync(projectDir, exp, actor);
     }
 
     return await getApplicationIdAsync(projectDir, exp, gradleContext);

--- a/packages/eas-cli/src/project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync.ts
+++ b/packages/eas-cli/src/project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync.ts
@@ -7,7 +7,7 @@ import { AppMutation } from '../graphql/mutations/AppMutation';
 import { AppQuery } from '../graphql/queries/AppQuery';
 import { ora } from '../ora';
 import { confirmAsync } from '../prompts';
-import { ensureLoggedInAsync } from '../user/actions';
+import { Actor } from '../user/User';
 
 /**
  * 1. Looks for an existing project on EAS servers. If found, ask the user whether this is the
@@ -23,7 +23,8 @@ export async function fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsyn
   },
   options: {
     nonInteractive: boolean;
-  }
+  },
+  actor: Actor
 ): Promise<string> {
   const { accountName, projectName } = projectInfo;
   const projectFullName = `@${accountName}/${projectName}`;
@@ -34,7 +35,6 @@ export async function fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsyn
     );
   }
 
-  const actor = await ensureLoggedInAsync({ nonInteractive: options.nonInteractive });
   const allAccounts = actor.accounts;
   const accountNamesWhereUserHasSufficientPublishPermissions = new Set(
     allAccounts

--- a/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
@@ -93,7 +93,7 @@ describe(ensureBundleIdentifierIsDefinedForManagedProjectAsync, () => {
         '/app'
       );
       await expect(
-        ensureBundleIdentifierIsDefinedForManagedProjectAsync('/app', {} as any)
+        ensureBundleIdentifierIsDefinedForManagedProjectAsync('/app', {} as any, mockJester)
       ).rejects.toThrowError(/we can't update this file programmatically/);
     });
     it('prompts for the bundle identifier if using app.json', async () => {
@@ -109,7 +109,7 @@ describe(ensureBundleIdentifierIsDefinedForManagedProjectAsync, () => {
       }));
 
       await expect(
-        ensureBundleIdentifierIsDefinedForManagedProjectAsync('/app', {} as any)
+        ensureBundleIdentifierIsDefinedForManagedProjectAsync('/app', {} as any, mockJester)
       ).resolves.toBe('com.expo.notdominik');
       expect(promptAsync).toHaveBeenCalled();
     });
@@ -126,7 +126,7 @@ describe(ensureBundleIdentifierIsDefinedForManagedProjectAsync, () => {
       }));
 
       await expect(
-        ensureBundleIdentifierIsDefinedForManagedProjectAsync('/app', {} as any)
+        ensureBundleIdentifierIsDefinedForManagedProjectAsync('/app', {} as any, mockJester)
       ).resolves.toBe('com.expo.notdominik');
       const appJson = JSON.parse(await fs.readFile('/app/app.json', 'utf-8'));
       expect(appJson).toMatchObject({

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -146,18 +146,17 @@ export async function getProjectIdAsync(
     }
   };
 
+  const actor = await ensureLoggedInAsync({ nonInteractive: options.nonInteractive });
   const projectId = await fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync(
     {
-      accountName: getAccountNameForEASProjectSync(
-        exp,
-        await ensureLoggedInAsync({ nonInteractive: options.nonInteractive })
-      ),
+      accountName: getAccountNameForEASProjectSync(exp, actor),
       projectName: exp.slug,
       privacy: toAppPrivacy(exp.privacy),
     },
     {
       nonInteractive: options.nonInteractive,
-    }
+    },
+    actor
   );
 
   const spinner = ora(`Linking local project to EAS project ${projectId}`).start();

--- a/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
@@ -99,6 +99,7 @@ describe(AndroidSubmitCommand, () => {
           changesNotSentForReview: false,
         },
         nonInteractive: true,
+        actor: mockJester,
       });
       const command = new AndroidSubmitCommand(ctx);
       await expect(command.runAsync()).rejects.toThrowError();
@@ -123,6 +124,7 @@ describe(AndroidSubmitCommand, () => {
           changesNotSentForReview: false,
         },
         nonInteractive: false,
+        actor: mockJester,
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
@@ -159,6 +161,7 @@ describe(AndroidSubmitCommand, () => {
           changesNotSentForReview: false,
         },
         nonInteractive: false,
+        actor: mockJester,
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();

--- a/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
@@ -153,6 +153,7 @@ describe(getServiceAccountKeyResultAsync, () => {
         changesNotSentForReview: false,
       },
       nonInteractive: true,
+      actor: mockJester,
     });
     const source: ServiceAccountSource = {
       sourceType: ServiceAccountSourceType.path,
@@ -188,6 +189,7 @@ describe(getServiceAccountKeyResultAsync, () => {
         changesNotSentForReview: false,
       },
       nonInteractive: true,
+      actor: mockJester,
     });
     const source: ServiceAccountSource = {
       sourceType: ServiceAccountSourceType.prompt,
@@ -219,6 +221,7 @@ describe(getServiceAccountKeyResultAsync, () => {
         changesNotSentForReview: false,
       },
       nonInteractive: true,
+      actor: mockJester,
     });
     const serviceAccountResult = await getServiceAccountKeyResultAsync(ctx, {
       sourceType: ServiceAccountSourceType.credentialsService,

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -9,7 +9,6 @@ import { CredentialsContext } from '../credentials/context';
 import { getExpoConfig } from '../project/expoConfig';
 import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 import { Actor } from '../user/User';
-import { ensureLoggedInAsync } from '../user/actions';
 
 export interface SubmissionContext<T extends Platform> {
   accountName: string;
@@ -44,17 +43,17 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
   projectDir: string;
   projectId: string;
   applicationIdentifier?: string;
+  actor: Actor;
 }): Promise<SubmissionContext<T>> {
-  const { applicationIdentifier, projectDir, nonInteractive } = params;
+  const { applicationIdentifier, projectDir, nonInteractive, actor } = params;
   const exp = getExpoConfig(projectDir, { env: params.env });
   const { env, ...rest } = params;
-  const user = await ensureLoggedInAsync({ nonInteractive });
   const projectName = exp.slug;
   const account = await getOwnerAccountForProjectIdAsync(params.projectId);
   const accountId = account.id;
   let credentialsCtx: CredentialsContext | undefined = params.credentialsCtx;
   if (!credentialsCtx) {
-    credentialsCtx = new CredentialsContext({ projectDir, user, exp, nonInteractive });
+    credentialsCtx = new CredentialsContext({ projectDir, user: actor, exp, nonInteractive });
   }
 
   const trackingCtx = {
@@ -72,7 +71,7 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
     credentialsCtx,
     exp,
     projectName,
-    user,
+    user: actor,
     trackingCtx,
     applicationIdentifierOverride: applicationIdentifier,
   };

--- a/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
@@ -50,6 +50,7 @@ async function getIosSubmissionContextAsync(): Promise<SubmissionContext<Platfor
       language: 'en-US',
     },
     nonInteractive: true,
+    actor: mockJester,
   });
 }
 

--- a/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
@@ -59,6 +59,7 @@ describe(getFromCredentialsServiceAsync, () => {
         language: 'en-US',
       },
       nonInteractive: false,
+      actor: mockJester,
     });
     jest
       .spyOn(SetUpSubmissionCredentials.prototype, 'runAsync')
@@ -86,6 +87,7 @@ describe(getFromCredentialsServiceAsync, () => {
         language: 'en-US',
       },
       nonInteractive: true,
+      actor: mockJester,
     });
     jest
       .spyOn(SetUpSubmissionCredentials.prototype, 'runAsync')

--- a/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
@@ -73,6 +73,7 @@ describe(IosSubmitCommand, () => {
           language: 'en-US',
         },
         nonInteractive: true,
+        actor: mockJester,
       });
       const command = new IosSubmitCommand(ctx);
       await expect(command.runAsync()).rejects.toThrowError();
@@ -98,6 +99,7 @@ describe(IosSubmitCommand, () => {
           ascAppId: '12345678',
         },
         nonInteractive: false,
+        actor: mockJester,
       });
       const command = new IosSubmitCommand(ctx);
       await command.runAsync();


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This uses the actor context introduced in https://github.com/expo/eas-cli/pull/1383.

This will allow commands to more declaratively specify that they require a logged-in user rather than needing the `allowUnauthenticated` property on the command class. The benefit of this over the `allowUnauthenticated` property is that it is type-safe. For a command to use actor, they need to specify the context dependency. Any command that doesn't need actor doesn't need to specify the context dependency, and is therefore by definition allowUnauthenticated.

# How

Remove most callsites to ensureLoggedInAsync (the remaining ones are in EasCommand and getProjectIdAsync which are going to be refactored out in the subsequent PRs).

# Test Plan

`yarn test`. Sanity check by running all changed commands.
