### PR TITLE
[eas-cli] Remove dependency on expo package from eas init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fixed the values of the distribution enum on the build profile schema receiving the incorrect descriptions. ([#1504](https://github.com/expo/eas-cli/pull/1504) by [@macksal](https://github.com/macksal))
+- Remove hard dependency on expo package being installed to init a project. ([#1517](https://github.com/expo/eas-cli/pull/1517) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -25,9 +25,13 @@ export async function saveProjectIdToAppConfigAsync(
   options: { env?: Env } = {}
 ): Promise<void> {
   const exp = getExpoConfig(projectDir, options);
-  const result = await modifyConfigAsync(projectDir, {
-    extra: { ...exp.extra, eas: { ...exp.extra?.eas, projectId } },
-  });
+  const result = await modifyConfigAsync(
+    projectDir,
+    {
+      extra: { ...exp.extra, eas: { ...exp.extra?.eas, projectId } },
+    },
+    { skipSDKVersionRequirement: true }
+  );
 
   switch (result.type) {
     case 'success':


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Hotfix because `eas build` should work out of the box with a new `@react-native-community/cli` initialized project

# How

See code

# Test Plan

```
npx react-native init my-project
cd my-project
eas init # or eas build
```

Without this patch, you will see an error like this:

```
eas init
✔ Which account should own this project? › brents
✔ Existing project found: @brents/trybuildsizeios (ID: 37e39e45-a33e-4541-bee5-625109b2b10c). Link this project? … yes
    ConfigError: Cannot determine which native SDK version your project uses because
    the module `expo` is not installed. Please install it with `yarn add expo` and try
     again.
    Code: MODULE_NOT_FOUND
```

Works with this patch

