### PR TITLE
[20/n][eas-cli] Simplify submit context creation

### DIFF
--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -181,7 +181,6 @@ export async function runBuildAndSubmitAsync(
         buildProfile: startedBuild.buildProfile.profile,
         submitProfile,
         nonInteractive: flags.nonInteractive,
-        getDynamicProjectConfigAsync,
       });
       startedBuild.build = await BuildQuery.withSubmissionsByIdAsync(startedBuild.build.id);
       submissions.push(submission);
@@ -323,7 +322,6 @@ async function prepareAndStartSubmissionAsync({
   buildProfile,
   submitProfile,
   nonInteractive,
-  getDynamicProjectConfigAsync,
 }: {
   build: BuildFragment;
   buildCtx: BuildContext<Platform>;
@@ -332,7 +330,6 @@ async function prepareAndStartSubmissionAsync({
   buildProfile: BuildProfile;
   submitProfile: SubmitProfile;
   nonInteractive: boolean;
-  getDynamicProjectConfigAsync: DynamicConfigContextFn;
 }): Promise<SubmissionFragment> {
   const platform = toPlatform(build.platform);
   const submissionCtx = await createSubmissionContextAsync({
@@ -345,7 +342,8 @@ async function prepareAndStartSubmissionAsync({
     credentialsCtx: buildCtx.credentialsCtx,
     applicationIdentifier: buildCtx.android?.applicationId ?? buildCtx.ios?.bundleIdentifier,
     actor: buildCtx.user,
-    getDynamicProjectConfigAsync,
+    projectId: buildCtx.projectId,
+    exp: buildCtx.exp,
   });
 
   if (moreBuilds) {

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -3,8 +3,8 @@ import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
 
 import EasCommand, {
-  EASCommandDynamicProjectConfigContext,
   EASCommandLoggedInContext,
+  EASCommandProjectConfigContext,
   EASCommandProjectDirContext,
 } from '../commandUtils/EasCommand';
 import { StatuspageServiceName, SubmissionFragment } from '../graphql/generated';
@@ -95,13 +95,16 @@ export default class Submit extends EasCommand {
 
   static override contextDefinition = {
     ...EASCommandLoggedInContext,
-    ...EASCommandDynamicProjectConfigContext,
+    ...EASCommandProjectConfigContext,
     ...EASCommandProjectDirContext,
   };
 
   async runAsync(): Promise<void> {
     const { flags: rawFlags } = await this.parse(Submit);
-    const { actor, getDynamicProjectConfigAsync, projectDir } = await this.getContextAsync(Submit, {
+    const {
+      actor,
+      projectConfig: { exp, projectId, projectDir },
+    } = await this.getContextAsync(Submit, {
       nonInteractive: false,
     });
 
@@ -121,6 +124,7 @@ export default class Submit extends EasCommand {
 
     const submissions: SubmissionFragment[] = [];
     for (const submissionProfile of submissionProfiles) {
+      // this command doesn't make use of env when getting the project config
       const ctx = await createSubmissionContextAsync({
         platform: submissionProfile.platform,
         projectDir,
@@ -128,7 +132,8 @@ export default class Submit extends EasCommand {
         archiveFlags: flagsWithPlatform.archiveFlags,
         nonInteractive: flagsWithPlatform.nonInteractive,
         actor,
-        getDynamicProjectConfigAsync,
+        exp,
+        projectId,
       });
 
       if (submissionProfiles.length > 1) {

--- a/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
@@ -90,11 +90,8 @@ describe(AndroidSubmitCommand, () => {
         },
         nonInteractive: true,
         actor: mockJester,
-        getDynamicProjectConfigAsync: async () => ({
-          exp: testProject.appJSON.expo,
-          projectId,
-          projectDir: testProject.projectRoot,
-        }),
+        exp: testProject.appJSON.expo,
+        projectId,
       });
       const command = new AndroidSubmitCommand(ctx);
       await expect(command.runAsync()).rejects.toThrowError();
@@ -119,11 +116,8 @@ describe(AndroidSubmitCommand, () => {
         },
         nonInteractive: false,
         actor: mockJester,
-        getDynamicProjectConfigAsync: async () => ({
-          exp: testProject.appJSON.expo,
-          projectId,
-          projectDir: testProject.projectRoot,
-        }),
+        exp: testProject.appJSON.expo,
+        projectId,
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
@@ -160,11 +154,8 @@ describe(AndroidSubmitCommand, () => {
         },
         nonInteractive: false,
         actor: mockJester,
-        getDynamicProjectConfigAsync: async () => ({
-          exp: testProject.appJSON.expo,
-          projectId,
-          projectDir: testProject.projectRoot,
-        }),
+        exp: testProject.appJSON.expo,
+        projectId,
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();

--- a/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
@@ -149,11 +149,8 @@ describe(getServiceAccountKeyResultAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
-      getDynamicProjectConfigAsync: async () => ({
-        exp: testProject.appJSON.expo,
-        projectId,
-        projectDir: testProject.projectRoot,
-      }),
+      exp: testProject.appJSON.expo,
+      projectId,
     });
     const source: ServiceAccountSource = {
       sourceType: ServiceAccountSourceType.path,
@@ -189,11 +186,8 @@ describe(getServiceAccountKeyResultAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
-      getDynamicProjectConfigAsync: async () => ({
-        exp: testProject.appJSON.expo,
-        projectId,
-        projectDir: testProject.projectRoot,
-      }),
+      exp: testProject.appJSON.expo,
+      projectId,
     });
     const source: ServiceAccountSource = {
       sourceType: ServiceAccountSourceType.prompt,
@@ -225,11 +219,8 @@ describe(getServiceAccountKeyResultAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
-      getDynamicProjectConfigAsync: async () => ({
-        exp: testProject.appJSON.expo,
-        projectId,
-        projectDir: testProject.projectRoot,
-      }),
+      exp: testProject.appJSON.expo,
+      projectId,
     });
     const serviceAccountResult = await getServiceAccountKeyResultAsync(ctx, {
       sourceType: ServiceAccountSourceType.credentialsService,

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -5,7 +5,6 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { TrackingContext } from '../analytics/common';
 import { Analytics, SubmissionEvent } from '../analytics/events';
-import { DynamicConfigContextFn } from '../commandUtils/context/DynamicProjectConfigContextField';
 import { CredentialsContext } from '../credentials/context';
 import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 import { Actor } from '../user/User';
@@ -43,10 +42,10 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
   projectDir: string;
   applicationIdentifier?: string;
   actor: Actor;
-  getDynamicProjectConfigAsync: DynamicConfigContextFn;
+  exp: ExpoConfig;
+  projectId: string;
 }): Promise<SubmissionContext<T>> {
-  const { applicationIdentifier, projectDir, nonInteractive, actor } = params;
-  const { exp, projectId } = await params.getDynamicProjectConfigAsync({ env: params.env });
+  const { applicationIdentifier, projectDir, nonInteractive, actor, exp, projectId } = params;
   const { env, ...rest } = params;
   const projectName = exp.slug;
   const account = await getOwnerAccountForProjectIdAsync(projectId);
@@ -74,11 +73,9 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
     ...rest,
     accountName: account.name,
     credentialsCtx,
-    exp,
     projectName,
     user: actor,
     trackingCtx,
-    projectId,
     applicationIdentifierOverride: applicationIdentifier,
   };
 }

--- a/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
@@ -46,11 +46,8 @@ async function getIosSubmissionContextAsync(): Promise<SubmissionContext<Platfor
     },
     nonInteractive: true,
     actor: mockJester,
-    getDynamicProjectConfigAsync: async () => ({
-      exp: testProject.appJSON.expo,
-      projectId,
-      projectDir: testProject.projectRoot,
-    }),
+    exp: testProject.appJSON.expo,
+    projectId,
   });
 }
 

--- a/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
@@ -55,11 +55,8 @@ describe(getFromCredentialsServiceAsync, () => {
       },
       nonInteractive: false,
       actor: mockJester,
-      getDynamicProjectConfigAsync: async () => ({
-        exp: testProject.appJSON.expo,
-        projectId,
-        projectDir: testProject.projectRoot,
-      }),
+      exp: testProject.appJSON.expo,
+      projectId,
     });
     jest
       .spyOn(SetUpSubmissionCredentials.prototype, 'runAsync')
@@ -87,11 +84,8 @@ describe(getFromCredentialsServiceAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
-      getDynamicProjectConfigAsync: async () => ({
-        exp: testProject.appJSON.expo,
-        projectId,
-        projectDir: testProject.projectRoot,
-      }),
+      exp: testProject.appJSON.expo,
+      projectId,
     });
     jest
       .spyOn(SetUpSubmissionCredentials.prototype, 'runAsync')

--- a/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
@@ -64,11 +64,8 @@ describe(IosSubmitCommand, () => {
         },
         nonInteractive: true,
         actor: mockJester,
-        getDynamicProjectConfigAsync: async () => ({
-          exp: testProject.appJSON.expo,
-          projectId,
-          projectDir: testProject.projectRoot,
-        }),
+        exp: testProject.appJSON.expo,
+        projectId,
       });
       const command = new IosSubmitCommand(ctx);
       await expect(command.runAsync()).rejects.toThrowError();
@@ -94,11 +91,8 @@ describe(IosSubmitCommand, () => {
         },
         nonInteractive: false,
         actor: mockJester,
-        getDynamicProjectConfigAsync: async () => ({
-          exp: testProject.appJSON.expo,
-          projectId,
-          projectDir: testProject.projectRoot,
-        }),
+        exp: testProject.appJSON.expo,
+        projectId,
       });
       const command = new IosSubmitCommand(ctx);
       await command.runAsync();


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Closes ENG-6471 (discussion: https://github.com/expo/eas-cli/pull/1387#discussion_r979799325)

# How

Replace dynamic config param with exp and project ID params, pass in from above (this context is only created with a single env per call).

# Test Plan

`yarn start` (tsc), run tests.
