### PR TITLE
[24/n][eas-cli] Start to move graphql into a context

### DIFF
--- a/packages/eas-cli/src/build/__tests__/cancel-test.ts
+++ b/packages/eas-cli/src/build/__tests__/cancel-test.ts
@@ -1,5 +1,7 @@
+import { instance, mock } from 'ts-mockito';
 import { v4 as uuid } from 'uuid';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { selectBuildToCancelAsync } from '../../commands/build/cancel';
 import { AppPlatform, BuildFragment, BuildPriority, BuildStatus } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
@@ -43,14 +45,18 @@ describe(selectBuildToCancelAsync.name, () => {
   });
 
   it('does not return build id when confirmation is rejected', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
     jest.mocked(confirmAsync).mockResolvedValueOnce(false);
-    expect(selectBuildToCancelAsync(projectId, 'blah')).resolves.toEqual(null);
+    expect(selectBuildToCancelAsync(graphqlClient, projectId, 'blah')).resolves.toEqual(null);
   });
 
   it('returns build id when confirmation is confirmed', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
     jest.mocked(selectAsync).mockResolvedValueOnce(selectedBuildId);
     jest.mocked(confirmAsync).mockResolvedValueOnce(true);
-    expect(selectBuildToCancelAsync(projectId, 'blah')).resolves.toEqual(selectedBuildId);
+    expect(selectBuildToCancelAsync(graphqlClient, projectId, 'blah')).resolves.toEqual(
+      selectedBuildId
+    );
   });
 });
 

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -63,7 +63,7 @@ This means that it will most likely produce an AAB and you will not be able to i
   const applicationId = await getApplicationIdAsync(ctx.projectDir, ctx.exp, gradleContext);
   const versionCodeOverride =
     ctx.easJsonCliConfig?.appVersionSource === AppVersionSource.REMOTE
