### PR TITLE
[15/n][eas-cli] Remove allowUnauthenticated command configuration

### DIFF
--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -24,12 +24,6 @@ import GitClient from '../vcs/clients/git';
 
 export interface CommandConfiguration {
   /**
-   * When user data is unavailable locally, determines if the command will
-   * force the user to log in. By default, all commands require authentication.
-   */
-  allowUnauthenticated?: boolean;
-
-  /**
    * Whether a command can be run outside of an Expo project directory.
    * By default, all commands must be run inside an Expo project directory.
    */
@@ -180,14 +174,8 @@ export default abstract class EasCommand extends Command {
       await this.ensureEasCliIsNotInDependenciesAsync(projectDir);
     }
 
-    if (!this.commandConfiguration.allowUnauthenticated) {
-      const { flags } = await this.parse();
-      const nonInteractive = (flags as any)['non-interactive'] ?? false;
-      await ensureLoggedInAsync({ nonInteractive });
-    } else {
-      await getUserAsync();
-    }
-
+    // this is needed for logEvent call below as it identifies the user in the analytics system
+    await getUserAsync();
     logEvent(AnalyticsEvent.ACTION, {
       // id is assigned by oclif in constructor based on the filepath:
       // commands/submit === submit, commands/build/list === build:list

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -7,7 +7,6 @@ export default class AccountLogin extends EasCommand {
   static override aliases = ['login'];
 
   protected override commandConfiguration: CommandConfiguration = {
-    allowUnauthenticated: true,
     canRunOutsideProject: true,
   };
 

--- a/packages/eas-cli/src/commands/account/logout.ts
+++ b/packages/eas-cli/src/commands/account/logout.ts
@@ -7,7 +7,6 @@ export default class AccountLogout extends EasCommand {
   static override aliases = ['logout'];
 
   protected override commandConfiguration: CommandConfiguration = {
-    allowUnauthenticated: true,
     canRunOutsideProject: true,
   };
 

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -9,7 +9,6 @@ export default class AccountView extends EasCommand {
   static override aliases = ['whoami'];
 
   protected override commandConfiguration: CommandConfiguration = {
-    allowUnauthenticated: true,
     canRunOutsideProject: true,
   };
 

--- a/packages/eas-cli/src/commands/analytics.ts
+++ b/packages/eas-cli/src/commands/analytics.ts
@@ -1,4 +1,4 @@
-import EasCommand, { CommandConfiguration } from '../commandUtils/EasCommand';
+import EasCommand from '../commandUtils/EasCommand';
 import Log from '../log';
 import UserSettings from '../user/UserSettings';
 
@@ -6,10 +6,6 @@ export default class AnalyticsView extends EasCommand {
   static override description = 'display or change analytics settings';
 
   static override args = [{ name: 'STATUS', options: ['on', 'off'] }];
-
-  protected override commandConfiguration: CommandConfiguration = {
-    allowUnauthenticated: true,
-  };
 
   async runAsync(): Promise<void> {
     const { STATUS: status } = (await this.parse(AnalyticsView)).args;

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -4,10 +4,7 @@ import { EasJsonAccessor, EasJsonUtils } from '@expo/eas-json';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
-import EasCommand, {
-  CommandConfiguration,
-  EASCommandDynamicProjectConfigContext,
-} from '../commandUtils/EasCommand';
+import EasCommand, { EASCommandDynamicProjectConfigContext } from '../commandUtils/EasCommand';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log from '../log';
 import { appPlatformEmojis } from '../platform';
@@ -29,10 +26,6 @@ export default class Config extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandDynamicProjectConfigContext,
-  };
-
-  protected override commandConfiguration: CommandConfiguration = {
-    allowUnauthenticated: true,
   };
 
   async runAsync(): Promise<void> {

--- a/packages/eas-cli/src/commands/diagnostics.ts
+++ b/packages/eas-cli/src/commands/diagnostics.ts
@@ -1,7 +1,7 @@
 import { Platform } from '@expo/eas-build-job';
 import envinfo from 'envinfo';
 
-import EasCommand, { CommandConfiguration } from '../commandUtils/EasCommand';
+import EasCommand from '../commandUtils/EasCommand';
 import Log from '../log';
 import { findProjectRootAsync } from '../project/projectUtils';
 import { resolveWorkflowAsync } from '../project/workflow';
@@ -9,10 +9,6 @@ import { easCliVersion } from '../utils/easCli';
 
 export default class Diagnostics extends EasCommand {
   static override description = 'display environment info';
-
-  protected override commandConfiguration: CommandConfiguration = {
-    allowUnauthenticated: true,
-  };
 
   async runAsync(): Promise<void> {
     const info = await envinfo.run(


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

The `allowUnauthenticated` option is now automatically derived from the context. Put another way, if the command needs the projectId and doesn't have one, they will need to be authenticated. Also if the command requires the actor, they will need to be authenticated. Otherwise, the command can run in an unauthenticated manner.

# How

Remove the flag.

# Test Plan

Run tests. Run all commands that used to have this flag and ensure they still can be run while logged-out.
