### PR TITLE
[ENG-6571][eas-cli] use resource class flag to select M1 resource class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add new experimental resource class for M1 Macs. ([#1425](https://github.com/expo/eas-cli/pull/1425) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -2037,71 +2037,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "subscribeToProduct",
-            "description": "Add a subscription",
-            "args": [
-              {
-                "name": "accountName",
-                "description": "",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "paymentSource",
-                "description": "",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "productId",
-                "description": "",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -14755,6 +14690,12 @@
           {
             "name": "IOS_LARGE",
             "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IOS_M1_LARGE",
+            "description": "@experimental This resource class is not yet ready to be used in production. For testing purposes only.",
             "isDeprecated": false,
             "deprecationReason": null
           },

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -7,7 +7,6 @@ import {
   EasJsonUtils,
   SubmitProfile,
 } from '@expo/eas-json';
-import { Errors } from '@oclif/core';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
@@ -99,11 +98,8 @@ function resolveResourceClass(
   resourceClassInput: UserInputResourceClass
 ): BuildResourceClass {
   if (platform !== Platform.IOS && resourceClassInput === UserInputResourceClass.M1_EXPERIMENTAL) {
-    Errors.error(
-      `Resource class ${UserInputResourceClass.M1_EXPERIMENTAL} is only available for iOS builds`,
-      {
-        exit: 1,
-      }
+    throw new Error(
+      `Resource class ${UserInputResourceClass.M1_EXPERIMENTAL} is only available for iOS builds`
     );
   }
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -9,6 +9,7 @@ import {
 } from '@expo/eas-json';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
+import { env } from 'process';
 
 import { DynamicConfigContextFn } from '../commandUtils/context/DynamicProjectConfigContextField';
 import {
@@ -138,9 +139,11 @@ export async function runBuildAndSubmitAsync(
       moreBuilds: platforms.length > 1,
       buildProfile,
       resourceClass:
-        platformToGraphQLResourceClassMapping[buildProfile.platform][
-          flags.userInputResourceClass ?? UserInputResourceClass.DEFAULT
-        ],
+        env.EXPO_USE_M1_RESOURCE_CLASS && buildProfile.platform === Platform.IOS
+          ? BuildResourceClass.IosM1Large
+          : platformToGraphQLResourceClassMapping[buildProfile.platform][
+              flags.userInputResourceClass ?? UserInputResourceClass.DEFAULT
+            ],
       easJsonCliConfig,
       actor,
       getDynamicProjectConfigAsync,

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -77,38 +77,44 @@ export interface BuildFlags {
   message?: string;
 }
 
+const iosUserInputResourceClassToBuildResourceClassMapping: Record<
+  UserInputResourceClass,
+  BuildResourceClass
+> = {
+  [UserInputResourceClass.DEFAULT]: BuildResourceClass.IosDefault,
+  [UserInputResourceClass.LARGE]: BuildResourceClass.IosLarge,
+  [UserInputResourceClass.M1_EXPERIMENTAL]: BuildResourceClass.IosM1Large,
+};
+
+const androidUserInputResourceClassToBuildResourceClassMapping: Record<
+  Exclude<UserInputResourceClass, UserInputResourceClass.M1_EXPERIMENTAL>,
+  BuildResourceClass
+> = {
+  [UserInputResourceClass.DEFAULT]: BuildResourceClass.AndroidDefault,
+  [UserInputResourceClass.LARGE]: BuildResourceClass.AndroidLarge,
+};
+
 function resolveResourceClass(
   platform: Platform,
   resourceClassInput: UserInputResourceClass
 ): BuildResourceClass {
-  const iosMapping: Record<UserInputResourceClass, BuildResourceClass> = {
-    [UserInputResourceClass.DEFAULT]: BuildResourceClass.IosDefault,
-    [UserInputResourceClass.LARGE]: BuildResourceClass.IosLarge,
-    [UserInputResourceClass.M1_EXPERIMENTAL]: BuildResourceClass.IosM1Large,
-  };
-
-  const androidMapping: Record<
-    Exclude<UserInputResourceClass, UserInputResourceClass.M1_EXPERIMENTAL>,
-    BuildResourceClass
-  > = {
-    [UserInputResourceClass.DEFAULT]: BuildResourceClass.AndroidDefault,
-    [UserInputResourceClass.LARGE]: BuildResourceClass.AndroidLarge,
-  };
-
   if (platform !== Platform.IOS && resourceClassInput === UserInputResourceClass.M1_EXPERIMENTAL) {
-    Errors.error('m1-experimental option for --resource-class flag is allowed only for iOS', {
-      exit: 1,
-    });
+    Errors.error(
+      `Resource class ${UserInputResourceClass.M1_EXPERIMENTAL} is only available for iOS builds`,
+      {
+        exit: 1,
+      }
+    );
   }
 
   return platform === Platform.ANDROID
-    ? androidMapping[
+    ? androidUserInputResourceClassToBuildResourceClassMapping[
         resourceClassInput as Exclude<
           UserInputResourceClass,
           UserInputResourceClass.M1_EXPERIMENTAL
         >
       ]
-    : iosMapping[resourceClassInput];
+    : iosUserInputResourceClassToBuildResourceClassMapping[resourceClassInput];
 }
 
 export async function runBuildAndSubmitAsync(

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -16,4 +16,9 @@ export enum BuildDistributionType {
 export enum UserInputResourceClass {
   DEFAULT = 'default',
   LARGE = 'large',
+  /**
+   * @experimental
+   * This resource class is not yet ready to be used in production. For testing purposes only. Might be depricated / deleted at any time.
+   */
+  M1_EXPERIMENTAL = 'm1-experimental',
 }

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -18,7 +18,7 @@ export enum UserInputResourceClass {
   LARGE = 'large',
   /**
    * @experimental
-   * This resource class is not yet ready to be used in production. For testing purposes only. Might be depricated / deleted at any time.
+   * This resource class is not yet ready to be used in production. For testing purposes only. Might be deprecated / deleted at any time.
    */
   M1_EXPERIMENTAL = 'm1-experimental',
 }

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -151,9 +151,12 @@ export default class Build extends EasCommand {
       flags['resource-class'] === UserInputResourceClass.M1_EXPERIMENTAL &&
       flags.platform !== Platform.IOS
     ) {
-      Errors.error('m1-experimental option for --resource-class flag is allowed only for iOS', {
-        exit: 1,
-      });
+      Errors.error(
+        `Resource class ${UserInputResourceClass.M1_EXPERIMENTAL} is only available for iOS builds`,
+        {
+          exit: 1,
+        }
+      );
     }
 
     const requestedPlatform =

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -147,6 +147,14 @@ export default class Build extends EasCommand {
     if (flags.json && !nonInteractive) {
       Errors.error('--json is allowed only when building in non-interactive mode', { exit: 1 });
     }
+    if (
+      flags['resource-class'] === UserInputResourceClass.M1_EXPERIMENTAL &&
+      flags.platform !== Platform.IOS
+    ) {
+      Errors.error('m1-experimental option for --resource-class flag is allowed only for iOS', {
+        exit: 1,
+      });
+    }
 
     const requestedPlatform =
       flags.platform &&

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -297,8 +297,6 @@ export type AccountMutation = {
   setPaymentSource: Account;
   /** Require authorization to send push notifications for experiences owned by this account */
   setPushSecurityEnabled: Account;
-  /** Add a subscription */
-  subscribeToProduct: Account;
 };
 
 
@@ -370,13 +368,6 @@ export type AccountMutationSetPaymentSourceArgs = {
 export type AccountMutationSetPushSecurityEnabledArgs = {
   accountID: Scalars['ID'];
   pushSecurityEnabled: Scalars['Boolean'];
-};
-
-
-export type AccountMutationSubscribeToProductArgs = {
-  accountName: Scalars['ID'];
-  paymentSource: Scalars['ID'];
-  productId: Scalars['ID'];
 };
 
 export type AccountQuery = {
@@ -2124,6 +2115,8 @@ export enum BuildResourceClass {
   AndroidLarge = 'ANDROID_LARGE',
   IosDefault = 'IOS_DEFAULT',
   IosLarge = 'IOS_LARGE',
+  /** @experimental This resource class is not yet ready to be used in production. For testing purposes only. */
+  IosM1Large = 'IOS_M1_LARGE',
   Legacy = 'LEGACY'
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-6571/add-m1-resource-class-for-eas-cli-use

# How

Add new `m1-experimental` option for `--resource-class` flag

# Test Plan

Test locally, run builds on staging
