### PR TITLE
[eas-cli] Add flag sanitization in updates command

### DIFF
--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -92,7 +92,7 @@ type UpdateFlags = {
   skipBundler: boolean;
   privateKeyPath?: string;
   json: boolean;
-  nonInteractive?: boolean;
+  nonInteractive: boolean;
 };
 
 async function ensureChannelExistsAsync(

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -92,7 +92,7 @@ type UpdateFlags = {
   skipBundler: boolean;
   privateKeyPath?: string;
   json: boolean;
-  nonInteractive: boolean;
+  nonInteractive?: boolean;
 };
 
 async function ensureChannelExistsAsync(

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -626,7 +626,7 @@ export default class UpdatePublish extends EasCommand {
   }
 
   private sanitizeFlags(flags: RawUpdateFlags): UpdateFlags {
-    const nonInteractive = flags['non-interactive'] ?? false;
+    const nonInteractive = flags['non-interactive'];
 
     const { auto, branch: branchName, message: updateMessage } = flags;
     if (nonInteractive && !auto && !(branchName && updateMessage)) {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -626,7 +626,7 @@ export default class UpdatePublish extends EasCommand {
   }
 
   private sanitizeFlags(flags: RawUpdateFlags): UpdateFlags {
-    const nonInteractive = flags['non-interactive'];
+    const nonInteractive = flags['non-interactive'] ?? false;
 
     const { auto, branch: branchName, message: updateMessage } = flags;
     if (nonInteractive && !auto && !(branchName && updateMessage)) {


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This starts ENG-5926 and is the first of a couple of stacked PRs to clean this command up.

# How

- Added `RawUpdateFlags` and `UpdateFlags`
- Added basic validation for incorrect combinations of flags
- Renamed a few variables in `runAsync` to emphasize entity relation
  - `group` → `groupId`
  - `message` → `updateMessage`

# Test Plan

`eas update` (with all flag-variations should work)
