### PR TITLE
revert #1460

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Initialize analytics consistently and move analytics into context. ([#1444](https://github.com/expo/eas-cli/pull/1444) by [@wschurman](https://github.com/wschurman))
-- Skip using `--non-interactive` and `--experimental-bundle` flags when local Expo CLI is installed. ([#1460](https://github.com/expo/eas-cli/pull/1460) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Revert using local CLI for `expo export` ([#1460](https://github.com/expo/eas-cli/pull/1460)). ([#1472](https://github.com/expo/eas-cli/pull/1472) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [2.5.0](https://github.com/expo/eas-cli/releases/tag/v2.5.0) - 2022-10-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Initialize analytics consistently and move analytics into context. ([#1444](https://github.com/expo/eas-cli/pull/1444) by [@wschurman](https://github.com/wschurman))
+- Skip using `--non-interactive` and `--experimental-bundle` flags when local Expo CLI is installed. ([#1460](https://github.com/expo/eas-cli/pull/1460) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -13,7 +13,7 @@ import { PublishMutation } from '../graphql/mutations/PublishMutation';
 import { PresignedPost } from '../graphql/mutations/UploadSessionMutation';
 import { PublishQuery } from '../graphql/queries/PublishQuery';
 import { uploadWithPresignedPostWithRetryAsync } from '../uploads';
-import { expoCommandAsync, shouldUseVersionedExpoCLI } from '../utils/expoCli';
+import { expoCommandAsync } from '../utils/expoCli';
 import chunk from '../utils/expodash/chunk';
 import uniqBy from '../utils/expodash/uniqBy';
 
@@ -157,19 +157,14 @@ export async function buildBundlesAsync({
     throw new Error('Could not locate package.json');
   }
 
-  if (shouldUseVersionedExpoCLI(projectDir)) {
-    await expoCommandAsync(projectDir, ['export', '--output-dir', inputDir, '--dump-sourcemap']);
-  } else {
-    // Legacy global Expo CLI
-    await expoCommandAsync(projectDir, [
-      'export',
-      '--output-dir',
-      inputDir,
-      '--experimental-bundle',
-      '--non-interactive',
-      '--dump-sourcemap',
-    ]);
-  }
+  await expoCommandAsync(projectDir, [
+    'export',
+    '--output-dir',
+    inputDir,
+    '--experimental-bundle',
+    '--non-interactive',
+    '--dump-sourcemap',
+  ]);
 }
 
 export async function resolveInputDirectoryAsync(customInputDirectory: string): Promise<string> {

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -1,15 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
-import { boolish } from 'getenv';
 import resolveFrom from 'resolve-from';
 
 import Log from '../log';
-
-export function shouldUseVersionedExpoCLI(projectDir: string): boolean {
-  // Users can disable local CLI settings EXPO_USE_LOCAL_CLI=false
-  // https://github.com/expo/expo/blob/69eddda7bb1dbfab44258f468cf7f22984c1e44e/packages/expo/bin/cli.js#L10
-  return !!resolveFrom.silent(projectDir, '@expo/cli') && boolish('EXPO_USE_LOCAL_CLI', true);
-}
 
 export async function expoCommandAsync(
   projectDir: string,


### PR DESCRIPTION
Revert https://github.com/expo/eas-cli/pull/1460 as this doesn't work with projects with older SDKs.
See https://exponent-internal.slack.com/archives/C017N0N99RA/p1666603376919699