### PR TITLE
[ENG-7006][eas-cli] Indicate in `eas build:run` when build artifacts has expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Ask for the missing application identifier consistently in `eas build:version:sync` command. ([#1543](https://github.com/expo/eas-cli/pull/1543) by [@wkozyra95](https://github.com/wkozyra95))
+- Disable selecting builds whose artifacts have expired in the `eas build:run` command. ([#1547](https://github.com/expo/eas-cli/pull/1547) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -153,7 +153,7 @@ function isAab(build: BuildFragment | undefined): boolean {
   return build?.artifacts?.applicationArchiveUrl?.endsWith('.aab') ?? false;
 }
 
-function didArtifactsExpired(build: BuildFragment): boolean {
+function didArtifactsExpire(build: BuildFragment): boolean {
   return new Date().getTime() - new Date(build.updatedAt).getTime() > 30 * 24 * 60 * 60 * 1000; // 30 days
 }
 
@@ -184,9 +184,9 @@ async function maybeGetBuildAsync(
       },
       queryOptions: paginatedQueryOptions,
       selectPromptDisabledFunction: build =>
-        !build.artifacts?.applicationArchiveUrl || isAab(build) || didArtifactsExpired(build),
+        !build.artifacts?.applicationArchiveUrl || isAab(build) || didArtifactsExpire(build),
       warningMessage:
-        'Artifacts for this build have expired and are no longer available or this is not a simulator/emulator build.',
+        'Artifacts for this build have expired and are no longer available, or this is not a simulator/emulator build.',
     });
   } else if (flags.runArchiveFlags.latest) {
     return await getLatestBuildAsync(graphqlClient, {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7006/indicate-in-eas-buildrun-when-build-artifacts-have-expired

# How

Disable choosing the build which finished over 30 days ago.

# Test Plan

Test manually
