### PR TITLE
[eas-cli] Update: improve DX on first run, correct error message

### DIFF
--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 
 import { getEASUpdateURL } from '../../api';
 import EasCommand from '../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { AppPlatform } from '../../graphql/generated';
 import Log, { learnMore } from '../../log';
 import { RequestedPlatform, appPlatformDisplayNames } from '../../platform';
@@ -70,6 +71,7 @@ export default class UpdateConfigure extends EasCommand {
       exp: updatedExp,
       platform,
       workflows,
+      graphqlClient,
     });
 
     Log.addNewLineIfNone();
@@ -296,19 +298,20 @@ async function configureNativeFilesForEASUpdateAsync({
   platform,
   workflows,
   projectId,
-}: ConfigureForEASUpdateArgs): Promise<void> {
+  graphqlClient,
+}: ConfigureForEASUpdateArgs & { graphqlClient: ExpoGraphqlClient }): Promise<void> {
   if (
     [RequestedPlatform.Android, RequestedPlatform.All].includes(platform) &&
     workflows.android === Workflow.GENERIC
   ) {
-    await syncAndroidUpdatesConfigurationAsync(graphqlClient, projectDir, updatedExp, projectId);
+    await syncAndroidUpdatesConfigurationAsync(graphqlClient, projectDir, exp, projectId);
     Log.withTick(`Configured ${chalk.bold('AndroidManifest.xml')} for EAS Update`);
   }
   if (
     [RequestedPlatform.Ios, RequestedPlatform.All].includes(platform) &&
     workflows.ios === Workflow.GENERIC
   ) {
-    await syncIosUpdatesConfigurationAsync(graphqlClient, projectDir, updatedExp, projectId);
+    await syncIosUpdatesConfigurationAsync(graphqlClient, projectDir, exp, projectId);
     Log.withTick(`Configured ${chalk.bold('Expo.plist')} for EAS Update`);
   }
 }

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -292,7 +292,7 @@ export async function configureAppJSONForEASUpdateAsync({
   return result.config.expo;
 }
 
-async function configureNativeFilesForEASUpdateAsync({
+export async function configureNativeFilesForEASUpdateAsync({
   projectDir,
   exp,
   platform,

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig, modifyConfigAsync } from '@expo/config';
-import { Workflow } from '@expo/eas-build-job';
+import { Platform, Workflow } from '@expo/eas-build-job';
 import { Flags } from '@oclif/core';
 import assert from 'assert';
 import chalk from 'chalk';
@@ -13,8 +13,7 @@ import {
   installExpoUpdatesAsync,
   isExpoUpdatesInstalledOrAvailable,
 } from '../../project/projectUtils';
-import { getCombinedWorkflowDataAsync } from '../../project/workflow';
-import type { CombinedWorkflowData } from '../../project/workflow';
+import { resolveWorkflowPerPlatformAsync } from '../../project/workflow';
 import { syncUpdatesConfigurationAsync as syncAndroidUpdatesConfigurationAsync } from '../../update/android/UpdatesModule';
 import { syncUpdatesConfigurationAsync as syncIosUpdatesConfigurationAsync } from '../../update/ios/UpdatesModule';
 
@@ -55,7 +54,7 @@ export default class UpdateConfigure extends EasCommand {
       await installExpoUpdatesAsync(projectDir);
     }
 
-    const workflows = await getCombinedWorkflowDataAsync(projectDir);
+    const workflows = await resolveWorkflowPerPlatformAsync(projectDir);
 
     const updatedExp = await configureAppJSONForEASUpdateAsync({
       projectDir,
@@ -82,7 +81,7 @@ type ConfigureForEASUpdateArgs = {
   projectDir: string;
   exp: ExpoConfig;
   platform: RequestedPlatform;
-  workflows: CombinedWorkflowData;
+  workflows: Record<Platform, Workflow>;
   projectId: string;
 };
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -595,7 +595,9 @@ function transformRuntimeVersions(exp: ExpoConfig, platforms: Platform[]): Recor
       platform,
       nullthrows(
         Updates.getRuntimeVersion(exp, platform),
-        `Unable to determine runtime version for ${requestedPlatformDisplayNames[platform]}. Learn more: https://docs.expo.dev/eas-update/runtime-versions/`
+        `Unable to determine runtime version for ${
+          requestedPlatformDisplayNames[platform]
+        }. ${chalk.dim('Learn more: https://docs.expo.dev/eas-update/runtime-versions/')}`
       ),
     ])
   );
@@ -623,10 +625,10 @@ async function getRuntimeVersionObjectAsync(
 
   try {
     return transformRuntimeVersions(exp, platforms);
-  } catch (error) {
-    Log.warn(error);
+  } catch (error: any) {
+    ora().start().fail(error.message);
 
-    const runConfig = await selectAsync(`Do you want us to run expo updates:config for you?`, [
+    const runConfig = await selectAsync(`Do you want us to run 'eas update:configure' for you?`, [
       { title: 'Yes', value: true },
       {
         title: 'No, I will edit files or run the command manually (EAS CLI exits)',

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -629,7 +629,7 @@ async function getRuntimeVersionObjectAsync(
     return [transformRuntimeVersions(exp, platforms), exp];
   } catch (error: any) {
     if (nonInteractive) {
-      Errors.error(error, { exit: 1 });
+      throw error;
     }
 
     Log.fail(error.message);

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -640,9 +640,9 @@ async function getRuntimeVersionObjectAsync(
     Log.fail(error.message);
 
     const runConfig = await selectAsync(
-      `Do you want us to run automatic ${chalk.bold(
+      `Configure runtime version in ${chalk.bold(
         'app.json'
-      )} configuration for EAS Update for you?`,
+      )} automatically for EAS Update?`,
       [
         { title: 'Yes', value: true },
         {
@@ -677,7 +677,7 @@ async function getRuntimeVersionObjectAsync(
     });
 
     const continueWithChanges = await selectAsync(
-      `Would you like to continue update process with uncommitted changes in repository?`,
+      `Continue update process with uncommitted changes in repository?`,
       [
         { title: 'Yes', value: true },
         {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -589,13 +589,13 @@ export default class UpdatePublish extends EasCommand {
   }
 }
 
-function transformRuntimeVersions(exp: ExpoConfig, platforms: Platform[]) {
+function transformRuntimeVersions(exp: ExpoConfig, platforms: Platform[]): Record<string, string> {
   return Object.fromEntries(
     platforms.map(platform => [
       platform,
       nullthrows(
         Updates.getRuntimeVersion(exp, platform),
-        `Unable to determine runtime version for ${requestedPlatformDisplayNames[platform]}.`
+        `Unable to determine runtime version for ${requestedPlatformDisplayNames[platform]}. Learn more: https://docs.expo.dev/eas-update/runtime-versions/`
       ),
     ])
   );

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -640,9 +640,7 @@ async function getRuntimeVersionObjectAsync(
     Log.fail(error.message);
 
     const runConfig = await selectAsync(
-      `Configure runtime version in ${chalk.bold(
-        'app.json'
-      )} automatically for EAS Update?`,
+      `Configure runtime version in ${chalk.bold('app.json')} automatically for EAS Update?`,
       [
         { title: 'Yes', value: true },
         {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -636,13 +636,18 @@ async function getRuntimeVersionObjectAsync(
 
     ora().start().fail(error.message);
 
-    const runConfig = await selectAsync(`Do you want us to run 'eas update:configure' for you?`, [
-      { title: 'Yes', value: true },
-      {
-        title: 'No, I will edit files or run the command manually (EAS CLI exits)',
-        value: false,
-      },
-    ]);
+    const runConfig = await selectAsync(
+      `Do you want us to run automatic ${chalk.bold(
+        'app.json'
+      )} configuration for EAS Update for you?`,
+      [
+        { title: 'Yes', value: true },
+        {
+          title: 'No, I will set the runtime version manually (EAS CLI exits)',
+          value: false,
+        },
+      ]
+    );
 
     if (!runConfig) {
       Errors.exit(1);

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -634,7 +634,7 @@ async function getRuntimeVersionObjectAsync(
       Errors.error(error, { exit: 1 });
     }
 
-    ora().start().fail(error.message);
+    Log.failed(error.message);
 
     const runConfig = await selectAsync(
       `Do you want us to run automatic ${chalk.bold(

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -58,6 +58,7 @@ import { maybeWarnAboutEasOutagesAsync } from '../../utils/statuspageService';
 import { getVcsClient } from '../../vcs';
 import { createUpdateBranchOnAppAsync } from '../branch/create';
 import { createUpdateChannelOnAppAsync } from '../channel/create';
+import { configureAppJSONForEASUpdateAsync } from './configure';
 
 export const defaultPublishPlatforms: PublishPlatform[] = ['android', 'ios'];
 export type PublishPlatformFlag = PublishPlatform | 'all';
@@ -337,7 +338,7 @@ export default class UpdatePublish extends EasCommand {
         if (updatesToRepublishFilteredByPlatform.length !== defaultPublishPlatforms.length) {
           Log.warn(`You are republishing an update that wasn't published for all platforms.`);
         }
-        publicationPlatformMessage = `The republished update will appear on the same plaforms it was originally published on: ${updatesToRepublishFilteredByPlatform
+        publicationPlatformMessage = `The republished update will appear on the same platforms it was originally published on: ${updatesToRepublishFilteredByPlatform
           .map(update => update.platform)
           .join(', ')}`;
       } else {
@@ -631,7 +632,7 @@ async function getRuntimeVersionObjectAsync(
       Errors.error(error, { exit: 1 });
     }
 
-    Log.failed(error.message);
+    Log.fail(error.message);
 
     const runConfig = await selectAsync(
       `Do you want us to run automatic ${chalk.bold(
@@ -650,7 +651,6 @@ async function getRuntimeVersionObjectAsync(
       Errors.exit(1);
     }
 
-    const { configureAppJSONForEASUpdateAsync } = await import('./configure');
     const newConfig = await configureAppJSONForEASUpdateAsync({
       exp,
       projectDir,

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -59,7 +59,6 @@ import { maybeWarnAboutEasOutagesAsync } from '../../utils/statuspageService';
 import { getVcsClient } from '../../vcs';
 import { createUpdateBranchOnAppAsync } from '../branch/create';
 import { createUpdateChannelOnAppAsync } from '../channel/create';
-import UpdateConfigure from './configure';
 
 export const defaultPublishPlatforms: PublishPlatform[] = ['android', 'ios'];
 export type PublishPlatformFlag = PublishPlatform | 'all';
@@ -640,6 +639,7 @@ async function getRuntimeVersionObjectAsync(
       Errors.exit(1);
     }
 
+    const { default: UpdateConfigure } = await import('./configure');
     await UpdateConfigure.run(['-p', platformFlag]);
 
     const { exp: newConfig } = await getDynamicProjectConfigAsync({

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -253,7 +253,8 @@ export default class UpdatePublish extends EasCommand {
       exp,
       platformFlag,
       projectDir,
-      getDynamicProjectConfigAsync
+      getDynamicProjectConfigAsync,
+      nonInteractive
     );
     await checkEASUpdateURLIsSetAsync(exp, projectId);
 
@@ -606,7 +607,8 @@ async function getRuntimeVersionObjectAsync(
   exp: ExpoConfig,
   platformFlag: PublishPlatformFlag,
   projectDir: string,
-  getDynamicProjectConfigAsync: DynamicConfigContextFn
+  getDynamicProjectConfigAsync: DynamicConfigContextFn,
+  nonInteractive: boolean
 ): Promise<Record<string, string>> {
   const platforms = (platformFlag === 'all' ? ['android', 'ios'] : [platformFlag]) as Platform[];
 
@@ -625,6 +627,10 @@ async function getRuntimeVersionObjectAsync(
   try {
     return transformRuntimeVersions(exp, platforms);
   } catch (error: any) {
+    if (nonInteractive) {
+      Errors.error(error, { exit: 1 });
+    }
+
     ora().start().fail(error.message);
 
     const runConfig = await selectAsync(`Do you want us to run 'eas update:configure' for you?`, [

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -42,7 +42,7 @@ import {
   isUploadedAssetCountAboveWarningThreshold,
   uploadAssetsAsync,
 } from '../../project/publish';
-import { getCombinedWorkflowDataAsync, resolveWorkflowAsync } from '../../project/workflow';
+import { resolveWorkflowAsync, resolveWorkflowPerPlatformAsync } from '../../project/workflow';
 import { confirmAsync, promptAsync, selectAsync } from '../../prompts';
 import { selectUpdateGroupOnBranchAsync } from '../../update/queries';
 import { formatUpdateMessage } from '../../update/utils';
@@ -659,7 +659,7 @@ async function getRuntimeVersionObjectAsync(
       projectDir,
       projectId,
       platform: platformFlag as RequestedPlatform,
-      workflows: await getCombinedWorkflowDataAsync(projectDir),
+      workflows: await resolveWorkflowPerPlatformAsync(projectDir),
     });
 
     return [transformRuntimeVersions(newConfig, platforms), newConfig];

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -45,6 +45,10 @@ export default class Log {
     Log.warn(`› ${chalk.bold('--' + flag)} flag is deprecated. ${message}`);
   }
 
+  public static failed(message: string): void {
+    Log.log(`${chalk.red(logSymbols.error)} ${message}`);
+  }
+
   public static succeed(message: string): void {
     Log.log(`${chalk.green(logSymbols.success)} ${message}`);
   }

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -45,7 +45,7 @@ export default class Log {
     Log.warn(`› ${chalk.bold('--' + flag)} flag is deprecated. ${message}`);
   }
 
-  public static failed(message: string): void {
+  public static fail(message: string): void {
     Log.log(`${chalk.red(logSymbols.error)} ${message}`);
   }
 

--- a/packages/eas-cli/src/project/__tests__/workflow-test.ts
+++ b/packages/eas-cli/src/project/__tests__/workflow-test.ts
@@ -1,16 +1,16 @@
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { vol } from 'memfs';
 
-import { resolveWorkflowAsync } from '../workflow';
+import { resolveWorkflowAsync, resolveWorkflowPerPlatformAsync } from '../workflow';
 
 jest.mock('fs');
+
+const projectDir = '/app';
 
 describe(resolveWorkflowAsync, () => {
   beforeEach(() => {
     vol.reset();
   });
-
-  const projectDir = '/app';
 
   test('bare workflow for both platforms', async () => {
     vol.fromJSON(
@@ -55,5 +55,26 @@ describe(resolveWorkflowAsync, () => {
       Workflow.MANAGED
     );
     await expect(resolveWorkflowAsync(projectDir, Platform.IOS)).resolves.toBe(Workflow.MANAGED);
+  });
+});
+
+describe(resolveWorkflowPerPlatformAsync, () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  test('returns the correct combined value', async () => {
+    vol.fromJSON(
+      {
+        './ios/helloworld.xcodeproj/project.pbxproj': 'fake',
+        './android/app/src/main/AndroidManifest.xml': 'fake',
+      },
+      projectDir
+    );
+
+    await expect(resolveWorkflowPerPlatformAsync(projectDir)).resolves.toEqual({
+      android: Workflow.GENERIC,
+      ios: Workflow.GENERIC,
+    });
   });
 });

--- a/packages/eas-cli/src/project/workflow.ts
+++ b/packages/eas-cli/src/project/workflow.ts
@@ -38,8 +38,9 @@ export async function resolveWorkflowAsync(
 export async function resolveWorkflowPerPlatformAsync(
   projectDir: string
 ): Promise<Record<Platform, Workflow>> {
-  return {
-    android: await resolveWorkflowAsync(projectDir, Platform.ANDROID),
-    ios: await resolveWorkflowAsync(projectDir, Platform.IOS),
-  };
+  const [android, ios] = await Promise.all([
+    resolveWorkflowAsync(projectDir, Platform.ANDROID),
+    resolveWorkflowAsync(projectDir, Platform.IOS),
+  ]);
+  return { android, ios };
 }

--- a/packages/eas-cli/src/project/workflow.ts
+++ b/packages/eas-cli/src/project/workflow.ts
@@ -34,3 +34,16 @@ export async function resolveWorkflowAsync(
   }
   return Workflow.MANAGED;
 }
+
+export type CombinedWorkflowData = {
+  [value in Platform]: Workflow;
+};
+
+export async function getCombinedWorkflowDataAsync(
+  projectDir: string
+): Promise<CombinedWorkflowData> {
+  return {
+    android: await resolveWorkflowAsync(projectDir, Platform.ANDROID),
+    ios: await resolveWorkflowAsync(projectDir, Platform.IOS),
+  };
+}

--- a/packages/eas-cli/src/project/workflow.ts
+++ b/packages/eas-cli/src/project/workflow.ts
@@ -35,13 +35,9 @@ export async function resolveWorkflowAsync(
   return Workflow.MANAGED;
 }
 
-export type CombinedWorkflowData = {
-  [value in Platform]: Workflow;
-};
-
-export async function getCombinedWorkflowDataAsync(
+export async function resolveWorkflowPerPlatformAsync(
   projectDir: string
-): Promise<CombinedWorkflowData> {
+): Promise<Record<Platform, Workflow>> {
   return {
     android: await resolveWorkflowAsync(projectDir, Platform.ANDROID),
     ios: await resolveWorkflowAsync(projectDir, Platform.IOS),


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes ENG-6013
Fixes ENG-6014

# How

This changeset adds the prompt for the user when there is no runtime version specified, which asks if setup the updates automatically for them (via `eas update:configure`).

If user do not want this the CLI exits as before.

If user selects "Yes", we are programmatically running `eas update:configure`, and then re-reading the modified config, so the process can continue without the interruption or command exit.

As always, the copy/messages content probably can be written better. 😉 

# Test Plan

The changes have been tested locally in few project by running `dev` bin of EAS CLI.

# Preview

<img width="810" alt="Screenshot 2022-10-07 at 21 43 45" src="https://user-images.githubusercontent.com/719641/194641425-be3cc99d-fdd8-4d74-8965-68174095ba66.png">

<img width="1186" alt="Screenshot 2022-10-07 at 21 40 31" src="https://user-images.githubusercontent.com/719641/194641163-4ae39fbd-edb2-4222-8566-ece3480e007b.png">

