### PR TITLE
[eas-cli] Clean up withAnalyticsAsync

### DIFF
--- a/packages/eas-cli/src/analytics/AnalyticsManager.ts
+++ b/packages/eas-cli/src/analytics/AnalyticsManager.ts
@@ -71,11 +71,13 @@ export enum MetadataEvent {
   APPLE_METADATA_UPLOAD = 'metadata cli upload apple response',
 }
 
+export type AnalyticsEventProperties = Record<string, string | number | boolean>;
+
 /**
  * The interface for commands to use to log events to analytics.
  */
 export interface Analytics {
-  logEvent(name: AnalyticsEvent, properties: Record<string, any>): void;
+  logEvent(name: AnalyticsEvent, properties: AnalyticsEventProperties): void;
 }
 
 /**
@@ -202,7 +204,7 @@ class RudderstackAnalytics implements AnalyticsWithOrchestration {
     this.identifiedActor = actor;
   }
 
-  public logEvent(name: AnalyticsEvent, properties: Record<string, any>): void {
+  public logEvent(name: AnalyticsEvent, properties: AnalyticsEventProperties): void {
     const userId = this.identifiedActor?.id;
     const deviceId = this.persistentDeviceId;
     const commonEventProperties = { source_version: easCliVersion, source: 'eas cli' };

--- a/packages/eas-cli/src/analytics/AnalyticsManager.ts
+++ b/packages/eas-cli/src/analytics/AnalyticsManager.ts
@@ -111,7 +111,7 @@ export async function getAnalyticsEnabledAsync(): Promise<boolean> {
 }
 
 /**
- * Create an instance of IAnalyticsManager based on the user's analytics enabled preferences.
+ * Create an instance of Analytics based on the user's analytics enabled preferences.
  */
 export async function createAnalyticsAsync(): Promise<AnalyticsWithOrchestration> {
   // TODO: remove after some time

--- a/packages/eas-cli/src/analytics/common.ts
+++ b/packages/eas-cli/src/analytics/common.ts
@@ -1,28 +1,28 @@
-import { Analytics, AnalyticsEvent } from './AnalyticsManager';
-
-export type TrackingContext = Record<string, string | number | boolean>;
+import { Analytics, AnalyticsEvent, AnalyticsEventProperties } from './AnalyticsManager';
 
 export async function withAnalyticsAsync<Result>(
   analytics: Analytics,
   fn: () => Promise<Result>,
   {
+    attemptEvent,
     successEvent,
     failureEvent,
-    trackingCtx,
+    properties,
   }: {
     attemptEvent: AnalyticsEvent;
     successEvent: AnalyticsEvent;
     failureEvent: AnalyticsEvent;
-    trackingCtx: TrackingContext;
+    properties: AnalyticsEventProperties;
   }
 ): Promise<Result> {
   try {
+    analytics.logEvent(attemptEvent, properties);
     const result = await fn();
-    analytics.logEvent(successEvent, trackingCtx);
+    analytics.logEvent(successEvent, properties);
     return result;
   } catch (error: any) {
     analytics.logEvent(failureEvent, {
-      ...trackingCtx,
+      ...properties,
       reason: error.message,
     });
     throw error;

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -84,7 +84,7 @@ export async function prepareBuildRequestForPlatformAsync<
       attemptEvent: BuildEvent.GATHER_CREDENTIALS_ATTEMPT,
       successEvent: BuildEvent.GATHER_CREDENTIALS_SUCCESS,
       failureEvent: BuildEvent.GATHER_CREDENTIALS_FAIL,
-      trackingCtx: ctx.trackingCtx,
+      properties: ctx.analyticsEventProperties,
     }
   );
 
@@ -95,7 +95,7 @@ export async function prepareBuildRequestForPlatformAsync<
       attemptEvent: BuildEvent.CONFIGURE_PROJECT_ATTEMPT,
       successEvent: BuildEvent.CONFIGURE_PROJECT_SUCCESS,
       failureEvent: BuildEvent.CONFIGURE_PROJECT_FAIL,
-      trackingCtx: ctx.trackingCtx,
+      properties: ctx.analyticsEventProperties,
     }
   );
 