-      ? await resolveRemoteVersionCodeAsync({
+      ? await resolveRemoteVersionCodeAsync(ctx.graphqlClient, {
           projectDir: ctx.projectDir,
           projectId: ctx.projectId,
           exp: ctx.exp,
@@ -84,7 +84,7 @@ export async function prepareAndroidBuildAsync(
       return await ensureAndroidCredentialsAsync(ctx);
     },
     syncProjectConfigurationAsync: async () => {
-      await syncProjectConfigurationAsync({
+      await syncProjectConfigurationAsync(ctx.graphqlClient, {
         projectDir: ctx.projectDir,
         exp: ctx.exp,
         localAutoIncrement:
@@ -108,7 +108,7 @@ export async function prepareAndroidBuildAsync(
     ): Promise<BuildResult> => {
       const graphqlMetadata = transformMetadata(metadata);
       const graphqlJob = transformJob(job);
-      return await BuildMutation.createAndroidBuildAsync({
+      return await BuildMutation.createAndroidBuildAsync(ctx.graphqlClient, {
         appId,
         job: graphqlJob,
         metadata: graphqlMetadata,

--- a/packages/eas-cli/src/build/android/syncProjectConfiguration.ts
+++ b/packages/eas-cli/src/build/android/syncProjectConfiguration.ts
@@ -6,30 +6,34 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import Log from '../../log';
 import { isExpoUpdatesInstalled } from '../../project/projectUtils';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { syncUpdatesConfigurationAsync } from '../../update/android/UpdatesModule';
 import { BumpStrategy, bumpVersionAsync, bumpVersionInAppJsonAsync } from './version';
 
-export async function syncProjectConfigurationAsync({
-  projectDir,
-  exp,
-  localAutoIncrement,
-  projectId,
-}: {
-  projectDir: string;
-  exp: ExpoConfig;
-  localAutoIncrement?: AndroidVersionAutoIncrement;
-  projectId: string;
-}): Promise<void> {
+export async function syncProjectConfigurationAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    projectDir,
+    exp,
+    localAutoIncrement,
+    projectId,
+  }: {
+    projectDir: string;
+    exp: ExpoConfig;
+    localAutoIncrement?: AndroidVersionAutoIncrement;
+    projectId: string;
+  }
+): Promise<void> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
   const versionBumpStrategy = resolveVersionBumpStrategy(localAutoIncrement ?? false);
 
   if (workflow === Workflow.GENERIC) {
     await cleanUpOldEasBuildGradleScriptAsync(projectDir);
     if (isExpoUpdatesInstalled(projectDir)) {
-      await syncUpdatesConfigurationAsync(projectDir, exp, projectId);
+      await syncUpdatesConfigurationAsync(graphqlClient, projectDir, exp, projectId);
     }
     await bumpVersionAsync({ projectDir, exp, bumpStrategy: versionBumpStrategy });
   } else {

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -5,6 +5,7 @@ import { BuildProfile } from '@expo/eas-json';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { AppPlatform } from '../../graphql/generated';
 import { AppVersionMutation } from '../../graphql/mutations/AppVersionMutation';
 import { AppVersionQuery } from '../../graphql/queries/AppVersionQuery';
@@ -174,20 +175,24 @@ async function writeBuildGradleAsync({
  * Returns buildNumber that will be used for the next build. If current build profile
  * has an 'autoIncrement' option set, it increments the version on server.
  */
-export async function resolveRemoteVersionCodeAsync({
-  projectDir,
-  projectId,
-  exp,
-  applicationId,
-  buildProfile,
-}: {
-  projectDir: string;
-  projectId: string;
-  exp: ExpoConfig;
-  applicationId: string;
-  buildProfile: BuildProfile<Platform.ANDROID>;
-}): Promise<string> {
+export async function resolveRemoteVersionCodeAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    projectDir,
+    projectId,
+    exp,
+    applicationId,
+    buildProfile,
+  }: {
+    projectDir: string;
+    projectId: string;
+    exp: ExpoConfig;
+    applicationId: string;
+    buildProfile: BuildProfile<Platform.ANDROID>;
+  }
+): Promise<string> {
   const remoteVersions = await AppVersionQuery.latestVersionAsync(
+    graphqlClient,
     projectId,
     AppPlatform.Android,
     applicationId
@@ -217,7 +222,7 @@ export async function resolveRemoteVersionCodeAsync({
       `Initializing versionCode with ${chalk.bold(currentBuildVersion)}.`
     ).start();
     try {
-      await AppVersionMutation.createAppVersionAsync({
+      await AppVersionMutation.createAppVersionAsync(graphqlClient, {
         appId: projectId,
         platform: AppPlatform.Android,
         applicationIdentifier: applicationId,
@@ -239,7 +244,7 @@ export async function resolveRemoteVersionCodeAsync({
       )}.`
     ).start();
     try {
-      await AppVersionMutation.createAppVersionAsync({
+      await AppVersionMutation.createAppVersionAsync(graphqlClient, {
         appId: projectId,
         platform: AppPlatform.Android,
         applicationIdentifier: applicationId,

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -8,6 +8,7 @@ import nullthrows from 'nullthrows';
 import { withAnalyticsAsync } from '../analytics/common';
 import { BuildEvent } from '../analytics/events';
 import { getExpoWebsiteBaseUrl } from '../api';
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   AppPlatform,
   BuildFragment,
@@ -213,6 +214,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         projectTarballPath = projectTarball.path;
 
         const { bucketKey } = await uploadFileAtPathToS3Async(
+          ctx.graphqlClient,
           UploadSessionType.EasBuildProjectSources,
           projectTarball.path,
           createProgressTracker({
@@ -275,6 +277,7 @@ async function sendBuildRequestAsync<TPlatform extends Platform, Credentials, TJ
 type MaybeBuildFragment = BuildFragment | null;
 
 export async function waitForBuildEndAsync(
+  graphqlClient: ExpoGraphqlClient,
   { buildIds, accountName }: { buildIds: string[]; accountName: string },
   { intervalSec = 10 } = {}
 ): Promise<MaybeBuildFragment[]> {
@@ -289,7 +292,7 @@ export async function waitForBuildEndAsync(
     spinner = ora('Waiting for builds to complete. You can press Ctrl+C to exit.').start();
   }
   while (true) {
-    const builds = await getBuildsSafelyAsync(buildIds);
+    const builds = await getBuildsSafelyAsync(graphqlClient, buildIds);
     const { refetch } =
       builds.length === 1
         ? await handleSingleBuildProgressAsync({ build: builds[0], accountName }, { spinner })
@@ -301,10 +304,13 @@ export async function waitForBuildEndAsync(
   }
 }
 
-async function getBuildsSafelyAsync(buildIds: string[]): Promise<MaybeBuildFragment[]> {
+async function getBuildsSafelyAsync(
+  graphqlClient: ExpoGraphqlClient,
+  buildIds: string[]
+): Promise<MaybeBuildFragment[]> {
   const promises = buildIds.map(async buildId => {
     try {
-      return await BuildQuery.byIdAsync(buildId, { useCache: false });
+      return await BuildQuery.byIdAsync(graphqlClient, buildId, { useCache: false });
     } catch (err) {
       Log.debug('Failed to fetch the build status', err);
       return null;

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -3,6 +3,7 @@ import { Platform, Workflow } from '@expo/eas-build-job';
 import { BuildProfile, EasJson } from '@expo/eas-json';
 
 import { TrackingContext } from '../analytics/common';
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { CredentialsContext } from '../credentials/context';
 import { Target } from '../credentials/ios/types';
 import { BuildResourceClass } from '../graphql/generated';
@@ -47,6 +48,7 @@ export interface BuildContext<T extends Platform> {
   message?: string;
   trackingCtx: TrackingContext;
   user: Actor;
+  graphqlClient: ExpoGraphqlClient;
   workflow: Workflow;
   android: T extends Platform.ANDROID ? AndroidBuildContext : undefined;
   ios: T extends Platform.IOS ? IosBuildContext : undefined;

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -46,7 +46,7 @@ export async function createIosContextAsync(
   const applicationTarget = findApplicationTarget(targets);
   const buildNumberOverride =
     ctx.easJsonCliConfig?.appVersionSource === AppVersionSource.REMOTE
-      ? await resolveRemoteBuildNumberAsync({
+      ? await resolveRemoteBuildNumberAsync(ctx.graphqlClient, {
           projectDir: ctx.projectDir,
           projectId: ctx.projectId,
           exp: ctx.exp,
@@ -72,7 +72,7 @@ export async function prepareIosBuildAsync(
       return ensureIosCredentialsAsync(ctx, ctx.ios.targets);
     },
     syncProjectConfigurationAsync: async () => {
-      await syncProjectConfigurationAsync({
+      await syncProjectConfigurationAsync(ctx.graphqlClient, {
         projectDir: ctx.projectDir,
         exp: ctx.exp,
         targets: ctx.ios.targets,
@@ -100,7 +100,7 @@ export async function prepareIosBuildAsync(
     ): Promise<BuildResult> => {
       const graphqlMetadata = transformMetadata(metadata);
       const graphqlJob = transformJob(job);
-      return await BuildMutation.createIosBuildAsync({
+      return await BuildMutation.createIosBuildAsync(ctx.graphqlClient, {
         appId,
         job: graphqlJob,
         metadata: graphqlMetadata,

--- a/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts
+++ b/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts
@@ -2,31 +2,35 @@ import { ExpoConfig } from '@expo/config';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { IosVersionAutoIncrement } from '@expo/eas-json';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { Target } from '../../credentials/ios/types';
 import { isExpoUpdatesInstalled } from '../../project/projectUtils';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { syncUpdatesConfigurationAsync } from '../../update/ios/UpdatesModule';
 import { BumpStrategy, bumpVersionAsync, bumpVersionInAppJsonAsync } from './version';
 
-export async function syncProjectConfigurationAsync({
-  projectDir,
-  exp,
-  targets,
-  localAutoIncrement,
-  projectId,
-}: {
-  projectDir: string;
-  exp: ExpoConfig;
-  targets: Target[];
-  localAutoIncrement?: IosVersionAutoIncrement;
-  projectId: string;
-}): Promise<void> {
+export async function syncProjectConfigurationAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    projectDir,
+    exp,
+    targets,
+    localAutoIncrement,
+    projectId,
+  }: {
+    projectDir: string;
+    exp: ExpoConfig;
+    targets: Target[];
+    localAutoIncrement?: IosVersionAutoIncrement;
+    projectId: string;
+  }
+): Promise<void> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
   const versionBumpStrategy = resolveVersionBumpStrategy(localAutoIncrement ?? false);
 
   if (workflow === Workflow.GENERIC) {
     if (isExpoUpdatesInstalled(projectDir)) {
-      await syncUpdatesConfigurationAsync(projectDir, exp, projectId);
+      await syncUpdatesConfigurationAsync(graphqlClient, projectDir, exp, projectId);
     }
     await bumpVersionAsync({ projectDir, exp, bumpStrategy: versionBumpStrategy, targets });
   } else {

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import path from 'path';
 import type { XCBuildConfiguration } from 'xcode';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { Target } from '../../credentials/ios/types';
 import { AppPlatform } from '../../graphql/generated';
 import { AppVersionMutation } from '../../graphql/mutations/AppVersionMutation';
@@ -255,20 +256,24 @@ export function evaluateTemplateString(
  * Returns buildNumber that will be used for the next build. If current build profile
  * has an 'autoIncrement' option set, it increments the version on server.
  */
-export async function resolveRemoteBuildNumberAsync({
-  projectDir,
-  projectId,
-  exp,
-  applicationTarget,
-  buildProfile,
-}: {
-  projectDir: string;
-  projectId: string;
-  exp: ExpoConfig;
-  applicationTarget: Target;
-  buildProfile: BuildProfile<Platform.IOS>;
-}): Promise<string> {
+export async function resolveRemoteBuildNumberAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    projectDir,
+    projectId,
+    exp,
+    applicationTarget,
+    buildProfile,
+  }: {
+    projectDir: string;
+    projectId: string;
+    exp: ExpoConfig;
+    applicationTarget: Target;
+    buildProfile: BuildProfile<Platform.IOS>;
+  }
+): Promise<string> {
   const remoteVersions = await AppVersionQuery.latestVersionAsync(
+    graphqlClient,
     projectId,
     AppPlatform.Ios,
     applicationTarget.bundleIdentifier
@@ -307,7 +312,7 @@ export async function resolveRemoteBuildNumberAsync({
       `Initializing buildNumber with ${chalk.bold(currentBuildVersion)}.`
     ).start();
     try {
-      await AppVersionMutation.createAppVersionAsync({
+      await AppVersionMutation.createAppVersionAsync(graphqlClient, {
         appId: projectId,
         platform: AppPlatform.Ios,
         applicationIdentifier: applicationTarget.bundleIdentifier,
@@ -329,7 +334,7 @@ export async function resolveRemoteBuildNumberAsync({
       )}.`
     ).start();
     try {
-      await AppVersionMutation.createAppVersionAsync({
+      await AppVersionMutation.createAppVersionAsync(graphqlClient, {
         appId: projectId,
         platform: AppPlatform.Ios,
         applicationIdentifier: applicationTarget.bundleIdentifier,

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { PaginatedQueryOptions } from '../commandUtils/pagination';
 import { BuildFilter, BuildFragment } from '../graphql/generated';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
@@ -10,19 +11,22 @@ import { formatGraphQLBuild } from './utils/formatBuild';
 
 export const BUILDS_LIMIT = 50;
 
-export async function listAndRenderBuildsOnAppAsync({
-  projectId,
-  projectDisplayName,
-  filter,
-  paginatedQueryOptions,
-}: {
-  projectId: string;
-  projectDisplayName: string;
-  filter?: BuildFilter;
-  paginatedQueryOptions: PaginatedQueryOptions;
-}): Promise<void> {
+export async function listAndRenderBuildsOnAppAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    projectId,
+    projectDisplayName,
+    filter,
+    paginatedQueryOptions,
+  }: {
+    projectId: string;
+    projectDisplayName: string;
+    filter?: BuildFilter;
+    paginatedQueryOptions: PaginatedQueryOptions;
+  }
+): Promise<void> {
   if (paginatedQueryOptions.nonInteractive) {
-    const builds = await BuildQuery.viewBuildsOnAppAsync({
+    const builds = await BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
       appId: projectId,
       limit: paginatedQueryOptions.limit ?? BUILDS_LIMIT,
       offset: paginatedQueryOptions.offset,
@@ -34,7 +38,7 @@ export async function listAndRenderBuildsOnAppAsync({
       limit: paginatedQueryOptions.limit ?? BUILDS_LIMIT,
       offset: paginatedQueryOptions.offset,
       queryToPerform: (limit, offset) =>
-        BuildQuery.viewBuildsOnAppAsync({
+        BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
           appId: projectId,
           limit,
           offset,

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -7,9 +7,9 @@ import {
   logEvent,
 } from '../analytics/rudderstackClient';
 import { getUserAsync } from '../user/User';
-import ActorContextField from './context/ActorContextField';
 import ContextField from './context/ContextField';
 import { DynamicProjectConfigContextField } from './context/DynamicProjectConfigContextField';
+import LoggedInContextField from './context/LoggedInContextField';
 import { OptionalProjectConfigContextField } from './context/OptionalProjectConfigContextField';
 import ProjectConfigContextField from './context/ProjectConfigContextField';
 import ProjectDirContextField from './context/ProjectDirContextField';
@@ -36,7 +36,7 @@ export default abstract class EasCommand extends Command {
      * Require this command to be run when logged-in. Returns the logged-in actor in the context.
      */
     LoggedIn: {
-      actor: new ActorContextField(),
+      loggedIn: new LoggedInContextField(),
     },
     /**
      * Require the project to be identified and registered on server if this command is being

--- a/packages/eas-cli/src/commandUtils/context/ActorContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/ActorContextField.ts
@@ -1,9 +1,0 @@
-import { Actor } from '../../user/User';
-import ContextField, { ContextOptions } from './ContextField';
-import { ensureLoggedInAsync } from './contextUtils/ensureLoggedInAsync';
-
-export default class ActorContextField extends ContextField<Actor> {
-  async getValueAsync({ nonInteractive }: ContextOptions): Promise<Actor> {
-    return await ensureLoggedInAsync({ nonInteractive });
-  }
-}

--- a/packages/eas-cli/src/commandUtils/context/LoggedInContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/LoggedInContextField.ts
@@ -1,0 +1,17 @@
+import { legacyGraphqlClient } from '../../graphql/client';
+import { Actor } from '../../user/User';
+import ContextField, { ContextOptions } from './ContextField';
+import { ExpoGraphqlClient } from './contextUtils/createGraphqlClient';
+import { ensureLoggedInAsync } from './contextUtils/ensureLoggedInAsync';
+
+export default class LoggedInContextField extends ContextField<{
+  actor: Actor;
+  graphqlClient: ExpoGraphqlClient;
+}> {
+  async getValueAsync({
+    nonInteractive,
+  }: ContextOptions): Promise<{ actor: Actor; graphqlClient: ExpoGraphqlClient }> {
+    const actor = await ensureLoggedInAsync({ nonInteractive });
+    return { actor, graphqlClient: legacyGraphqlClient };
+  }
+}

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/createGraphqlClient.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/createGraphqlClient.ts
@@ -1,0 +1,65 @@
+import {
+  Client,
+  OperationContext,
+  OperationResult,
+  PromisifiedSource,
+  TypedDocumentNode,
+  cacheExchange,
+  createClient as createUrqlClient,
+  dedupExchange,
+  fetchExchange,
+} from '@urql/core';
+import { retryExchange } from '@urql/exchange-retry';
+import { DocumentNode } from 'graphql';
+import fetch from 'node-fetch';
+
+import { getExpoApiBaseUrl } from '../../../api';
+import { httpsProxyAgent } from '../../../fetch';
+import { getAccessToken, getSessionSecret } from '../../../user/sessionStorage';
+
+export interface ExpoGraphqlClient extends Client {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  query<Data = any, Variables extends object = {}>(
+    query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+    variables: Variables | undefined,
+    context: Partial<OperationContext> & { additionalTypenames: string[] }
+  ): PromisifiedSource<OperationResult<Data, Variables>>;
+}
+
+export function createGraphqlClient(): ExpoGraphqlClient {
+  return createUrqlClient({
+    url: getExpoApiBaseUrl() + '/graphql',
+    exchanges: [
+      dedupExchange,
+      cacheExchange,
+      retryExchange({
+        maxDelayMs: 4000,
+        retryIf: (err, operation) => {
+          return !!(
+            err &&
+            !operation.context.noRetry &&
+            (err.networkError || err.graphQLErrors.some(e => e?.extensions?.isTransient))
+          );
+        },
+      }),
+      fetchExchange,
+    ],
+    // @ts-expect-error Type 'typeof fetch' is not assignable to type '(input: RequestInfo, init?: RequestInit | undefined) => Promise<Response>'.
+    fetch,
+    fetchOptions: (): RequestInit => {
+      const headers: Record<string, string> = {};
+      const token = getAccessToken();
+      if (token) {
+        headers.authorization = `Bearer ${token}`;
+      }
+      const sessionSecret = getSessionSecret();
+      if (!token && sessionSecret) {
+        headers['expo-session'] = sessionSecret;
+      }
+      return {
+        ...(httpsProxyAgent ? { agent: httpsProxyAgent } : {}),
+        headers,
+      };
+    },
+  }) as ExpoGraphqlClient;
+}

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -3,6 +3,7 @@ import { ExpoConfig } from '@expo/config-types';
 import { Env } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
+import { legacyGraphqlClient } from '../../../graphql/client';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import Log, { learnMore } from '../../../log';
 import { ora } from '../../../ora';
@@ -76,7 +77,7 @@ export async function getProjectIdAsync(
   const localProjectId = exp.extra?.eas?.projectId;
   if (localProjectId) {
     // check that the local project ID matches account and slug
-    const appForProjectId = await AppQuery.byIdAsync(localProjectId);
+    const appForProjectId = await AppQuery.byIdAsync(legacyGraphqlClient, localProjectId);
     if (exp.owner && exp.owner !== appForProjectId.ownerAccount.name) {
       throw new Error(
         `Project config: Project identified by "extra.eas.projectId" (${

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -14,12 +14,14 @@ export default class BranchList extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BranchList);
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(BranchList, {
       nonInteractive: flags['non-interactive'],
     });
@@ -29,6 +31,6 @@ export default class BranchList extends EasCommand {
       enableJsonOutput();
     }
 
-    await listAndRenderBranchesOnAppAsync({ projectId, paginatedQueryOptions });
+    await listAndRenderBranchesOnAppAsync(graphqlClient, { projectId, paginatedQueryOptions });
   }
 }

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -28,6 +28,7 @@ export default class BranchView extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -38,6 +39,7 @@ export default class BranchView extends EasCommand {
     const { 'non-interactive': nonInteractive } = flags;
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(BranchView, {
       nonInteractive,
     });
@@ -52,7 +54,7 @@ export default class BranchView extends EasCommand {
         throw new Error('Branch name may not be empty.');
       }
 
-      ({ name: branchName } = await selectBranchOnAppAsync({
+      ({ name: branchName } = await selectBranchOnAppAsync(graphqlClient, {
         projectId,
         promptTitle: 'Which branch would you like to view?',
         displayTextForListItem: updateBranch => updateBranch.name,
@@ -65,7 +67,7 @@ export default class BranchView extends EasCommand {
       }));
     }
 
-    await listAndRenderUpdateGroupsOnBranchAsync({
+    await listAndRenderUpdateGroupsOnBranchAsync(graphqlClient, {
       projectId,
       branchName,
       paginatedQueryOptions,

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -27,12 +27,14 @@ export default class BuildConfigure extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildConfigure);
     const {
       projectConfig: { exp, projectId, projectDir },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildConfigure, {
       nonInteractive: false,
     });
@@ -65,14 +67,14 @@ export default class BuildConfigure extends EasCommand {
       if ([RequestedPlatform.Android, RequestedPlatform.All].includes(platform)) {
         const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
         if (workflow === Workflow.GENERIC) {
-          await syncAndroidUpdatesConfigurationAsync(projectDir, exp, projectId);
+          await syncAndroidUpdatesConfigurationAsync(graphqlClient, projectDir, exp, projectId);
         }
       }
 
       if ([RequestedPlatform.Ios, RequestedPlatform.All].includes(platform)) {
         const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
         if (workflow === Workflow.GENERIC) {
-          await syncIosUpdatesConfigurationAsync(projectDir, exp, projectId);
+          await syncIosUpdatesConfigurationAsync(graphqlClient, projectDir, exp, projectId);
         }
       }
     }

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -110,7 +110,11 @@ export default class Build extends EasCommand {
     }
     const flags = this.sanitizeFlags(rawFlags);
 
-    const { actor, getDynamicProjectConfigAsync, projectDir } = await this.getContextAsync(Build, {
+    const {
+      loggedIn: { actor, graphqlClient },
+      getDynamicProjectConfigAsync,
+      projectDir,
+    } = await this.getContextAsync(Build, {
       nonInteractive: flags.nonInteractive,
     });
 
@@ -118,6 +122,7 @@ export default class Build extends EasCommand {
 
     if (!flags.localBuildOptions.enable) {
       await maybeWarnAboutEasOutagesAsync(
+        graphqlClient,
         flags.autoSubmit
           ? [StatuspageServiceName.EasBuild, StatuspageServiceName.EasSubmit]
           : [StatuspageServiceName.EasBuild]
@@ -127,6 +132,7 @@ export default class Build extends EasCommand {
     const flagsWithPlatform = await this.ensurePlatformSelectedAsync(flags);
 
     await runBuildAndSubmitAsync(
+      graphqlClient,
       projectDir,
       flagsWithPlatform,
       actor,

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -69,12 +69,13 @@ export default class BuildInspect extends EasCommand {
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildInspect);
-    const { actor, getDynamicProjectConfigAsync, projectDir } = await this.getContextAsync(
-      BuildInspect,
-      {
-        nonInteractive: false,
-      }
-    );
+    const {
+      loggedIn: { actor, graphqlClient },
+      getDynamicProjectConfigAsync,
+      projectDir,
+    } = await this.getContextAsync(BuildInspect, {
+      nonInteractive: false,
+    });
 
     const outputDirectory = path.resolve(process.cwd(), flags.output);
     const tmpWorkingdir = path.join(getTmpDirectory(), uuidv4());
@@ -95,6 +96,7 @@ export default class BuildInspect extends EasCommand {
     } else {
       try {
         await runBuildAndSubmitAsync(
+          graphqlClient,
           projectDir,
           {
             nonInteractive: false,

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -57,6 +57,7 @@ export default class BuildList extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -71,6 +72,7 @@ export default class BuildList extends EasCommand {
     } = flags;
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildList, {
       nonInteractive,
     });
@@ -81,9 +83,9 @@ export default class BuildList extends EasCommand {
     const platform = toAppPlatform(requestedPlatform);
     const graphqlBuildStatus = toGraphQLBuildStatus(buildStatus);
     const graphqlBuildDistribution = toGraphQLBuildDistribution(buildDistribution);
-    const displayName = await getDisplayNameForProjectIdAsync(projectId);
+    const displayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
 
-    await listAndRenderBuildsOnAppAsync({
+    await listAndRenderBuildsOnAppAsync(graphqlClient, {
       projectId,
       projectDisplayName: displayName,
       filter: {

--- a/packages/eas-cli/src/commands/build/version/sync.ts
+++ b/packages/eas-cli/src/commands/build/version/sync.ts
@@ -62,12 +62,13 @@ export default class BuildVersionSyncView extends EasCommand {
 
   public async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildVersionSyncView);
-    const { actor, getDynamicProjectConfigAsync, projectDir } = await this.getContextAsync(
-      BuildVersionSyncView,
-      {
-        nonInteractive: true,
-      }
-    );
+    const {
+      loggedIn: { actor, graphqlClient },
+      getDynamicProjectConfigAsync,
+      projectDir,
+    } = await this.getContextAsync(BuildVersionSyncView, {
+      nonInteractive: true,
+    });
 
     const requestedPlatform = await selectRequestedPlatformAsync(flags.platform);
     const easJsonAccessor = new EasJsonAccessor(projectDir);
@@ -96,6 +97,7 @@ export default class BuildVersionSyncView extends EasCommand {
         actor
       );
       const remoteVersions = await AppVersionQuery.latestVersionAsync(
+        graphqlClient,
         projectId,
         toAppPlatform(profileInfo.platform),
         applicationIdentifier

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -19,6 +19,7 @@ export default class BuildView extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -28,6 +29,7 @@ export default class BuildView extends EasCommand {
     } = await this.parse(BuildView);
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildView, {
       nonInteractive: true,
     });
@@ -35,7 +37,7 @@ export default class BuildView extends EasCommand {
       enableJsonOutput();
     }
 
-    const displayName = await getDisplayNameForProjectIdAsync(projectId);
+    const displayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
 
     const spinner = ora().start('Fetching the build…');
 
@@ -43,9 +45,9 @@ export default class BuildView extends EasCommand {
       let build: BuildFragment;
 
       if (buildId) {
-        build = await BuildQuery.byIdAsync(buildId);
+        build = await BuildQuery.byIdAsync(graphqlClient, buildId);
       } else {
-        const builds = await BuildQuery.viewBuildsOnAppAsync({
+        const builds = await BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
           appId: projectId,
           offset: 0,
           limit: 1,

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -19,6 +19,7 @@ export default class ChannelList extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -27,6 +28,7 @@ export default class ChannelList extends EasCommand {
     const { json: jsonFlag, 'non-interactive': nonInteractive } = flags;
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelList, {
       nonInteractive,
     });
@@ -34,7 +36,7 @@ export default class ChannelList extends EasCommand {
       enableJsonOutput();
     }
 
-    await listAndRenderChannelsOnAppAsync({
+    await listAndRenderChannelsOnAppAsync(graphqlClient, {
       projectId,
       paginatedQueryOptions,
     });

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -27,6 +27,7 @@ export default class ChannelView extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -38,6 +39,7 @@ export default class ChannelView extends EasCommand {
     const { json: jsonFlag, 'non-interactive': nonInteractive } = flags;
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelView, {
       nonInteractive,
     });
@@ -50,7 +52,7 @@ export default class ChannelView extends EasCommand {
       if (nonInteractive) {
         throw new Error(validationMessage);
       }
-      const selectedUpdateChannel = await selectChannelOnAppAsync({
+      const selectedUpdateChannel = await selectChannelOnAppAsync(graphqlClient, {
         projectId,
         selectionPromptTitle: 'Select a channel to view',
         paginatedQueryOptions: {
@@ -63,7 +65,7 @@ export default class ChannelView extends EasCommand {
       assert(channelName, `A channel must be selected.`);
     }
 
-    await listAndRenderBranchesAndUpdatesOnChannelAsync({
+    await listAndRenderBranchesAndUpdatesOnChannelAsync(graphqlClient, {
       projectId,
       channelName,
       paginatedQueryOptions,

--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -17,10 +17,18 @@ export default class Credentials extends EasCommand {
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(Credentials);
-    const { actor, projectConfig } = await this.getContextAsync(Credentials, {
+    const {
+      loggedIn: { actor, graphqlClient },
+      projectConfig,
+    } = await this.getContextAsync(Credentials, {
       nonInteractive: false,
     });
 
-    await new SelectPlatform(actor, projectConfig ?? null, flags.platform).runAsync();
+    await new SelectPlatform(
+      actor,
+      graphqlClient,
+      projectConfig ?? null,
+      flags.platform
+    ).runAsync();
   }
 }

--- a/packages/eas-cli/src/commands/device/create.ts
+++ b/packages/eas-cli/src/commands/device/create.ts
@@ -13,13 +13,17 @@ export default class DeviceCreate extends EasCommand {
 
   async runAsync(): Promise<void> {
     // this command is interactive by design
-    const { actor, projectConfig } = await this.getContextAsync(DeviceCreate, {
+    const {
+      loggedIn: { actor, graphqlClient },
+      projectConfig,
+    } = await this.getContextAsync(DeviceCreate, {
       nonInteractive: false,
     });
 
     const ctx = await createContextAsync({
       appStore: new AppStoreApi(),
       user: actor,
+      graphqlClient,
       projectId: projectConfig?.projectId,
     });
     const manager = new DeviceManager(ctx);

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -22,6 +22,7 @@ export default class BuildList extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -29,6 +30,7 @@ export default class BuildList extends EasCommand {
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildList, {
       nonInteractive: paginatedQueryOptions.nonInteractive,
     });
@@ -38,11 +40,11 @@ export default class BuildList extends EasCommand {
       enableJsonOutput();
     }
 
-    const account = await getOwnerAccountForProjectIdAsync(projectId);
+    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
 
     // if they don't provide a team id, fetch devices on their account
     if (!appleTeamIdentifier) {
-      const selectedAppleTeam = await selectAppleTeamOnAccountAsync({
+      const selectedAppleTeam = await selectAppleTeamOnAccountAsync(graphqlClient, {
         accountName: account.name,
         paginatedQueryOptions: {
           ...paginatedQueryOptions,
@@ -56,7 +58,7 @@ export default class BuildList extends EasCommand {
     }
 
     assert(appleTeamIdentifier, 'No team identifier is specified');
-    await listAndRenderAppleDevicesOnAppleTeamAsync({
+    await listAndRenderAppleDevicesOnAppleTeamAsync(graphqlClient, {
       accountName: account.name,
       appleTeam: {
         appleTeamIdentifier,

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -12,6 +12,7 @@ export default class DeviceView extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -32,15 +33,20 @@ If you are not sure what is the UDID of the device you are looking for, run:
     }
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(DeviceView, {
       nonInteractive: true,
     });
-    const account = await getOwnerAccountForProjectIdAsync(projectId);
+    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
 
     const spinner = ora().start(`Fetching device details for ${UDID}…`);
 
     try {
-      const device = await AppleDeviceQuery.getByDeviceIdentifierAsync(account.name, UDID);
+      const device = await AppleDeviceQuery.getByDeviceIdentifierAsync(
+        graphqlClient,
+        account.name,
+        UDID
+      );
 
       if (device) {
         spinner.succeed('Fetched device details');

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -31,7 +31,7 @@ export default class MetadataPull extends EasCommand {
 
     const { flags } = await this.parse(MetadataPull);
     const {
-      actor,
+      loggedIn: { actor, graphqlClient },
       projectConfig: { exp, projectId, projectDir },
     } = await this.getContextAsync(MetadataPull, {
       nonInteractive: false,
@@ -44,6 +44,7 @@ export default class MetadataPull extends EasCommand {
       projectInfo: { exp, projectId },
       projectDir,
       user: actor,
+      graphqlClient,
       nonInteractive: false,
     });
 

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -29,7 +29,7 @@ export default class MetadataPush extends EasCommand {
 
     const { flags } = await this.parse(MetadataPush);
     const {
-      actor,
+      loggedIn: { actor, graphqlClient },
       projectConfig: { exp, projectId, projectDir },
     } = await this.getContextAsync(MetadataPush, {
       nonInteractive: false,
@@ -42,6 +42,7 @@ export default class MetadataPush extends EasCommand {
       projectInfo: { exp, projectId },
       projectDir,
       user: actor,
+      graphqlClient,
       nonInteractive: false,
     });
 

--- a/packages/eas-cli/src/commands/open.ts
+++ b/packages/eas-cli/src/commands/open.ts
@@ -10,17 +10,19 @@ export default class Open extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
     // this command is interactive by nature (only really run by humans in a terminal)
     const {
       projectConfig: { projectId, exp },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(Open, {
       nonInteractive: false,
     });
 
-    const account = await getOwnerAccountForProjectIdAsync(projectId);
+    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
 
     const projectName = exp.slug;
 

--- a/packages/eas-cli/src/commands/project/__tests__/init.test.ts
+++ b/packages/eas-cli/src/commands/project/__tests__/init.test.ts
@@ -1,9 +1,11 @@
 import { AppJSONConfig, PackageJSONConfig, getConfig } from '@expo/config';
 import chalk from 'chalk';
 import { vol } from 'memfs';
+import { instance, mock } from 'ts-mockito';
 
-import ActorContextField from '../../../commandUtils/context/ActorContextField';
+import LoggedInContextField from '../../../commandUtils/context/LoggedInContextField';
 import ProjectDirContextField from '../../../commandUtils/context/ProjectDirContextField';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { saveProjectIdToAppConfigAsync } from '../../../commandUtils/context/contextUtils/getProjectIdAsync';
 import { jester } from '../../../credentials/__tests__/fixtures-constants';
 import { AppMutation } from '../../../graphql/mutations/AppMutation';
@@ -71,10 +73,13 @@ function mockTestProject(options: {
   );
 
   const mockManifest = { exp: appJSON.expo };
+  const graphqlClient = instance(mock<ExpoGraphqlClient>());
 
   jest.mocked(getConfig).mockReturnValue(mockManifest as any);
   jest.spyOn(ProjectDirContextField.prototype, 'getValueAsync').mockResolvedValue('/test-project');
-  jest.spyOn(ActorContextField.prototype, 'getValueAsync').mockResolvedValue(jester);
+  jest
+    .spyOn(LoggedInContextField.prototype, 'getValueAsync')
+    .mockResolvedValue({ actor: jester, graphqlClient });
 }
 
 const commandOptions = { root: '/test-project' } as any;

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -23,6 +23,7 @@ export default class EnvironmentSecretDelete extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -31,6 +32,7 @@ export default class EnvironmentSecretDelete extends EasCommand {
     } = await this.parse(EnvironmentSecretDelete);
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentSecretDelete, {
       nonInteractive,
     });
@@ -42,7 +44,7 @@ export default class EnvironmentSecretDelete extends EasCommand {
         throw new Error(validationMessage);
       }
 
-      const secrets = await EnvironmentSecretsQuery.allAsync(projectId);
+      const secrets = await EnvironmentSecretsQuery.allAsync(graphqlClient, projectId);
       ({ secret } = await promptAsync({
         type: 'autocomplete',
         name: 'secret',
@@ -83,7 +85,7 @@ export default class EnvironmentSecretDelete extends EasCommand {
       }
     }
 
-    await EnvironmentSecretMutation.deleteAsync(id);
+    await EnvironmentSecretMutation.deleteAsync(graphqlClient, id);
 
     Log.withTick(`️Deleted secret${secret?.name ? ` "${secret?.name}"` : ''} with id "${id}".`);
   }

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -12,16 +12,18 @@ export default class EnvironmentSecretList extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentSecretList, {
       nonInteractive: true,
     });
 
-    const secrets = await EnvironmentSecretsQuery.allAsync(projectId);
+    const secrets = await EnvironmentSecretsQuery.allAsync(graphqlClient, projectId);
 
     const table = new Table({
       head: ['Name', 'Type', 'Scope', 'ID', 'Updated at'],

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -98,7 +98,7 @@ export default class Submit extends EasCommand {
   async runAsync(): Promise<void> {
     const { flags: rawFlags } = await this.parse(Submit);
     const {
-      actor,
+      loggedIn: { actor, graphqlClient },
       projectConfig: { exp, projectId, projectDir },
     } = await this.getContextAsync(Submit, {
       nonInteractive: false,
@@ -106,7 +106,7 @@ export default class Submit extends EasCommand {
 
     const flags = this.sanitizeFlags(rawFlags);
 
-    await maybeWarnAboutEasOutagesAsync([StatuspageServiceName.EasSubmit]);
+    await maybeWarnAboutEasOutagesAsync(graphqlClient, [StatuspageServiceName.EasSubmit]);
 
     const flagsWithPlatform = await this.ensurePlatformSelectedAsync(flags);
 
@@ -128,6 +128,7 @@ export default class Submit extends EasCommand {
         archiveFlags: flagsWithPlatform.archiveFlags,
         nonInteractive: flagsWithPlatform.nonInteractive,
         actor,
+        graphqlClient,
         exp,
         projectId,
       });
@@ -150,7 +151,7 @@ export default class Submit extends EasCommand {
     printSubmissionDetailsUrls(submissions);
 
     if (flagsWithPlatform.wait) {
-      const completedSubmissions = await waitToCompleteAsync(submissions, {
+      const completedSubmissions = await waitToCompleteAsync(graphqlClient, submissions, {
         verbose: flagsWithPlatform.verbose,
       });
       exitWithNonZeroCodeIfSomeSubmissionsDidntFinish(completedSubmissions);

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -34,6 +34,7 @@ export default class UpdateConfigure extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -43,6 +44,7 @@ export default class UpdateConfigure extends EasCommand {
     const { flags } = await this.parse(UpdateConfigure);
     const {
       projectConfig: { projectId, exp, projectDir },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(UpdateConfigure, {
       nonInteractive: true,
     });
@@ -74,14 +76,14 @@ export default class UpdateConfigure extends EasCommand {
       [RequestedPlatform.Android, RequestedPlatform.All].includes(platform) &&
       androidWorkflow === Workflow.GENERIC
     ) {
-      await syncAndroidUpdatesConfigurationAsync(projectDir, updatedExp, projectId);
+      await syncAndroidUpdatesConfigurationAsync(graphqlClient, projectDir, updatedExp, projectId);
       Log.withTick(`Configured ${chalk.bold('AndroidManifest.xml')} for EAS Update`);
     }
     if (
       [RequestedPlatform.Ios, RequestedPlatform.All].includes(platform) &&
       iosWorkflow === Workflow.GENERIC
     ) {
-      await syncIosUpdatesConfigurationAsync(projectDir, updatedExp, projectId);
+      await syncIosUpdatesConfigurationAsync(graphqlClient, projectDir, updatedExp, projectId);
       Log.withTick(`Configured ${chalk.bold('Expo.plist')} for EAS Update`);
     }
 

--- a/packages/eas-cli/src/commands/update/list.ts
+++ b/packages/eas-cli/src/commands/update/list.ts
@@ -34,6 +34,7 @@ export default class UpdateList extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -41,6 +42,7 @@ export default class UpdateList extends EasCommand {
     const { branch: branchFlag, all, json: jsonFlag, 'non-interactive': nonInteractive } = flags;
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(UpdateList, {
       nonInteractive,
     });
@@ -51,10 +53,10 @@ export default class UpdateList extends EasCommand {
     }
 
     if (all) {
-      listAndRenderUpdateGroupsOnAppAsync({ projectId, paginatedQueryOptions });
+      listAndRenderUpdateGroupsOnAppAsync(graphqlClient, { projectId, paginatedQueryOptions });
     } else {
       if (branchFlag) {
-        listAndRenderUpdateGroupsOnBranchAsync({
+        listAndRenderUpdateGroupsOnBranchAsync(graphqlClient, {
           projectId,
           branchName: branchFlag,
           paginatedQueryOptions,
@@ -65,7 +67,7 @@ export default class UpdateList extends EasCommand {
           throw new Error(validationMessage);
         }
 
-        const selectedBranch = await selectBranchOnAppAsync({
+        const selectedBranch = await selectBranchOnAppAsync(graphqlClient, {
           projectId,
           promptTitle: 'Which branch would you like to view?',
           displayTextForListItem: updateBranch => updateBranch.name,
@@ -77,7 +79,7 @@ export default class UpdateList extends EasCommand {
               offset: 0,
             },
         });
-        listAndRenderUpdateGroupsOnBranchAsync({
+        listAndRenderUpdateGroupsOnBranchAsync(graphqlClient, {
           projectId,
           branchName: selectedBranch.name,
           paginatedQueryOptions,

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -24,16 +24,23 @@ export default class UpdateView extends EasCommand {
     ...EasJsonOnlyFlag,
   };
 
+  static override contextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+  };
+
   async runAsync(): Promise<void> {
     const {
       args: { groupId },
       flags: { json: jsonFlag },
     } = await this.parse(UpdateView);
+    const {
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(UpdateView, { nonInteractive: true });
     if (jsonFlag) {
       enableJsonOutput();
     }
 
-    const updatesByGroup = await UpdateQuery.viewUpdateGroupAsync({ groupId });
+    const updatesByGroup = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, { groupId });
     const [updateGroupDescription] = getUpdateGroupDescriptions([updatesByGroup]);
 
     if (jsonFlag) {

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -27,12 +27,14 @@ export default class WebhookCreate extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(WebhookCreate);
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(WebhookCreate, {
       nonInteractive: flags['non-interactive'],
     });
@@ -40,7 +42,7 @@ export default class WebhookCreate extends EasCommand {
 
     const spinner = ora('Creating a webhook').start();
     try {
-      await WebhookMutation.createWebhookAsync(projectId, webhookInputParams);
+      await WebhookMutation.createWebhookAsync(graphqlClient, projectId, webhookInputParams);
       spinner.succeed('Successfully created a webhook');
     } catch (err) {
       spinner.fail('Failed to create a webhook');

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -21,6 +21,7 @@ export default class WebhookList extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -29,15 +30,20 @@ export default class WebhookList extends EasCommand {
     } = await this.parse(WebhookList);
     const {
       projectConfig: { projectId },
+      loggedIn: { graphqlClient },
     } = await this.getContextAsync(WebhookList, {
       nonInteractive: true,
     });
 
-    const projectDisplayName = await getDisplayNameForProjectIdAsync(projectId);
+    const projectDisplayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
 
     const spinner = ora(`Fetching the list of webhook on project ${projectDisplayName}`).start();
     try {
-      const webhooks = await WebhookQuery.byAppIdAsync(projectId, event && { event });
+      const webhooks = await WebhookQuery.byAppIdAsync(
+        graphqlClient,
+        projectId,
+        event && { event }
+      );
       if (webhooks.length === 0) {
         spinner.fail(`There are no webhooks on project ${projectDisplayName}`);
       } else {

--- a/packages/eas-cli/src/commands/webhook/view.ts
+++ b/packages/eas-cli/src/commands/webhook/view.ts
@@ -15,14 +15,21 @@ export default class WebhookView extends EasCommand {
     },
   ];
 
+  static override contextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+  };
+
   async runAsync(): Promise<void> {
     const {
       args: { ID: webhookId },
     } = await this.parse(WebhookView);
+    const {
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(WebhookView, { nonInteractive: true });
 
     const spinner = ora(`Fetching the webhook details for ID ${webhookId}`).start();
     try {
-      const webhook = await WebhookQuery.byIdAsync(webhookId);
+      const webhook = await WebhookQuery.byIdAsync(graphqlClient, webhookId);
       spinner.succeed(`Found the webhook details`);
       Log.log(`\n${formatWebhook(webhook)}`);
     } catch (err) {

--- a/packages/eas-cli/src/credentials/android/actions/AssignFcm.ts
+++ b/packages/eas-cli/src/credentials/android/actions/AssignFcm.ts
@@ -14,8 +14,12 @@ export class AssignFcm {
     fcm: AndroidFcmFragment
   ): Promise<CommonAndroidAppCredentialsFragment> {
     const appCredentials =
-      await ctx.android.createOrGetExistingAndroidAppCredentialsWithBuildCredentialsAsync(this.app);
+      await ctx.android.createOrGetExistingAndroidAppCredentialsWithBuildCredentialsAsync(
+        ctx.graphqlClient,
+        this.app
+      );
     const updatedAppCredentials = await ctx.android.updateAndroidAppCredentialsAsync(
+      ctx.graphqlClient,
       appCredentials,
       {
         androidFcmId: fcm.id,

--- a/packages/eas-cli/src/credentials/android/actions/AssignGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/AssignGoogleServiceAccountKey.ts
@@ -14,8 +14,12 @@ export class AssignGoogleServiceAccountKey {
     googleServiceAccountKey: GoogleServiceAccountKeyFragment
   ): Promise<CommonAndroidAppCredentialsFragment> {
     const appCredentials =
-      await ctx.android.createOrGetExistingAndroidAppCredentialsWithBuildCredentialsAsync(this.app);
+      await ctx.android.createOrGetExistingAndroidAppCredentialsWithBuildCredentialsAsync(
+        ctx.graphqlClient,
+        this.app
+      );
     const updatedAppCredentials = await ctx.android.updateAndroidAppCredentialsAsync(
+      ctx.graphqlClient,
       appCredentials,
       {
         googleServiceAccountKeyForSubmissionsId: googleServiceAccountKey.id,

--- a/packages/eas-cli/src/credentials/android/actions/CreateFcm.ts
+++ b/packages/eas-cli/src/credentials/android/actions/CreateFcm.ts
@@ -19,6 +19,7 @@ export class CreateFcm {
       },
     ]);
     const fcmFragment = await ctx.android.createFcmAsync(
+      ctx.graphqlClient,
       this.account,
       fcmApiKey,
       AndroidFcmVersion.Legacy

--- a/packages/eas-cli/src/credentials/android/actions/CreateGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/CreateGoogleServiceAccountKey.ts
@@ -20,6 +20,7 @@ export class CreateGoogleServiceAccountKey {
     }
     const jsonKeyObject = await this.provideAsync(ctx);
     const gsaKeyFragment = await ctx.android.createGoogleServiceAccountKeyAsync(
+      ctx.graphqlClient,
       this.account,
       jsonKeyObject
     );

--- a/packages/eas-cli/src/credentials/android/actions/CreateKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/CreateKeystore.ts
@@ -1,3 +1,4 @@
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { AccountFragment, AndroidKeystoreFragment } from '../../../graphql/generated';
 import Log from '../../../log';
 import { CredentialsContext } from '../../context';
@@ -15,19 +16,26 @@ export class CreateKeystore {
     }
 
     const projectId = ctx.projectId;
-    const keystore = await this.provideOrGenerateAsync(projectId);
-    const keystoreFragment = await ctx.android.createKeystoreAsync(this.account, keystore);
+    const keystore = await this.provideOrGenerateAsync(ctx.graphqlClient, projectId);
+    const keystoreFragment = await ctx.android.createKeystoreAsync(
+      ctx.graphqlClient,
+      this.account,
+      keystore
+    );
     Log.succeed('Created keystore');
     return keystoreFragment;
   }
 
-  private async provideOrGenerateAsync(projectId: string): Promise<KeystoreWithType> {
+  private async provideOrGenerateAsync(
+    graphqlClient: ExpoGraphqlClient,
+    projectId: string
+  ): Promise<KeystoreWithType> {
     const providedKeystore = await askForUserProvidedAsync(keystoreSchema);
     if (providedKeystore) {
       const providedKeystoreWithType = getKeystoreWithType(providedKeystore);
       validateKeystore(providedKeystoreWithType);
       return providedKeystoreWithType;
     }
-    return await generateRandomKeystoreAsync(projectId);
+    return await generateRandomKeystoreAsync(graphqlClient, projectId);
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/RemoveFcm.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveFcm.ts
@@ -13,6 +13,7 @@ export class RemoveFcm {
       );
     }
     const appCredentials = await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(
+      ctx.graphqlClient,
       this.app
     );
     const fcm = appCredentials?.androidFcm;
@@ -33,7 +34,7 @@ export class RemoveFcm {
       return;
     }
 
-    await ctx.android.deleteFcmAsync(fcm);
+    await ctx.android.deleteFcmAsync(ctx.graphqlClient, fcm);
     Log.succeed('FCM API Key removed');
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveGoogleServiceAccountKey.ts
@@ -15,6 +15,7 @@ export class SelectAndRemoveGoogleServiceAccountKey {
     }
 
     const gsaKeyFragments = await ctx.android.getGoogleServiceAccountKeysForAccountAsync(
+      ctx.graphqlClient,
       this.account
     );
     if (gsaKeyFragments.length === 0) {
@@ -47,6 +48,9 @@ export class RemoveGoogleServiceAccountKey {
     }
 
     Log.log('Removing Google Service Account Key.');
-    await ctx.android.deleteGoogleServiceAccountKeyAsync(this.googleServiceAccountKey);
+    await ctx.android.deleteGoogleServiceAccountKeyAsync(
+      ctx.graphqlClient,
+      this.googleServiceAccountKey
+    );
   }
 }

--- a/packages/eas-cli/src/credentials/android/actions/RemoveKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/RemoveKeystore.ts
@@ -37,7 +37,7 @@ export class RemoveKeystore {
     }
     await new BackupKeystore(this.app).runAsync(ctx, buildCredentials);
 
-    await ctx.android.deleteKeystoreAsync(keystore);
+    await ctx.android.deleteKeystoreAsync(ctx.graphqlClient, keystore);
     Log.succeed('Keystore removed');
   }
 

--- a/packages/eas-cli/src/credentials/android/actions/SetUpBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/actions/SetUpBuildCredentials.ts
@@ -68,9 +68,14 @@ export class SetUpBuildCredentials {
     keystore: AndroidKeystoreFragment;
   }): Promise<AndroidAppBuildCredentialsFragment> {
     if (name) {
-      return await ctx.android.createOrUpdateAndroidAppBuildCredentialsByNameAsync(app, name, {
-        androidKeystoreId: keystore.id,
-      });
+      return await ctx.android.createOrUpdateAndroidAppBuildCredentialsByNameAsync(
+        ctx.graphqlClient,
+        app,
+        name,
+        {
+          androidKeystoreId: keystore.id,
+        }
+      );
     }
     return await createOrUpdateDefaultAndroidAppBuildCredentialsAsync(ctx, app, {
       androidKeystoreId: keystore.id,
@@ -91,6 +96,7 @@ export class SetUpBuildCredentials {
     }
 
     const defaultBuildCredentials = await ctx.android.getDefaultAndroidAppBuildCredentialsAsync(
+      ctx.graphqlClient,
       app
     );
     const defaultKeystore = defaultBuildCredentials?.androidKeystore ?? null;
@@ -113,6 +119,7 @@ export class SetUpBuildCredentials {
     name: string;
   }): Promise<AndroidAppBuildCredentialsFragment | null> {
     const maybeBuildCredentials = await ctx.android.getAndroidAppBuildCredentialsByNameAsync(
+      ctx.graphqlClient,
       app,
       name
     );

--- a/packages/eas-cli/src/credentials/android/actions/SetUpBuildCredentialsFromCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/android/actions/SetUpBuildCredentialsFromCredentialsJson.ts
@@ -62,6 +62,7 @@ export class SetUpBuildCredentialsFromCredentialsJson {
       }
     }
     const keystoreFragment = await ctx.android.createKeystoreAsync(
+      ctx.graphqlClient,
       this.app.account,
       providedKeystoreWithType
     );
@@ -70,12 +71,17 @@ export class SetUpBuildCredentialsFromCredentialsJson {
       selectBuildCredentialsResult.resultType ===
       SelectAndroidBuildCredentialsResultType.CREATE_REQUEST
     ) {
-      buildCredentials = await ctx.android.createAndroidAppBuildCredentialsAsync(this.app, {
-        ...selectBuildCredentialsResult.result,
-        androidKeystoreId: keystoreFragment.id,
-      });
+      buildCredentials = await ctx.android.createAndroidAppBuildCredentialsAsync(
+        ctx.graphqlClient,
+        this.app,
+        {
+          ...selectBuildCredentialsResult.result,
+          androidKeystoreId: keystoreFragment.id,
+        }
+      );
     } else {
       buildCredentials = await ctx.android.updateAndroidAppBuildCredentialsAsync(
+        ctx.graphqlClient,
         selectBuildCredentialsResult.result,
         {
           androidKeystoreId: keystoreFragment.id,

--- a/packages/eas-cli/src/credentials/android/actions/SetUpGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/SetUpGoogleServiceAccountKey.ts
@@ -21,7 +21,10 @@ export class SetUpGoogleServiceAccountKey {
     if (isKeySetup) {
       Log.succeed('Google Service Account Key already set up.');
       return nullthrows(
-        await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(this.app),
+        await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(
+          ctx.graphqlClient,
+          this.app
+        ),
         'androidAppCredentials cannot be null if google service account key is already set up'
       );
     }
@@ -32,6 +35,7 @@ export class SetUpGoogleServiceAccountKey {
     }
 
     const keysForAccount = await ctx.android.getGoogleServiceAccountKeysForAccountAsync(
+      ctx.graphqlClient,
       this.app.account
     );
     let googleServiceAccountKey = null;
@@ -47,6 +51,7 @@ export class SetUpGoogleServiceAccountKey {
 
   private async isGoogleServiceAccountKeySetupAsync(ctx: CredentialsContext): Promise<boolean> {
     const appCredentials = await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(
+      ctx.graphqlClient,
       this.app
     );
     return !!appCredentials?.googleServiceAccountKeyForSubmissions;

--- a/packages/eas-cli/src/credentials/android/actions/UseExistingGoogleServiceAccountKey.ts
+++ b/packages/eas-cli/src/credentials/android/actions/UseExistingGoogleServiceAccountKey.ts
@@ -13,6 +13,7 @@ export class UseExistingGoogleServiceAccountKey {
       );
     }
     const gsaKeyFragments = await ctx.android.getGoogleServiceAccountKeysForAccountAsync(
+      ctx.graphqlClient,
       this.account
     );
     if (gsaKeyFragments.length === 0) {

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/CreateKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/CreateKeystore-test.ts
@@ -40,6 +40,7 @@ describe('CreateKeystore', () => {
 
     // expect keystore to be created on expo servers
     expect(ctx.android.createKeystoreAsync).toHaveBeenCalledWith(
+      ctx.graphqlClient,
       appLookupParams.account,
       expect.objectContaining(testKeystore)
     );

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetUpBuildCredentialsFromCredentialsJson-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetUpBuildCredentialsFromCredentialsJson-test.ts
@@ -72,13 +72,17 @@ describe(SetUpBuildCredentialsFromCredentialsJson, () => {
 
     // expect keystore to be created with credentials.json content
     expect(ctx.android.createKeystoreAsync).toHaveBeenCalledTimes(1);
-    expect(ctx.android.createKeystoreAsync).toBeCalledWith(appLookupParams.account, {
-      keystorePassword: testJksAndroidKeystoreFragment.keystorePassword,
-      keyAlias: testJksAndroidKeystoreFragment.keyAlias,
-      keyPassword: testJksAndroidKeystoreFragment.keyPassword,
-      keystore: Buffer.from('some-binary-content').toString('base64'),
-      type: AndroidKeystoreType.Unknown,
-    });
+    expect(ctx.android.createKeystoreAsync).toBeCalledWith(
+      ctx.graphqlClient,
+      appLookupParams.account,
+      {
+        keystorePassword: testJksAndroidKeystoreFragment.keystorePassword,
+        keyAlias: testJksAndroidKeystoreFragment.keyAlias,
+        keyPassword: testJksAndroidKeystoreFragment.keyPassword,
+        keystore: Buffer.from('some-binary-content').toString('base64'),
+        type: AndroidKeystoreType.Unknown,
+      }
+    );
 
     // expect new build credentials to be created
     expect(ctx.android.createAndroidAppBuildCredentialsAsync).toHaveBeenCalledTimes(1);
@@ -122,13 +126,17 @@ describe(SetUpBuildCredentialsFromCredentialsJson, () => {
 
     // expect keystore to be created with credentials.json content
     expect(ctx.android.createKeystoreAsync).toHaveBeenCalledTimes(1);
-    expect(ctx.android.createKeystoreAsync).toBeCalledWith(appLookupParams.account, {
-      keystorePassword: testJksAndroidKeystoreFragment.keystorePassword,
-      keyAlias: testJksAndroidKeystoreFragment.keyAlias,
-      keyPassword: testJksAndroidKeystoreFragment.keyPassword,
-      keystore: Buffer.from('some-binary-content').toString('base64'),
-      type: AndroidKeystoreType.Unknown,
-    });
+    expect(ctx.android.createKeystoreAsync).toBeCalledWith(
+      ctx.graphqlClient,
+      appLookupParams.account,
+      {
+        keystorePassword: testJksAndroidKeystoreFragment.keystorePassword,
+        keyAlias: testJksAndroidKeystoreFragment.keyAlias,
+        keyPassword: testJksAndroidKeystoreFragment.keyPassword,
+        keystore: Buffer.from('some-binary-content').toString('base64'),
+        type: AndroidKeystoreType.Unknown,
+      }
+    );
 
     // expect existing build credentials to be updated
     expect(ctx.android.updateAndroidAppBuildCredentialsAsync).toHaveBeenCalledTimes(1);

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppBuildCredentialsMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AndroidAppBuildCredentialsFragment,
   AndroidAppBuildCredentialsInput,
@@ -17,6 +18,7 @@ export type AndroidAppBuildCredentialsMetadataInput = Omit<
 >;
 export const AndroidAppBuildCredentialsMutation = {
   async createAndroidAppBuildCredentialsAsync(
+    graphqlClient: ExpoGraphqlClient,
     androidAppBuildCredentialsInput: AndroidAppBuildCredentialsInput,
     androidAppCredentialsId: string
   ): Promise<AndroidAppBuildCredentialsFragment> {
@@ -54,6 +56,7 @@ export const AndroidAppBuildCredentialsMutation = {
     return data.androidAppBuildCredentials.createAndroidAppBuildCredentials;
   },
   async setKeystoreAsync(
+    graphqlClient: ExpoGraphqlClient,
     androidAppBuildCredentialsId: string,
     keystoreId: string
   ): Promise<AndroidAppBuildCredentialsFragment> {

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppCredentialsMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   CommonAndroidAppCredentialsFragment,
   CreateAndroidAppCredentialsMutation,
@@ -13,6 +14,7 @@ import { CommonAndroidAppCredentialsFragmentNode } from '../../../../../graphql/
 
 export const AndroidAppCredentialsMutation = {
   async createAndroidAppCredentialsAsync(
+    graphqlClient: ExpoGraphqlClient,
     androidAppCredentialsInput: {
       fcmId?: string;
     },
@@ -56,6 +58,7 @@ export const AndroidAppCredentialsMutation = {
     return data.androidAppCredentials.createAndroidAppCredentials;
   },
   async setFcmKeyAsync(
+    graphqlClient: ExpoGraphqlClient,
     androidAppCredentialsId: string,
     fcmId: string
   ): Promise<CommonAndroidAppCredentialsFragment> {
@@ -84,6 +87,7 @@ export const AndroidAppCredentialsMutation = {
     return data.androidAppCredentials.setFcm;
   },
   async setGoogleServiceAccountKeyForSubmissionsAsync(
+    graphqlClient: ExpoGraphqlClient,
     androidAppCredentialsId: string,
     googleServiceAccountKeyId: string
   ): Promise<CommonAndroidAppCredentialsFragment> {

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidFcmMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidFcmMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AndroidFcmFragment,
   AndroidFcmInput,
@@ -13,6 +14,7 @@ import { AndroidFcmFragmentNode } from '../../../../../graphql/types/credentials
 
 export const AndroidFcmMutation = {
   async createAndroidFcmAsync(
+    graphqlClient: ExpoGraphqlClient,
     androidFcmInput: AndroidFcmInput,
     accountId: string
   ): Promise<AndroidFcmFragment> {
@@ -43,7 +45,10 @@ export const AndroidFcmMutation = {
     );
     return data.androidFcm.createAndroidFcm;
   },
-  async deleteAndroidFcmAsync(androidFcmId: string): Promise<void> {
+  async deleteAndroidFcmAsync(
+    graphqlClient: ExpoGraphqlClient,
+    androidFcmId: string
+  ): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteAndroidFcmMutation>(

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidKeystoreMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AndroidKeystoreFragment,
   AndroidKeystoreInput,
@@ -13,6 +14,7 @@ import { AndroidKeystoreFragmentNode } from '../../../../../graphql/types/creden
 
 export const AndroidKeystoreMutation = {
   async createAndroidKeystoreAsync(
+    graphqlClient: ExpoGraphqlClient,
     androidKeystoreInput: AndroidKeystoreInput,
     accountId: string
   ): Promise<AndroidKeystoreFragment> {
@@ -49,7 +51,10 @@ export const AndroidKeystoreMutation = {
     );
     return data.androidKeystore.createAndroidKeystore;
   },
-  async deleteAndroidKeystoreAsync(androidKeystoreId: string): Promise<void> {
+  async deleteAndroidKeystoreAsync(
+    graphqlClient: ExpoGraphqlClient,
+    androidKeystoreId: string
+  ): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteAndroidKeystoreMutation>(

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/GoogleServiceAccountKeyMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/GoogleServiceAccountKeyMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   CreateGoogleServiceAccountKeyMutation,
   DeleteGoogleServiceAccountKeyMutation,
@@ -13,6 +14,7 @@ import { GoogleServiceAccountKeyFragmentNode } from '../../../../../graphql/type
 
 export const GoogleServiceAccountKeyMutation = {
   async createGoogleServiceAccountKeyAsync(
+    graphqlClient: ExpoGraphqlClient,
     googleServiceAccountKeyInput: GoogleServiceAccountKeyInput,
     accountId: string
   ): Promise<GoogleServiceAccountKeyFragment> {
@@ -49,7 +51,10 @@ export const GoogleServiceAccountKeyMutation = {
     );
     return data.googleServiceAccountKey.createGoogleServiceAccountKey;
   },
-  async deleteGoogleServiceAccountKeyAsync(googleServiceAccountKeyId: string): Promise<void> {
+  async deleteGoogleServiceAccountKeyAsync(
+    graphqlClient: ExpoGraphqlClient,
+    googleServiceAccountKeyId: string
+  ): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteGoogleServiceAccountKeyMutation>(

--- a/packages/eas-cli/src/credentials/android/api/graphql/queries/AndroidAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/queries/AndroidAppCredentialsQuery.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   CommonAndroidAppCredentialsFragment,
   CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQuery,
@@ -11,6 +12,7 @@ import { CommonAndroidAppCredentialsFragmentNode } from '../../../../../graphql/
 
 export const AndroidAppCredentialsQuery = {
   async withCommonFieldsByApplicationIdentifierAsync(
+    graphqlClient: ExpoGraphqlClient,
     projectFullName: string,
     {
       androidApplicationIdentifier,

--- a/packages/eas-cli/src/credentials/android/api/graphql/queries/GoogleServiceAccountKeyQuery.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/queries/GoogleServiceAccountKeyQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   GoogleServiceAccountKeyByAccountQuery,
   GoogleServiceAccountKeyFragment,
@@ -9,7 +10,10 @@ import {
 import { GoogleServiceAccountKeyFragmentNode } from '../../../../../graphql/types/credentials/GoogleServiceAccountKey';
 
 export const GoogleServiceAccountKeyQuery = {
-  async getAllForAccountAsync(accountName: string): Promise<GoogleServiceAccountKeyFragment[]> {
+  async getAllForAccountAsync(
+    graphqlClient: ExpoGraphqlClient,
+    accountName: string
+  ): Promise<GoogleServiceAccountKeyFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<GoogleServiceAccountKeyByAccountQuery>(

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -3,6 +3,7 @@ import { Env } from '@expo/eas-build-job';
 import { EasJson } from '@expo/eas-json';
 import chalk from 'chalk';
 
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import Log from '../log';
 import { getExpoConfig } from '../project/expoConfig';
 import { confirmAsync } from '../prompts';
@@ -24,6 +25,7 @@ export class CredentialsContext {
   public readonly nonInteractive: boolean;
   public readonly projectDir: string;
   public readonly user: Actor;
+  public readonly graphqlClient: ExpoGraphqlClient;
   public readonly easJsonCliConfig?: EasJson['cli'];
 
   private shouldAskAuthenticateAppStore: boolean = true;
@@ -38,12 +40,14 @@ export class CredentialsContext {
       nonInteractive: boolean;
       projectDir: string;
       user: Actor;
+      graphqlClient: ExpoGraphqlClient;
       env?: Env;
     }
   ) {
     this.easJsonCliConfig = options.easJsonCliConfig;
     this.projectDir = options.projectDir;
     this.user = options.user;
+    this.graphqlClient = options.graphqlClient;
     this.nonInteractive = options.nonInteractive ?? false;
     this.projectInfo = options.projectInfo;
   }

--- a/packages/eas-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/update.ts
@@ -210,12 +210,15 @@ async function getTargetBuildCredentialsAsync(
   target: Target,
   iosDistributionType: IosDistributionType
 ): Promise<TargetCredentials | null> {
-  const appCredentials = await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync({
-    account: app.account,
-    projectName: app.projectName,
-    bundleIdentifier: target.bundleIdentifier,
-    parentBundleIdentifier: target.parentBundleIdentifier,
-  });
+  const appCredentials = await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(
+    ctx.graphqlClient,
+    {
+      account: app.account,
+      projectName: app.projectName,
+      bundleIdentifier: target.bundleIdentifier,
+      parentBundleIdentifier: target.parentBundleIdentifier,
+    }
+  );
   const appBuildCredentials =
     appCredentials?.iosAppBuildCredentialsList.find(
       appBuildCredentials => appBuildCredentials.iosDistributionType === iosDistributionType

--- a/packages/eas-cli/src/credentials/ios/actions/AppleTeamUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AppleTeamUtils.ts
@@ -9,7 +9,7 @@ export async function resolveAppleTeamIfAuthenticatedAsync(
   if (!ctx.appStore.authCtx) {
     return null;
   }
-  return await ctx.ios.createOrGetExistingAppleTeamAsync(app.account, {
+  return await ctx.ios.createOrGetExistingAppleTeamAsync(ctx.graphqlClient, app.account, {
     appleTeamIdentifier: ctx.appStore.authCtx.team.id,
     appleTeamName: ctx.appStore.authCtx.team.name,
   });

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -169,7 +169,10 @@ export async function getAscApiKeysFromAccountAsync(
   account: AccountFragment,
   { filterDifferentAppleTeam }: { filterDifferentAppleTeam?: boolean } = {}
 ): Promise<AppStoreConnectApiKeyFragment[]> {
-  const ascApiKeysForAccount = await ctx.ios.getAscApiKeysForAccountAsync(account);
+  const ascApiKeysForAccount = await ctx.ios.getAscApiKeysForAccountAsync(
+    ctx.graphqlClient,
+    account
+  );
 
   if (!filterDifferentAppleTeam) {
     return ascApiKeysForAccount;

--- a/packages/eas-cli/src/credentials/ios/actions/AssignAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AssignAscApiKey.ts
@@ -19,14 +19,19 @@ export class AssignAscApiKey {
     const appleTeam =
       (await resolveAppleTeamIfAuthenticatedAsync(ctx, this.app)) ?? ascApiKey.appleTeam ?? null;
     const appCredentials = await ctx.ios.createOrGetIosAppCredentialsWithCommonFieldsAsync(
+      ctx.graphqlClient,
       this.app,
       { appleTeam: appleTeam ?? undefined }
     );
     let updatedAppCredentials;
     if (purpose === AppStoreApiKeyPurpose.SUBMISSION_SERVICE) {
-      updatedAppCredentials = await ctx.ios.updateIosAppCredentialsAsync(appCredentials, {
-        ascApiKeyIdForSubmissions: ascApiKey.id,
-      });
+      updatedAppCredentials = await ctx.ios.updateIosAppCredentialsAsync(
+        ctx.graphqlClient,
+        appCredentials,
+        {
+          ascApiKeyIdForSubmissions: ascApiKey.id,
+        }
+      );
     } else {
       throw new Error(`${purpose} is not yet supported.`);
     }

--- a/packages/eas-cli/src/credentials/ios/actions/AssignPushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AssignPushKey.ts
@@ -14,12 +14,17 @@ export class AssignPushKey {
     const appleTeam =
       (await resolveAppleTeamIfAuthenticatedAsync(ctx, this.app)) ?? pushKey.appleTeam ?? null;
     const appCredentials = await ctx.ios.createOrGetIosAppCredentialsWithCommonFieldsAsync(
+      ctx.graphqlClient,
       this.app,
       { appleTeam: appleTeam ?? undefined }
     );
-    const updatedAppCredentials = await ctx.ios.updateIosAppCredentialsAsync(appCredentials, {
-      applePushKeyId: pushKey.id,
-    });
+    const updatedAppCredentials = await ctx.ios.updateIosAppCredentialsAsync(
+      ctx.graphqlClient,
+      appCredentials,
+      {
+        applePushKeyId: pushKey.id,
+      }
+    );
     Log.succeed(`Push Key assigned to ${this.app.projectName}: ${this.app.bundleIdentifier}`);
     return updatedAppCredentials;
   }

--- a/packages/eas-cli/src/credentials/ios/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/BuildCredentialsUtils.ts
@@ -17,7 +17,11 @@ export async function getAllBuildCredentialsAsync(
   ctx: CredentialsContext,
   app: AppLookupParams
 ): Promise<IosAppBuildCredentialsFragment[]> {
-  const appCredentials = await ctx.ios.getIosAppCredentialsWithBuildCredentialsAsync(app, {});
+  const appCredentials = await ctx.ios.getIosAppCredentialsWithBuildCredentialsAsync(
+    ctx.graphqlClient,
+    app,
+    {}
+  );
   if (!appCredentials) {
     return [];
   }
@@ -29,9 +33,13 @@ export async function getBuildCredentialsAsync(
   app: AppLookupParams,
   iosDistributionType: GraphQLIosDistributionType
 ): Promise<IosAppBuildCredentialsFragment | null> {
-  const appCredentials = await ctx.ios.getIosAppCredentialsWithBuildCredentialsAsync(app, {
-    iosDistributionType,
-  });
+  const appCredentials = await ctx.ios.getIosAppCredentialsWithBuildCredentialsAsync(
+    ctx.graphqlClient,
+    app,
+    {
+      iosDistributionType,
+    }
+  );
   if (!appCredentials || appCredentials.iosAppBuildCredentialsList.length === 0) {
     return null;
   }
@@ -69,10 +77,11 @@ export async function assignBuildCredentialsAsync(
     appleTeam ?? (await resolveAppleTeamIfAuthenticatedAsync(ctx, app))
   );
   const appleAppIdentifier = await ctx.ios.createOrGetExistingAppleAppIdentifierAsync(
+    ctx.graphqlClient,
     app,
     resolvedAppleTeam
   );
-  return await ctx.ios.createOrUpdateIosAppBuildCredentialsAsync(app, {
+  return await ctx.ios.createOrUpdateIosAppBuildCredentialsAsync(ctx.graphqlClient, app, {
     appleTeam: resolvedAppleTeam,
     appleAppIdentifierId: appleAppIdentifier.id,
     appleDistributionCertificateId: distCert.id,
@@ -85,7 +94,7 @@ export async function getAppFromContextAsync(ctx: CredentialsContext): Promise<A
   ctx.ensureProjectContext();
   const projectName = ctx.exp.slug;
   const projectId = ctx.projectId;
-  const account = await getOwnerAccountForProjectIdAsync(projectId);
+  const account = await getOwnerAccountForProjectIdAsync(ctx.graphqlClient, projectId);
   return {
     account,
     projectName,

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -100,6 +100,7 @@ export class ConfigureProvisioningProfile {
     const spinner = ora(`Updating Expo profile for ${projectTag}`).start();
     try {
       const configuredProvisioningProfile = await ctx.ios.updateProvisioningProfileAsync(
+        ctx.graphqlClient,
         this.originalProvisioningProfile.id,
         {
           appleProvisioningProfile: updatedProfile.provisioningProfile,

--- a/packages/eas-cli/src/credentials/ios/actions/CreateAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateAscApiKey.ts
@@ -15,7 +15,7 @@ export class CreateAscApiKey {
     }
 
     const ascApiKey = await provideOrGenerateAscApiKeyAsync(ctx, purpose);
-    const result = await ctx.ios.createAscApiKeyAsync(this.account, ascApiKey);
+    const result = await ctx.ios.createAscApiKeyAsync(ctx.graphqlClient, this.account, ascApiKey);
     Log.succeed('Created App Store Connect API Key');
     return result;
   }

--- a/packages/eas-cli/src/credentials/ios/actions/CreateDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateDistributionCertificate.ts
@@ -11,7 +11,11 @@ export class CreateDistributionCertificate {
     ctx: CredentialsContext
   ): Promise<AppleDistributionCertificateMutationResult> {
     const distCert = await provideOrGenerateDistributionCertificateAsync(ctx);
-    const result = await ctx.ios.createDistributionCertificateAsync(this.account, distCert);
+    const result = await ctx.ios.createDistributionCertificateAsync(
+      ctx.graphqlClient,
+      this.account,
+      distCert
+    );
     Log.succeed('Created distribution certificate');
     return result;
   }

--- a/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
@@ -32,10 +32,12 @@ export class CreateProvisioningProfile {
     const provisioningProfile = await this.provideOrGenerateAsync(ctx, appleAuthCtx);
     const appleTeam = nullthrows(await resolveAppleTeamIfAuthenticatedAsync(ctx, this.app));
     const appleAppIdentifier = await ctx.ios.createOrGetExistingAppleAppIdentifierAsync(
+      ctx.graphqlClient,
       this.app,
       appleTeam
     );
     const provisioningProfileMutationResult = await ctx.ios.createProvisioningProfileAsync(
+      ctx.graphqlClient,
       this.app,
       appleAppIdentifier,
       {

--- a/packages/eas-cli/src/credentials/ios/actions/CreatePushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreatePushKey.ts
@@ -12,7 +12,7 @@ export class CreatePushKey {
     }
 
     const pushKey = await provideOrGeneratePushKeyAsync(ctx);
-    const result = await ctx.ios.createPushKeyAsync(this.account, pushKey);
+    const result = await ctx.ios.createPushKeyAsync(ctx.graphqlClient, this.account, pushKey);
     Log.succeed('Created push key');
     return result;
   }

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -86,7 +86,10 @@ export async function selectDistributionCertificateWithDependenciesAsync(
   ctx: CredentialsContext,
   account: AccountFragment
 ): Promise<AppleDistributionCertificateFragment | null> {
-  const distCertsForAccount = await ctx.ios.getDistributionCertificatesForAccountAsync(account);
+  const distCertsForAccount = await ctx.ios.getDistributionCertificatesForAccountAsync(
+    ctx.graphqlClient,
+    account
+  );
   if (distCertsForAccount.length === 0) {
     Log.warn(`There are no Distribution Certificates available in your EAS account.`);
     return null;
@@ -113,6 +116,7 @@ export async function selectValidDistributionCertificateAsync(
   appLookupParams: AppLookupParams
 ): Promise<AppleDistributionCertificateFragment | null> {
   const distCertsForAccount = await ctx.ios.getDistributionCertificatesForAccountAsync(
+    ctx.graphqlClient,
     appLookupParams.account
   );
   if (distCertsForAccount.length === 0) {

--- a/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
@@ -115,7 +115,7 @@ export async function selectPushKeyAsync(
   ctx: CredentialsContext,
   account: AccountFragment
 ): Promise<ApplePushKeyFragment | null> {
-  const pushKeysForAccount = await ctx.ios.getPushKeysForAccountAsync(account);
+  const pushKeysForAccount = await ctx.ios.getPushKeysForAccountAsync(ctx.graphqlClient, account);
   if (pushKeysForAccount.length === 0) {
     Log.warn(`There are no Push Keys available in your EAS account.`);
     return null;

--- a/packages/eas-cli/src/credentials/ios/actions/RemoveAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemoveAscApiKey.ts
@@ -35,7 +35,7 @@ export class RemoveAscApiKey {
     }
 
     Log.log('Removing API Key');
-    await ctx.ios.deleteAscApiKeyAsync(this.ascApiKey.id);
+    await ctx.ios.deleteAscApiKeyAsync(ctx.graphqlClient, this.ascApiKey.id);
 
     let shouldRevoke = false;
     if (!ctx.nonInteractive) {

--- a/packages/eas-cli/src/credentials/ios/actions/RemoveDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemoveDistributionCertificate.ts
@@ -50,7 +50,10 @@ export class RemoveDistributionCertificate {
     }
 
     Log.log('Removing Distribution Certificate');
-    await ctx.ios.deleteDistributionCertificateAsync(this.distributionCertificate.id);
+    await ctx.ios.deleteDistributionCertificateAsync(
+      ctx.graphqlClient,
+      this.distributionCertificate.id
+    );
 
     if (this.distributionCertificate.developerPortalIdentifier) {
       let shouldRevoke = false;

--- a/packages/eas-cli/src/credentials/ios/actions/RemoveProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemoveProvisioningProfile.ts
@@ -22,6 +22,7 @@ export class RemoveProvisioningProfiles {
       return;
     }
     await ctx.ios.deleteProvisioningProfilesAsync(
+      ctx.graphqlClient,
       this.provisioningProfiles.map(profile => profile.id)
     );
     const appAndBundles = this.apps

--- a/packages/eas-cli/src/credentials/ios/actions/RemovePushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemovePushKey.ts
@@ -38,7 +38,7 @@ export class RemovePushKey {
     }
 
     Log.log('Removing Push Key');
-    await ctx.ios.deletePushKeyAsync(this.pushKey.id);
+    await ctx.ios.deletePushKeyAsync(ctx.graphqlClient, this.pushKey.id);
 
     let shouldRevoke = false;
     if (!ctx.nonInteractive) {

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpAscApiKey.ts
@@ -44,7 +44,7 @@ export class SetUpAscApiKey {
     if (isKeySetup) {
       Log.succeed('App Store Connect API Key already set up.');
       return nullthrows(
-        await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(this.app),
+        await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(ctx.graphqlClient, this.app),
         'iosAppCredentials cannot be null if App Store Connect API Key is already set up'
       );
     }
@@ -103,7 +103,10 @@ export class SetUpAscApiKey {
     ctx: CredentialsContext,
     purpose: AppStoreApiKeyPurpose
   ): Promise<boolean> {
-    const appCredentials = await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(this.app);
+    const appCredentials = await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(
+      ctx.graphqlClient,
+      this.app
+    );
     if (purpose !== AppStoreApiKeyPurpose.SUBMISSION_SERVICE) {
       throw new Error(`App Store Connect API Key setup is not yet supported for ${purpose}.`);
     }

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpDistributionCertificate.ts
@@ -28,6 +28,7 @@ export class SetUpDistributionCertificate {
 
     try {
       const currentCertificate = await ctx.ios.getDistributionCertificateForAppAsync(
+        ctx.graphqlClient,
         this.app,
         this.distributionType,
         { appleTeam }
@@ -179,6 +180,7 @@ export class SetUpDistributionCertificate {
     const validDistCertSerialNumberSet = new Set(validDistCertSerialNumbers);
 
     const distCertsForAccount = await ctx.ios.getDistributionCertificatesForAccountAsync(
+      ctx.graphqlClient,
       this.app.account
     );
     const distCertsForAppleTeam = distCertsForAccount.filter(distCert => {

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
@@ -46,7 +46,7 @@ export class SetUpProvisioningProfile {
   ): Promise<IosAppBuildCredentialsFragment> {
     const buildCredentials = await this.createAndAssignProfileAsync(ctx, distCert);
     // delete 'currentProfile' since its no longer valid
-    await ctx.ios.deleteProvisioningProfilesAsync([currentProfile.id]);
+    await ctx.ios.deleteProvisioningProfilesAsync(ctx.graphqlClient, [currentProfile.id]);
     return buildCredentials;
   }
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpPushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpPushKey.ts
@@ -18,7 +18,7 @@ export class SetUpPushKey {
   constructor(private app: AppLookupParams) {}
 
   async isPushKeySetupAsync(ctx: CredentialsContext): Promise<boolean> {
-    const pushKey = await ctx.ios.getPushKeyForAppAsync(this.app);
+    const pushKey = await ctx.ios.getPushKeyForAppAsync(ctx.graphqlClient, this.app);
     return !!pushKey;
   }
 
@@ -29,10 +29,13 @@ export class SetUpPushKey {
 
     const isPushKeySetup = await this.isPushKeySetupAsync(ctx);
     if (isPushKeySetup) {
-      return await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(this.app);
+      return await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(ctx.graphqlClient, this.app);
     }
 
-    const pushKeysForAccount = await ctx.ios.getPushKeysForAccountAsync(this.app.account);
+    const pushKeysForAccount = await ctx.ios.getPushKeysForAccountAsync(
+      ctx.graphqlClient,
+      this.app.account
+    );
     let pushKey: ApplePushKeyFragment;
     if (pushKeysForAccount.length === 0) {
       pushKey = await new CreatePushKey(this.app.account).runAsync(ctx);
@@ -43,7 +46,10 @@ export class SetUpPushKey {
   }
 
   private async createOrReusePushKeyAsync(ctx: CredentialsContext): Promise<ApplePushKeyFragment> {
-    const pushKeysForAccount = await ctx.ios.getPushKeysForAccountAsync(this.app.account);
+    const pushKeysForAccount = await ctx.ios.getPushKeysForAccountAsync(
+      ctx.graphqlClient,
+      this.app.account
+    );
     assert(
       pushKeysForAccount.length > 0,
       'createOrReusePushKeyAsync: There are no Push Keys available in your EAS account.'

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpTargetBuildCredentialsFromCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpTargetBuildCredentialsFromCredentialsJson.ts
@@ -44,10 +44,14 @@ export class SetUpTargetBuildCredentialsFromCredentialsJson {
     const appleTeamFromProvisioningProfile = readAppleTeam(
       this.targetCredentials.provisioningProfile
     );
-    const appleTeam = await ctx.ios.createOrGetExistingAppleTeamAsync(this.app.account, {
-      appleTeamIdentifier: appleTeamFromProvisioningProfile.teamId,
-      appleTeamName: appleTeamFromProvisioningProfile.teamName,
-    });
+    const appleTeam = await ctx.ios.createOrGetExistingAppleTeamAsync(
+      ctx.graphqlClient,
+      this.app.account,
+      {
+        appleTeamIdentifier: appleTeamFromProvisioningProfile.teamId,
+        appleTeamName: appleTeamFromProvisioningProfile.teamName,
+      }
+    );
     const distributionCertificateToAssign = await this.getDistributionCertificateToAssignAsync(
       ctx,
       appleTeam,
@@ -109,7 +113,7 @@ export class SetUpTargetBuildCredentialsFromCredentialsJson {
     const { certificateP12, certificatePassword } = this.targetCredentials.distributionCertificate;
 
     if (!currentDistributionCertificate) {
-      return await ctx.ios.createDistributionCertificateAsync(this.app.account, {
+      return await ctx.ios.createDistributionCertificateAsync(ctx.graphqlClient, this.app.account, {
         certP12: certificateP12,
         certPassword: certificatePassword,
         teamId: appleTeam.appleTeamIdentifier,
@@ -119,7 +123,7 @@ export class SetUpTargetBuildCredentialsFromCredentialsJson {
 
     const isSameCertificate = currentDistributionCertificate.certificateP12 === certificateP12;
     if (!isSameCertificate) {
-      return await ctx.ios.createDistributionCertificateAsync(this.app.account, {
+      return await ctx.ios.createDistributionCertificateAsync(ctx.graphqlClient, this.app.account, {
         certP12: certificateP12,
         certPassword: certificatePassword,
         teamId: appleTeam.appleTeamIdentifier,
@@ -158,12 +162,18 @@ export class SetUpTargetBuildCredentialsFromCredentialsJson {
     const { provisioningProfile } = this.targetCredentials;
 
     const appleAppIdentifier = await ctx.ios.createOrGetExistingAppleAppIdentifierAsync(
+      ctx.graphqlClient,
       this.app,
       appleTeam
     );
-    return await ctx.ios.createProvisioningProfileAsync(this.app, appleAppIdentifier, {
-      appleProvisioningProfile: provisioningProfile,
-    });
+    return await ctx.ios.createProvisioningProfileAsync(
+      ctx.graphqlClient,
+      this.app,
+      appleAppIdentifier,
+      {
+        appleProvisioningProfile: provisioningProfile,
+      }
+    );
   }
 }
 

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/DistributionCertificateUtils-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/DistributionCertificateUtils-test.ts
@@ -1,5 +1,7 @@
 import mockdate from 'mockdate';
+import { instance, mock } from 'ts-mockito';
 
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { AppleDistributionCertificateQuery } from '../../api/graphql/queries/AppleDistributionCertificateQuery';
 import { formatDistributionCertificate } from '../DistributionCertificateUtils';
 jest.mock('../../api/graphql/queries/AppleDistributionCertificateQuery');
@@ -13,8 +15,9 @@ jest.mock('chalk', () => {
 mockdate.set(new Date('4/20/2021'));
 describe('select credentials', () => {
   it('select an AppleDistributionCertificate fragment', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
     const testDistCerts = (
-      await AppleDistributionCertificateQuery.getAllForAccountAsync('quinAccount')
+      await AppleDistributionCertificateQuery.getAllForAccountAsync(graphqlClient, 'quinAccount')
     ).sort((a, b) => (a.serialNumber > b.serialNumber ? 1 : -1));
     const loggedSoFar = testDistCerts
       .map(cert => formatDistributionCertificate(cert))

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppStoreConnectApiKeyMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppStoreConnectApiKeyMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppStoreConnectApiKeyFragment,
   AppStoreConnectApiKeyInput,
@@ -13,6 +14,7 @@ import { AppStoreConnectApiKeyFragmentNode } from '../../../../../graphql/types/
 
 export const AppStoreConnectApiKeyMutation = {
   async createAppStoreConnectApiKeyAsync(
+    graphqlClient: ExpoGraphqlClient,
     appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput,
     accountId: string
   ): Promise<AppStoreConnectApiKeyFragment> {
@@ -49,7 +51,10 @@ export const AppStoreConnectApiKeyMutation = {
     );
     return data.appStoreConnectApiKey.createAppStoreConnectApiKey;
   },
-  async deleteAppStoreConnectApiKeyAsync(appStoreConnectApiKeyId: string): Promise<void> {
+  async deleteAppStoreConnectApiKeyAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appStoreConnectApiKeyId: string
+  ): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteAppStoreConnectApiKeyMutation>(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleAppIdentifierMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleAppIdentifierFragment,
   AppleAppIdentifierInput,
@@ -12,6 +13,7 @@ import { AppleAppIdentifierFragmentNode } from '../../../../../graphql/types/cre
 
 export const AppleAppIdentifierMutation = {
   async createAppleAppIdentifierAsync(
+    graphqlClient: ExpoGraphqlClient,
     appleAppIdentifierInput: AppleAppIdentifierInput,
     accountId: string
   ): Promise<AppleAppIdentifierFragment> {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceMutation.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleDeviceFragment,
   AppleDeviceInput,
@@ -12,6 +13,7 @@ import { AppleDeviceFragmentNode } from '../../../../../graphql/types/credential
 
 export const AppleDeviceMutation = {
   async createAppleDeviceAsync(
+    graphqlClient: ExpoGraphqlClient,
     appleDeviceInput: AppleDeviceInput,
     accountId: string
   ): Promise<AppleDeviceFragment> {
@@ -41,7 +43,10 @@ export const AppleDeviceMutation = {
     );
     return data.appleDevice.createAppleDevice;
   },
-  async deleteAppleDeviceAsync(deviceId: string): Promise<string> {
+  async deleteAppleDeviceAsync(
+    graphqlClient: ExpoGraphqlClient,
+    deviceId: string
+  ): Promise<string> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteAppleDeviceResult>(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleDeviceRegistrationRequestFragment,
   CreateAppleDeviceRegistrationRequestMutation,
@@ -10,6 +11,7 @@ import { AppleDeviceRegistrationRequestFragmentNode } from '../../../../../graph
 
 export const AppleDeviceRegistrationRequestMutation = {
   async createAppleDeviceRegistrationRequestAsync(
+    graphqlClient: ExpoGraphqlClient,
     appleTeamId: string,
     accountId: string
   ): Promise<AppleDeviceRegistrationRequestFragment> {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleDistributionCertificateMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleDistributionCertificateFragment,
   AppleDistributionCertificateInput,
@@ -19,6 +20,7 @@ export type AppleDistributionCertificateMutationResult = AppleDistributionCertif
 
 export const AppleDistributionCertificateMutation = {
   async createAppleDistributionCertificateAsync(
+    graphqlClient: ExpoGraphqlClient,
     appleDistributionCertificateInput: AppleDistributionCertificateInput,
     accountId: string
   ): Promise<AppleDistributionCertificateMutationResult> {
@@ -61,6 +63,7 @@ export const AppleDistributionCertificateMutation = {
     return data.appleDistributionCertificate.createAppleDistributionCertificate;
   },
   async deleteAppleDistributionCertificateAsync(
+    graphqlClient: ExpoGraphqlClient,
     appleDistributionCertificateId: string
   ): Promise<void> {
     await withErrorHandlingAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleProvisioningProfileMutation.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleProvisioningProfileFragment,
   AppleProvisioningProfileInput,
@@ -18,6 +19,7 @@ export type AppleProvisioningProfileMutationResult = AppleProvisioningProfileFra
 
 export const AppleProvisioningProfileMutation = {
   async createAppleProvisioningProfileAsync(
+    graphqlClient: ExpoGraphqlClient,
     appleProvisioningProfileInput: AppleProvisioningProfileInput,
     accountId: string,
     appleAppIdentifierId: string
@@ -60,6 +62,7 @@ export const AppleProvisioningProfileMutation = {
     return data.appleProvisioningProfile.createAppleProvisioningProfile;
   },
   async updateAppleProvisioningProfileAsync(
+    graphqlClient: ExpoGraphqlClient,
     appleProvisioningProfileId: string,
     appleProvisioningProfileInput: {
       appleProvisioningProfile: string;
@@ -100,7 +103,10 @@ export const AppleProvisioningProfileMutation = {
     );
     return data.appleProvisioningProfile.updateAppleProvisioningProfile;
   },
-  async deleteAppleProvisioningProfilesAsync(appleProvisioningProfileIds: string[]): Promise<void> {
+  async deleteAppleProvisioningProfilesAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appleProvisioningProfileIds: string[]
+  ): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<UpdateAppleProvisioningProfileMutation>(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/ApplePushKeyMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/ApplePushKeyMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   ApplePushKeyFragment,
   ApplePushKeyInput,
@@ -13,6 +14,7 @@ import { ApplePushKeyFragmentNode } from '../../../../../graphql/types/credentia
 
 export const ApplePushKeyMutation = {
   async createApplePushKeyAsync(
+    graphqlClient: ExpoGraphqlClient,
     applePushKeyInput: ApplePushKeyInput,
     accountId: string
   ): Promise<ApplePushKeyFragment> {
@@ -46,7 +48,10 @@ export const ApplePushKeyMutation = {
     );
     return data.applePushKey.createApplePushKey;
   },
-  async deleteApplePushKeyAsync(applePushKeyId: string): Promise<void> {
+  async deleteApplePushKeyAsync(
+    graphqlClient: ExpoGraphqlClient,
+    applePushKeyId: string
+  ): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteApplePushKeyMutation>(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/AppleTeamMutation.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AccountFragment,
   AppleTeamFragment,
@@ -17,6 +18,7 @@ export type AppleTeamMutationResult = AppleTeamFragment & {
 
 export const AppleTeamMutation = {
   async createAppleTeamAsync(
+    graphqlClient: ExpoGraphqlClient,
     appleTeamInput: AppleTeamInput,
     accountId: string
   ): Promise<AppleTeamMutationResult> {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppBuildCredentialsMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   IosAppBuildCredentials,
   IosAppBuildCredentialsFragment,
@@ -13,6 +14,7 @@ import { IosAppBuildCredentialsFragmentNode } from '../../../../../graphql/types
 
 export const IosAppBuildCredentialsMutation = {
   async createIosAppBuildCredentialsAsync(
+    graphqlClient: ExpoGraphqlClient,
     iosAppBuildCredentialsInput: IosAppBuildCredentialsInput,
     iosAppCredentialsId: string
   ): Promise<IosAppBuildCredentials> {
@@ -48,6 +50,7 @@ export const IosAppBuildCredentialsMutation = {
     return data.iosAppBuildCredentials.createIosAppBuildCredentials;
   },
   async setDistributionCertificateAsync(
+    graphqlClient: ExpoGraphqlClient,
     iosAppBuildCredentialsId: string,
     distributionCertificateId: string
   ): Promise<IosAppBuildCredentials> {
@@ -83,6 +86,7 @@ export const IosAppBuildCredentialsMutation = {
     return data.iosAppBuildCredentials.setDistributionCertificate;
   },
   async setProvisioningProfileAsync(
+    graphqlClient: ExpoGraphqlClient,
     iosAppBuildCredentialsId: string,
     provisioningProfileId: string
   ): Promise<IosAppBuildCredentialsFragment> {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/mutations/IosAppCredentialsMutation.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   CommonIosAppCredentialsFragment,
   CreateIosAppCredentialsMutation,
@@ -14,6 +15,7 @@ import { CommonIosAppCredentialsFragmentNode } from '../../../../../graphql/type
 
 export const IosAppCredentialsMutation = {
   async createIosAppCredentialsAsync(
+    graphqlClient: ExpoGraphqlClient,
     iosAppCredentialsInput: IosAppCredentialsInput,
     appId: string,
     appleAppIdentifierId: string
@@ -55,6 +57,7 @@ export const IosAppCredentialsMutation = {
     return data.iosAppCredentials.createIosAppCredentials;
   },
   async setPushKeyAsync(
+    graphqlClient: ExpoGraphqlClient,
     iosAppCredentialsId: string,
     pushKeyId: string
   ): Promise<CommonIosAppCredentialsFragment> {
@@ -82,6 +85,7 @@ export const IosAppCredentialsMutation = {
     return data.iosAppCredentials.setPushKey;
   },
   async setAppStoreConnectApiKeyForSubmissionsAsync(
+    graphqlClient: ExpoGraphqlClient,
     iosAppCredentialsId: string,
     ascApiKeyId: string
   ): Promise<CommonIosAppCredentialsFragment> {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppStoreConnectApiKeyQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppStoreConnectApiKeyQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppStoreConnectApiKeyByAccountQuery,
   AppStoreConnectApiKeyFragment,
@@ -9,7 +10,10 @@ import {
 import { AppStoreConnectApiKeyFragmentNode } from '../../../../../graphql/types/credentials/AppStoreConnectApiKey';
 
 export const AppStoreConnectApiKeyQuery = {
-  async getAllForAccountAsync(accountName: string): Promise<AppStoreConnectApiKeyFragment[]> {
+  async getAllForAccountAsync(
+    graphqlClient: ExpoGraphqlClient,
+    accountName: string
+  ): Promise<AppStoreConnectApiKeyFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<AppStoreConnectApiKeyByAccountQuery>(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleAppIdentifierQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleAppIdentifierByBundleIdQuery,
   AppleAppIdentifierFragment,
@@ -10,6 +11,7 @@ import { AppleAppIdentifierFragmentNode } from '../../../../../graphql/types/cre
 
 export const AppleAppIdentifierQuery = {
   async byBundleIdentifierAsync(
+    graphqlClient: ExpoGraphqlClient,
     accountName: string,
     bundleIdentifier: string
   ): Promise<AppleAppIdentifierFragment | null> {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -2,8 +2,9 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { DeviceNotFoundError } from '../../../../../devices/utils/errors';
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleDevice,
   AppleDeviceFragment,
@@ -36,6 +37,7 @@ export type AppleDevicesByIdentifierQueryResult = AppleDeviceQueryResult & {
 
 export const AppleDeviceQuery = {
   async getAllByAppleTeamIdentifierAsync(
+    graphqlClient: ExpoGraphqlClient,
     accountId: string,
     appleTeamIdentifier: string,
     { useCache = true }: { useCache?: boolean } = {}
@@ -83,12 +85,10 @@ export const AppleDeviceQuery = {
     return appleDevices;
   },
 
-  async getAllForAppleTeamAsync({
-    accountName,
-    appleTeamIdentifier,
-    offset,
-    limit,
-  }: AppleDevicesByTeamIdentifierQueryVariables): Promise<AppleDeviceFragment[]> {
+  async getAllForAppleTeamAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { accountName, appleTeamIdentifier, offset, limit }: AppleDevicesByTeamIdentifierQueryVariables
+  ): Promise<AppleDeviceFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<AppleDevicesByTeamIdentifierQuery>(
@@ -135,6 +135,7 @@ export const AppleDeviceQuery = {
   },
 
   async getByDeviceIdentifierAsync(
+    graphqlClient: ExpoGraphqlClient,
     accountName: string,
     identifier: string
   ): Promise<AppleDevicesByIdentifierQueryResult> {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDistributionCertificateQuery.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleDistributionCertificateByAccountQuery,
   AppleDistributionCertificateByAppQuery,
@@ -14,6 +15,7 @@ import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/
 
 export const AppleDistributionCertificateQuery = {
   async getForAppAsync(
+    graphqlClient: ExpoGraphqlClient,
     projectFullName: string,
     {
       appleAppIdentifierId,
@@ -76,6 +78,7 @@ export const AppleDistributionCertificateQuery = {
     );
   },
   async getAllForAccountAsync(
+    graphqlClient: ExpoGraphqlClient,
     accountName: string
   ): Promise<AppleDistributionCertificateFragment[]> {
     const data = await withErrorHandlingAsync(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleProvisioningProfileQuery.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleAppIdentifierFragment,
   AppleDeviceFragment,
@@ -21,6 +22,7 @@ export type AppleProvisioningProfileQueryResult = AppleProvisioningProfileFragme
 } & { appleDevices: AppleDeviceFragment[] } & { appleAppIdentifier: AppleAppIdentifierFragment };
 export const AppleProvisioningProfileQuery = {
   async getForAppAsync(
+    graphqlClient: ExpoGraphqlClient,
     projectFullName: string,
     {
       appleAppIdentifierId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/ApplePushKeyQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/ApplePushKeyQuery.ts
@@ -1,12 +1,16 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import { ApplePushKeyByAccountQuery, ApplePushKeyFragment } from '../../../../../graphql/generated';
 import { ApplePushKeyFragmentNode } from '../../../../../graphql/types/credentials/ApplePushKey';
 
 export const ApplePushKeyQuery = {
-  async getAllForAccountAsync(accountName: string): Promise<ApplePushKeyFragment[]> {
+  async getAllForAccountAsync(
+    graphqlClient: ExpoGraphqlClient,
+    accountName: string
+  ): Promise<ApplePushKeyFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<ApplePushKeyByAccountQuery>(

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleTeamQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleTeamByIdentifierQuery,
   AppleTeamFragment,
@@ -11,11 +12,10 @@ import {
 import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
 
 export const AppleTeamQuery = {
-  async getAllForAccountAsync({
-    accountName,
-    offset,
-    limit,
-  }: AppleTeamsByAccountNameQueryVariables): Promise<AppleTeamFragment[]> {
+  async getAllForAccountAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { accountName, offset, limit }: AppleTeamsByAccountNameQueryVariables
+  ): Promise<AppleTeamFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<AppleTeamsByAccountNameQuery>(
@@ -44,6 +44,7 @@ export const AppleTeamQuery = {
     return data.account.byName.appleTeams ?? [];
   },
   async getByAppleTeamIdentifierAsync(
+    graphqlClient: ExpoGraphqlClient,
     accountId: string,
     appleTeamIdentifier: string
   ): Promise<AppleTeamFragment | null> {

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppBuildCredentialsQuery.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQuery,
   IosAppBuildCredentialsFragment,
@@ -12,6 +13,7 @@ import { IosAppBuildCredentialsFragmentNode } from '../../../../../graphql/types
 
 export const IosAppBuildCredentialsQuery = {
   async byAppIdentifierIdAndDistributionTypeAsync(
+    graphqlClient: ExpoGraphqlClient,
     projectFullName: string,
     {
       appleAppIdentifierId,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/IosAppCredentialsQuery.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../../../../../graphql/client';
+import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   CommonIosAppCredentialsFragment,
   CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery,
@@ -17,6 +18,7 @@ import {
 
 export const IosAppCredentialsQuery = {
   async withBuildCredentialsByAppIdentifierIdAsync(
+    graphqlClient: ExpoGraphqlClient,
     projectFullName: string,
     {
       appleAppIdentifierId,
@@ -69,6 +71,7 @@ export const IosAppCredentialsQuery = {
     return data.app.byFullName.iosAppCredentials[0] ?? null;
   },
   async withCommonFieldsByAppIdentifierIdAsync(
+    graphqlClient: ExpoGraphqlClient,
     projectFullName: string,
     {
       appleAppIdentifierId,

--- a/packages/eas-cli/src/credentials/ios/utils/__tests__/printCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/__tests__/printCredentials-test.ts
@@ -1,6 +1,8 @@
 import mockdate from 'mockdate';
 import nullthrows from 'nullthrows';
+import { instance, mock } from 'ts-mockito';
 
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import Log from '../../../../log';
 import { IosAppCredentialsQuery } from '../../api/graphql/queries/IosAppCredentialsQuery';
 import { App, Target } from '../../types';
@@ -14,6 +16,7 @@ mockdate.set(new Date('4/20/2021'));
 
 describe('print credentials', () => {
   it('prints the IosAppCredentials map', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
     const app: App = {
       account: {
         id: 'account-id',
@@ -23,9 +26,13 @@ describe('print credentials', () => {
       projectName: 'test52',
     };
     const testIosAppCredentialsData =
-      await IosAppCredentialsQuery.withCommonFieldsByAppIdentifierIdAsync('@quinlanj/test52', {
-        appleAppIdentifierId: 'test-id',
-      });
+      await IosAppCredentialsQuery.withCommonFieldsByAppIdentifierIdAsync(
+        graphqlClient,
+        '@quinlanj/test52',
+        {
+          appleAppIdentifierId: 'test-id',
+        }
+      );
     const appCredentials = {
       test52: nullthrows(testIosAppCredentialsData),
     };

--- a/packages/eas-cli/src/credentials/manager/HelperActions.ts
+++ b/packages/eas-cli/src/credentials/manager/HelperActions.ts
@@ -1,3 +1,4 @@
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import Log from '../../log';
 import { pressAnyKeyToContinueAsync } from '../../prompts';
 import { Actor } from '../../user/User';
@@ -5,6 +6,7 @@ import { CredentialsContext, CredentialsContextProjectInfo } from '../context';
 
 export interface Action<T = void> {
   actor: Actor;
+  graphqlClient: ExpoGraphqlClient;
   projectInfo: CredentialsContextProjectInfo | null;
   runAsync(ctx: CredentialsContext): Promise<T>;
 }

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -56,6 +56,7 @@ export class ManageAndroid {
       projectDir: process.cwd(),
       projectInfo: this.callingAction.projectInfo,
       user: this.callingAction.actor,
+      graphqlClient: this.callingAction.graphqlClient,
       env: buildProfile?.env,
       nonInteractive: false,
     });
@@ -71,6 +72,7 @@ export class ManageAndroid {
         if (ctx.hasProjectContext) {
           const appLookupParams = await getAppLookupParamsFromContextAsync(ctx, gradleContext);
           const appCredentials = await ctx.android.getAndroidAppCredentialsWithCommonFieldsAsync(
+            ctx.graphqlClient,
             appLookupParams
           );
           if (!appCredentials) {
@@ -161,12 +163,17 @@ export class ManageAndroid {
         selectBuildCredentialsResult.resultType ===
         SelectAndroidBuildCredentialsResultType.CREATE_REQUEST
       ) {
-        await ctx.android.createAndroidAppBuildCredentialsAsync(appLookupParams, {
-          ...selectBuildCredentialsResult.result,
-          androidKeystoreId: keystore.id,
-        });
+        await ctx.android.createAndroidAppBuildCredentialsAsync(
+          ctx.graphqlClient,
+          appLookupParams,
+          {
+            ...selectBuildCredentialsResult.result,
+            androidKeystoreId: keystore.id,
+          }
+        );
       } else {
         await ctx.android.updateAndroidAppBuildCredentialsAsync(
+          ctx.graphqlClient,
           selectBuildCredentialsResult.result,
           {
             androidKeystoreId: keystore.id,

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -65,6 +65,7 @@ export class ManageIos {
       projectDir: process.cwd(),
       projectInfo: this.callingAction.projectInfo,
       user: this.callingAction.actor,
+      graphqlClient: this.callingAction.graphqlClient,
       env: buildProfile?.env,
       nonInteractive: false,
     });
@@ -75,7 +76,7 @@ export class ManageIos {
     await ctx.bestEffortAppStoreAuthenticateAsync();
 
     const getAccountForProjectAsync = async (projectId: string): Promise<AccountFragment> => {
-      return await getOwnerAccountForProjectIdAsync(projectId);
+      return await getOwnerAccountForProjectIdAsync(ctx.graphqlClient, projectId);
     };
 
     const account = ctx.hasProjectContext
@@ -99,7 +100,10 @@ export class ManageIos {
           for (const target of targets) {
             const appLookupParams = await getAppLookupParamsFromContextAsync(ctx, target);
             iosAppCredentialsMap[target.targetName] =
-              await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(appLookupParams);
+              await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(
+                ctx.graphqlClient,
+                appLookupParams
+              );
           }
           displayIosCredentials(app, iosAppCredentialsMap, targets);
         }
@@ -283,6 +287,7 @@ export class ManageIos {
       }
       case IosActionType.RemoveProvisioningProfile: {
         const iosAppCredentials = await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(
+          ctx.graphqlClient,
           appLookupParams
         );
         const provisioningProfile = iosAppCredentials?.iosAppBuildCredentialsList.find(

--- a/packages/eas-cli/src/credentials/manager/SelectAndroidBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectAndroidBuildCredentials.ts
@@ -26,7 +26,10 @@ export class SelectAndroidBuildCredentials {
         result: AndroidAppBuildCredentialsFragment;
       }
   > {
-    const buildCredentialsList = await ctx.android.getAndroidAppBuildCredentialsListAsync(this.app);
+    const buildCredentialsList = await ctx.android.getAndroidAppBuildCredentialsListAsync(
+      ctx.graphqlClient,
+      this.app
+    );
     if (buildCredentialsList.length === 0) {
       return {
         resultType: SelectAndroidBuildCredentialsResultType.CREATE_REQUEST,
@@ -87,7 +90,10 @@ export class SelectExistingAndroidBuildCredentials {
   constructor(private app: AppLookupParams) {}
 
   async runAsync(ctx: CredentialsContext): Promise<AndroidAppBuildCredentialsFragment | null> {
-    const buildCredentialsList = await ctx.android.getAndroidAppBuildCredentialsListAsync(this.app);
+    const buildCredentialsList = await ctx.android.getAndroidAppBuildCredentialsListAsync(
+      ctx.graphqlClient,
+      this.app
+    );
     if (buildCredentialsList.length === 0) {
       Log.log(`You don't have any Android Build Credentials`);
       return null;

--- a/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
@@ -1,3 +1,4 @@
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { selectPlatformAsync } from '../../platform';
 import { Actor } from '../../user/User';
 import { CredentialsContextProjectInfo } from '../context';
@@ -7,6 +8,7 @@ import { ManageIos } from './ManageIos';
 export class SelectPlatform {
   constructor(
     public readonly actor: Actor,
+    public readonly graphqlClient: ExpoGraphqlClient,
     public readonly projectInfo: CredentialsContextProjectInfo | null,
     private readonly flagPlatform?: string
   ) {}

--- a/packages/eas-cli/src/devices/__tests__/manager-test.ts
+++ b/packages/eas-cli/src/devices/__tests__/manager-test.ts
@@ -1,5 +1,7 @@
 import prompts from 'prompts';
+import { instance, mock } from 'ts-mockito';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { Role } from '../../graphql/generated';
 import { AppQuery } from '../../graphql/queries/AppQuery';
 import { Actor } from '../../user/User';
@@ -58,11 +60,12 @@ describe(AccountResolver, () => {
       });
 
       it('returns the account defined in app.json/app.config.js if user confirms', async () => {
+        const graphqlClient = instance(mock<ExpoGraphqlClient>());
         jest.mocked(prompts).mockImplementationOnce(async () => ({
           value: true,
         }));
 
-        const resolver = new AccountResolver('1234', user);
+        const resolver = new AccountResolver(graphqlClient, '1234', user);
         const account = await resolver.resolveAccountAsync();
         expect(account).toEqual({
           id: user.accounts[1].id,
@@ -72,6 +75,7 @@ describe(AccountResolver, () => {
       });
 
       it('asks the user to choose the account from his account list if he rejects to use the one defined in app.json / app.config.js', async () => {
+        const graphqlClient = instance(mock<ExpoGraphqlClient>());
         jest.mocked(prompts).mockImplementationOnce(async () => ({
           useProjectAccount: false,
         }));
@@ -79,7 +83,7 @@ describe(AccountResolver, () => {
           account: user.accounts[0],
         }));
 
-        const resolver = new AccountResolver('1234', user);
+        const resolver = new AccountResolver(graphqlClient, '1234', user);
         const account = await resolver.resolveAccountAsync();
         expect(account).toEqual(user.accounts[0]);
       });
@@ -87,11 +91,12 @@ describe(AccountResolver, () => {
 
     describe('when outside project dir', () => {
       it('asks the user to choose the account from his account list', async () => {
+        const graphqlClient = instance(mock<ExpoGraphqlClient>());
         jest.mocked(prompts).mockImplementationOnce(async () => ({
           account: user.accounts[0],
         }));
 
-        const resolver = new AccountResolver(null, user);
+        const resolver = new AccountResolver(graphqlClient, null, user);
         const account = await resolver.resolveAccountAsync();
         expect(account).toEqual(user.accounts[0]);
       });

--- a/packages/eas-cli/src/devices/actions/create/__tests__/action-test.ts
+++ b/packages/eas-cli/src/devices/actions/create/__tests__/action-test.ts
@@ -1,6 +1,7 @@
 import prompts from 'prompts';
 import { instance, mock } from 'ts-mockito';
 
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import AppStoreApi from '../../../../credentials/ios/appstore/AppStoreApi';
 import { AccountFragment, Role } from '../../../../graphql/generated';
 import DeviceCreateAction, { RegistrationMethod } from '../action';
@@ -26,6 +27,8 @@ beforeEach(() => {
 describe(DeviceCreateAction, () => {
   describe('#runAsync', () => {
     it('calls runRegistrationUrlMethodAsync if user chooses the website method', async () => {
+      const graphqlClient = instance(mock<ExpoGraphqlClient>());
+
       jest.mocked(prompts).mockImplementationOnce(async () => ({
         method: RegistrationMethod.WEBSITE,
       }));
@@ -49,13 +52,15 @@ describe(DeviceCreateAction, () => {
         appleTeamIdentifier: 'ABC123Y',
         appleTeamName: 'John Doe (Individual)',
       };
-      const action = new DeviceCreateAction(appStoreApi, account, appleTeam);
+      const action = new DeviceCreateAction(graphqlClient, appStoreApi, account, appleTeam);
       await action.runAsync();
 
       expect(runRegistrationUrlMethodAsync).toBeCalled();
     });
 
     it('calls runInputMethodAsync if user chooses the input method', async () => {
+      const graphqlClient = instance(mock<ExpoGraphqlClient>());
+
       jest.mocked(prompts).mockImplementationOnce(async () => ({
         method: RegistrationMethod.INPUT,
       }));
@@ -79,13 +84,15 @@ describe(DeviceCreateAction, () => {
         appleTeamIdentifier: 'ABC123Y',
         appleTeamName: 'John Doe (Individual)',
       };
-      const action = new DeviceCreateAction(appStoreApi, account, appleTeam);
+      const action = new DeviceCreateAction(graphqlClient, appStoreApi, account, appleTeam);
       await action.runAsync();
 
       expect(runInputMethodAsync).toBeCalled();
     });
 
     it('calls runDeveloperPortalMethodAsync if user chooses the developer portal method', async () => {
+      const graphqlClient = instance(mock<ExpoGraphqlClient>());
+
       jest.mocked(prompts).mockImplementationOnce(async () => ({
         method: RegistrationMethod.DEVELOPER_PORTAL,
       }));
@@ -109,7 +116,7 @@ describe(DeviceCreateAction, () => {
         appleTeamIdentifier: 'ABC123Y',
         appleTeamName: 'John Doe (Individual)',
       };
-      const action = new DeviceCreateAction(appStoreApi, account, appleTeam);
+      const action = new DeviceCreateAction(graphqlClient, appStoreApi, account, appleTeam);
       await action.runAsync();
 
       expect(runDeveloperPortalMethodAsync).toBeCalled();

--- a/packages/eas-cli/src/devices/actions/create/__tests__/inputMethod-test.ts
+++ b/packages/eas-cli/src/devices/actions/create/__tests__/inputMethod-test.ts
@@ -1,5 +1,7 @@
 import prompts from 'prompts';
+import { instance, mock } from 'ts-mockito';
 
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { AppleDeviceMutation } from '../../../../credentials/ios/api/graphql/mutations/AppleDeviceMutation';
 import { AppleDeviceClass, AppleTeam } from '../../../../graphql/generated';
 import { runInputMethodAsync } from '../inputMethod';
@@ -22,6 +24,7 @@ describe(runInputMethodAsync, () => {
     mockDeviceData('b12cba9856d89c932ab7a4b813c4d932534e1679', 'my iPad', AppleDeviceClass.Ipad);
     jest.mocked(prompts).mockImplementationOnce(async () => ({ value: false }));
 
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
     const accountId = 'account-id';
     // @ts-expect-error appleTeam is missing properties of AppleTeam GraphQL type
     const appleTeam: AppleTeam = {
@@ -30,7 +33,7 @@ describe(runInputMethodAsync, () => {
       appleTeamName: 'John Doe (Individual)',
     };
 
-    await runInputMethodAsync(accountId, appleTeam);
+    await runInputMethodAsync(graphqlClient, accountId, appleTeam);
 
     expect(AppleDeviceMutation.createAppleDeviceAsync).toHaveBeenCalledTimes(2);
   });

--- a/packages/eas-cli/src/devices/actions/create/action.ts
+++ b/packages/eas-cli/src/devices/actions/create/action.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import AppStoreApi from '../../../credentials/ios/appstore/AppStoreApi';
 import { AccountFragment, AppleTeam } from '../../../graphql/generated';
 import Log from '../../../log';
@@ -17,6 +18,7 @@ export enum RegistrationMethod {
 
 export default class DeviceCreateAction {
   constructor(
+    private graphqlClient: ExpoGraphqlClient,
     private appStoreApi: AppStoreApi,
     private account: AccountFragment,
     private appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName' | 'id'>
@@ -25,11 +27,16 @@ export default class DeviceCreateAction {
   public async runAsync(): Promise<RegistrationMethod> {
     const method = await this.askForRegistrationMethodAsync();
     if (method === RegistrationMethod.WEBSITE) {
-      await runRegistrationUrlMethodAsync(this.account.id, this.appleTeam);
+      await runRegistrationUrlMethodAsync(this.graphqlClient, this.account.id, this.appleTeam);
     } else if (method === RegistrationMethod.DEVELOPER_PORTAL) {
-      await runDeveloperPortalMethodAsync(this.appStoreApi, this.account.id, this.appleTeam);
+      await runDeveloperPortalMethodAsync(
+        this.graphqlClient,
+        this.appStoreApi,
+        this.account.id,
+        this.appleTeam
+      );
     } else if (method === RegistrationMethod.INPUT) {
-      await runInputMethodAsync(this.account.id, this.appleTeam);
+      await runInputMethodAsync(this.graphqlClient, this.account.id, this.appleTeam);
     } else if (method === RegistrationMethod.EXIT) {
       Log.log('Bye!');
       process.exit(0);

--- a/packages/eas-cli/src/devices/actions/create/registrationUrlMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/registrationUrlMethod.ts
@@ -4,15 +4,21 @@ import qrcodeTerminal from 'qrcode-terminal';
 import { URL } from 'url';
 
 import { getExpoWebsiteBaseUrl } from '../../../api';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { AppleDeviceRegistrationRequestMutation } from '../../../credentials/ios/api/graphql/mutations/AppleDeviceRegistrationRequestMutation';
 import { AppleTeam } from '../../../graphql/generated';
 import Log from '../../../log';
 
 export async function runRegistrationUrlMethodAsync(
+  graphqlClient: ExpoGraphqlClient,
   accountId: string,
   appleTeam: Pick<AppleTeam, 'id'>
 ): Promise<void> {
-  const registrationURL = await generateDeviceRegistrationURLAsync(accountId, appleTeam);
+  const registrationURL = await generateDeviceRegistrationURLAsync(
+    graphqlClient,
+    accountId,
+    appleTeam
+  );
   Log.newLine();
   qrcodeTerminal.generate(registrationURL, { small: true }, code =>
     Log.log(`${indentString(code, 2)}\n`)
@@ -25,11 +31,13 @@ export async function runRegistrationUrlMethodAsync(
 }
 
 async function generateDeviceRegistrationURLAsync(
+  graphqlClient: ExpoGraphqlClient,
   accountId: string,
   appleTeam: Pick<AppleTeam, 'id'>
 ): Promise<string> {
   const appleDeviceRegistrationRequest =
     await AppleDeviceRegistrationRequestMutation.createAppleDeviceRegistrationRequestAsync(
+      graphqlClient,
       appleTeam.id,
       accountId
     );

--- a/packages/eas-cli/src/devices/context.ts
+++ b/packages/eas-cli/src/devices/context.ts
@@ -1,24 +1,29 @@
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import AppStoreApi from '../credentials/ios/appstore/AppStoreApi';
 import { Actor } from '../user/User';
 
 export interface DeviceManagerContext {
   appStore: AppStoreApi;
   user: Actor;
+  graphqlClient: ExpoGraphqlClient;
   projectId: string | null;
 }
 
 export async function createContextAsync({
   appStore,
   user,
+  graphqlClient,
   projectId,
 }: {
   appStore: AppStoreApi;
   user: Actor;
+  graphqlClient: ExpoGraphqlClient;
   projectId: string | undefined;
 }): Promise<DeviceManagerContext> {
   return {
     appStore,
     user,
+    graphqlClient,
     projectId: projectId ?? null,
   };
 }

--- a/packages/eas-cli/src/devices/queries.ts
+++ b/packages/eas-cli/src/devices/queries.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { PaginatedQueryOptions } from '../commandUtils/pagination';
 import { formatAppleTeam } from '../credentials/ios/actions/AppleTeamFormatting';
 import { formatDeviceLabel } from '../credentials/ios/actions/DeviceUtils';
@@ -17,15 +18,18 @@ import formatDevice, { AppleTeamIdAndName } from './utils/formatDevice';
 export const TEAMS_LIMIT = 50;
 export const DEVICES_LIMIT = 50;
 
-export async function selectAppleTeamOnAccountAsync({
-  accountName,
-  selectionPromptTitle,
-  paginatedQueryOptions,
-}: {
-  accountName: string;
-  selectionPromptTitle: string;
-  paginatedQueryOptions: PaginatedQueryOptions;
-}): Promise<AppleTeamFragment> {
+export async function selectAppleTeamOnAccountAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    accountName,
+    selectionPromptTitle,
+    paginatedQueryOptions,
+  }: {
+    accountName: string;
+    selectionPromptTitle: string;
+    paginatedQueryOptions: PaginatedQueryOptions;
+  }
+): Promise<AppleTeamFragment> {
   if (paginatedQueryOptions.nonInteractive) {
     throw new Error('Unable to select an Apple team in non-interactive mode.');
   } else {
@@ -33,7 +37,7 @@ export async function selectAppleTeamOnAccountAsync({
       limit: paginatedQueryOptions.limit ?? TEAMS_LIMIT,
       offset: paginatedQueryOptions.offset,
       queryToPerform: (limit, offset) =>
-        AppleTeamQuery.getAllForAccountAsync({
+        AppleTeamQuery.getAllForAccountAsync(graphqlClient, {
           accountName,
           limit,
           offset,
@@ -54,17 +58,20 @@ export async function selectAppleTeamOnAccountAsync({
   }
 }
 
-export async function selectAppleDeviceOnAppleTeamAsync({
-  accountName,
-  appleTeamIdentifier,
-  selectionPromptTitle,
-  paginatedQueryOptions,
-}: {
-  accountName: string;
-  appleTeamIdentifier: string;
-  selectionPromptTitle: string;
-  paginatedQueryOptions: PaginatedQueryOptions;
-}): Promise<AppleDeviceFragment> {
+export async function selectAppleDeviceOnAppleTeamAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    accountName,
+    appleTeamIdentifier,
+    selectionPromptTitle,
+    paginatedQueryOptions,
+  }: {
+    accountName: string;
+    appleTeamIdentifier: string;
+    selectionPromptTitle: string;
+    paginatedQueryOptions: PaginatedQueryOptions;
+  }
+): Promise<AppleDeviceFragment> {
   if (paginatedQueryOptions.nonInteractive) {
     throw new Error('Unable to select an Apple device in non-interactive mode.');
   } else {
@@ -72,7 +79,7 @@ export async function selectAppleDeviceOnAppleTeamAsync({
       limit: paginatedQueryOptions.limit ?? DEVICES_LIMIT,
       offset: paginatedQueryOptions.offset,
       queryToPerform: (limit, offset) =>
-        AppleDeviceQuery.getAllForAppleTeamAsync({
+        AppleDeviceQuery.getAllForAppleTeamAsync(graphqlClient, {
           accountName,
           appleTeamIdentifier,
           limit,
@@ -93,17 +100,20 @@ export async function selectAppleDeviceOnAppleTeamAsync({
   }
 }
 
-export async function listAndRenderAppleDevicesOnAppleTeamAsync({
-  accountName,
-  appleTeam,
-  paginatedQueryOptions,
-}: {
-  accountName: string;
-  appleTeam: AppleTeamIdAndName;
-  paginatedQueryOptions: PaginatedQueryOptions;
-}): Promise<void> {
+export async function listAndRenderAppleDevicesOnAppleTeamAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    accountName,
+    appleTeam,
+    paginatedQueryOptions,
+  }: {
+    accountName: string;
+    appleTeam: AppleTeamIdAndName;
+    paginatedQueryOptions: PaginatedQueryOptions;
+  }
+): Promise<void> {
   if (paginatedQueryOptions.nonInteractive) {
-    const devices = await AppleDeviceQuery.getAllForAppleTeamAsync({
+    const devices = await AppleDeviceQuery.getAllForAppleTeamAsync(graphqlClient, {
       accountName,
       appleTeamIdentifier: appleTeam.appleTeamIdentifier,
       offset: paginatedQueryOptions.offset,
@@ -115,7 +125,7 @@ export async function listAndRenderAppleDevicesOnAppleTeamAsync({
       limit: paginatedQueryOptions.limit ?? DEVICES_LIMIT,
       offset: paginatedQueryOptions.offset,
       queryToPerform: (limit, offset) =>
-        AppleDeviceQuery.getAllForAppleTeamAsync({
+        AppleDeviceQuery.getAllForAppleTeamAsync(graphqlClient, {
           accountName,
           appleTeamIdentifier: appleTeam.appleTeamIdentifier,
           limit,

--- a/packages/eas-cli/src/graphql/client.ts
+++ b/packages/eas-cli/src/graphql/client.ts
@@ -1,69 +1,9 @@
-import {
-  Client,
-  CombinedError as GraphqlError,
-  OperationContext,
-  OperationResult,
-  PromisifiedSource,
-  TypedDocumentNode,
-  cacheExchange,
-  createClient as createUrqlClient,
-  dedupExchange,
-  fetchExchange,
-} from '@urql/core';
-import { retryExchange } from '@urql/exchange-retry';
-import { DocumentNode } from 'graphql';
-import fetch from 'node-fetch';
+import { CombinedError as GraphqlError, OperationResult } from '@urql/core';
 
-import { getExpoApiBaseUrl } from '../api';
-import { httpsProxyAgent } from '../fetch';
+import { createGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import Log from '../log';
-import { getAccessToken, getSessionSecret } from '../user/sessionStorage';
 
-export const graphqlClient = createUrqlClient({
-  url: getExpoApiBaseUrl() + '/graphql',
-  exchanges: [
-    dedupExchange,
-    cacheExchange,
-    retryExchange({
-      maxDelayMs: 4000,
-      retryIf: (err, operation) => {
-        return !!(
-          err &&
-          !operation.context.noRetry &&
-          (err.networkError || err.graphQLErrors.some(e => e?.extensions?.isTransient))
-        );
-      },
-    }),
-    fetchExchange,
-  ],
-  // @ts-expect-error Type 'typeof fetch' is not assignable to type '(input: RequestInfo, init?: RequestInit | undefined) => Promise<Response>'.
-  fetch,
-  fetchOptions: (): RequestInit => {
-    const headers: Record<string, string> = {};
-    const token = getAccessToken();
-    if (token) {
-      headers.authorization = `Bearer ${token}`;
-    }
-    const sessionSecret = getSessionSecret();
-    if (!token && sessionSecret) {
-      headers['expo-session'] = sessionSecret;
-    }
-    return {
-      ...(httpsProxyAgent ? { agent: httpsProxyAgent } : {}),
-      headers,
-    };
-  },
-}) as StricterClient;
-
-/* Specify additionalTypenames in your Graphql queries */
-export interface StricterClient extends Client {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  query<Data = any, Variables extends object = {}>(
-    query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
-    variables: Variables | undefined,
-    context: Partial<OperationContext> & { additionalTypenames: string[] }
-  ): PromisifiedSource<OperationResult<Data, Variables>>;
-}
+export const legacyGraphqlClient = createGraphqlClient();
 
 export async function withErrorHandlingAsync<T>(promise: Promise<OperationResult<T>>): Promise<T> {
   const { data, error } = await promise;

--- a/packages/eas-cli/src/graphql/mutations/AppMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/AppMutation.ts
@@ -1,15 +1,19 @@
 import assert from 'assert';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import { AppPrivacy, CreateAppMutation, CreateAppMutationVariables } from '../generated';
 
 export const AppMutation = {
-  async createAppAsync(appInput: {
-    accountId: string;
-    projectName: string;
-    privacy: AppPrivacy;
-  }): Promise<string> {
+  async createAppAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appInput: {
+      accountId: string;
+      projectName: string;
+      privacy: AppPrivacy;
+    }
+  ): Promise<string> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<CreateAppMutation, CreateAppMutationVariables>(

--- a/packages/eas-cli/src/graphql/mutations/AppVersionMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/AppVersionMutation.ts
@@ -1,7 +1,8 @@
 import assert from 'assert';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   AppPlatform,
   CreateAppVersionMutation,
@@ -9,14 +10,17 @@ import {
 } from '../generated';
 
 export const AppVersionMutation = {
-  async createAppVersionAsync(appVersionInput: {
-    appId: string;
-    platform: AppPlatform;
-    applicationIdentifier: string;
-    storeVersion: string;
-    buildVersion: string;
-    runtimeVersion?: string;
-  }): Promise<string> {
+  async createAppVersionAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appVersionInput: {
+      appId: string;
+      platform: AppPlatform;
+      applicationIdentifier: string;
+      storeVersion: string;
+      buildVersion: string;
+      runtimeVersion?: string;
+    }
+  ): Promise<string> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<CreateAppVersionMutation, CreateAppVersionMutationVariables>(

--- a/packages/eas-cli/src/graphql/mutations/BuildMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/BuildMutation.ts
@@ -2,7 +2,8 @@ import { print } from 'graphql';
 import gql from 'graphql-tag';
 import nullthrows from 'nullthrows';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   AndroidJobInput,
   BuildFragment,
@@ -23,12 +24,15 @@ export interface BuildResult {
 }
 
 export const BuildMutation = {
-  async createAndroidBuildAsync(input: {
-    appId: string;
-    job: AndroidJobInput;
-    metadata: BuildMetadataInput;
-    buildParams: BuildParamsInput;
-  }): Promise<BuildResult> {
+  async createAndroidBuildAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: {
+      appId: string;
+      job: AndroidJobInput;
+      metadata: BuildMetadataInput;
+      buildParams: BuildParamsInput;
+    }
+  ): Promise<BuildResult> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<CreateAndroidBuildMutation, CreateAndroidBuildMutationVariables>(
@@ -66,12 +70,15 @@ export const BuildMutation = {
     );
     return nullthrows(data.build?.createAndroidBuild);
   },
-  async createIosBuildAsync(input: {
-    appId: string;
-    job: IosJobInput;
-    metadata: BuildMetadataInput;
-    buildParams: BuildParamsInput;
-  }): Promise<BuildResult> {
+  async createIosBuildAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: {
+      appId: string;
+      job: IosJobInput;
+      metadata: BuildMetadataInput;
+      buildParams: BuildParamsInput;
+    }
+  ): Promise<BuildResult> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<CreateIosBuildMutation, CreateIosBuildMutationVariables>(

--- a/packages/eas-cli/src/graphql/mutations/EnvironmentSecretMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/EnvironmentSecretMutation.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   CreateEnvironmentSecretForAccountMutation,
   CreateEnvironmentSecretForAppMutation,
@@ -13,6 +14,7 @@ import { EnvironmentSecretFragmentNode } from '../types/EnvironmentSecret';
 
 export const EnvironmentSecretMutation = {
   async createForAccountAsync(
+    graphqlClient: ExpoGraphqlClient,
     input: { name: string; value: string; type: EnvironmentSecretType },
     accountId: string
   ): Promise<EnvironmentSecretFragment> {
@@ -44,6 +46,7 @@ export const EnvironmentSecretMutation = {
     return data.environmentSecret.createEnvironmentSecretForAccount;
   },
   async createForAppAsync(
+    graphqlClient: ExpoGraphqlClient,
     input: { name: string; value: string; type: EnvironmentSecretType },
     appId: string
   ): Promise<EnvironmentSecretFragment> {
@@ -71,7 +74,7 @@ export const EnvironmentSecretMutation = {
 
     return data.environmentSecret.createEnvironmentSecretForApp;
   },
-  async deleteAsync(id: string): Promise<{ id: string }> {
+  async deleteAsync(graphqlClient: ExpoGraphqlClient, id: string): Promise<{ id: string }> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteEnvironmentSecretMutation>(

--- a/packages/eas-cli/src/graphql/mutations/KeystoreGenerationUrlMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/KeystoreGenerationUrlMutation.ts
@@ -1,10 +1,11 @@
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import { CreateKeystoreGenerationUrlMutation } from '../generated';
 
 export const KeystoreGenerationUrlMutation = {
-  async createKeystoreGenerationUrlAsync(): Promise<string> {
+  async createKeystoreGenerationUrlAsync(graphqlClient: ExpoGraphqlClient): Promise<string> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<CreateKeystoreGenerationUrlMutation>(

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   CodeSigningInfoInput,
   GetSignedUploadMutation,
@@ -12,6 +13,7 @@ import {
 
 export const PublishMutation = {
   async getUploadURLsAsync(
+    graphqlClient: ExpoGraphqlClient,
     contentTypes: string[]
   ): Promise<GetSignedUploadMutation['asset']['getSignedAssetUploadSpecifications']> {
     const data = await withErrorHandlingAsync(
@@ -35,6 +37,7 @@ export const PublishMutation = {
     return data.asset.getSignedAssetUploadSpecifications;
   },
   async publishUpdateGroupAsync(
+    graphqlClient: ExpoGraphqlClient,
     publishUpdateGroupsInput: PublishUpdateGroupInput[]
   ): Promise<UpdatePublishMutation['updateBranch']['publishUpdateGroups']> {
     const data = await withErrorHandlingAsync(
@@ -61,6 +64,7 @@ export const PublishMutation = {
   },
 
   async setCodeSigningInfoAsync(
+    graphqlClient: ExpoGraphqlClient,
     updateId: string,
     codeSigningInfo: CodeSigningInfoInput
   ): Promise<SetCodeSigningInfoMutation['update']['setCodeSigningInfo']> {

--- a/packages/eas-cli/src/graphql/mutations/SubmissionMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/SubmissionMutation.ts
@@ -2,7 +2,8 @@ import { print } from 'graphql';
 import gql from 'graphql-tag';
 import nullthrows from 'nullthrows';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   CreateAndroidSubmissionInput,
   CreateAndroidSubmissionMutation,
@@ -16,6 +17,7 @@ import { SubmissionFragmentNode } from '../types/Submission';
 
 export const SubmissionMutation = {
   async createAndroidSubmissionAsync(
+    graphqlClient: ExpoGraphqlClient,
     input: CreateAndroidSubmissionInput
   ): Promise<SubmissionFragment> {
     const data = await withErrorHandlingAsync(
@@ -46,7 +48,10 @@ export const SubmissionMutation = {
     );
     return nullthrows(data.submission.createAndroidSubmission.submission);
   },
-  async createIosSubmissionAsync(input: CreateIosSubmissionInput): Promise<SubmissionFragment> {
+  async createIosSubmissionAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: CreateIosSubmissionInput
+  ): Promise<SubmissionFragment> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<CreateIosSubmissionMutation, CreateIosSubmissionMutationVariables>(

--- a/packages/eas-cli/src/graphql/mutations/UploadSessionMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/UploadSessionMutation.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   CreateUploadSessionMutation,
   CreateUploadSessionMutationVariables,
@@ -13,7 +14,10 @@ export interface PresignedPost {
 }
 
 export const UploadSessionMutation = {
-  async createUploadSessionAsync(type: UploadSessionType): Promise<PresignedPost> {
+  async createUploadSessionAsync(
+    graphqlClient: ExpoGraphqlClient,
+    type: UploadSessionType
+  ): Promise<PresignedPost> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<CreateUploadSessionMutation, CreateUploadSessionMutationVariables>(

--- a/packages/eas-cli/src/graphql/mutations/WebhookMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/WebhookMutation.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   CreateWebhookMutation,
   CreateWebhookMutationVariables,
@@ -15,7 +16,11 @@ import {
 import { WebhookFragmentNode } from '../types/Webhook';
 
 export const WebhookMutation = {
-  async createWebhookAsync(appId: string, webhookInput: WebhookInput): Promise<WebhookFragment> {
+  async createWebhookAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appId: string,
+    webhookInput: WebhookInput
+  ): Promise<WebhookFragment> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<CreateWebhookMutation, CreateWebhookMutationVariables>(
@@ -37,6 +42,7 @@ export const WebhookMutation = {
     return data.webhook.createWebhook;
   },
   async updateWebhookAsync(
+    graphqlClient: ExpoGraphqlClient,
     webhookId: string,
     webhookInput: WebhookInput
   ): Promise<WebhookFragment> {
@@ -60,7 +66,7 @@ export const WebhookMutation = {
     );
     return data.webhook.updateWebhook;
   },
-  async deleteWebhookAsync(webhookId: string): Promise<void> {
+  async deleteWebhookAsync(graphqlClient: ExpoGraphqlClient, webhookId: string): Promise<void> {
     await withErrorHandlingAsync(
       graphqlClient
         .mutation<DeleteWebhookMutation, DeleteWebhookMutationVariables>(

--- a/packages/eas-cli/src/graphql/queries/AppQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/AppQuery.ts
@@ -2,12 +2,13 @@ import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import { AppByFullNameQuery, AppByIdQuery, AppFragment } from '../generated';
 import { AppFragmentNode } from '../types/App';
 
 export const AppQuery = {
-  async byIdAsync(projectId: string): Promise<AppFragment> {
+  async byIdAsync(graphqlClient: ExpoGraphqlClient, projectId: string): Promise<AppFragment> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<AppByIdQuery>(
@@ -33,7 +34,7 @@ export const AppQuery = {
     assert(data.app, 'GraphQL: `app` not defined in server response');
     return data.app.byId;
   },
-  async byFullNameAsync(fullName: string): Promise<AppFragment> {
+  async byFullNameAsync(graphqlClient: ExpoGraphqlClient, fullName: string): Promise<AppFragment> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<AppByFullNameQuery>(

--- a/packages/eas-cli/src/graphql/queries/AppVersionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/AppVersionQuery.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   AppPlatform,
   AppVersion,
@@ -10,6 +11,7 @@ import {
 
 export const AppVersionQuery = {
   async latestVersionAsync(
+    graphqlClient: ExpoGraphqlClient,
     appId: string,
     platform: AppPlatform,
     applicationIdentifier: string

--- a/packages/eas-cli/src/graphql/queries/BranchQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BranchQuery.ts
@@ -2,7 +2,8 @@ import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { BranchNotFoundError } from '../../branch/utils';
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   BranchesByAppQuery,
   BranchesByAppQueryVariables,
@@ -20,12 +21,10 @@ export type UpdateBranchOnChannelObject = NonNullable<
 >['updateBranches'][number];
 
 export const BranchQuery = {
-  async getBranchByNameAsync({
-    appId,
-    name,
-  }: ViewBranchQueryVariables): Promise<
-    NonNullable<ViewBranchQuery['app']['byId']['updateBranchByName']>
-  > {
+  async getBranchByNameAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { appId, name }: ViewBranchQueryVariables
+  ): Promise<NonNullable<ViewBranchQuery['app']['byId']['updateBranchByName']>> {
     const response = await withErrorHandlingAsync<ViewBranchQuery>(
       graphqlClient
         .query<ViewBranchQuery, ViewBranchQueryVariables>(
@@ -56,11 +55,10 @@ export const BranchQuery = {
     }
     return updateBranchByName;
   },
-  async listBranchesOnAppAsync({
-    appId,
-    limit,
-    offset,
-  }: BranchesByAppQueryVariables): Promise<UpdateBranchFragment[]> {
+  async listBranchesOnAppAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { appId, limit, offset }: BranchesByAppQueryVariables
+  ): Promise<UpdateBranchFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<BranchesByAppQuery, BranchesByAppQueryVariables>(
@@ -90,12 +88,10 @@ export const BranchQuery = {
 
     return data?.app?.byId.updateBranches ?? [];
   },
-  async listBranchesOnChannelAsync({
-    appId,
-    channelName,
-    offset,
-    limit,
-  }: ViewBranchesOnUpdateChannelQueryVariables): Promise<UpdateBranchOnChannelObject[]> {
+  async listBranchesOnChannelAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { appId, channelName, offset, limit }: ViewBranchesOnUpdateChannelQueryVariables
+  ): Promise<UpdateBranchOnChannelObject[]> {
     const response = await withErrorHandlingAsync(
       graphqlClient
         .query<ViewBranchesOnUpdateChannelQuery, ViewBranchesOnUpdateChannelQueryVariables>(

--- a/packages/eas-cli/src/graphql/queries/BuildQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BuildQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   BuildFragment,
   BuildWithSubmissionsFragment,
@@ -16,6 +17,7 @@ import { BuildFragmentNode, BuildFragmentWithSubmissionsNode } from '../types/Bu
 
 export const BuildQuery = {
   async byIdAsync(
+    graphqlClient: ExpoGraphqlClient,
     buildId: string,
     { useCache = true }: { useCache?: boolean } = {}
   ): Promise<BuildFragment> {
@@ -45,6 +47,7 @@ export const BuildQuery = {
     return data.builds.byId;
   },
   async withSubmissionsByIdAsync(
+    graphqlClient: ExpoGraphqlClient,
     buildId: string,
     { useCache = true }: { useCache?: boolean } = {}
   ): Promise<BuildWithSubmissionsFragment> {
@@ -73,12 +76,10 @@ export const BuildQuery = {
 
     return data.builds.byId;
   },
-  async viewBuildsOnAppAsync({
-    appId,
-    limit,
-    offset,
-    filter,
-  }: ViewBuildsOnAppQueryVariables): Promise<BuildFragment[]> {
+  async viewBuildsOnAppAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { appId, limit, offset, filter }: ViewBuildsOnAppQueryVariables
+  ): Promise<BuildFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<ViewBuildsOnAppQuery, ViewBuildsOnAppQueryVariables>(

--- a/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   ViewUpdateChannelOnAppQuery,
   ViewUpdateChannelOnAppQueryVariables,
@@ -19,10 +20,10 @@ export type UpdateChannelByNameObject = NonNullable<
 >;
 
 export const ChannelQuery = {
-  async viewUpdateChannelAsync({
-    appId,
-    channelName,
-  }: ViewUpdateChannelOnAppQueryVariables): Promise<UpdateChannelByNameObject> {
+  async viewUpdateChannelAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { appId, channelName }: ViewUpdateChannelOnAppQueryVariables
+  ): Promise<UpdateChannelByNameObject> {
     const response = await withErrorHandlingAsync(
       graphqlClient
         .query<ViewUpdateChannelOnAppQuery, ViewUpdateChannelOnAppQueryVariables>(
@@ -63,11 +64,10 @@ export const ChannelQuery = {
 
     return updateChannelByName;
   },
-  async viewUpdateChannelsOnAppAsync({
-    appId,
-    limit,
-    offset,
-  }: ViewUpdateChannelsOnAppQueryVariables): Promise<UpdateChannelObject[]> {
+  async viewUpdateChannelsOnAppAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { appId, limit, offset }: ViewUpdateChannelsOnAppQueryVariables
+  ): Promise<UpdateChannelObject[]> {
     const response = await withErrorHandlingAsync(
       graphqlClient
         .query<ViewUpdateChannelsOnAppQuery, ViewUpdateChannelsOnAppQueryVariables>(

--- a/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EnvironmentSecretsQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import { EnvironmentSecretFragment, EnvironmentSecretsByAppIdQuery } from '../generated';
 import { EnvironmentSecretFragmentNode } from '../types/EnvironmentSecret';
 
@@ -15,7 +16,10 @@ export type EnvironmentSecretWithScope = EnvironmentSecretFragment & {
 };
 
 export const EnvironmentSecretsQuery = {
-  async byAppIdAsync(appId: string): Promise<{
+  async byAppIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appId: string
+  ): Promise<{
     accountSecrets: EnvironmentSecretFragment[];
     appSecrets: EnvironmentSecretFragment[];
   }> {
@@ -54,8 +58,11 @@ export const EnvironmentSecretsQuery = {
       appSecrets: data.app?.byId.environmentSecrets ?? [],
     };
   },
-  async allAsync(projectId: string): Promise<EnvironmentSecretWithScope[]> {
-    const { accountSecrets, appSecrets } = await this.byAppIdAsync(projectId);
+  async allAsync(
+    graphqlClient: ExpoGraphqlClient,
+    projectId: string
+  ): Promise<EnvironmentSecretWithScope[]> {
+    const { accountSecrets, appSecrets } = await this.byAppIdAsync(graphqlClient, projectId);
     return [
       ...appSecrets.map(s => ({ ...s, scope: EnvironmentSecretScope.PROJECT })),
       ...accountSecrets.map(s => ({ ...s, scope: EnvironmentSecretScope.ACCOUNT })),

--- a/packages/eas-cli/src/graphql/queries/PublishQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/PublishQuery.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   AssetMetadataResult,
   GetAssetLimitPerUpdateGroupForAppQuery,
@@ -9,7 +10,10 @@ import {
 } from '../generated';
 
 export const PublishQuery = {
-  async getAssetMetadataAsync(storageKeys: string[]): Promise<AssetMetadataResult[]> {
+  async getAssetMetadataAsync(
+    graphqlClient: ExpoGraphqlClient,
+    storageKeys: string[]
+  ): Promise<AssetMetadataResult[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<GetAssetMetadataQuery>(
@@ -36,6 +40,7 @@ export const PublishQuery = {
     return data.asset.metadata;
   },
   async getAssetLimitPerUpdateGroupAsync(
+    graphqlClient: ExpoGraphqlClient,
     appId: string
   ): Promise<GetAssetLimitPerUpdateGroupForAppQuery['app']['byId']['assetLimitPerUpdateGroup']> {
     const data = await withErrorHandlingAsync(

--- a/packages/eas-cli/src/graphql/queries/StatuspageServiceQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/StatuspageServiceQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   StatuspageServiceByServiceNamesQuery,
   StatuspageServiceByServiceNamesQueryVariables,
@@ -12,6 +13,7 @@ import { StatuspageServiceFragmentNode } from '../types/StatuspageService';
 
 export const StatuspageServiceQuery = {
   async statuspageServicesAsync(
+    graphqlClient: ExpoGraphqlClient,
     serviceNames: StatuspageServiceName[]
   ): Promise<StatuspageServiceFragment[]> {
     const data = await withErrorHandlingAsync(

--- a/packages/eas-cli/src/graphql/queries/SubmissionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/SubmissionQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   AppPlatform,
   GetAllSubmissionsForAppQuery,
@@ -22,6 +23,7 @@ type Filters = {
 
 export const SubmissionQuery = {
   async byIdAsync(
+    graphqlClient: ExpoGraphqlClient,
     submissionId: string,
     { useCache = true }: { useCache?: boolean } = {}
   ): Promise<SubmissionFragment> {
@@ -51,6 +53,7 @@ export const SubmissionQuery = {
   },
 
   async allForAppAsync(
+    graphqlClient: ExpoGraphqlClient,
     appId: string,
     { limit = 10, offset = 0, status, platform }: Filters
   ): Promise<SubmissionFragment[]> {

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   UpdateFragment,
   ViewUpdateGroupsOnAppQuery,
@@ -14,9 +15,10 @@ import {
 import { UpdateFragmentNode } from '../types/Update';
 
 export const UpdateQuery = {
-  async viewUpdateGroupAsync({
-    groupId,
-  }: ViewUpdatesByGroupQueryVariables): Promise<UpdateFragment[]> {
+  async viewUpdateGroupAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { groupId }: ViewUpdatesByGroupQueryVariables
+  ): Promise<UpdateFragment[]> {
     const { updatesByGroup } = await withErrorHandlingAsync(
       graphqlClient
         .query<ViewUpdatesByGroupQuery, ViewUpdatesByGroupQueryVariables>(
@@ -43,13 +45,10 @@ export const UpdateQuery = {
 
     return updatesByGroup;
   },
-  async viewUpdateGroupsOnBranchAsync({
-    limit,
-    offset,
-    appId,
-    branchName,
-    filter,
-  }: ViewUpdateGroupsOnBranchQueryVariables): Promise<UpdateFragment[][]> {
+  async viewUpdateGroupsOnBranchAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { limit, offset, appId, branchName, filter }: ViewUpdateGroupsOnBranchQueryVariables
+  ): Promise<UpdateFragment[][]> {
     const response = await withErrorHandlingAsync(
       graphqlClient
         .query<ViewUpdateGroupsOnBranchQuery, ViewUpdateGroupsOnBranchQueryVariables>(
@@ -95,12 +94,10 @@ export const UpdateQuery = {
 
     return branch.updateGroups;
   },
-  async viewUpdateGroupsOnAppAsync({
-    limit,
-    offset,
-    appId,
-    filter,
-  }: ViewUpdateGroupsOnAppQueryVariables): Promise<UpdateFragment[][]> {
+  async viewUpdateGroupsOnAppAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { limit, offset, appId, filter }: ViewUpdateGroupsOnAppQueryVariables
+  ): Promise<UpdateFragment[][]> {
     const response = await withErrorHandlingAsync(
       graphqlClient
         .query<ViewUpdateGroupsOnAppQuery, ViewUpdateGroupsOnAppQueryVariables>(

--- a/packages/eas-cli/src/graphql/queries/UserQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UserQuery.ts
@@ -1,12 +1,13 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import { CurrentUserQuery } from '../generated';
 import { AccountFragmentNode } from '../types/Account';
 
 export const UserQuery = {
-  async currentUserAsync(): Promise<CurrentUserQuery['meActor']> {
+  async currentUserAsync(graphqlClient: ExpoGraphqlClient): Promise<CurrentUserQuery['meActor']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<CurrentUserQuery>(

--- a/packages/eas-cli/src/graphql/queries/WebhookQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/WebhookQuery.ts
@@ -1,7 +1,8 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
-import { graphqlClient, withErrorHandlingAsync } from '../client';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
 import {
   WebhookByIdQuery,
   WebhookByIdQueryVariables,
@@ -13,7 +14,11 @@ import {
 import { WebhookFragmentNode } from '../types/Webhook';
 
 export const WebhookQuery = {
-  async byAppIdAsync(appId: string, webhookFilter?: WebhookFilter): Promise<WebhookFragment[]> {
+  async byAppIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appId: string,
+    webhookFilter?: WebhookFilter
+  ): Promise<WebhookFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<WebhooksByAppIdQuery, WebhooksByAppIdQueryVariables>(
@@ -40,7 +45,7 @@ export const WebhookQuery = {
     );
     return data.app?.byId.webhooks ?? [];
   },
-  async byIdAsync(webhookId: string): Promise<WebhookFragment> {
+  async byIdAsync(graphqlClient: ExpoGraphqlClient, webhookId: string): Promise<WebhookFragment> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<WebhookByIdQuery, WebhookByIdQueryVariables>(

--- a/packages/eas-cli/src/project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync.ts
+++ b/packages/eas-cli/src/project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import terminalLink from 'terminal-link';
 
 import { getProjectDashboardUrl } from '../build/utils/url';
+import { legacyGraphqlClient } from '../graphql/client';
 import { AppPrivacy, Role } from '../graphql/generated';
 import { AppMutation } from '../graphql/mutations/AppMutation';
 import { AppQuery } from '../graphql/queries/AppQuery';
@@ -87,7 +88,7 @@ export async function fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsyn
 
   const spinner = ora(`Creating ${chalk.bold(projectFullName)} on Expo`).start();
   try {
-    const id = await AppMutation.createAppAsync({
+    const id = await AppMutation.createAppAsync(legacyGraphqlClient, {
       accountId: account.id,
       projectName,
       privacy: projectInfo.privacy ?? AppPrivacy.Public,
@@ -111,7 +112,7 @@ export async function findProjectIdByAccountNameAndSlugNullableAsync(
   slug: string
 ): Promise<string | null> {
   try {
-    const { id } = await AppQuery.byFullNameAsync(`@${accountName}/${slug}`);
+    const { id } = await AppQuery.byFullNameAsync(legacyGraphqlClient, `@${accountName}/${slug}`);
     return id;
   } catch (err: any) {
     if (err.graphQLErrors?.some((it: any) => it.extensions?.errorCode !== 'EXPERIENCE_NOT_FOUND')) {

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { AccountFragment, AppPrivacy } from '../graphql/generated';
 import { AppQuery } from '../graphql/queries/AppQuery';
 import Log from '../log';
@@ -105,13 +106,17 @@ export async function installExpoUpdatesAsync(projectDir: string): Promise<void>
 }
 
 export async function getOwnerAccountForProjectIdAsync(
+  graphqlClient: ExpoGraphqlClient,
   projectId: string
 ): Promise<AccountFragment> {
-  const app = await AppQuery.byIdAsync(projectId);
+  const app = await AppQuery.byIdAsync(graphqlClient, projectId);
   return app.ownerAccount;
 }
 
-export async function getDisplayNameForProjectIdAsync(projectId: string): Promise<string> {
-  const app = await AppQuery.byIdAsync(projectId);
+export async function getDisplayNameForProjectIdAsync(
+  graphqlClient: ExpoGraphqlClient,
+  projectId: string
+): Promise<string> {
+  const app = await AppQuery.byIdAsync(graphqlClient, projectId);
   return app.fullName;
 }

--- a/packages/eas-cli/src/submit/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submit/BaseSubmitter.ts
@@ -2,6 +2,7 @@ import { Platform } from '@expo/eas-build-job';
 
 import { withAnalyticsAsync } from '../analytics/common';
 import { Event, SubmissionEvent } from '../analytics/events';
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   AndroidSubmissionConfigInput,
   IosSubmissionConfigInput,
@@ -78,7 +79,10 @@ export default abstract class BaseSubmitter<
     const platformDisplayName = appPlatformDisplayNames[toAppPlatform(this.ctx.platform)];
     const scheduleSpinner = ora(`Scheduling ${platformDisplayName} submission`).start();
     try {
-      const submission = this.createPlatformSubmissionAsync(submissionInput);
+      const submission = this.createPlatformSubmissionAsync(
+        this.ctx.graphqlClient,
+        submissionInput
+      );
       scheduleSpinner.succeed(`Scheduled ${platformDisplayName} submission`);
       return submission;
     } catch (err) {
@@ -102,6 +106,7 @@ export default abstract class BaseSubmitter<
   }
 
   protected abstract createPlatformSubmissionAsync(
+    graphqlClient: ExpoGraphqlClient,
     input: SubmissionInput<P>
   ): Promise<SubmissionFragment>;
 }

--- a/packages/eas-cli/src/submit/__tests__/ArchiveSource-test.ts
+++ b/packages/eas-cli/src/submit/__tests__/ArchiveSource-test.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import { vol } from 'memfs';
 import { v4 as uuidv4 } from 'uuid';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { AppPlatform, BuildFragment, UploadSessionType } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import { toAppPlatform } from '../../graphql/types/AppPlatform';
@@ -47,6 +48,8 @@ const SOURCE_STUB_INPUT = {
 };
 
 describe(getArchiveAsync, () => {
+  let graphqlClient: ExpoGraphqlClient;
+
   beforeEach(() => {
     vol.reset();
 
@@ -59,10 +62,12 @@ describe(getArchiveAsync, () => {
     jest.mocked(confirmAsync).mockImplementation(async () => {
       throw new Error(`unhandled prompts call - this shouldn't happen - fix tests!`);
     });
+
+    graphqlClient = {} as any as ExpoGraphqlClient;
   });
 
   it('handles URL source', async () => {
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.url,
       url: ARCHIVE_URL,
@@ -77,7 +82,7 @@ describe(getArchiveAsync, () => {
       .mockResolvedValueOnce({ sourceType: ArchiveSourceType.url })
       .mockResolvedValueOnce({ url: ARCHIVE_URL });
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.url,
       url: 'invalid',
@@ -91,7 +96,7 @@ describe(getArchiveAsync, () => {
     jest.mocked(confirmAsync).mockResolvedValueOnce(true);
     jest.mocked(BuildQuery.byIdAsync).mockResolvedValueOnce(MOCK_BUILD_FRAGMENT as BuildFragment);
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.url,
       url: 'https://expo.dev/accounts/turtle/projects/blah/builds/81da6b36-efe4-4262-8970-84f03efeec81',
@@ -108,7 +113,7 @@ describe(getArchiveAsync, () => {
       .mockResolvedValueOnce({ sourceType: ArchiveSourceType.url })
       .mockResolvedValueOnce({ url: ARCHIVE_URL });
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.prompt,
     });
@@ -120,13 +125,13 @@ describe(getArchiveAsync, () => {
     const buildId = uuidv4();
     jest.mocked(BuildQuery.byIdAsync).mockResolvedValueOnce(MOCK_BUILD_FRAGMENT as BuildFragment);
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.buildId,
       id: buildId,
     });
 
-    expect(BuildQuery.byIdAsync).toBeCalledWith(buildId);
+    expect(BuildQuery.byIdAsync).toBeCalledWith(graphqlClient, buildId);
     assertArchiveResult(archive, ArchiveSourceType.buildId);
   });
 
@@ -137,7 +142,7 @@ describe(getArchiveAsync, () => {
       .mockResolvedValueOnce({ sourceType: ArchiveSourceType.url })
       .mockResolvedValueOnce({ url: ARCHIVE_URL });
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.buildId,
       id: uuidv4(),
@@ -152,13 +157,14 @@ describe(getArchiveAsync, () => {
       .mocked(getRecentBuildsForSubmissionAsync)
       .mockResolvedValueOnce([MOCK_BUILD_FRAGMENT as BuildFragment]);
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       projectId,
       sourceType: ArchiveSourceType.latest,
     });
 
     expect(getRecentBuildsForSubmissionAsync).toBeCalledWith(
+      graphqlClient,
       toAppPlatform(SOURCE_STUB_INPUT.platform),
       projectId
     );
@@ -172,7 +178,7 @@ describe(getArchiveAsync, () => {
       .mockResolvedValueOnce({ sourceType: ArchiveSourceType.url })
       .mockResolvedValueOnce({ url: ARCHIVE_URL });
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.latest,
     });
@@ -187,13 +193,14 @@ describe(getArchiveAsync, () => {
       .mockResolvedValueOnce([MOCK_BUILD_FRAGMENT as BuildFragment]);
     jest.mocked(promptAsync).mockResolvedValueOnce({ selectedBuild: MOCK_BUILD_FRAGMENT });
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       projectId,
       sourceType: ArchiveSourceType.buildList,
     });
 
     expect(getRecentBuildsForSubmissionAsync).toBeCalledWith(
+      graphqlClient,
       toAppPlatform(SOURCE_STUB_INPUT.platform),
       projectId,
       { limit: BUILD_LIST_ITEM_COUNT }
@@ -213,7 +220,7 @@ describe(getArchiveAsync, () => {
       .mockResolvedValueOnce({ sourceType: ArchiveSourceType.url })
       .mockResolvedValueOnce({ url: ARCHIVE_URL });
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.buildList,
     });
@@ -231,7 +238,7 @@ describe(getArchiveAsync, () => {
       .mockResolvedValueOnce({ sourceType: ArchiveSourceType.url })
       .mockResolvedValueOnce({ url: ARCHIVE_URL });
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.buildList,
     });
@@ -247,13 +254,14 @@ describe(getArchiveAsync, () => {
       .mocked(uploadFileAtPathToS3Async)
       .mockResolvedValueOnce({ url: ARCHIVE_URL, bucketKey: 'wat' });
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.path,
       path,
     });
 
     expect(uploadFileAtPathToS3Async).toBeCalledWith(
+      graphqlClient,
       UploadSessionType.EasSubmitAppArchive,
       path,
       expect.anything()
@@ -267,7 +275,7 @@ describe(getArchiveAsync, () => {
       .mockResolvedValueOnce({ sourceType: ArchiveSourceType.url })
       .mockResolvedValueOnce({ url: ARCHIVE_URL });
 
-    const archive = await getArchiveAsync({
+    const archive = await getArchiveAsync(graphqlClient, {
       ...SOURCE_STUB_INPUT,
       sourceType: ArchiveSourceType.path,
       path: './doesnt/exist.aab',

--- a/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
@@ -2,6 +2,7 @@ import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
 import { SubmissionEvent } from '../../analytics/events';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   AndroidSubmissionConfigInput,
   SubmissionAndroidReleaseStatus,
@@ -47,7 +48,7 @@ export default class AndroidSubmitter extends BaseSubmitter<
   constructor(ctx: SubmissionContext<Platform.ANDROID>, options: AndroidSubmissionOptions) {
     const sourceOptionsResolver = {
       // eslint-disable-next-line async-protect/async-suffix
-      archive: async () => await getArchiveAsync(this.options.archiveSource),
+      archive: async () => await getArchiveAsync(ctx.graphqlClient, this.options.archiveSource),
       // eslint-disable-next-line async-protect/async-suffix
       serviceAccountKeyResult: async () => {
         return await getServiceAccountKeyResultAsync(this.ctx, this.options.serviceAccountSource);
@@ -84,12 +85,11 @@ export default class AndroidSubmitter extends BaseSubmitter<
     };
   }
 
-  protected async createPlatformSubmissionAsync({
-    projectId,
-    submissionConfig,
-    buildId,
-  }: SubmissionInput<Platform.ANDROID>): Promise<SubmissionFragment> {
-    return await SubmissionMutation.createAndroidSubmissionAsync({
+  protected async createPlatformSubmissionAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { projectId, submissionConfig, buildId }: SubmissionInput<Platform.ANDROID>
+  ): Promise<SubmissionFragment> {
+    return await SubmissionMutation.createAndroidSubmissionAsync(graphqlClient, {
       appId: projectId,
       config: submissionConfig,
       submittedBuildId: buildId,

--- a/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
@@ -3,6 +3,7 @@ import { AndroidReleaseStatus, AndroidReleaseTrack } from '@expo/eas-json';
 import { vol } from 'memfs';
 import { v4 as uuidv4 } from 'uuid';
 
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   jester as mockJester,
   testProjectId,
@@ -76,6 +77,7 @@ describe(AndroidSubmitCommand, () => {
   describe('non-interactive mode', () => {
     it("throws error if didn't provide serviceAccountKeyPath in the submit profile", async () => {
       const projectId = uuidv4();
+      const graphqlClient = {} as any as ExpoGraphqlClient;
 
       const ctx = await createSubmissionContextAsync({
         platform: Platform.ANDROID,
@@ -90,6 +92,7 @@ describe(AndroidSubmitCommand, () => {
         },
         nonInteractive: true,
         actor: mockJester,
+        graphqlClient,
         exp: testProject.appJSON.expo,
         projectId,
       });
@@ -101,6 +104,7 @@ describe(AndroidSubmitCommand, () => {
   describe('sending submission', () => {
     it('sends a request to Submission Service', async () => {
       const projectId = uuidv4();
+      const graphqlClient = {} as any as ExpoGraphqlClient;
 
       const ctx = await createSubmissionContextAsync({
         platform: Platform.ANDROID,
@@ -116,13 +120,14 @@ describe(AndroidSubmitCommand, () => {
         },
         nonInteractive: false,
         actor: mockJester,
+        graphqlClient,
         exp: testProject.appJSON.expo,
         projectId,
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
 
-      expect(SubmissionMutation.createAndroidSubmissionAsync).toHaveBeenCalledWith({
+      expect(SubmissionMutation.createAndroidSubmissionAsync).toHaveBeenCalledWith(graphqlClient, {
         appId: projectId,
         config: {
           archiveUrl: 'http://expo.dev/fake.apk',
@@ -136,6 +141,7 @@ describe(AndroidSubmitCommand, () => {
 
     it('assigns the build ID to submission', async () => {
       const projectId = uuidv4();
+      const graphqlClient = {} as any as ExpoGraphqlClient;
       jest
         .mocked(getRecentBuildsForSubmissionAsync)
         .mockResolvedValueOnce([fakeBuildFragment as BuildFragment]);
@@ -154,13 +160,14 @@ describe(AndroidSubmitCommand, () => {
         },
         nonInteractive: false,
         actor: mockJester,
+        graphqlClient,
         exp: testProject.appJSON.expo,
         projectId,
       });
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
 
-      expect(SubmissionMutation.createAndroidSubmissionAsync).toHaveBeenCalledWith({
+      expect(SubmissionMutation.createAndroidSubmissionAsync).toHaveBeenCalledWith(graphqlClient, {
         appId: projectId,
         config: {
           googleServiceAccountKeyJson: fakeFiles['/google-service-account.json'],

--- a/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
@@ -1,8 +1,10 @@
 import { Platform } from '@expo/eas-build-job';
 import { AndroidReleaseStatus, AndroidReleaseTrack } from '@expo/eas-json';
 import { vol } from 'memfs';
+import { instance, mock } from 'ts-mockito';
 import { v4 as uuidv4 } from 'uuid';
 
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { testAndroidAppCredentialsFragment } from '../../../credentials/__tests__/fixtures-android';
 import {
   jester as mockJester,
@@ -136,6 +138,7 @@ describe(getServiceAccountKeyPathAsync, () => {
 
 describe(getServiceAccountKeyResultAsync, () => {
   it('returns a local Service Account Key file with a ServiceAccountSourceType.path source', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
     const ctx = await createSubmissionContextAsync({
       platform: Platform.ANDROID,
       projectDir: testProject.projectRoot,
@@ -149,6 +152,7 @@ describe(getServiceAccountKeyResultAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
+      graphqlClient,
       exp: testProject.appJSON.expo,
       projectId,
     });
@@ -173,6 +177,7 @@ describe(getServiceAccountKeyResultAsync, () => {
     jest.mocked(promptAsync).mockImplementationOnce(async () => ({
       filePath: '/project_dir/subdir/service-account.json',
     }));
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
     const ctx = await createSubmissionContextAsync({
       platform: Platform.ANDROID,
       projectDir: testProject.projectRoot,
@@ -186,6 +191,7 @@ describe(getServiceAccountKeyResultAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
+      graphqlClient,
       exp: testProject.appJSON.expo,
       projectId,
     });
@@ -206,6 +212,7 @@ describe(getServiceAccountKeyResultAsync, () => {
   });
 
   it('returns a remote Service Account Key file with a ServiceAccountSourceType.credentialService source', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
     const ctx = await createSubmissionContextAsync({
       platform: Platform.ANDROID,
       projectDir: testProject.projectRoot,
@@ -219,6 +226,7 @@ describe(getServiceAccountKeyResultAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
+      graphqlClient,
       exp: testProject.appJSON.expo,
       projectId,
     });

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { TrackingContext } from '../analytics/common';
 import { Analytics, SubmissionEvent } from '../analytics/events';
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { CredentialsContext } from '../credentials/context';
 import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 import { Actor } from '../user/User';
@@ -22,6 +23,7 @@ export interface SubmissionContext<T extends Platform> {
   projectId: string;
   projectName: string;
   user: Actor;
+  graphqlClient: ExpoGraphqlClient;
   applicationIdentifierOverride?: string;
 }
 
@@ -42,19 +44,29 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
   projectDir: string;
   applicationIdentifier?: string;
   actor: Actor;
+  graphqlClient: ExpoGraphqlClient;
   exp: ExpoConfig;
   projectId: string;
 }): Promise<SubmissionContext<T>> {
-  const { applicationIdentifier, projectDir, nonInteractive, actor, exp, projectId } = params;
+  const {
+    applicationIdentifier,
+    projectDir,
+    nonInteractive,
+    actor,
+    exp,
+    projectId,
+    graphqlClient,
+  } = params;
   const { env, ...rest } = params;
   const projectName = exp.slug;
-  const account = await getOwnerAccountForProjectIdAsync(projectId);
+  const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
   const accountId = account.id;
   let credentialsCtx: CredentialsContext | undefined = params.credentialsCtx;
   if (!credentialsCtx) {
     credentialsCtx = new CredentialsContext({
       projectDir,
       user: actor,
+      graphqlClient,
       projectInfo: { exp, projectId },
       nonInteractive,
     });

--- a/packages/eas-cli/src/submit/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitter.ts
@@ -2,6 +2,7 @@ import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
 import { SubmissionEvent } from '../../analytics/events';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { MinimalAscApiKey } from '../../credentials/ios/credentials';
 import { IosSubmissionConfigInput, SubmissionFragment } from '../../graphql/generated';
 import { SubmissionMutation } from '../../graphql/mutations/SubmissionMutation';
@@ -55,7 +56,7 @@ export default class IosSubmitter extends BaseSubmitter<
   constructor(ctx: SubmissionContext<Platform.IOS>, options: IosSubmissionOptions) {
     const sourceOptionsResolver = {
       // eslint-disable-next-line async-protect/async-suffix
-      archive: async () => await getArchiveAsync(this.options.archiveSource),
+      archive: async () => await getArchiveAsync(ctx.graphqlClient, this.options.archiveSource),
       // eslint-disable-next-line async-protect/async-suffix
       credentials: async () => {
         const maybeAppSpecificPassword = this.options.appSpecificPasswordSource
@@ -109,12 +110,11 @@ export default class IosSubmitter extends BaseSubmitter<
     };
   }
 
-  protected async createPlatformSubmissionAsync({
-    projectId,
-    submissionConfig,
-    buildId,
-  }: SubmissionInput<Platform.IOS>): Promise<SubmissionFragment> {
-    return await SubmissionMutation.createIosSubmissionAsync({
+  protected async createPlatformSubmissionAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { projectId, submissionConfig, buildId }: SubmissionInput<Platform.IOS>
+  ): Promise<SubmissionFragment> {
+    return await SubmissionMutation.createIosSubmissionAsync(graphqlClient, {
       appId: projectId,
       config: submissionConfig,
       submittedBuildId: buildId,

--- a/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
@@ -1,7 +1,9 @@
 import { Platform } from '@expo/eas-build-job';
 import { vol } from 'memfs';
+import { instance, mock } from 'ts-mockito';
 import { v4 as uuidv4 } from 'uuid';
 
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   jester as mockJester,
   testAppQueryByIdResponse,
@@ -35,6 +37,7 @@ const testProject = createTestProject(testProjectId, mockJester.accounts[0].name
 const projectId = uuidv4();
 
 async function getIosSubmissionContextAsync(): Promise<SubmissionContext<Platform.IOS>> {
+  const graphqlClient = instance(mock<ExpoGraphqlClient>());
   return await createSubmissionContextAsync({
     platform: Platform.IOS,
     projectDir: testProject.projectRoot,
@@ -46,6 +49,7 @@ async function getIosSubmissionContextAsync(): Promise<SubmissionContext<Platfor
     },
     nonInteractive: true,
     actor: mockJester,
+    graphqlClient,
     exp: testProject.appJSON.expo,
     projectId,
   });

--- a/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/CredentialsServiceSource-test.ts
@@ -1,6 +1,8 @@
 import { Platform } from '@expo/eas-build-job';
+import { instance, mock } from 'ts-mockito';
 import { v4 as uuidv4 } from 'uuid';
 
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   jester as mockJester,
   testAppQueryByIdResponse,
@@ -44,6 +46,7 @@ describe(getFromCredentialsServiceAsync, () => {
   });
 
   it('returns an App Specific Password from the credentialService source', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
     const ctx = await createSubmissionContextAsync({
       platform: Platform.IOS,
       projectDir: testProject.projectRoot,
@@ -55,6 +58,7 @@ describe(getFromCredentialsServiceAsync, () => {
       },
       nonInteractive: false,
       actor: mockJester,
+      graphqlClient,
       exp: testProject.appJSON.expo,
       projectId,
     });
@@ -73,6 +77,7 @@ describe(getFromCredentialsServiceAsync, () => {
     });
   });
   it('returns an ASC API Key from the credentialService source', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
     const ctx = await createSubmissionContextAsync({
       platform: Platform.IOS,
       projectDir: testProject.projectRoot,
@@ -84,6 +89,7 @@ describe(getFromCredentialsServiceAsync, () => {
       },
       nonInteractive: true,
       actor: mockJester,
+      graphqlClient,
       exp: testProject.appJSON.expo,
       projectId,
     });

--- a/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
@@ -2,6 +2,7 @@ import { Platform } from '@expo/eas-build-job';
 import { vol } from 'memfs';
 import { v4 as uuidv4 } from 'uuid';
 
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   jester as mockJester,
   testProjectId,
@@ -52,6 +53,7 @@ describe(IosSubmitCommand, () => {
   describe('non-interactive mode', () => {
     it("throws error if didn't provide appleId and ascAppId in the submit profile", async () => {
       const projectId = uuidv4();
+      const graphqlClient = {} as any as ExpoGraphqlClient;
 
       const ctx = await createSubmissionContextAsync({
         platform: Platform.IOS,
@@ -64,6 +66,7 @@ describe(IosSubmitCommand, () => {
         },
         nonInteractive: true,
         actor: mockJester,
+        graphqlClient,
         exp: testProject.appJSON.expo,
         projectId,
       });
@@ -75,6 +78,7 @@ describe(IosSubmitCommand, () => {
   describe('sending submission', () => {
     it('sends a request to Submission Service', async () => {
       const projectId = uuidv4();
+      const graphqlClient = {} as any as ExpoGraphqlClient;
 
       process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD = 'supersecret';
 
@@ -91,13 +95,14 @@ describe(IosSubmitCommand, () => {
         },
         nonInteractive: false,
         actor: mockJester,
+        graphqlClient,
         exp: testProject.appJSON.expo,
         projectId,
       });
       const command = new IosSubmitCommand(ctx);
       await command.runAsync();
 
-      expect(SubmissionMutation.createIosSubmissionAsync).toHaveBeenCalledWith({
+      expect(SubmissionMutation.createIosSubmissionAsync).toHaveBeenCalledWith(graphqlClient, {
         appId: projectId,
         config: {
           archiveUrl: 'http://expo.dev/fake.ipa',

--- a/packages/eas-cli/src/submit/submit.ts
+++ b/packages/eas-cli/src/submit/submit.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import { withAnalyticsAsync } from '../analytics/common';
 import { SubmissionEvent } from '../analytics/events';
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { AppPlatform, SubmissionFragment, SubmissionStatus } from '../graphql/generated';
 import Log, { link } from '../log';
 import { appPlatformDisplayNames, appPlatformEmojis } from '../platform';
@@ -33,11 +34,12 @@ export async function submitAsync<T extends Platform>(
 }
 
 export async function waitToCompleteAsync(
+  graphqlClient: ExpoGraphqlClient,
   submissions: SubmissionFragment[],
   { verbose = false }: { verbose?: boolean } = {}
 ): Promise<SubmissionFragment[]> {
   Log.newLine();
-  const completedSubmissions = await waitForSubmissionsEndAsync(submissions);
+  const completedSubmissions = await waitForSubmissionsEndAsync(graphqlClient, submissions);
   const moreSubmissions = completedSubmissions.length > 1;
   if (moreSubmissions) {
     Log.newLine();

--- a/packages/eas-cli/src/submit/utils/builds.ts
+++ b/packages/eas-cli/src/submit/utils/builds.ts
@@ -1,12 +1,14 @@
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { AppPlatform, BuildFragment, BuildStatus, DistributionType } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 
 export async function getRecentBuildsForSubmissionAsync(
+  graphqlClient: ExpoGraphqlClient,
   platform: AppPlatform,
   appId: string,
   { limit = 1 }: { limit?: number } = {}
 ): Promise<BuildFragment[]> {
-  return await BuildQuery.viewBuildsOnAppAsync({
+  return await BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
     appId,
     limit,
     offset: 0,

--- a/packages/eas-cli/src/submit/utils/files.ts
+++ b/packages/eas-cli/src/submit/utils/files.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { UploadSessionType } from '../../graphql/generated';
 import { uploadFileAtPathToS3Async } from '../../uploads';
 import { createProgressTracker } from '../../utils/progress';
@@ -13,9 +14,13 @@ export async function isExistingFileAsync(filePath: string): Promise<boolean> {
   }
 }
 
-export async function uploadAppArchiveAsync(path: string): Promise<string> {
+export async function uploadAppArchiveAsync(
+  graphqlClient: ExpoGraphqlClient,
+  path: string
+): Promise<string> {
   const fileSize = (await fs.stat(path)).size;
   const { url } = await uploadFileAtPathToS3Async(
+    graphqlClient,
     UploadSessionType.EasSubmitAppArchive,
     path,
     createProgressTracker({

--- a/packages/eas-cli/src/submit/utils/wait.ts
+++ b/packages/eas-cli/src/submit/utils/wait.ts
@@ -1,5 +1,6 @@
 import nullthrows from 'nullthrows';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { AppPlatform, SubmissionFragment, SubmissionStatus } from '../../graphql/generated';
 import { SubmissionQuery } from '../../graphql/queries/SubmissionQuery';
 import Log from '../../log';
@@ -14,6 +15,7 @@ const APP_STORE_NAMES: Record<AppPlatform, string> = {
 const CHECK_INTERVAL_MS = 5_000;
 
 export async function waitForSubmissionsEndAsync(
+  graphqlClient: ExpoGraphqlClient,
   initialSubmissions: SubmissionFragment[]
 ): Promise<SubmissionFragment[]> {
   Log.log(
@@ -28,7 +30,7 @@ export async function waitForSubmissionsEndAsync(
     const submissions = await Promise.all(
       initialSubmissions.map(({ id }) => {
         try {
-          return SubmissionQuery.byIdAsync(id, { useCache: false });
+          return SubmissionQuery.byIdAsync(graphqlClient, id, { useCache: false });
         } catch (err) {
           Log.debug('Failed to fetch the submission status', err);
           return null;

--- a/packages/eas-cli/src/update/__tests__/update-queries-test.ts
+++ b/packages/eas-cli/src/update/__tests__/update-queries-test.ts
@@ -1,3 +1,6 @@
+import { instance, mock } from 'ts-mockito';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import { selectUpdateGroupOnBranchAsync } from '../queries';
 
@@ -26,8 +29,9 @@ describe('update queries', () => {
     });
 
     it('to throw when no items are available', async () => {
+      const graphqlClient = instance(mock<ExpoGraphqlClient>());
       expect(async () => {
-        await selectUpdateGroupOnBranchAsync({
+        await selectUpdateGroupOnBranchAsync(graphqlClient, {
           branchName,
           projectId: appId,
           paginatedQueryOptions: {
@@ -41,8 +45,9 @@ describe('update queries', () => {
     });
 
     it('to throw when in non-interactive mode', async () => {
+      const graphqlClient = instance(mock<ExpoGraphqlClient>());
       expect(async () => {
-        await selectUpdateGroupOnBranchAsync({
+        await selectUpdateGroupOnBranchAsync(graphqlClient, {
           branchName,
           projectId: appId,
           paginatedQueryOptions: {

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -1,17 +1,19 @@
 import { ExpoConfig } from '@expo/config';
 import { AndroidConfig, AndroidManifest } from '@expo/config-plugins';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { RequestedPlatform } from '../../platform';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { ensureValidVersions } from '../utils';
 
 export async function syncUpdatesConfigurationAsync(
+  graphqlClient: ExpoGraphqlClient,
   projectDir: string,
   exp: ExpoConfig,
   projectId: string
 ): Promise<void> {
   ensureValidVersions(exp, RequestedPlatform.Android);
-  const accountName = (await getOwnerAccountForProjectIdAsync(projectId)).name;
+  const accountName = (await getOwnerAccountForProjectIdAsync(graphqlClient, projectId)).name;
 
   const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
   const androidManifest = await getAndroidManifestAsync(projectDir);

--- a/packages/eas-cli/src/update/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/ios/UpdatesModule.ts
@@ -1,6 +1,7 @@
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
 
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { RequestedPlatform } from '../../platform';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { readPlistAsync, writePlistAsync } from '../../utils/plist';
@@ -8,12 +9,13 @@ import { getVcsClient } from '../../vcs';
 import { ensureValidVersions } from '../utils';
 
 export async function syncUpdatesConfigurationAsync(
+  graphqlClient: ExpoGraphqlClient,
   projectDir: string,
   exp: ExpoConfig,
   projectId: string
 ): Promise<void> {
   ensureValidVersions(exp, RequestedPlatform.Ios);
-  const accountName = (await getOwnerAccountForProjectIdAsync(projectId)).name;
+  const accountName = (await getOwnerAccountForProjectIdAsync(graphqlClient, projectId)).name;
   const expoPlist = await readExpoPlistAsync(projectDir);
   const updatedExpoPlist = IOSConfig.Updates.setUpdatesConfig(
     projectDir,

--- a/packages/eas-cli/src/update/queries.ts
+++ b/packages/eas-cli/src/update/queries.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 import CliTable from 'cli-table3';
 
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { PaginatedQueryOptions } from '../commandUtils/pagination';
 import {
   UpdateFragment,
@@ -27,15 +28,18 @@ import {
 export const UPDATES_LIMIT = 50;
 export const UPDATE_GROUPS_LIMIT = 25;
 
-export async function listAndRenderUpdateGroupsOnAppAsync({
-  projectId,
-  paginatedQueryOptions,
-}: {
-  projectId: string;
-  paginatedQueryOptions: PaginatedQueryOptions;
-}): Promise<void> {
+export async function listAndRenderUpdateGroupsOnAppAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    projectId,
+    paginatedQueryOptions,
+  }: {
+    projectId: string;
+    paginatedQueryOptions: PaginatedQueryOptions;
+  }
+): Promise<void> {
   if (paginatedQueryOptions.nonInteractive) {
-    const updateGroups = await queryUpdateGroupsOnAppAsync({
+    const updateGroups = await queryUpdateGroupsOnAppAsync(graphqlClient, {
       limit: paginatedQueryOptions.limit ?? UPDATE_GROUPS_LIMIT,
       offset: paginatedQueryOptions.offset,
       appId: projectId,
@@ -46,7 +50,7 @@ export async function listAndRenderUpdateGroupsOnAppAsync({
       limit: paginatedQueryOptions.limit ?? UPDATE_GROUPS_LIMIT,
       offset: paginatedQueryOptions.offset,
       queryToPerform: (limit, offset) =>
-        queryUpdateGroupsOnAppAsync({ limit, offset, appId: projectId }),
+        queryUpdateGroupsOnAppAsync(graphqlClient, { limit, offset, appId: projectId }),
       promptOptions: {
         title: 'Load more update groups?',
         renderListItems: updateGroups =>
@@ -56,17 +60,20 @@ export async function listAndRenderUpdateGroupsOnAppAsync({
   }
 }
 
-export async function listAndRenderUpdateGroupsOnBranchAsync({
-  projectId,
-  branchName,
-  paginatedQueryOptions,
-}: {
-  projectId: string;
-  branchName: string;
-  paginatedQueryOptions: PaginatedQueryOptions;
-}): Promise<void> {
+export async function listAndRenderUpdateGroupsOnBranchAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    projectId,
+    branchName,
+    paginatedQueryOptions,
+  }: {
+    projectId: string;
+    branchName: string;
+    paginatedQueryOptions: PaginatedQueryOptions;
+  }
+): Promise<void> {
   if (paginatedQueryOptions.nonInteractive) {
-    const updateGroups = await queryUpdateGroupsOnBranchAsync({
+    const updateGroups = await queryUpdateGroupsOnBranchAsync(graphqlClient, {
       limit: paginatedQueryOptions.limit ?? UPDATE_GROUPS_LIMIT,
       offset: paginatedQueryOptions.offset,
       appId: projectId,
@@ -78,7 +85,12 @@ export async function listAndRenderUpdateGroupsOnBranchAsync({
       limit: paginatedQueryOptions.limit ?? UPDATE_GROUPS_LIMIT,
       offset: paginatedQueryOptions.offset,
       queryToPerform: (limit, offset) =>
-        queryUpdateGroupsOnBranchAsync({ limit, offset, appId: projectId, branchName }),
+        queryUpdateGroupsOnBranchAsync(graphqlClient, {
+          limit,
+          offset,
+          appId: projectId,
+          branchName,
+        }),
       promptOptions: {
         title: 'Load more update groups?',
         renderListItems: updateGroups =>
@@ -88,15 +100,18 @@ export async function listAndRenderUpdateGroupsOnBranchAsync({
   }
 }
 
-export async function selectUpdateGroupOnBranchAsync({
-  projectId,
-  branchName,
-  paginatedQueryOptions,
-}: {
-  projectId: string;
-  branchName: string;
-  paginatedQueryOptions: PaginatedQueryOptions;
-}): Promise<UpdateFragment[]> {
+export async function selectUpdateGroupOnBranchAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    projectId,
+    branchName,
+    paginatedQueryOptions,
+  }: {
+    projectId: string;
+    branchName: string;
+    paginatedQueryOptions: PaginatedQueryOptions;
+  }
+): Promise<UpdateFragment[]> {
   if (paginatedQueryOptions.nonInteractive) {
     throw new Error('Unable to select an update in non-interactive mode.');
   }
@@ -105,7 +120,12 @@ export async function selectUpdateGroupOnBranchAsync({
     limit: paginatedQueryOptions.limit ?? UPDATE_GROUPS_LIMIT,
     offset: paginatedQueryOptions.offset,
     queryToPerform: (limit, offset) =>
-      queryUpdateGroupsOnBranchAsync({ appId: projectId, branchName, limit, offset }),
+      queryUpdateGroupsOnBranchAsync(graphqlClient, {
+        appId: projectId,
+        branchName,
+        limit,
+        offset,
+      }),
     promptOptions: {
       title: 'Load more update groups?',
       createDisplayTextForSelectionPromptListItem: updateGroup => formatUpdateTitle(updateGroup[0]),
@@ -121,15 +141,17 @@ export async function selectUpdateGroupOnBranchAsync({
 }
 
 async function queryUpdateGroupsOnBranchAsync(
+  graphqlClient: ExpoGraphqlClient,
   args: ViewUpdateGroupsOnBranchQueryVariables
 ): Promise<UpdateFragment[][]> {
-  return await UpdateQuery.viewUpdateGroupsOnBranchAsync(args);
+  return await UpdateQuery.viewUpdateGroupsOnBranchAsync(graphqlClient, args);
 }
 
 async function queryUpdateGroupsOnAppAsync(
+  graphqlClient: ExpoGraphqlClient,
   args: ViewUpdateGroupsOnAppQueryVariables
 ): Promise<UpdateFragment[][]> {
-  return await UpdateQuery.viewUpdateGroupsOnAppAsync(args);
+  return await UpdateQuery.viewUpdateGroupsOnAppAsync(graphqlClient, args);
 }
 
 function renderUpdateGroupsOnBranchAsTable({

--- a/packages/eas-cli/src/uploads.ts
+++ b/packages/eas-cli/src/uploads.ts
@@ -6,17 +6,19 @@ import nullthrows from 'nullthrows';
 import promiseRetry from 'promise-retry';
 import { URL } from 'url';
 
+import { ExpoGraphqlClient } from './commandUtils/context/contextUtils/createGraphqlClient';
 import fetch from './fetch';
 import { UploadSessionType } from './graphql/generated';
 import { PresignedPost, UploadSessionMutation } from './graphql/mutations/UploadSessionMutation';
 import { ProgressHandler } from './utils/progress';
 
 export async function uploadFileAtPathToS3Async(
+  graphqlClient: ExpoGraphqlClient,
   type: UploadSessionType,
   path: string,
   handleProgressEvent: ProgressHandler
 ): Promise<{ url: string; bucketKey: string }> {
-  const presignedPost = await UploadSessionMutation.createUploadSessionAsync(type);
+  const presignedPost = await UploadSessionMutation.createUploadSessionAsync(graphqlClient, type);
   assert(presignedPost.fields.key, 'key is not specified in in presigned post');
 
   const response = await uploadWithPresignedPostWithProgressAsync(

--- a/packages/eas-cli/src/user/User.ts
+++ b/packages/eas-cli/src/user/User.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 import * as Analytics from '../analytics/rudderstackClient';
 import { api } from '../api';
-import { graphqlClient } from '../graphql/client';
+import { legacyGraphqlClient } from '../graphql/client';
 import { CurrentUserQuery } from '../graphql/generated';
 import { UserQuery } from '../graphql/queries/UserQuery';
 import { getAccessToken, getSessionSecret, setSessionAsync } from './sessionStorage';
@@ -32,7 +32,7 @@ export function getActorDisplayName(user?: Actor): string {
 
 export async function getUserAsync(): Promise<Actor | undefined> {
   if (!currentUser && (getAccessToken() || getSessionSecret())) {
-    const user = await UserQuery.currentUserAsync();
+    const user = await UserQuery.currentUserAsync(legacyGraphqlClient);
     currentUser = user ?? undefined;
     if (user) {
       await Analytics.setUserDataAsync(user.id, {
@@ -56,7 +56,7 @@ export async function loginAsync({
 }): Promise<void> {
   const body = await api.postAsync('auth/loginAsync', { body: { username, password, otp } });
   const { sessionSecret } = body.data;
-  const result = await graphqlClient
+  const result = await legacyGraphqlClient
     .query(
       gql`
         query UserQuery {

--- a/packages/eas-cli/src/user/__tests__/User-test.ts
+++ b/packages/eas-cli/src/user/__tests__/User-test.ts
@@ -20,7 +20,7 @@ jest.mock('../../api', () => ({
   ApiV2Error: jest.requireActual('../../api').ApiV2Error,
 }));
 jest.mock('../../graphql/client', () => ({
-  graphqlClient: {
+  legacyGraphqlClient: {
     query: () => {
       return {
         toPromise: () =>

--- a/packages/eas-cli/src/utils/statuspageService.ts
+++ b/packages/eas-cli/src/utils/statuspageService.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   StatuspageServiceFragment,
   StatuspageServiceName,
@@ -9,9 +10,10 @@ import { StatuspageServiceQuery } from '../graphql/queries/StatuspageServiceQuer
 import Log, { link } from '../log';
 
 export async function maybeWarnAboutEasOutagesAsync(
+  graphqlClient: ExpoGraphqlClient,
   serviceNames: StatuspageServiceName[]
 ): Promise<void> {
-  const services = await getStatuspageServiceAsync(serviceNames);
+  const services = await getStatuspageServiceAsync(graphqlClient, serviceNames);
 
   for (const service of services) {
     warnAboutServiceOutage(service);
@@ -49,10 +51,11 @@ function warnAboutServiceOutage(service: StatuspageServiceFragment): void {
 }
 
 async function getStatuspageServiceAsync(
+  graphqlClient: ExpoGraphqlClient,
   serviceNames: StatuspageServiceName[]
 ): Promise<StatuspageServiceFragment[]> {
   try {
-    return await StatuspageServiceQuery.statuspageServicesAsync(serviceNames);
+    return await StatuspageServiceQuery.statuspageServicesAsync(graphqlClient, serviceNames);
   } catch {
     return [];
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

There is one more major piece that can be moved to context: the graphql client. By moving this to the context:
- Global shared state is reduced (or eliminated). Previously the current user and graphql client were stored globally, and whatever was in the current session (access token or session token) was injected into the graphql request on every call no matter whether the call needed to be authenticated or not.
- We can more accurately determine which commands need to be logged-in. Previously this was done with a member variable and by moving this into the context we can determine this with 100% accuracy (since the tokens that signify being logged-in are only used in graphql).
- We can further isolate the internals of the authentication mechanisms from commands that don't need to access them. This provides the more complex authentication API only to commands that need it (login, logout) and the rest of the other commands now don't need access to anything but the graphql client from the context.

# How

This first PR simulates a move of the graphql client to a context member. These changes were done procedurally by solely using the typechecker.

Here's how this PR was generated:
1. Rename `graphqlClient` to `legacyGraphqlClient`. Inject it in via method arguments all the way up and down the call tree in places that require it.
2. Make `LoggedInContextField` (replacement for `ActorContextField`) that requires login and exposes the actor and `legacyGraphqlClient` (a graphql client that will be replaced with a logged-in graphql client (a client configured to use the access token / session secret belonging the actor) in a follow-up PR in this stack).
3. Use `yarn tsc` to make all replacements and pipe the graphql field all the way from the context down to the leaves (usually the queries or mutations). 

This allows for a few things:
- Better testability. Since these are now injected, we can mock them (using ts-mockito) without needing to mock them globally (using jest mock).

# Test Plan

- Run all changed commands, ensure their graphql features are working.
- Run all tests.
