### PR TITLE
[eas-cli] Add --channel flag to eas update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Adds `--channel` flag to `eas update`. ([#1567](https://github.com/expo/eas-cli/pull/1567) by [@jonsamp](https://github.com/jonsamp))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/channel/errors.ts
+++ b/packages/eas-cli/src/channel/errors.ts
@@ -1,0 +1,5 @@
+export class ChannelNotFoundError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Channel not found.');
+  }
+}

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -1,0 +1,174 @@
+import { instance, mock } from 'ts-mockito';
+
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { UpdateBranch, UpdateChannel } from '../../../graphql/generated';
+import { ChannelQuery } from '../../../graphql/queries/ChannelQuery';
+import UpdatePublish from '../index';
+
+const projectRoot = '/test-project';
+const commandOptions = { root: projectRoot } as any;
+
+jest.mock('../../../graphql/queries/ChannelQuery');
+jest.mock('../../../graphql/queries/BranchQuery');
+
+describe(UpdatePublish.prototype.getBranchNameFromChannelNameAsync, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns branch name when channel exists and has one connected branch', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
+    jest.mocked(ChannelQuery.viewUpdateChannelAsync).mockImplementationOnce(
+      async () =>
+        mockUpdateChannel({
+          channelName: 'test-channel-name',
+          branchNames: ['test-branch-name'],
+        }) as any
+    );
+
+    const UpdatePublishCommand = new UpdatePublish([], commandOptions);
+
+    const result = await UpdatePublishCommand.getBranchNameFromChannelNameAsync(
+      graphqlClient,
+      'test-project-id',
+      'channel-name'
+    );
+
+    expect(result).toBe('test-branch-name');
+  });
+
+  test('errors when no branch is connected to channel', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
+    jest.mocked(ChannelQuery.viewUpdateChannelAsync).mockImplementationOnce(
+      async () =>
+        mockUpdateChannel({
+          channelName: 'test-channel-name',
+        }) as any
+    );
+
+    const UpdatePublishCommand = new UpdatePublish([], commandOptions);
+
+    expect(
+      UpdatePublishCommand.getBranchNameFromChannelNameAsync(
+        graphqlClient,
+        'test-project-id',
+        'test-channel-name'
+      )
+    ).rejects.toThrow(
+      "Channel has no branches associated with it. Run 'eas channel:edit' to map a branch"
+    );
+  });
+
+  test('errors when more than one branch is connected to channel', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
+    jest.mocked(ChannelQuery.viewUpdateChannelAsync).mockImplementationOnce(
+      async () =>
+        mockUpdateChannel({
+          channelName: 'test-channel-name',
+          branchNames: ['test-branch-name', 'test-branch-name-2'],
+        }) as any
+    );
+
+    const UpdatePublishCommand = new UpdatePublish([], commandOptions);
+
+    expect(
+      UpdatePublishCommand.getBranchNameFromChannelNameAsync(
+        graphqlClient,
+        'test-project-id',
+        'test-channel-name'
+      )
+    ).rejects.toThrow(
+      "Channel has multiple branches associated with it. Instead, use 'eas update --branch'"
+    );
+  });
+
+  test('creates channel and branch when channel does not exist, and returns branch name', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
+    jest.mocked(ChannelQuery.viewUpdateChannelAsync).mockImplementationOnce(
+      async () =>
+        mockUpdateChannel({
+          channelName: 'test-channel-name',
+          branchNames: ['test-branch-name'],
+        }) as any
+    );
+
+    const UpdatePublishCommand = new UpdatePublish([], commandOptions);
+
+    const result = await UpdatePublishCommand.getBranchNameFromChannelNameAsync(
+      graphqlClient,
+      'test-project-id',
+      'test-channel-name'
+    );
+
+    expect(result).toBe('test-branch-name');
+  });
+});
+
+function mockUpdateChannel({
+  channelName,
+  branchNames,
+}: {
+  channelName?: string;
+  branchNames?: string[];
+}): UpdateChannel {
+  return {
+    id: 'a2a1fa12-9d6a-433a-a432-49c64ef8439f',
+    name: channelName ?? 'default-channel-name',
+    createdAt: '2022-12-07T02:24:29.786Z',
+    appId: '123',
+    updatedAt: '2022-12-07T02:24:29.786Z',
+    branchMapping:
+      '{"data":[{"branchId":"f9dc4dbb-663f-4a19-8cf2-a783b484d2db","branchMappingLogic":"true"}],"version":0}',
+    updateBranches: branchNames ? mockUpdateBranches(branchNames) : [],
+    __typename: 'UpdateChannel',
+  };
+}
+
+function mockUpdateBranches(branchNames: string[]): UpdateBranch[] {
+  return branchNames.map(branchName => ({
+    id: 'f9dc4dbb-663f-4a19-8cf2-a783b484d2db',
+    name: branchName ?? 'default-branch-name',
+    appId: '123',
+    createdAt: '2022-12-07T02:24:29.786Z',
+    updatedAt: '2022-12-07T02:24:29.786Z',
+    updates: [],
+    updateGroups: [
+      [
+        {
+          id: '8503286d-4b18-4b38-a0f7-2b9ae09531a0',
+          group: 'd715bc20-76b5-477b-a060-3f8184aae87a',
+          message: 'my message',
+          createdAt: '2022-12-07T02:24:43.487Z',
+          runtimeVersion: '1.0.0',
+          platform: 'ios',
+          manifestFragment: '...',
+          activityTimestamp: '2022-12-07T02:24:43.487Z',
+          branchId: '',
+          awaitingCodeSigningInfo: false,
+          isGitWorkingTreeDirty: false,
+          manifestPermalink: '...',
+          updatedAt: '2022-12-07T02:24:43.487Z',
+          gitCommitHash: 'abc5baf77eee821b800af97879d19cc3132b46a7',
+          actor: {
+            __typename: 'User' as const,
+            id: 'f42b73a3-ce6c-4059-a825-e5ddafa022f7',
+            username: 'jonexpo',
+          } as any,
+          branch: {
+            id: 'f9dc4dbb-663f-4a19-8cf2-a783b484d2db',
+            name: 'production3',
+            appId: '123',
+            createdAt: '2022-12-07T02:24:29.786Z',
+            updatedAt: '2022-12-07T02:24:29.786Z',
+            updateGroups: [],
+            updates: [],
+            __typename: 'UpdateBranch' as const,
+          },
+          codeSigningInfo: null,
+          __typename: 'Update' as const,
+        },
+      ],
+    ],
+    __typename: 'UpdateBranch' as const,
+  }));
+}

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -37,7 +37,7 @@ import {
 } from '../../project/publish';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { promptAsync } from '../../prompts';
