### PR TITLE
[ENG-4932][eas-cli] handle errors form new platform-specific kill switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add and use command context to declare command dependencies.  ([#1383](https://github.com/expo/eas-cli/pull/1383), [#1384](https://github.com/expo/eas-cli/pull/1384), [#1387](https://github.com/expo/eas-cli/pull/1387), [#1388](https://github.com/expo/eas-cli/pull/1388), [#1390](https://github.com/expo/eas-cli/pull/1390), [#1391](https://github.com/expo/eas-cli/pull/1391), [#1394](https://github.com/expo/eas-cli/pull/1394), [#1402](https://github.com/expo/eas-cli/pull/1402), [#1403](https://github.com/expo/eas-cli/pull/1403), by [@wschurman](https://github.com/wschurman))
 - Fix typo in the ad hoc build message. ([#1407](https://github.com/expo/eas-cli/pull/1407) by [@Simek](https://github.com/Simek))
 - Improve errors and error messages formatting related to **eas.json**. ([#1414](https://github.com/expo/eas-cli/pull/1414) by [@Simek](https://github.com/Simek))
+- Handle errors from platform-specific kill switches to disable free tier builds. ([#1401](https://github.com/expo/eas-cli/pull/1401) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [2.1.0](https://github.com/expo/eas-cli/releases/tag/v2.1.0) - 2022-09-05
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -147,27 +147,27 @@ function handleBuildRequestError(error: any, platform: Platform): never {
     throw new Error('Build request failed.');
   } else if (error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED') {
     Log.error(
-      `EAS Build free tier is temporarily disabled. Try again later. Check ${link(
-        'https://status.expo.dev/'
-      )} for updates. ${learnMore('https://expo.fyi/eas-build-queues')}`
+      `EAS Build free tier is temporarily disabled and we are not accepting new builds. Try again later. ${learnMore(
+        'https://expo.fyi/eas-build-queues'
+      )}`
     );
     throw new Error('Build request failed.');
   } else if (
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED_IOS'
   ) {
     Log.error(
-      `EAS Build free tier is temporarily disabled for iOS. Try again later. Check ${link(
-        'https://status.expo.dev/'
-      )} for updates. ${learnMore('https://expo.fyi/eas-build-queues')}`
+      `EAS Build free tier is temporarily disabled for iOS and we are not accepting new builds. Try again later. ${learnMore(
+        'https://expo.fyi/eas-build-queues'
+      )}`
     );
     throw new Error('Build request failed.');
   } else if (
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED_ANDROID'
   ) {
     Log.error(
-      `EAS Build free tier is temporarily disabled for Android. Try again later. Check ${link(
-        'https://status.expo.dev/'
-      )} for updates. ${learnMore('https://expo.fyi/eas-build-queues')}`
+      `EAS Build free tier is temporarily disabled for Android and we are not accepting new builds. Try again later. ${learnMore(
+        'https://expo.fyi/eas-build-queues'
+      )}`
     );
     throw new Error('Build request failed.');
   } else if (

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -149,6 +149,20 @@ function handleBuildRequestError(error: any, platform: Platform): never {
     );
     throw new Error('Build request failed.');
   } else if (
+    error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED_IOS'
+  ) {
+    Log.error(
+      'EAS Build free tier is temporarily disabled for iOS. Try again later. Check https://status.expo.dev/ for updates.'
+    );
+    throw new Error('Build request failed.');
+  } else if (
+    error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED_ANDROID'
+  ) {
+    Log.error(
+      'EAS Build free tier is temporarily disabled for Android. Try again later. Check https://status.expo.dev/ for updates.'
+    );
+    throw new Error('Build request failed.');
+  } else if (
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_TOO_MANY_PENDING_BUILDS'
   ) {
     Log.error(

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -147,7 +147,7 @@ function handleBuildRequestError(error: any, platform: Platform): never {
     throw new Error('Build request failed.');
   } else if (error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED') {
     Log.error(
-      `EAS Build free tier is temporarily disabled and we are not accepting new builds. Try again later. ${learnMore(
+      `EAS Build free tier is temporarily disabled and we are not accepting any new builds. Try again later. ${learnMore(
         'https://expo.fyi/eas-build-queues'
       )}`
     );
@@ -156,7 +156,7 @@ function handleBuildRequestError(error: any, platform: Platform): never {
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED_IOS'
   ) {
     Log.error(
-      `EAS Build free tier is temporarily disabled for iOS and we are not accepting new builds. Try again later. ${learnMore(
+      `EAS Build free tier is temporarily disabled for iOS and we are not accepting any new builds. Try again later. ${learnMore(
         'https://expo.fyi/eas-build-queues'
       )}`
     );
@@ -165,7 +165,7 @@ function handleBuildRequestError(error: any, platform: Platform): never {
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED_ANDROID'
   ) {
     Log.error(
-      `EAS Build free tier is temporarily disabled for Android and we are not accepting new builds. Try again later. ${learnMore(
+      `EAS Build free tier is temporarily disabled for Android and we are not accepting any new builds. Try again later. ${learnMore(
         'https://expo.fyi/eas-build-queues'
       )}`
     );

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -18,7 +18,7 @@ import {
 } from '../graphql/generated';
 import { BuildResult } from '../graphql/mutations/BuildMutation';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
-import Log, { learnMore } from '../log';
+import Log, { learnMore, link } from '../log';
 import { Ora, ora } from '../ora';
 import {
   appPlatformDisplayNames,
@@ -140,26 +140,34 @@ function handleBuildRequestError(error: any, platform: Platform): never {
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_DOWN_FOR_MAINTENANCE'
   ) {
     Log.error(
-      'EAS Build is down for maintenance. Try again later. Check https://status.expo.dev/ for updates.'
+      `EAS Build is down for maintenance. Try again later. Check ${link(
+        'https://status.expo.dev/'
+      )} for updates.`
     );
     throw new Error('Build request failed.');
   } else if (error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED') {
     Log.error(
-      'EAS Build free tier is temporarily disabled. Try again later. Check https://status.expo.dev/ for updates.'
+      `EAS Build free tier is temporarily disabled. Try again later. Check ${link(
+        'https://status.expo.dev/'
+      )} for updates. ${learnMore('https://expo.fyi/eas-build-queues')}`
     );
     throw new Error('Build request failed.');
   } else if (
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED_IOS'
   ) {
     Log.error(
-      'EAS Build free tier is temporarily disabled for iOS. Try again later. Check https://status.expo.dev/ for updates.'
+      `EAS Build free tier is temporarily disabled for iOS. Try again later. Check ${link(
+        'https://status.expo.dev/'
+      )} for updates. ${learnMore('https://expo.fyi/eas-build-queues')}`
     );
     throw new Error('Build request failed.');
   } else if (
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED_ANDROID'
   ) {
     Log.error(
-      'EAS Build free tier is temporarily disabled for Android. Try again later. Check https://status.expo.dev/ for updates.'
+      `EAS Build free tier is temporarily disabled for Android. Try again later. Check ${link(
+        'https://status.expo.dev/'
+      )} for updates. ${learnMore('https://expo.fyi/eas-build-queues')}`
     );
     throw new Error('Build request failed.');
   } else if (


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-4932/dealing-with-platform-specific-issues-on-eas
Companion to https://github.com/expo/universe/pull/10576.

# How

Handle errors from new platform-specific kill switches to stop accepting builds for a given platform, so users see an accurate message for which platform we are not accepting builds vs just seeing generic information that the whole free tier is disabled.

# Test Plan

Tested locally
