### PR TITLE
feat: use versioned cli for export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Initialize analytics consistently and move analytics into context. ([#1444](https://github.com/expo/eas-cli/pull/1444) by [@wschurman](https://github.com/wschurman))
+- Skip using `--non-interactive` and `--experimental-bundle` flags when local Expo CLI is installed. ([#1460](https://github.com/expo/eas-cli/pull/1460) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -13,7 +13,7 @@ import { PublishMutation } from '../graphql/mutations/PublishMutation';
 import { PresignedPost } from '../graphql/mutations/UploadSessionMutation';
 import { PublishQuery } from '../graphql/queries/PublishQuery';
 import { uploadWithPresignedPostWithRetryAsync } from '../uploads';
-import { expoCommandAsync, hasVersionedExpoCli } from '../utils/expoCli';
+import { expoCommandAsync, shouldUseVersionedExpoCLI } from '../utils/expoCli';
 import chunk from '../utils/expodash/chunk';
 import uniqBy from '../utils/expodash/uniqBy';
 
@@ -157,7 +157,7 @@ export async function buildBundlesAsync({
     throw new Error('Could not locate package.json');
   }
 
-  if (hasVersionedExpoCli(projectDir)) {
+  if (shouldUseVersionedExpoCLI(projectDir)) {
     await expoCommandAsync(projectDir, ['export', '--output-dir', inputDir, '--dump-sourcemap']);
   } else {
     // Legacy global Expo CLI

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -13,7 +13,7 @@ import { PublishMutation } from '../graphql/mutations/PublishMutation';
 import { PresignedPost } from '../graphql/mutations/UploadSessionMutation';
 import { PublishQuery } from '../graphql/queries/PublishQuery';
 import { uploadWithPresignedPostWithRetryAsync } from '../uploads';
-import { expoCommandAsync } from '../utils/expoCli';
+import { expoCommandAsync, hasVersionedExpoCli } from '../utils/expoCli';
 import chunk from '../utils/expodash/chunk';
 import uniqBy from '../utils/expodash/uniqBy';
 
@@ -157,14 +157,19 @@ export async function buildBundlesAsync({
     throw new Error('Could not locate package.json');
   }
 
-  await expoCommandAsync(projectDir, [
-    'export',
-    '--output-dir',
-    inputDir,
-    '--experimental-bundle',
-    '--non-interactive',
-    '--dump-sourcemap',
-  ]);
+  if (hasVersionedExpoCli(projectDir)) {
+    await expoCommandAsync(projectDir, ['export', '--output-dir', inputDir, '--dump-sourcemap']);
+  } else {
+    // Legacy global Expo CLI
+    await expoCommandAsync(projectDir, [
+      'export',
+      '--output-dir',
+      inputDir,
+      '--experimental-bundle',
+      '--non-interactive',
+      '--dump-sourcemap',
+    ]);
+  }
 }
 
 export async function resolveInputDirectoryAsync(customInputDirectory: string): Promise<string> {

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -1,11 +1,14 @@
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
+import { boolish } from 'getenv';
 import resolveFrom from 'resolve-from';
 
 import Log from '../log';
 
-export function hasVersionedExpoCli(projectDir: string): boolean {
-  return !!resolveFrom.silent(projectDir, '@expo/cli');
+export function shouldUseVersionedExpoCLI(projectDir: string): boolean {
+  // Users can disable local CLI settings EXPO_USE_LOCAL_CLI=false
+  // https://github.com/expo/expo/blob/69eddda7bb1dbfab44258f468cf7f22984c1e44e/packages/expo/bin/cli.js#L10
+  return !!resolveFrom.silent(projectDir, '@expo/cli') && boolish('EXPO_USE_LOCAL_CLI', true);
 }
 
 export async function expoCommandAsync(

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -4,6 +4,10 @@ import resolveFrom from 'resolve-from';
 
 import Log from '../log';
 
+export function hasVersionedExpoCli(projectDir: string): boolean {
+  return !!resolveFrom.silent(projectDir, '@expo/cli');
+}
+
 export async function expoCommandAsync(
   projectDir: string,
   args: string[],


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fix ENG-6079

- Hide warning:
```
 --non-interactive is not supported, use $CI=1 instead
```

# How

- Check if `@expo/cli` is available in the project. Users can disable this behavior with `EXPO_USE_LOCAL_CLI=false`.
- Ideally, we'd have something like this for changing the default script:
```json
{
  "scripts": {
    "build": "expo export"
  }
}
```
- This seems most aligned with [how web frameworks work](https://vercel.com/docs/concepts/deployments/configure-a-build#build-command).

# Test Plan

- `eas update` in a project with the latest CLI, there will be no warning.