### PR TITLE
[eas-cli] Pass through platform to export command

### DIFF
--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -378,7 +378,7 @@ export default class UpdatePublish extends EasCommand {
       if (!skipBundler) {
         const bundleSpinner = ora().start('Building bundle...');
         try {
-          await buildBundlesAsync({ projectDir, inputDir });
+          await buildBundlesAsync({ projectDir, inputDir, platform: platformFlag });
           bundleSpinner.succeed('Built bundle!');
         } catch (e) {
           bundleSpinner.fail('Failed to build bundle!');

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -147,9 +147,11 @@ export async function buildUnsortedUpdateInfoGroupAsync(
 export async function buildBundlesAsync({
   projectDir,
   inputDir,
+  platform = 'all',
 }: {
   projectDir: string;
   inputDir: string;
+  platform?: PublishPlatform | 'all';
 }): Promise<void> {
   const packageJSON = JsonFile.read(path.resolve(projectDir, 'package.json'));
   if (!packageJSON) {
@@ -160,6 +162,8 @@ export async function buildBundlesAsync({
     'export',
     '--output-dir',
     inputDir,
+    '--platform',
+    platform,
     '--experimental-bundle',
     '--non-interactive',
     '--dump-sourcemap',


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

When publishing an update for a specific platform, eg: `eas update -p ios`, we should only build the bundle for that platform. Currently, we build for both platforms regardless. So, `eas update -p ios` will build both iOS and Android bundles. This was a problem for Fernando because his Android codebase wasn't compiling at the time, but iOS worked fine.

# How

Pass through the platform flag. `expo-cli export` and `npx expo export` both support `--platform ios|android|all` so this was straightforward.

# Test Plan

Run the command with a single platform and it should work:

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/90494/191622161-c26ba314-8e3a-4a26-bc56-a7970f26acbb.png">

Ah, nevermind. Server changes needed :) Opened this PR in WIP state until that is ready.