### PR TITLE
[eas-cli] Replace device:create input summary table with format fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Replace `secret:list` table with formatted fields. ([#1464](https://github.com/expo/eas-cli/pull/1464) by [@byCedric](https://github.com/byCedric))
+- Replace `device:create` input table with formatted fields. ([#1465](https://github.com/expo/eas-cli/pull/1465) by [@byCedric](https://github.com/byCedric))
 
 ## [2.5.1](https://github.com/expo/eas-cli/releases/tag/v2.5.1) - 2022-10-24
 

--- a/packages/eas-cli/src/devices/actions/create/inputMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/inputMethod.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import Table from 'cli-table3';
 
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { AppleDeviceMutation } from '../../../credentials/ios/api/graphql/mutations/AppleDeviceMutation';
@@ -8,17 +7,13 @@ import Log from '../../../log';
 import { ora } from '../../../ora';
 import { confirmAsync, promptAsync } from '../../../prompts';
 import { isValidUDID, normalizeUDID } from '../../udids';
+import { formatNewDevice } from '../../utils/formatDevice';
 
 interface DeviceData {
   udid: string;
   name?: string;
   deviceClass: AppleDeviceClass | null;
 }
-
-const DEVICE_CLASS_DISPLAY_NAMES: Record<AppleDeviceClass, string> = {
-  [AppleDeviceClass.Iphone]: 'iPhone',
-  [AppleDeviceClass.Ipad]: 'iPad',
-};
 
 export async function runInputMethodAsync(
   graphqlClient: ExpoGraphqlClient,
@@ -89,7 +84,7 @@ async function collectDeviceDataAsync(
 This will ${chalk.bold('not')} register the device on the Apple Developer Portal yet.`
   );
   Log.newLine();
-  printDeviceDataSummary(deviceData, appleTeam);
+  Log.log(formatNewDevice({ ...deviceData, identifier: deviceData.udid }, appleTeam));
   Log.newLine();
 
   const registrationConfirmed = await confirmAsync({
@@ -155,22 +150,4 @@ async function promptForDeviceClassAsync(
     initial: initial !== undefined && values.indexOf(initial),
   });
   return deviceClass;
-}
-
-function printDeviceDataSummary(
-  { udid, name, deviceClass }: DeviceData,
-  appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName'>
-): void {
-  const deviceSummary = new Table({
-    colWidths: [25, 55],
-    wordWrap: true,
-  });
-  deviceSummary.push(
-    ['Apple Team ID', appleTeam.appleTeamIdentifier],
-    ['Apple Team Name', appleTeam.appleTeamName ?? '(unknown)'],
-    ['Device UDID', udid],
-    ['Device Name', name ?? '(empty)'],
-    ['Device Class', deviceClass ? DEVICE_CLASS_DISPLAY_NAMES[deviceClass] : '(unknown)']
-  );
-  Log.log(deviceSummary.toString());
 }

--- a/packages/eas-cli/src/devices/utils/formatDevice.ts
+++ b/packages/eas-cli/src/devices/utils/formatDevice.ts
@@ -1,7 +1,8 @@
-import { AppleDevice, AppleTeam } from '../../graphql/generated';
+import { AppleDevice, AppleDeviceClass, AppleTeam } from '../../graphql/generated';
 import formatFields from '../../utils/formatFields';
 
 type Device = Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'deviceClass' | 'enabled' | 'model'>;
+type NewDevice = Pick<AppleDevice, 'identifier' | 'name' | 'deviceClass'>;
 
 export type AppleTeamIdAndName = Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName'>;
 
@@ -20,10 +21,34 @@ export default function formatDevice(device: Device, team?: AppleTeamIdAndName):
 
   if (team) {
     fields.push(
-      ...[
-        { label: 'Apple Team ID', value: team.appleTeamIdentifier },
-        { label: 'Apple Team Name', value: team.appleTeamName ?? 'Unknown' },
-      ]
+      { label: 'Apple Team ID', value: team.appleTeamIdentifier },
+      { label: 'Apple Team Name', value: team.appleTeamName ?? 'Unknown' }
+    );
+  }
+
+  return formatFields(fields);
+}
+
+// TODO: integrate this with `formatDevice`
+const DEVICE_CLASS_DISPLAY_NAMES: Record<AppleDeviceClass, string> = {
+  [AppleDeviceClass.Iphone]: 'iPhone',
+  [AppleDeviceClass.Ipad]: 'iPad',
+};
+
+export function formatNewDevice(device: NewDevice, team?: AppleTeamIdAndName): string {
+  const fields = [
+    { label: 'Name', value: device.name ?? '(empty)' },
+    {
+      label: 'Class',
+      value: device.deviceClass ? DEVICE_CLASS_DISPLAY_NAMES[device.deviceClass] : 'Unknown',
+    },
+    { label: 'UDID', value: device.identifier },
+  ];
+
+  if (team) {
+    fields.push(
+      { label: 'Apple Team ID', value: team.appleTeamIdentifier },
+      { label: 'Apple Team Name', value: team.appleTeamName ?? 'Unknown' }
     );
   }
 

--- a/packages/eas-cli/src/devices/utils/formatDevice.ts
+++ b/packages/eas-cli/src/devices/utils/formatDevice.ts
@@ -1,20 +1,33 @@
 import { AppleDevice, AppleDeviceClass, AppleTeam } from '../../graphql/generated';
-import formatFields from '../../utils/formatFields';
+import formatFields, { FormatFieldsItem } from '../../utils/formatFields';
 
 type Device = Pick<AppleDevice, 'id' | 'identifier' | 'name' | 'deviceClass' | 'enabled' | 'model'>;
 type NewDevice = Pick<AppleDevice, 'identifier' | 'name' | 'deviceClass'>;
 
 export type AppleTeamIdAndName = Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName'>;
 
+const DEVICE_CLASS_DISPLAY_NAMES: Record<AppleDeviceClass, string> = {
+  [AppleDeviceClass.Iphone]: 'iPhone',
+  [AppleDeviceClass.Ipad]: 'iPad',
+};
+
+function formatDeviceClass(device: Device | NewDevice): string {
+  if (!device.deviceClass || !DEVICE_CLASS_DISPLAY_NAMES[device.deviceClass]) {
+    return 'Unknown';
+  }
+
+  return [DEVICE_CLASS_DISPLAY_NAMES[device.deviceClass], 'model' in device ? device.model : '']
+    .filter(value => !!value)
+    .join(' ');
+}
+
 export default function formatDevice(device: Device, team?: AppleTeamIdAndName): string {
-  const fields = [
+  const fields: FormatFieldsItem[] = [
     { label: 'ID', value: device.id },
     { label: 'Name', value: device.name ?? 'Unknown' },
     {
       label: 'Class',
-      value: device.deviceClass
-        ? `${device.deviceClass}${device.model ? ` ${device.model}` : ''}`
-        : 'Unknown',
+      value: formatDeviceClass(device),
     },
     { label: 'UDID', value: device.identifier },
   ];
@@ -29,18 +42,12 @@ export default function formatDevice(device: Device, team?: AppleTeamIdAndName):
   return formatFields(fields);
 }
 
-// TODO: integrate this with `formatDevice`
-const DEVICE_CLASS_DISPLAY_NAMES: Record<AppleDeviceClass, string> = {
-  [AppleDeviceClass.Iphone]: 'iPhone',
-  [AppleDeviceClass.Ipad]: 'iPad',
-};
-
 export function formatNewDevice(device: NewDevice, team?: AppleTeamIdAndName): string {
-  const fields = [
+  const fields: FormatFieldsItem[] = [
     { label: 'Name', value: device.name ?? '(empty)' },
     {
       label: 'Class',
-      value: device.deviceClass ? DEVICE_CLASS_DISPLAY_NAMES[device.deviceClass] : 'Unknown',
+      value: formatDeviceClass(device),
     },
     { label: 'UDID', value: device.identifier },
   ];

--- a/packages/eas-cli/src/utils/formatFields.ts
+++ b/packages/eas-cli/src/utils/formatFields.ts
@@ -4,8 +4,10 @@ type FormatFieldsOptions = {
   labelFormat: (raw: string) => string;
 };
 
+export type FormatFieldsItem = { label: string; value: string };
+
 export default function formatFields(
-  fields: { label: string; value: string }[],
+  fields: FormatFieldsItem[],
   options: FormatFieldsOptions = { labelFormat: chalk.dim }
 ): string {
   const columnWidth = fields.reduce((a, b) => (a.label.length > b.label.length ? a : b)).label


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Replaces the CLI table for `eas device:create` with formatted fields, similarly to how `eas device:list` works.

# How

- Created new `formatNewDevice` method, as some fields don't exist yet.
- Moved device class formatting over
- Resort the fields to match `formatDevice`

# Test Plan

- Run `eas device:create`
- Pick `input` mode
<img width="742" alt="image" src="https://user-images.githubusercontent.com/1203991/197529759-791e7454-1dd9-49d0-82ee-ca207fb13f70.png">

- Fill in details
- See device summary being formatted fields instead of a table
<img width="401" alt="Screenshot 2022-10-24 at 14 55 35" src="https://user-images.githubusercontent.com/1203991/197530593-7ed0cc71-1aae-47a1-a6c3-e4947287e8a2.png">
