### PR TITLE
[ENG-7058][eas-cli] Add `build:resign` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add channel configurations to **eas.json** during `eas update:configure`. ([#1570](https://github.com/expo/eas-cli/pull/1570) by [@jonsamp](https://github.com/jonsamp))
+- Add `build:resign` command. ([#1575](https://github.com/expo/eas-cli/pull/1575) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql-codegen.yml
+++ b/packages/eas-cli/graphql-codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://staging-api.expo.dev/graphql'
+schema: 'http://127.0.0.1:3000/--/graphql'
 documents:
   - 'src/graphql/**/!(*.d).{ts,tsx}'
   - 'src/credentials/ios/api/graphql/**/!(*.d).{ts,tsx}'

--- a/packages/eas-cli/graphql-codegen.yml
+++ b/packages/eas-cli/graphql-codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'http://127.0.0.1:3000/--/graphql'
+schema: 'https://staging-api.expo.dev/graphql'
 documents:
   - 'src/graphql/**/!(*.d).{ts,tsx}'
   - 'src/credentials/ios/api/graphql/**/!(*.d).{ts,tsx}'

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -23354,7 +23354,7 @@
             "deprecationReason": null
           },
           {
-            "name": "NOOP",
+            "name": "NONE",
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -5082,6 +5082,18 @@
             "deprecationReason": null
           },
           {
+            "name": "mode",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "projectArchive",
             "description": "",
             "type": {
@@ -5381,6 +5393,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mode",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
               "ofType": null
             },
             "defaultValue": null,
@@ -12009,7 +12033,20 @@
           {
             "name": "canRetry",
             "description": "",
-            "args": [],
+            "args": [
+              {
+                "name": "newMode",
+                "description": "",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "BuildMode",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13858,6 +13895,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "BuildMode",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILD",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESIGN",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "BuildMutation",
         "description": "",
@@ -14711,6 +14771,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "BuildResignInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "applicationArchiveSource",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectArchiveSourceInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "BuildResourceClass",
         "description": "",
@@ -14843,6 +14926,12 @@
           },
           {
             "name": "MANAGED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNKNOWN",
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null
@@ -20962,6 +21051,18 @@
             "deprecationReason": null
           },
           {
+            "name": "mode",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "projectArchive",
             "description": "",
             "type": {
@@ -21233,11 +21334,35 @@
             "deprecationReason": null
           },
           {
+            "name": "mode",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "releaseChannel",
             "description": "",
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resign",
+            "description": "",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildResignInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -21274,6 +21399,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildWorkflow",
               "ofType": null
             },
             "defaultValue": null,
@@ -23212,6 +23349,12 @@
         "enumValues": [
           {
             "name": "GCS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOOP",
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -2259,22 +2259,6 @@
             "deprecationReason": null
           },
           {
-            "name": "redirectUri",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "revokeEndpoint",
             "description": "",
             "args": [],
@@ -2433,22 +2417,6 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "redirectUri",
-            "description": "",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -2738,22 +2706,6 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "redirectUri",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6618,6 +6570,51 @@
             "type": {
               "kind": "OBJECT",
               "name": "Deployment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deploymentNew",
+            "description": "",
+            "args": [
+              {
+                "name": "channel",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "runtimeVersion",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "DeploymentNew",
               "ofType": null
             },
             "isDeprecated": false,
@@ -16500,6 +16497,224 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "DeploymentBuildEdge",
+        "description": "",
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Build",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeploymentBuildsConnection",
+        "description": "",
+        "fields": [
+          {
+            "name": "edges",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DeploymentBuildEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeploymentNew",
+        "description": "Represents a Deployment - a set of Builds with the same Runtime Version and Channel",
+        "fields": [
+          {
+            "name": "builds",
+            "description": "",
+            "args": [
+              {
+                "name": "after",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeploymentBuildsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "channel",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UpdateChannel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "runtime",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Runtime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "DeploymentOptions",
         "description": "",
@@ -17580,13 +17795,9 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -22480,6 +22691,73 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "PageInfo",
+        "description": "",
+        "fields": [
+          {
+            "name": "endCursor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasNextPage",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasPreviousPage",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startCursor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "PartialManifest",
         "description": "",
@@ -25118,6 +25396,81 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "WebhookQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Runtime",
+        "description": "",
+        "fields": [
+          {
+            "name": "app",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstBuildCreatedAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/src/branch/queries.ts
+++ b/packages/eas-cli/src/branch/queries.ts
@@ -15,6 +15,7 @@ import Log from '../log';
 import { formatBranch, getBranchDescription } from '../update/utils';
 import { printJsonOnlyOutput } from '../utils/json';
 import {
+  SelectPromptEntry,
   paginatedQueryWithConfirmPromptAsync,
   paginatedQueryWithSelectPromptAsync,
 } from '../utils/queries';
@@ -31,7 +32,7 @@ export async function selectBranchOnAppAsync(
     paginatedQueryOptions,
   }: {
     projectId: string;
-    displayTextForListItem: (queryItem: UpdateBranchFragment) => string;
+    displayTextForListItem: (queryItem: UpdateBranchFragment) => SelectPromptEntry;
     promptTitle: string;
     paginatedQueryOptions: PaginatedQueryOptions;
   }

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -1,5 +1,7 @@
 import { Platform } from '@expo/eas-build-job';
+import { BuildProfile } from '@expo/eas-json';
 
+import { CredentialsContext } from '../../credentials/context';
 import IosCredentialsProvider from '../../credentials/ios/IosCredentialsProvider';
 import { getAppFromContextAsync } from '../../credentials/ios/actions/BuildCredentialsUtils';
 import { IosCredentials, Target } from '../../credentials/ios/types';
@@ -23,6 +25,27 @@ export async function ensureIosCredentialsAsync(
   });
 
   const { credentialsSource } = buildCtx.buildProfile;
+
+  logCredentialsSource(credentialsSource, Platform.IOS);
+  return {
+    credentials: await provider.getCredentialsAsync(credentialsSource),
+    source: credentialsSource,
+  };
+}
+
+export async function ensureIosCredentialsForBuildResignAsync(
+  credentialsCtx: CredentialsContext,
+  targets: Target[],
+  buildProfile: BuildProfile<Platform.IOS>
+): Promise<CredentialsResult<IosCredentials>> {
+  const provider = new IosCredentialsProvider(credentialsCtx, {
+    app: await getAppFromContextAsync(credentialsCtx),
+    targets,
+    distribution: 'internal',
+    enterpriseProvisioning: buildProfile.enterpriseProvisioning,
+  });
+
+  const { credentialsSource } = buildProfile;
 
   logCredentialsSource(credentialsSource, Platform.IOS);
   return {

--- a/packages/eas-cli/src/build/ios/graphql.ts
+++ b/packages/eas-cli/src/build/ios/graphql.ts
@@ -26,7 +26,7 @@ export function transformJob(job: Ios.Job): IosJobInput {
   };
 }
 
-function transformIosSecrets(secrets: {
+export function transformIosSecrets(secrets: {
   buildCredentials?: Ios.BuildCredentials;
 }): IosJobSecretsInput {
   const buildCredentials: IosJobSecretsInput['buildCredentials'] = [];

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -62,6 +62,7 @@ export async function listAndSelectBuildOnAppAsync(
   graphqlClient: ExpoGraphqlClient,
   {
     projectId,
+    title,
     filter,
     paginatedQueryOptions,
   }: {
@@ -85,7 +86,7 @@ export async function listAndSelectBuildOnAppAsync(
           filter,
         }),
       promptOptions: {
-        title: 'Load more builds?',
+        title,
         getIdentifierForQueryItem: build => build.id,
         createDisplayTextForSelectionPromptListItem: formatBuildChoiceTitleAndDescription,
       },

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -8,7 +8,10 @@ import Log from '../log';
 import { promptAsync } from '../prompts';
 import { fromNow } from '../utils/date';
 import { printJsonOnlyOutput } from '../utils/json';
-import { paginatedQueryWithConfirmPromptAsync } from '../utils/queries';
+import {
+  paginatedQueryWithConfirmPromptAsync,
+  paginatedQueryWithSelectPromptAsync,
+} from '../utils/queries';
 import { formatGraphQLBuild } from './utils/formatBuild';
 
 export const BUILDS_LIMIT = 50;
@@ -50,6 +53,41 @@ export async function listAndRenderBuildsOnAppAsync(
         title: 'Load more builds?',
         renderListItems: builds =>
           renderPageOfBuilds({ builds, projectDisplayName, paginatedQueryOptions }),
+      },
+    });
+  }
+}
+
+export async function listAndSelectBuildOnAppAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    projectId,
+    filter,
+    paginatedQueryOptions,
+  }: {
+    projectId: string;
+    title: string;
+    filter?: BuildFilter;
+    paginatedQueryOptions: PaginatedQueryOptions;
+  }
+): Promise<BuildFragment | void> {
+  if (paginatedQueryOptions.nonInteractive) {
+    throw new Error('Unable to select a build in non-interactive mode.');
+  } else {
+    return await paginatedQueryWithSelectPromptAsync({
+      limit: paginatedQueryOptions.limit ?? BUILDS_LIMIT,
+      offset: paginatedQueryOptions.offset,
+      queryToPerform: (limit, offset) =>
+        BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
+          appId: projectId,
+          limit,
+          offset,
+          filter,
+        }),
+      promptOptions: {
+        title: 'Load more builds?',
+        getIdentifierForQueryItem: build => build.id,
+        createDisplayTextForSelectionPromptListItem: formatBuildChoiceTitleAndDescription,
       },
     });
   }

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -46,7 +46,7 @@ export async function selectChannelOnAppAsync(
       queryChannelsOnAppAsync(graphqlClient, { appId: projectId, limit, offset }),
     promptOptions: {
       title: selectionPromptTitle,
-      createDisplayTextForSelectionPromptListItem: updateChannel => updateChannel.name,
+      createDisplayTextForSelectionPromptListItem: updateChannel => ({ title: updateChannel.name }),
       getIdentifierForQueryItem: updateChannel => updateChannel.id,
     },
   });

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -120,7 +120,7 @@ export default class BranchDelete extends EasCommand {
       }
       ({ name: branchName } = await selectBranchOnAppAsync(graphqlClient, {
         projectId,
-        displayTextForListItem: updateBranch => updateBranch.name,
+        displayTextForListItem: updateBranch => ({ title: updateBranch.name }),
         promptTitle: 'Which branch would you like to delete?',
         paginatedQueryOptions,
       }));

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -57,7 +57,9 @@ export default class BranchView extends EasCommand {
       ({ name: branchName } = await selectBranchOnAppAsync(graphqlClient, {
         projectId,
         promptTitle: 'Which branch would you like to view?',
-        displayTextForListItem: updateBranch => updateBranch.name,
+        displayTextForListItem: updateBranch => ({
+          title: updateBranch.name,
+        }),
         // discard limit and offset because this query is not their intended target
         paginatedQueryOptions: {
           json: paginatedQueryOptions.json,

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -245,7 +245,7 @@ export default class Build extends EasCommand {
   }
 }
 
-async function handleDeprecatedEasJsonAsync(
+export async function handleDeprecatedEasJsonAsync(
   projectDir: string,
   nonInteractive: boolean
 ): Promise<void> {

--- a/packages/eas-cli/src/commands/build/resign.ts
+++ b/packages/eas-cli/src/commands/build/resign.ts
@@ -33,7 +33,7 @@ import { requestedPlatformDisplayNames, selectPlatformAsync } from '../../platfo
 import { resolveXcodeBuildContextAsync } from '../../project/ios/scheme';
 import { resolveTargetsAsync } from '../../project/ios/target';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
-import { printJsonOnlyOutput } from '../../utils/json';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import { maybeWarnAboutEasOutagesAsync } from '../../utils/statuspageService';
 
 interface BuildResignFlags {
@@ -92,6 +92,10 @@ export default class BuildResign extends EasCommand {
 
   async runAsync(): Promise<void> {
     const { flags: rawFlags } = await this.parse(BuildResign);
+    if (rawFlags.json) {
+      enableJsonOutput();
+    }
+
     const flags = this.sanitizeFlags(rawFlags as RawBuildResignFlags);
     const { limit, offset, nonInteractive } = flags;
 
@@ -208,7 +212,7 @@ export default class BuildResign extends EasCommand {
     const nonInteractive = flags['non-interactive'];
     if (nonInteractive && !flags.id) {
       throw new Error(
-        `${chalk.bold('--build-id')} is required when running with ${chalk.bold(
+        `${chalk.bold('--id')} is required when running with ${chalk.bold(
           '--non-interactive'
         )} flag.`
       );

--- a/packages/eas-cli/src/commands/build/resign.ts
+++ b/packages/eas-cli/src/commands/build/resign.ts
@@ -54,7 +54,7 @@ interface RawBuildResignFlags {
   platform: 'android' | 'ios' | undefined;
   profile: string | undefined;
   wait: boolean;
-  'build-id': string | undefined;
+  id: string | undefined;
 }
 
 export default class BuildResign extends EasCommand {
@@ -206,8 +206,7 @@ export default class BuildResign extends EasCommand {
 
   sanitizeFlags(flags: RawBuildResignFlags): BuildResignFlags {
     const nonInteractive = flags['non-interactive'];
-    const maybeBuildId = flags['build-id'];
-    if (nonInteractive && !maybeBuildId) {
+    if (nonInteractive && !flags.id) {
       throw new Error(
         `${chalk.bold('--build-id')} is required when running with ${chalk.bold(
           '--non-interactive'
@@ -221,7 +220,7 @@ export default class BuildResign extends EasCommand {
       limit: flags.limit,
       platform: flags.platform as Platform | undefined,
       profile: flags.profile,
-      maybeBuildId,
+      maybeBuildId: flags.id,
       wait: flags.wait,
     };
   }

--- a/packages/eas-cli/src/commands/build/resign.ts
+++ b/packages/eas-cli/src/commands/build/resign.ts
@@ -58,7 +58,7 @@ interface RawBuildResignFlags {
 }
 
 export default class BuildResign extends EasCommand {
-  static override description = 'resign a build archive';
+  static override description = 're-sign a build archive';
 
   static override flags = {
     platform: Flags.enum({
@@ -74,10 +74,10 @@ export default class BuildResign extends EasCommand {
     wait: Flags.boolean({
       default: true,
       allowNo: true,
-      description: 'Wait for build(s) to complete',
+      description: 'Wait for build(s) to complete.',
     }),
-    'build-id': Flags.string({
-      description: 'Id of the build to resign',
+    id: Flags.string({
+      description: 'ID of the build to re-sign.',
     }),
     ...EasPaginatedQueryFlags,
     ...EasNonInteractiveAndJsonFlags,
@@ -203,6 +203,7 @@ export default class BuildResign extends EasCommand {
       printJsonOnlyOutput(buildResult[0]);
     }
   }
+
   sanitizeFlags(flags: RawBuildResignFlags): BuildResignFlags {
     const nonInteractive = flags['non-interactive'];
     const maybeBuildId = flags['build-id'];
@@ -248,7 +249,7 @@ export default class BuildResign extends EasCommand {
     }
     const build = await listAndSelectBuildOnAppAsync(graphqlClient, {
       projectId,
-      title: 'Which build would you like to sign with a new credentials?',
+      title: 'Which build would you like to re-sign with new credentials?',
       paginatedQueryOptions: {
         limit,
         offset: offset ?? 0,
@@ -262,7 +263,7 @@ export default class BuildResign extends EasCommand {
       },
     });
     if (!build) {
-      throw new Error('There are no builds that can be resigned on this project.');
+      throw new Error('There are no builds that can be re-signed on this project.');
     }
     return build;
   }
@@ -275,14 +276,14 @@ export default class BuildResign extends EasCommand {
     if (maybeBuildId) {
       const build = await BuildQuery.byIdAsync(graphqlClient, maybeBuildId);
       if (build.distribution !== DistributionType.Internal) {
-        throw new Error('This is not internal distribution build.');
+        throw new Error('This is not an internal distribution build.');
       }
       if (build.status !== BuildStatus.Finished) {
-        throw new Error('You can only resign builds that finished successfully.');
+        throw new Error('Only builds that finished successfully can be re-signed.');
       }
       if (maybePlatform && build.platform !== toAppPlatform(maybePlatform)) {
         throw new Error(
-          `Build with id ${maybeBuildId} was not created for platform ${requestedPlatformDisplayNames[maybePlatform]}.`
+          `Build with ID ${maybeBuildId} was not created for platform ${requestedPlatformDisplayNames[maybePlatform]}.`
         );
       }
       return build;

--- a/packages/eas-cli/src/commands/build/resign.ts
+++ b/packages/eas-cli/src/commands/build/resign.ts
@@ -1,0 +1,279 @@
+import { Platform } from '@expo/eas-build-job';
+import { CredentialsSource, EasJson, EasJsonAccessor, EasJsonUtils } from '@expo/eas-json';
+import { Flags } from '@oclif/core';
+import assert from 'assert';
+import chalk from 'chalk';
+
+import { handleDeprecatedEasJsonAsync } from '.';
+import { waitForBuildEndAsync } from '../../build/build';
+import { ensureIosCredentialsForBuildResignAsync } from '../../build/ios/credentials';
+import { prepareCredentialsToResign } from '../../build/ios/prepareJob';
+import { listAndSelectBuildOnAppAsync } from '../../build/queries';
+import { printBuildResults, printLogsUrls } from '../../build/utils/printBuildInfo';
+import EasCommand from '../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { EasPaginatedQueryFlags } from '../../commandUtils/pagination';
+import { CredentialsContext } from '../../credentials/context';
+import {
+  BuildFragment,
+  BuildStatus,
+  DistributionType,
+  StatuspageServiceName,
+} from '../../graphql/generated';
+import { BuildMutation } from '../../graphql/mutations/BuildMutation';
+import { BuildQuery } from '../../graphql/queries/BuildQuery';
+import { toAppPlatform } from '../../graphql/types/AppPlatform';
+import Log from '../../log';
+import { requestedPlatformDisplayNames, selectPlatformAsync } from '../../platform';
+import { resolveXcodeBuildContextAsync } from '../../project/ios/scheme';
+import { resolveTargetsAsync } from '../../project/ios/target';
+import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
+import { printJsonOnlyOutput } from '../../utils/json';
+import { maybeWarnAboutEasOutagesAsync } from '../../utils/statuspageService';
+
+interface BuildResignFlags {
+  json: boolean;
+  nonInteractive: boolean;
+  offset?: number;
+  limit?: number;
+  platform?: Platform;
+  profile?: string;
+  maybeBuildId?: string;
+  wait: boolean;
+}
+interface RawBuildResignFlags {
+  json: boolean;
+  'non-interactive': boolean;
+  offset: number | undefined;
+  limit: number | undefined;
+  platform: 'android' | 'ios' | undefined;
+  profile: string | undefined;
+  wait: boolean;
+  'build-id': string | undefined;
+}
+
+export default class BuildResign extends EasCommand {
+  static override description = 'resign a build archive';
+
+  static override flags = {
+    platform: Flags.enum({
+      char: 'p',
+      options: ['android', 'ios'],
+    }),
+    profile: Flags.string({
+      char: 'e',
+      description:
+        'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
+      helpValue: 'PROFILE_NAME',
+    }),
+    wait: Flags.boolean({
+      default: true,
+      allowNo: true,
+      description: 'Wait for build(s) to complete',
+    }),
+    'build-id': Flags.string({
+      description: 'Id of the build to resign',
+    }),
+    ...EasPaginatedQueryFlags,
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+    ...this.ContextOptions.DynamicProjectConfig,
+    ...this.ContextOptions.ProjectDir,
+    ...this.ContextOptions.Analytics,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags: rawFlags } = await this.parse(BuildResign);
+    const flags = this.sanitizeFlags(rawFlags as RawBuildResignFlags);
+    const { limit, offset, nonInteractive } = flags;
+
+    const {
+      loggedIn: { actor, graphqlClient },
+      getDynamicProjectConfigAsync,
+      projectDir,
+      analytics,
+    } = await this.getContextAsync(BuildResign, {
+      nonInteractive: flags.nonInteractive,
+    });
+
+    const maybeBuild = flags.maybeBuildId
+      ? await this.maybeGetBuildAsync(graphqlClient, flags.maybeBuildId)
+      : undefined;
+    const platform =
+      (maybeBuild?.platform.toLowerCase() as Platform | undefined) ??
+      (await selectPlatformAsync(flags.platform));
+    if (platform === Platform.ANDROID) {
+      throw new Error('Re-signing archives is not supported on Android yet.');
+    }
+
+    await handleDeprecatedEasJsonAsync(projectDir, flags.nonInteractive);
+
+    await maybeWarnAboutEasOutagesAsync(graphqlClient, [StatuspageServiceName.EasBuild]);
+    const easJsonAccessor = new EasJsonAccessor(projectDir);
+    const easJsonCliConfig: EasJson['cli'] =
+      (await EasJsonUtils.getCliConfigAsync(easJsonAccessor)) ?? {};
+
+    const buildProfile = await EasJsonUtils.getBuildProfileAsync(
+      easJsonAccessor,
+      platform,
+      flags.profile ?? 'production'
+    );
+    const { exp, projectId } = await getDynamicProjectConfigAsync({ env: buildProfile.env });
+    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
+    const build = await this.ensureBuildSelectedAsync(
+      { graphqlClient, projectId, platform, nonInteractive, limit, offset },
+      maybeBuild
+    );
+    const credentialsCtx = new CredentialsContext({
+      projectInfo: { exp, projectId },
+      nonInteractive,
+      projectDir,
+      user: actor,
+      graphqlClient,
+      analytics,
+      env: buildProfile.env,
+      easJsonCliConfig,
+    });
+    if (buildProfile.credentialsSource !== CredentialsSource.LOCAL) {
+      await credentialsCtx.appStore.ensureAuthenticatedAsync();
+    }
+    const xcodeBuildContext = await resolveXcodeBuildContextAsync(
+      {
+        projectDir,
+        nonInteractive,
+        exp,
+      },
+      buildProfile
+    );
+    const targets = await resolveTargetsAsync({
+      projectDir,
+      exp,
+      xcodeBuildContext,
+      env: buildProfile.env,
+    });
+    const credentialsResult = await ensureIosCredentialsForBuildResignAsync(
+      credentialsCtx,
+      targets,
+      buildProfile
+    );
+    const job = {
+      buildId: build.id,
+      jobOverrides: {
+        secrets: prepareCredentialsToResign(credentialsResult.credentials),
+        builderEnvironment: { image: 'default' },
+      },
+    };
+    const newBuild = await BuildMutation.retryIosBuildAsync(graphqlClient, job);
+
+    Log.addNewLineIfNone();
+    printLogsUrls([newBuild]);
+    Log.newLine();
+    if (!flags.wait) {
+      if (flags.json) {
+        printJsonOnlyOutput(newBuild);
+      }
+      return;
+    }
+
+    const buildResult = await waitForBuildEndAsync(graphqlClient, {
+      buildIds: [newBuild.id],
+      accountName: account.name,
+    });
+    if (!flags.json) {
+      printBuildResults(buildResult);
+    } else {
+      assert(buildResult[0], 'missing build results');
+      printJsonOnlyOutput(buildResult[0]);
+    }
+  }
+  sanitizeFlags(flags: RawBuildResignFlags): BuildResignFlags {
+    const nonInteractive = flags['non-interactive'];
+    const maybeBuildId = flags['build-id'];
+    if (nonInteractive && !maybeBuildId) {
+      throw new Error(
+        `${chalk.bold('--build-id')} is required when running with ${chalk.bold(
+          '--non-interactive'
+        )} flag.`
+      );
+    }
+    return {
+      json: flags.json,
+      nonInteractive,
+      offset: flags.offset,
+      limit: flags.limit,
+      platform: flags.platform as Platform | undefined,
+      profile: flags.profile,
+      maybeBuildId,
+      wait: flags.wait,
+    };
+  }
+
+  async ensureBuildSelectedAsync(
+    {
+      graphqlClient,
+      projectId,
+      platform,
+      nonInteractive,
+      limit,
+      offset,
+    }: {
+      graphqlClient: ExpoGraphqlClient;
+      projectId: string;
+      platform: Platform;
+      nonInteractive: boolean;
+      limit?: number;
+      offset?: number;
+    },
+    maybeBuild?: BuildFragment
+  ): Promise<BuildFragment> {
+    if (maybeBuild) {
+      return maybeBuild;
+    }
+    const build = await listAndSelectBuildOnAppAsync(graphqlClient, {
+      projectId,
+      title: 'Which build would you like to sign with a new credentials?',
+      paginatedQueryOptions: {
+        limit,
+        offset: offset ?? 0,
+        nonInteractive,
+        json: false,
+      },
+      filter: {
+        distribution: DistributionType.Internal,
+        platform: toAppPlatform(platform),
+        //status: BuildStatus.Finished,
+      },
+    });
+    if (!build) {
+      throw new Error('There are no builds that can be resigned on this project.');
+    }
+    return build;
+  }
+
+  async maybeGetBuildAsync(
+    graphqlClient: ExpoGraphqlClient,
+    maybeBuildId?: string,
+    maybePlatform?: Platform
+  ): Promise<BuildFragment | undefined> {
+    if (maybeBuildId) {
+      const build = await BuildQuery.byIdAsync(graphqlClient, maybeBuildId);
+      if (build.distribution !== DistributionType.Internal) {
+        throw new Error('This is not internal distribution build.');
+      }
+      if (build.status !== BuildStatus.Finished) {
+        throw new Error('You can only resign builds that finished successfully.');
+      }
+      if (maybePlatform && build.platform !== toAppPlatform(maybePlatform)) {
+        throw new Error(
+          `Build with id ${maybeBuildId} was not created for platform ${requestedPlatformDisplayNames[maybePlatform]}.`
+        );
+      }
+      return build;
+    }
+    return undefined;
+  }
+}

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -107,7 +107,7 @@ export default class ChannelEdit extends EasCommand {
       : await selectBranchOnAppAsync(graphqlClient, {
           projectId,
           promptTitle: `Which branch would you like ${existingChannel.name} to point at?`,
-          displayTextForListItem: updateBranch => updateBranch.name,
+          displayTextForListItem: updateBranch => ({ title: updateBranch.name }),
           paginatedQueryOptions: {
             json,
             nonInteractive,

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -214,10 +214,11 @@ export default class UpdatePublish extends EasCommand {
           const branch = await selectBranchOnAppAsync(graphqlClient, {
             projectId,
             promptTitle: `Which branch would you like to publish on?`,
-            displayTextForListItem: updateBranch =>
-              `${updateBranch.name} ${chalk.grey(
+            displayTextForListItem: updateBranch => ({
+              title: `${updateBranch.name} ${chalk.grey(
                 `- current update: ${formatUpdateMessage(updateBranch.updates[0])}`
               )}`,
+            }),
             paginatedQueryOptions,
           });
           branchName = branch.name;

--- a/packages/eas-cli/src/commands/update/list.ts
+++ b/packages/eas-cli/src/commands/update/list.ts
@@ -70,7 +70,9 @@ export default class UpdateList extends EasCommand {
         const selectedBranch = await selectBranchOnAppAsync(graphqlClient, {
           projectId,
           promptTitle: 'Which branch would you like to view?',
-          displayTextForListItem: updateBranch => updateBranch.name,
+          displayTextForListItem: updateBranch => ({
+            title: updateBranch.name,
+          }),
           paginatedQueryOptions:
             // discard limit and offset because this query is not those flag's intended target
             {

--- a/packages/eas-cli/src/devices/queries.ts
+++ b/packages/eas-cli/src/devices/queries.ts
@@ -44,10 +44,11 @@ export async function selectAppleTeamOnAccountAsync(
         }),
       promptOptions: {
         title: selectionPromptTitle,
-        createDisplayTextForSelectionPromptListItem: appleTeam =>
-          appleTeam.appleTeamName
+        createDisplayTextForSelectionPromptListItem: appleTeam => ({
+          title: appleTeam.appleTeamName
             ? `${appleTeam.appleTeamName} (ID: ${appleTeam.appleTeamIdentifier})`
             : appleTeam.appleTeamIdentifier,
+        }),
         getIdentifierForQueryItem: appleTeam => appleTeam.id,
       },
     });
@@ -87,7 +88,9 @@ export async function selectAppleDeviceOnAppleTeamAsync(
         }),
       promptOptions: {
         title: selectionPromptTitle,
-        createDisplayTextForSelectionPromptListItem: appleDevice => formatDeviceLabel(appleDevice),
+        createDisplayTextForSelectionPromptListItem: appleDevice => ({
+          title: formatDeviceLabel(appleDevice),
+        }),
         getIdentifierForQueryItem: appleTeam => appleTeam.id,
       },
     });

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -784,6 +784,7 @@ export type AndroidJobInput = {
   developmentClient?: InputMaybe<Scalars['Boolean']>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
   gradleCommand?: InputMaybe<Scalars['String']>;
+  mode?: InputMaybe<BuildMode>;
   projectArchive: ProjectArchiveSourceInput;
   projectRootDirectory: Scalars['String'];
   releaseChannel?: InputMaybe<Scalars['String']>;
@@ -812,6 +813,7 @@ export type AndroidJobOverridesInput = {
   developmentClient?: InputMaybe<Scalars['Boolean']>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
   gradleCommand?: InputMaybe<Scalars['String']>;
+  mode?: InputMaybe<BuildMode>;
   releaseChannel?: InputMaybe<Scalars['String']>;
   secrets?: InputMaybe<AndroidJobSecretsInput>;
   updates?: InputMaybe<BuildUpdatesInput>;
@@ -1805,6 +1807,12 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   workerStartedAt?: Maybe<Scalars['DateTime']>;
 };
 
+
+/** Represents an EAS Build */
+export type BuildCanRetryArgs = {
+  newMode?: InputMaybe<BuildMode>;
+};
+
 export type BuildArtifact = {
   __typename?: 'BuildArtifact';
   manifestPlistUrl?: Maybe<Scalars['String']>;
@@ -1965,6 +1973,11 @@ export type BuildMetrics = {
   buildWaitTime?: Maybe<Scalars['Int']>;
 };
 
+export enum BuildMode {
+  Build = 'BUILD',
+  Resign = 'RESIGN'
+}
+
 export type BuildMutation = {
   __typename?: 'BuildMutation';
   /**
@@ -2121,6 +2134,10 @@ export type BuildQueryByIdArgs = {
   buildId: Scalars['ID'];
 };
 
+export type BuildResignInput = {
+  applicationArchiveSource?: InputMaybe<ProjectArchiveSourceInput>;
+};
+
 export enum BuildResourceClass {
   AndroidDefault = 'ANDROID_DEFAULT',
   AndroidLarge = 'ANDROID_LARGE',
@@ -2146,7 +2163,8 @@ export type BuildUpdatesInput = {
 
 export enum BuildWorkflow {
   Generic = 'GENERIC',
-  Managed = 'MANAGED'
+  Managed = 'MANAGED',
+  Unknown = 'UNKNOWN'
 }
 
 export enum CacheControlScope {
@@ -3017,6 +3035,7 @@ export type IosJobInput = {
   /** @deprecated */
   distribution?: InputMaybe<DistributionType>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
+  mode?: InputMaybe<BuildMode>;
   projectArchive: ProjectArchiveSourceInput;
   projectRootDirectory: Scalars['String'];
   releaseChannel?: InputMaybe<Scalars['String']>;
@@ -3043,10 +3062,13 @@ export type IosJobOverridesInput = {
   /** @deprecated */
   distribution?: InputMaybe<DistributionType>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
+  mode?: InputMaybe<BuildMode>;
   releaseChannel?: InputMaybe<Scalars['String']>;
+  resign?: InputMaybe<BuildResignInput>;
   scheme?: InputMaybe<Scalars['String']>;
   secrets?: InputMaybe<IosJobSecretsInput>;
   simulator?: InputMaybe<Scalars['Boolean']>;
+  type?: InputMaybe<BuildWorkflow>;
   updates?: InputMaybe<BuildUpdatesInput>;
   username?: InputMaybe<Scalars['String']>;
   version?: InputMaybe<IosJobVersionInput>;
@@ -3341,6 +3363,7 @@ export type ProjectArchiveSourceInput = {
 
 export enum ProjectArchiveSourceType {
   Gcs = 'GCS',
+  Noop = 'NOOP',
   S3 = 'S3',
   Url = 'URL'
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3363,7 +3363,7 @@ export type ProjectArchiveSourceInput = {
 
 export enum ProjectArchiveSourceType {
   Gcs = 'GCS',
-  Noop = 'NOOP',
+  None = 'NONE',
   S3 = 'S3',
   Url = 'URL'
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -400,7 +400,6 @@ export type AccountSsoConfiguration = {
   id: Scalars['ID'];
   issuer?: Maybe<Scalars['String']>;
   jwksEndpoint?: Maybe<Scalars['String']>;
-  redirectUri: Scalars['String'];
   revokeEndpoint?: Maybe<Scalars['String']>;
   tokenEndpoint?: Maybe<Scalars['String']>;
   updatedAt: Scalars['DateTime'];
@@ -415,7 +414,6 @@ export type AccountSsoConfigurationData = {
   clientSecret: Scalars['String'];
   issuer?: InputMaybe<Scalars['String']>;
   jwksEndpoint?: InputMaybe<Scalars['String']>;
-  redirectUri: Scalars['String'];
   revokeEndpoint?: InputMaybe<Scalars['String']>;
   tokenEndpoint?: InputMaybe<Scalars['String']>;
   userInfoEndpoint?: InputMaybe<Scalars['String']>;
@@ -458,7 +456,6 @@ export type AccountSsoConfigurationPublicData = {
   id: Scalars['ID'];
   issuer?: Maybe<Scalars['String']>;
   jwksEndpoint?: Maybe<Scalars['String']>;
-  redirectUri: Scalars['String'];
   revokeEndpoint?: Maybe<Scalars['String']>;
   tokenEndpoint?: Maybe<Scalars['String']>;
   userInfoEndpoint?: Maybe<Scalars['String']>;
@@ -922,6 +919,7 @@ export type App = Project & {
   /** Classic update release channel names that have at least one build */
   buildsReleaseChannels: Array<Scalars['String']>;
   deployment?: Maybe<Deployment>;
+  deploymentNew?: Maybe<DeploymentNew>;
   /** Deployments associated with this app */
   deployments: Array<Deployment>;
   description: Scalars['String'];
@@ -1047,6 +1045,13 @@ export type AppBuildsArgs = {
 export type AppDeploymentArgs = {
   channel: Scalars['String'];
   options?: InputMaybe<DeploymentOptions>;
+  runtimeVersion: Scalars['String'];
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppDeploymentNewArgs = {
+  channel: Scalars['String'];
   runtimeVersion: Scalars['String'];
 };
 
@@ -2381,6 +2386,36 @@ export type Deployment = {
   runtimeVersion: Scalars['String'];
 };
 
+export type DeploymentBuildEdge = {
+  __typename?: 'DeploymentBuildEdge';
+  cursor: Scalars['String'];
+  node: Build;
+};
+
+export type DeploymentBuildsConnection = {
+  __typename?: 'DeploymentBuildsConnection';
+  edges: Array<DeploymentBuildEdge>;
+  pageInfo: PageInfo;
+};
+
+/** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
+export type DeploymentNew = {
+  __typename?: 'DeploymentNew';
+  builds: DeploymentBuildsConnection;
+  channel: UpdateChannel;
+  id: Scalars['ID'];
+  runtime: Runtime;
+};
+
+
+/** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
+export type DeploymentNewBuildsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
 export type DeploymentOptions = {
   /** Max number of associated builds to return */
   buildListMaxSize?: InputMaybe<Scalars['Int']>;
@@ -2547,7 +2582,7 @@ export type GitHubAppInstallationAccessibleRepositoriesArgs = {
 
 export type GitHubAppInstallationAccessibleRepository = {
   __typename?: 'GitHubAppInstallationAccessibleRepository';
-  defaultBranch: Scalars['String'];
+  defaultBranch?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
   name: Scalars['String'];
@@ -3249,6 +3284,14 @@ export enum Order {
   Desc = 'DESC'
 }
 
+export type PageInfo = {
+  __typename?: 'PageInfo';
+  endCursor?: Maybe<Scalars['String']>;
+  hasNextPage: Scalars['Boolean'];
+  hasPreviousPage: Scalars['Boolean'];
+  startCursor?: Maybe<Scalars['String']>;
+};
+
 export type PartialManifest = {
   assets: Array<InputMaybe<PartialManifestAsset>>;
   extra?: InputMaybe<Scalars['JSONObject']>;
@@ -3630,6 +3673,14 @@ export type RootQueryUserByUserIdArgs = {
 
 export type RootQueryUserByUsernameArgs = {
   username: Scalars['String'];
+};
+
+export type Runtime = {
+  __typename?: 'Runtime';
+  app: App;
+  firstBuildCreatedAt: Scalars['DateTime'];
+  id: Scalars['ID'];
+  version: Scalars['String'];
 };
 
 export type SecondFactorBooleanResult = {
@@ -5031,6 +5082,14 @@ export type CreateIosBuildMutationVariables = Exact<{
 
 
 export type CreateIosBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createIosBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }, deprecationInfo?: { __typename?: 'EASBuildDeprecationInfo', type: EasBuildDeprecationInfoType, message: string } | null } } };
+
+export type RetryIosBuildMutationVariables = Exact<{
+  buildId: Scalars['ID'];
+  jobOverrides: IosJobOverridesInput;
+}>;
+
+
+export type RetryIosBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', retryIosBuild: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
 
 export type CreateEnvironmentSecretForAccountMutationVariables = Exact<{
   input: CreateEnvironmentSecretInput;

--- a/packages/eas-cli/src/graphql/mutations/BuildMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/BuildMutation.ts
@@ -15,6 +15,9 @@ import {
   CreateIosBuildMutationVariables,
   EasBuildDeprecationInfo,
   IosJobInput,
+  IosJobOverridesInput,
+  RetryIosBuildMutation,
+  RetryIosBuildMutationVariables,
 } from '../generated';
 import { BuildFragmentNode } from '../types/Build';
 
@@ -115,5 +118,33 @@ export const BuildMutation = {
         .toPromise()
     );
     return nullthrows(data.build?.createIosBuild);
+  },
+  async retryIosBuildAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: {
+      buildId: string;
+      jobOverrides: IosJobOverridesInput;
+    }
+  ): Promise<BuildFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<RetryIosBuildMutation, RetryIosBuildMutationVariables>(
+          gql`
+            mutation RetryIosBuildMutation($buildId: ID!, $jobOverrides: IosJobOverridesInput!) {
+              build {
+                retryIosBuild(buildId: $buildId, jobOverrides: $jobOverrides) {
+                  id
+                  ...BuildFragment
+                }
+              }
+            }
+            ${print(BuildFragmentNode)}
+          `,
+          input,
+          { noRetry: true }
+        )
+        .toPromise()
+    );
+    return nullthrows(data.build?.retryIosBuild);
   },
 };

--- a/packages/eas-cli/src/update/queries.ts
+++ b/packages/eas-cli/src/update/queries.ts
@@ -126,7 +126,9 @@ export async function selectUpdateGroupOnBranchAsync(
       }),
     promptOptions: {
       title: 'Load more update groups?',
-      createDisplayTextForSelectionPromptListItem: updateGroup => formatUpdateTitle(updateGroup[0]),
+      createDisplayTextForSelectionPromptListItem: updateGroup => ({
+        title: formatUpdateTitle(updateGroup[0]),
+      }),
       getIdentifierForQueryItem: updateGroup => updateGroup[0].group,
     },
   });

--- a/packages/eas-cli/src/utils/__tests__/queries-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/queries-test.ts
@@ -129,7 +129,7 @@ describe(paginatedQueryWithSelectPromptAsync.name, () => {
         promptOptions: {
           title: '',
           getIdentifierForQueryItem: item => item.id,
-          createDisplayTextForSelectionPromptListItem: item => 'item: ' + item.value,
+          createDisplayTextForSelectionPromptListItem: item => ({ title: 'item: ' + item.value }),
         },
       });
 
@@ -179,7 +179,7 @@ describe(paginatedQueryWithSelectPromptAsync.name, () => {
       promptOptions: {
         title: '',
         getIdentifierForQueryItem: item => item.id,
-        createDisplayTextForSelectionPromptListItem: item => item.value,
+        createDisplayTextForSelectionPromptListItem: item => ({ title: item.value }),
       },
     });
 

--- a/packages/eas-cli/src/utils/queries.ts
+++ b/packages/eas-cli/src/utils/queries.ts
@@ -3,6 +3,11 @@ import uniqBy from './expodash/uniqBy';
 
 const fetchMoreValue = '_fetchMore';
 
+export interface SelectPromptEntry {
+  title: string;
+  description?: string;
+}
+
 type BasePaginatedQueryArgs<QueryReturnType extends Record<string, any>> = {
   limit: number;
   offset: number;
@@ -21,7 +26,9 @@ type PaginatedQueryWithSelectPromptArgs<QueryReturnType extends Record<string, a
   BasePaginatedQueryArgs<QueryReturnType> & {
     promptOptions: {
       readonly title: string;
-      createDisplayTextForSelectionPromptListItem: (queryItem: QueryReturnType) => string;
+      createDisplayTextForSelectionPromptListItem: (
+        queryItem: QueryReturnType
+      ) => SelectPromptEntry;
       getIdentifierForQueryItem: (queryItem: QueryReturnType) => string;
     };
   };
@@ -100,7 +107,7 @@ async function paginatedQueryWithSelectPromptInternalAsync<
   const selectionPromptListItems = uniqBy(newAccumulator, queryItem =>
     promptOptions.getIdentifierForQueryItem(queryItem)
   ).map(queryItem => ({
-    title: promptOptions.createDisplayTextForSelectionPromptListItem(queryItem),
+    ...promptOptions.createDisplayTextForSelectionPromptListItem(queryItem),
     value: promptOptions.getIdentifierForQueryItem(queryItem),
   }));
   if (areMorePagesAvailable) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

This is not finished yet, I'm waiting for some server-side changes before i can finish the implementation.

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Add `build:resign` command.

In the first iteration command only supports iOS archives that were created by EAS Build for internal distribution. After the user selects a build, we are running the same code as normally when resolving credentials for the build. The only difference is that we are forcing apple authentication.

# How

- if buildId is specified platform option is not needed.
- If buildId is not specified we are showing a paginated select prompt of finished internal distribution builds for that platform.
- Add helper to query builds with paginated select. I modified what `createDisplayTextForSelectionPromptListItem` is returning, so we can specify both title and description for select prompt entries. cc @szdziedzic consider using that in `eas build:run`.
- Credentials are resolved using the same flow as during the build. It's mostly copy-paste, but I don't think that logic should be extracted to any function.
- For now, this is mostly one big function, I don't think it makes sense to refactor that yet. A better time to do that will be when we add android support or start using resigning for different actions e.g. resigning for the store.

# Test Plan

Tested by
- start internal build
- cancel build
- run build:resign
This is a workaround until api is ready, I'll retest that latter

![20221213_14h16m33s_grim](https://user-images.githubusercontent.com/9753141/207335260-eb6138b5-9a5f-44cc-99e6-81c21f934d33.png)

