### PR TITLE
[ENG-6491] remove internal expo id from device:list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Better wording in eas submit. ([#1527](https://github.com/expo/eas-cli/pull/1527) by [@dsokal](https://github.com/dsokal))
 - Upload project sources for EAS Build and archives for EAS Submit to GCS. ([#1524](https://github.com/expo/eas-cli/pull/1524) by [@wkozyra95](https://github.com/wkozyra95))
 - Add a better error message for when an invalid `image` is set in `eas-json`. ([#1531](https://github.com/expo/eas-cli/pull/1531) by [@szdziedzic](https://github.com/szdziedzic))
+- Remove internal expo id from device formatter. ([#1541](https://github.com/expo/eas-cli/pull/1541) by [@dsokal](https://github.com/dsokal))
 
 ## [2.7.1](https://github.com/expo/eas-cli/releases/tag/v2.7.1) - 2022-11-16
 

--- a/packages/eas-cli/src/devices/utils/formatDevice.ts
+++ b/packages/eas-cli/src/devices/utils/formatDevice.ts
@@ -23,13 +23,12 @@ function formatDeviceClass(device: Device | NewDevice): string {
 
 export default function formatDevice(device: Device, team?: AppleTeamIdAndName): string {
   const fields: FormatFieldsItem[] = [
-    { label: 'ID', value: device.id },
+    { label: 'UDID', value: device.identifier },
     { label: 'Name', value: device.name ?? 'Unknown' },
     {
       label: 'Class',
       value: formatDeviceClass(device),
     },
-    { label: 'UDID', value: device.identifier },
   ];
 
   if (team) {


### PR DESCRIPTION
- Remove expo ID from `formatDevice` method. The ID is not needed for anything.
- Move UDID to the top.

<img width="727" alt="Screenshot 2022-11-25 at 15 08 44" src="https://user-images.githubusercontent.com/5256730/204004901-a471f855-700c-4abf-a6f1-39631d819075.png">
