### PR TITLE
[eas-cli] Add support for asset excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add support for EAS Update asset excludes. ([#1526](https://github.com/expo/eas-cli/pull/1526) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -23268,6 +23268,26 @@
             "deprecationReason": null
           },
           {
+            "name": "excludedAssets",
+            "description": "",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PartialManifestAsset",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "gitCommitHash",
             "description": "",
             "type": {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3347,6 +3347,7 @@ export type PublicArtifacts = {
 export type PublishUpdateGroupInput = {
   awaitingCodeSigningInfo?: InputMaybe<Scalars['Boolean']>;
   branchId: Scalars['String'];
+  excludedAssets?: InputMaybe<Array<PartialManifestAsset>>;
   gitCommitHash?: InputMaybe<Scalars['String']>;
   message?: InputMaybe<Scalars['String']>;
   runtimeVersion: Scalars['String'];

--- a/packages/eas-cli/src/utils/expodash/__tests__/partition-test.ts
+++ b/packages/eas-cli/src/utils/expodash/__tests__/partition-test.ts
@@ -1,0 +1,13 @@
+import { truthy } from '../filter';
+import partition from '../partition';
+
+describe(partition, () => {
+  it('partitions', () => {
+    expect(partition([true, false], truthy)).toMatchObject([[true], [false]]);
+
+    expect(partition([1, 2, 3, 4], e => e <= 2)).toMatchObject([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+});

--- a/packages/eas-cli/src/utils/expodash/partition.ts
+++ b/packages/eas-cli/src/utils/expodash/partition.ts
@@ -1,0 +1,14 @@
+export default function partition<T>(arr: T[], predicate: (item: T) => boolean): [T[], T[]] {
+  const trueItems: T[] = [];
+  const falseItems: T[] = [];
+
+  for (const item of arr) {
+    if (predicate(item)) {
+      trueItems.push(item);
+    } else {
+      falseItems.push(item);
+    }
+  }
+
+  return [trueItems, falseItems];
+}

--- a/packages/eas-json/src/schema.ts
+++ b/packages/eas-json/src/schema.ts
@@ -13,4 +13,7 @@ export const EasJsonSchema = Joi.object({
   }),
   build: Joi.object().pattern(Joi.string(), BuildProfileSchema),
   submit: Joi.object().pattern(Joi.string(), SubmitProfileSchema),
+  update: Joi.object({
+    assetExcludePatterns: Joi.array().items(Joi.string()),
+  }),
 });

--- a/packages/eas-json/src/types.ts
+++ b/packages/eas-json/src/types.ts
@@ -25,4 +25,7 @@ export interface EasJson {
   };
   build?: { [profileName: string]: EasJsonBuildProfile };
   submit?: { [profileName: string]: EasJsonSubmitProfile };
+  update?: {
+    assetExcludePatterns?: string[];
+  };
 }

--- a/packages/eas-json/src/utils.ts
+++ b/packages/eas-json/src/utils.ts
@@ -48,4 +48,18 @@ export class EasJsonUtils {
     const easJson = await accessor.readAsync();
     return resolveSubmitProfile({ easJson, platform, profileName });
   }
+
+  public static async getUpdatesConfigAsync(
+    accessor: EasJsonAccessor
+  ): Promise<EasJson['update'] | null> {
+    try {
+      const easJson = await accessor.readAsync();
+      return easJson.update ?? null;
+    } catch (err: any) {
+      if (err instanceof MissingEasJsonError) {
+        return null;
+      }
+      throw err;
+    }
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Closes ENG-6894.

Server component: https://github.com/expo/universe/pull/10875
Depends on: https://github.com/expo/eas-cli/pull/1488

EAS Update currently has an asset limit of 1000. More than this creates a poor UX for end-users as they must then download a lot of assets on their mobile network. But, some apps using classic updates have more than this. We need a solution to allow them to move to EAS Update. This PR provides that solution.

The way this is going to work is:
1. configure project `eas.json` to have `update.assetExcludePatterns` (array of globs)
2. eas-cli will read that config and exclude matching assets from upload process
3. eas-cli will indicate to www that certain assets were excluded so that www knows not to try to create edges for them (this PR)

# How

1. Add update section to eas.json config
2. Read that config during asset upload
3. Exclude assets matching the config from upload
4. Report to the server during publish that certain assets were excluded.

# Test Plan

In combination with https://github.com/expo/universe/pull/10875:
1. create app
2. add updates.assetExcludePatterns to eas.json
3. add an asset that matches the glob
4. run `~/expo/eas-cli/packages/eas-cli/bin/run update --branch preview --message "testing3"`, see that it reports that assets were excluded and see the update doesn't have the asset (note that this update won't work in expo go).
