### PR TITLE
[19/n][eas-cli] Reduce code duplication in project config context commands

### DIFF
--- a/packages/eas-cli/src/commandUtils/context/ProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/ProjectConfigContextField.ts
@@ -16,10 +16,12 @@ import ProjectDirContextField from './ProjectDirContextField';
 export default class ProjectConfigContextField extends ContextField<{
   projectId: string;
   exp: ExpoConfig;
+  projectDir: string;
 }> {
   async getValueAsync({ nonInteractive }: ContextOptions): Promise<{
     projectId: string;
     exp: ExpoConfig;
+    projectDir: string;
   }> {
     const projectDir = await ProjectDirContextField['findProjectDirAndVerifyProjectSetupAsync']();
     const expBefore = getExpoConfig(projectDir);
@@ -31,6 +33,7 @@ export default class ProjectConfigContextField extends ContextField<{
     return {
       projectId,
       exp,
+      projectDir,
     };
   }
 

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -4,10 +4,7 @@ import chalk from 'chalk';
 
 import { cleanUpOldEasBuildGradleScriptAsync } from '../../build/android/syncProjectConfiguration';
 import { ensureProjectConfiguredAsync } from '../../build/configure';
-import EasCommand, {
-  EASCommandProjectConfigContext,
-  EASCommandProjectDirContext,
-} from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import Log, { learnMore } from '../../log';
 import { RequestedPlatform } from '../../platform';
 import { isExpoUpdatesInstalled } from '../../project/projectUtils';
@@ -30,14 +27,12 @@ export default class BuildConfigure extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandProjectConfigContext,
-    ...EASCommandProjectDirContext,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildConfigure);
     const {
-      projectConfig: { exp, projectId },
-      projectDir,
+      projectConfig: { exp, projectId, projectDir },
     } = await this.getContextAsync(BuildConfigure, {
       nonInteractive: false,
     });

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -6,7 +6,6 @@ import { ensureProjectConfiguredAsync } from '../../build/configure';
 import EasCommand, {
   EASCommandLoggedInContext,
   EASCommandProjectConfigContext,
-  EASCommandProjectDirContext,
 } from '../../commandUtils/EasCommand';
 import { CredentialsContext } from '../../credentials/context';
 import Log, { learnMore } from '../../log';
@@ -28,7 +27,6 @@ export default class MetadataPull extends EasCommand {
   static override contextDefinition = {
     ...EASCommandProjectConfigContext,
     ...EASCommandLoggedInContext,
-    ...EASCommandProjectDirContext,
   };
 
   async runAsync(): Promise<void> {
@@ -37,8 +35,7 @@ export default class MetadataPull extends EasCommand {
     const { flags } = await this.parse(MetadataPull);
     const {
       actor,
-      projectConfig: { exp, projectId },
-      projectDir,
+      projectConfig: { exp, projectId, projectDir },
     } = await this.getContextAsync(MetadataPull, {
       nonInteractive: false,
     });

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -4,7 +4,6 @@ import { ensureProjectConfiguredAsync } from '../../build/configure';
 import EasCommand, {
   EASCommandLoggedInContext,
   EASCommandProjectConfigContext,
-  EASCommandProjectDirContext,
 } from '../../commandUtils/EasCommand';
 import { CredentialsContext } from '../../credentials/context';
 import Log, { learnMore } from '../../log';
@@ -26,7 +25,6 @@ export default class MetadataPush extends EasCommand {
   static override contextDefinition = {
     ...EASCommandProjectConfigContext,
     ...EASCommandLoggedInContext,
-    ...EASCommandProjectDirContext,
   };
 
   async runAsync(): Promise<void> {
@@ -35,8 +33,7 @@ export default class MetadataPush extends EasCommand {
     const { flags } = await this.parse(MetadataPush);
     const {
       actor,
-      projectConfig: { exp, projectId },
-      projectDir,
+      projectConfig: { exp, projectId, projectDir },
     } = await this.getContextAsync(MetadataPush, {
       nonInteractive: false,
     });

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -5,10 +5,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 
 import { getEASUpdateURL } from '../../api';
-import EasCommand, {
-  EASCommandProjectConfigContext,
-  EASCommandProjectDirContext,
-} from '../../commandUtils/EasCommand';
+import EasCommand, { EASCommandProjectConfigContext } from '../../commandUtils/EasCommand';
 import { AppPlatform } from '../../graphql/generated';
 import Log, { learnMore } from '../../log';
 import { RequestedPlatform, appPlatformDisplayNames } from '../../platform';
@@ -37,7 +34,6 @@ export default class UpdateConfigure extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandProjectConfigContext,
-    ...EASCommandProjectDirContext,
   };
 
   async runAsync(): Promise<void> {
@@ -46,8 +42,7 @@ export default class UpdateConfigure extends EasCommand {
     );
     const { flags } = await this.parse(UpdateConfigure);
     const {
-      projectConfig: { projectId, exp },
-      projectDir,
+      projectConfig: { projectId, exp, projectDir },
     } = await this.getContextAsync(UpdateConfigure, {
       nonInteractive: true,
     });


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

By also exporting projectDir from the config context, we can deduplicate extra calls to findProjectRoot.

# Test Plan

`yarn start` (tsc)
