### PR TITLE
[eas-cli] Add --channel to update republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `--channel` option to `update:republish`. ([#1580](https://github.com/expo/eas-cli/pull/1580) by [@byCedric](https://github.com/byCedric))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
@@ -54,9 +54,39 @@ jest.mock('../../../ora', () => ({
 describe(UpdateRepublish.name, () => {
   afterEach(() => vol.reset());
 
-  it('errors without --branch or --group', async () => {
+  it('errors without --channel, --branch, or --group', async () => {
     await expect(new UpdateRepublish([], commandOptions).run()).rejects.toThrow(
       '--channel, --branch, or --group must be specified'
+    );
+  });
+
+  it('errors when providing both --group and --branch', async () => {
+    const flags = ['--group=1234', '--branch=main'];
+
+    mockTestProject();
+
+    await expect(new UpdateRepublish(flags, commandOptions).run()).rejects.toThrow(
+      /--branch=main cannot also be provided when using --group/
+    );
+  });
+
+  it('errors when providing both --channel and --branch', async () => {
+    const flags = ['--channel=main', '--branch=main'];
+
+    mockTestProject();
+
+    await expect(new UpdateRepublish(flags, commandOptions).run()).rejects.toThrow(
+      /--branch=main cannot also be provided when using --channel/
+    );
+  });
+
+  it('errors when providing both --group and --channel', async () => {
+    const flags = ['--group=1234', '--channel=main'];
+
+    mockTestProject();
+
+    await expect(new UpdateRepublish(flags, commandOptions).run()).rejects.toThrow(
+      /--channel=main cannot also be provided when using --group/
     );
   });
 
@@ -84,16 +114,6 @@ describe(UpdateRepublish.name, () => {
 
     await expect(new UpdateRepublish(flags, commandOptions).run()).rejects.toThrow(
       'There are no updates on branch "main" published for the platform(s) "android" with group ID "1234". Did you mean to publish a new update instead?'
-    );
-  });
-
-  it('errors when republishing update with both --group and --branch', async () => {
-    const flags = ['--group=1234', '--branch=main'];
-
-    mockTestProject();
-
-    await expect(new UpdateRepublish(flags, commandOptions).run()).rejects.toThrow(
-      /--branch=main cannot also be provided when using --group/
     );
   });
 

--- a/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
@@ -12,6 +12,8 @@ import { CodeSigningInfo, UpdateFragment } from '../../../graphql/generated';
 import { PublishMutation } from '../../../graphql/mutations/PublishMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { UpdateQuery } from '../../../graphql/queries/UpdateQuery';
+import { getBranchNameFromChannelNameAsync } from '../../../update/getBranchNameFromChannelNameAsync';
+import { selectUpdateGroupOnBranchAsync } from '../../../update/queries';
 import UpdateRepublish from '../republish';
 
 const projectRoot = '/test-project';
@@ -41,6 +43,8 @@ jest.mock('../../../commandUtils/context/contextUtils/getProjectIdAsync');
 jest.mock('../../../graphql/mutations/PublishMutation');
 jest.mock('../../../graphql/queries/AppQuery');
 jest.mock('../../../graphql/queries/UpdateQuery');
+jest.mock('../../../update/getBranchNameFromChannelNameAsync');
+jest.mock('../../../update/queries');
 jest.mock('../../../ora', () => ({
   ora: () => ({
     start: () => ({ succeed: () => {}, fail: () => {} }),
@@ -52,7 +56,7 @@ describe(UpdateRepublish.name, () => {
 
   it('errors without --branch or --group', async () => {
     await expect(new UpdateRepublish([], commandOptions).run()).rejects.toThrow(
-      '--branch or --group must be specified'
+      '--channel, --branch, or --group must be specified'
     );
   });
 
@@ -93,7 +97,7 @@ describe(UpdateRepublish.name, () => {
     );
   });
 
-  it('creates a new update from existing update', async () => {
+  it('re-creates update with --group and --message', async () => {
     const flags = ['--group=1234', '--message=test-republish'];
 
     mockTestProject();
@@ -129,7 +133,7 @@ describe(UpdateRepublish.name, () => {
     expect(PublishMutation.setCodeSigningInfoAsync).not.toHaveBeenCalled();
   });
 
-  it('creates a new update from existing update with codesigning', async () => {
+  it('re-creates update using codesigning with --group and --message', async () => {
     const flags = ['--group=1234', '--message=test-republish'];
     const codeSigning = {
       alg: 'alg',
@@ -174,6 +178,86 @@ describe(UpdateRepublish.name, () => {
       expect.any(Object), // graphql client
       'update-new',
       expect.objectContaining(codeSigning)
+    );
+  });
+
+  it('re-creates update with --branch and --message', async () => {
+    const flags = ['--branch=branch123', '--message=test-republish'];
+
+    mockTestProject();
+    // Mock the prompt to ask the user which update to republish, from branch
+    jest.mocked(selectUpdateGroupOnBranchAsync).mockResolvedValue([updateStub]);
+    // Mock mutations to store the new update
+    jest.mocked(PublishMutation.publishUpdateGroupAsync).mockResolvedValue([
+      {
+        ...updateStub,
+        id: 'update-new',
+        platform: 'ios',
+        manifestPermalink: 'https://expo.dev/@test/test-project/manifest',
+      },
+    ]);
+
+    await new UpdateRepublish(flags, commandOptions).run();
+
+    expect(selectUpdateGroupOnBranchAsync).toHaveBeenCalledWith(
+      expect.any(Object), // graphql client
+      expect.objectContaining({ branchName: 'branch123' })
+    );
+
+    expect(PublishMutation.publishUpdateGroupAsync).toHaveBeenCalledWith(
+      expect.any(Object), // graphql client
+      expect.arrayContaining([
+        expect.objectContaining({
+          branchId: updateStub.branch.id,
+          runtimeVersion: updateStub.runtimeVersion,
+          updateInfoGroup: expect.objectContaining({
+            ios: expect.any(Object),
+          }),
+          gitCommitHash: updateStub.gitCommitHash,
+          awaitingCodeSigningInfo: false,
+        }),
+      ])
+    );
+  });
+
+  it('re-creates update with --channel and --message', async () => {
+    const flags = ['--channel=channel123', '--message=test-republish'];
+
+    mockTestProject();
+    // Mock resolving the channel to branch name, only valid for a single branch connected
+    jest.mocked(getBranchNameFromChannelNameAsync).mockResolvedValue('branchFromChannel');
+    // Mock the prompt to ask the user which update to republish, from branch
+    jest.mocked(selectUpdateGroupOnBranchAsync).mockResolvedValue([updateStub]);
+    // Mock mutations to store the new update
+    jest.mocked(PublishMutation.publishUpdateGroupAsync).mockResolvedValue([
+      {
+        ...updateStub,
+        id: 'update-new',
+        platform: 'ios',
+        manifestPermalink: 'https://expo.dev/@test/test-project/manifest',
+      },
+    ]);
+
+    await new UpdateRepublish(flags, commandOptions).run();
+
+    expect(selectUpdateGroupOnBranchAsync).toHaveBeenCalledWith(
+      expect.any(Object), // graphql client
+      expect.objectContaining({ branchName: 'branchFromChannel' })
+    );
+
+    expect(PublishMutation.publishUpdateGroupAsync).toHaveBeenCalledWith(
+      expect.any(Object), // graphql client
+      expect.arrayContaining([
+        expect.objectContaining({
+          branchId: updateStub.branch.id,
+          runtimeVersion: updateStub.runtimeVersion,
+          updateInfoGroup: expect.objectContaining({
+            ios: expect.any(Object),
+          }),
+          gitCommitHash: updateStub.gitCommitHash,
+          awaitingCodeSigningInfo: false,
+        }),
+      ])
     );
   });
 });

--- a/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
@@ -61,7 +61,7 @@ describe(getBranchNameFromChannelNameAsync, () => {
     expect(
       getBranchNameFromChannelNameAsync(graphqlClient, 'test-project-id', 'test-channel-name')
     ).rejects.toThrow(
-      "Channel has multiple branches associated with it. Instead, use 'eas update --branch'"
+      "Channel has multiple branches associated with it. Instead, use '--branch' instead of '--channel'"
     );
   });
 

--- a/packages/eas-cli/src/update/getBranchNameFromChannelNameAsync.ts
+++ b/packages/eas-cli/src/update/getBranchNameFromChannelNameAsync.ts
@@ -25,7 +25,7 @@ export async function getBranchNameFromChannelNameAsync(
       );
     } else {
       throw new Error(
-        "Channel has multiple branches associated with it. Instead, use 'eas update --branch'"
+        `Channel has multiple branches associated with it. Instead, use '--branch' instead of '--channel'`
       );
     }
   } catch (error) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Keep the usage of `update` and `update:republish` similar, by adding `--channel` to republish.

# How

This only works for channels that are pointing to a single branch. When that branch is fetched, it reuses the code from the `--branch` flag.

# Test Plan

- See tests
- `eas update:republish --channel <channelName>`
    → should prompt you to select an update from the branch that is connected to the channel
    → should fail with `--non-interactive`, `--group`, or `--branch`
- `eas update:republish --branch <branchName>`
    → should prompt you to select an update from the branch
    → should fail with `--non-interactive`, `--group`, or `--channel`
- `eas update:republish --group <updateGroupId>`
    → should work with `--non-interactive`
    → should fail with `--branch` or `--channel`
