### PR TITLE
[ENG-6941][eas-json] add better error message for when invalid image is set in the `eas.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Better wording in eas submit. ([#1527](https://github.com/expo/eas-cli/pull/1527) by [@dsokal](https://github.com/dsokal))
 - Upload project sources for EAS Build and archives for EAS Submit to GCS. ([#1524](https://github.com/expo/eas-cli/pull/1524) by [@wkozyra95](https://github.com/wkozyra95))
+- Add a better error message for when an invalid `image` is set in `eas-json`. ([#1531](https://github.com/expo/eas-cli/pull/1531) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [2.7.1](https://github.com/expo/eas-cli/releases/tag/v2.7.1) - 2022-11-16
 

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -14,6 +14,7 @@
     "joi": "17.6.4",
     "log-symbols": "4.1.0",
     "semver": "7.3.8",
+    "terminal-link": "2.1.1",
     "tslib": "2.4.0"
   },
   "devDependencies": {

--- a/packages/eas-json/src/log.ts
+++ b/packages/eas-json/src/log.ts
@@ -1,0 +1,16 @@
+import chalk from 'chalk';
+import terminalLink from 'terminal-link';
+
+// link function from packages/eas-cli/src/log.ts
+export function link(
+  url: string,
+  { text = url, dim = true }: { text?: string; dim?: boolean } = {}
+): string {
+  let output: string;
+  if (terminalLink.isSupported) {
+    output = terminalLink(text, url);
+  } else {
+    output = `${text === url ? '' : text + ': '}${chalk.underline(url)}`;
+  }
+  return dim ? chalk.dim(output) : output;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-6941/add-error-message-for-when-image-validation-fails-in-the-cli

# How

Add a custom error message handler when the `image` field is invalid.


<img width="905" alt="Screenshot 2022-11-21 at 14 59 51" src="https://user-images.githubusercontent.com/55145344/203073867-fa05339b-4b44-4596-a273-2698b8026342.png">


# Test Plan

Test locally.
