### PR TITLE
[eas-cli] Extract entity utilities from update command class

### DIFF
--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -202,7 +202,7 @@ function renderChannelHeaderContent({
   Log.log(chalk`{bold Branches pointed at this channel and their most recent update group:}`);
 }
 
-export async function createChannelAsync(
+export async function createChannelOnAppAsync(
   graphqlClient: ExpoGraphqlClient,
   {
     appId,
@@ -248,7 +248,7 @@ export async function ensureChannelExistsAsync(
   { appId, branchId, channelName }: { appId: string; branchId: string; channelName: string }
 ): Promise<void> {
   try {
-    await createChannelAsync(graphqlClient, {
+    await createChannelOnAppAsync(graphqlClient, {
       appId,
       channelName,
       branchId,

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -1,8 +1,12 @@
 import chalk from 'chalk';
+import gql from 'graphql-tag';
 
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { PaginatedQueryOptions } from '../commandUtils/pagination';
+import { withErrorHandlingAsync } from '../graphql/client';
 import {
+  CreateUpdateChannelOnAppMutation,
+  CreateUpdateChannelOnAppMutationVariables,
   ViewBranchesOnUpdateChannelQueryVariables,
   ViewUpdateChannelsOnAppQueryVariables,
 } from '../graphql/generated';
@@ -196,4 +200,65 @@ function renderChannelHeaderContent({
   );
   Log.addNewLineIfNone();
   Log.log(chalk`{bold Branches pointed at this channel and their most recent update group:}`);
+}
+
+export async function createChannelAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    appId,
+    branchId,
+    channelName,
+  }: {
+    appId: string;
+    branchId: string;
+    channelName: string;
+  }
+): Promise<CreateUpdateChannelOnAppMutation> {
+  // Point the new channel at a branch with its same name.
+  const branchMapping = JSON.stringify({
+    data: [{ branchId, branchMappingLogic: 'true' }],
+    version: 0,
+  });
+  return await withErrorHandlingAsync(
+    graphqlClient
+      .mutation<CreateUpdateChannelOnAppMutation, CreateUpdateChannelOnAppMutationVariables>(
+        gql`
+          mutation CreateUpdateChannelOnApp($appId: ID!, $name: String!, $branchMapping: String!) {
+            updateChannel {
+              createUpdateChannelForApp(appId: $appId, name: $name, branchMapping: $branchMapping) {
+                id
+                name
+                branchMapping
+              }
+            }
+          }
+        `,
+        {
+          appId,
+          name: channelName,
+          branchMapping,
+        }
+      )
+      .toPromise()
+  );
+}
+
+export async function ensureChannelExistsAsync(
+  graphqlClient: ExpoGraphqlClient,
+  { appId, branchId, channelName }: { appId: string; branchId: string; channelName: string }
+): Promise<void> {
+  try {
+    await createChannelAsync(graphqlClient, {
+      appId,
+      channelName,
+      branchId,
+    });
+  } catch (e: any) {
+    const isIgnorableError =
+      e.graphQLErrors?.length === 1 &&
+      e.graphQLErrors[0].extensions.errorCode === 'CHANNEL_ALREADY_EXISTS';
+    if (!isIgnorableError) {
+      throw e;
+    }
+  }
 }

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -16,6 +16,7 @@ import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
+// NOTE(cedric): copied to src/branch/queries.ts to reuse in multiple commands
 export async function createUpdateBranchOnAppAsync(
   graphqlClient: ExpoGraphqlClient,
   { appId, name }: CreateUpdateBranchForAppMutationVariables

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -1,52 +1,13 @@
 import chalk from 'chalk';
-import gql from 'graphql-tag';
 
+import { createUpdateBranchOnAppAsync } from '../../branch/queries';
 import { getDefaultBranchNameAsync } from '../../branch/utils';
 import EasCommand from '../../commandUtils/EasCommand';
-import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import { withErrorHandlingAsync } from '../../graphql/client';
-import {
-  CreateUpdateBranchForAppMutation,
-  CreateUpdateBranchForAppMutationVariables,
-  UpdateBranch,
-} from '../../graphql/generated';
 import Log from '../../log';
 import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
-
-// NOTE(cedric): copied to src/branch/queries.ts to reuse in multiple commands
-export async function createUpdateBranchOnAppAsync(
-  graphqlClient: ExpoGraphqlClient,
-  { appId, name }: CreateUpdateBranchForAppMutationVariables
-): Promise<Pick<UpdateBranch, 'id' | 'name'>> {
-  const result = await withErrorHandlingAsync(
-    graphqlClient
-      .mutation<CreateUpdateBranchForAppMutation, CreateUpdateBranchForAppMutationVariables>(
-        gql`
-          mutation createUpdateBranchForApp($appId: ID!, $name: String!) {
-            updateBranch {
-              createUpdateBranchForApp(appId: $appId, name: $name) {
-                id
-                name
-              }
-            }
-          }
-        `,
-        {
-          appId,
-          name,
-        }
-      )
-      .toPromise()
-  );
-  const newBranch = result.updateBranch.createUpdateBranchForApp;
-  if (!newBranch) {
-    throw new Error(`Could not create branch ${name}.`);
-  }
-  return newBranch;
-}
 
 export default class BranchCreate extends EasCommand {
   static override description = 'create a branch';

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -18,6 +18,7 @@ import formatFields from '../../utils/formatFields';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import { createUpdateBranchOnAppAsync } from '../branch/create';
 
+// NOTE(cedric): copied to src/channel/queries.ts to reuse in multiple commands
 export async function createUpdateChannelOnAppAsync(
   graphqlClient: ExpoGraphqlClient,
   {

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 
+import { createUpdateBranchOnAppAsync } from '../../branch/queries';
 import { BranchNotFoundError } from '../../branch/utils';
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
@@ -16,7 +17,6 @@ import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import formatFields from '../../utils/formatFields';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
-import { createUpdateBranchOnAppAsync } from '../branch/create';
 
 // NOTE(cedric): copied to src/channel/queries.ts to reuse in multiple commands
 export async function createUpdateChannelOnAppAsync(

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -1,64 +1,16 @@
 import chalk from 'chalk';
-import gql from 'graphql-tag';
 
 import { createUpdateBranchOnAppAsync } from '../../branch/queries';
 import { BranchNotFoundError } from '../../branch/utils';
+import { createChannelOnAppAsync } from '../../channel/queries';
 import EasCommand from '../../commandUtils/EasCommand';
-import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import { withErrorHandlingAsync } from '../../graphql/client';
-import {
-  CreateUpdateChannelOnAppMutation,
-  CreateUpdateChannelOnAppMutationVariables,
-} from '../../graphql/generated';
 import { BranchQuery } from '../../graphql/queries/BranchQuery';
 import Log from '../../log';
 import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import formatFields from '../../utils/formatFields';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
-
-// NOTE(cedric): copied to src/channel/queries.ts to reuse in multiple commands
-export async function createUpdateChannelOnAppAsync(
-  graphqlClient: ExpoGraphqlClient,
-  {
-    appId,
-    channelName,
-    branchId,
-  }: {
-    appId: string;
-    channelName: string;
-    branchId: string;
-  }
-): Promise<CreateUpdateChannelOnAppMutation> {
-  // Point the new channel at a branch with its same name.
-  const branchMapping = JSON.stringify({
-    data: [{ branchId, branchMappingLogic: 'true' }],
-    version: 0,
-  });
-  return await withErrorHandlingAsync(
-    graphqlClient
-      .mutation<CreateUpdateChannelOnAppMutation, CreateUpdateChannelOnAppMutationVariables>(
-        gql`
-          mutation CreateUpdateChannelOnApp($appId: ID!, $name: String!, $branchMapping: String!) {
-            updateChannel {
-              createUpdateChannelForApp(appId: $appId, name: $name, branchMapping: $branchMapping) {
-                id
-                name
-                branchMapping
-              }
-            }
-          }
-        `,
-        {
-          appId,
-          name: channelName,
-          branchMapping,
-        }
-      )
-      .toPromise()
-  );
-}
 
 export default class ChannelCreate extends EasCommand {
   static override description = 'create a channel';
@@ -133,7 +85,7 @@ export default class ChannelCreate extends EasCommand {
 
     const {
       updateChannel: { createUpdateChannelForApp: newChannel },
-    } = await createUpdateChannelOnAppAsync(graphqlClient, {
+    } = await createChannelOnAppAsync(graphqlClient, {
       appId: projectId,
       channelName,
       branchId,

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -92,7 +92,7 @@ type UpdateFlags = {
   skipBundler: boolean;
   privateKeyPath?: string;
   json: boolean;
-  nonInteractive?: boolean;
+  nonInteractive: boolean;
 };
 
 async function ensureChannelExistsAsync(

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -423,6 +423,7 @@ export default class UpdatePublish extends EasCommand {
       branchId,
       channelName: branchName,
     });
+    Log.withTick(`Channel: ${chalk.bold(branchName)} pointed at branch: ${chalk.bold(branchName)}`);
 
     // Sort the updates into different groups based on their platform specific runtime versions
     const updateGroups: PublishUpdateGroupInput[] = Object.entries(runtimeToPlatformMapping).map(

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -92,7 +92,7 @@ type UpdateFlags = {
   skipBundler: boolean;
   privateKeyPath?: string;
   json: boolean;
-  nonInteractive: boolean;
+  nonInteractive?: boolean;
 };
 
 async function ensureChannelExistsAsync(

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -626,7 +626,7 @@ export default class UpdatePublish extends EasCommand {
   }
 
   private sanitizeFlags(flags: RawUpdateFlags): UpdateFlags {
-    const nonInteractive = flags['non-interactive'] ?? false;
+    const nonInteractive = flags['non-interactive'];
 
     const { auto, branch: branchName, message: updateMessage } = flags;
     if (nonInteractive && !auto && !(branchName && updateMessage)) {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -626,7 +626,7 @@ export default class UpdatePublish extends EasCommand {
   }
 
   private sanitizeFlags(flags: RawUpdateFlags): UpdateFlags {
-    const nonInteractive = flags['non-interactive'];
+    const nonInteractive = flags['non-interactive'] ?? false;
 
     const { auto, branch: branchName, message: updateMessage } = flags;
     if (nonInteractive && !auto && !(branchName && updateMessage)) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Continuation of PR #1473 and ENG-5926.

# How

- Moved ensure methods from `UpdatePublish` to `src/branch|channel/queries.ts`.
- Copied other methods from commands `BranchCreate` and `ChannelCreate`, to keep queries contained in `src/branch|channel/queries.ts` files.
- Validated the logging is similar (still slightly different)
  - _branch logging_
    - removed: `Created branch: <branchName>`
    - why: The branch is both listed in the formatted fields (first field), and the "Channel is pointing to branch" logging, seems not worth it to determine if the branch was created or already existed. (_but if people disagree, I'd be happy to change it_)
  - _channel logging_  
    - from: `Created a channel: <channelName> pointed at branch: <branchName>` (_only logged when created_)
    - to: `Channel: <channelName> pointed at branch: <branchName>` (_always logged_) 
    - why: The channel name is not part of the formatted fields at the end. We either need to display this, or maybe even add it to the formatted fields as item? (_instead of the `Log.withTick`_)

# Test Plan

- `eas update --branch new-branch`
- `eas update --branch existing-branch`
