### PR TITLE
[eas-cli] Fix update --channel and --branch flag validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix update `--channel` and `--branch` flag validation. ([#1579](https://github.com/expo/eas-cli/pull/1579) by [@byCedric](https://github.com/byCedric))
+
 ### 🧹 Chores
 
 ## [3.1.0](https://github.com/expo/eas-cli/releases/tag/v3.1.0) - 2022-12-17

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -39,7 +39,7 @@ jest.mock('../../../project/publish', () => ({
   ...jest.requireActual('../../../project/publish'),
   buildBundlesAsync: jest.fn(),
   collectAssetsAsync: jest.fn(),
-  resolveInputDirectoryAsync: jest.fn(() => path.join(projectRoot, 'dist')),
+  resolveInputDirectoryAsync: jest.fn((inputDir = 'dist') => path.join(projectRoot, inputDir)),
   uploadAssetsAsync: jest.fn(),
 }));
 

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -1,0 +1,205 @@
+import { AppJSONConfig, PackageJSONConfig, Platform, getConfig } from '@expo/config';
+import { Updates } from '@expo/config-plugins';
+import { vol } from 'memfs';
+import path from 'path';
+import { instance, mock } from 'ts-mockito';
+
+import UpdatePublish from '..';
+import { ensureBranchExistsAsync } from '../../../branch/queries';
+import { DynamicProjectConfigContextField } from '../../../commandUtils/context/DynamicProjectConfigContextField';
+import LoggedInContextField from '../../../commandUtils/context/LoggedInContextField';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import FeatureGateEnvOverrides from '../../../commandUtils/gating/FeatureGateEnvOverrides';
+import FeatureGating from '../../../commandUtils/gating/FeatureGating';
+import { jester } from '../../../credentials/__tests__/fixtures-constants';
+import { PublishMutation } from '../../../graphql/mutations/PublishMutation';
+import { AppQuery } from '../../../graphql/queries/AppQuery';
+import { collectAssetsAsync, uploadAssetsAsync } from '../../../project/publish';
+
+const projectRoot = '/test-project';
+const commandOptions = { root: projectRoot } as any;
+
+jest.mock('fs');
+jest.mock('@expo/config');
+jest.mock('@expo/config-plugins');
+jest.mock('../../../branch/queries');
+jest.mock('../../../commandUtils/context/contextUtils/getProjectIdAsync');
+jest.mock('../../../update/configure');
+jest.mock('../../../graphql/mutations/PublishMutation');
+jest.mock('../../../graphql/queries/AppQuery');
+jest.mock('../../../graphql/queries/UpdateQuery');
+jest.mock('../../../ora', () => ({
+  ora: () => ({
+    start: () => ({ succeed: () => {}, fail: () => {} }),
+  }),
+}));
+jest.mock('../../../project/publish', () => ({
+  ...jest.requireActual('../../../project/publish'),
+  buildBundlesAsync: jest.fn(),
+  collectAssetsAsync: jest.fn(),
+  resolveInputDirectoryAsync: jest.fn(() => path.join(projectRoot, 'dist')),
+  uploadAssetsAsync: jest.fn(),
+}));
+
+describe(UpdatePublish.name, () => {
+  afterEach(() => vol.reset());
+
+  // Deprecated and split to a new command: update:republish
+  it('errors with --republish', async () => {
+    await expect(new UpdatePublish(['--republish'], commandOptions).run()).rejects.toThrow(
+      '--group and --republish flags are deprecated'
+    );
+  });
+
+  // Deprecated and split to a new command: update:republish
+  it('errors with --group', async () => {
+    await expect(new UpdatePublish(['--group=abc123'], commandOptions).run()).rejects.toThrow(
+      '--group and --republish flags are deprecated'
+    );
+  });
+
+  it('errors with both --channel and --branch', async () => {
+    const flags = ['--channel=channel123', '--branch=branch123'];
+
+    mockTestProject();
+
+    await expect(new UpdatePublish(flags, commandOptions).run()).rejects.toThrow(
+      'Cannot specify both --channel and --branch. Specify either --channel, --branch, or --auto'
+    );
+  });
+
+  it('creates a new update with --non-interactive, --branch, and --message', async () => {
+    const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
+
+    mockTestProject();
+    const { platforms, runtimeVersion } = mockTestExport();
+
+    jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
+      branchId: 'branch123',
+      createdBranch: false,
+    });
+
+    jest.mocked(PublishMutation.publishUpdateGroupAsync).mockResolvedValue(
+      platforms.map(platform => ({
+        id: 'update123',
+        group: 'group123',
+        runtimeVersion,
+        platform,
+        manifestPermalink: 'https://example.com/update123/manifest',
+      }))
+    );
+
+    await new UpdatePublish(flags, commandOptions).run();
+  });
+});
+
+/** Create a new in-memory project, copied from src/commands/update/__tests__/republish.test.ts */
+function mockTestProject({
+  configuredProjectId = '1234',
+}: {
+  configuredProjectId?: string;
+} = {}): void {
+  const packageJSON: PackageJSONConfig = {
+    name: 'testing123',
+    version: '0.1.0',
+    description: 'fake description',
+    main: 'index.js',
+  };
+
+  const appJSON: AppJSONConfig = {
+    expo: {
+      name: 'testing 123',
+      version: '0.1.0',
+      slug: 'testing-123',
+      sdkVersion: '33.0.0',
+      owner: jester.accounts[0].name,
+      extra: {
+        eas: {
+          projectId: configuredProjectId,
+        },
+      },
+    },
+  };
+
+  vol.fromJSON(
+    {
+      'package.json': JSON.stringify(packageJSON),
+      'app.json': JSON.stringify(appJSON),
+    },
+    projectRoot
+  );
+
+  const mockManifest = { exp: appJSON.expo };
+  const graphqlClient = instance(mock<ExpoGraphqlClient>({}));
+
+  jest.mocked(getConfig).mockReturnValue(mockManifest as any);
+  jest
+    .spyOn(DynamicProjectConfigContextField.prototype, 'getValueAsync')
+    .mockResolvedValue(async () => ({
+      exp: mockManifest.exp,
+      projectDir: projectRoot,
+      projectId: configuredProjectId,
+    }));
+
+  jest.spyOn(LoggedInContextField.prototype, 'getValueAsync').mockResolvedValue({
+    actor: jester,
+    featureGating: new FeatureGating({}, new FeatureGateEnvOverrides()),
+    graphqlClient,
+  });
+
+  jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
+    id: '1234',
+    slug: 'testing-123',
+    fullName: '@jester/testing-123',
+    ownerAccount: jester.accounts[0],
+  });
+}
+
+/** Create a new in-memory export of the project */
+function mockTestExport({
+  exportDir = 'dist',
+  platforms = ['android', 'ios'],
+}: {
+  exportDir?: string;
+  platforms?: Platform[];
+} = {}): {
+  inputDir: string;
+  platforms: Platform[];
+  runtimeVersion: string;
+} {
+  /* eslint-disable node/no-sync */
+  vol.mkdirpSync(path.join(projectRoot, exportDir, 'bundles'));
+  for (const platform of platforms) {
+    vol.writeFileSync(
+      path.join(projectRoot, exportDir, 'bundles', `${platform}-fake.js`),
+      `console.log("fake bundle for ${platform}");`
+    );
+  }
+
+  jest.mocked(collectAssetsAsync).mockResolvedValue(
+    Object.fromEntries(
+      platforms.map(platform => [
+        platform,
+        {
+          assets: [],
+          launchAsset: {
+            contentType: 'application/javascript',
+            path: path.join(projectRoot, exportDir, 'bundles', `${platform}-fake.js`),
+          },
+        },
+      ])
+    )
+  );
+
+  jest.mocked(uploadAssetsAsync).mockResolvedValue({
+    // 3 platforms are mocked all containing only the launch asset
+    assetCount: platforms.length,
+    uniqueAssetCount: platforms.length,
+    uniqueUploadedAssetCount: platforms.length,
+    assetLimitPerUpdateGroup: 9001,
+  });
+
+  jest.mocked(Updates.getRuntimeVersion).mockReturnValue('exposdk:47.0.0');
+
+  return { inputDir: exportDir, platforms, runtimeVersion: 'exposdk:47.0.0' };
+}

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -137,7 +137,7 @@ function mockTestProject({
   configuredProjectId = '1234',
 }: {
   configuredProjectId?: string;
-} = {}): { projectId: string; } {
+} = {}): { projectId: string } {
   const packageJSON: PackageJSONConfig = {
     name: 'testing123',
     version: '0.1.0',

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -159,9 +159,11 @@ function mockTestProject({
 function mockTestExport({
   exportDir = 'dist',
   platforms = ['android', 'ios'],
+  runtimeVersion = 'exposdk:47.0.0',
 }: {
   exportDir?: string;
   platforms?: Platform[];
+  runtimeVersion?: string;
 } = {}): {
   inputDir: string;
   platforms: Platform[];
@@ -192,14 +194,14 @@ function mockTestExport({
   );
 
   jest.mocked(uploadAssetsAsync).mockResolvedValue({
-    // 3 platforms are mocked all containing only the launch asset
+    // platforms are mocked all containing only the launch asset
     assetCount: platforms.length,
     uniqueAssetCount: platforms.length,
     uniqueUploadedAssetCount: platforms.length,
     assetLimitPerUpdateGroup: 9001,
   });
 
-  jest.mocked(Updates.getRuntimeVersion).mockReturnValue('exposdk:47.0.0');
+  jest.mocked(Updates.getRuntimeVersion).mockReturnValue(runtimeVersion);
 
-  return { inputDir: exportDir, platforms, runtimeVersion: 'exposdk:47.0.0' };
+  return { inputDir: exportDir, platforms, runtimeVersion };
 }

--- a/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
@@ -48,6 +48,8 @@ jest.mock('../../../ora', () => ({
 }));
 
 describe(UpdateRepublish.name, () => {
+  afterEach(() => vol.reset());
+
   it('errors without --branch or --group', async () => {
     await expect(new UpdateRepublish([], commandOptions).run()).rejects.toThrow(
       '--branch or --group must be specified'

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -511,7 +511,7 @@ export default class UpdatePublish extends EasCommand {
     const { auto, branch: branchName, channel: channelName, message: updateMessage } = flags;
     if (nonInteractive && !auto && !(updateMessage && (branchName || channelName))) {
       Errors.error(
-      '--branch and --message, or --channel and --message are required when updating in non-interactive mode unless --auto is specified',
+        '--branch and --message, or --channel and --message are required when updating in non-interactive mode unless --auto is specified',
         { exit: 1 }
       );
     }

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -511,7 +511,7 @@ export default class UpdatePublish extends EasCommand {
     const { auto, branch: branchName, channel: channelName, message: updateMessage } = flags;
     if (nonInteractive && !auto && !(updateMessage && (branchName || channelName))) {
       Errors.error(
-      '--auto, --branch and --message, or --channel and --message are required when updating in non-interactive mode',
+      '--branch and --message, or --channel and --message are required when updating in non-interactive mode unless --auto is specified',
         { exit: 1 }
       );
     }

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -511,7 +511,7 @@ export default class UpdatePublish extends EasCommand {
     const { auto, branch: branchName, channel: channelName, message: updateMessage } = flags;
     if (nonInteractive && !auto && !(updateMessage && (branchName || channelName))) {
       Errors.error(
-        '--auto or --message and either --branch or --channel are required when updating in non-interactive mode',
+      '--auto, --branch and --message, or --channel and --message are required when updating in non-interactive mode',
         { exit: 1 }
       );
     }

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -509,9 +509,9 @@ export default class UpdatePublish extends EasCommand {
     const nonInteractive = flags['non-interactive'] ?? false;
 
     const { auto, branch: branchName, channel: channelName, message: updateMessage } = flags;
-    if (nonInteractive && !auto && !(branchName && channelName && updateMessage)) {
+    if (nonInteractive && !auto && !(updateMessage && (branchName || channelName))) {
       Errors.error(
-        '--auto or both --channel or --branch and --message are required when updating in non-interactive mode',
+        '--auto or --message and either --branch or --channel are required when updating in non-interactive mode',
         { exit: 1 }
       );
     }

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -31,6 +31,7 @@ export type RawAsset = {
   contentType: string;
   path: string;
 };
+
 type CollectedAssets = {
   [platform in Platform]?: {
     launchAsset: RawAsset;


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

A partner reported an issue when using the following command combination:

```bash
$ eas update --branch "..." --message "..." --non-interactive
> Error: --auto or both --channel or --branch and --message are required
> when updating in non-interactive mode
```

# How

It seems that PR #1570 introduced an incorrect validation combination, where it requires users to provide all flags (`--branch`, `--channel`, _and_ `--message`) when not using `--auto`.

This changes:
- The validation to allow combinations like:
  - `--branch` + `--message`
  - `--channel` + `--message`
  - `--branch` + `--channel` + `--message` (this is caught after flag validation as incorrect combination)
- Change the error message in attempt to improve communicating the allowed combinations
  > ```bash
  > Error: --branch and --message, or --channel and --message are required when updating in non-interactive mode unless --auto is specified
  > ```

# Test Plan

Added basic test for this case, including some `--republish` deprecation tests.