@@ -238,7 +238,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         attemptEvent: BuildEvent.PROJECT_UPLOAD_ATTEMPT,
         successEvent: BuildEvent.PROJECT_UPLOAD_SUCCESS,
         failureEvent: BuildEvent.PROJECT_UPLOAD_FAIL,
-        trackingCtx: ctx.trackingCtx,
+        properties: ctx.analyticsEventProperties,
       }
     );
   } finally {
@@ -276,7 +276,7 @@ async function sendBuildRequestAsync<TPlatform extends Platform, Credentials, TJ
       attemptEvent: BuildEvent.BUILD_REQUEST_ATTEMPT,
       successEvent: BuildEvent.BUILD_REQUEST_SUCCESS,
       failureEvent: BuildEvent.BUILD_REQUEST_FAIL,
-      trackingCtx: ctx.trackingCtx,
+      properties: ctx.analyticsEventProperties,
     }
   );
 }

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -2,8 +2,7 @@ import { ExpoConfig } from '@expo/config';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { BuildProfile, EasJson } from '@expo/eas-json';
 
-import { Analytics } from '../analytics/AnalyticsManager';
-import { TrackingContext } from '../analytics/common';
+import { Analytics, AnalyticsEventProperties } from '../analytics/AnalyticsManager';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { CredentialsContext } from '../credentials/context';
 import { Target } from '../credentials/ios/types';
@@ -47,7 +46,7 @@ export interface BuildContext<T extends Platform> {
   projectId: string;
   projectName: string;
   message?: string;
-  trackingCtx: TrackingContext;
+  analyticsEventProperties: AnalyticsEventProperties;
   user: Actor;
   graphqlClient: ExpoGraphqlClient;
   analytics: Analytics;

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -5,8 +5,7 @@ import getenv from 'getenv';
 import resolveFrom from 'resolve-from';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Analytics, BuildEvent } from '../analytics/AnalyticsManager';
-import { TrackingContext } from '../analytics/common';
+import { Analytics, AnalyticsEventProperties, BuildEvent } from '../analytics/AnalyticsManager';
 import { DynamicConfigContextFn } from '../commandUtils/context/DynamicProjectConfigContextField';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { CredentialsContext } from '../credentials/context';
@@ -76,7 +75,7 @@ export async function createBuildContextAsync<T extends Platform>({
     projectDir,
     buildProfile,
   });
