### PR TITLE
[ENG-6183] add secret:push command

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -37,6 +37,7 @@
     "cli-progress": "3.11.2",
     "cli-table3": "0.6.2",
     "dateformat": "4.6.3",
+    "dotenv": "16.0.3",
     "env-paths": "2.2.0",
     "envinfo": "7.8.1",
     "fast-deep-equal": "3.1.3",

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -153,7 +153,7 @@ export default class EnvironmentSecretCreate extends EasCommand {
         // eslint-disable-next-line async-protect/async-suffix
         validate: async secretValue => {
           if (!secretValue) {
-            return 'Secret value may not be empty.';
+            return validationMessage;
           }
           if (secretType === SecretType.FILE) {
             const secretFilePath = path.resolve(secretValue);
@@ -208,13 +208,13 @@ export default class EnvironmentSecretCreate extends EasCommand {
 
       if (secretType === SecretType.STRING) {
         Log.withTick(
-          `️Created a new secret ${chalk.bold(name)} with value ${chalk.bold(
+          `Created a new secret ${chalk.bold(name)} with value ${chalk.bold(
             secretValue
           )} on project ${chalk.bold(projectDisplayName)}.`
         );
       } else {
         Log.withTick(
-          `️Created a new secret ${chalk.bold(name)} from file ${chalk.bold(
+          `Created a new secret ${chalk.bold(name)} from file ${chalk.bold(
             secretFilePath
           )} on project ${chalk.bold(projectDisplayName)}.`
         );
@@ -252,13 +252,13 @@ export default class EnvironmentSecretCreate extends EasCommand {
 
       if (secretType === SecretType.STRING) {
         Log.withTick(
-          `️Created a new secret ${chalk.bold(name)} with value ${chalk.bold(
+          `Created a new secret ${chalk.bold(name)} with value ${chalk.bold(
             secretValue
           )} on account ${chalk.bold(ownerAccount.name)}.`
         );
       } else {
         Log.withTick(
-          `️Created a new secret ${chalk.bold(name)} from file ${chalk.bold(
+          `Created a new secret ${chalk.bold(name)} from file ${chalk.bold(
             secretFilePath
           )} on account ${chalk.bold(ownerAccount.name)}.`
         );

--- a/packages/eas-cli/src/commands/secret/push.ts
+++ b/packages/eas-cli/src/commands/secret/push.ts
@@ -22,7 +22,7 @@ import {
 import { promptAsync } from '../../prompts';
 import intersection from '../../utils/expodash/intersection';
 
-export default class EnvironmentSecretSync extends EasCommand {
+export default class EnvironmentSecretPush extends EasCommand {
   static override description = 'read environment secrets from env file and store on the server';
 
   static override flags = {
@@ -49,11 +49,11 @@ export default class EnvironmentSecretSync extends EasCommand {
   async runAsync(): Promise<void> {
     const {
       flags: { scope, force, 'env-file': maybeEnvFilePath, 'non-interactive': nonInteractive },
-    } = await this.parse(EnvironmentSecretSync);
+    } = await this.parse(EnvironmentSecretPush);
     const {
       projectConfig: { projectId },
       loggedIn: { graphqlClient },
-    } = await this.getContextAsync(EnvironmentSecretSync, {
+    } = await this.getContextAsync(EnvironmentSecretPush, {
       nonInteractive,
     });
 

--- a/packages/eas-cli/src/commands/secret/sync.ts
+++ b/packages/eas-cli/src/commands/secret/sync.ts
@@ -1,0 +1,224 @@
+import { Errors, Flags } from '@oclif/core';
+import assert from 'assert';
+import chalk from 'chalk';
+import dotenv from 'dotenv';
+import fs from 'fs-extra';
+import path from 'path';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { EASNonInteractiveFlag } from '../../commandUtils/flags';
+import { EnvironmentSecretFragment, EnvironmentSecretType } from '../../graphql/generated';
+import { EnvironmentSecretMutation } from '../../graphql/mutations/EnvironmentSecretMutation';
+import {
+  EnvironmentSecretScope,
+  EnvironmentSecretsQuery,
+} from '../../graphql/queries/EnvironmentSecretsQuery';
+import Log from '../../log';
+import { ora } from '../../ora';
+import {
+  getDisplayNameForProjectIdAsync,
+  getOwnerAccountForProjectIdAsync,
+} from '../../project/projectUtils';
+import { promptAsync } from '../../prompts';
+import intersection from '../../utils/expodash/intersection';
+
+export default class EnvironmentSecretSync extends EasCommand {
+  static override description = 'read environment secrets from env file and store on the server';
+
+  static override flags = {
+    scope: Flags.enum({
+      description: 'Scope for the secrets',
+      options: [EnvironmentSecretScope.ACCOUNT, EnvironmentSecretScope.PROJECT],
+      default: EnvironmentSecretScope.PROJECT,
+    }),
+    'env-file': Flags.string({
+      description: 'Env file with secrets',
+    }),
+    force: Flags.boolean({
+      description: 'Delete and recreate existing secrets',
+      default: false,
+    }),
+    ...EASNonInteractiveFlag,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    let {
+      flags: { scope, force, 'env-file': envFilePath, 'non-interactive': nonInteractive },
+    } = await this.parse(EnvironmentSecretSync);
+    const {
+      projectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(EnvironmentSecretSync, {
+      nonInteractive,
+    });
+
+    const projectDisplayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
+    const ownerAccount = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
+
+    if (!envFilePath) {
+      const validationMessage = 'Env file must be passed.';
+      if (nonInteractive) {
+        throw new Error(validationMessage);
+      }
+
+      ({ envFilePath } = await promptAsync({
+        type: 'text',
+        name: 'envFilePath',
+        message: 'Path to the env file with secrets:',
+        // eslint-disable-next-line async-protect/async-suffix
+        validate: async secretValueRaw => {
+          if (!secretValueRaw) {
+            return validationMessage;
+          }
+          envFilePath = path.resolve(secretValueRaw);
+          if (!(await fs.pathExists(envFilePath))) {
+            return `File "${envFilePath}" does not exist.`;
+          }
+          return true;
+        },
+      }));
+    }
+
+    assert(envFilePath);
+    if (!(await fs.pathExists(envFilePath))) {
+      throw new Error(`File "${envFilePath}" does not exist`);
+    }
+
+    const newSecrets: Record<string, string> = dotenv.parse(await fs.readFile(envFilePath));
+
+    const serverSecrets = await readAllSecretsFromServerAsync(graphqlClient, projectId, scope);
+    const commonSecretNames = findCommonSecretNames(serverSecrets, newSecrets);
+
+    if (commonSecretNames.length > 0) {
+      if (!force) {
+        Log.log(`This ${scope} already has environment secrets with the following names:`);
+        for (const name of commonSecretNames) {
+          Log.log(`- ${name}`);
+        }
+        Log.error('Run with --force flag to proceed');
+        Errors.exit(1);
+      } else {
+        const spinner = ora('Deleting secrets already present on server...').start();
+        const commonSecretNameSet = new Set(commonSecretNames);
+        const commonServerSecrets = serverSecrets.filter(({ name }) =>
+          commonSecretNameSet.has(name)
+        );
+        await deleteSecretsAsync(graphqlClient, commonServerSecrets);
+        spinner.succeed();
+      }
+    }
+
+    await createSecretsAsync(
+      graphqlClient,
+      {
+        scope,
+        accountId: ownerAccount.id,
+        accountName: ownerAccount.name,
+        projectId,
+        projectDisplayName,
+      },
+      newSecrets
+    );
+
+    Log.withTick(
+      `Created the following secrets on ${scope} ${chalk.bold(
+        scope === EnvironmentSecretScope.ACCOUNT ? ownerAccount.name : projectDisplayName
+      )}:`
+    );
+    for (const secretName of Object.keys(newSecrets)) {
+      Log.log(`- ${secretName}`);
+    }
+  }
+}
+
+async function readAllSecretsFromServerAsync(
+  graphqlClient: ExpoGraphqlClient,
+  projectId: string,
+  scope: EnvironmentSecretScope
+): Promise<EnvironmentSecretFragment[]> {
+  const { appSecrets, accountSecrets } = await EnvironmentSecretsQuery.byAppIdAsync(
+    graphqlClient,
+    projectId
+  );
+
+  return scope === EnvironmentSecretScope.ACCOUNT ? accountSecrets : appSecrets;
+}
+
+function findCommonSecretNames(
+  serverSecrets: EnvironmentSecretFragment[],
+  newSecrets: Record<string, string>
+): string[] {
+  const serverSecretKeys = serverSecrets.map(({ name }) => name);
+  const newSecretKeys = Object.keys(newSecrets);
+  const commonKeys = intersection(serverSecretKeys, newSecretKeys);
+  return commonKeys;
+}
+
+async function deleteSecretsAsync(
+  graphqlClient: ExpoGraphqlClient,
+  secrets: EnvironmentSecretFragment[]
+): Promise<void> {
+  const promises = secrets.map(secret =>
+    EnvironmentSecretMutation.deleteAsync(graphqlClient, secret.id)
+  );
+  await Promise.all(promises);
+}
+
+async function createSecretsAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    scope,
+    accountId,
+    accountName,
+    projectId,
+    projectDisplayName,
+  }: {
+    scope: EnvironmentSecretScope;
+    accountId: string;
+    accountName: string;
+    projectId: string;
+    projectDisplayName: string;
+  },
+  secrets: Record<string, string>
+): Promise<void> {
+  const promises = [];
+
+  const spinner = ora(
+    `Creating secrets on ${scope} ${chalk.bold(
+      scope === EnvironmentSecretScope.ACCOUNT ? accountName : projectDisplayName
+    )}...`
+  ).start();
+  for (const [secretName, secretValue] of Object.entries(secrets)) {
+    if (scope === EnvironmentSecretScope.ACCOUNT) {
+      promises.push(
+        EnvironmentSecretMutation.createForAccountAsync(
+          graphqlClient,
+          { name: secretName, value: secretValue, type: EnvironmentSecretType.String },
+          accountId
+        )
+      );
+    } else {
+      promises.push(
+        EnvironmentSecretMutation.createForAppAsync(
+          graphqlClient,
+          { name: secretName, value: secretValue, type: EnvironmentSecretType.String },
+          projectId
+        )
+      );
+    }
+  }
+
+  try {
+    await Promise.all(promises);
+    spinner.succeed();
+  } catch (err) {
+    spinner.fail();
+    throw err;
+  }
+}

--- a/packages/eas-cli/src/utils/expodash/__tests__/intersection-test.ts
+++ b/packages/eas-cli/src/utils/expodash/__tests__/intersection-test.ts
@@ -1,0 +1,13 @@
+import intersection from '../intersection';
+
+describe(intersection, () => {
+  it('returns an empty list if the are no common items', () => {
+    expect(intersection([1, 2, 3], [4, 5, 6])).toEqual([]);
+  });
+  it('returns a list with common items if the are some', () => {
+    expect(intersection([1, 2, 3, 4], [3, 4, 5, 6])).toEqual([3, 4]);
+  });
+  it('works for empty lists', () => {
+    expect(intersection([], [])).toEqual([]);
+  });
+});

--- a/packages/eas-cli/src/utils/expodash/intersection.ts
+++ b/packages/eas-cli/src/utils/expodash/intersection.ts
@@ -1,0 +1,5 @@
+export default function intersection<T = any>(items1: T[], items2: T[]): T[] {
+  const set1 = new Set(items1);
+  const set2 = new Set(items2);
+  return Array.from(new Set([...set1].filter(i => set2.has(i))));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5890,6 +5890,11 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 dotenv@^16.0.0:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We want to add support for Doppler (secret storage/sync service).
This PR adds the `eas secret:push` command that allows importing secrets from a dot env-like file to EAS secret.

It looks sth like this:
`eas secret:push --scope project --env-file ./eas/.env --force`

This allows using Doppler:
`doppler run --mount ./eas/.env -- eas secret:push --scope project --env-file ./eas/.env --force`

The dot env file should look sth like this:
```
ABC=123
DEF=456
```

# How

- The command is mostly a copy-paste of `secret:create`.
- It checks whether any of the secrets defined in the file is already present on the server.
  - If there is, and `--force` is passed. Those secrets are deleted from the server.
  - If `--force` is not passed, the command exits.
- If `--env-file` is not passed,  the command display a prompt.

# Test Plan

I created an account on https://doppler.com/  and tested the command:

<img width="1532" alt="Screenshot 2022-10-19 at 14 45 05" src="https://user-images.githubusercontent.com/5256730/196695977-33b73c18-4355-45b6-8e06-fd11b6ee4d4f.png">
<img width="1400" alt="Screenshot 2022-10-19 at 14 49 02" src="https://user-images.githubusercontent.com/5256730/196695967-f963b896-a9c4-4e84-8f5b-6d366dddc174.png">
<img width="1334" alt="Screenshot 2022-10-19 at 14 48 38" src="https://user-images.githubusercontent.com/5256730/196695973-c58db5cd-0716-4b3d-be29-2b1723d90dda.png">

