### PR TITLE
[eas-cli] Replace secret:list table with format fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Replace `secret:list` table with formatted fields. ([#1464](https://github.com/expo/eas-cli/pull/1464) by [@byCedric](https://github.com/byCedric))
+
 ## [2.5.1](https://github.com/expo/eas-cli/releases/tag/v2.5.1) - 2022-10-24
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -38,6 +38,7 @@ function formatSecret(secret: EnvironmentSecretWithScope): string {
     { label: 'Name', value: secret.name },
     { label: 'Scope', value: secret.scope },
     { label: 'Type', value: secret.type },
-    { label: 'Updated at', value: dateFormat(secret.updatedAt, 'mmm dd HH:MM:ss') },
+    // TODO: Figure out why do we name it updated, while it's created at?
+    { label: 'Updated at', value: dateFormat(secret.createdAt, 'mmm dd HH:MM:ss') },
   ]);
 }

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -38,7 +38,6 @@ function formatSecret(secret: EnvironmentSecretWithScope): string {
     { label: 'Name', value: secret.name },
     { label: 'Scope', value: secret.scope },
     { label: 'Type', value: secret.type },
-    // TODO: Figure out why do we name it updated, while it's created at?
-    { label: 'Updated at', value: dateFormat(secret.createdAt, 'mmm dd HH:MM:ss') },
+    { label: 'Updated at', value: dateFormat(secret.updatedAt, 'mmm dd HH:MM:ss') },
   ]);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Follow up on #1463, to get rid of tables in general.

# How

Reused the same formatting as `eas device:list` ([here](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/devices/queries.ts#L163-L165)).

# Test Plan

Just a visual output change.
