### PR TITLE
[12/n][eas-cli] Use new context for project ID

### DIFF
--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -10,7 +10,7 @@ import { Analytics, BuildEvent } from '../analytics/events';
 import { CredentialsContext } from '../credentials/context';
 import { BuildResourceClass } from '../graphql/generated';
 import { getExpoConfig } from '../project/expoConfig';
-import { getOwnerAccountForProjectIdAsync, getProjectIdAsync } from '../project/projectUtils';
+import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 import { resolveWorkflowAsync } from '../project/workflow';
 import { Actor } from '../user/User';
 import { createAndroidContextAsync } from './android/build';
@@ -31,6 +31,7 @@ export async function createBuildContextAsync<T extends Platform>({
   resourceClass,
   message,
   actor,
+  projectId,
 }: {
   buildProfileName: string;
   buildProfile: BuildProfile<T>;
@@ -44,14 +45,11 @@ export async function createBuildContextAsync<T extends Platform>({
   resourceClass: BuildResourceClass;
   message?: string;
   actor: Actor;
+  projectId: string;
 }): Promise<BuildContext<T>> {
   const exp = getExpoConfig(projectDir, { env: buildProfile.env });
 
   const projectName = exp.slug;
-  const projectId = await getProjectIdAsync(exp, {
-    env: buildProfile.env,
-    nonInteractive,
-  });
   const account = await getOwnerAccountForProjectIdAsync(projectId);
   const workflow = await resolveWorkflowAsync(projectDir, platform);
   const accountId = account.id;

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -7,9 +7,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { TrackingContext } from '../analytics/common';
 import { Analytics, BuildEvent } from '../analytics/events';
+import { DynamicConfigContextFn } from '../commandUtils/EasCommand';
 import { CredentialsContext } from '../credentials/context';
 import { BuildResourceClass } from '../graphql/generated';
-import { getExpoConfig } from '../project/expoConfig';
 import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 import { resolveWorkflowAsync } from '../project/workflow';
 import { Actor } from '../user/User';
@@ -31,7 +31,7 @@ export async function createBuildContextAsync<T extends Platform>({
   resourceClass,
   message,
   actor,
-  projectId,
+  getDynamicProjectConfigAsync,
 }: {
   buildProfileName: string;
   buildProfile: BuildProfile<T>;
@@ -45,9 +45,9 @@ export async function createBuildContextAsync<T extends Platform>({
   resourceClass: BuildResourceClass;
   message?: string;
   actor: Actor;
-  projectId: string;
+  getDynamicProjectConfigAsync: DynamicConfigContextFn;
 }): Promise<BuildContext<T>> {
-  const exp = getExpoConfig(projectDir, { env: buildProfile.env });
+  const { exp, projectId } = await getDynamicProjectConfigAsync({ env: buildProfile.env });
 
   const projectName = exp.slug;
   const account = await getOwnerAccountForProjectIdAsync(projectId);

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -92,7 +92,8 @@ const platformToGraphQLResourceClassMapping: Record<
 export async function runBuildAndSubmitAsync(
   projectDir: string,
   flags: BuildFlags,
-  actor: Actor
+  actor: Actor,
+  projectId: string
 ): Promise<void> {
   await getVcsClient().ensureRepoExistsAsync();
   await ensureRepoIsCleanAsync(flags.nonInteractive);
@@ -141,6 +142,7 @@ export async function runBuildAndSubmitAsync(
         ],
       easJsonCliConfig,
       actor,
+      projectId,
     });
     if (maybeBuild) {
       startedBuilds.push({ build: maybeBuild, buildProfile });
@@ -235,6 +237,7 @@ async function prepareAndStartBuildAsync({
   resourceClass,
   easJsonCliConfig,
   actor,
+  projectId,
 }: {
   projectDir: string;
   flags: BuildFlags;
@@ -243,6 +246,7 @@ async function prepareAndStartBuildAsync({
   resourceClass: BuildResourceClass;
   easJsonCliConfig: EasJson['cli'];
   actor: Actor;
+  projectId: string;
 }): Promise<{ build: BuildFragment | undefined; buildCtx: BuildContext<Platform> }> {
   const buildCtx = await createBuildContextAsync({
     buildProfileName: buildProfile.profileName,
@@ -257,6 +261,7 @@ async function prepareAndStartBuildAsync({
     easJsonCliConfig,
     message: flags.message,
     actor,
+    projectId,
   });
 
   if (moreBuilds) {

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import gql from 'graphql-tag';
 
 import { getDefaultBranchNameAsync } from '../../branch/utils';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -62,7 +62,7 @@ export default class BranchCreate extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -70,7 +70,9 @@ export default class BranchCreate extends EasCommand {
       args: { name },
       flags: { json: jsonFlag, 'non-interactive': nonInteractive },
     } = await this.parse(BranchCreate);
-    const { projectId } = await this.getContextAsync(BranchCreate, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(BranchCreate, {
       nonInteractive,
     });
 

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import gql from 'graphql-tag';
 
 import { getDefaultBranchNameAsync } from '../../branch/utils';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -11,12 +11,7 @@ import {
   UpdateBranch,
 } from '../../graphql/generated';
 import Log from '../../log';
-import { getExpoConfig } from '../../project/expoConfig';
-import {
-  findProjectRootAsync,
-  getDisplayNameForProjectIdAsync,
-  getProjectIdAsync,
-} from '../../project/projectUtils';
+import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
@@ -66,18 +61,23 @@ export default class BranchCreate extends EasCommand {
     ...EasNonInteractiveAndJsonFlags,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     let {
       args: { name },
       flags: { json: jsonFlag, 'non-interactive': nonInteractive },
     } = await this.parse(BranchCreate);
+    const { projectId } = await this.getContextAsync(BranchCreate, {
+      nonInteractive,
+    });
+
     if (jsonFlag) {
       enableJsonOutput();
     }
 
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
     const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
 
     if (!name) {

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import gql from 'graphql-tag';
 
 import { selectBranchOnAppAsync } from '../../branch/queries';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { getPaginatedQueryOptions } from '../../commandUtils/pagination';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
@@ -77,7 +77,7 @@ export default class BranchDelete extends EasCommand {
   static override description = 'delete a branch';
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   static override args = [
@@ -104,7 +104,9 @@ export default class BranchDelete extends EasCommand {
       enableJsonOutput();
     }
 
-    const { projectId } = await this.getContextAsync(BranchDelete, { nonInteractive });
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(BranchDelete, { nonInteractive });
     const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
 
     if (!branchName) {

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -1,5 +1,5 @@
 import { listAndRenderBranchesOnAppAsync } from '../../branch/queries';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { EasPaginatedQueryFlags, getPaginatedQueryOptions } from '../../commandUtils/pagination';
 import { enableJsonOutput } from '../../utils/json';
@@ -13,12 +13,14 @@ export default class BranchList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BranchList);
-    const { projectId } = await this.getContextAsync(BranchList, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(BranchList, {
       nonInteractive: flags['non-interactive'],
     });
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -12,12 +12,7 @@ import {
   UpdateBranch,
 } from '../../graphql/generated';
 import Log from '../../log';
-import { getExpoConfig } from '../../project/expoConfig';
-import {
-  findProjectRootAsync,
-  getDisplayNameForProjectIdAsync,
-  getProjectIdAsync,
-} from '../../project/projectUtils';
+import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
@@ -67,17 +62,21 @@ export default class BranchRename extends EasCommand {
     ...EasNonInteractiveAndJsonFlags,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     let {
       flags: { json: jsonFlag, from: currentName, to: newName, 'non-interactive': nonInteractive },
     } = await this.parse(BranchRename);
+    const { projectId } = await this.getContextAsync(BranchRename, {
+      nonInteractive,
+    });
     if (jsonFlag) {
       enableJsonOutput();
     }
 
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
     const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
 
     if (!currentName) {

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -63,14 +63,16 @@ export default class BranchRename extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     let {
       flags: { json: jsonFlag, from: currentName, to: newName, 'non-interactive': nonInteractive },
     } = await this.parse(BranchRename);
-    const { projectId } = await this.getContextAsync(BranchRename, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(BranchRename, {
       nonInteractive,
     });
     if (jsonFlag) {

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -1,13 +1,11 @@
 import { selectBranchOnAppAsync } from '../../branch/queries';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import {
   EasPaginatedQueryFlags,
   getLimitFlagWithCustomValues,
   getPaginatedQueryOptions,
 } from '../../commandUtils/pagination';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { listAndRenderUpdateGroupsOnBranchAsync } from '../../update/queries';
 import { enableJsonOutput } from '../../utils/json';
 
@@ -28,21 +26,24 @@ export default class BranchView extends EasCommand {
     limit: getLimitFlagWithCustomValues({ defaultTo: 25, limit: 50 }),
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     let {
       args: { name: branchName },
       flags,
     } = await this.parse(BranchView);
     const { 'non-interactive': nonInteractive } = flags;
+    const { projectId } = await this.getContextAsync(BranchView, {
+      nonInteractive,
+    });
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
 
     if (paginatedQueryOptions.json) {
       enableJsonOutput();
     }
-
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
 
     if (!branchName) {
       if (nonInteractive) {

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -1,5 +1,5 @@
 import { selectBranchOnAppAsync } from '../../branch/queries';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import {
   EasPaginatedQueryFlags,
@@ -27,7 +27,7 @@ export default class BranchView extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -36,7 +36,9 @@ export default class BranchView extends EasCommand {
       flags,
     } = await this.parse(BranchView);
     const { 'non-interactive': nonInteractive } = flags;
-    const { projectId } = await this.getContextAsync(BranchView, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(BranchView, {
       nonInteractive,
     });
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -14,12 +14,7 @@ import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
 import { ora } from '../../ora';
 import { appPlatformEmojis } from '../../platform';
-import { getExpoConfig } from '../../project/expoConfig';
-import {
-  findProjectRootAsync,
-  getDisplayNameForProjectIdAsync,
-  getProjectIdAsync,
-} from '../../project/projectUtils';
+import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { confirmAsync, selectAsync } from '../../prompts';
 
 async function cancelBuildAsync(buildId: string): Promise<Pick<Build, 'id' | 'status'>> {
@@ -133,15 +128,19 @@ export default class BuildCancel extends EasCommand {
     ...EASNonInteractiveFlag,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const {
       args: { BUILD_ID: buildIdFromArg },
       flags: { 'non-interactive': nonInteractive },
     } = await this.parse(BuildCancel);
+    const { projectId } = await this.getContextAsync(BuildCancel, {
+      nonInteractive,
+    });
 
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
     const displayName = await getDisplayNameForProjectIdAsync(projectId);
 
     if (buildIdFromArg) {

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -129,7 +129,7 @@ export default class BuildCancel extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -137,7 +137,9 @@ export default class BuildCancel extends EasCommand {
       args: { BUILD_ID: buildIdFromArg },
       flags: { 'non-interactive': nonInteractive },
     } = await this.parse(BuildCancel);
-    const { projectId } = await this.getContextAsync(BuildCancel, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(BuildCancel, {
       nonInteractive,
     });
 

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -4,10 +4,9 @@ import chalk from 'chalk';
 
 import { cleanUpOldEasBuildGradleScriptAsync } from '../../build/android/syncProjectConfiguration';
 import { ensureProjectConfiguredAsync } from '../../build/configure';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import Log, { learnMore } from '../../log';
 import { RequestedPlatform } from '../../platform';
-import { getExpoConfig } from '../../project/expoConfig';
 import { findProjectRootAsync, isExpoUpdatesInstalled } from '../../project/projectUtils';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { promptAsync } from '../../prompts';
@@ -26,8 +25,17 @@ export default class BuildConfigure extends EasCommand {
     }),
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectConfigContext,
+  };
+
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildConfigure);
+    const {
+      projectConfig: { exp },
+    } = await this.getContextAsync(BuildConfigure, {
+      nonInteractive: false,
+    });
 
     Log.log(
       '💡 The following process will configure your iOS and/or Android project to be compatible with EAS Build. These changes only apply to your local project files and you can safely revert them at any time.'
@@ -55,8 +63,6 @@ export default class BuildConfigure extends EasCommand {
 
     // configure expo-updates
     if (expoUpdatesIsInstalled) {
-      const exp = getExpoConfig(projectDir);
-
       if ([RequestedPlatform.Android, RequestedPlatform.All].includes(platform)) {
         const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
         if (workflow === Workflow.GENERIC) {

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -8,8 +8,8 @@ import path from 'path';
 import { BuildFlags, runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import { UserInputResourceClass } from '../../build/types';
 import EasCommand, {
+  EASCommandDynamicProjectConfigContext,
   EASCommandLoggedInContext,
-  EASCommandProjectIdContext,
 } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { StatuspageServiceName } from '../../graphql/generated';
@@ -101,7 +101,7 @@ export default class Build extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandLoggedInContext,
-    ...EASCommandProjectIdContext,
+    ...EASCommandDynamicProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -112,7 +112,7 @@ export default class Build extends EasCommand {
     }
     const flags = this.sanitizeFlags(rawFlags);
 
-    const { actor, projectId } = await this.getContextAsync(Build, {
+    const { actor, getDynamicProjectConfigAsync } = await this.getContextAsync(Build, {
       nonInteractive: flags.nonInteractive,
     });
 
@@ -130,7 +130,12 @@ export default class Build extends EasCommand {
 
     const flagsWithPlatform = await this.ensurePlatformSelectedAsync(flags);
 
-    await runBuildAndSubmitAsync(projectDir, flagsWithPlatform, actor, projectId);
+    await runBuildAndSubmitAsync(
+      projectDir,
+      flagsWithPlatform,
+      actor,
+      getDynamicProjectConfigAsync
+    );
   }
 
   private sanitizeFlags(

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -7,7 +7,10 @@ import path from 'path';
 
 import { BuildFlags, runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import { UserInputResourceClass } from '../../build/types';
-import EasCommand, { EASCommandLoggedInContext } from '../../commandUtils/EasCommand';
+import EasCommand, {
+  EASCommandLoggedInContext,
+  EASCommandProjectIdContext,
+} from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { StatuspageServiceName } from '../../graphql/generated';
 import Log, { link } from '../../log';
@@ -98,6 +101,7 @@ export default class Build extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandLoggedInContext,
+    ...EASCommandProjectIdContext,
   };
 
   async runAsync(): Promise<void> {
@@ -108,7 +112,7 @@ export default class Build extends EasCommand {
     }
     const flags = this.sanitizeFlags(rawFlags);
 
-    const { actor } = await this.getContextAsync(Build, {
+    const { actor, projectId } = await this.getContextAsync(Build, {
       nonInteractive: flags.nonInteractive,
     });
 
@@ -126,7 +130,7 @@ export default class Build extends EasCommand {
 
     const flagsWithPlatform = await this.ensurePlatformSelectedAsync(flags);
 
-    await runBuildAndSubmitAsync(projectDir, flagsWithPlatform, actor);
+    await runBuildAndSubmitAsync(projectDir, flagsWithPlatform, actor, projectId);
   }
 
   private sanitizeFlags(

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -6,8 +6,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import EasCommand, {
+  EASCommandDynamicProjectConfigContext,
   EASCommandLoggedInContext,
-  EASCommandProjectIdContext,
 } from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import { ora } from '../../ora';
@@ -67,12 +67,12 @@ export default class BuildInspect extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandLoggedInContext,
-    ...EASCommandProjectIdContext,
+    ...EASCommandDynamicProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildInspect);
-    const { actor, projectId } = await this.getContextAsync(BuildInspect, {
+    const { actor, getDynamicProjectConfigAsync } = await this.getContextAsync(BuildInspect, {
       nonInteractive: false,
     });
 
@@ -115,7 +115,7 @@ export default class BuildInspect extends EasCommand {
             },
           },
           actor,
-          projectId
+          getDynamicProjectConfigAsync
         );
         if (!flags.verbose) {
           Log.log(chalk.green('Build successful'));

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -5,7 +5,10 @@ import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
 import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
-import EasCommand, { EASCommandLoggedInContext } from '../../commandUtils/EasCommand';
+import EasCommand, {
+  EASCommandLoggedInContext,
+  EASCommandProjectIdContext,
+} from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import { ora } from '../../ora';
 import { RequestedPlatform } from '../../platform';
@@ -64,11 +67,12 @@ export default class BuildInspect extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandLoggedInContext,
+    ...EASCommandProjectIdContext,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildInspect);
-    const { actor } = await this.getContextAsync(BuildInspect, {
+    const { actor, projectId } = await this.getContextAsync(BuildInspect, {
       nonInteractive: false,
     });
 
@@ -110,7 +114,8 @@ export default class BuildInspect extends EasCommand {
               artifactsDir: path.join(tmpWorkingdir, 'artifacts'),
             },
           },
-          actor
+          actor,
+          projectId
         );
         if (!flags.verbose) {
           Log.log(chalk.green('Build successful'));

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core';
 
 import { BUILDS_LIMIT, listAndRenderBuildsOnAppAsync } from '../../build/queries';
 import { BuildDistributionType, BuildStatus } from '../../build/types';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import {
   EasPaginatedQueryFlags,
@@ -56,7 +56,7 @@ export default class BuildList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -69,7 +69,9 @@ export default class BuildList extends EasCommand {
       distribution: buildDistribution,
       'non-interactive': nonInteractive,
     } = flags;
-    const { projectId } = await this.getContextAsync(BuildList, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(BuildList, {
       nonInteractive,
     });
     if (jsonFlag) {

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -1,5 +1,5 @@
 import { formatGraphQLBuild } from '../../build/utils/formatBuild';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasJsonOnlyFlag } from '../../commandUtils/flags';
 import { BuildFragment } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
@@ -18,7 +18,7 @@ export default class BuildView extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -26,7 +26,9 @@ export default class BuildView extends EasCommand {
       args: { BUILD_ID: buildId },
       flags,
     } = await this.parse(BuildView);
-    const { projectId } = await this.getContextAsync(BuildView, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(BuildView, {
       nonInteractive: true,
     });
     if (flags.json) {

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -1,16 +1,11 @@
 import { formatGraphQLBuild } from '../../build/utils/formatBuild';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasJsonOnlyFlag } from '../../commandUtils/flags';
 import { BuildFragment } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
 import { ora } from '../../ora';
-import { getExpoConfig } from '../../project/expoConfig';
-import {
-  findProjectRootAsync,
-  getDisplayNameForProjectIdAsync,
-  getProjectIdAsync,
-} from '../../project/projectUtils';
+import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class BuildView extends EasCommand {
@@ -22,20 +17,22 @@ export default class BuildView extends EasCommand {
     ...EasJsonOnlyFlag,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const {
       args: { BUILD_ID: buildId },
       flags,
     } = await this.parse(BuildView);
+    const { projectId } = await this.getContextAsync(BuildView, {
+      nonInteractive: true,
+    });
     if (flags.json) {
       enableJsonOutput();
     }
 
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-
-    // this command is always non-interactive
-    const projectId = await getProjectIdAsync(exp, { nonInteractive: true });
     const displayName = await getDisplayNameForProjectIdAsync(projectId);
 
     const spinner = ora().start('Fetching the build…');

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import gql from 'graphql-tag';
 
 import { BranchNotFoundError } from '../../branch/utils';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -71,7 +71,7 @@ export default class ChannelCreate extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -79,7 +79,9 @@ export default class ChannelCreate extends EasCommand {
       args: { name: channelName },
       flags: { json: jsonFlag, 'non-interactive': nonInteractive },
     } = await this.parse(ChannelCreate);
-    const { projectId } = await this.getContextAsync(ChannelCreate, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(ChannelCreate, {
       nonInteractive,
     });
     if (jsonFlag) {

--- a/packages/eas-cli/src/commands/channel/delete.ts
+++ b/packages/eas-cli/src/commands/channel/delete.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 import { selectChannelOnAppAsync } from '../../channel/queries';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -30,7 +30,7 @@ export default class ChannelDelete extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -38,7 +38,9 @@ export default class ChannelDelete extends EasCommand {
       args: { name: nameArg },
       flags: { json: jsonFlag, 'non-interactive': nonInteractive },
     } = await this.parse(ChannelDelete);
-    const { projectId } = await this.getContextAsync(ChannelDelete, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(ChannelDelete, {
       nonInteractive,
     });
     if (jsonFlag) {

--- a/packages/eas-cli/src/commands/channel/delete.ts
+++ b/packages/eas-cli/src/commands/channel/delete.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 import { selectChannelOnAppAsync } from '../../channel/queries';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -11,8 +11,6 @@ import {
 } from '../../graphql/generated';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
 import Log from '../../log';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { toggleConfirmAsync } from '../../prompts';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
@@ -31,18 +29,21 @@ export default class ChannelDelete extends EasCommand {
     ...EasNonInteractiveAndJsonFlags,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const {
       args: { name: nameArg },
       flags: { json: jsonFlag, 'non-interactive': nonInteractive },
     } = await this.parse(ChannelDelete);
+    const { projectId } = await this.getContextAsync(ChannelDelete, {
+      nonInteractive,
+    });
     if (jsonFlag) {
       enableJsonOutput();
     }
-
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
 
     let channelId, channelName;
     if (nameArg) {

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 
 import { selectBranchOnAppAsync } from '../../branch/queries';
 import { selectChannelOnAppAsync } from '../../channel/queries';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -66,7 +66,7 @@ export default class ChannelEdit extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -74,7 +74,9 @@ export default class ChannelEdit extends EasCommand {
       args,
       flags: { branch: branchFlag, json, 'non-interactive': nonInteractive },
     } = await this.parse(ChannelEdit);
-    const { projectId } = await this.getContextAsync(ChannelEdit, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(ChannelEdit, {
       nonInteractive,
     });
     if (json) {

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 
 import { selectBranchOnAppAsync } from '../../branch/queries';
 import { selectChannelOnAppAsync } from '../../channel/queries';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import {
@@ -14,8 +14,6 @@ import {
 import { BranchQuery } from '../../graphql/queries/BranchQuery';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
 import Log from '../../log';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export async function updateChannelBranchMappingAsync({
@@ -67,18 +65,21 @@ export default class ChannelEdit extends EasCommand {
     ...EasNonInteractiveAndJsonFlags,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const {
       args,
       flags: { branch: branchFlag, json, 'non-interactive': nonInteractive },
     } = await this.parse(ChannelEdit);
+    const { projectId } = await this.getContextAsync(ChannelEdit, {
+      nonInteractive,
+    });
     if (json) {
       enableJsonOutput();
     }
-
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
 
     const existingChannel = args.name
       ? await ChannelQuery.viewUpdateChannelAsync({ appId: projectId, channelName: args.name })

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -1,13 +1,11 @@
 import { CHANNELS_LIMIT, listAndRenderChannelsOnAppAsync } from '../../channel/queries';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import {
   EasPaginatedQueryFlags,
   getLimitFlagWithCustomValues,
   getPaginatedQueryOptions,
 } from '../../commandUtils/pagination';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { enableJsonOutput } from '../../utils/json';
 
 export default class ChannelList extends EasCommand {
@@ -19,17 +17,20 @@ export default class ChannelList extends EasCommand {
     ...EasNonInteractiveAndJsonFlags,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(ChannelList);
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     const { json: jsonFlag, 'non-interactive': nonInteractive } = flags;
+    const { projectId } = await this.getContextAsync(ChannelList, {
+      nonInteractive,
+    });
     if (jsonFlag) {
       enableJsonOutput();
     }
-
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
 
     await listAndRenderChannelsOnAppAsync({
       projectId,

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -1,5 +1,5 @@
 import { CHANNELS_LIMIT, listAndRenderChannelsOnAppAsync } from '../../channel/queries';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import {
   EasPaginatedQueryFlags,
@@ -18,14 +18,16 @@ export default class ChannelList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(ChannelList);
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     const { json: jsonFlag, 'non-interactive': nonInteractive } = flags;
-    const { projectId } = await this.getContextAsync(ChannelList, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(ChannelList, {
       nonInteractive,
     });
     if (jsonFlag) {

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
 import { BranchMapping, getBranchMapping } from '../../channel/utils';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { UpdateBranch } from '../../graphql/generated';
 import { BranchQuery } from '../../graphql/queries/BranchQuery';
@@ -312,7 +312,7 @@ export default class ChannelRollout extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -326,7 +326,9 @@ export default class ChannelRollout extends EasCommand {
         'non-interactive': nonInteractive,
       },
     } = await this.parse(ChannelRollout);
-    const { projectId } = await this.getContextAsync(ChannelRollout, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(ChannelRollout, {
       nonInteractive,
     });
     if (jsonFlag) {

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -2,18 +2,13 @@ import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
 import { BranchMapping, getBranchMapping } from '../../channel/utils';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { UpdateBranch } from '../../graphql/generated';
 import { BranchQuery } from '../../graphql/queries/BranchQuery';
 import { ChannelQuery, UpdateChannelByNameObject } from '../../graphql/queries/ChannelQuery';
 import Log from '../../log';
-import { getExpoConfig } from '../../project/expoConfig';
-import {
-  findProjectRootAsync,
-  getDisplayNameForProjectIdAsync,
-  getProjectIdAsync,
-} from '../../project/projectUtils';
+import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync, selectAsync } from '../../prompts';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import { updateChannelBranchMappingAsync } from './edit';
@@ -316,6 +311,10 @@ export default class ChannelRollout extends EasCommand {
     ...EasNonInteractiveAndJsonFlags,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const {
       args: { channel: channelName },
@@ -327,13 +326,13 @@ export default class ChannelRollout extends EasCommand {
         'non-interactive': nonInteractive,
       },
     } = await this.parse(ChannelRollout);
+    const { projectId } = await this.getContextAsync(ChannelRollout, {
+      nonInteractive,
+    });
     if (jsonFlag) {
       enableJsonOutput();
     }
 
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
     const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
 
     const channel = await ChannelQuery.viewUpdateChannelAsync({

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -4,7 +4,7 @@ import {
   listAndRenderBranchesAndUpdatesOnChannelAsync,
   selectChannelOnAppAsync,
 } from '../../channel/queries';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { EasPaginatedQueryFlags, getPaginatedQueryOptions } from '../../commandUtils/pagination';
 import { enableJsonOutput } from '../../utils/json';
@@ -26,7 +26,7 @@ export default class ChannelView extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -36,7 +36,9 @@ export default class ChannelView extends EasCommand {
     } = await this.parse(ChannelView);
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     const { json: jsonFlag, 'non-interactive': nonInteractive } = flags;
-    const { projectId } = await this.getContextAsync(ChannelView, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(ChannelView, {
       nonInteractive,
     });
     if (jsonFlag) {

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -4,11 +4,9 @@ import {
   listAndRenderBranchesAndUpdatesOnChannelAsync,
   selectChannelOnAppAsync,
 } from '../../channel/queries';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { EasPaginatedQueryFlags, getPaginatedQueryOptions } from '../../commandUtils/pagination';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { enableJsonOutput } from '../../utils/json';
 
 export default class ChannelView extends EasCommand {
@@ -27,6 +25,10 @@ export default class ChannelView extends EasCommand {
     ...EasPaginatedQueryFlags,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     let {
       args: { name: channelName },
@@ -34,13 +36,12 @@ export default class ChannelView extends EasCommand {
     } = await this.parse(ChannelView);
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     const { json: jsonFlag, 'non-interactive': nonInteractive } = flags;
+    const { projectId } = await this.getContextAsync(ChannelView, {
+      nonInteractive,
+    });
     if (jsonFlag) {
       enableJsonOutput();
     }
-
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
 
     if (!channelName) {
       const validationMessage = 'A channel name is required to view a specific channel.';

--- a/packages/eas-cli/src/commands/device/delete.ts
+++ b/packages/eas-cli/src/commands/device/delete.ts
@@ -2,7 +2,7 @@ import { Device, DeviceStatus } from '@expo/apple-utils';
 import { Flags } from '@oclif/core';
 import assert from 'assert';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { chooseDevicesToDeleteAsync } from '../../credentials/ios/actions/DeviceUtils';
 import { AppleDeviceMutation } from '../../credentials/ios/api/graphql/mutations/AppleDeviceMutation';
 import {
@@ -28,14 +28,16 @@ export default class DeviceDelete extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     let {
       flags: { 'apple-team-id': appleTeamIdentifier, udid: udids },
     } = await this.parse(DeviceDelete);
-    const { projectId } = await this.getContextAsync(DeviceDelete, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(DeviceDelete, {
       nonInteractive: false,
     });
 

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core';
 import assert from 'assert';
 import chalk from 'chalk';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import { AppleTeamQuery } from '../../credentials/ios/api/graphql/queries/AppleTeamQuery';
 import formatDevice from '../../devices/utils/formatDevice';
@@ -19,12 +19,14 @@ export default class BuildList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     let appleTeamIdentifier = (await this.parse(BuildList)).flags['apple-team-id'];
-    const { projectId } = await this.getContextAsync(BuildList, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(BuildList, {
       nonInteractive: false,
     });
 

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -2,18 +2,13 @@ import { Flags } from '@oclif/core';
 import assert from 'assert';
 import chalk from 'chalk';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import { AppleTeamQuery } from '../../credentials/ios/api/graphql/queries/AppleTeamQuery';
 import formatDevice from '../../devices/utils/formatDevice';
 import Log from '../../log';
 import { Ora, ora } from '../../ora';
-import { getExpoConfig } from '../../project/expoConfig';
-import {
-  findProjectRootAsync,
-  getOwnerAccountForProjectIdAsync,
-  getProjectIdAsync,
-} from '../../project/projectUtils';
+import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 
 export default class BuildList extends EasCommand {
@@ -23,14 +18,16 @@ export default class BuildList extends EasCommand {
     'apple-team-id': Flags.string(),
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     let appleTeamIdentifier = (await this.parse(BuildList)).flags['apple-team-id'];
+    const { projectId } = await this.getContextAsync(BuildList, {
+      nonInteractive: false,
+    });
 
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-
-    // this command is interactive by design
-    const projectId = await getProjectIdAsync(exp, { nonInteractive: false });
     const account = await getOwnerAccountForProjectIdAsync(projectId);
 
     let spinner: Ora;

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -1,19 +1,18 @@
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import formatDevice from '../../devices/utils/formatDevice';
 import Log from '../../log';
 import { ora } from '../../ora';
-import { getExpoConfig } from '../../project/expoConfig';
-import {
-  findProjectRootAsync,
-  getOwnerAccountForProjectIdAsync,
-  getProjectIdAsync,
-} from '../../project/projectUtils';
+import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 
 export default class DeviceView extends EasCommand {
   static override description = 'view a device for your project';
 
   static override args = [{ name: 'UDID' }];
+
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
 
   async runAsync(): Promise<void> {
     const { UDID } = (await this.parse(DeviceView)).args;
@@ -31,12 +30,9 @@ If you are not sure what is the UDID of the device you are looking for, run:
       );
       throw new Error('Device UDID is missing');
     }
-
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-
-    // this command is non-interactive by design
-    const projectId = await getProjectIdAsync(exp, { nonInteractive: true });
+    const { projectId } = await this.getContextAsync(DeviceView, {
+      nonInteractive: true,
+    });
     const account = await getOwnerAccountForProjectIdAsync(projectId);
 
     const spinner = ora().start(`Fetching device details for ${UDID}…`);

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -1,4 +1,4 @@
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { AppleDeviceQuery } from '../../credentials/ios/api/graphql/queries/AppleDeviceQuery';
 import formatDevice from '../../devices/utils/formatDevice';
 import Log from '../../log';
@@ -11,7 +11,7 @@ export default class DeviceView extends EasCommand {
   static override args = [{ name: 'UDID' }];
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -30,7 +30,9 @@ If you are not sure what is the UDID of the device you are looking for, run:
       );
       throw new Error('Device UDID is missing');
     }
-    const { projectId } = await this.getContextAsync(DeviceView, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(DeviceView, {
       nonInteractive: true,
     });
     const account = await getOwnerAccountForProjectIdAsync(projectId);

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -1,4 +1,3 @@
-import { getConfig } from '@expo/config';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 import path from 'path';
@@ -6,7 +5,7 @@ import path from 'path';
 import { ensureProjectConfiguredAsync } from '../../build/configure';
 import EasCommand, {
   EASCommandLoggedInContext,
-  EASCommandProjectIdContext,
+  EASCommandProjectConfigContext,
 } from '../../commandUtils/EasCommand';
 import { CredentialsContext } from '../../credentials/context';
 import Log, { learnMore } from '../../log';
@@ -27,7 +26,7 @@ export default class MetadataPull extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
     ...EASCommandLoggedInContext,
   };
 
@@ -35,10 +34,14 @@ export default class MetadataPull extends EasCommand {
     Log.warn('EAS Metadata is in beta and subject to breaking changes.');
 
     const { flags } = await this.parse(MetadataPull);
-    const { actor } = await this.getContextAsync(MetadataPull, { nonInteractive: false });
+    const {
+      actor,
+      projectConfig: { exp },
+    } = await this.getContextAsync(MetadataPull, {
+      nonInteractive: false,
+    });
 
     const projectDir = await findProjectRootAsync();
-    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
 
     // this command is interactive (all nonInteractive flags passed to utility functions are false)
     await ensureProjectConfiguredAsync({ projectDir, nonInteractive: false });

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -1,10 +1,9 @@
-import { getConfig } from '@expo/config';
 import { Flags } from '@oclif/core';
 
 import { ensureProjectConfiguredAsync } from '../../build/configure';
 import EasCommand, {
   EASCommandLoggedInContext,
-  EASCommandProjectIdContext,
+  EASCommandProjectConfigContext,
 } from '../../commandUtils/EasCommand';
 import { CredentialsContext } from '../../credentials/context';
 import Log, { learnMore } from '../../log';
@@ -25,7 +24,7 @@ export default class MetadataPush extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
     ...EASCommandLoggedInContext,
   };
 
@@ -33,10 +32,14 @@ export default class MetadataPush extends EasCommand {
     Log.warn('EAS Metadata is in beta and subject to breaking changes.');
 
     const { flags } = await this.parse(MetadataPush);
-    const { actor } = await this.getContextAsync(MetadataPush, { nonInteractive: false });
+    const {
+      actor,
+      projectConfig: { exp },
+    } = await this.getContextAsync(MetadataPush, {
+      nonInteractive: false,
+    });
 
     const projectDir = await findProjectRootAsync();
-    const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
 
     // this command is interactive (all nonInteractive flags passed to utility functions are false)
     await ensureProjectConfiguredAsync({ projectDir, nonInteractive: false });

--- a/packages/eas-cli/src/commands/open.ts
+++ b/packages/eas-cli/src/commands/open.ts
@@ -1,25 +1,24 @@
 import openBrowserAsync from 'better-opn';
 
 import { getProjectDashboardUrl } from '../build/utils/url';
-import EasCommand, { EASCommandProjectIdContext } from '../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../commandUtils/EasCommand';
 import { ora } from '../ora';
-import { getExpoConfig } from '../project/expoConfig';
-import { findProjectRootAsync, getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
+import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 
 export default class Open extends EasCommand {
   static override description = 'open the project page in a web browser';
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     // this command is interactive by nature (only really run by humans in a terminal)
-    const { projectId } = await this.getContextAsync(Open, {
+    const {
+      projectConfig: { projectId, exp },
+    } = await this.getContextAsync(Open, {
       nonInteractive: false,
     });
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
 
     const account = await getOwnerAccountForProjectIdAsync(projectId);
 

--- a/packages/eas-cli/src/commands/open.ts
+++ b/packages/eas-cli/src/commands/open.ts
@@ -1,25 +1,26 @@
 import openBrowserAsync from 'better-opn';
 
 import { getProjectDashboardUrl } from '../build/utils/url';
-import EasCommand from '../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../commandUtils/EasCommand';
 import { ora } from '../ora';
 import { getExpoConfig } from '../project/expoConfig';
-import {
-  findProjectRootAsync,
-  getOwnerAccountForProjectIdAsync,
-  getProjectIdAsync,
-} from '../project/projectUtils';
+import { findProjectRootAsync, getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 
 export default class Open extends EasCommand {
   static override description = 'open the project page in a web browser';
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
+    // this command is interactive by nature (only really run by humans in a terminal)
+    const { projectId } = await this.getContextAsync(Open, {
+      nonInteractive: false,
+    });
     const projectDir = await findProjectRootAsync();
     const exp = getExpoConfig(projectDir);
 
-    // this command is interactive by nature (only really run by humans in a terminal)
-    // this ensures the project exists before opening the browser
-    const projectId = await getProjectIdAsync(exp, { nonInteractive: false });
     const account = await getOwnerAccountForProjectIdAsync(projectId);
 
     const projectName = exp.slug;

--- a/packages/eas-cli/src/commands/project/info.ts
+++ b/packages/eas-cli/src/commands/project/info.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import { AppInfoQuery, AppInfoQueryVariables } from '../../graphql/generated';
 import Log from '../../log';
@@ -33,11 +33,13 @@ export default class ProjectInfo extends EasCommand {
   static override description = 'information about the current project';
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
-    const { projectId } = await this.getContextAsync(ProjectInfo, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(ProjectInfo, {
       nonInteractive: true,
     });
 

--- a/packages/eas-cli/src/commands/project/info.ts
+++ b/packages/eas-cli/src/commands/project/info.ts
@@ -1,11 +1,9 @@
 import gql from 'graphql-tag';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { graphqlClient, withErrorHandlingAsync } from '../../graphql/client';
 import { AppInfoQuery, AppInfoQueryVariables } from '../../graphql/generated';
 import Log from '../../log';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import formatFields from '../../utils/formatFields';
 
 async function projectInfoByIdAsync(appId: string): Promise<AppInfoQuery> {
@@ -34,12 +32,14 @@ async function projectInfoByIdAsync(appId: string): Promise<AppInfoQuery> {
 export default class ProjectInfo extends EasCommand {
   static override description = 'information about the current project';
 
-  async runAsync(): Promise<void> {
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
 
-    // this command is non-interactive by design
-    const projectId = await getProjectIdAsync(exp, { nonInteractive: true });
+  async runAsync(): Promise<void> {
+    const { projectId } = await this.getContextAsync(ProjectInfo, {
+      nonInteractive: true,
+    });
 
     const { app } = await projectInfoByIdAsync(projectId);
     if (!app) {

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
 import {
@@ -50,7 +50,7 @@ export default class EnvironmentSecretCreate extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -64,7 +64,9 @@ export default class EnvironmentSecretCreate extends EasCommand {
         'non-interactive': nonInteractive,
       },
     } = await this.parse(EnvironmentSecretCreate);
-    const { projectId } = await this.getContextAsync(EnvironmentSecretCreate, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(EnvironmentSecretCreate, {
       nonInteractive,
     });
 

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
 import {
@@ -16,12 +16,9 @@ import {
   SecretTypeToEnvironmentSecretType,
 } from '../../graphql/types/EnvironmentSecret';
 import Log from '../../log';
-import { getExpoConfig } from '../../project/expoConfig';
 import {
-  findProjectRootAsync,
   getDisplayNameForProjectIdAsync,
   getOwnerAccountForProjectIdAsync,
-  getProjectIdAsync,
 } from '../../project/projectUtils';
 import { promptAsync, selectAsync } from '../../prompts';
 
@@ -52,6 +49,10 @@ export default class EnvironmentSecretCreate extends EasCommand {
     ...EASNonInteractiveFlag,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     let {
       flags: {
@@ -63,10 +64,10 @@ export default class EnvironmentSecretCreate extends EasCommand {
         'non-interactive': nonInteractive,
       },
     } = await this.parse(EnvironmentSecretCreate);
+    const { projectId } = await this.getContextAsync(EnvironmentSecretCreate, {
+      nonInteractive,
+    });
 
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
     const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
     const ownerAccount = await getOwnerAccountForProjectIdAsync(projectId);
 

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
 import {
@@ -9,8 +9,6 @@ import {
   EnvironmentSecretsQuery,
 } from '../../graphql/queries/EnvironmentSecretsQuery';
 import Log from '../../log';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
 
 export default class EnvironmentSecretDelete extends EasCommand {
@@ -23,15 +21,18 @@ export default class EnvironmentSecretDelete extends EasCommand {
     ...EASNonInteractiveFlag,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     let {
       flags: { id, 'non-interactive': nonInteractive },
     } = await this.parse(EnvironmentSecretDelete);
+    const { projectId } = await this.getContextAsync(EnvironmentSecretDelete, {
+      nonInteractive,
+    });
     let secret: EnvironmentSecretWithScope | undefined;
-
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
 
     if (!id) {
       const validationMessage = 'You must select which secret to delete.';

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
 import {
@@ -22,14 +22,16 @@ export default class EnvironmentSecretDelete extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     let {
       flags: { id, 'non-interactive': nonInteractive },
     } = await this.parse(EnvironmentSecretDelete);
-    const { projectId } = await this.getContextAsync(EnvironmentSecretDelete, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(EnvironmentSecretDelete, {
       nonInteractive,
     });
     let secret: EnvironmentSecretWithScope | undefined;

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -2,26 +2,23 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 import dateFormat from 'dateformat';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EnvironmentSecretsQuery } from '../../graphql/queries/EnvironmentSecretsQuery';
 import { EnvironmentSecretTypeToSecretType } from '../../graphql/types/EnvironmentSecret';
 import Log from '../../log';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 
 export default class EnvironmentSecretList extends EasCommand {
   static override description = 'list environment secrets available for your current app';
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
-    const projectDir = await findProjectRootAsync();
-    if (!projectDir) {
-      throw new Error("Run this command inside your project's directory");
-    }
+    const { projectId } = await this.getContextAsync(EnvironmentSecretList, {
+      nonInteractive: true,
+    });
 
-    const exp = getExpoConfig(projectDir);
-
-    // this command is non-interacive by design
-    const projectId = await getProjectIdAsync(exp, { nonInteractive: true });
     const secrets = await EnvironmentSecretsQuery.allAsync(projectId);
 
     const table = new Table({

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 import dateFormat from 'dateformat';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EnvironmentSecretsQuery } from '../../graphql/queries/EnvironmentSecretsQuery';
 import { EnvironmentSecretTypeToSecretType } from '../../graphql/types/EnvironmentSecret';
 import Log from '../../log';
@@ -11,11 +11,13 @@ export default class EnvironmentSecretList extends EasCommand {
   static override description = 'list environment secrets available for your current app';
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
-    const { projectId } = await this.getContextAsync(EnvironmentSecretList, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(EnvironmentSecretList, {
       nonInteractive: true,
     });
 

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -3,8 +3,8 @@ import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
 
 import EasCommand, {
+  EASCommandDynamicProjectConfigContext,
   EASCommandLoggedInContext,
-  EASCommandProjectIdContext,
 } from '../commandUtils/EasCommand';
 import { StatuspageServiceName, SubmissionFragment } from '../graphql/generated';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
@@ -95,12 +95,14 @@ export default class Submit extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandLoggedInContext,
-    ...EASCommandProjectIdContext,
+    ...EASCommandDynamicProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     const { flags: rawFlags } = await this.parse(Submit);
-    const { actor, projectId } = await this.getContextAsync(Submit, { nonInteractive: false });
+    const { actor, getDynamicProjectConfigAsync } = await this.getContextAsync(Submit, {
+      nonInteractive: false,
+    });
 
     const flags = this.sanitizeFlags(rawFlags);
 
@@ -123,11 +125,11 @@ export default class Submit extends EasCommand {
       const ctx = await createSubmissionContextAsync({
         platform: submissionProfile.platform,
         projectDir,
-        projectId,
         profile: submissionProfile.profile,
         archiveFlags: flagsWithPlatform.archiveFlags,
         nonInteractive: flagsWithPlatform.nonInteractive,
         actor,
+        getDynamicProjectConfigAsync,
       });
 
       if (submissionProfiles.length > 1) {

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -5,11 +5,10 @@ import assert from 'assert';
 import chalk from 'chalk';
 
 import { getEASUpdateURL } from '../../api';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { AppPlatform } from '../../graphql/generated';
 import Log, { learnMore } from '../../log';
 import { RequestedPlatform, appPlatformDisplayNames } from '../../platform';
-import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
   installExpoUpdatesAsync,
@@ -35,7 +34,7 @@ export default class UpdateConfigure extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -43,12 +42,13 @@ export default class UpdateConfigure extends EasCommand {
       '💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.'
     );
     const { flags } = await this.parse(UpdateConfigure);
-    const { projectId } = await this.getContextAsync(UpdateConfigure, {
+    const {
+      projectConfig: { projectId, exp },
+    } = await this.getContextAsync(UpdateConfigure, {
       nonInteractive: true,
     });
     const platform = flags.platform as RequestedPlatform;
     const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
 
     if (!isExpoUpdatesInstalledOrAvailable(projectDir, exp.sdkVersion)) {
       await installExpoUpdatesAsync(projectDir);

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -5,14 +5,13 @@ import assert from 'assert';
 import chalk from 'chalk';
 
 import { getEASUpdateURL } from '../../api';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { AppPlatform } from '../../graphql/generated';
 import Log, { learnMore } from '../../log';
 import { RequestedPlatform, appPlatformDisplayNames } from '../../platform';
 import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
-  getProjectIdAsync,
   installExpoUpdatesAsync,
   isExpoUpdatesInstalledOrAvailable,
 } from '../../project/projectUtils';
@@ -35,11 +34,18 @@ export default class UpdateConfigure extends EasCommand {
     }),
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     Log.log(
       '💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.'
     );
     const { flags } = await this.parse(UpdateConfigure);
+    const { projectId } = await this.getContextAsync(UpdateConfigure, {
+      nonInteractive: true,
+    });
     const platform = flags.platform as RequestedPlatform;
     const projectDir = await findProjectRootAsync();
     const exp = getExpoConfig(projectDir);
@@ -61,6 +67,7 @@ export default class UpdateConfigure extends EasCommand {
         android: androidWorkflow,
         ios: iosWorkflow,
       },
+      projectId,
     });
     Log.withTick(`Configured ${chalk.bold('app.json')} for EAS Update`);
 
@@ -90,6 +97,7 @@ async function configureAppJSONForEASUpdateAsync({
   exp,
   platform,
   workflows,
+  projectId,
 }: {
   projectDir: string;
   exp: ExpoConfig;
@@ -97,9 +105,9 @@ async function configureAppJSONForEASUpdateAsync({
   workflows: {
     [key in RequestedPlatform.Android | RequestedPlatform.Ios]: Workflow;
   };
+  projectId: string;
 }): Promise<ExpoConfig> {
   // this command is non-interactive in the way it was designed
-  const projectId = await getProjectIdAsync(exp, { nonInteractive: true });
   const easUpdateURL = getEASUpdateURL(projectId);
   const updates = { ...exp.updates, url: easUpdateURL };
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -10,7 +10,7 @@ import { getEASUpdateURL } from '../../api';
 import { selectBranchOnAppAsync } from '../../branch/queries';
 import { BranchNotFoundError, getDefaultBranchNameAsync } from '../../branch/utils';
 import { getUpdateGroupUrl } from '../../build/utils/url';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandDynamicProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { getPaginatedQueryOptions } from '../../commandUtils/pagination';
 import fetch from '../../fetch';
@@ -27,7 +27,6 @@ import { BranchQuery } from '../../graphql/queries/BranchQuery';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import Log, { learnMore, link } from '../../log';
 import { ora } from '../../ora';
-import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
   getOwnerAccountForProjectIdAsync,
@@ -169,7 +168,7 @@ export default class UpdatePublish extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandDynamicProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -188,7 +187,7 @@ export default class UpdatePublish extends EasCommand {
       'non-interactive': nonInteractive,
       json: jsonFlag,
     } = flags;
-    const { projectId } = await this.getContextAsync(UpdatePublish, {
+    const { getDynamicProjectConfigAsync } = await this.getContextAsync(UpdatePublish, {
       nonInteractive,
     });
 
@@ -201,11 +200,11 @@ export default class UpdatePublish extends EasCommand {
     republish = republish || !!group;
 
     const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir, {
+    const { exp, projectId } = await getDynamicProjectConfigAsync({
       isPublicConfig: true,
     });
 
-    const expPrivate = getExpoConfig(projectDir, {
+    const { exp: expPrivate } = await getDynamicProjectConfigAsync({
       isPublicConfig: false,
     });
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -10,7 +10,7 @@ import { getEASUpdateURL } from '../../api';
 import { selectBranchOnAppAsync } from '../../branch/queries';
 import { BranchNotFoundError, getDefaultBranchNameAsync } from '../../branch/utils';
 import { getUpdateGroupUrl } from '../../build/utils/url';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { getPaginatedQueryOptions } from '../../commandUtils/pagination';
 import fetch from '../../fetch';
@@ -31,7 +31,6 @@ import { getExpoConfig } from '../../project/expoConfig';
 import {
   findProjectRootAsync,
   getOwnerAccountForProjectIdAsync,
-  getProjectIdAsync,
   installExpoUpdatesAsync,
   isExpoUpdatesInstalledOrAvailable,
 } from '../../project/projectUtils';
@@ -169,6 +168,10 @@ export default class UpdatePublish extends EasCommand {
     ...EasNonInteractiveAndJsonFlags,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(UpdatePublish);
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
@@ -185,6 +188,9 @@ export default class UpdatePublish extends EasCommand {
       'non-interactive': nonInteractive,
       json: jsonFlag,
     } = flags;
+    const { projectId } = await this.getContextAsync(UpdatePublish, {
+      nonInteractive,
+    });
 
     if (jsonFlag) {
       enableJsonOutput();
@@ -234,7 +240,6 @@ export default class UpdatePublish extends EasCommand {
     }
 
     const runtimeVersions = await getRuntimeVersionObjectAsync(exp, platformFlag, projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
     await checkEASUpdateURLIsSetAsync(exp, projectId);
 
     if (!branchName) {

--- a/packages/eas-cli/src/commands/update/list.ts
+++ b/packages/eas-cli/src/commands/update/list.ts
@@ -1,7 +1,7 @@
 import { Flags } from '@oclif/core';
 
 import { selectBranchOnAppAsync } from '../../branch/queries';
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import {
   EasPaginatedQueryFlags,
@@ -33,13 +33,15 @@ export default class UpdateList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(UpdateList);
     const { branch: branchFlag, all, json: jsonFlag, 'non-interactive': nonInteractive } = flags;
-    const { projectId } = await this.getContextAsync(UpdateList, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(UpdateList, {
       nonInteractive,
     });
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);

--- a/packages/eas-cli/src/commands/update/list.ts
+++ b/packages/eas-cli/src/commands/update/list.ts
@@ -1,15 +1,13 @@
 import { Flags } from '@oclif/core';
 
 import { selectBranchOnAppAsync } from '../../branch/queries';
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import {
   EasPaginatedQueryFlags,
   getLimitFlagWithCustomValues,
   getPaginatedQueryOptions,
 } from '../../commandUtils/pagination';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import {
   listAndRenderUpdateGroupsOnAppAsync,
   listAndRenderUpdateGroupsOnBranchAsync,
@@ -34,18 +32,21 @@ export default class UpdateList extends EasCommand {
     ...EasNonInteractiveAndJsonFlags,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(UpdateList);
     const { branch: branchFlag, all, json: jsonFlag, 'non-interactive': nonInteractive } = flags;
+    const { projectId } = await this.getContextAsync(UpdateList, {
+      nonInteractive,
+    });
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
 
     if (jsonFlag) {
       enableJsonOutput();
     }
-
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
 
     if (all) {
       listAndRenderUpdateGroupsOnAppAsync({ projectId, paginatedQueryOptions });

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -1,12 +1,10 @@
 import { Flags } from '@oclif/core';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
 import { ora } from '../../ora';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { prepareInputParamsAsync } from '../../webhooks/input';
 
 export default class WebhookCreate extends EasCommand {
@@ -27,14 +25,16 @@ export default class WebhookCreate extends EasCommand {
     ...EASNonInteractiveFlag,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(WebhookCreate);
+    const { projectId } = await this.getContextAsync(WebhookCreate, {
+      nonInteractive: flags['non-interactive'],
+    });
     const webhookInputParams = await prepareInputParamsAsync(flags);
-
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-
-    const projectId = await getProjectIdAsync(exp, { nonInteractive: flags['non-interactive'] });
 
     const spinner = ora('Creating a webhook').start();
     try {

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
@@ -26,12 +26,14 @@ export default class WebhookCreate extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(WebhookCreate);
-    const { projectId } = await this.getContextAsync(WebhookCreate, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(WebhookCreate, {
       nonInteractive: flags['non-interactive'],
     });
     const webhookInputParams = await prepareInputParamsAsync(flags);

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { WebhookFragment } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
@@ -28,7 +28,7 @@ export default class WebhookDelete extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
@@ -36,7 +36,9 @@ export default class WebhookDelete extends EasCommand {
       args: { ID: webhookId },
       flags: { 'non-interactive': nonInteractive },
     } = await this.parse(WebhookDelete);
-    const { projectId } = await this.getContextAsync(WebhookDelete, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(WebhookDelete, {
       nonInteractive,
     });
 

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -2,15 +2,13 @@ import assert from 'assert';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { WebhookFragment } from '../../graphql/generated';
 import { WebhookMutation } from '../../graphql/mutations/WebhookMutation';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import Log from '../../log';
 import { ora } from '../../ora';
-import { getExpoConfig } from '../../project/expoConfig';
-import { findProjectRootAsync, getProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync, toggleConfirmAsync } from '../../prompts';
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
@@ -29,15 +27,18 @@ export default class WebhookDelete extends EasCommand {
     ...EASNonInteractiveFlag,
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     let {
       args: { ID: webhookId },
       flags: { 'non-interactive': nonInteractive },
     } = await this.parse(WebhookDelete);
-
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-    const projectId = await getProjectIdAsync(exp, { nonInteractive });
+    const { projectId } = await this.getContextAsync(WebhookDelete, {
+      nonInteractive,
+    });
 
     let webhook: WebhookFragment | undefined =
       webhookId && (await WebhookQuery.byIdAsync(webhookId));

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -1,17 +1,12 @@
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
-import EasCommand from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import Log from '../../log';
 import { ora } from '../../ora';
-import { getExpoConfig } from '../../project/expoConfig';
-import {
-  findProjectRootAsync,
-  getDisplayNameForProjectIdAsync,
-  getProjectIdAsync,
-} from '../../project/projectUtils';
+import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { formatWebhook } from '../../webhooks/formatWebhook';
 
 export default class WebhookList extends EasCommand {
@@ -24,16 +19,18 @@ export default class WebhookList extends EasCommand {
     }),
   };
 
+  static override contextDefinition = {
+    ...EASCommandProjectIdContext,
+  };
+
   async runAsync(): Promise<void> {
     const {
       flags: { event },
     } = await this.parse(WebhookList);
+    const { projectId } = await this.getContextAsync(WebhookList, {
+      nonInteractive: true,
+    });
 
-    const projectDir = await findProjectRootAsync();
-    const exp = getExpoConfig(projectDir);
-
-    // this command is non-interactive by design
-    const projectId = await getProjectIdAsync(exp, { nonInteractive: true });
     const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
 
     const spinner = ora(`Fetching the list of webhook on project ${projectDisplayName}`).start();

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -1,7 +1,7 @@
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
-import EasCommand, { EASCommandProjectIdContext } from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import Log from '../../log';
@@ -20,14 +20,16 @@ export default class WebhookList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...EASCommandProjectIdContext,
+    ...EASCommandProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     const {
       flags: { event },
     } = await this.parse(WebhookList);
-    const { projectId } = await this.getContextAsync(WebhookList, {
+    const {
+      projectConfig: { projectId },
+    } = await this.getContextAsync(WebhookList, {
       nonInteractive: true,
     });
 

--- a/packages/eas-cli/src/metadata/context.ts
+++ b/packages/eas-cli/src/metadata/context.ts
@@ -6,7 +6,6 @@ import assert from 'assert';
 
 import { CredentialsContext } from '../credentials/context';
 import { getRequestContext } from '../credentials/ios/appstore/authenticate';
-import { getExpoConfig } from '../project/expoConfig';
 import { getBundleIdentifierAsync } from '../project/ios/bundleIdentifier';
 import { Actor } from '../user/User';
 
@@ -43,7 +42,7 @@ export type MetadataAppStoreAuthentication = {
 export async function createMetadataContextAsync(params: {
   projectDir: string;
   credentialsCtx: CredentialsContext;
-  exp?: ExpoConfig;
+  exp: ExpoConfig;
   profileName?: string;
 }): Promise<MetadataContext> {
   const easJsonAccessor = new EasJsonAccessor(params.projectDir);
@@ -53,7 +52,7 @@ export async function createMetadataContextAsync(params: {
     params.profileName
   );
 
-  const exp = params.exp ?? getExpoConfig(params.projectDir);
+  const exp = params.exp;
   const user = params.credentialsCtx.user;
   const bundleIdentifier =
     submitProfile.bundleIdentifier ?? (await getBundleIdentifierAsync(params.projectDir, exp));

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -1,12 +1,13 @@
 import { ExpoConfig, getConfig } from '@expo/config';
 import { Env } from '@expo/eas-build-job';
 
-interface Options {
+export interface ExpoConfigOptions {
   env?: Env;
   isPublicConfig?: boolean;
+  skipSDKVersionRequirement?: boolean;
 }
 
-export function getExpoConfig(projectDir: string, opts: Options = {}): ExpoConfig {
+export function getExpoConfig(projectDir: string, opts: ExpoConfigOptions = {}): ExpoConfig {
   const originalProcessEnv: NodeJS.ProcessEnv = process.env;
   try {
     process.env = {

--- a/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
@@ -64,11 +64,6 @@ describe(AndroidSubmitCommand, () => {
       ...testProject.projectTree,
       ...fakeFiles,
     });
-
-    const mockManifest = { exp: testProject.appJSON.expo };
-    jest.mock('@expo/config', () => ({
-      getConfig: jest.fn(() => mockManifest),
-    }));
   });
   afterAll(() => {
     vol.reset();
@@ -89,7 +84,6 @@ describe(AndroidSubmitCommand, () => {
       const ctx = await createSubmissionContextAsync({
         platform: Platform.ANDROID,
         projectDir: testProject.projectRoot,
-        projectId,
         archiveFlags: {
           url: 'http://expo.dev/fake.apk',
         },
@@ -100,6 +94,7 @@ describe(AndroidSubmitCommand, () => {
         },
         nonInteractive: true,
         actor: mockJester,
+        getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
       });
       const command = new AndroidSubmitCommand(ctx);
       await expect(command.runAsync()).rejects.toThrowError();
@@ -113,7 +108,6 @@ describe(AndroidSubmitCommand, () => {
       const ctx = await createSubmissionContextAsync({
         platform: Platform.ANDROID,
         projectDir: testProject.projectRoot,
-        projectId,
         archiveFlags: {
           url: 'http://expo.dev/fake.apk',
         },
@@ -125,6 +119,7 @@ describe(AndroidSubmitCommand, () => {
         },
         nonInteractive: false,
         actor: mockJester,
+        getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
@@ -150,7 +145,6 @@ describe(AndroidSubmitCommand, () => {
       const ctx = await createSubmissionContextAsync({
         platform: Platform.ANDROID,
         projectDir: testProject.projectRoot,
-        projectId,
         archiveFlags: {
           latest: true,
         },
@@ -162,6 +156,7 @@ describe(AndroidSubmitCommand, () => {
         },
         nonInteractive: false,
         actor: mockJester,
+        getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();

--- a/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
@@ -33,10 +33,6 @@ const testProject = createTestProject(testProjectId, mockJester.accounts[0].name
     package: 'com.expo.test.project',
   },
 });
-const mockManifest = { exp: testProject.appJSON.expo };
-jest.mock('@expo/config', () => ({
-  getConfig: jest.fn(() => mockManifest),
-}));
 
 const projectId = uuidv4();
 const mockDetectableServiceAccountJson = JSON.stringify({
@@ -143,7 +139,6 @@ describe(getServiceAccountKeyResultAsync, () => {
     const ctx = await createSubmissionContextAsync({
       platform: Platform.ANDROID,
       projectDir: testProject.projectRoot,
-      projectId,
       archiveFlags: {
         url: 'http://expo.dev/fake.apk',
       },
@@ -154,6 +149,7 @@ describe(getServiceAccountKeyResultAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
+      getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
     });
     const source: ServiceAccountSource = {
       sourceType: ServiceAccountSourceType.path,
@@ -179,7 +175,6 @@ describe(getServiceAccountKeyResultAsync, () => {
     const ctx = await createSubmissionContextAsync({
       platform: Platform.ANDROID,
       projectDir: testProject.projectRoot,
-      projectId,
       archiveFlags: {
         url: 'http://expo.dev/fake.apk',
       },
@@ -190,6 +185,7 @@ describe(getServiceAccountKeyResultAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
+      getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
     });
     const source: ServiceAccountSource = {
       sourceType: ServiceAccountSourceType.prompt,
@@ -211,7 +207,6 @@ describe(getServiceAccountKeyResultAsync, () => {
     const ctx = await createSubmissionContextAsync({
       platform: Platform.ANDROID,
       projectDir: testProject.projectRoot,
-      projectId,
       archiveFlags: {
         url: 'http://expo.dev/fake.apk',
       },
@@ -222,6 +217,7 @@ describe(getServiceAccountKeyResultAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
+      getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
     });
     const serviceAccountResult = await getServiceAccountKeyResultAsync(ctx, {
       sourceType: ServiceAccountSourceType.credentialsService,

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -5,8 +5,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { TrackingContext } from '../analytics/common';
 import { Analytics, SubmissionEvent } from '../analytics/events';
+import { DynamicConfigContextFn } from '../commandUtils/EasCommand';
 import { CredentialsContext } from '../credentials/context';
-import { getExpoConfig } from '../project/expoConfig';
 import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 import { Actor } from '../user/User';
 
@@ -41,15 +41,15 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
   platform: T;
   profile: SubmitProfile<T>;
   projectDir: string;
-  projectId: string;
   applicationIdentifier?: string;
   actor: Actor;
+  getDynamicProjectConfigAsync: DynamicConfigContextFn;
 }): Promise<SubmissionContext<T>> {
   const { applicationIdentifier, projectDir, nonInteractive, actor } = params;
-  const exp = getExpoConfig(projectDir, { env: params.env });
+  const { exp, projectId } = await params.getDynamicProjectConfigAsync({ env: params.env });
   const { env, ...rest } = params;
   const projectName = exp.slug;
-  const account = await getOwnerAccountForProjectIdAsync(params.projectId);
+  const account = await getOwnerAccountForProjectIdAsync(projectId);
   const accountId = account.id;
   let credentialsCtx: CredentialsContext | undefined = params.credentialsCtx;
   if (!credentialsCtx) {
@@ -60,7 +60,7 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
     tracking_id: uuidv4(),
     platform: params.platform,
     ...(accountId && { account_id: accountId }),
-    project_id: params.projectId,
+    project_id: projectId,
   };
 
   Analytics.logEvent(SubmissionEvent.SUBMIT_COMMAND, trackingCtx);
@@ -73,6 +73,7 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
     projectName,
     user: actor,
     trackingCtx,
+    projectId,
     applicationIdentifierOverride: applicationIdentifier,
   };
 }

--- a/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
@@ -32,17 +32,12 @@ const testProject = createTestProject(testProjectId, mockJester.accounts[0].name
     package: 'com.expo.test.project',
   },
 });
-const mockManifest = { exp: testProject.appJSON.expo };
-jest.mock('@expo/config', () => ({
-  getConfig: jest.fn(() => mockManifest),
-}));
 const projectId = uuidv4();
 
 async function getIosSubmissionContextAsync(): Promise<SubmissionContext<Platform.IOS>> {
   return await createSubmissionContextAsync({
     platform: Platform.IOS,
     projectDir: testProject.projectRoot,
-    projectId,
     archiveFlags: {
       url: 'http://expo.dev/fake.apk',
     },
@@ -51,6 +46,7 @@ async function getIosSubmissionContextAsync(): Promise<SubmissionContext<Platfor
     },
     nonInteractive: true,
     actor: mockJester,
+    getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
   });
 }
 

--- a/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
@@ -32,10 +32,6 @@ const testProject = createTestProject(testProjectId, mockJester.accounts[0].name
     package: 'com.expo.test.project',
   },
 });
-const mockManifest = { exp: testProject.appJSON.expo };
-jest.mock('@expo/config', () => ({
-  getConfig: jest.fn(() => mockManifest),
-}));
 const projectId = uuidv4();
 
 beforeEach(() => {
@@ -51,7 +47,6 @@ describe(getFromCredentialsServiceAsync, () => {
     const ctx = await createSubmissionContextAsync({
       platform: Platform.IOS,
       projectDir: testProject.projectRoot,
-      projectId,
       archiveFlags: {
         url: 'http://expo.dev/fake.apk',
       },
@@ -60,6 +55,7 @@ describe(getFromCredentialsServiceAsync, () => {
       },
       nonInteractive: false,
       actor: mockJester,
+      getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
     });
     jest
       .spyOn(SetUpSubmissionCredentials.prototype, 'runAsync')
@@ -79,7 +75,6 @@ describe(getFromCredentialsServiceAsync, () => {
     const ctx = await createSubmissionContextAsync({
       platform: Platform.IOS,
       projectDir: testProject.projectRoot,
-      projectId,
       archiveFlags: {
         url: 'http://expo.dev/fake.apk',
       },
@@ -88,6 +83,7 @@ describe(getFromCredentialsServiceAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
+      getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
     });
     jest
       .spyOn(SetUpSubmissionCredentials.prototype, 'runAsync')

--- a/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
@@ -39,11 +39,6 @@ describe(IosSubmitCommand, () => {
       ...testProject.projectTree,
       ...fakeFiles,
     });
-
-    const mockManifest = { exp: testProject.appJSON.expo };
-    jest.mock('@expo/config', () => ({
-      getConfig: jest.fn(() => mockManifest),
-    }));
   });
   afterAll(() => {
     vol.reset();
@@ -65,7 +60,6 @@ describe(IosSubmitCommand, () => {
       const ctx = await createSubmissionContextAsync({
         platform: Platform.IOS,
         projectDir: testProject.projectRoot,
-        projectId,
         archiveFlags: {
           url: 'http://expo.dev/fake.ipa',
         },
@@ -74,6 +68,7 @@ describe(IosSubmitCommand, () => {
         },
         nonInteractive: true,
         actor: mockJester,
+        getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
       });
       const command = new IosSubmitCommand(ctx);
       await expect(command.runAsync()).rejects.toThrowError();
@@ -89,7 +84,6 @@ describe(IosSubmitCommand, () => {
       const ctx = await createSubmissionContextAsync({
         platform: Platform.IOS,
         projectDir: testProject.projectRoot,
-        projectId,
         archiveFlags: {
           url: 'http://expo.dev/fake.ipa',
         },
@@ -100,6 +94,7 @@ describe(IosSubmitCommand, () => {
         },
         nonInteractive: false,
         actor: mockJester,
+        getDynamicProjectConfigAsync: async () => ({ exp: testProject.appJSON.expo, projectId }),
       });
       const command = new IosSubmitCommand(ctx);
       await command.runAsync();


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Same as https://github.com/expo/eas-cli/pull/1384 but for `projectId`.

# How

Replace most of `getProjectIdAsync` with the new context param.

# Test Plan

`yarn test`

Run all changed commands as a sanity check.
