### PR TITLE
[eas-cli] Fix eas cli `node:assert` import error by using imports from `assert` instead of `node:assert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Make the not recognized image error handler run only if the image is present under a valid key and has an invalid value. ([#1565](https://github.com/expo/eas-cli/pull/1565) by [@szdziedzic](https://github.com/szdziedzic))
+- Fix the `node:assert` import error by using imports from `assert` instead of from `node:assert`. ([#1569](https://github.com/expo/eas-cli/pull/1569) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -1,6 +1,6 @@
 import { Errors, Flags } from '@oclif/core';
+import assert from 'assert';
 import { pathExists } from 'fs-extra';
-import assert from 'node:assert';
 import path from 'path';
 
 import { getLatestBuildAsync, listAndSelectBuildsOnAppAsync } from '../../build/queries';

--- a/packages/eas-cli/src/run/android/emulator.ts
+++ b/packages/eas-cli/src/run/android/emulator.ts
@@ -1,6 +1,6 @@
 import spawnAsync, { SpawnResult } from '@expo/spawn-async';
+import assert from 'assert';
 import chalk from 'chalk';
-import assert from 'node:assert';
 import os from 'os';
 import path from 'path';
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://github.com/expo/eas-cli/issues/1566

# How

I downgraded to node `14.17.5` and was able to replicate the issue. Once I updated all wrong imports to use the `assert` module (as we did in other places), instead of the `node:assert` module everything started to work. I also checked for higher node version `18.12.1` and everything seems fine as well.

# Test Plan

Test manually.
