### PR TITLE
[eas-json] fix ordering of distribution enum values

### DIFF
--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -113,7 +113,7 @@
           "markdownDescription": "The channel is a name we can give to multiple builds to identify them easily. [Learn more](https://docs.expo.dev/eas-update/how-eas-update-works/)\n\n**This field only applies to the EAS Update service**, if your project still uses Classic Updates then use the [releaseChannel](https://docs.expo.dev/build-reference/eas-json/#releasechannel) field instead."
         },
         "distribution": {
-          "enum": ["store", "internal"],
+          "enum": ["internal", "store"],
           "description": "The method of distributing your app. Learn more: https://docs.expo.dev/build/internal-distribution/",
           "markdownDescription": "The method of distributing your app.\n\n- `internal` - with this option you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK or IPA file. Otherwise, the shareable URL will be useless. [Learn more](https://docs.expo.dev/build/internal-distribution/)\n- `store` - produces builds for store uploads, your build URLs won't be shareable.",
           "markdownEnumDescriptions": [


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

In the vscode extension, the intellisense for the `distribution` property of a build profile is incorrect. The `store` value gets the markdown description for the `internal` value, and vice versa:

<img width="717" alt="image" src="https://user-images.githubusercontent.com/33101443/200111211-05a0c21c-404a-4d0b-9013-46b53fac2b72.png">

# How

I reordered the enum values to corresponding with the ordering in the markdown descriptions. (In the descriptions, `internal` appears first, but it was second in the array of values).

# Test Plan

This is a trivial change, so I have not tested it.
