### PR TITLE
[eas-cli] Provide more context about uploaded assets when publishing

### DIFF
--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -46,7 +46,7 @@ jest.mock('../../../graphql/queries/AppQuery');
 jest.mock('../../../graphql/queries/UpdateQuery');
 jest.mock('../../../ora', () => ({
   ora: () => ({
-    start: () => ({ succeed: () => {}, fail: () => {} }),
+    start: () => ({ succeed: () => {}, fail: () => {}, stop: () => {} }),
   }),
 }));
 jest.mock('../../../project/publish', () => ({
@@ -246,6 +246,8 @@ function mockTestExport({
     uniqueAssetCount: platforms.length,
     uniqueUploadedAssetCount: platforms.length,
     assetLimitPerUpdateGroup: 9001,
+    launchAssetCount: 2,
+    uniqueUploadedAssetPaths: [],
   });
 
   jest.mocked(Updates.getRuntimeVersion).mockReturnValue(runtimeVersion);


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes ENG-6081

This change renders the "original path" (from `assetmap.json`), or the "asset name" (from `manifest.json`, if `assetmap.json` isn't there or not containing the asset hash).

This also changes the logging text. Idea is that while app bundles are "assets" for EAS Update, users might not associate bundles as assets. Instead of "assets", I split the story into:
- "app bundles" (technically `launchAssets`)
- "normal assets" (just `assets`)
 
Not sure if that's correct, but I think that this helps communicate what was uploaded and what not.

# How

- Added `launchAssetCount` and `uniqueUploadedAssetPaths` outputs to `uploadAssetsAsync`
- Added optional `assetmap.json` loading to resolve the original filenames of the assets
  - _When there is no `assetmap.json`, e.g. when using `--skip-bundler` and `--input-dir`, it uses the name from the `manifest.json`._
- Updated the tests to reflect this

> Note, I made a big assumption that we would preferably avoid. I left a note in the code. Ideally, we could infer the "type" (launch asset or normal asset) from the `RawAsset` type. That would make things easier to determine the uniquely uploaded asset types.

## New output

<details><summary><code>When only bundles are uploaded</summary></code>

<img width="281" alt="image" src="https://user-images.githubusercontent.com/1203991/198365228-5c21e069-5722-470c-96ff-d9d98dd2a1a2.png">

```log
╭╴~/Projects/bycedric/dogfood test* 
╰╴$ easd update --branch assets --message "Testing asset logging PR"
[expo-cli] --non-interactive is not supported, use $CI=1 instead
[expo-cli] Starting Metro Bundler
[expo-cli] 
[expo-cli] Android Bundling complete 8727ms
[expo-cli] 
[expo-cli] Bundle                     Size
[expo-cli] ┌ index.ios.js          1.08 MB
[expo-cli] ├ index.android.js      1.08 MB
[expo-cli] ├ index.ios.js.map      4.14 MB
[expo-cli] └ index.android.js.map  4.15 MB
[expo-cli] 💡 JavaScript bundle sizes affect startup time. Learn more: https://expo.fyi/javascript-bundle-sizes
[expo-cli] 
[expo-cli] iOS Bundling complete 8730ms
[expo-cli] 
[expo-cli] Finished saving JS Bundles
[expo-cli] Saving assets
[expo-cli] saving /src/assets/big-asset-1.jpg
[expo-cli] saving /src/assets/big-asset-2.jpg
[expo-cli] saving /src/screens/big-asset-3.jpg
[expo-cli] saving /src/assets/big-asset-4.jpg
[expo-cli] saving /src/assets/big-asset-5.jpg
[expo-cli] saving /src/assets/big-asset-6.jpg
[expo-cli] saving /src/assets/big-asset-7.jpg
[expo-cli] saving /src/assets/big-asset-8.jpg
[expo-cli] Files successfully saved.
[expo-cli] Processing asset bundle patterns:
[expo-cli] - /Users/cedric/Projects/bycedric/dogfood/**/*
[expo-cli] Dumping asset map
[expo-cli] Dumping source maps
[expo-cli] Preparing additional debugging files
[expo-cli] Export was successful. Your exported files can be found in dist
✔ App bundling complete
✔ Uploaded 2 app bundles
✔ Uploading assets skipped - no new assets found
✔ Published!

Branch             assets
Runtime version    exposdk:46.0.0
Platform           android, ios
Update group ID    61e110a8-8b38-455d-932e-dc356f0ab0fb
Android update ID  1d6e9254-6875-42af-bb88-3679417b8bfe
iOS update ID      8a0ce4f4-f721-47e3-9502-15b57213fdf3
Message            Testing asset logging PR
Website link       https://expo.dev/accounts/bycedric/projects/dogfood-assets/updates/61e110a8-8b38-455d-932e-dc356f0ab0fb
```

</details>

<details><summary><code>When new assets are uploaded</code></summary>

<img width="222" alt="image" src="https://user-images.githubusercontent.com/1203991/198365032-eebcf5fd-d7b7-4bb4-8454-5b1d593f86e5.png">

```log
╭╴~/Projects/bycedric/dogfood test* 
╰╴$ easd update --branch assets --message "Testing asset logging PR"                            130 ↵
[expo-cli] --non-interactive is not supported, use $CI=1 instead
[expo-cli] Starting Metro Bundler
[expo-cli] 
[expo-cli] iOS Bundling complete 6545ms
[expo-cli] 
[expo-cli] Bundle                     Size
[expo-cli] ┌ index.ios.js          1.08 MB
[expo-cli] ├ index.android.js      1.08 MB
[expo-cli] ├ index.ios.js.map      4.14 MB
[expo-cli] └ index.android.js.map  4.15 MB
[expo-cli] 
[expo-cli] 💡 JavaScript bundle sizes affect startup time. Learn more: https://expo.fyi/javascript-bundle-sizes
[expo-cli] Android Bundling complete 6675ms
[expo-cli] Finished saving JS Bundles
[expo-cli] Saving assets
[expo-cli] saving /src/assets/big-asset-1.jpg
[expo-cli] saving /src/assets/big-asset-2.jpg
[expo-cli] saving /src/screens/big-asset-3.jpg
[expo-cli] saving /src/assets/big-asset-4.jpg
[expo-cli] saving /src/assets/big-asset-5.jpg
[expo-cli] saving /src/assets/big-asset-6.jpg
[expo-cli] saving /src/assets/big-asset-7.jpg
[expo-cli] saving /src/assets/big-asset-8.jpg
[expo-cli] Files successfully saved.
[expo-cli] Processing asset bundle patterns:
[expo-cli] - /Users/cedric/Projects/bycedric/dogfood/**/*
[expo-cli] Dumping asset map
[expo-cli] Dumping source maps
[expo-cli] Preparing additional debugging files
[expo-cli] Export was successful. Your exported files can be found in dist
✔ App bundling complete
✔ Uploaded 2 app bundles
✔ Uploaded 2 assets (reused 8 assets)
- /src/assets/big-asset-7.jpg
- /src/assets/big-asset-8.jpg
✔ Published!

Branch             assets
Runtime version    exposdk:46.0.0
Platform           android, ios
Update group ID    33046d11-50d1-4908-980b-6dee029c4d6a
Android update ID  a9cdccc4-7adc-41d2-97c1-ff8c3df8e0aa
iOS update ID      c07e9a46-6d03-42a3-9650-83f802921d9a
Message            Testing asset logging PR
Website link       https://expo.dev/accounts/bycedric/projects/dogfood-assets/updates/33046d11-50d1-4908-980b-6dee029c4d6a
```

</details>

# Test Plan

- `eas update`