### PR TITLE
[21/21][eas-cli] Validate that owner and projectId and slug all are in alignment

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -11200,7 +11200,32 @@
           {
             "name": "appleDevices",
             "description": "",
-            "args": [],
+            "args": [
+              {
+                "name": "limit",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14249,6 +14274,50 @@
         ]
       },
       {
+        "kind": "OBJECT",
+        "name": "BuildOrBuildJobQuery",
+        "description": "",
+        "fields": [
+          {
+            "name": "byId",
+            "description": "Look up EAS Build or Classic Build Job by ID",
+            "args": [
+              {
+                "name": "buildOrBuildJobId",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "EASBuildOrClassicBuildJob",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "BuildParamsInput",
         "description": "",
@@ -16462,6 +16531,27 @@
         "possibleTypes": null
       },
       {
+        "kind": "UNION",
+        "name": "EASBuildOrClassicBuildJob",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Build",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "BuildJob",
+            "ofType": null
+          }
+        ]
+      },
+      {
         "kind": "ENUM",
         "name": "EASServiceMetric",
         "description": "",
@@ -17680,6 +17770,87 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "searchRepositories",
+            "description": "",
+            "args": [
+              {
+                "name": "githubAppInstallationId",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "page",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "1",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "perPage",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "50",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "query",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GitHubAppInstallationAccessibleRepository",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -24164,6 +24335,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "BuildJobQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildOrBuildJob",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BuildOrBuildJobQuery",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1639,6 +1639,12 @@ export type AppleTeamAppleAppIdentifiersArgs = {
 };
 
 
+export type AppleTeamAppleDevicesArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+};
+
+
 export type AppleTeamAppleProvisioningProfilesArgs = {
   appleAppIdentifierId?: InputMaybe<Scalars['ID']>;
 };
@@ -2030,6 +2036,17 @@ export type BuildOrBuildJob = {
   id: Scalars['ID'];
 };
 
+export type BuildOrBuildJobQuery = {
+  __typename?: 'BuildOrBuildJobQuery';
+  /** Look up EAS Build or Classic Build Job by ID */
+  byId: EasBuildOrClassicBuildJob;
+};
+
+
+export type BuildOrBuildJobQueryByIdArgs = {
+  buildOrBuildJobId: Scalars['ID'];
+};
+
 export type BuildParamsInput = {
   resourceClass: BuildResourceClass;
 };
@@ -2374,6 +2391,8 @@ export enum EasBuildDeprecationInfoType {
   UserFacing = 'USER_FACING'
 }
 
+export type EasBuildOrClassicBuildJob = Build | BuildJob;
+
 export enum EasServiceMetric {
   AssetsRequests = 'ASSETS_REQUESTS',
   BandwidthUsage = 'BANDWIDTH_USAGE',
@@ -2554,6 +2573,15 @@ export type GitHubAppQuery = {
   __typename?: 'GitHubAppQuery';
   appIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
+  searchRepositories: Array<GitHubAppInstallationAccessibleRepository>;
+};
+
+
+export type GitHubAppQuerySearchRepositoriesArgs = {
+  githubAppInstallationId: Scalars['ID'];
+  page?: InputMaybe<Scalars['Int']>;
+  perPage?: InputMaybe<Scalars['Int']>;
+  query: Scalars['String'];
 };
 
 export type GitHubRepository = {
@@ -3467,6 +3495,7 @@ export type RootQuery = {
   appleTeam: AppleTeamQuery;
   asset: AssetQuery;
   buildJobs: BuildJobQuery;
+  buildOrBuildJob: BuildOrBuildJobQuery;
   /** Top-level query object for querying BuildPublicData publicly. */
   buildPublicData: BuildPublicDataQuery;
   builds: BuildQuery;

--- a/packages/eas-cli/src/graphql/types/App.ts
+++ b/packages/eas-cli/src/graphql/types/App.ts
@@ -9,6 +9,7 @@ export const AppFragmentNode = gql`
     slug
     ownerAccount {
       id
+      name
       ...AccountFragment
     }
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This PR is the final PR in the stack and is part of what drove this new pattern. It becomes very easy to validate that the slug, owner, and projectId fields are all correct.

Closes ENG-6193.

# How

Add validation to the context field that is used in all commands that use this context.

# Test Plan

Run the test.
