### PR TITLE
[eas-cli] Pass env variables when resolving config in credentials manager.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Use envs from the build profile to resolve credentials in `eas credentials`. ([#1520](https://github.com/expo/eas-cli/pull/1520) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [2.7.0](https://github.com/expo/eas-cli/releases/tag/v2.7.0) - 2022-11-11

--- a/packages/eas-cli/src/commands/credentials.ts
+++ b/packages/eas-cli/src/commands/credentials.ts
@@ -13,6 +13,7 @@ export default class Credentials extends EasCommand {
   static override contextDefinition = {
     ...this.ContextOptions.LoggedIn,
     ...this.ContextOptions.OptionalProjectConfig,
+    ...this.ContextOptions.DynamicProjectConfig,
     ...this.ContextOptions.Analytics,
   };
 
@@ -21,6 +22,7 @@ export default class Credentials extends EasCommand {
     const {
       loggedIn: { actor, graphqlClient },
       projectConfig,
+      getDynamicProjectConfigAsync,
       analytics,
     } = await this.getContextAsync(Credentials, {
       nonInteractive: false,
@@ -31,6 +33,7 @@ export default class Credentials extends EasCommand {
       graphqlClient,
       analytics,
       projectConfig ?? null,
+      getDynamicProjectConfigAsync,
       flags.platform
     ).runAsync();
   }

--- a/packages/eas-cli/src/credentials/manager/HelperActions.ts
+++ b/packages/eas-cli/src/credentials/manager/HelperActions.ts
@@ -1,4 +1,5 @@
 import { Analytics } from '../../analytics/AnalyticsManager';
+import { DynamicConfigContextFn } from '../../commandUtils/context/DynamicProjectConfigContextField';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import Log from '../../log';
 import { pressAnyKeyToContinueAsync } from '../../prompts';
@@ -10,6 +11,7 @@ export interface Action<T = void> {
   graphqlClient: ExpoGraphqlClient;
   analytics: Analytics;
   projectInfo: CredentialsContextProjectInfo | null;
+  getDynamicProjectConfigAsync: DynamicConfigContextFn;
   runAsync(ctx: CredentialsContext): Promise<T>;
 }
 

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -27,7 +27,7 @@ import {
   displayAndroidAppCredentials,
   displayEmptyAndroidCredentials,
 } from '../android/utils/printCredentials';
-import { CredentialsContext } from '../context';
+import { CredentialsContext, CredentialsContextProjectInfo } from '../context';
 import { ActionInfo, AndroidActionType, Scope } from './Actions';
 import {
   buildCredentialsActions,
@@ -52,9 +52,16 @@ export class ManageAndroid {
     const buildProfile = hasProjectContext
       ? await new SelectBuildProfileFromEasJson(this.projectDir, Platform.ANDROID).runAsync()
       : null;
+    let projectInfo: CredentialsContextProjectInfo | null = null;
+    if (hasProjectContext) {
+      const { exp, projectId } = await this.callingAction.getDynamicProjectConfigAsync({
+        env: buildProfile?.env,
+      });
+      projectInfo = { exp, projectId };
+    }
     const ctx = new CredentialsContext({
       projectDir: process.cwd(),
-      projectInfo: this.callingAction.projectInfo,
+      projectInfo,
       user: this.callingAction.actor,
       graphqlClient: this.callingAction.graphqlClient,
       analytics: this.callingAction.analytics,

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -15,7 +15,7 @@ import { resolveTargetsAsync } from '../../project/ios/target';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { confirmAsync, promptAsync, selectAsync } from '../../prompts';
 import { ensureActorHasPrimaryAccount } from '../../user/actions';
-import { CredentialsContext } from '../context';
+import { CredentialsContext, CredentialsContextProjectInfo } from '../context';
 import {
   AppStoreApiKeyPurpose,
   selectAscApiKeysFromAccountAsync,
@@ -61,9 +61,18 @@ export class ManageIos {
     const buildProfile = this.callingAction.projectInfo
       ? await new SelectBuildProfileFromEasJson(this.projectDir, Platform.IOS).runAsync()
       : null;
+
+    let projectInfo: CredentialsContextProjectInfo | null = null;
+    if (this.callingAction.projectInfo) {
+      const { exp, projectId } = await this.callingAction.getDynamicProjectConfigAsync({
+        env: buildProfile?.env,
+      });
+      projectInfo = { exp, projectId };
+    }
+
     const ctx = new CredentialsContext({
       projectDir: process.cwd(),
-      projectInfo: this.callingAction.projectInfo,
+      projectInfo,
       user: this.callingAction.actor,
       graphqlClient: this.callingAction.graphqlClient,
       analytics: this.callingAction.analytics,

--- a/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
@@ -1,4 +1,5 @@
 import { Analytics } from '../../analytics/AnalyticsManager';
+import { DynamicConfigContextFn } from '../../commandUtils/context/DynamicProjectConfigContextField';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { selectPlatformAsync } from '../../platform';
 import { Actor } from '../../user/User';
@@ -12,6 +13,7 @@ export class SelectPlatform {
     public readonly graphqlClient: ExpoGraphqlClient,
     public readonly analytics: Analytics,
     public readonly projectInfo: CredentialsContextProjectInfo | null,
+    public readonly getDynamicProjectConfigAsync: DynamicConfigContextFn,
     private readonly flagPlatform?: string
   ) {}
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

When you have a logic that is changing slug or bundle identifier based on some envs that are specified in eas.json, the credentials manager does not take that into account when resolving values in app.json.

https://exponent-internal.slack.com/archives/C017N0N99RA/p1668430103460189?thread_ts=1668006887.615549&cid=C017N0N99RA

# How

Resolve `exp` dynamically after profile is selected.

# Test Plan

TODO Not tested yet.