### PR TITLE
[eas-json] Make not recognized image error handler run only if image is present under valid key with invalid value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Make the not recognized image error handler run only if the image is present under a valid key and has an invalid value. ([#1565](https://github.com/expo/eas-cli/pull/1565) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 - Remove old republish code from the update command. ([#1535](https://github.com/expo/eas-cli/pull/1535) by [@byCedric](https://github.com/byCedric))

--- a/packages/eas-json/src/accessor.ts
+++ b/packages/eas-json/src/accessor.ts
@@ -15,12 +15,19 @@ const customErrorMessageHandlers: ((err: ValidationError) => void)[] = [
   // Ask user to upgrade eas-cli version or check the docs when image is invalid.
   (err: ValidationError) => {
     for (const detail of err.details) {
-      if (detail.path[detail.path.length - 1] === 'image') {
+      // image should be only placed under 'build.profilename.platform.image' key
+      // if it's not the case show standard Joi error
+      if (
+        detail.path.length === 4 &&
+        detail.path[0] === 'build' &&
+        ['ios', 'android'].includes(detail.path[2].toString()) &&
+        detail.path[3] === 'image'
+      ) {
         throw new InvalidEasJsonError(
           chalk.red(
-            `Specified build image '${
-              detail?.context?.value
-            }' is not recognized. Please update your EAS CLI and see ${link(
+            `Specified build image '${detail?.context?.value}' under the '${detail.path.join(
+              '.'
+            )}' key is not recognized. Please update your EAS CLI and see ${link(
               'https://docs.expo.dev/build-reference/infrastructure/'
             )} for supported build images.`
           )

--- a/packages/eas-json/src/accessor.ts
+++ b/packages/eas-json/src/accessor.ts
@@ -25,9 +25,9 @@ const customErrorMessageHandlers: ((err: ValidationError) => void)[] = [
       ) {
         throw new InvalidEasJsonError(
           chalk.red(
-            `Specified build image '${detail?.context?.value}' under the '${detail.path.join(
-              '.'
-            )}' key is not recognized. Please update your EAS CLI and see ${link(
+            `Specified build image '${
+              detail?.context?.value
+            }' is not recognized. Please update your EAS CLI and see ${link(
               'https://docs.expo.dev/build-reference/infrastructure/'
             )} for supported build images.`
           )


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://github.com/expo/eas-cli/issues/1562

Before this fix, the handler would show the error message if anything is invalid about the `image` field in the `eas-json`. We want it only to show the custom error when `image` is placed in the correct spot but has an invalid value.

# How

Run the handler only if `image` is placed under the proper key.

# Test Plan

Test manually.
