### PR TITLE
[eas-cli] Fix command statistic analytics

### DIFF
--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -132,10 +132,6 @@ export default abstract class EasCommand extends Command {
    */
   private readonly sessionManager = new SessionManager();
 
-  override get ctor(): typeof EasCommand {
-    return this.constructor as typeof EasCommand;
-  }
-
   protected abstract runAsync(): Promise<any>;
 
   // eslint-disable-next-line async-protect/async-suffix
@@ -145,7 +141,7 @@ export default abstract class EasCommand extends Command {
     // identify the user in the analytics system ahead of running the command
     // to log run before any potential ctrl-c
     let actor: Actor | undefined;
-    if ('loggedIn' in this.ctor.contextDefinition) {
+    if ('loggedIn' in (this.ctor as typeof EasCommand).contextDefinition) {
       // don't throw for invalid flags/args here (this should be handled in the command's own parse call)
       let nonInteractive: boolean;
       try {

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -146,8 +146,14 @@ export default abstract class EasCommand extends Command {
     // to log run before any potential ctrl-c
     let actor: Actor | undefined;
     if ('loggedIn' in this.ctor.contextDefinition) {
-      const { flags } = await this.parse();
-      const nonInteractive = (flags as any)['non-interactive'] ?? false;
+      // don't throw for invalid flags/args here (this should be handled in the command's own parse call)
+      let nonInteractive: boolean;
+      try {
+        const { flags } = await this.parse();
+        nonInteractive = (flags as any)['non-interactive'] ?? false;
+      } catch {
+        nonInteractive = false;
+      }
       actor = (await this.sessionManager.ensureLoggedInAsync({ nonInteractive })).actor;
     } else {
       actor = await this.sessionManager.getUserAsync();

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -6,7 +6,9 @@ import {
   initAsync as initAnalyticsAsync,
   logEvent,
 } from '../analytics/rudderstackClient';
+import * as Analytics from '../analytics/rudderstackClient';
 import SessionManager from '../user/SessionManager';
+import { Actor, getActorDisplayName } from '../user/User';
 import ContextField from './context/ContextField';
 import { DynamicProjectConfigContextField } from './context/DynamicProjectConfigContextField';
 import LoggedInContextField from './context/LoggedInContextField';
@@ -76,8 +78,11 @@ export default abstract class EasCommand extends Command {
     },
     /**
      * Require the project to be identified and registered on server. Returns the project config in the context.
+     * This also requires the user to be logged in (getProjectIdAsync requires logged in), so also expose that context.
+     * Exposing the loggedIn context here helps us determine ahead of time to require user login for logging purposes.
      */
     ProjectConfig: {
+      loggedIn: new LoggedInContextField(),
       projectConfig: new ProjectConfigContextField(),
     },
   };
@@ -127,14 +132,33 @@ export default abstract class EasCommand extends Command {
    */
   private readonly sessionManager = new SessionManager();
 
+  override get ctor(): typeof EasCommand {
+    return this.constructor as typeof EasCommand;
+  }
+
   protected abstract runAsync(): Promise<any>;
 
   // eslint-disable-next-line async-protect/async-suffix
   async run(): Promise<any> {
     await initAnalyticsAsync();
 
-    // this is needed for logEvent call below as it identifies the user in the analytics system
-    await this.sessionManager.getUserAsync();
+    // identify the user in the analytics system ahead of running the command
+    // to log run before any potential ctrl-c
+    let actor: Actor | undefined;
+    if ('loggedIn' in this.ctor.contextDefinition) {
+      const { flags } = await this.parse();
+      const nonInteractive = (flags as any)['non-interactive'] ?? false;
+      actor = (await this.sessionManager.ensureLoggedInAsync({ nonInteractive })).actor;
+    } else {
+      actor = await this.sessionManager.getUserAsync();
+    }
+    if (actor) {
+      await Analytics.setUserDataAsync(actor.id, {
+        username: getActorDisplayName(actor),
+        user_id: actor.id,
+        user_type: actor.__typename,
+      });
+    }
 
     logEvent(AnalyticsEvent.ACTION, {
       // id is assigned by oclif in constructor based on the filepath:

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -131,6 +131,24 @@ describe(EasCommand.name, () => {
         action: `eas ${TestEasCommand.id}`,
       });
     });
+
+    it('logs events even if there are invalid flags passed', async () => {
+      const sessionManagerEnsureLoggedInSpy = jest.spyOn(
+        SessionManager.prototype,
+        'ensureLoggedInAsync'
+      );
+      sessionManagerEnsureLoggedInSpy.mockResolvedValue({
+        actor: jester,
+        authenticationInfo: { accessToken: null, sessionSecret: '' },
+      });
+
+      const TestEasCommand = createTestEasCommand({ requireLoggedIn: true });
+      await TestEasCommand.run(['--wat']);
+
+      expect(logEvent).toHaveBeenCalledWith('action', {
+        action: `eas ${TestEasCommand.id}`,
+      });
+    });
   });
 
   describe('after exceptions', () => {

--- a/packages/eas-cli/src/commands/project/__tests__/init.test.ts
+++ b/packages/eas-cli/src/commands/project/__tests__/init.test.ts
@@ -11,6 +11,7 @@ import { jester } from '../../../credentials/__tests__/fixtures-constants';
 import { AppMutation } from '../../../graphql/mutations/AppMutation';
 import { findProjectIdByAccountNameAndSlugNullableAsync } from '../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 import { confirmAsync, promptAsync } from '../../../prompts';
+import SessionManager from '../../../user/SessionManager';
 import ProjectInit from '../init';
 
 jest.mock('fs');
@@ -80,6 +81,10 @@ function mockTestProject(options: {
   jest
     .spyOn(LoggedInContextField.prototype, 'getValueAsync')
     .mockResolvedValue({ actor: jester, graphqlClient });
+  jest.spyOn(SessionManager.prototype, 'ensureLoggedInAsync').mockResolvedValue({
+    actor: jester,
+    authenticationInfo: { accessToken: null, sessionSecret: '' },
+  });
 }
 
 const commandOptions = { root: '/test-project' } as any;

--- a/packages/eas-cli/src/user/SessionManager.ts
+++ b/packages/eas-cli/src/user/SessionManager.ts
@@ -5,7 +5,6 @@ import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
 import { ApiV2Error } from '../ApiV2Error';
-import * as Analytics from '../analytics/rudderstackClient';
 import { ApiV2Client } from '../api';
 import { createGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { CurrentUserQuery } from '../graphql/generated';
@@ -13,7 +12,6 @@ import { UserQuery } from '../graphql/queries/UserQuery';
 import Log, { learnMore } from '../log';
 import { promptAsync, selectAsync } from '../prompts';
 import { getStateJsonPath } from '../utils/paths';
-import { getActorDisplayName } from './User';
 import { fetchSessionSecretAndUserAsync } from './fetchSessionSecretAndUser';
 
 type UserSettingsData = {
@@ -95,13 +93,6 @@ export default class SessionManager {
       };
       const user = await UserQuery.currentUserAsync(createGraphqlClient(authenticationInfo));
       this.currentUser = user ?? undefined;
-      if (user) {
-        await Analytics.setUserDataAsync(user.id, {
-          username: getActorDisplayName(user),
-          user_id: user.id,
-          user_type: user.__typename,
-        });
-      }
     }
     return this.currentUser;
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://github.com/expo/eas-cli/pull/1390 changed the semantics around this initial log call.

Before that PR, it would require login before logging the action. This meant that users that had not already logged-in would be prompted to do so before the command was logged, so there would be non-anonymous identification for the event.

That PR changed it to just use the user that is already logged-in to log the event, and if they hadn't logged in before log anonymously.

This changed our metrics a bit, and this PR reverts that change (in the new context-based world).

# How

Change EasCommand to pre-require logging in (ahead of context evaluation) if context will require it in the future anyways. Note that this still isn't perfect in the same way as before: the user can ctrl-c out of signing in.

This also makes one other important change. Now that the session is not able to be modified globally, we can grep for `getUserAsync` and be guaranteed that this is the only place we'd need to call `Analytics.setUserDataAsync`, so we can get rid of the weird side-effect pattern from `getUserAsync`.

# Test Plan

- Run some commands, see via `console.log` that things are behaving as they should.
- Run new test.
