### PR TITLE
[eas-cli] Base implementation for running builds directly from GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `--json` flag to `eas config` command. ([#1568](https://github.com/expo/eas-cli/pull/1568) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores
 
 - Remove unnecessary workaround for trailing backslash in .gitignore. ([#1622](https://github.com/expo/eas-cli/pull/1622) by [@wkozyra95](https://github.com/wkozyra95))
+- Internal command that will be run on EAS worker when building from GitHub. ([#1568](https://github.com/expo/eas-cli/pull/1568) by [@wkozyra95](https://github.com/wkozyra95))
 
 ## [3.3.2](https://github.com/expo/eas-cli/releases/tag/v3.3.2) - 2023-01-12
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -115,15 +115,15 @@ export async function prepareBuildRequestForPlatformAsync<
       type: ArchiveSourceType.PATH,
       path: (await makeProjectTarballAsync()).path,
     };
-  } else if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.DISABLED) {
-    projectArchive = {
-      type: ArchiveSourceType.GCS,
-      bucketKey: await uploadProjectAsync(ctx),
-    };
   } else if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.INTERNAL) {
     projectArchive = {
       type: ArchiveSourceType.PATH,
       path: process.cwd(),
+    };
+  } else if (!ctx.localBuildOptions.localBuildMode) {
+    projectArchive = {
+      type: ArchiveSourceType.GCS,
+      bucketKey: await uploadProjectAsync(ctx),
     };
   }
   assert(projectArchive);
@@ -139,15 +139,15 @@ export async function prepareBuildRequestForPlatformAsync<
     if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.LOCAL_BUILD_PLUGIN) {
       await runLocalBuildAsync(job, metadata, ctx.localBuildOptions);
       return undefined;
-    } else if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.DISABLED) {
+    } else if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.INTERNAL) {
+      printJsonOnlyOutput({ job, metadata });
+      return undefined;
+    } else if (!ctx.localBuildOptions.localBuildMode) {
       try {
         return await sendBuildRequestAsync(builder, job, metadata, buildParams);
       } catch (error: any) {
         handleBuildRequestError(error, job.platform);
       }
-    } else if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.INTERNAL) {
-      printJsonOnlyOutput({ job, metadata });
-      return undefined;
     } else {
       throw new Error('Unknown localBuildMode.');
     }

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -1,5 +1,6 @@
 import { ArchiveSource, ArchiveSourceType, Job, Metadata, Platform } from '@expo/eas-build-job';
 import { CredentialsSource } from '@expo/eas-json';
+import assert from 'assert';
 import chalk from 'chalk';
 import cliProgress from 'cli-progress';
 import fs from 'fs-extra';
@@ -28,11 +29,12 @@ import {
 } from '../platform';
 import { uploadFileAtPathToGCSAsync } from '../uploads';
 import { formatBytes } from '../utils/files';
+import { printJsonOnlyOutput } from '../utils/json';
 import { createProgressTracker } from '../utils/progress';
 import { sleepAsync } from '../utils/promise';
 import { getVcsClient } from '../vcs';
 import { BuildContext } from './context';
-import { runLocalBuildAsync } from './local';
+import { LocalBuildMode, runLocalBuildAsync } from './local';
 import { collectMetadataAsync } from './metadata';
 import { printDeprecationWarnings } from './utils/printBuildInfo';
 import { makeProjectTarballAsync, reviewAndCommitChangesAsync } from './utils/repository';
@@ -107,15 +109,24 @@ export async function prepareBuildRequestForPlatformAsync<
     );
   }
 
