### PR TITLE
[eas-cli][update] Attach Git Commit to EAS Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add Git commit to EAS Update record. ([#1499](https://github.com/expo/eas-cli/pull/1499) by [@fiberjw](https://github.com/fiberjw))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql-codegen.yml
+++ b/packages/eas-cli/graphql-codegen.yml
@@ -5,6 +5,8 @@ documents:
   - 'src/credentials/ios/api/graphql/**/!(*.d).{ts,tsx}'
   - 'src/credentials/android/api/graphql/**/!(*.d).{ts,tsx}'
   - 'src/commands/**/*.ts'
+  - 'src/branch/**/*.ts'
+  - 'src/channel/**/*.ts'
 generates:
   src/graphql/generated.ts:
     plugins:

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -23177,6 +23177,18 @@
             "deprecationReason": null
           },
           {
+            "name": "gitCommitHash",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "message",
             "description": "",
             "type": {
@@ -27508,6 +27520,18 @@
                 "name": "DateTime",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "gitCommitHash",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/branch/queries.ts
+++ b/packages/eas-cli/src/branch/queries.ts
@@ -128,7 +128,7 @@ export async function createUpdateBranchOnAppAsync(
     graphqlClient
       .mutation<CreateUpdateBranchForAppMutation, CreateUpdateBranchForAppMutationVariables>(
         gql`
-          mutation createUpdateBranchForApp($appId: ID!, $name: String!) {
+          mutation CreateUpdateBranchForApp($appId: ID!, $name: String!) {
             updateBranch {
               createUpdateBranchForApp(appId: $appId, name: $name) {
                 id

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -546,6 +546,7 @@ export default class UpdatePublish extends EasCommand {
               : []),
             ...(newIosUpdate ? [{ label: 'iOS update ID', value: newIosUpdate.id }] : []),
             { label: 'Message', value: truncatedMessage },
+            ...(gitCommitHash ? [{ label: 'Commit', value: gitCommitHash }] : []),
             { label: 'Website link', value: updateGroupLink },
           ])
         );

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -425,6 +425,8 @@ export default class UpdatePublish extends EasCommand {
     });
     Log.withTick(`Channel: ${chalk.bold(branchName)} pointed at branch: ${chalk.bold(branchName)}`);
 
+    const gitCommitHash = await getVcsClient().getCommitHashAsync();
+
     // Sort the updates into different groups based on their platform specific runtime versions
     const updateGroups: PublishUpdateGroupInput[] = Object.entries(runtimeToPlatformMapping).map(
       ([runtime, platforms]) => {
@@ -445,6 +447,7 @@ export default class UpdatePublish extends EasCommand {
           updateInfoGroup: localUpdateInfoGroup,
           runtimeVersion: republish ? oldRuntimeVersion : runtime,
           message: truncatedMessage,
+          gitCommitHash,
           awaitingCodeSigningInfo: !!codeSigningInfo,
         };
       }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3336,6 +3336,7 @@ export type PublicArtifacts = {
 export type PublishUpdateGroupInput = {
   awaitingCodeSigningInfo?: InputMaybe<Scalars['Boolean']>;
   branchId: Scalars['String'];
+  gitCommitHash?: InputMaybe<Scalars['String']>;
   message?: InputMaybe<Scalars['String']>;
   runtimeVersion: Scalars['String'];
   updateInfoGroup: UpdateInfoGroup;
@@ -3992,6 +3993,7 @@ export type Update = ActivityTimelineProjectActivity & {
   branchId: Scalars['ID'];
   codeSigningInfo?: Maybe<CodeSigningInfo>;
   createdAt: Scalars['DateTime'];
+  gitCommitHash?: Maybe<Scalars['String']>;
   group: Scalars['String'];
   id: Scalars['ID'];
   manifestFragment: Scalars['String'];
@@ -4540,6 +4542,15 @@ export type CreateUpdateBranchForAppMutationVariables = Exact<{
 
 export type CreateUpdateBranchForAppMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', createUpdateBranchForApp: { __typename?: 'UpdateBranch', id: string, name: string } } };
 
+export type CreateUpdateChannelOnAppMutationVariables = Exact<{
+  appId: Scalars['ID'];
+  name: Scalars['String'];
+  branchMapping: Scalars['String'];
+}>;
+
+
+export type CreateUpdateChannelOnAppMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', createUpdateChannelForApp: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
+
 export type GetBranchInfoQueryVariables = Exact<{
   appId: Scalars['String'];
   name: Scalars['String'];
@@ -4568,15 +4579,6 @@ export type CancelBuildMutationVariables = Exact<{
 
 
 export type CancelBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', cancel: { __typename?: 'Build', id: string, status: BuildStatus } } };
-
-export type CreateUpdateChannelOnAppMutationVariables = Exact<{
-  appId: Scalars['ID'];
-  name: Scalars['String'];
-  branchMapping: Scalars['String'];
-}>;
-
-
-export type CreateUpdateChannelOnAppMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', createUpdateChannelForApp: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
 
 export type DeleteUpdateChannelMutationVariables = Exact<{
   channelId: Scalars['ID'];


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

We'd like for users to be able to associate an Update with a Git commit.

# How

I added `gitCommitHash` to the input we send to our GraphQL API for creating Update records. I also had to fix a few GraphQL codegen issues because we did a refactor which changed where some GraphQL mutations were defined.

I use the same method that we use to get the git commit hash for builds: `await vcsClient.getCommitHashAsync()`

# Test Plan

Using a local version of the CLI and website, I published a new update on Staging and used the website to render the new commit data (and GitHub link 👀 )

![Screen Shot 2022-11-01 at 16 11 30](https://user-images.githubusercontent.com/12488826/199334014-1676c83b-5bbc-4bba-b08c-68302b4efbdc.png)
![Screen Shot 2022-11-01 at 16 10 53](https://user-images.githubusercontent.com/12488826/199334015-e04cf007-9198-4824-915a-0ceae51bb83f.png)

Updated log:

![Screen Shot 2022-11-01 at 16 33 20](https://user-images.githubusercontent.com/12488826/199335614-63b97a51-cc07-4eb1-9627-2b9b2dc813f5.png)

