### PR TITLE
[ENG-6652] automatically choose next version when releasing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 ## Releasing a new version
 
-1. Run `yarn release` in the repository root folder.
+1. Run `yarn release` in the repository root folder. The next version is chosen automatically based on the changelog entries. If you want to use different version, pass the version string as a positional argument to the command, e.g. `yarn release 1.2.3`.
 2. That's it! GitHub Actions is going to take care of the rest. Watch the #eas-cli Slack channel for a successful release notification.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch": "yarn start",
     "eas": "packages/eas-cli/bin/run",
     "lint": "eslint .",
-    "release": "./scripts/bin/run update-local-plugin && lerna version --exact",
+    "release": "./scripts/bin/run release",
     "test": "jest",
     "clean": "lerna run clean && rm -rf node_modules coverage"
   },

--- a/scripts/bin/run
+++ b/scripts/bin/run
@@ -5,5 +5,5 @@ set -eo pipefail
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 
 pushd $SCRIPTS_DIR >/dev/null 2>&1
-yarn $@
+yarn --silent $@
 popd >/dev/null 2>&1

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,6 +5,8 @@
   "version": "0.31.0",
   "scripts": {
     "changelog-entry": "ts-node-esm src/changelogEntry.ts",
+    "next-version": "ts-node-esm src/nextVersion.ts",
+    "release": "./src/release.sh",
     "release-changelog": "ts-node-esm src/releaseChangelog.ts",
     "update-local-plugin": "./src/updateLocalPlugin.sh",
     "typecheck": "tsc"

--- a/scripts/src/nextVersion.ts
+++ b/scripts/src/nextVersion.ts
@@ -1,0 +1,67 @@
+import { CATEGORY_HEADERS, EntryCategory } from './changelog/consts.js';
+import { readAndParseChangelogAsync } from './changelog/file.js';
+import * as markdown from './markdown.js';
+
+enum BumpStrategy {
+  MAJOR = 'major',
+  MINOR = 'minor',
+  PATCH = 'patch',
+}
+
+type Counts = Record<EntryCategory, number>;
+
+(async function main(): Promise<void> {
+  const tokens = await readAndParseChangelogAsync();
+  const counts = countEntriesPerCategory(tokens);
+  // eslint-disable-next-line no-console
+  console.log(getBumpStrategy(counts));
+})().catch(err => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});
+
+function countEntriesPerCategory(tokens: markdown.Tokens): Counts {
+  const counts = Object.values(EntryCategory).reduce((acc, i) => {
+    acc[i] = 0;
+    return acc;
+  }, {} as Counts);
+
+  for (const [categoryHeader, categoryHeaderText] of Object.entries(CATEGORY_HEADERS)) {
+    let i = 0;
+    while (true) {
+      const token = tokens[i];
+      if (
+        token.type === markdown.TokenType.HEADING &&
+        token.depth === 3 &&
+        token.text === categoryHeaderText
+      ) {
+        break;
+      } else {
+        i++;
+      }
+    }
+
+    // if next token is a heading, there are no entries for this category
+    if (tokens[i + 1].type === markdown.TokenType.HEADING) {
+      continue;
+    }
+
+    // i points at the category heading
+    // tokens[i + 1] is a list token
+    const listToken = tokens[i + 1] as unknown as markdown.ListToken;
+    counts[categoryHeader as EntryCategory] = listToken.items.length;
+  }
+
+  return counts;
+}
+
+function getBumpStrategy(counts: Counts): BumpStrategy {
+  if (counts[EntryCategory.BreakingChange] > 0) {
+    return BumpStrategy.MAJOR;
+  }
+  if (counts[EntryCategory.NewFeature] > 0) {
+    return BumpStrategy.MINOR;
+  }
+  return BumpStrategy.PATCH;
+}

--- a/scripts/src/release.sh
+++ b/scripts/src/release.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+ROOT_DIR="$( cd "$SCRIPTS_DIR"/.. && pwd )"
+
+$SCRIPTS_DIR/bin/run update-local-plugin
+
+next_version_bump=$($SCRIPTS_DIR/bin/run next-version)
+next_version=${1:-$next_version_bump}
+
+lerna version --exact "$next_version"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1664960139821809

We want to use strict semver when releasing EAS CLI. This PR should let us avoid mistakes when choosing the next version for a release.

# How

Use the following algorithm for bumping the version:
- If there are some entries under "Breaking changes", bump the major version.
- Otherwise, if there are some entries under "New features", bump the minor version.
- In all other cases bump the patch.

# Test Plan

Tested locally.