-  const projectArchive = ctx.localBuildOptions.enable
-    ? ({
-        type: ArchiveSourceType.PATH,
-        path: (await makeProjectTarballAsync()).path,
-      } as const)
-    : ({
-        type: ArchiveSourceType.GCS,
-        bucketKey: await uploadProjectAsync(ctx),
-      } as const);
+  let projectArchive: ArchiveSource | undefined;
+  if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.LOCAL_BUILD_PLUGIN) {
+    projectArchive = {
+      type: ArchiveSourceType.PATH,
+      path: (await makeProjectTarballAsync()).path,
+    };
+  } else if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.DISABLED) {
+    projectArchive = {
+      type: ArchiveSourceType.GCS,
+      bucketKey: await uploadProjectAsync(ctx),
+    };
+  } else if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.INTERNAL) {
+    projectArchive = {
+      type: ArchiveSourceType.PATH,
+      path: process.cwd(),
+    };
+  }
+  assert(projectArchive);
 
   const metadata = await collectMetadataAsync(ctx);
   const buildParams = resolveBuildParamsInput(ctx);
@@ -125,15 +136,20 @@ export async function prepareBuildRequestForPlatformAsync<
   });
 
   return async () => {
-    if (ctx.localBuildOptions.enable) {
+    if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.LOCAL_BUILD_PLUGIN) {
       await runLocalBuildAsync(job, metadata, ctx.localBuildOptions);
       return undefined;
-    } else {
+    } else if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.DISABLED) {
       try {
         return await sendBuildRequestAsync(builder, job, metadata, buildParams);
       } catch (error: any) {
         handleBuildRequestError(error, job.platform);
       }
+    } else if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.INTERNAL) {
+      printJsonOnlyOutput({ job, metadata });
+      return undefined;
+    } else {
+      throw new Error('Unknown localBuildMode.');
     }
   };
 }

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -8,8 +8,14 @@ import { ora } from '../ora';
 const PLUGIN_PACKAGE_NAME = 'eas-cli-local-build-plugin';
 const PLUGIN_PACKAGE_VERSION = '0.0.120';
 
