### PR TITLE
[cli] surface context error with invalid eas.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add and use command context to declare command dependencies.  ([#1383](https://github.com/expo/eas-cli/pull/1383), [#1384](https://github.com/expo/eas-cli/pull/1384), [#1387](https://github.com/expo/eas-cli/pull/1387), [#1388](https://github.com/expo/eas-cli/pull/1388), [#1390](https://github.com/expo/eas-cli/pull/1390), [#1391](https://github.com/expo/eas-cli/pull/1391), [#1394](https://github.com/expo/eas-cli/pull/1394), [#1402](https://github.com/expo/eas-cli/pull/1402), [#1403](https://github.com/expo/eas-cli/pull/1403), by [@wschurman](https://github.com/wschurman))
 - Fix typo in the ad hoc build message. ([#1407](https://github.com/expo/eas-cli/pull/1407) by [@Simek](https://github.com/Simek))
 - Improve errors and error messages formatting related to **eas.json**. ([#1414](https://github.com/expo/eas-cli/pull/1414) by [@Simek](https://github.com/Simek))
+- Surface invalid eas.json errors in an optional project context. ([#1418](https://github.com/expo/eas-cli/pull/1418) by [@quinlanj](https://github.com/quinlanj))
 
 ## [2.1.0](https://github.com/expo/eas-cli/releases/tag/v2.1.0) - 2022-09-05
 

--- a/packages/eas-cli/src/commandUtils/context/OptionalProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/OptionalProjectConfigContextField.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig } from '@expo/config-types';
+import { InvalidEasJsonError } from '@expo/eas-json/build/errors';
 
 import { getExpoConfig } from '../../project/expoConfig';
 import ContextField, { ContextOptions } from './ContextField';
@@ -27,7 +28,10 @@ export class OptionalProjectConfigContextField extends ContextField<
       if (!projectDir) {
         return undefined;
       }
-    } catch {
+    } catch (e) {
+      if (e instanceof InvalidEasJsonError) {
+        throw e;
+      }
       return undefined;
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

I had an invalid eas.json and I was having trouble figuring out why the project context wasn't set. Would be better if invalid eas.json errors were surfaced since it indicates the user intends to be in a project context 

