### PR TITLE
[eas-cli] Handle case where git is installed but not working properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Handle case where git is installed but not working properly. ([#1454](https://github.com/expo/eas-cli/pull/1454) by [@brentvatne](https://github.com/brentvatne))
+
 ## [2.4.1](https://github.com/expo/eas-cli/releases/tag/v2.4.1) - 2022-10-17
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -18,9 +18,21 @@ import { Client } from '../vcs';
 
 export default class GitClient extends Client {
   public override async ensureRepoExistsAsync(): Promise<void> {
-    if (!(await isGitInstalledAsync())) {
+    try {
+      if (!(await isGitInstalledAsync())) {
+        Log.error(
+          `${chalk.bold('git')} command not found. Install it before proceeding or set ${chalk.bold(
+            'EAS_NO_VCS=1'
+          )} to use EAS CLI without Git (or any other version control system).`
+        );
+        Log.error(learnMore('https://expo.fyi/eas-vcs-workflow'));
+        Errors.exit(1);
+      }
+    } catch (error: any) {
       Log.error(
-        `${chalk.bold('git')} command not found. Install it before proceeding or set ${chalk.bold(
+        `${chalk.bold('git')} found, but ${chalk.bold('git --help')} exited with status ${
+          error.status
+        }. Repair your Git installation, or set ${chalk.bold(
           'EAS_NO_VCS=1'
         )} to use EAS CLI without Git (or any other version control system).`
       );

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -31,8 +31,16 @@ export default class GitClient extends Client {
     } catch (error: any) {
       Log.error(
         `${chalk.bold('git')} found, but ${chalk.bold('git --help')} exited with status ${
-          error.status
-        }. Repair your Git installation, or set ${chalk.bold(
+          error?.status
+        }${error?.stderr ? `:` : '.'}`
+      );
+
+      if (error?.stderr) {
+        Log.error(error?.stderr);
+      }
+
+      Log.error(
+        `Repair your Git installation, or set ${chalk.bold(
           'EAS_NO_VCS=1'
         )} to use EAS CLI without Git (or any other version control system).`
       );


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

@ccheever encountered the following error when running `eas build:configure` on a fresh-ish Mac:

<img width="922" alt="Untitled" src="https://user-images.githubusercontent.com/90494/196557700-b95a0c83-c397-4237-8d04-c958cea15d1f.png">

He tried running git to see why, and was greeted with this beauty:

<img width="814" alt="image" src="https://user-images.githubusercontent.com/90494/196557762-00b3ccb1-5912-4d7d-b148-e6816c33ac0e.png">

So, I think it is useful for us to handle every case where `git --help` exits with an error that doesn't match `ENOENT` as some unknown error that points to a problem with the git installation. I let the developer know in the message specifically that `git --help` failed so that they can run it themselves and verify and debug from there.  

# How

Handle all unknown error types as an indication that git isn't configured correctly and provide a message explaining what is happening.

<img width="723" alt="image" src="https://user-images.githubusercontent.com/90494/196558120-9522514e-d637-42be-9872-39fb8a153390.png">

# Test Plan

I didn't know how to get back to the state that @ccheever was in, so I changed the command that we use to check the git installation from `git --help` to `git --haha` to test that this worked as expected.
