### PR TITLE
[eas-cli] Add learn more link to project ID mismatch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Improve errors and error messages formatting related to **eas.json**. ([#1414](https://github.com/expo/eas-cli/pull/1414) by [@Simek](https://github.com/Simek))
 - Handle errors from platform-specific kill switches to disable free tier builds. ([#1401](https://github.com/expo/eas-cli/pull/1401) by [@szdziedzic](https://github.com/szdziedzic))
 - Surface invalid eas.json errors in an optional project context. ([#1418](https://github.com/expo/eas-cli/pull/1418) by [@quinlanj](https://github.com/quinlanj))
+- Improve message when project ID doesn't match either slug or owner. ([#1420](https://github.com/expo/eas-cli/pull/1420) by [@brentvatne](https://github.com/brentvatne))
 
 ## [2.1.0](https://github.com/expo/eas-cli/releases/tag/v2.1.0) - 2022-09-05
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
@@ -120,7 +120,7 @@ describe(getProjectIdAsync, () => {
         { nonInteractive: false }
       )
     ).rejects.toThrow(
-      `Project config: Slug for project identified by 'extra.eas.projectId' (test) does not match the 'slug' field (wat). ${learnMore(
+      `Project config: Slug for project identified by "extra.eas.projectId" (test) does not match the "slug" field (wat). ${learnMore(
         'https://expo.fyi/eas-project-id'
       )}`
     );

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
@@ -3,6 +3,7 @@ import { vol } from 'memfs';
 
 import { Role } from '../../../../graphql/generated';
 import { AppQuery } from '../../../../graphql/queries/AppQuery';
+import { learnMore } from '../../../../log';
 import { fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync } from '../../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 import { ensureLoggedInAsync } from '../../contextUtils/ensureLoggedInAsync';
 import { findProjectRootAsync } from '../findProjectDirAndVerifyProjectSetupAsync';
@@ -96,7 +97,9 @@ describe(getProjectIdAsync, () => {
         { nonInteractive: false }
       )
     ).rejects.toThrow(
-      `Project config: Project identified by 'extra.eas.projectId' is not owned by owner specified in the 'owner' field. (project = 'notnotbrent', config = 'wat')`
+      `Project config: Project identified by 'extra.eas.projectId' (notnotbrent) is not owned by owner specified in the 'owner' field (wat). ${learnMore(
+        'https://expo.fyi/eas-project-id'
+      )}`
     );
   });
 
@@ -117,7 +120,9 @@ describe(getProjectIdAsync, () => {
         { nonInteractive: false }
       )
     ).rejects.toThrow(
-      `Project config: Slug for project identified by 'extra.eas.projectId' does not match the 'slug' field. (project = 'test', config = 'wat')`
+      `Project config: Slug for project identified by 'extra.eas.projectId' (test) does not match the 'slug' field (wat). ${learnMore(
+        'https://expo.fyi/eas-project-id'
+      )}`
     );
   });
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
@@ -97,7 +97,7 @@ describe(getProjectIdAsync, () => {
         { nonInteractive: false }
       )
     ).rejects.toThrow(
-      `Project config: Project identified by 'extra.eas.projectId' (notnotbrent) is not owned by owner specified in the 'owner' field (wat). ${learnMore(
+      `Project config: Project identified by "extra.eas.projectId" (notnotbrent) is not owned by owner specified in the "owner" field (wat). ${learnMore(
         'https://expo.fyi/eas-project-id'
       )}`
     );

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -4,7 +4,7 @@ import { Env } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
 import { AppQuery } from '../../../graphql/queries/AppQuery';
-import Log from '../../../log';
+import Log, { learnMore } from '../../../log';
 import { ora } from '../../../ora';
 import { getExpoConfig } from '../../../project/expoConfig';
 import { fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync } from '../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
@@ -79,13 +79,21 @@ export async function getProjectIdAsync(
     const appForProjectId = await AppQuery.byIdAsync(localProjectId);
     if (exp.owner && exp.owner !== appForProjectId.ownerAccount.name) {
       throw new Error(
-        `Project config: Project identified by 'extra.eas.projectId' is not owned by owner specified in the 'owner' field. (project = '${appForProjectId.ownerAccount.name}', config = '${exp.owner}')`
+        `Project config: Project identified by 'extra.eas.projectId' (${
+          appForProjectId.ownerAccount.name
+        }) is not owned by owner specified in the 'owner' field (${exp.owner}). ${learnMore(
+          'https://expo.fyi/eas-project-id'
+        )}`
       );
     }
 
     if (exp.slug && exp.slug !== appForProjectId.slug) {
       throw new Error(
-        `Project config: Slug for project identified by 'extra.eas.projectId' does not match the 'slug' field. (project = '${appForProjectId.slug}', config = '${exp.slug}')`
+        `Project config: Slug for project identified by 'extra.eas.projectId' (${
+          appForProjectId.slug
+        }) does not match the 'slug' field (${exp.slug}). ${learnMore(
+          'https://expo.fyi/eas-project-id'
+        )}`
       );
     }
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -89,9 +89,9 @@ export async function getProjectIdAsync(
 
     if (exp.slug && exp.slug !== appForProjectId.slug) {
       throw new Error(
-        `Project config: Slug for project identified by 'extra.eas.projectId' (${
+        `Project config: Slug for project identified by "extra.eas.projectId" (${
           appForProjectId.slug
-        }) does not match the 'slug' field (${exp.slug}). ${learnMore(
+        }) does not match the "slug" field (${exp.slug}). ${learnMore(
           'https://expo.fyi/eas-project-id'
         )}`
       );

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -79,9 +79,9 @@ export async function getProjectIdAsync(
     const appForProjectId = await AppQuery.byIdAsync(localProjectId);
     if (exp.owner && exp.owner !== appForProjectId.ownerAccount.name) {
       throw new Error(
-        `Project config: Project identified by 'extra.eas.projectId' (${
+        `Project config: Project identified by "extra.eas.projectId" (${
           appForProjectId.ownerAccount.name
-        }) is not owned by owner specified in the 'owner' field (${exp.owner}). ${learnMore(
+        }) is not owned by owner specified in the "owner" field (${exp.owner}). ${learnMore(
           'https://expo.fyi/eas-project-id'
         )}`
       );


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Error messages are frustrating, and by providing a link to an FYI page we can easily provide more context on what is happening, why, and suggestions for how to adapt your workflow.

# How

I created a simple placeholder FYI page and then linked to it from here. I also changed the formatting of the message slightly to inline the mismatched values in parens.

# Test Plan

I changed the slug and owner in an existing project and tried running commands.

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/90494/193720272-05b85f59-0020-44fc-8058-c04c4e83c7a4.png">
