### PR TITLE
[eas-cli] Drop remaining cli tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Replace `device:create` input table with formatted fields. ([#1465](https://github.com/expo/eas-cli/pull/1465) by [@byCedric](https://github.com/byCedric))
 - Replace `channel:view` table with formatted fields. ([#1466](https://github.com/expo/eas-cli/pull/1466) by [@byCedric](https://github.com/byCedric))
 - Upgrade dependencies. ([#1480](https://github.com/expo/eas-cli/pull/1480) by [@dsokal](https://github.com/dsokal))
+- Replace all remaining tables with formatted fields. ([#1481](https://github.com/expo/eas-cli/pull/1481) by [@byCedric](https://github.com/byCedric))
 
 ## [2.5.1](https://github.com/expo/eas-cli/releases/tag/v2.5.1) - 2022-10-24
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -38,7 +38,6 @@
     "better-opn": "3.0.2",
     "chalk": "4.1.2",
     "cli-progress": "3.11.2",
-    "cli-table3": "0.6.3",
     "dateformat": "4.6.3",
     "dotenv": "16.0.3",
     "env-paths": "2.2.0",

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -153,14 +153,13 @@ function renderPageOfChannels(
     printJsonOnlyOutput({ currentPage });
   } else {
     for (const channel of currentPage) {
+      renderChannelHeaderContent({ channelName: channel.name, channelId: channel.id });
       Log.addNewLineIfNone();
-      Log.log(
-        formatFields([
-          { label: 'Name', value: channel.name },
-          { label: 'ID', value: channel.id },
-        ])
-      );
       logChannelDetails(channel);
+
+      if (currentPage.indexOf(channel) < currentPage.length - 1) {
+        Log.log(`\n${chalk.dim('———')}\n`);
+      }
     }
   }
 }
@@ -174,13 +173,8 @@ function renderPageOfBranchesOnChannel(
   if (json) {
     printJsonOnlyOutput({ currentPage: channelWithNewBranches });
   } else {
+    // The channel details contain both the branch and latest update group
     Log.addNewLineIfNone();
-    Log.log(
-      formatFields([
-        { label: 'Name', value: channel.name },
-        { label: 'ID', value: channel.id },
-      ])
-    );
     logChannelDetails(channelWithNewBranches);
   }
 }

--- a/packages/eas-cli/src/update/queries.ts
+++ b/packages/eas-cli/src/update/queries.ts
@@ -18,11 +18,9 @@ import {
   paginatedQueryWithSelectPromptAsync,
 } from '../utils/queries';
 import {
-  UPDATE_COLUMNS,
   UPDATE_COLUMNS_WITH_BRANCH,
   formatUpdateGroup,
   formatUpdateTitle,
-  getUpdateGroupDescriptions,
   getUpdateGroupDescriptionsWithBranch,
 } from './utils';
 

--- a/packages/eas-cli/src/update/utils.ts
+++ b/packages/eas-cli/src/update/utils.ts
@@ -40,6 +40,7 @@ export type FormattedUpdateGroupDescription = {
 
 export type FormattedBranchDescription = {
   branch: string;
+  branchRolloutPercentage?: number;
   update?: FormattedUpdateGroupDescription;
 };
 
@@ -65,9 +66,18 @@ export function formatUpdateGroup(update: FormattedUpdateGroupDescription): stri
   ]);
 }
 
-export function formatBranch({ branch, update }: FormattedBranchDescription): string {
+export function formatBranch({
+  branch,
+  branchRolloutPercentage,
+  update,
+}: FormattedBranchDescription): string {
+  const rolloutField = branchRolloutPercentage
+    ? [{ label: 'Rollout', value: `${branchRolloutPercentage}%` }]
+    : [];
+
   return formatFields([
     { label: 'Branch', value: branch },
+    ...rolloutField,
     { label: 'Platforms', value: update?.platforms ?? 'N/A' },
     { label: 'Runtime Version', value: update?.runtimeVersion ?? 'N/A' },
     { label: 'Message', value: update?.message ?? 'N/A' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1280,11 +1280,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@colors/colors@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
-  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
-
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -5352,15 +5347,6 @@ cli-spinners@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.4.0.tgz#c6256db216b878cfba4720e719cec7cf72685d7f"
   integrity sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==
-
-cli-table3@0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
-  integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
-  dependencies:
-    string-width "^4.2.0"
-  optionalDependencies:
-    "@colors/colors" "1.5.0"
 
 cli-table@^0.3.1:
   version "0.3.11"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Converts all remaining CLI tables to formatted fields.

# How

Went through all commands:

### Old output

<details><summary><code>eas update:list</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test*
╰╴$ easd update:list
✔ Which branch would you like to view? › main

Branch:
Name  main
ID    7072afed-8681-4dd2-855a-cf02f224b73e

┌──────────────────────────────────────────────────────────────────────────┬────────────────────────┬──────────────────────────────────────┬──────────────────┐
│ Update message                                                           │ Update runtime version │ Update group ID                      │ Update platforms │
├──────────────────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ "chore: configure eas build and fix entrypoint" (1 week ago by bycedric) │ exposdk:46.0.0         │ 5569dd65-9d79-42c4-9fd1-d922f71182fa │ android, ios     │
├──────────────────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ "chore: configure eas build and fix entrypoint" (1 week ago by bycedric) │ exposdk:46.0.0         │ 1a36d4d1-dbd5-40eb-bf43-c2abf1a3dea4 │ android, ios     │
└──────────────────────────────────────────────────────────────────────────┴────────────────────────┴──────────────────────────────────────┴──────────────────┘


```

</details>

<details><summary><code>eas update:list --all</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test*
╰╴$ eas update:list --all

Recent update groups:

┌────────┬──────────────────────────────────────────────────────────────────────────┬────────────────────────┬──────────────────────────────────────┬──────────────────┐
│ Branch │ Update message                                                           │ Update runtime version │ Update group ID                      │ Update platforms │
├────────┼──────────────────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ test   │ "docs: add note about index.js" (23 hours ago by bycedric)               │ exposdk:46.0.0         │ 401e4385-c801-4e33-ae3c-520141ee3cf8 │ android, ios     │
├────────┼──────────────────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ main   │ "chore: configure eas build and fix entrypoint" (1 week ago by bycedric) │ exposdk:46.0.0         │ 5569dd65-9d79-42c4-9fd1-d922f71182fa │ android, ios     │
├────────┼──────────────────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ test   │ "docs: add note about index.js" (1 day ago by bycedric)                  │ exposdk:46.0.0         │ 1988f700-b427-47f2-bffb-a1a02799786f │ android, ios     │
├────────┼──────────────────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ main   │ "chore: configure eas build and fix entrypoint" (1 week ago by bycedric) │ exposdk:46.0.0         │ 1a36d4d1-dbd5-40eb-bf43-c2abf1a3dea4 │ android, ios     │
└────────┴──────────────────────────────────────────────────────────────────────────┴────────────────────────┴──────────────────────────────────────┴──────────────────┘

```

</details>

<details><summary><code>eas update:view [id]</code></summary>

_changed in PR #1463_

```log
╭╴~/Projects/bycedric/dogfood test*
╰╴$ easd update:view 5569dd65-9d79-42c4-9fd1-d922f71182fa
Update group:
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         5569dd65-9d79-42c4-9fd1-d922f71182fa
```

</details>

<details><summary><code>eas channel:list</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test*
╰╴$ easd channel:list

Name  test
ID    f81a4073-dc5b-4aeb-a883-eff45f8d78f8
┌────────┬────────────────────────────────────────────────────────────┬────────────────────────┬──────────────────────────────────────┬──────────────────┐
│ branch │ Update message                                             │ Update runtime version │ Update group ID                      │ Update platforms │
├────────┼────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ test   │ "docs: add note about index.js" (19 hours ago by bycedric) │ exposdk:46.0.0         │ 401e4385-c801-4e33-ae3c-520141ee3cf8 │ android, ios     │
└────────┴────────────────────────────────────────────────────────────┴────────────────────────┴──────────────────────────────────────┴──────────────────┘

Name  main
ID    cb801677-6904-467d-a2dc-df489cba5d49
┌────────┬──────────────────────────────────────────────────────────────────────────┬────────────────────────┬──────────────────────────────────────┬──────────────────┐
│ branch │ Update message                                                           │ Update runtime version │ Update group ID                      │ Update platforms │
├────────┼──────────────────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ main   │ "chore: configure eas build and fix entrypoint" (1 week ago by bycedric) │ exposdk:46.0.0         │ 5569dd65-9d79-42c4-9fd1-d922f71182fa │ android, ios     │
└────────┴──────────────────────────────────────────────────────────────────────────┴────────────────────────┴──────────────────────────────────────┴──────────────────┘

```

</details>

<details><summary><code>eas channel:view [name]</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test*
╰╴$ easd channel:view
✔ Select a channel to view › test

Channel:
Name  test
ID    f81a4073-dc5b-4aeb-a883-eff45f8d78f8

Branches pointed at this channel and their most recent update group:

Name  test
ID    f81a4073-dc5b-4aeb-a883-eff45f8d78f8
┌────────┬────────────────────────────────────────────────────────────┬────────────────────────┬──────────────────────────────────────┬──────────────────┐
│ branch │ Update message                                             │ Update runtime version │ Update group ID                      │ Update platforms │
├────────┼────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ test   │ "docs: add note about index.js" (19 hours ago by bycedric) │ exposdk:46.0.0         │ 401e4385-c801-4e33-ae3c-520141ee3cf8 │ android, ios     │
└────────┴────────────────────────────────────────────────────────────┴────────────────────────┴──────────────────────────────────────┴──────────────────┘

```

</details>

<details><summary><code>eas branch:list</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test* 
╰╴$ eas branch:list

Branches:

┌──────────┬──────────────────────────────────────────────────────────────────────────┬────────────────────────┬──────────────────────────────────────┬──────────────────┐
│ Branch   │ Update message                                                           │ Update runtime version │ Update group ID                      │ Update platforms │
├──────────┼──────────────────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ biepboep │ N/A                                                                      │ N/A                    │ N/A                                  │ N/A              │
├──────────┼──────────────────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ test     │ "docs: add note about index.js" (1 day ago by bycedric)                  │ exposdk:46.0.0         │ 401e4385-c801-4e33-ae3c-520141ee3cf8 │ android, ios     │
├──────────┼──────────────────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ main     │ "chore: configure eas build and fix entrypoint" (1 week ago by bycedric) │ exposdk:46.0.0         │ 5569dd65-9d79-42c4-9fd1-d922f71182fa │ android, ios     │
└──────────┴──────────────────────────────────────────────────────────────────────────┴────────────────────────┴──────────────────────────────────────┴──────────────────┘
                             
```

</details>

<details><summary><code>eas branch:view [name]</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test*
╰╴$ easd branch:view
✔ Which branch would you like to view? › test

Branch:
Name  test
ID    78513a47-c3f5-4b52-89f9-b021722a3aef

┌────────────────────────────────────────────────────────────┬────────────────────────┬──────────────────────────────────────┬──────────────────┐
│ Update message                                             │ Update runtime version │ Update group ID                      │ Update platforms │
├────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ "docs: add note about index.js" (19 hours ago by bycedric) │ exposdk:46.0.0         │ 401e4385-c801-4e33-ae3c-520141ee3cf8 │ android, ios     │
├────────────────────────────────────────────────────────────┼────────────────────────┼──────────────────────────────────────┼──────────────────┤
│ "docs: add note about index.js" (20 hours ago by bycedric) │ exposdk:46.0.0         │ 1988f700-b427-47f2-bffb-a1a02799786f │ android, ios     │
└────────────────────────────────────────────────────────────┴────────────────────────┴──────────────────────────────────────┴──────────────────┘

```

</details>


### New output

<details><summary><code>eas update:list</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test* 
╰╴$ easd update:list      
✔ Which branch would you like to view? › main

Branch:
Name  main
ID    7072afed-8681-4dd2-855a-cf02f224b73e

Recent update groups:

Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         5569dd65-9d79-42c4-9fd1-d922f71182fa

———

Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         1a36d4d1-dbd5-40eb-bf43-c2abf1a3dea4

```

</details>

<details><summary><code>eas update:list --all</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test* 
╰╴$ easd update:list --all

Recent update groups:

Branch           test
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "docs: add note about index.js" (1 day ago by bycedric)
Group ID         401e4385-c801-4e33-ae3c-520141ee3cf8

———

Branch           main
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         5569dd65-9d79-42c4-9fd1-d922f71182fa

———

Branch           test
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "docs: add note about index.js" (1 day ago by bycedric)
Group ID         1988f700-b427-47f2-bffb-a1a02799786f

———

Branch           main
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         1a36d4d1-dbd5-40eb-bf43-c2abf1a3dea4
                     
```

</details>

<details><summary><code>eas update:view [id]</code></summary>

_changed in PR #1463_

```log
╭╴~/Projects/bycedric/dogfood test*
╰╴$ easd update:view 5569dd65-9d79-42c4-9fd1-d922f71182fa
Update group:
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         5569dd65-9d79-42c4-9fd1-d922f71182fa
```

</details>

<details><summary><code>eas channel:list</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test* 
╰╴$ easd channel:list     

Channel:
Name  biepboep
ID    bc31c856-11b9-4f42-ab5f-a00789286518

Branches pointed at this channel and their most recent update group:

No branches are pointed to this channel.

———

Channel:
Name  test
ID    f81a4073-dc5b-4aeb-a883-eff45f8d78f8

Branches pointed at this channel and their most recent update group:

Branch           test
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "docs: add note about index.js" (1 day ago by bycedric)
Group ID         401e4385-c801-4e33-ae3c-520141ee3cf8

———

Channel:
Name  main
ID    cb801677-6904-467d-a2dc-df489cba5d49

Branches pointed at this channel and their most recent update group:

Branch           main
Rollout          75%
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         5569dd65-9d79-42c4-9fd1-d922f71182fa

```

</details>

<details><summary><code>eas channel:view [name]</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test* 
╰╴$ easd channel:view main

Channel:
Name  main
ID    cb801677-6904-467d-a2dc-df489cba5d49

Branches pointed at this channel and their most recent update group:

Branch           main
Rollout          75%
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         5569dd65-9d79-42c4-9fd1-d922f71182fa

```

</details>

<details><summary><code>eas branch:list</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test* 
╰╴$ easd branch:list      

Branches:

Branch           biepboep
Platforms        N/A
Runtime Version  N/A
Message          N/A
Group ID         N/A

———

Branch           test
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "docs: add note about index.js" (1 day ago by bycedric)
Group ID         401e4385-c801-4e33-ae3c-520141ee3cf8

———

Branch           main
Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         5569dd65-9d79-42c4-9fd1-d922f71182fa
                                          
```

</details>

<details><summary><code>eas branch:view [name]</code></summary>

```log
╭╴~/Projects/bycedric/dogfood test* 
╰╴$ easd branch:view main  

Branch:
Name  main
ID    7072afed-8681-4dd2-855a-cf02f224b73e

Recent update groups:

Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         5569dd65-9d79-42c4-9fd1-d922f71182fa

———

Platforms        android, ios
Runtime Version  exposdk:46.0.0
Message          "chore: configure eas build and fix entrypoint" (1 week ago by bycedric)
Group ID         1a36d4d1-dbd5-40eb-bf43-c2abf1a3dea4

```

</details>


# Test Plan

You can run each command to test it. As you might have spotted, I also tested with a rollout branch. Not sure what the status is of this, but you can enable that with:

```
$ eas channel:rollout <existing-channel> --branch <new-branch> --percent 25
```
