### PR TITLE
[ENG-7007][eas-cli] change Android start intent to `MAIN` instead of `RUN` in `eas build:run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Ask for the missing application identifier consistently in `eas build:version:sync` command. ([#1543](https://github.com/expo/eas-cli/pull/1543) by [@wkozyra95](https://github.com/wkozyra95))
 - Disable selecting builds whose artifacts have expired in the `eas build:run` command. ([#1547](https://github.com/expo/eas-cli/pull/1547) by [@szdziedzic](https://github.com/szdziedzic))
+- Change intent with which the `eas build:run` command opens an Android app to `android.intent.action.MAIN`. ([#1556](https://github.com/expo/eas-cli/pull/1556) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/run/android/emulator.ts
+++ b/packages/eas-cli/src/run/android/emulator.ts
@@ -149,7 +149,7 @@ export async function startAppAsync(
     'am',
     'start',
     '-a',
-    'android.intent.action.RUN',
+    'android.intent.action.MAIN',
     '-f',
     '0x20000000', // FLAG_ACTIVITY_SINGLE_TOP -- If set, the activity will not be launched if it is already running at the top of the history stack.
     '-n',


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7007/deep-link-received-when-launching-dev-client-with-eas-buildrun

I discussed this with @lukmccall and we decided that `MAIN` intent is a better option than `RUN`.
It solves the issue with the dev client and also works fine for other builds.

# How

Change Android start intent from `android.intent.action.RUN` to `android.intent.action.MAIN` in the `eas build:run` command.

# Test Plan

Run command for a dev client build and for other types of builds as well.