### PR TITLE
[eas-cli] warn about channel configuration before build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add pagination to build commands. ([#1353](https://github.com/expo/eas-cli/pull/1353) by [@kgc00](https://github.com/kgc00))
 - Provide suggestions for developers when archive size is large. ([#1363](https://github.com/expo/eas-cli/pull/1363) by [@szdziedzic](https://github.com/szdziedzic))
 - Improve `eas init` command. ([#1376](https://github.com/expo/eas-cli/pull/1376) by [@wschurman](https://github.com/wschurman))
+- Warn about outdated channel configuration before build when using eas update. ([#1397](https://github.com/expo/eas-cli/pull/1397) by [@kbrandwijk](https://github.com/kbrandwijk))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -29,10 +29,7 @@ import {
 } from '../platform';
 import { checkExpoSdkIsSupportedAsync } from '../project/expoSdk';
 import { validateMetroConfigForManagedWorkflowAsync } from '../project/metroConfig';
-import {
-  getProjectIdAsync,
-  validateAppVersionRuntimePolicySupportAsync,
-} from '../project/projectUtils';
+import { validateAppVersionRuntimePolicySupportAsync } from '../project/projectUtils';
 import {
   validateAppConfigForRemoteVersionSource,
   validateBuildProfileVersionSettings,
@@ -263,11 +260,10 @@ async function prepareAndStartBuildAsync({
     );
   }
 
-  const projectId = await getProjectIdAsync(buildCtx.exp, { nonInteractive: flags.nonInteractive });
   await validateBuildProfileConfigMatchesProjectConfigAsync(
     buildCtx.exp,
     buildProfile,
-    projectId,
+    buildCtx.projectId,
     flags.nonInteractive
   );
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -29,7 +29,10 @@ import {
 } from '../platform';
 import { checkExpoSdkIsSupportedAsync } from '../project/expoSdk';
 import { validateMetroConfigForManagedWorkflowAsync } from '../project/metroConfig';
-import { validateAppVersionRuntimePolicySupportAsync } from '../project/projectUtils';
+import {
+  getProjectIdAsync,
+  validateAppVersionRuntimePolicySupportAsync,
+} from '../project/projectUtils';
 import {
   validateAppConfigForRemoteVersionSource,
   validateBuildProfileVersionSettings,
@@ -41,6 +44,7 @@ import {
   waitToCompleteAsync as waitForSubmissionsToCompleteAsync,
 } from '../submit/submit';
 import { printSubmissionDetailsUrls } from '../submit/utils/urls';
+import { validateBuildProfileConfigMatchesProjectConfigAsync } from '../update/utils';
 import { printJsonOnlyOutput } from '../utils/json';
 import { ProfileData, getProfilesAsync } from '../utils/profiles';
 import { getVcsClient } from '../vcs';
@@ -258,6 +262,15 @@ async function prepareAndStartBuildAsync({
       )}`
     );
   }
+
+  const projectId = await getProjectIdAsync(buildCtx.exp, { nonInteractive: flags.nonInteractive });
+  await validateBuildProfileConfigMatchesProjectConfigAsync(
+    buildCtx.exp,
+    buildProfile,
+    projectId,
+    flags.nonInteractive
+  );
+
   await validateAppVersionRuntimePolicySupportAsync(buildCtx.projectDir, buildCtx.exp);
   if (easJsonCliConfig?.appVersionSource === AppVersionSource.REMOTE) {
     validateAppConfigForRemoteVersionSource(buildCtx.exp, buildProfile.platform);

--- a/packages/eas-cli/src/update/utils.ts
+++ b/packages/eas-cli/src/update/utils.ts
@@ -3,11 +3,13 @@ import { format } from '@expo/timeago.js';
 import chalk from 'chalk';
 import dateFormat from 'dateformat';
 
+import { getEASUpdateURL } from '../api';
 import { Maybe, Robot, Update, UpdateFragment, User } from '../graphql/generated';
-import { learnMore } from '../log';
+import Log, { learnMore } from '../log';
 import { RequestedPlatform } from '../platform';
 import { getActorDisplayName } from '../user/User';
 import groupBy from '../utils/expodash/groupBy';
+import { ProfileData } from '../utils/profiles';
 
 export type FormatUpdateParameter = Pick<Update, 'id' | 'createdAt' | 'message'> & {
   actor?: Maybe<Pick<User, 'username' | 'id'> | Pick<Robot, 'firstName' | 'id'>>;
@@ -157,4 +159,43 @@ export function getUpdateGroupDescriptionsWithBranch(
     group: updateGroup[0].group,
     platforms: formatPlatformForUpdateGroup(updateGroup),
   }));
+}
+
+export async function checkEASUpdateURLIsSetAsync(
+  exp: ExpoConfig,
+  projectId: string
+): Promise<boolean> {
+  const configuredURL = exp.updates?.url;
+  const expectedURL = getEASUpdateURL(projectId);
+
+  return configuredURL === expectedURL;
+}
+
+export async function validateBuildProfileConfigMatchesProjectConfigAsync(
+  exp: ExpoConfig,
+  buildProfile: ProfileData<'build'>,
+  projectId: string,
+  nonInteractive: boolean
+): Promise<void> {
+  if ((await checkEASUpdateURLIsSetAsync(exp, projectId)) && buildProfile.profile.releaseChannel) {
+    const error = `Your project is configured for EAS Update, but build profile "${
+      buildProfile.profileName
+    }" in ${chalk.bold('eas.json')} specifies the \`releaseChannel\` property.
+For EAS Update, you need to specify the \`channel\` property, or your build will not be able to receive any updates
+
+${learnMore('https://docs.expo.dev/eas-update/getting-started/#configure-your-project')}`;
+
+    const warning = `» Your project is configured for EAS Update, but build profile "${
+      buildProfile.profileName
+    }" in ${chalk.bold('eas.json')} specifies the \`releaseChannel\` property.
+  For EAS Update, you need to specify the \`channel\` property, or your build will not be able to receive any updates
+
+  ${learnMore('https://docs.expo.dev/eas-update/getting-started/#configure-your-project')}`;
+
+    if (nonInteractive) {
+      Log.warn(warning);
+    } else {
+      throw new Error(error);
+    }
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Forgetting to migrate `releaseChannel` to `channel` is one of the most common issues with EAS Update. This PR addresses this by warning/erroring when the project is configured for EAS Update, but the build profile still uses `releaseChannel`. This is split off of my earlier PR, that tried to address this in 3 different places at once.

# How

For each build, check the buildProfile and project configuration. On non-interactive builds, display a warning. On interactive builds, throw an error. 
![image](https://user-images.githubusercontent.com/852069/191885228-1b03a7f4-84fa-45a9-8549-5e7a1cbde2c4.png)
![image](https://user-images.githubusercontent.com/852069/191885256-c3faa831-2c05-4deb-8762-ceb275859dc7.png)


# Test Plan

Tested locally with a variety of build profile configurations (more specifically, global vs per-platform configuration).