-import { ensureEASUpdatesIsConfiguredAsync } from '../../update/configure';
+import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
 import { getBranchNameFromChannelNameAsync } from '../../update/getBranchNameFromChannelNameAsync';
 import { formatUpdateMessage, truncateString as truncateUpdateMessage } from '../../update/utils';
 import {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -556,7 +556,7 @@ export default class UpdatePublish extends EasCommand {
     graphqlClient: ExpoGraphqlClient,
     projectId: string,
     channelName: string
-  ): Promise<string | undefined> {
+  ): Promise<string> {
     let branchName;
 
     try {

--- a/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
@@ -1,6 +1,7 @@
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
+import { ChannelNotFoundError } from '../../channel/errors';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../client';
 import {
@@ -59,7 +60,7 @@ export const ChannelQuery = {
 
     const { updateChannelByName } = response.app.byId;
     if (!updateChannelByName) {
-      throw new Error(`Could not find channel with the name ${channelName}`);
+      throw new ChannelNotFoundError(`Could not find channel with the name ${channelName}`);
     }
 
     return updateChannelByName;

--- a/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
@@ -1,17 +1,14 @@
 import { instance, mock } from 'ts-mockito';
 
-import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
-import { UpdateBranch, UpdateChannel } from '../../../graphql/generated';
-import { ChannelQuery } from '../../../graphql/queries/ChannelQuery';
-import UpdatePublish from '../index';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { UpdateBranch, UpdateChannel } from '../../graphql/generated';
+import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import { getBranchNameFromChannelNameAsync } from '../getBranchNameFromChannelNameAsync';
 
-const projectRoot = '/test-project';
-const commandOptions = { root: projectRoot } as any;
+jest.mock('../../graphql/queries/ChannelQuery');
+jest.mock('../../graphql/queries/BranchQuery');
 
-jest.mock('../../../graphql/queries/ChannelQuery');
-jest.mock('../../../graphql/queries/BranchQuery');
-
-describe(UpdatePublish.prototype.getBranchNameFromChannelNameAsync, () => {
+describe(getBranchNameFromChannelNameAsync, () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
@@ -26,9 +23,7 @@ describe(UpdatePublish.prototype.getBranchNameFromChannelNameAsync, () => {
         }) as any
     );
 
-    const UpdatePublishCommand = new UpdatePublish([], commandOptions);
-
-    const result = await UpdatePublishCommand.getBranchNameFromChannelNameAsync(
+    const result = await getBranchNameFromChannelNameAsync(
       graphqlClient,
       'test-project-id',
       'channel-name'
@@ -46,14 +41,8 @@ describe(UpdatePublish.prototype.getBranchNameFromChannelNameAsync, () => {
         }) as any
     );
 
-    const UpdatePublishCommand = new UpdatePublish([], commandOptions);
-
     expect(
-      UpdatePublishCommand.getBranchNameFromChannelNameAsync(
-        graphqlClient,
-        'test-project-id',
-        'test-channel-name'
-      )
+      getBranchNameFromChannelNameAsync(graphqlClient, 'test-project-id', 'test-channel-name')
     ).rejects.toThrow(
       "Channel has no branches associated with it. Run 'eas channel:edit' to map a branch"
     );
@@ -69,14 +58,8 @@ describe(UpdatePublish.prototype.getBranchNameFromChannelNameAsync, () => {
         }) as any
     );
 
-    const UpdatePublishCommand = new UpdatePublish([], commandOptions);
-
     expect(
-      UpdatePublishCommand.getBranchNameFromChannelNameAsync(
-        graphqlClient,
-        'test-project-id',
-        'test-channel-name'
-      )
+      getBranchNameFromChannelNameAsync(graphqlClient, 'test-project-id', 'test-channel-name')
     ).rejects.toThrow(
       "Channel has multiple branches associated with it. Instead, use 'eas update --branch'"
     );
@@ -92,9 +75,7 @@ describe(UpdatePublish.prototype.getBranchNameFromChannelNameAsync, () => {
         }) as any
     );
 
-    const UpdatePublishCommand = new UpdatePublish([], commandOptions);
-
-    const result = await UpdatePublishCommand.getBranchNameFromChannelNameAsync(
+    const result = await getBranchNameFromChannelNameAsync(
       graphqlClient,
       'test-project-id',
       'test-channel-name'

--- a/packages/eas-cli/src/update/getBranchNameFromChannelNameAsync.ts
+++ b/packages/eas-cli/src/update/getBranchNameFromChannelNameAsync.ts
@@ -1,0 +1,58 @@
+import { ensureBranchExistsAsync } from '../branch/queries';
+import { ChannelNotFoundError } from '../channel/errors';
+import { createChannelOnAppAsync } from '../channel/queries';
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { ChannelQuery } from '../graphql/queries/ChannelQuery';
+
+export async function getBranchNameFromChannelNameAsync(
+  graphqlClient: ExpoGraphqlClient,
+  projectId: string,
+  channelName: string
+): Promise<string> {
+  let branchName;
+
+  try {
+    const channel = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      appId: projectId,
+      channelName,
+    });
+
+    if (channel.updateBranches.length === 1) {
+      branchName = channel.updateBranches[0].name;
+    } else if (channel.updateBranches.length === 0) {
+      throw new Error(
+        "Channel has no branches associated with it. Run 'eas channel:edit' to map a branch"
+      );
+    } else {
+      throw new Error(
+        "Channel has multiple branches associated with it. Instead, use 'eas update --branch'"
+      );
+    }
+  } catch (error) {
+    if (!(error instanceof ChannelNotFoundError)) {
+      throw error;
+    }
+
+    const { branchId } = await ensureBranchExistsAsync(graphqlClient, {
+      appId: projectId,
+      branchName: channelName,
+    });
+    const {
+      updateChannel: { createUpdateChannelForApp: newChannel },
+    } = await createChannelOnAppAsync(graphqlClient, {
+      appId: projectId,
+      channelName,
+      branchId,
+    });
+
+    if (!newChannel) {
+      throw new Error(
+        `Could not create channel with name ${channelName} on project with id ${projectId}`
+      );
+    }
+
+    branchName = channelName;
+  }
+
+  return branchName;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

To make EAS Update easier for people to use, we are adding a `--channel` flag to `eas update`. This flag allows developers to run a command like `eas update --channel channel-name`.

The command looks for the specified channel, then:
- if it exists, it finds the branch mapped to the channel and publishes to that branch
  - if there are multiple branches, it errors
  - if there are no branches, it errors (should not be possible, but I still handled it)
- If the channel does not exist, it creates it, then:
  - if a branch exists of the same name, then map it to the newly made channel
  - if a branch noes not exist, create one, then map it to the channel

# Test Plan

Run `easd update --channel test-channel-name` to test out the feature.
Also, run the unit tests.