### PR TITLE
[eas-cli] Warn about outdated build deployment when configuring EAS Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add custom metadata validation command with more complex rules. ([#1416](https://github.com/expo/eas-cli/pull/1416) by [@byCedric](https://github.com/byCedric))
 - Add `eas build:run` command which runs iOS simulator builds from the CLI. ([#1447](https://github.com/expo/eas-cli/pull/1447) by [@szdziedzic](https://github.com/szdziedzic))
 - Add feature gate support. ([#1475](https://github.com/expo/eas-cli/pull/1475) by [@wschurman](https://github.com/wschurman))
+- Warn about outdated build deployment when configuring EAS Update.
+  ([#TODO](https://github.com/expo/eas-cli/pull/TODO) by [@fiberjw](https://github.com/fiberjw))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add `eas build:run` command which runs iOS simulator builds from the CLI. ([#1447](https://github.com/expo/eas-cli/pull/1447) by [@szdziedzic](https://github.com/szdziedzic))
 - Add feature gate support. ([#1475](https://github.com/expo/eas-cli/pull/1475) by [@wschurman](https://github.com/wschurman))
 - Warn about outdated build deployment when configuring EAS Update.
-  ([#TODO](https://github.com/expo/eas-cli/pull/TODO) by [@fiberjw](https://github.com/fiberjw))
+  ([#1467](https://github.com/expo/eas-cli/pull/1467) by [@fiberjw](https://github.com/fiberjw))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -7,7 +7,6 @@ import chalk from 'chalk';
 import { getEASUpdateURL } from '../../api';
 import EasCommand from '../../commandUtils/EasCommand';
 import { AppPlatform } from '../../graphql/generated';
-import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log, { learnMore } from '../../log';
 import { RequestedPlatform, appPlatformDisplayNames } from '../../platform';
 import {
@@ -88,18 +87,10 @@ export default class UpdateConfigure extends EasCommand {
       Log.withTick(`Configured ${chalk.bold('Expo.plist')} for EAS Update`);
     }
 
-    const builds = await BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
-      appId: projectId,
-      limit: 1,
-      offset: 0,
-    });
-
-    if (builds.length > 0) {
-      Log.addNewLineIfNone();
-      Log.warn(
-        `If you have previously deployed this app to users, you will need to rebuild and submit a new version before you can update your app with EAS Update.`
-      );
-    }
+    Log.addNewLineIfNone();
+    Log.warn(
+      `If you have previously deployed this app to users, you will need to rebuild and submit a new version before you can update your app with EAS Update.`
+    );
 
     Log.addNewLineIfNone();
     Log.log(`🎉 Your app is configured to run EAS Update!`);

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -89,7 +89,7 @@ export default class UpdateConfigure extends EasCommand {
 
     Log.addNewLineIfNone();
     Log.warn(
-      `If you have previously deployed this app to users, you will need to rebuild and submit a new version before you can update your app with EAS Update.`
+      `All builds of your app going forward will be eligible to receive updates published with EAS Update.`
     );
 
     Log.addNewLineIfNone();

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 import { getEASUpdateURL } from '../../api';
 import EasCommand from '../../commandUtils/EasCommand';
 import { AppPlatform } from '../../graphql/generated';
+import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log, { learnMore } from '../../log';
 import { RequestedPlatform, appPlatformDisplayNames } from '../../platform';
 import {
@@ -85,6 +86,19 @@ export default class UpdateConfigure extends EasCommand {
     ) {
       await syncIosUpdatesConfigurationAsync(graphqlClient, projectDir, updatedExp, projectId);
       Log.withTick(`Configured ${chalk.bold('Expo.plist')} for EAS Update`);
+    }
+
+    const builds = await BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
+      appId: projectId,
+      limit: 1,
+      offset: 0,
+    });
+
+    if (builds.length > 0) {
+      Log.addNewLineIfNone();
+      Log.warn(
+        `If you have previously deployed this app to users, you will need to rebuild and submit a new version before you can update your app with EAS Update.`
+      );
     }
 
     Log.addNewLineIfNone();


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Some users can get confused about why EAS Update doesn't work after adding it to an existing app without rebuilding it.

# How

I added a warning to rebuild and resubmit your app after running `eas update:configure`. 

# Test Plan

<img width="1552" alt="Screen Shot 2022-10-20 at 13 27 17" src="https://user-images.githubusercontent.com/12488826/197017747-d76f4c69-000f-4859-acf4-72e9f3d14e8f.png">



