### PR TITLE
[eas-cli] Adds channels to build profiles on eas update:configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add channel configurations to **eas.json** during `eas update:configure`. ([#1570](https://github.com/expo/eas-cli/pull/1570) by [@jonsamp](https://github.com/jonsamp))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -1,10 +1,11 @@
 import { Flags } from '@oclif/core';
+import chalk from 'chalk';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import Log from '../../log';
 import { RequestedPlatform } from '../../platform';
-import { ensureEASUpdatesIsConfiguredAsync } from '../../update/configure';
+import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
 
 export default class UpdateConfigure extends EasCommand {
   static override description = 'configure the project to support EAS Update';
@@ -38,7 +39,7 @@ export default class UpdateConfigure extends EasCommand {
       '💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.'
     );
 
-    await ensureEASUpdatesIsConfiguredAsync(graphqlClient, {
+    await ensureEASUpdateIsConfiguredAsync(graphqlClient, {
       exp,
       projectId,
       projectDir,
@@ -46,6 +47,25 @@ export default class UpdateConfigure extends EasCommand {
     });
 
     Log.addNewLineIfNone();
-    Log.log(`🎉 Your app is configured to run EAS Update!`);
+    Log.log(`🎉 Your app is configured with EAS Update!`);
+    Log.newLine();
+    Log.log(`${chalk.bold('Next steps')}:`);
+    Log.newLine();
+    Log.log('Update a production build:');
+    Log.log(`1. Create a new build. Example: ${chalk.green('`eas build --profile production`')}.`);
+    Log.log('2. Make changes in your project.');
+    Log.log(`3. Publish an update. Example: ${chalk.green('`eas update --channel production`')}.`);
+    Log.log('4. Force close and reopen your app at least twice to view the published update.');
+
+    Log.newLine();
+    Log.log('Preview an update:');
+    Log.log(
+      `1. Publish an update to a branch. Example: ${chalk.green(
+        '`eas update --branch new-feature`'
+      )}`
+    );
+    Log.log(
+      '2. In Expo Go or a development build, navigate to Projects > [project name] > Branch > Open.'
+    );
   }
 }

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -60,8 +60,8 @@ export default class UpdateConfigure extends EasCommand {
     Log.newLine();
     Log.log('Preview an update:');
     Log.log(
-      `1. Publish an update to a branch. Example: ${chalk.green(
-        '`eas update --branch new-feature`'
+      `1. Publish an update to a branch. Example: ${chalk.bold(
+        'eas update --branch new-feature'
       )}.`
     );
     Log.log(

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -52,9 +52,9 @@ export default class UpdateConfigure extends EasCommand {
     Log.log(`${chalk.bold('Next steps')}:`);
     Log.newLine();
     Log.log('Update a production build:');
-    Log.log(`1. Create a new build. Example: ${chalk.green('`eas build --profile production`')}.`);
+    Log.log(`1. Create a new build. Example: ${chalk.bold('eas build --profile production')}.`);
     Log.log('2. Make changes in your project.');
-    Log.log(`3. Publish an update. Example: ${chalk.green('`eas update --channel production`')}.`);
+    Log.log(`3. Publish an update. Example: ${chalk.bold('eas update --channel production')}.`);
     Log.log('4. Force close and reopen the app at least twice to view the update.');
 
     Log.newLine();

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -55,14 +55,14 @@ export default class UpdateConfigure extends EasCommand {
     Log.log(`1. Create a new build. Example: ${chalk.green('`eas build --profile production`')}.`);
     Log.log('2. Make changes in your project.');
     Log.log(`3. Publish an update. Example: ${chalk.green('`eas update --channel production`')}.`);
-    Log.log('4. Force close and reopen your app at least twice to view the published update.');
+    Log.log('4. Force close and reopen the app at least twice to view the update.');
 
     Log.newLine();
     Log.log('Preview an update:');
     Log.log(
       `1. Publish an update to a branch. Example: ${chalk.green(
         '`eas update --branch new-feature`'
-      )}`
+      )}.`
     );
     Log.log(
       '2. In Expo Go or a development build, navigate to Projects > [project name] > Branch > Open.'

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -60,9 +60,7 @@ export default class UpdateConfigure extends EasCommand {
     Log.newLine();
     Log.log('Preview an update:');
     Log.log(
-      `1. Publish an update to a branch. Example: ${chalk.bold(
-        'eas update --branch new-feature'
-      )}.`
+      `1. Publish an update to a branch. Example: ${chalk.bold('eas update --branch new-feature')}.`
     );
     Log.log(
       '2. In Expo Go or a development build, navigate to Projects > [project name] > Branch > Open.'

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -37,7 +37,7 @@ import {
 } from '../../project/publish';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { promptAsync } from '../../prompts';
-import { ensureEASUpdatesIsConfiguredAsync } from '../../update/configure';
+import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
 import { formatUpdateMessage, truncateString as truncateUpdateMessage } from '../../update/utils';
 import {
   checkManifestBodyAgainstUpdateInfoGroup,
@@ -192,7 +192,7 @@ export default class UpdatePublish extends EasCommand {
 
     await maybeWarnAboutEasOutagesAsync(graphqlClient, [StatuspageServiceName.EasUpdate]);
 
-    await ensureEASUpdatesIsConfiguredAsync(graphqlClient, {
+    await ensureEASUpdateIsConfiguredAsync(graphqlClient, {
       exp: expPossiblyWithoutEasUpdateConfigured,
       platform: getRequestedPlatform(platformFlag),
       projectDir,

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -1,7 +1,9 @@
 import { modifyConfigAsync } from '@expo/config';
 import { ExpoConfig } from '@expo/config-types';
 import { Platform, Workflow } from '@expo/eas-build-job';
+import { EasJsonAccessor } from '@expo/eas-json';
 import chalk from 'chalk';
+import fs from 'fs-extra';
 
 import { getEASUpdateURL } from '../api';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
@@ -225,7 +227,7 @@ function warnEASUpdatesManualConfig({
 /**
  * Make sure that the current `app.json` configuration for EAS Updates is set natively.
  */
-async function ensureEASUpdatesIsConfiguredNativelyAsync(
+async function ensureEASUpdateIsConfiguredNativelyAsync(
   graphqlClient: ExpoGraphqlClient,
   {
     exp,
@@ -253,6 +255,71 @@ async function ensureEASUpdatesIsConfiguredNativelyAsync(
 }
 
 /**
+ * Make sure EAS Build profiles are configured to work with EAS Update by adding channels to build profiles.
+ */
+
+async function ensureEASUpdateIsConfiguredInEasConfigAsync({
+  projectDir,
+}: {
+  projectDir: string;
+}): Promise<void> {
+  const easConfigPath = EasJsonAccessor.formatEasJsonPath(projectDir);
+
+  if (await fs.pathExists(easConfigPath)) {
+    try {
+      const easConfigJson = await fs.readFile(easConfigPath, 'utf-8');
+      const easConfigData = JSON.parse(easConfigJson);
+      const easBuildProfilesWithChannels = Object.keys(easConfigData.build).reduce(
+        (acc, profileNameKey) => {
+          const buildProfile = easConfigData.build[profileNameKey];
+          const isNotAlreadyConfigured = !buildProfile.channel && !buildProfile.releaseChannel;
+
+          if (isNotAlreadyConfigured) {
+            return {
+              ...acc,
+              [profileNameKey]: {
+                ...buildProfile,
+                channel: profileNameKey,
+              },
+            };
+          }
+
+          return {
+            ...acc,
+            [profileNameKey]: {
+              ...easConfigData.build[profileNameKey],
+            },
+          };
+        },
+        {}
+      );
+
+      await fs.writeFile(
+        easConfigPath,
+        `${JSON.stringify(
+          {
+            ...easConfigData,
+            build: easBuildProfilesWithChannels,
+          },
+          null,
+          2
+        )}\n`
+      );
+
+      Log.withTick(`Configured ${chalk.bold('eas.json')}.`);
+    } catch (error) {
+      Log.error(`We were not able to configure ${chalk.bold('eas.json')}. Error: ${error}.`);
+    }
+  } else {
+    Log.warn(
+      `EAS Build is not configured. If you'd like to use EAS Build with EAS Update, run \`eas build:configure\`, then re-run \`eas update:configure\` to configure ${chalk.bold(
+        'eas.json'
+      )} with EAS Update.`
+    );
+  }
+}
+
+/**
  * Make sure EAS Update is fully configured in the current project.
  * This goes over a checklist and performs the following checks or changes:
  *   - Enure the `expo-updates` package is currently installed.
@@ -261,7 +328,7 @@ async function ensureEASUpdatesIsConfiguredNativelyAsync(
  *     - Sets `updates.url` if not set
  *   - Ensure latest changes are reflected in the native config, if any
  */
-export async function ensureEASUpdatesIsConfiguredAsync(
+export async function ensureEASUpdateIsConfiguredAsync(
   graphqlClient: ExpoGraphqlClient,
   {
     exp: expWithoutUpdates,
@@ -300,8 +367,10 @@ export async function ensureEASUpdatesIsConfiguredAsync(
       workflows,
     });
 
+  await ensureEASUpdateIsConfiguredInEasConfigAsync({ projectDir });
+
   if (projectChanged || !hasExpoUpdates) {
-    await ensureEASUpdatesIsConfiguredNativelyAsync(graphqlClient, {
+    await ensureEASUpdateIsConfiguredNativelyAsync(graphqlClient, {
       exp: expWithUpdates,
       projectDir,
       projectId,

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -263,7 +263,7 @@ async function ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir: string): Pr
 
   if (!(await fs.pathExists(easJsonPath))) {
     Log.warn(
-      `EAS Build is not configured. If you'd like to use EAS Build with EAS Update, run \`eas build:configure\`, then re-run ${chalk.bold(
+      `EAS Build is not configured. If you'd like to use EAS Build with EAS Update, run ${chalk.bold('eas build:configure')}, then re-run ${chalk.bold(
         'eas update:configure'
       )} to configure ${chalk.bold('eas.json')} with EAS Update.`
     );

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -263,9 +263,11 @@ async function ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir: string): Pr
 
   if (!(await fs.pathExists(easJsonPath))) {
     Log.warn(
-      `EAS Build is not configured. If you'd like to use EAS Build with EAS Update, run ${chalk.bold('eas build:configure')}, then re-run ${chalk.bold(
-        'eas update:configure'
-      )} to configure ${chalk.bold('eas.json')} with EAS Update.`
+      `EAS Build is not configured. If you'd like to use EAS Build with EAS Update, run ${chalk.bold(
+        'eas build:configure'
+      )}, then re-run ${chalk.bold('eas update:configure')} to configure ${chalk.bold(
+        'eas.json'
+      )} with EAS Update.`
     );
     return;
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

To make EAS Update easier to set up, we are adding `channel` properties to build profiles when running `eas update:configure`.

The logic is:
- If eas.json is present:
  - if there is not pre-existing channel or release channel, set a channel named after the profile name
  - else do nothing (leave as is)
- else warn that the developer may need to run `eas build:configure`, then re-run `eas update:configure` to set everything up.

In addition, I updated the "Next steps" text, so there's actionable items after running `eas update:configure`.

<img width="861" alt="Screenshot 2022-12-07 at 12 47 10 PM" src="https://user-images.githubusercontent.com/6455018/206269931-8b89ea20-5e3e-4c3b-863c-d6ad077677ed.png">


# Test Plan

Run `easd update:configure` in a project. Check:
- that projects with channels in build profiles are not overwritten
- that projects with release channels in build profiles are not overwritten
- that projects get a channel when none is specified after running `eas update:configure`
- that if **eas.json** is not present, you see a readable error message