### PR TITLE
[cli] more robust platform check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Make Apple Platform detection more robust. ([#1417](https://github.com/expo/eas-cli/pull/1417) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🧹 Chores
 
 ## [2.2.0](https://github.com/expo/eas-cli/releases/tag/v2.2.0) - 2022-10-04
@@ -35,7 +37,6 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix automatic eas.json generation when running `eas build`. ([#1415](https://github.com/expo/eas-cli/pull/1415) by [@wkozyra95](https://github.com/wkozyra95))
-- Make Apple Platform detection more robust. ([#1417](https://github.com/expo/eas-cli/pull/1417) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🧹 Chores
 
@@ -43,7 +44,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Remove 'owner' app config field dependency. ([#1368](https://github.com/expo/eas-cli/pull/1368), [#1369](https://github.com/expo/eas-cli/pull/1369), [#1371](https://github.com/expo/eas-cli/pull/1371), [#1372](https://github.com/expo/eas-cli/pull/1372), [#1373](https://github.com/expo/eas-cli/pull/1373), by [@wschurman](https://github.com/wschurman))
 - Add Xcode 14 image. ([#1365](https://github.com/expo/eas-cli/pull/1365) by [@szdziedzic](https://github.com/szdziedzic))
 - Update max `versionCode` for Android. ([#1400](https://github.com/expo/eas-cli/pull/1400) by [@wkozyra95](https://github.com/wkozyra95))
-- Add and use command context to declare command dependencies.  ([#1383](https://github.com/expo/eas-cli/pull/1383), [#1384](https://github.com/expo/eas-cli/pull/1384), [#1387](https://github.com/expo/eas-cli/pull/1387), [#1388](https://github.com/expo/eas-cli/pull/1388), [#1390](https://github.com/expo/eas-cli/pull/1390), [#1391](https://github.com/expo/eas-cli/pull/1391), [#1394](https://github.com/expo/eas-cli/pull/1394), [#1402](https://github.com/expo/eas-cli/pull/1402), [#1403](https://github.com/expo/eas-cli/pull/1403), by [@wschurman](https://github.com/wschurman))
+- Add and use command context to declare command dependencies. ([#1383](https://github.com/expo/eas-cli/pull/1383), [#1384](https://github.com/expo/eas-cli/pull/1384), [#1387](https://github.com/expo/eas-cli/pull/1387), [#1388](https://github.com/expo/eas-cli/pull/1388), [#1390](https://github.com/expo/eas-cli/pull/1390), [#1391](https://github.com/expo/eas-cli/pull/1391), [#1394](https://github.com/expo/eas-cli/pull/1394), [#1402](https://github.com/expo/eas-cli/pull/1402), [#1403](https://github.com/expo/eas-cli/pull/1403), by [@wschurman](https://github.com/wschurman))
 - Fix typo in the ad hoc build message. ([#1407](https://github.com/expo/eas-cli/pull/1407) by [@Simek](https://github.com/Simek))
 - Improve errors and error messages formatting related to **eas.json**. ([#1414](https://github.com/expo/eas-cli/pull/1414) by [@Simek](https://github.com/Simek))
 - Handle errors from platform-specific kill switches to disable free tier builds. ([#1401](https://github.com/expo/eas-cli/pull/1401) by [@szdziedzic](https://github.com/szdziedzic))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix automatic eas.json generation when running `eas build`. ([#1415](https://github.com/expo/eas-cli/pull/1415) by [@wkozyra95](https://github.com/wkozyra95))
+- Make Apple Platform detection more robust. ([#1417](https://github.com/expo/eas-cli/pull/1417) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../graphql/generated';
 import Log from '../../../log';
 import { ora } from '../../../ora';
-import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
+import { getApplePlatformFromTarget } from '../../../project/ios/target';
 import { CredentialsContext } from '../../context';
 import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppleProvisioningProfileMutationResult } from '../api/graphql/mutations/AppleProvisioningProfileMutation';
@@ -46,7 +46,7 @@ export class ConfigureProvisioningProfile {
       return null;
     }
 
-    const applePlatform = await getApplePlatformFromSdkRoot(this.target);
+    const applePlatform = await getApplePlatformFromTarget(this.target);
     const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
       this.app.bundleIdentifier,
       applePlatform

--- a/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
+import { getApplePlatformFromTarget } from '../../../project/ios/target';
 import { CredentialsContext } from '../../context';
 import {
   DistributionCertificate,
@@ -29,7 +29,7 @@ export async function generateProvisioningProfileAsync(
   const appleAuthCtx = await ctx.appStore.ensureAuthenticatedAsync();
   const type = appleAuthCtx.team.inHouse ? 'Enterprise ' : 'AppStore';
   const profileName = `*[expo] ${bundleIdentifier} ${type} ${new Date().toISOString()}`; // Apple drops [ if its the first char (!!)
-  const applePlatform = await getApplePlatformFromSdkRoot(target);
+  const applePlatform = await getApplePlatformFromTarget(target);
   return await ctx.appStore.createProvisioningProfileAsync(
     bundleIdentifier,
     distCert,

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
@@ -13,7 +13,7 @@ import {
   IosDistributionType,
 } from '../../../graphql/generated';
 import Log from '../../../log';
-import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
+import { getApplePlatformFromTarget } from '../../../project/ios/target';
 import { confirmAsync, pressAnyKeyToContinueAsync, promptAsync } from '../../../prompts';
 import differenceBy from '../../../utils/expodash/differenceBy';
 import { CredentialsContext } from '../../context';
@@ -121,7 +121,7 @@ export class SetUpAdhocProvisioningProfile {
     );
 
     // 4. Reuse or create the profile on Apple Developer Portal
-    const applePlatform = await getApplePlatformFromSdkRoot(target);
+    const applePlatform = await getApplePlatformFromTarget(target);
     const profileType =
       applePlatform === ApplePlatform.TV_OS
         ? ProfileType.TVOS_APP_ADHOC

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
@@ -6,7 +6,7 @@ import {
   IosAppBuildCredentialsFragment,
   IosDistributionType,
 } from '../../../graphql/generated';
-import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
+import { getApplePlatformFromTarget } from '../../../project/ios/target';
 import { confirmAsync } from '../../../prompts';
 import { CredentialsContext } from '../../context';
 import { MissingCredentialsNonInteractiveError } from '../../errors';
@@ -114,7 +114,7 @@ export class SetUpProvisioningProfile {
     }
 
     // See if the profile we have exists on the Apple Servers
-    const applePlatform = await getApplePlatformFromSdkRoot(this.target);
+    const applePlatform = await getApplePlatformFromTarget(this.target);
     const existingProfiles = await ctx.appStore.listProvisioningProfilesAsync(
       this.app.bundleIdentifier,
       applePlatform

--- a/packages/eas-cli/src/credentials/ios/validators/validateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validateProvisioningProfile.ts
@@ -6,7 +6,7 @@ import nullthrows from 'nullthrows';
 
 import { IosAppBuildCredentialsFragment, IosDistributionType } from '../../../graphql/generated';
 import Log from '../../../log';
-import { getApplePlatformFromSdkRoot } from '../../../project/ios/target';
+import { getApplePlatformFromTarget } from '../../../project/ios/target';
 import { CredentialsContext } from '../../context';
 import { AppLookupParams } from '../api/graphql/types/AppLookupParams';
 import { ProfileClass } from '../appstore/provisioningProfile';
@@ -94,7 +94,7 @@ async function validateProvisioningProfileWithAppleAsync(
   assert(buildCredentials.provisioningProfile, 'Provisioning Profile must be defined');
   const { developerPortalIdentifier, provisioningProfile } = buildCredentials.provisioningProfile;
 
-  const applePlatform = await getApplePlatformFromSdkRoot(target);
+  const applePlatform = await getApplePlatformFromTarget(target);
   const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
     app.bundleIdentifier,
     applePlatform,

--- a/packages/eas-cli/src/project/ios/__tests__/target-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/target-test.ts
@@ -1,5 +1,6 @@
 import { testTarget } from '../../../credentials/__tests__/fixtures-ios';
 import { ApplePlatform } from '../../../credentials/ios/appstore/constants';
+import { Target } from '../../../credentials/ios/types';
 import { getApplePlatformFromDeviceFamily, getApplePlatformFromSdkRoot } from '../target';
 
 function getApplePlatformWithSdkRoot(sdkRoot: string): ApplePlatform | null {

--- a/packages/eas-cli/src/project/ios/__tests__/target-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/target-test.ts
@@ -1,8 +1,8 @@
 import { testTarget } from '../../../credentials/__tests__/fixtures-ios';
 import { ApplePlatform } from '../../../credentials/ios/appstore/constants';
-import { getApplePlatformFromSdkRoot } from '../target';
+import { getApplePlatformFromDeviceFamily, getApplePlatformFromSdkRoot } from '../target';
 
-function getApplePlatform(sdkRoot: string): ApplePlatform {
+function getApplePlatformWithSdkRoot(sdkRoot: string): ApplePlatform | null {
   const target = {
     ...testTarget,
     buildSettings: {
@@ -10,6 +10,18 @@ function getApplePlatform(sdkRoot: string): ApplePlatform {
     },
   };
   return getApplePlatformFromSdkRoot(target);
+}
+
+function getApplePlatformWithDeviceFamily(
+  deviceFamily: string | number | undefined
+): ApplePlatform | null {
+  const target = {
+    ...testTarget,
+    buildSettings: {
+      TARGETED_DEVICE_FAMILY: deviceFamily,
+    },
+  };
+  return getApplePlatformFromDeviceFamily(target);
 }
 
 describe(getApplePlatformFromSdkRoot, () => {
@@ -21,13 +33,24 @@ describe(getApplePlatformFromSdkRoot, () => {
   });
   test('existing SDKs work with the function', () => {
     // sdks from `xcodebuild -showsdks`
-    expect(getApplePlatform('iphoneos14.4')).toBe(ApplePlatform.IOS);
-    expect(getApplePlatform('iphonesimulator14.4')).toBe(ApplePlatform.IOS);
-    expect(getApplePlatform('driverkit.macosx20.2 ')).toBe(ApplePlatform.MAC_OS);
-    expect(getApplePlatform('macosx11.1')).toBe(ApplePlatform.MAC_OS);
-    expect(getApplePlatform('appletvos14.3')).toBe(ApplePlatform.TV_OS);
-    expect(getApplePlatform('appletvsimulator14.3')).toBe(ApplePlatform.IOS);
-    expect(getApplePlatform('watchos7.2')).toBe(ApplePlatform.IOS);
-    expect(getApplePlatform('watchsimulator7.2')).toBe(ApplePlatform.IOS);
+    expect(getApplePlatformWithSdkRoot('iphoneos14.4')).toBe(ApplePlatform.IOS);
+    expect(getApplePlatformWithSdkRoot('iphonesimulator14.4')).toBe(null);
+    expect(getApplePlatformWithSdkRoot('driverkit.macosx20.2 ')).toBe(ApplePlatform.MAC_OS);
+    expect(getApplePlatformWithSdkRoot('macosx11.1')).toBe(ApplePlatform.MAC_OS);
+    expect(getApplePlatformWithSdkRoot('appletvos14.3')).toBe(ApplePlatform.TV_OS);
+    expect(getApplePlatformWithSdkRoot('appletvsimulator14.3')).toBe(null);
+    expect(getApplePlatformWithSdkRoot('watchos7.2')).toBe(null);
+    expect(getApplePlatformWithSdkRoot('watchsimulator7.2')).toBe(null);
+  });
+});
+
+describe(getApplePlatformFromDeviceFamily, () => {
+  test('apple platform can be obtained from device family types', () => {
+    expect(getApplePlatformWithDeviceFamily('1')).toBe(ApplePlatform.IOS);
+    expect(getApplePlatformWithDeviceFamily('3')).toBe(ApplePlatform.TV_OS);
+    expect(getApplePlatformWithDeviceFamily(1)).toBe(ApplePlatform.IOS);
+    expect(getApplePlatformWithDeviceFamily(3)).toBe(ApplePlatform.TV_OS);
+    expect(getApplePlatformWithDeviceFamily(undefined)).toBe(null);
+    expect(getApplePlatformWithDeviceFamily('ilovecats')).toBe(null);
   });
 });

--- a/packages/eas-cli/src/project/ios/__tests__/target-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/target-test.ts
@@ -15,7 +15,7 @@ function getApplePlatformWithSdkRoot(sdkRoot: string): ApplePlatform | null {
 function getApplePlatformWithDeviceFamily(
   deviceFamily: string | number | undefined
 ): ApplePlatform | null {
-  const target = {
+  const target: Target = {
     ...testTarget,
     buildSettings: {
       TARGETED_DEVICE_FAMILY: deviceFamily,

--- a/packages/eas-cli/src/project/ios/__tests__/target-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/target-test.ts
@@ -46,6 +46,7 @@ describe(getApplePlatformFromSdkRoot, () => {
 
 describe(getApplePlatformFromDeviceFamily, () => {
   test('apple platform can be obtained from device family types', () => {
+    expect(getApplePlatformWithDeviceFamily('1,2')).toBe(ApplePlatform.IOS);
     expect(getApplePlatformWithDeviceFamily('1')).toBe(ApplePlatform.IOS);
     expect(getApplePlatformWithDeviceFamily('3')).toBe(ApplePlatform.TV_OS);
     expect(getApplePlatformWithDeviceFamily(1)).toBe(ApplePlatform.IOS);

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -274,11 +274,10 @@ export function getApplePlatformFromDeviceFamily(target: Target): ApplePlatform 
   if (!deviceFamily) {
     return null;
   }
-  if (deviceFamily === '1,2') {
-    return ApplePlatform.IOS;
-  }
   if (typeof deviceFamily === 'string') {
-    const deviceFamilyNumber = Number(deviceFamily);
+    const devices = deviceFamily.split(',');
+    const arbitraryDevice = devices[0];
+    const deviceFamilyNumber = Number(arbitraryDevice);
     return deviceFamilyToPlatform(deviceFamilyNumber);
   } else if (typeof deviceFamily === 'number') {
     return deviceFamilyToPlatform(deviceFamily);

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -229,13 +229,25 @@ function resolveBareProjectBuildSettings(
 }
 
 /**
- * Get Apple Platform from the Xcode SDKROOT where possible.
+ * Get Apple Platform from the Xcode Target where possible.
  * @returns - Apple Platform when known, defaults to IOS when unknown
  */
-export function getApplePlatformFromSdkRoot(target: Target): ApplePlatform {
+export function getApplePlatformFromTarget(target: Target): ApplePlatform {
+  return (
+    getApplePlatformFromSdkRoot(target) ??
+    getApplePlatformFromDeviceFamily(target) ??
+    ApplePlatform.IOS
+  );
+}
+
+/**
+ * Get Apple Platform from the Xcode SDKROOT where possible.
+ * @returns - Apple Platform when known, defaults to null when unknown
+ */
+export function getApplePlatformFromSdkRoot(target: Target): ApplePlatform | null {
   const sdkRoot = target.buildSettings?.SDKROOT;
   if (!sdkRoot) {
-    return ApplePlatform.IOS;
+    return null;
   }
   if (sdkRoot.includes('iphoneos')) {
     return ApplePlatform.IOS;
@@ -244,6 +256,32 @@ export function getApplePlatformFromSdkRoot(target: Target): ApplePlatform {
   } else if (sdkRoot.includes('macosx')) {
     return ApplePlatform.MAC_OS;
   } else {
+    return null;
+  }
+}
+
+export function getApplePlatformFromDeviceFamily(target: Target): ApplePlatform | null {
+  const deviceFamily = target.buildSettings?.TARGETED_DEVICE_FAMILY;
+  if (!deviceFamily) {
+    return null;
+  }
+  if (typeof deviceFamily === 'string') {
+    const deviceFamilyNumber = parseInt(deviceFamily, 10);
+    return deviceFamilyToPlatform(deviceFamilyNumber);
+  } else if (typeof deviceFamily === 'number') {
+    return deviceFamilyToPlatform(deviceFamily);
+  }
+  throw new Error(
+    `Unexpected device family type in XCode build settings: ${JSON.stringify(deviceFamily)}`
+  );
+}
+
+function deviceFamilyToPlatform(deviceFamily: number): ApplePlatform | null {
+  if (deviceFamily === 1 || deviceFamily === 2) {
     return ApplePlatform.IOS;
+  } else if (deviceFamily === 3) {
+    return ApplePlatform.TV_OS;
+  } else {
+    return null;
   }
 }

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -260,6 +260,15 @@ export function getApplePlatformFromSdkRoot(target: Target): ApplePlatform | nul
   }
 }
 
+/**
+ * Get Apple Platform from the Xcode TARGETED_DEVICE_FAMILY where possible.
+ *
+ * References:
+ * https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html
+ * https://stackoverflow.com/questions/39677524/xcode-8-how-to-change-targeted-device-family#comment100316573_39677659
+ *
+ * @returns - Apple Platform when known, defaults to null when unknown
+ */
 export function getApplePlatformFromDeviceFamily(target: Target): ApplePlatform | null {
   const deviceFamily = target.buildSettings?.TARGETED_DEVICE_FAMILY;
   if (!deviceFamily) {

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -265,8 +265,11 @@ export function getApplePlatformFromDeviceFamily(target: Target): ApplePlatform 
   if (!deviceFamily) {
     return null;
   }
+  if (deviceFamily === '1,2') {
+    return ApplePlatform.IOS;
+  }
   if (typeof deviceFamily === 'string') {
-    const deviceFamilyNumber = parseInt(deviceFamily, 10);
+    const deviceFamilyNumber = Number(deviceFamily);
     return deviceFamilyToPlatform(deviceFamilyNumber);
   } else if (typeof deviceFamily === 'number') {
     return deviceFamilyToPlatform(deviceFamily);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We don't have any docs on how our users should build their project for tvOS yet (assuming it will be released after we complete https://linear.app/expo/issue/ENG-5930/research-requirements-to-make-apple-tv-targets-buildable). I'm not really sure what users are doing to build for tvOS but having a more robust check seems like a good improvement and will probably help https://github.com/expo/eas-cli/issues/1349  .

After talking to @douglowder , we should be looking at the following Xcode build settings to determine which Apple Platform we should be building for:
- SDK_ROOT
- TARGETED_DEVICE_FAMILY



# Test Plan

new tests pass
