### PR TITLE
[eas-cli] add paginated multi-select

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -37,6 +37,7 @@
     "cli-progress": "3.11.2",
     "cli-table3": "0.6.2",
     "dateformat": "4.6.3",
+    "enquirer": "2.3.6",
     "env-paths": "2.2.0",
     "envinfo": "7.8.1",
     "fast-deep-equal": "3.1.3",

--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -55,7 +55,22 @@ export async function selectAsync<T>(
   );
   return value ?? null;
 }
-
+export async function multiselectAsync<T>(
+  message: string,
+  choices: ExpoChoice<T>[],
+  options?: Options
+): Promise<T[]> {
+  const { value } = await promptAsync(
+    {
+      message,
+      choices,
+      name: 'value',
+      type: 'multiselect',
+    },
+    options
+  );
+  return value ?? null;
+}
 /**
  * Create a more dynamic yes/no confirmation that can be cancelled.
  *

--- a/packages/eas-cli/src/utils/__tests__/queries-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/queries-test.ts
@@ -4,6 +4,7 @@ import {
   paginatedQueryWithMultiSelectPromptAsync,
   paginatedQueryWithSelectPromptAsync,
 } from '../queries';
+import { PAGINATION_FETCH_MORE_VALUE } from '../queryConstants';
 
 jest.mock('../../prompts', () => ({
   selectAsync: jest.fn(),
@@ -21,7 +22,7 @@ const mockRenderMethod = jest.fn();
 
 const selectMoreObject = {
   title: 'Next page...',
-  value: '_fetchMore',
+  value: PAGINATION_FETCH_MORE_VALUE,
 };
 
 function createPaginatedQueryResponse(
@@ -120,8 +121,8 @@ describe(paginatedQueryWithSelectPromptAsync.name, () => {
         );
       jest
         .mocked(selectAsync)
-        .mockResolvedValueOnce(selectMoreObject.value)
-        .mockResolvedValueOnce(selectMoreObject.value)
+        .mockResolvedValueOnce(PAGINATION_FETCH_MORE_VALUE)
+        .mockResolvedValueOnce(PAGINATION_FETCH_MORE_VALUE)
         .mockResolvedValueOnce(selectedItem.value);
 
       const selectedQueryItem = await paginatedQueryWithSelectPromptAsync({
@@ -201,8 +202,8 @@ describe(paginatedQueryWithMultiSelectPromptAsync.name, () => {
 
   it('carries over user selections to new pages', async () => {
     const selectionStates = [
-      ['first-2', 'first-3', selectMoreObject.value],
-      ['first-2', 'second-1', selectMoreObject.value],
+      ['first-2', 'first-3', PAGINATION_FETCH_MORE_VALUE],
+      ['first-2', 'second-1', PAGINATION_FETCH_MORE_VALUE],
       ['first-2', 'second-1', 'third-3'],
     ];
     const limit = 5;

--- a/packages/eas-cli/src/utils/queries.ts
+++ b/packages/eas-cli/src/utils/queries.ts
@@ -1,7 +1,6 @@
 import { ExpoChoice, confirmAsync, multiselectAsync, selectAsync } from '../prompts';
 import uniqBy from './expodash/uniqBy';
-
-const fetchMoreValue = '_fetchMore';
+import { PAGINATION_FETCH_MORE_VALUE } from './queryConstants';
 
 type BasePaginatedQueryArgs<QueryReturnType extends Record<string, any>> = {
   limit: number;
@@ -100,18 +99,18 @@ async function paginatedQueryWithSelectPromptInternalAsync<
     value: promptOptions.getIdentifierForQueryItem(queryItem),
   }));
   if (areMorePagesAvailable) {
-    selectionPromptListItems.push({ title: 'Next page...', value: fetchMoreValue });
+    selectionPromptListItems.push({ title: 'Next page...', value: PAGINATION_FETCH_MORE_VALUE });
   }
   if (selectionPromptListItems.length === 0) {
     return;
   }
 
-  const valueOfUserSelectedListItem = await selectAsync<string>(
+  const valueOfUserSelectedListItem = await selectAsync(
     promptOptions.title,
     selectionPromptListItems
   );
 
-  if (valueOfUserSelectedListItem === fetchMoreValue) {
+  if (valueOfUserSelectedListItem === PAGINATION_FETCH_MORE_VALUE) {
     return await paginatedQueryWithSelectPromptInternalAsync(
       {
         limit,
@@ -163,21 +162,21 @@ async function paginatedQueryWithMultiSelectPromptInternalAsync<
     selected: selectedIdsAccumulator.includes(promptOptions.getIdentifierForQueryItem(queryItem)),
   }));
   if (areMorePagesAvailable) {
-    selectionPromptListItems.push({ title: 'Next page...', value: fetchMoreValue });
+    selectionPromptListItems.push({ title: 'Next page...', value: PAGINATION_FETCH_MORE_VALUE });
   }
   if (selectionPromptListItems.length === 0) {
     return;
   }
 
-  const valueOfUserSelectedListItems = await multiselectAsync<string>(
+  const valueOfUserSelectedListItems = await multiselectAsync(
     promptOptions.title,
     selectionPromptListItems
   );
   const newSelectedIdsAccumulator = valueOfUserSelectedListItems.filter(
-    id => id !== fetchMoreValue
+    id => id !== PAGINATION_FETCH_MORE_VALUE
   );
 
-  if (valueOfUserSelectedListItems.includes(fetchMoreValue)) {
+  if (valueOfUserSelectedListItems.includes(PAGINATION_FETCH_MORE_VALUE)) {
     return await paginatedQueryWithMultiSelectPromptInternalAsync(
       {
         limit,

--- a/packages/eas-cli/src/utils/queryConstants.ts
+++ b/packages/eas-cli/src/utils/queryConstants.ts
@@ -1,0 +1,1 @@
+export const PAGINATION_FETCH_MORE_VALUE = '_fetchMore';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4191,6 +4191,11 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ansi-colors@^4.1.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
+
 ansi-escapes@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -5960,6 +5965,13 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+enquirer@2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  dependencies:
+    ansi-colors "^4.1.1"
 
 env-paths@2.2.0, env-paths@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

#1381 requires pagination on a multi-select prompt. Split it out to its own PR to isolate changes.

closes https://linear.app/expo/issue/ENG-6422/add-multiselect-support-on-paginated-queries

# How

- added in a new utility method `paginatedQueryWithMultiSelectPromptAsync`
- added explicit `ExpoChoice` typing for `paginatedQueryWithSelect*` methods

# Test Plan

Added an automated test. Manually tested by changing a random select prompt to a multiselect prompt. 

### Demo
Initial approach -- require an 'enter' press after selecting a new page:

https://user-images.githubusercontent.com/15132641/191625689-b0240d26-c921-4377-b875-e5ef8e48096d.mov

Alternative approach -- auto-submit when a user selects a new page:

https://user-images.githubusercontent.com/15132641/192012158-777c5d96-68f2-4b7c-9f49-a73b20366593.mov

