### PR TITLE
[ENG-6238][eas-cli] prompt developer to download the simulator app after build is finished when in interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Add caching for `eas build:run` command. ([#1542](https://github.com/expo/eas-cli/pull/1542) by [@szdziedzic](https://github.com/szdziedzic))
 - Add `isGitWorkingTreeDirty` to EAS Update records. ([#1550](https://github.com/expo/eas-cli/pull/1550) by [@FiberJW](https://github.com/FiberJW))
+- Prompt developer to download the app after the simulator build is finished. ([#1554](https://github.com/expo/eas-cli/pull/1554) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -281,7 +281,7 @@ async function sendBuildRequestAsync<TPlatform extends Platform, Credentials, TJ
   );
 }
 
-type MaybeBuildFragment = BuildFragment | null;
+export type MaybeBuildFragment = BuildFragment | null;
 
 export async function waitForBuildEndAsync(
   graphqlClient: ExpoGraphqlClient,

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -40,7 +40,7 @@ import {
 } from '../project/remoteVersionSource';
 import { confirmAsync } from '../prompts';
 import { runAsync } from '../run/run';
-import { isRunableOnSimulatorOrEmulator } from '../run/utils';
+import { isRunnableOnSimulatorOrEmulator } from '../run/utils';
 import { createSubmissionContextAsync } from '../submit/context';
 import {
   exitWithNonZeroCodeIfSomeSubmissionsDidntFinish,
@@ -432,7 +432,7 @@ async function maybeDownloadAndRunSimulatorBuildsAsync(
   builds: MaybeBuildFragment[],
   flags: BuildFlags
 ): Promise<void> {
-  const simBuilds = builds.filter(truthy).filter(isRunableOnSimulatorOrEmulator);
+  const simBuilds = builds.filter(truthy).filter(isRunnableOnSimulatorOrEmulator);
 
   if (simBuilds.length > 0 && !flags.autoSubmit && !flags.nonInteractive) {
     for (const simBuild of simBuilds) {

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -250,6 +250,7 @@ export async function runBuildAndSubmitAsync(
 
   const simBuilds = builds.filter(
     build =>
+      build?.status === BuildStatus.Finished &&
       !!build?.artifacts?.applicationArchiveUrl &&
       (build?.distribution === DistributionType.Simulator ||
         !build.artifacts.applicationArchiveUrl.endsWith('aab'))

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -439,7 +439,7 @@ async function maybeDownloadAndRunSimulatorBuildsAsync(
       if (simBuild.platform === AppPlatform.Android || process.platform === 'darwin') {
         Log.newLine();
         const confirm = await confirmAsync({
-          message: `Would you like to run the ${
+          message: `Install and run the ${
             simBuild.platform === AppPlatform.Android ? 'Android' : 'iOS'
           } build on ${simBuild.platform === AppPlatform.Android ? 'an emulator' : 'a simulator'}?`,
         });

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -17,7 +17,7 @@ import Log from '../../log';
 import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { RunArchiveFlags, runAsync } from '../../run/run';
-import { isRunableOnSimulatorOrEmulator } from '../../run/utils';
+import { isRunnableOnSimulatorOrEmulator } from '../../run/utils';
 import {
   downloadAndMaybeExtractAppAsync,
   extractAppFromLocalArchiveAsync,
@@ -176,7 +176,7 @@ async function maybeGetBuildAsync(
         status: BuildStatus.Finished,
       },
       queryOptions: paginatedQueryOptions,
-      selectPromptDisabledFunction: build => !isRunableOnSimulatorOrEmulator(build),
+      selectPromptDisabledFunction: build => !isRunnableOnSimulatorOrEmulator(build),
       warningMessage:
         'Artifacts for this build have expired and are no longer available, or this is not a simulator/emulator build.',
     });

--- a/packages/eas-cli/src/run/ios/simulator.ts
+++ b/packages/eas-cli/src/run/ios/simulator.ts
@@ -33,7 +33,7 @@ export async function selectSimulatorAsync(): Promise<IosSimulator> {
     message: `Select a simulator to run your app on`,
     name: 'selectedSimulator',
     choices: simulators.map(simulator => ({
-      title: `ios ${simulator.osVersion} ${simulator.name}`,
+      title: `iOS ${simulator.osVersion} ${simulator.name}`,
       value: simulator,
     })),
   });

--- a/packages/eas-cli/src/run/utils.ts
+++ b/packages/eas-cli/src/run/utils.ts
@@ -1,0 +1,19 @@
+import { AppPlatform, BuildFragment, BuildStatus, DistributionType } from '../graphql/generated';
+
+function isAab(build: BuildFragment): boolean {
+  return build.artifacts?.applicationArchiveUrl?.endsWith('.aab') ?? false;
+}
+
+function didArtifactsExpire(build: BuildFragment): boolean {
+  return new Date().getTime() - new Date(build.updatedAt).getTime() > 30 * 24 * 60 * 60 * 1000; // 30 days
+}
+
+export function isRunableOnSimulatorOrEmulator(build: BuildFragment): boolean {
+  return (
+    build.status === BuildStatus.Finished &&
+    !!build.artifacts?.applicationArchiveUrl &&
+    ((build.platform === AppPlatform.Ios && build.distribution === DistributionType.Simulator) ||
+      (build.platform === AppPlatform.Android && !isAab(build))) &&
+    !didArtifactsExpire(build)
+  );
+}

--- a/packages/eas-cli/src/run/utils.ts
+++ b/packages/eas-cli/src/run/utils.ts
@@ -8,7 +8,7 @@ function didArtifactsExpire(build: BuildFragment): boolean {
   return new Date().getTime() - new Date(build.updatedAt).getTime() > 30 * 24 * 60 * 60 * 1000; // 30 days
 }
 
-export function isRunableOnSimulatorOrEmulator(build: BuildFragment): boolean {
+export function isRunnableOnSimulatorOrEmulator(build: BuildFragment): boolean {
   return (
     build.status === BuildStatus.Finished &&
     !!build.artifacts?.applicationArchiveUrl &&

--- a/packages/eas-cli/src/utils/download.ts
+++ b/packages/eas-cli/src/utils/download.ts
@@ -7,7 +7,7 @@ import { extract } from 'tar';
 import { promisify } from 'util';
 import { v4 as uuidv4 } from 'uuid';
 
-import fetch, { RequestInit } from '../fetch';
+import fetch, { RequestInit, Response } from '../fetch';
 import { AppPlatform } from '../graphql/generated';
 import Log from '../log';
 import { formatBytes } from './files';
@@ -16,9 +16,12 @@ import { ProgressHandler, createProgressTracker } from './progress';
 
 const pipeline = promisify(Stream.pipeline);
 
-let didProgressBarFinish = false;
-
-function wrapFetchWithProgress() {
+function wrapFetchWithProgress(): (
+  url: string,
+  init: RequestInit,
+  progressHandler: ProgressHandler
+) => Promise<Response> {
+  let didProgressBarFinish = false;
   return async (url: string, init: RequestInit, progressHandler: ProgressHandler) => {
     const response = await fetch(url, init);
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

The last addition to the `eas build:run` feature

# How

If `eas build` is run in interactive mode and any of the builds is successfully finished simulator build prompt the user to install it on the emulator/simulator.


https://user-images.githubusercontent.com/55145344/205007745-62ca3f09-a671-436c-aadb-6393837e710a.mov


https://user-images.githubusercontent.com/55145344/205007773-c5d40293-cac4-47f6-8790-c217d7979fd5.mov


https://user-images.githubusercontent.com/55145344/205007792-f7b926d9-ed8f-4791-a583-ba5cc88eed25.mov

# Test Plan

Test manually.