-  const trackingCtx = {
+  const analyticsEventProperties = {
     tracking_id: uuidv4(),
     platform,
     ...(accountId && { account_id: accountId }),
@@ -86,7 +85,7 @@ export async function createBuildContextAsync<T extends Platform>({
     no_wait: noWait,
     run_from_ci: runFromCI,
   };
-  analytics.logEvent(BuildEvent.BUILD_COMMAND, trackingCtx);
+  analytics.logEvent(BuildEvent.BUILD_COMMAND, analyticsEventProperties);
 
   const commonContext: CommonContext<T> = {
     accountName: account.name,
@@ -104,7 +103,7 @@ export async function createBuildContextAsync<T extends Platform>({
     projectDir,
     projectId,
     projectName,
-    trackingCtx,
+    analyticsEventProperties,
     user: actor,
     graphqlClient,
     analytics,
@@ -135,7 +134,7 @@ function getDevClientEventProperties({
   platform: Platform;
   projectDir: string;
   buildProfile: BuildProfile;
-}): Partial<TrackingContext> {
+}): Partial<AnalyticsEventProperties> {
   let includesDevClient;
   const version = tryGetDevClientVersion(projectDir);
   if (platform === Platform.ANDROID && 'gradleCommand' in buildProfile) {

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -30,7 +30,7 @@ export async function collectMetadataAsync<T extends Platform>(
       ? 'simulator'
       : ctx.buildProfile.distribution) ?? 'store';
   const metadata: Metadata = {
-    trackingContext: ctx.trackingCtx,
+    trackingContext: ctx.analyticsEventProperties,
     ...(await maybeResolveVersionsAsync(ctx)),
     cliVersion: easCliVersion,
     workflow: ctx.workflow,

--- a/packages/eas-cli/src/submit/BaseSubmitter.ts
+++ b/packages/eas-cli/src/submit/BaseSubmitter.ts
@@ -54,7 +54,7 @@ export default abstract class BaseSubmitter<
         attemptEvent: sourceOptionAnalytics.attemptEvent,
         successEvent: sourceOptionAnalytics.successEvent,
         failureEvent: sourceOptionAnalytics.failureEvent,
-        trackingCtx: this.ctx.trackingCtx,
+        properties: this.ctx.analyticsEventProperties,
       });
       resolvedSourceOptions[sourceOptionKey] = sourceOption;
     }
@@ -97,7 +97,7 @@ export default abstract class BaseSubmitter<
         attemptEvent: SubmissionEvent.SUBMIT_REQUEST_ATTEMPT,
         successEvent: SubmissionEvent.SUBMIT_REQUEST_SUCCESS,
         failureEvent: SubmissionEvent.SUBMIT_REQUEST_FAIL,
-        trackingCtx: this.ctx.trackingCtx,
+        properties: this.ctx.analyticsEventProperties,
       }
     );
   }

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -3,8 +3,11 @@ import { Platform } from '@expo/eas-build-job';
 import { SubmitProfile } from '@expo/eas-json';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Analytics, SubmissionEvent } from '../analytics/AnalyticsManager';
-import { TrackingContext } from '../analytics/common';
+import {
+  Analytics,
+  AnalyticsEventProperties,
+  SubmissionEvent,
+} from '../analytics/AnalyticsManager';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { CredentialsContext } from '../credentials/context';
 import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
@@ -14,7 +17,7 @@ export interface SubmissionContext<T extends Platform> {
   accountName: string;
   archiveFlags: SubmitArchiveFlags;
   credentialsCtx: CredentialsContext;
-  trackingCtx: TrackingContext;
+  analyticsEventProperties: AnalyticsEventProperties;
   exp: ExpoConfig;
   nonInteractive: boolean;
   platform: T;
@@ -76,14 +79,14 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
     });
   }
 
-  const trackingCtx = {
+  const analyticsEventProperties = {
     tracking_id: uuidv4(),
     platform: params.platform,
     ...(accountId && { account_id: accountId }),
     project_id: projectId,
   };
 
-  rest.analytics.logEvent(SubmissionEvent.SUBMIT_COMMAND, trackingCtx);
+  rest.analytics.logEvent(SubmissionEvent.SUBMIT_COMMAND, analyticsEventProperties);
 
   return {
     ...rest,
@@ -91,7 +94,7 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
     credentialsCtx,
     projectName,
     user: actor,
-    trackingCtx,
+    analyticsEventProperties,
     applicationIdentifierOverride: applicationIdentifier,
   };
 }

--- a/packages/eas-cli/src/submit/submit.ts
+++ b/packages/eas-cli/src/submit/submit.ts
@@ -29,7 +29,7 @@ export async function submitAsync<T extends Platform>(
       attemptEvent: SubmissionEvent.SUBMIT_COMMAND_ATTEMPT,
       successEvent: SubmissionEvent.SUBMIT_COMMAND_SUCCESS,
       failureEvent: SubmissionEvent.SUBMIT_COMMAND_FAIL,
-      trackingCtx: ctx.trackingCtx,
+      properties: ctx.analyticsEventProperties,
     }
   );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://github.com/expo/eas-cli/pull/1444#discussion_r996812052

This PR cleans this up.

# How

- Rename trackingCtx to analyticsEventProperties and make the type consistent across the entire analytics system.
- Fix bug from https://github.com/expo/eas-cli/pull/757 where the attempt event was never logged.

I opted to keep this in its own file since I couldn't think of a good method name that would be callable of the form `analytics.<do_with_try_catch_logging_analytics>(fn, properties)` if this were on the analytics object. Open to suggestions.

# Test Plan

Inspect.
