### PR TITLE
[ENG-6866][eas-cli] Consistent prompt for application identifier for both platorms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Ask for the missing application identifier consistently in `eas build:version:sync` command. ([#1543](https://github.com/expo/eas-cli/pull/1543) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [2.8.0](https://github.com/expo/eas-cli/releases/tag/v2.8.0) - 2022-11-28


### PR DESCRIPTION

<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

> The command will ask for the Android package name, but will bail on the missing ios.bundleIdentifier.

This happens only on managed, for bare projects we would just fail, but it's hard to create native project where those values are not defined, so it should not be a big issue.

# How


# Test Plan

remove package name and bundle identifier from app.json and run `eas bulid:version:sync`