### PR TITLE
[eas-cli] Show what prompt failed when running in non interactive shell.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Print prompt message when failing because of the non-interactive shell. ([#1523](https://github.com/expo/eas-cli/pull/1523) by [@wkozyra95](https://github.com/wkozyra95))
+
 ## [2.7.0](https://github.com/expo/eas-cli/releases/tag/v2.7.0) - 2022-11-11
 
 ### 🎉 New features

--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -14,7 +14,10 @@ export async function promptAsync<T extends string = string>(
   options: Options = {}
 ): Promise<Answers<T>> {
   if (!process.stdin.isTTY && !global.test) {
-    throw new Error('Input is required, but stdin is not readable.');
+    const message = Array.isArray(questions) ? questions[0]?.message : questions.message;
+    throw new Error(
+      `Input is required, but stdin is not readable. Failed to display prompt: ${message}`
+    );
   }
   return await prompts<T>(questions, {
     onCancel() {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

If cli tries to display prompt on CI it's hard to identify in some cases what was the problem, because it's not clear which prompt failed.
https://github.com/expo/eas-cli/issues/1521

# How

Print prompt message.

# Test Plan
