### PR TITLE
[scripts] run yarn install before running scripts

### DIFF
--- a/scripts/bin/run
+++ b/scripts/bin/run
@@ -5,5 +5,8 @@ set -eo pipefail
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 
 pushd $SCRIPTS_DIR >/dev/null 2>&1
+# Install modules
+yarn --silent
+# Run script
 yarn --silent $@
 popd >/dev/null 2>&1


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

@brentvatne has run into an issue where he couldn't trigger a release because he didn't have node modules installed in the `scripts` directory.

# How

Run `yarn install` before running scripts from `scripts`.

# Test Plan

- Remove `node_modules` from `scripts`.
- Run `yarn lint-changelog` in the root dir and see it passes.