### PR TITLE
[13/n][eas-cli] Use projectId context in remaining commands

### DIFF
--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -91,7 +91,7 @@ export async function prepareAndroidBuildAsync(
           ctx.easJsonCliConfig?.appVersionSource === AppVersionSource.REMOTE
             ? false
             : ctx.buildProfile.autoIncrement,
-        nonInteractive: ctx.nonInteractive,
+        projectId: ctx.projectId,
       });
     },
     prepareJobAsync: async (

--- a/packages/eas-cli/src/build/android/syncProjectConfiguration.ts
+++ b/packages/eas-cli/src/build/android/syncProjectConfiguration.ts
@@ -16,12 +16,12 @@ export async function syncProjectConfigurationAsync({
   projectDir,
   exp,
   localAutoIncrement,
-  nonInteractive,
+  projectId,
 }: {
   projectDir: string;
   exp: ExpoConfig;
   localAutoIncrement?: AndroidVersionAutoIncrement;
-  nonInteractive: boolean;
+  projectId: string;
 }): Promise<void> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
   const versionBumpStrategy = resolveVersionBumpStrategy(localAutoIncrement ?? false);
@@ -29,7 +29,7 @@ export async function syncProjectConfigurationAsync({
   if (workflow === Workflow.GENERIC) {
     await cleanUpOldEasBuildGradleScriptAsync(projectDir);
     if (isExpoUpdatesInstalled(projectDir)) {
-      await syncUpdatesConfigurationAsync(projectDir, exp, { nonInteractive });
+      await syncUpdatesConfigurationAsync(projectDir, exp, projectId);
     }
     await bumpVersionAsync({ projectDir, exp, bumpStrategy: versionBumpStrategy });
   } else {

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -56,7 +56,7 @@ export async function createBuildContextAsync<T extends Platform>({
   const runFromCI = getenv.boolish('CI', false);
 
   const credentialsCtx = new CredentialsContext({
-    exp,
+    projectInfo: { exp, projectId },
     nonInteractive,
     projectDir,
     user: actor,

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -80,7 +80,7 @@ export async function prepareIosBuildAsync(
           ctx.easJsonCliConfig?.appVersionSource === AppVersionSource.REMOTE
             ? false
             : ctx.buildProfile.autoIncrement,
-        nonInteractive: ctx.nonInteractive,
+        projectId: ctx.projectId,
       });
     },
     prepareJobAsync: async (

--- a/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts
+++ b/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts
@@ -13,20 +13,20 @@ export async function syncProjectConfigurationAsync({
   exp,
   targets,
   localAutoIncrement,
-  nonInteractive,
+  projectId,
 }: {
   projectDir: string;
   exp: ExpoConfig;
   targets: Target[];
   localAutoIncrement?: IosVersionAutoIncrement;
-  nonInteractive: boolean;
+  projectId: string;
 }): Promise<void> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
   const versionBumpStrategy = resolveVersionBumpStrategy(localAutoIncrement ?? false);
 
   if (workflow === Workflow.GENERIC) {
     if (isExpoUpdatesInstalled(projectDir)) {
-      await syncUpdatesConfigurationAsync(projectDir, exp, { nonInteractive });
+      await syncUpdatesConfigurationAsync(projectDir, exp, projectId);
     }
     await bumpVersionAsync({ projectDir, exp, bumpStrategy: versionBumpStrategy, targets });
   } else {

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -76,6 +76,35 @@ export class DynamicProjectConfigContextField extends ContextField<DynamicConfig
   }
 }
 
+export class OptionalProjectConfigContextField extends ContextField<
+  | {
+      projectId: string;
+      exp: ExpoConfig;
+    }
+  | undefined
+> {
+  async getValueAsync({ nonInteractive }: ContextOptions): Promise<
+    | {
+        projectId: string;
+        exp: ExpoConfig;
+      }
+    | undefined
+  > {
+    let projectDir: string;
+    try {
+      projectDir = await findProjectRootAsync();
+      if (!projectDir) {
+        return undefined;
+      }
+    } catch {
+      return undefined;
+    }
+
+    const exp = getExpoConfig(projectDir);
+    return { exp, projectId: await getProjectIdAsync(exp, { nonInteractive }) };
+  }
+}
+
 export class ActorContextField extends ContextField<Actor> {
   async getValueAsync({ nonInteractive }: ContextOptions): Promise<Actor> {
     return await ensureLoggedInAsync({ nonInteractive });
@@ -89,6 +118,10 @@ export const EASCommandProjectConfigContext = {
 export const EASCommandDynamicProjectConfigContext = {
   // eslint-disable-next-line async-protect/async-suffix
   getDynamicProjectConfigAsync: new DynamicProjectConfigContextField(),
+};
+
+export const EASCommandOptionalProjectConfigContext = {
+  projectConfig: new OptionalProjectConfigContextField(),
 };
 
 export const EASCommandLoggedInContext = {

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -32,7 +32,7 @@ export default class BuildConfigure extends EasCommand {
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildConfigure);
     const {
-      projectConfig: { exp },
+      projectConfig: { exp, projectId },
     } = await this.getContextAsync(BuildConfigure, {
       nonInteractive: false,
     });
@@ -66,14 +66,14 @@ export default class BuildConfigure extends EasCommand {
       if ([RequestedPlatform.Android, RequestedPlatform.All].includes(platform)) {
         const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
         if (workflow === Workflow.GENERIC) {
-          await syncAndroidUpdatesConfigurationAsync(projectDir, exp, { nonInteractive: false });
+          await syncAndroidUpdatesConfigurationAsync(projectDir, exp, projectId);
         }
       }
 
       if ([RequestedPlatform.Ios, RequestedPlatform.All].includes(platform)) {
         const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
         if (workflow === Workflow.GENERIC) {
-          await syncIosUpdatesConfigurationAsync(projectDir, exp, { nonInteractive: false });
+          await syncIosUpdatesConfigurationAsync(projectDir, exp, projectId);
         }
       }
     }

--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -1,6 +1,9 @@
 import { Flags } from '@oclif/core';
 
-import EasCommand, { EASCommandLoggedInContext } from '../commandUtils/EasCommand';
+import EasCommand, {
+  EASCommandLoggedInContext,
+  EASCommandOptionalProjectConfigContext,
+} from '../commandUtils/EasCommand';
 import { SelectPlatform } from '../credentials/manager/SelectPlatform';
 
 export default class Credentials extends EasCommand {
@@ -12,12 +15,15 @@ export default class Credentials extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandLoggedInContext,
+    ...EASCommandOptionalProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(Credentials);
-    const { actor } = await this.getContextAsync(Credentials, { nonInteractive: false });
+    const { actor, projectConfig } = await this.getContextAsync(Credentials, {
+      nonInteractive: false,
+    });
 
-    await new SelectPlatform(actor, flags.platform).runAsync();
+    await new SelectPlatform(actor, projectConfig ?? null, flags.platform).runAsync();
   }
 }

--- a/packages/eas-cli/src/commands/device/create.ts
+++ b/packages/eas-cli/src/commands/device/create.ts
@@ -1,4 +1,7 @@
-import EasCommand, { EASCommandLoggedInContext } from '../../commandUtils/EasCommand';
+import EasCommand, {
+  EASCommandLoggedInContext,
+  EASCommandOptionalProjectConfigContext,
+} from '../../commandUtils/EasCommand';
 import AppStoreApi from '../../credentials/ios/appstore/AppStoreApi';
 import { createContextAsync } from '../../devices/context';
 import DeviceManager from '../../devices/manager';
@@ -8,13 +11,20 @@ export default class DeviceCreate extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandLoggedInContext,
+    ...EASCommandOptionalProjectConfigContext,
   };
 
   async runAsync(): Promise<void> {
     // this command is interactive by design
-    const { actor } = await this.getContextAsync(DeviceCreate, { nonInteractive: false });
+    const { actor, projectConfig } = await this.getContextAsync(DeviceCreate, {
+      nonInteractive: false,
+    });
 
-    const ctx = await createContextAsync({ appStore: new AppStoreApi(), user: actor });
+    const ctx = await createContextAsync({
+      appStore: new AppStoreApi(),
+      user: actor,
+      projectId: projectConfig?.projectId,
+    });
     const manager = new DeviceManager(ctx);
     await manager.createAsync();
   }

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -36,7 +36,7 @@ export default class MetadataPull extends EasCommand {
     const { flags } = await this.parse(MetadataPull);
     const {
       actor,
-      projectConfig: { exp },
+      projectConfig: { exp, projectId },
     } = await this.getContextAsync(MetadataPull, {
       nonInteractive: false,
     });
@@ -47,7 +47,7 @@ export default class MetadataPull extends EasCommand {
     await ensureProjectConfiguredAsync({ projectDir, nonInteractive: false });
 
     const credentialsCtx = new CredentialsContext({
-      exp,
+      projectInfo: { exp, projectId },
       projectDir,
       user: actor,
       nonInteractive: false,

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -34,7 +34,7 @@ export default class MetadataPush extends EasCommand {
     const { flags } = await this.parse(MetadataPush);
     const {
       actor,
-      projectConfig: { exp },
+      projectConfig: { exp, projectId },
     } = await this.getContextAsync(MetadataPush, {
       nonInteractive: false,
     });
@@ -45,7 +45,7 @@ export default class MetadataPush extends EasCommand {
     await ensureProjectConfiguredAsync({ projectDir, nonInteractive: false });
 
     const credentialsCtx = new CredentialsContext({
-      exp,
+      projectInfo: { exp, projectId },
       projectDir,
       user: actor,
       nonInteractive: false,

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -76,14 +76,14 @@ export default class UpdateConfigure extends EasCommand {
       [RequestedPlatform.Android, RequestedPlatform.All].includes(platform) &&
       androidWorkflow === Workflow.GENERIC
     ) {
-      await syncAndroidUpdatesConfigurationAsync(projectDir, updatedExp, { nonInteractive: true });
+      await syncAndroidUpdatesConfigurationAsync(projectDir, updatedExp, projectId);
       Log.withTick(`Configured ${chalk.bold('AndroidManifest.xml')} for EAS Update`);
     }
     if (
       [RequestedPlatform.Ios, RequestedPlatform.All].includes(platform) &&
       iosWorkflow === Workflow.GENERIC
     ) {
-      await syncIosUpdatesConfigurationAsync(projectDir, updatedExp, { nonInteractive: true });
+      await syncIosUpdatesConfigurationAsync(projectDir, updatedExp, projectId);
       Log.withTick(`Configured ${chalk.bold('Expo.plist')} for EAS Update`);
     }
 

--- a/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
@@ -8,7 +8,6 @@ import { GradleBuildContext } from '../../../project/android/gradle';
 import {
   getOwnerAccountForProjectIdAsync,
   getProjectConfigDescription,
-  getProjectIdAsync,
 } from '../../../project/projectUtils';
 import { promptAsync } from '../../../prompts';
 import { CredentialsContext } from '../../context';
@@ -93,7 +92,7 @@ export async function getAppLookupParamsFromContextAsync(
 ): Promise<AppLookupParams> {
   ctx.ensureProjectContext();
   const projectName = ctx.exp.slug;
-  const projectId = await getProjectIdAsync(ctx.exp, { nonInteractive: ctx.nonInteractive });
+  const projectId = ctx.projectId;
   const account = await getOwnerAccountForProjectIdAsync(projectId);
 
   const androidApplicationIdentifier = await getApplicationIdAsync(

--- a/packages/eas-cli/src/credentials/android/actions/CreateKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/CreateKeystore.ts
@@ -1,6 +1,5 @@
 import { AccountFragment, AndroidKeystoreFragment } from '../../../graphql/generated';
 import Log from '../../../log';
-import { getProjectIdAsync } from '../../../project/projectUtils';
 import { CredentialsContext } from '../../context';
 import { askForUserProvidedAsync } from '../../utils/promptForCredentials';
 import { KeystoreWithType, keystoreSchema } from '../credentials';
@@ -15,7 +14,7 @@ export class CreateKeystore {
       throw new Error(`New keystore cannot be created in non-interactive mode.`);
     }
 
-    const projectId = await getProjectIdAsync(ctx.exp, { nonInteractive: ctx.nonInteractive });
+    const projectId = ctx.projectId;
     const keystore = await this.provideOrGenerateAsync(projectId);
     const keystoreFragment = await ctx.android.createKeystoreAsync(this.account, keystore);
     Log.succeed('Created keystore');

--- a/packages/eas-cli/src/credentials/ios/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/BuildCredentialsUtils.ts
@@ -7,7 +7,7 @@ import {
   IosDistributionType as GraphQLIosDistributionType,
   IosAppBuildCredentialsFragment,
 } from '../../../graphql/generated';
-import { getOwnerAccountForProjectIdAsync, getProjectIdAsync } from '../../../project/projectUtils';
+import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
 import { CredentialsContext } from '../../context';
 import { AppLookupParams } from '../api/graphql/types/AppLookupParams';
 import { App, Target } from '../types';
@@ -84,7 +84,7 @@ export async function assignBuildCredentialsAsync(
 export async function getAppFromContextAsync(ctx: CredentialsContext): Promise<App> {
   ctx.ensureProjectContext();
   const projectName = ctx.exp.slug;
-  const projectId = await getProjectIdAsync(ctx.exp, { nonInteractive: ctx.nonInteractive });
+  const projectId = ctx.projectId;
   const account = await getOwnerAccountForProjectIdAsync(projectId);
   return {
     account,

--- a/packages/eas-cli/src/credentials/manager/HelperActions.ts
+++ b/packages/eas-cli/src/credentials/manager/HelperActions.ts
@@ -1,10 +1,11 @@
 import Log from '../../log';
 import { pressAnyKeyToContinueAsync } from '../../prompts';
 import { Actor } from '../../user/User';
-import { CredentialsContext } from '../context';
+import { CredentialsContext, CredentialsContextProjectInfo } from '../context';
 
 export interface Action<T = void> {
   actor: Actor;
+  projectInfo: CredentialsContextProjectInfo | null;
   runAsync(ctx: CredentialsContext): Promise<T>;
 }
 

--- a/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
@@ -1,10 +1,15 @@
 import { selectPlatformAsync } from '../../platform';
 import { Actor } from '../../user/User';
+import { CredentialsContextProjectInfo } from '../context';
 import { ManageAndroid } from './ManageAndroid';
 import { ManageIos } from './ManageIos';
 
 export class SelectPlatform {
-  constructor(public readonly actor: Actor, private readonly flagPlatform?: string) {}
+  constructor(
+    public readonly actor: Actor,
+    public readonly projectInfo: CredentialsContextProjectInfo | null,
+    private readonly flagPlatform?: string
+  ) {}
 
   async runAsync(): Promise<void> {
     const platform = await selectPlatformAsync(this.flagPlatform);

--- a/packages/eas-cli/src/devices/__tests__/manager-test.ts
+++ b/packages/eas-cli/src/devices/__tests__/manager-test.ts
@@ -44,16 +44,6 @@ describe(AccountResolver, () => {
     };
 
     describe('when inside project dir', () => {
-      const exp = {
-        name: 'wat',
-        slug: 'wat',
-        extra: {
-          eas: {
-            projectId: '1234',
-          },
-        },
-      };
-
       beforeEach(() => {
         jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
           id: 'test-project-id',
@@ -72,7 +62,7 @@ describe(AccountResolver, () => {
           value: true,
         }));
 
-        const resolver = new AccountResolver(exp, user);
+        const resolver = new AccountResolver('1234', user);
         const account = await resolver.resolveAccountAsync();
         expect(account).toEqual({
           id: user.accounts[1].id,
@@ -89,7 +79,7 @@ describe(AccountResolver, () => {
           account: user.accounts[0],
         }));
 
-        const resolver = new AccountResolver(exp, user);
+        const resolver = new AccountResolver('1234', user);
         const account = await resolver.resolveAccountAsync();
         expect(account).toEqual(user.accounts[0]);
       });

--- a/packages/eas-cli/src/devices/context.ts
+++ b/packages/eas-cli/src/devices/context.ts
@@ -1,35 +1,24 @@
-import { ExpoConfig, getConfig } from '@expo/config';
-
 import AppStoreApi from '../credentials/ios/appstore/AppStoreApi';
-import { findProjectRootAsync } from '../project/projectUtils';
 import { Actor } from '../user/User';
 
 export interface DeviceManagerContext {
   appStore: AppStoreApi;
-  exp: ExpoConfig | null;
-  projectDir: string | null;
   user: Actor;
+  projectId: string | null;
 }
 
 export async function createContextAsync({
   appStore,
-  cwd,
   user,
+  projectId,
 }: {
   appStore: AppStoreApi;
-  cwd?: string;
   user: Actor;
+  projectId: string | undefined;
 }): Promise<DeviceManagerContext> {
-  const projectDir = await findProjectRootAsync({ cwd });
-  let exp: ExpoConfig | null = null;
-  if (projectDir) {
-    const config = getConfig(projectDir, { skipSDKVersionRequirement: true });
-    exp = config.exp;
-  }
   return {
     appStore,
-    projectDir,
-    exp,
     user,
+    projectId: projectId ?? null,
   };
 }

--- a/packages/eas-cli/src/devices/manager.ts
+++ b/packages/eas-cli/src/devices/manager.ts
@@ -1,4 +1,3 @@
-import { ExpoConfig } from '@expo/config';
 import assert from 'assert';
 import chalk from 'chalk';
 
@@ -6,7 +5,7 @@ import { AppleTeamMutation } from '../credentials/ios/api/graphql/mutations/Appl
 import { AppleTeamQuery } from '../credentials/ios/api/graphql/queries/AppleTeamQuery';
 import { AccountFragment, AppleTeamFragment } from '../graphql/generated';
 import Log from '../log';
-import { getOwnerAccountForProjectIdAsync, getProjectIdAsync } from '../project/projectUtils';
+import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 import { Choice, confirmAsync, promptAsync } from '../prompts';
 import { Actor } from '../user/User';
 import DeviceCreateAction from './actions/create/action';
@@ -38,16 +37,16 @@ export default class DeviceManager {
   }
 
   private async resolveAccountAsync(): Promise<AccountFragment> {
-    const resolver = new AccountResolver(this.ctx.exp, this.ctx.user);
+    const resolver = new AccountResolver(this.ctx.projectId, this.ctx.user);
     return await resolver.resolveAccountAsync();
   }
 }
 
 export class AccountResolver {
-  constructor(private exp: ExpoConfig | null, private user: Actor) {}
+  constructor(private projectId: string | null, private user: Actor) {}
 
   public async resolveAccountAsync(): Promise<AccountFragment> {
-    if (this.exp) {
+    if (this.projectId) {
       const account = await this.resolveProjectAccountAsync();
       if (account) {
         return account;
@@ -57,11 +56,8 @@ export class AccountResolver {
   }
 
   private async resolveProjectAccountAsync(): Promise<AccountFragment | undefined> {
-    assert(this.exp, 'expo config is not set');
-
-    // this command is interactive by design
-    const projectId = await getProjectIdAsync(this.exp, { nonInteractive: false });
-    const account = await getOwnerAccountForProjectIdAsync(projectId);
+    assert(this.projectId, 'expo config is not set');
+    const account = await getOwnerAccountForProjectIdAsync(this.projectId);
 
     const useProjectAccount = await confirmAsync({
       message: `You're inside the project directory. Would you like to use the ${chalk.underline(

--- a/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../graphql/generated';
 import { SubmissionMutation } from '../../../graphql/mutations/SubmissionMutation';
 import { createTestProject } from '../../../project/__tests__/project-utils';
-import { getOwnerAccountForProjectIdAsync, getProjectIdAsync } from '../../../project/projectUtils';
+import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
 import { createSubmissionContextAsync } from '../../context';
 import { getRecentBuildsForSubmissionAsync } from '../../utils/builds';
 import AndroidSubmitCommand from '../AndroidSubmitCommand';
@@ -71,10 +71,6 @@ describe(AndroidSubmitCommand, () => {
 
   beforeEach(() => {
     jest.mocked(getOwnerAccountForProjectIdAsync).mockResolvedValue(mockJester.accounts[0]);
-  });
-
-  afterEach(() => {
-    jest.mocked(getProjectIdAsync).mockClear();
   });
 
   describe('non-interactive mode', () => {

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -53,7 +53,12 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
   const accountId = account.id;
   let credentialsCtx: CredentialsContext | undefined = params.credentialsCtx;
   if (!credentialsCtx) {
-    credentialsCtx = new CredentialsContext({ projectDir, user: actor, exp, nonInteractive });
+    credentialsCtx = new CredentialsContext({
+      projectDir,
+      user: actor,
+      projectInfo: { exp, projectId },
+      nonInteractive,
+    });
   }
 
   const trackingCtx = {

--- a/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../credentials/__tests__/fixtures-constants';
 import { SubmissionMutation } from '../../../graphql/mutations/SubmissionMutation';
 import { createTestProject } from '../../../project/__tests__/project-utils';
-import { getOwnerAccountForProjectIdAsync, getProjectIdAsync } from '../../../project/projectUtils';
+import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
 import { createSubmissionContextAsync } from '../../context';
 import IosSubmitCommand from '../IosSubmitCommand';
 
@@ -47,10 +47,6 @@ describe(IosSubmitCommand, () => {
 
   beforeEach(() => {
     jest.mocked(getOwnerAccountForProjectIdAsync).mockResolvedValue(mockJester.accounts[0]);
-  });
-
-  afterEach(() => {
-    jest.mocked(getProjectIdAsync).mockClear();
   });
 
   describe('non-interactive mode', () => {

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -2,16 +2,15 @@ import { ExpoConfig } from '@expo/config';
 import { AndroidConfig, AndroidManifest } from '@expo/config-plugins';
 
 import { RequestedPlatform } from '../../platform';
-import { getOwnerAccountForProjectIdAsync, getProjectIdAsync } from '../../project/projectUtils';
+import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { ensureValidVersions } from '../utils';
 
 export async function syncUpdatesConfigurationAsync(
   projectDir: string,
   exp: ExpoConfig,
-  { nonInteractive }: { nonInteractive: boolean }
+  projectId: string
 ): Promise<void> {
   ensureValidVersions(exp, RequestedPlatform.Android);
-  const projectId = await getProjectIdAsync(exp, { nonInteractive });
   const accountName = (await getOwnerAccountForProjectIdAsync(projectId)).name;
 
   const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);

--- a/packages/eas-cli/src/update/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/ios/UpdatesModule.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
 
 import { RequestedPlatform } from '../../platform';
-import { getOwnerAccountForProjectIdAsync, getProjectIdAsync } from '../../project/projectUtils';
+import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { readPlistAsync, writePlistAsync } from '../../utils/plist';
 import { getVcsClient } from '../../vcs';
 import { ensureValidVersions } from '../utils';
@@ -10,10 +10,9 @@ import { ensureValidVersions } from '../utils';
 export async function syncUpdatesConfigurationAsync(
   projectDir: string,
   exp: ExpoConfig,
-  { nonInteractive }: { nonInteractive: boolean }
+  projectId: string
 ): Promise<void> {
   ensureValidVersions(exp, RequestedPlatform.Ios);
-  const projectId = await getProjectIdAsync(exp, { nonInteractive });
   const accountName = (await getOwnerAccountForProjectIdAsync(projectId)).name;
   const expoPlist = await readExpoPlistAsync(projectDir);
   const updatedExpoPlist = IOSConfig.Updates.setUpdatesConfig(


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Same as https://github.com/expo/eas-cli/pull/1387 but for the remaining commands.

Note that it seems that there's actually no need for `EASCommandProjectIdIfProjectDirContext` (both commands that use it require being run in a project directory) so it will be removed in the next PR.

# How

Add context arg where necessary, pipe through secondary derived contexts.

# Test Plan

`yarn test`, run all changed commands.
