### PR TITLE
[ENG-6184] try to fix the account name discrepancy in URLs

### DIFF
--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -184,8 +184,13 @@ export async function runBuildAndSubmitAsync(
     return;
   }
 
+  const { accountName } = Object.values(buildCtxByPlatform)[0];
+
   Log.newLine();
-  printLogsUrls(startedBuilds.map(startedBuild => startedBuild.build));
+  printLogsUrls(
+    startedBuilds.map(startedBuild => startedBuild.build),
+    accountName
+  );
   Log.newLine();
 
   const submissions: SubmissionFragment[] = [];
@@ -230,13 +235,12 @@ export async function runBuildAndSubmitAsync(
     return;
   }
 
-  const { accountName } = Object.values(buildCtxByPlatform)[0];
   const builds = await waitForBuildEndAsync(graphqlClient, {
     buildIds: startedBuilds.map(({ build }) => build.id),
     accountName,
   });
   if (!flags.json) {
-    printBuildResults(builds);
+    printBuildResults(builds, accountName);
   }
 
   const haveAllBuildsFailedOrCanceled = builds.every(

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -76,7 +76,10 @@ export function formatGraphQLBuild(build: BuildFragment): string {
     },
     {
       label: 'Logs',
-      value: getBuildLogsUrl(build),
+      value: getBuildLogsUrl(
+        build,
+        build.project.__typename === 'App' ? build.project.ownerAccount.name : undefined
+      ),
     },
     {
       label: 'Artifact',

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -16,12 +16,12 @@ import Log, { learnMore } from '../../log';
 import { appPlatformDisplayNames, appPlatformEmojis } from '../../platform';
 import { getBuildLogsUrl, getInternalDistributionInstallUrl } from './url';
 
-export function printLogsUrls(builds: BuildFragment[]): void {
+export function printLogsUrls(builds: BuildFragment[], accountName: string): void {
   if (builds.length === 1) {
-    Log.log(`Build details: ${chalk.underline(getBuildLogsUrl(builds[0]))}`);
+    Log.log(`Build details: ${chalk.underline(getBuildLogsUrl(builds[0], accountName))}`);
   } else {
     builds.forEach(build => {
-      const logsUrl = getBuildLogsUrl(build);
+      const logsUrl = getBuildLogsUrl(build, accountName);
       Log.log(
         `${appPlatformEmojis[build.platform]} ${
           appPlatformDisplayNames[build.platform]
@@ -31,18 +31,20 @@ export function printLogsUrls(builds: BuildFragment[]): void {
   }
 }
 
-export function printBuildResults(builds: (BuildFragment | null)[]): void {
+export function printBuildResults(builds: (BuildFragment | null)[], accountName: string): void {
   Log.newLine();
   if (builds.length === 1) {
     const [build] = builds;
     assert(build, 'Build should be defined');
-    printBuildResult(build);
+    printBuildResult(build, accountName);
   } else {
-    (builds.filter(i => i) as BuildFragment[]).forEach(build => printBuildResult(build));
+    (builds.filter(i => i) as BuildFragment[]).forEach(build =>
+      printBuildResult(build, accountName)
+    );
   }
 }
 
-function printBuildResult(build: BuildFragment): void {
+function printBuildResult(build: BuildFragment, accountName: string): void {
   Log.addNewLineIfNone();
   if (build.status === BuildStatus.Errored) {
     const userError = build.error;
@@ -66,7 +68,7 @@ function printBuildResult(build: BuildFragment): void {
   }
 
   if (build.distribution === DistributionType.Internal) {
-    const logsUrl = getBuildLogsUrl(build);
+    const logsUrl = getBuildLogsUrl(build, accountName);
     // It's tricky to install the .apk file directly on Android so let's fallback
     // to the build details page and let people press the button to download there
     const qrcodeUrl =

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -10,12 +10,14 @@ export function getProjectDashboardUrl(accountName: string, projectName: string)
   ).toString();
 }
 
-export function getBuildLogsUrl(build: BuildFragment): string {
+export function getBuildLogsUrl(build: BuildFragment, accountName?: string): string {
   const { project } = build;
   const url =
     project.__typename !== 'App'
       ? `/builds/${build.id}`
-      : `/accounts/${project.ownerAccount.name}/projects/${project.slug}/builds/${build.id}`;
+      : `/accounts/${accountName ?? project.ownerAccount.name}/projects/${project.slug}/builds/${
+          build.id
+        }`;
 
   return new URL(url, getExpoWebsiteBaseUrl()).toString();
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-6184/build-progress-message-in-cli-shows-different-link-for-concurrency-and

We cannot repro this but it seems that after the project transfer, the account names in the build details URL and in the account concurrency URL can be sometimes different.

# How

I don't know what's causing the issue. I also couldn't reproduce it. It's probably some weird caching issue on the server side / with GraphQL cache.
My proposed solution makes the URL formatter always accept the account name even though it's available in the build object.

# Test Plan
<img width="841" alt="Screenshot 2022-10-27 at 14 57 35" src="https://user-images.githubusercontent.com/5256730/198296527-cda02525-0f85-486c-9577-e7319d24dfbe.png">


