### PR TITLE
refactor(update): deprecate the --auto flag for eas update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Remove friction from the initial EAS update setup. ([#1479](https://github.com/expo/eas-cli/pull/1479) by [@byCedric](https://github.com/byCedric))
+- Deprecate `--auto` flag on `eas update` and always default `--branch` or `--message` from git. ([#1500](https://github.com/expo/eas-cli/pull/1500) by [@byCedric](https://github.com/byCedric))
 
 ## [2.6.0](https://github.com/expo/eas-cli/releases/tag/v2.6.0) - 2022-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Remove friction from the initial EAS update setup. ([#1479](https://github.com/expo/eas-cli/pull/1479) by [@byCedric](https://github.com/byCedric))
+
 ## [2.6.0](https://github.com/expo/eas-cli/releases/tag/v2.6.0) - 2022-10-27
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -1,25 +1,9 @@
-import { ExpoConfig, modifyConfigAsync } from '@expo/config';
-import { Platform, Workflow } from '@expo/eas-build-job';
 import { Flags } from '@oclif/core';
-import assert from 'assert';
-import chalk from 'chalk';
 
-import { getEASUpdateURL } from '../../api';
 import EasCommand from '../../commandUtils/EasCommand';
-import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
-import { AppPlatform } from '../../graphql/generated';
-import Log, { learnMore } from '../../log';
-import { RequestedPlatform, appPlatformDisplayNames } from '../../platform';
-import {
-  installExpoUpdatesAsync,
-  isExpoUpdatesInstalledOrAvailable,
-} from '../../project/projectUtils';
-import { resolveWorkflowPerPlatformAsync } from '../../project/workflow';
-import { syncUpdatesConfigurationAsync as syncAndroidUpdatesConfigurationAsync } from '../../update/android/UpdatesModule';
-import { syncUpdatesConfigurationAsync as syncIosUpdatesConfigurationAsync } from '../../update/ios/UpdatesModule';
-
-const DEFAULT_MANAGED_RUNTIME_VERSION = { policy: 'sdkVersion' } as const;
-const DEFAULT_BARE_RUNTIME_VERSION = '1.0.0' as const;
+import Log from '../../log';
+import { RequestedPlatform } from '../../platform';
+import { ensureEASUpdatesIsConfiguredAsync } from '../../update/configure';
 
 export default class UpdateConfigure extends EasCommand {
   static override description = 'configure the project to support EAS Update';
@@ -42,294 +26,24 @@ export default class UpdateConfigure extends EasCommand {
     Log.log(
       '💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.'
     );
+
     const { flags } = await this.parse(UpdateConfigure);
+    const platform = flags.platform as RequestedPlatform;
     const {
       projectConfig: { projectId, exp, projectDir },
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(UpdateConfigure, {
       nonInteractive: true,
     });
-    const platform = flags.platform as RequestedPlatform;
 
-    if (!isExpoUpdatesInstalledOrAvailable(projectDir, exp.sdkVersion)) {
-      await installExpoUpdatesAsync(projectDir);
-    }
-
-    const workflows = await resolveWorkflowPerPlatformAsync(projectDir);
-
-    const updatedExp = await configureAppJSONForEASUpdateAsync({
-      projectDir,
-      projectId,
+    await ensureEASUpdatesIsConfiguredAsync(graphqlClient, {
       exp,
-      platform,
-      workflows,
-    });
-
-    await configureNativeFilesForEASUpdateAsync({
-      projectDir,
       projectId,
-      exp: updatedExp,
+      projectDir,
       platform,
-      workflows,
-      graphqlClient,
     });
-
-    Log.addNewLineIfNone();
-    Log.warn(
-      `All builds of your app going forward will be eligible to receive updates published with EAS Update.`
-    );
 
     Log.addNewLineIfNone();
     Log.log(`🎉 Your app is configured to run EAS Update!`);
-  }
-}
-
-type ConfigureForEASUpdateArgs = {
-  projectDir: string;
-  exp: ExpoConfig;
-  platform: RequestedPlatform;
-  workflows: Record<Platform, Workflow>;
-  projectId: string;
-};
-
-export async function configureAppJSONForEASUpdateAsync({
-  projectDir,
-  exp,
-  platform,
-  workflows,
-  projectId,
-}: ConfigureForEASUpdateArgs): Promise<ExpoConfig> {
-  // this command is non-interactive in the way it was designed
-  const easUpdateURL = getEASUpdateURL(projectId);
-  const updates = { ...exp.updates, url: easUpdateURL };
-
-  const androidDefaultRuntimeVersion =
-    workflows.android === Workflow.GENERIC
-      ? DEFAULT_BARE_RUNTIME_VERSION
-      : DEFAULT_MANAGED_RUNTIME_VERSION;
-  const iosDefaultRuntimeVersion =
-    workflows.ios === Workflow.GENERIC
-      ? DEFAULT_BARE_RUNTIME_VERSION
-      : DEFAULT_MANAGED_RUNTIME_VERSION;
-
-  const newAndroidRuntimeVersion =
-    exp.android?.runtimeVersion ?? exp.runtimeVersion ?? androidDefaultRuntimeVersion;
-  const newIosRuntimeVersion =
-    exp.ios?.runtimeVersion ?? exp.runtimeVersion ?? iosDefaultRuntimeVersion;
-
-  let newConfig: Partial<ExpoConfig>;
-  let newConfigOnlyAddedValues: Partial<ExpoConfig>;
-  switch (platform) {
-    case RequestedPlatform.All: {
-      if (isRuntimeEqual(newAndroidRuntimeVersion, newIosRuntimeVersion)) {
-        newConfig = {
-          runtimeVersion: newAndroidRuntimeVersion,
-          android: {
-            ...exp.android,
-            runtimeVersion: undefined,
-          },
-          ios: { ...exp.ios, runtimeVersion: undefined },
-          updates,
-        };
-        newConfigOnlyAddedValues = {
-          runtimeVersion: newAndroidRuntimeVersion,
-          ...(exp.android && 'runtimeVersion' in exp.android
-            ? {
-                android: {
-                  runtimeVersion: '<remove this key>',
-                },
-              }
-            : {}),
-          ...(exp.ios && 'runtimeVersion' in exp.ios
-            ? {
-                ios: {
-                  runtimeVersion: '<remove this key>',
-                },
-              }
-            : {}),
-          updates: {
-            url: easUpdateURL,
-          },
-        };
-      } else {
-        newConfig = {
-          runtimeVersion: undefined, // top level runtime is redundant if it is specified in both android and ios
-          android: {
-            ...exp.android,
-            runtimeVersion: newAndroidRuntimeVersion,
-          },
-          ios: {
-            ...exp.ios,
-            runtimeVersion: newIosRuntimeVersion,
-          },
-          updates,
-        };
-        newConfigOnlyAddedValues = {
-          ...('runtimeVersion' in exp
-            ? {
-                runtimeVersion: '<remove this key>', // top level runtime is redundant if it is specified in both android and ios
-              }
-            : {}),
-          android: {
-            runtimeVersion: newAndroidRuntimeVersion,
-          },
-          ios: {
-            runtimeVersion: newIosRuntimeVersion,
-          },
-          updates: {
-            url: easUpdateURL,
-          },
-        };
-      }
-      break;
-    }
-    case RequestedPlatform.Android: {
-      newConfig = {
-        android: {
-          ...exp.android,
-          runtimeVersion: newAndroidRuntimeVersion,
-        },
-        updates,
-      };
-      newConfigOnlyAddedValues = {
-        android: {
-          runtimeVersion: newAndroidRuntimeVersion,
-        },
-        updates: {
-          url: easUpdateURL,
-        },
-      };
-      break;
-    }
-    case RequestedPlatform.Ios: {
-      newConfig = {
-        ios: {
-          ...exp.ios,
-          runtimeVersion: newIosRuntimeVersion,
-        },
-        updates,
-      };
-      newConfigOnlyAddedValues = {
-        ios: {
-          runtimeVersion: newIosRuntimeVersion,
-        },
-        updates: {
-          url: easUpdateURL,
-        },
-      };
-      break;
-    }
-    default: {
-      throw new Error(`Unsupported platform: ${platform}`);
-    }
-  }
-
-  const result = await modifyConfigAsync(projectDir, newConfig);
-
-  const preexistingAndroidRuntimeVersion = exp.android?.runtimeVersion ?? exp.runtimeVersion;
-  const preexistingIosRuntimeVersion = exp.ios?.runtimeVersion ?? exp.runtimeVersion;
-  switch (result.type) {
-    case 'success':
-      if (exp.updates?.url) {
-        if (exp.updates.url !== easUpdateURL) {
-          Log.withTick(
-            `Overwrote "${exp.updates?.url}" with "${easUpdateURL}" for the updates.url value in app.json`
-          );
-        }
-      } else {
-        Log.withTick(`Set updates.url value, to "${easUpdateURL}" in app.json`);
-      }
-
-      if (
-        !preexistingAndroidRuntimeVersion &&
-        [RequestedPlatform.Android, RequestedPlatform.All].includes(platform)
-      ) {
-        Log.withTick(
-          `Set ${appPlatformDisplayNames[AppPlatform.Android]} runtimeVersion to "${JSON.stringify(
-            newConfig.android?.runtimeVersion ?? newConfig.runtimeVersion
-          )}" in app.json`
-        );
-      }
-      if (
-        !preexistingIosRuntimeVersion &&
-        [RequestedPlatform.Ios, RequestedPlatform.All].includes(platform)
-      ) {
-        Log.withTick(
-          `Set ${appPlatformDisplayNames[AppPlatform.Ios]} runtimeVersion to "${JSON.stringify(
-            newConfig.ios?.runtimeVersion ?? newConfig.runtimeVersion
-          )}" in app.json`
-        );
-      }
-      break;
-    case 'warn': {
-      Log.addNewLineIfNone();
-      Log.warn(
-        `It looks like you are using a dynamic configuration! ${learnMore(
-          'https://docs.expo.dev/workflow/configuration/#dynamic-configuration-with-appconfigjs)'
-        )}`
-      );
-      Log.warn(
-        `In order to finish configuring your project for EAS Update, you are going to need manually add the following to your ${chalk.bold(
-          'app.config.js'
-        )}:\n${learnMore('https://expo.fyi/eas-update-config.md')}\n`
-      );
-      Log.log(chalk.bold(JSON.stringify(newConfigOnlyAddedValues, null, 2)));
-      Log.addNewLineIfNone();
-      if (workflows['android'] === Workflow.GENERIC || workflows['ios'] === Workflow.GENERIC) {
-        Log.warn(
-          `You will also have to manually edit the projects ${chalk.bold(
-            'Expo.plist/AndroidManifest.xml'
-          )}. ${learnMore('https://expo.fyi/eas-update-config.md#native-configuration')}`
-        );
-      }
-      Log.addNewLineIfNone();
-      throw new Error(result.message);
-    }
-    case 'fail':
-      throw new Error(result.message);
-    default:
-      throw new Error('Unexpected result type from modifyConfigAsync');
-  }
-  assert(result.config, 'A successful result should have a config');
-
-  Log.withTick(`Configured ${chalk.bold('app.json')} for EAS Update`);
-
-  return result.config.expo;
-}
-
-export async function configureNativeFilesForEASUpdateAsync({
-  projectDir,
-  exp,
-  platform,
-  workflows,
-  projectId,
-  graphqlClient,
-}: ConfigureForEASUpdateArgs & { graphqlClient: ExpoGraphqlClient }): Promise<void> {
-  if (
-    [RequestedPlatform.Android, RequestedPlatform.All].includes(platform) &&
-    workflows.android === Workflow.GENERIC
-  ) {
-    await syncAndroidUpdatesConfigurationAsync(graphqlClient, projectDir, exp, projectId);
-    Log.withTick(`Configured ${chalk.bold('AndroidManifest.xml')} for EAS Update`);
-  }
-  if (
-    [RequestedPlatform.Ios, RequestedPlatform.All].includes(platform) &&
-    workflows.ios === Workflow.GENERIC
-  ) {
-    await syncIosUpdatesConfigurationAsync(graphqlClient, projectDir, exp, projectId);
-    Log.withTick(`Configured ${chalk.bold('Expo.plist')} for EAS Update`);
-  }
-}
-
-function isRuntimeEqual(
-  runtimeVersionA: string | { policy: 'sdkVersion' | 'nativeVersion' | 'appVersion' },
-  runtimeVersionB: string | { policy: 'sdkVersion' | 'nativeVersion' | 'appVersion' }
-): boolean {
-  if (typeof runtimeVersionA === 'string' && typeof runtimeVersionB === 'string') {
-    return runtimeVersionA === runtimeVersionB;
-  } else if (typeof runtimeVersionA === 'object' && typeof runtimeVersionB === 'object') {
-    return runtimeVersionA.policy === runtimeVersionB.policy;
-  } else {
-    return false;
   }
 }

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -1,6 +1,7 @@
 import { Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
+import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import Log from '../../log';
 import { RequestedPlatform } from '../../platform';
 import { ensureEASUpdatesIsConfiguredAsync } from '../../update/configure';
@@ -15,6 +16,7 @@ export default class UpdateConfigure extends EasCommand {
       options: ['android', 'ios', 'all'],
       default: 'all',
     }),
+    ...EASNonInteractiveFlag,
   };
 
   static override contextDefinition = {
@@ -23,18 +25,18 @@ export default class UpdateConfigure extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    Log.log(
-      '💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.'
-    );
-
     const { flags } = await this.parse(UpdateConfigure);
     const platform = flags.platform as RequestedPlatform;
     const {
       projectConfig: { projectId, exp, projectDir },
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(UpdateConfigure, {
-      nonInteractive: true,
+      nonInteractive: flags['non-interactive'],
     });
+
+    Log.log(
+      '💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.'
+    );
 
     await ensureEASUpdatesIsConfiguredAsync(graphqlClient, {
       exp,

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -38,7 +38,11 @@ import {
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { promptAsync } from '../../prompts';
 import { selectUpdateGroupOnBranchAsync } from '../../update/queries';
-import { checkEASUpdateURLIsSetAsync, formatUpdateMessage } from '../../update/utils';
+import {
+  checkEASUpdateURLIsSetAsync,
+  formatUpdateMessage,
+  truncateString as truncateUpdateMessage,
+} from '../../update/utils';
 import {
   checkManifestBodyAgainstUpdateInfoGroup,
   getCodeSigningInfoAsync,
@@ -182,7 +186,7 @@ export default class UpdatePublish extends EasCommand {
     const [runtimeVersions, exp] = await getRuntimeVersionObjectAsync(
       expBeforeRuntimeVersionUpdate,
       platformFlag,
-      projectDir,
+      projectDir
       // projectId,
       // nonInteractive,
       // graphqlClient,
@@ -367,7 +371,10 @@ export default class UpdatePublish extends EasCommand {
       }
     }
 
-    const truncatedMessage = truncatePublishUpdateMessage(updateMessage!);
+    const truncatedMessage = truncateUpdateMessage(updateMessage!, 1024);
+    if (truncatedMessage !== updateMessage) {
+      Log.warn('Update message exceeds the allowed 1024 character limit. Truncating message...');
+    }
 
     const runtimeToPlatformMapping: Record<string, string[]> = {};
     for (const runtime of new Set(Object.values(runtimeVersions))) {
@@ -575,7 +582,7 @@ function transformRuntimeVersions(exp: ExpoConfig, platforms: Platform[]): Recor
 async function getRuntimeVersionObjectAsync(
   exp: ExpoConfig,
   platformFlag: PublishPlatformFlag,
-  projectDir: string,
+  projectDir: string
   // projectId: string,
   // nonInteractive: boolean,
   // graphqlClient: ExpoGraphqlClient,
@@ -661,11 +668,3 @@ async function getRuntimeVersionObjectAsync(
   //   return [transformRuntimeVersions(newConfig, platforms), newConfig];
   // }
 }
-
-export const truncatePublishUpdateMessage = (originalMessage: string): string => {
-  if (originalMessage.length > 1024) {
-    Log.warn('Update message exceeds the allowed 1024 character limit. Truncating message...');
-    return originalMessage.substring(0, 1021) + '...';
-  }
-  return originalMessage;
-};

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -175,12 +175,17 @@ export default class UpdatePublish extends EasCommand {
 
     await maybeWarnAboutEasOutagesAsync(graphqlClient, [StatuspageServiceName.EasUpdate]);
 
-    const { exp } = await ensureEASUpdatesIsConfiguredAsync(graphqlClient, {
+    const { projectChanged } = await ensureEASUpdatesIsConfiguredAsync(graphqlClient, {
       exp: expPossiblyWithoutEasUpdateConfigured,
       platform: platformFlag,
       projectDir,
       projectId,
     });
+
+    // Reload the project config when the project was changed
+    const exp = projectChanged
+      ? (await getDynamicProjectConfigAsync()).exp
+      : expPossiblyWithoutEasUpdateConfigured;
 
     const codeSigningInfo = await getCodeSigningInfoAsync(expPrivate, privateKeyPath);
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -184,11 +184,7 @@ export default class UpdatePublish extends EasCommand {
 
     const codeSigningInfo = await getCodeSigningInfoAsync(expPrivate, privateKeyPath);
 
-    const runtimeVersions = await getRuntimeVersionObjectAsync(
-      expPossiblyWithoutEasUpdateConfigured,
-      platformFlag,
-      projectDir
-    );
+    const runtimeVersions = await getRuntimeVersionObjectAsync(exp, platformFlag, projectDir);
 
     if (!branchName) {
       if (autoFlag) {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -117,8 +117,9 @@ export default class UpdatePublish extends EasCommand {
       required: false,
     }),
     auto: Flags.boolean({
+      // Deprecated, but OCLIF deprecated logs is not great
       description:
-        'Use the current git branch and commit message for the EAS branch and update message',
+        'Use the current git branch and commit message for the EAS branch and update message (deprecated)',
       default: false,
     }),
     'private-key-path': Flags.string({
@@ -532,12 +533,12 @@ export default class UpdatePublish extends EasCommand {
 
   private sanitizeFlags(flags: RawUpdateFlags): UpdateFlags {
     const nonInteractive = flags['non-interactive'] ?? false;
-
     const { auto, branch: branchName, message: updateMessage } = flags;
-    if (nonInteractive && !auto && !(branchName && updateMessage)) {
-      Errors.error(
-        '--auto or both --branch and --message are required when updating in non-interactive mode',
-        { exit: 1 }
+
+    if (auto) {
+      // When `branchName` or `updateMessage` is omitted, we always (auto) default to git
+      Log.warn(
+        '--auto flag is deprecated. When --branch and --message are not provided, both flags default to git branch and commit message.'
       );
     }
 
@@ -548,7 +549,8 @@ export default class UpdatePublish extends EasCommand {
     }
 
     return {
-      auto,
+      // TODO(cedric): remove this flag when refactoring the update command
+      auto: true,
       branchName,
       updateMessage,
       groupId,

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -97,10 +97,20 @@ export async function validateAppVersionRuntimePolicySupportAsync(
   );
 }
 
-export async function installExpoUpdatesAsync(projectDir: string): Promise<void> {
+export async function installExpoUpdatesAsync(
+  projectDir: string,
+  options?: { silent: boolean }
+): Promise<void> {
   Log.log(chalk.gray`> npx expo install expo-updates`);
-  await expoCommandAsync(projectDir, ['install', 'expo-updates']);
-  Log.newLine();
+  try {
+    await expoCommandAsync(projectDir, ['install', 'expo-updates'], { silent: options?.silent });
+    Log.withTick('Installed expo-updates');
+  } catch (error: any) {
+    if (options?.silent) {
+      Log.error('stdout' in error ? error.stdout : error.message);
+    }
+    throw error;
+  }
 }
 
 export async function getOwnerAccountForProjectIdAsync(

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -104,7 +104,6 @@ export async function installExpoUpdatesAsync(
   Log.log(chalk.gray`> npx expo install expo-updates`);
   try {
     await expoCommandAsync(projectDir, ['install', 'expo-updates'], { silent: options?.silent });
-    Log.withTick('Installed expo-updates');
   } catch (error: any) {
     if (options?.silent) {
       Log.error('stdout' in error ? error.stdout : error.message);

--- a/packages/eas-cli/src/update/__tests__/utils-test.ts
+++ b/packages/eas-cli/src/update/__tests__/utils-test.ts
@@ -1,28 +1,18 @@
-import Log from '../../log';
 import { getPlatformsForGroup, truncateString } from '../utils';
 
 describe('update utility functions', () => {
   describe(truncateString, () => {
-    const warnSpy = jest.spyOn(Log, 'warn');
-    beforeEach(() => {
-      warnSpy.mockClear();
-    });
-
     it('does not alter messages with less than 1024 characters', () => {
       const message = 'Small message =)';
-      const truncatedMessage = truncateString(message);
+      const truncatedMessage = truncateString(message, 1024);
       expect(truncatedMessage).toEqual(message);
-      expect(warnSpy).not.toBeCalled();
     });
 
     it('truncates messages to a length of 1024, including ellipses', () => {
       const longMessage = Array.from({ length: 2024 }, () => 'a').join('');
-      const truncatedMessage = truncateString(longMessage);
+      const truncatedMessage = truncateString(longMessage, 1024);
       expect(truncatedMessage.length).toEqual(1024);
       expect(truncatedMessage.slice(-3)).toEqual('...');
-      expect(warnSpy).toBeCalledWith(
-        'Update message exceeds the allowed 1024 character limit. Truncating message...'
-      );
     });
   });
 

--- a/packages/eas-cli/src/update/__tests__/utils-test.ts
+++ b/packages/eas-cli/src/update/__tests__/utils-test.ts
@@ -1,9 +1,8 @@
-import { truncatePublishUpdateMessage } from '../../commands/update';
 import Log from '../../log';
-import { getPlatformsForGroup } from '../utils';
+import { getPlatformsForGroup, truncateString } from '../utils';
 
 describe('update utility functions', () => {
-  describe(truncatePublishUpdateMessage.name, () => {
+  describe(truncateString, () => {
     const warnSpy = jest.spyOn(Log, 'warn');
     beforeEach(() => {
       warnSpy.mockClear();
@@ -11,14 +10,14 @@ describe('update utility functions', () => {
 
     it('does not alter messages with less than 1024 characters', () => {
       const message = 'Small message =)';
-      const truncatedMessage = truncatePublishUpdateMessage(message);
+      const truncatedMessage = truncateString(message);
       expect(truncatedMessage).toEqual(message);
       expect(warnSpy).not.toBeCalled();
     });
 
     it('truncates messages to a length of 1024, including ellipses', () => {
       const longMessage = Array.from({ length: 2024 }, () => 'a').join('');
-      const truncatedMessage = truncatePublishUpdateMessage(longMessage);
+      const truncatedMessage = truncateString(longMessage);
       expect(truncatedMessage.length).toEqual(1024);
       expect(truncatedMessage.slice(-3)).toEqual('...');
       expect(warnSpy).toBeCalledWith(

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -95,14 +95,14 @@ export async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
   // NOTE(cedric): might be better with a mergeDeep method, or handle in `modifyConfigAsync`
   const mergedExp = {
     runtimeVersion: modifyConfig.runtimeVersion ?? exp.runtimeVersion,
-    updates: { ...exp.updates, url: modifyConfig.updates?.url ?? exp.updates?.url },
+    updates: { ...exp.updates, ...modifyConfig.updates },
     android: {
       ...exp.android,
-      runtimeVersion: modifyConfig.android?.runtimeVersion ?? exp.android?.runtimeVersion,
+      ...modifyConfig.android,
     },
     ios: {
       ...exp.ios,
-      runtimeVersion: modifyConfig.ios?.runtimeVersion ?? exp.ios?.runtimeVersion,
+      ...modifyConfig.ios,
     },
   };
 

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -108,6 +108,7 @@ export async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
   };
 
   // TODO(cedric): check where these properties are coming from, they pop up in `eas update`
+  delete mergedExp['_internal'];
   delete mergedExp.originalFullName;
   delete mergedExp.currentFullName;
   delete mergedExp.platforms;

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -232,6 +232,15 @@ export async function ensureEASUpdatesIsConfiguredNativelyAsync(
   }
 }
 
+/**
+ * Make sure EAS Update is fully configured in the current project.
+ * This goes over a checklist and performs the following checks or changes:
+ *   - Enure the `expo-updates` package is currently installed.
+ *   - Ensure `app.json` is configured for EAS Updates
+ *     - Sets `runtimeVersion` if not set
+ *     - Sets `updates.url` if not set
+ *   - Ensure latest changes are reflected in the native config, if any
+ */
 export async function ensureEASUpdatesIsConfiguredAsync(
   graphqlClient: ExpoGraphqlClient,
   {

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -108,6 +108,7 @@ export async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
   };
 
   // TODO(cedric): check where these properties are coming from, they pop up in `eas update`
+  delete mergedExp.sdkVersion; // Note(cedric): this is always returned from `getConfig`, but we don't want to set it
   delete mergedExp['_internal'];
   delete mergedExp.originalFullName;
   delete mergedExp.currentFullName;

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -239,7 +239,7 @@ export async function ensureEASUpdatesIsConfiguredNativelyAsync(
 export async function ensureEASUpdatesIsConfiguredAsync(
   graphqlClient: ExpoGraphqlClient,
   {
-    exp,
+    exp: expWithoutUpdates,
     projectId,
     projectDir,
     platform,
@@ -249,25 +249,29 @@ export async function ensureEASUpdatesIsConfiguredAsync(
     projectDir: string;
     platform: RequestedPlatform;
   }
-): Promise<{ projectChanged: boolean; exp: ExpoConfig }> {
-  const hasExpoUpdates = isExpoUpdatesInstalledOrAvailable(projectDir, exp.sdkVersion);
+): Promise<{ projectChanged: boolean }> {
+  const hasExpoUpdates = isExpoUpdatesInstalledOrAvailable(
+    projectDir,
+    expWithoutUpdates.sdkVersion
+  );
   if (!hasExpoUpdates) {
     await installExpoUpdatesAsync(projectDir, { silent: true });
     Log.withTick('Installed expo updates');
   }
 
   const workflows = await resolveWorkflowPerPlatformAsync(projectDir);
-  const { projectChanged, exp: newExp } = await ensureEASUpdatesIsConfiguredInExpoConfigAsync({
-    exp,
-    projectDir,
-    projectId,
-    platform,
-    workflows,
-  });
+  const { projectChanged, exp: expWithUpdates } =
+    await ensureEASUpdatesIsConfiguredInExpoConfigAsync({
+      exp: expWithoutUpdates,
+      projectDir,
+      projectId,
+      platform,
+      workflows,
+    });
 
   if (projectChanged || !hasExpoUpdates) {
     await ensureEASUpdatesIsConfiguredNativelyAsync(graphqlClient, {
-      exp: newExp,
+      exp: expWithUpdates,
       projectDir,
       projectId,
       platform,
@@ -283,5 +287,5 @@ export async function ensureEASUpdatesIsConfiguredAsync(
     Log.newLine();
   }
 
-  return { projectChanged, exp: newExp };
+  return { projectChanged };
 }

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -94,7 +94,6 @@ export async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
 
   // NOTE(cedric): might be better with a mergeDeep method, or handle in `modifyConfigAsync`
   const mergedExp = {
-    ...exp,
     runtimeVersion: modifyConfig.runtimeVersion ?? exp.runtimeVersion,
     updates: { ...exp.updates, url: modifyConfig.updates?.url ?? exp.updates?.url },
     android: {
@@ -107,12 +106,6 @@ export async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
     },
   };
 
-  // TODO(cedric): check where these properties are coming from, they pop up in `eas update`
-  delete mergedExp.sdkVersion; // Note(cedric): this is always returned from `getConfig`, but we don't want to set it
-  delete mergedExp['_internal'];
-  delete mergedExp.originalFullName;
-  delete mergedExp.currentFullName;
-  delete mergedExp.platforms;
   const result = await modifyConfigAsync(projectDir, mergedExp);
 
   switch (result.type) {
@@ -121,7 +114,7 @@ export async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
       return {
         projectChanged: true,
         // TODO(cedric): fix return type of `modifyConfigAsync` to avoid `null` for type === success repsonses
-        exp: result.config?.expo ?? mergedExp,
+        exp: result.config?.expo!,
       };
 
     case 'warn':

--- a/packages/eas-cli/src/utils/statuspageService.ts
+++ b/packages/eas-cli/src/utils/statuspageService.ts
@@ -33,6 +33,7 @@ function warnAboutServiceOutage(service: StatuspageServiceFragment): void {
 
   const outageType = service.status === StatuspageServiceStatus.MajorOutage ? 'major' : 'partial';
 
+  Log.addNewLineIfNone();
   Log.warn(
     chalk.bold(`${humanReadableServiceName[service.name]} is experiencing a ${outageType} outage.`)
   );


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Users can define a custom `--branch` and `--message` value when publishing an update. Previously, when one of these wasn't provided, it would fail unless you added the `--auto` flag.

With this change, you don't need to provide `--auto`.

# How

I did not use the `deprecated: true` option on the flag, which always logs a warning (even when not using the flag)
![image](https://user-images.githubusercontent.com/1203991/199349527-d046530f-7d59-48b9-9395-80bda0ed511d.png)

Instead, I moved this logging to `sanitizeFlags` and only warn people not to use it when they actually use it.

When used | When omitted
--- | ---
![image](https://user-images.githubusercontent.com/1203991/199349734-42ad243e-11fd-4e91-8898-0b898138dbc7.png) | ![image](https://user-images.githubusercontent.com/1203991/199349801-9794f10c-3e3b-476d-a0be-406fd596a644.png)


# Test Plan

You can use my test version of EAS CLI with `npx @bycedric/some-cli-test@3.0.5 <command>`, or build it yourself.

- `eas update`
- `eas update --auto`
- `eas update --republish --groupId`