+export enum LocalBuildMode {
+  DISABLED,
+  LOCAL_BUILD_PLUGIN,
+  INTERNAL,
+}
+
 export interface LocalBuildOptions {
-  enable: boolean;
+  localBuildMode: LocalBuildMode;
   skipCleanup?: boolean;
   skipNativeBuild?: boolean;
   artifactsDir?: string;

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -9,13 +9,25 @@ const PLUGIN_PACKAGE_NAME = 'eas-cli-local-build-plugin';
 const PLUGIN_PACKAGE_VERSION = '0.0.120';
 
 export enum LocalBuildMode {
-  DISABLED,
+  /**
+   * Local build that users can run on their own machines. Instead
+   * of sending build request to EAS Servers it's passing it as an argument
+   * to local-build-plugin, that will run the build locally.
+   *
+   * Triggered when running `eas build --local`.
+   */
   LOCAL_BUILD_PLUGIN,
+  /**
+   * Type of local build that is not accessible to users directly. When
+   * cloud build is triggered by git based integration, we are running
+   * in this mode. Instead of sending build request to EAS Servers it's
+   * printing it to the stdout as JSON, so EAS Build worker can read it.
+   */
   INTERNAL,
 }
 
 export interface LocalBuildOptions {
-  localBuildMode: LocalBuildMode;
+  localBuildMode?: LocalBuildMode;
   skipCleanup?: boolean;
   skipNativeBuild?: boolean;
   artifactsDir?: string;

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -62,7 +62,7 @@ import { ensureProjectConfiguredAsync } from './configure';
 import { BuildContext } from './context';
 import { createBuildContextAsync } from './createContext';
 import { prepareIosBuildAsync } from './ios/build';
-import { LocalBuildMode, LocalBuildOptions } from './local';
+import { LocalBuildOptions } from './local';
 import { ensureExpoDevClientInstalledForDevClientBuildsAsync } from './utils/devClient';
 import { printBuildResults, printLogsUrls } from './utils/printBuildInfo';
 import { ensureRepoIsCleanAsync } from './utils/repository';
@@ -221,7 +221,7 @@ export async function runBuildAndSubmitAsync(
     buildCtxByPlatform[toAppPlatform(buildProfile.platform)] = buildCtx;
   }
 
-  if (flags.localBuildOptions.localBuildMode !== LocalBuildMode.DISABLED) {
+  if (flags.localBuildOptions.localBuildMode) {
     return;
   }
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -62,7 +62,7 @@ import { ensureProjectConfiguredAsync } from './configure';
 import { BuildContext } from './context';
 import { createBuildContextAsync } from './createContext';
 import { prepareIosBuildAsync } from './ios/build';
-import { LocalBuildOptions } from './local';
+import { LocalBuildMode, LocalBuildOptions } from './local';
 import { ensureExpoDevClientInstalledForDevClientBuildsAsync } from './utils/devClient';
 import { printBuildResults, printLogsUrls } from './utils/printBuildInfo';
 import { ensureRepoIsCleanAsync } from './utils/repository';
@@ -221,7 +221,7 @@ export async function runBuildAndSubmitAsync(
     buildCtxByPlatform[toAppPlatform(buildProfile.platform)] = buildCtx;
   }
 
-  if (flags.localBuildOptions.enable) {
+  if (flags.localBuildOptions.localBuildMode !== LocalBuildMode.DISABLED) {
     return;
   }
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -127,7 +127,7 @@ export default class Build extends EasCommand {
 
     await handleDeprecatedEasJsonAsync(projectDir, flags.nonInteractive);
 
-    if (flags.localBuildOptions.localBuildMode === LocalBuildMode.DISABLED) {
+    if (!flags.localBuildOptions.localBuildMode) {
       await maybeWarnAboutEasOutagesAsync(
         graphqlClient,
         flags.autoSubmit
@@ -199,9 +199,7 @@ export default class Build extends EasCommand {
             verbose: true,
             artifactPath: flags.output && path.resolve(process.cwd(), flags.output),
           }
-        : {
-            localBuildMode: LocalBuildMode.DISABLED,
-          },
+        : {},
       wait: flags['wait'],
       clearCache: flags['clear-cache'],
       json: flags['json'],
@@ -217,7 +215,7 @@ export default class Build extends EasCommand {
   ): Promise<BuildFlags> {
     const requestedPlatform = await selectRequestedPlatformAsync(flags.requestedPlatform);
 
-    if (flags.localBuildOptions.localBuildMode !== LocalBuildMode.DISABLED) {
+    if (!flags.localBuildOptions.localBuildMode) {
       if (flags.autoSubmit) {
         // TODO: implement this
         Errors.error('Auto-submits are not yet supported when building locally', { exit: 1 });

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -6,6 +6,7 @@ import figures from 'figures';
 import fs from 'fs-extra';
 import path from 'path';
 
+import { LocalBuildMode } from '../../build/local';
 import { BuildFlags, runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
@@ -126,7 +127,7 @@ export default class Build extends EasCommand {
 
     await handleDeprecatedEasJsonAsync(projectDir, flags.nonInteractive);
 
-    if (!flags.localBuildOptions.enable) {
+    if (flags.localBuildOptions.localBuildMode === LocalBuildMode.DISABLED) {
       await maybeWarnAboutEasOutagesAsync(
         graphqlClient,
         flags.autoSubmit
@@ -194,12 +195,12 @@ export default class Build extends EasCommand {
       nonInteractive,
       localBuildOptions: flags['local']
         ? {
-            enable: true,
+            localBuildMode: LocalBuildMode.LOCAL_BUILD_PLUGIN,
             verbose: true,
             artifactPath: flags.output && path.resolve(process.cwd(), flags.output),
           }
         : {
-            enable: false,
+            localBuildMode: LocalBuildMode.DISABLED,
           },
       wait: flags['wait'],
       clearCache: flags['clear-cache'],
@@ -216,7 +217,7 @@ export default class Build extends EasCommand {
   ): Promise<BuildFlags> {
     const requestedPlatform = await selectRequestedPlatformAsync(flags.requestedPlatform);
 
-    if (flags.localBuildOptions.enable) {
+    if (flags.localBuildOptions.localBuildMode !== LocalBuildMode.DISABLED) {
       if (flags.autoSubmit) {
         // TODO: implement this
         Errors.error('Auto-submits are not yet supported when building locally', { exit: 1 });

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
+import { LocalBuildMode } from '../../build/local';
 import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import EasCommand from '../../commandUtils/EasCommand';
 import Log from '../../log';
@@ -110,7 +111,7 @@ export default class BuildInspect extends EasCommand {
             requestedPlatform: flags.platform,
             profile: flags.profile,
             localBuildOptions: {
-              enable: true,
+              localBuildMode: LocalBuildMode.LOCAL_BUILD_PLUGIN,
               ...(flags.stage === InspectStage.PRE_BUILD ? { skipNativeBuild: true } : {}),
               ...(flags.stage === InspectStage.POST_BUILD ? { skipCleanup: true } : {}),
               verbose: flags.verbose,

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -7,8 +7,13 @@ import EasCommand from '../../commandUtils/EasCommand';
 import { RequestedPlatform } from '../../platform';
 import { enableJsonOutput } from '../../utils/json';
 
+/**
+ * This command will be run on the EAS Build workers, when building
+ * directly from git. This command resolves credentials and other
+ * build configuration, that normally would be included in the
+ * job and metadata objects, and prints them to stdout.
+ */
 export default class BuildInternal extends EasCommand {
-  static override description = 'start a build';
   static override hidden = true;
 
   static override flags = {

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -1,0 +1,71 @@
+import { Flags } from '@oclif/core';
+
+import { handleDeprecatedEasJsonAsync } from '.';
+import { LocalBuildMode } from '../../build/local';
+import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
+import EasCommand from '../../commandUtils/EasCommand';
+import { RequestedPlatform } from '../../platform';
+import { enableJsonOutput } from '../../utils/json';
+
+export default class BuildInternal extends EasCommand {
+  static override description = 'start a build';
+  static override hidden = true;
+
+  static override flags = {
+    platform: Flags.enum({
+      char: 'p',
+      options: ['android', 'ios'],
+      required: true,
+    }),
+    profile: Flags.string({
+      char: 'e',
+      description:
+        'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
+      helpValue: 'PROFILE_NAME',
+    }),
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+    ...this.ContextOptions.DynamicProjectConfig,
+    ...this.ContextOptions.ProjectDir,
+    ...this.ContextOptions.Analytics,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(BuildInternal);
+    // This command is always run with implicit --non-interactive and --json options
+    enableJsonOutput();
+
+    const {
+      loggedIn: { actor, graphqlClient },
+      getDynamicProjectConfigAsync,
+      projectDir,
+      analytics,
+    } = await this.getContextAsync(BuildInternal, {
+      nonInteractive: true,
+    });
+
+    await handleDeprecatedEasJsonAsync(projectDir, flags.nonInteractive);
+
+    await runBuildAndSubmitAsync(
+      graphqlClient,
+      analytics,
+      projectDir,
+      {
+        requestedPlatform: flags.platform as RequestedPlatform,
+        profile: flags.profile,
+        nonInteractive: true,
+        wait: false,
+        clearCache: false,
+        json: true,
+        autoSubmit: false,
+        localBuildOptions: {
+          localBuildMode: LocalBuildMode.INTERNAL,
+        },
+      },
+      actor,
+      getDynamicProjectConfigAsync
+    );
+  }
+}

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -5,10 +5,12 @@ import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
 import EasCommand from '../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../commandUtils/flags';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log from '../log';
 import { appPlatformEmojis } from '../platform';
 import { selectAsync } from '../prompts';
+import { enableJsonOutput, printJsonOnlyOutput } from '../utils/json';
 
 export default class Config extends EasCommand {
   static override description = 'display project configuration (app.json + eas.json)';
@@ -21,6 +23,10 @@ export default class Config extends EasCommand {
         'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
       helpValue: 'PROFILE_NAME',
     }),
+    'eas-json-only': Flags.boolean({
+      hidden: true,
+    }),
+    ...EasNonInteractiveAndJsonFlags,
   };
 
   static override contextDefinition = {
@@ -30,6 +36,9 @@ export default class Config extends EasCommand {
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(Config);
+    if (flags.json) {
+      enableJsonOutput();
+    }
     const { platform: maybePlatform, profile: maybeProfile } = flags;
     const { getDynamicProjectConfigAsync, projectDir } = await this.getContextAsync(Config, {
       nonInteractive: false,
@@ -61,21 +70,37 @@ export default class Config extends EasCommand {
       ]));
 
     const profile = await EasJsonUtils.getBuildProfileAsync(accessor, platform, profileName);
-    const { exp: config } = await getDynamicProjectConfigAsync({
-      env: profile.env,
-      isPublicConfig: true,
-    });
+    if (flags['eas-json-only']) {
+      if (flags.json) {
+        printJsonOnlyOutput({ buildProfile: profile });
+      } else {
+        const appPlatform = toAppPlatform(platform);
+        const platformEmoji = appPlatformEmojis[appPlatform];
+        Log.log(`${platformEmoji} ${chalk.bold(`Build profile "${profileName}"`)}`);
+        Log.newLine();
+        Log.log(JSON.stringify(profile, null, 2));
+      }
+    } else {
+      const { exp: appConfig } = await getDynamicProjectConfigAsync({
+        env: profile.env,
+        isPublicConfig: true,
+      });
 
-    Log.addNewLineIfNone();
-    Log.log(chalk.bold(getProjectConfigDescription(projectDir)));
-    Log.newLine();
-    Log.log(JSON.stringify(config, null, 2));
-    Log.newLine();
-    Log.newLine();
-    const appPlatform = toAppPlatform(platform);
-    const platformEmoji = appPlatformEmojis[appPlatform];
-    Log.log(`${platformEmoji} ${chalk.bold(`Build profile "${profileName}"`)}`);
-    Log.newLine();
-    Log.log(JSON.stringify(profile, null, 2));
+      if (flags.json) {
+        printJsonOnlyOutput({ buildProfile: profile, appConfig });
+      } else {
+        Log.addNewLineIfNone();
+        Log.log(chalk.bold(getProjectConfigDescription(projectDir)));
+        Log.newLine();
+        Log.log(JSON.stringify(appConfig, null, 2));
+        Log.newLine();
+        Log.newLine();
+        const appPlatform = toAppPlatform(platform);
+        const platformEmoji = appPlatformEmojis[appPlatform];
+        Log.log(`${platformEmoji} ${chalk.bold(`Build profile "${profileName}"`)}`);
+        Log.newLine();
+        Log.log(JSON.stringify(profile, null, 2));
+      }
+    }
   }
 }

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -23,6 +23,7 @@ export default class Config extends EasCommand {
         'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
       helpValue: 'PROFILE_NAME',
     }),
+    // This option is used only on EAS Build worker to read build profile from eas.json.
     'eas-json-only': Flags.boolean({
       hidden: true,
     }),


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Part of the effort to run EAS Build directly from GitHub. 

Adds new local build mode that runs the same, code as a local build, but:
- Instead of spawning local-build-plugin it prints job and metadata to stdout
- It always runs in non-interactive mode
- It can only be triggered from a hidden command

Add `--json`/`--non-interactive`/`--eas-json-only` flags to the `expo config` command. We need that command to read eas.json at the beginning of the process before pre install hook is called. It needs to be part of the `eas-cli` to make it possible to users to force their own version of the `eas-cli`. `--eas-json-only` is needed because we can't evaluate app config before `yarn install` and we need to have that value before pre-install hook is called.

# How

- Add `eas build:internal` command and make it hidden
- `--json`/`--non-interactive`/`--eas-json-only` options to `expo config` where `--eas-json-only` is a hidden option.

# Test Plan

Tested with local builds. I did not do extensive testing on all possible flows, but all the additional work to support this feature is basically making sure non-interactive flow works well.
