### PR TITLE
[eas-cli] Increase the timeout for loading the command config

### DIFF
--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -59,7 +59,7 @@ describe(EasCommand.name, () => {
 
       const sessionManagerSpy = jest.spyOn(SessionManager.prototype, 'getUserAsync');
       expect(sessionManagerSpy).toBeCalledTimes(1);
-    }, 15_000);
+    }, 30_000);
 
     it('initializes analytics', async () => {
       const TestEasCommand = createTestEasCommand();


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

> This is an internal change and does not face the user.

# Why

I'm running into this timeout quite a lot, see:
- https://github.com/expo/eas-cli/actions/runs/3734346601/jobs/6336291927#step:6:154
- https://github.com/expo/eas-cli/actions/runs/3734012233/jobs/6336146018#step:6:154
- https://github.com/expo/eas-cli/actions/runs/3732872371/jobs/6332899405#step:6:154

# How

Increased the allowed timeout from 15s to 30s.

# Test Plan

- Rerun the CI a couple of times, and see if they fail on errors like: https://github.com/expo/eas-cli/actions/runs/3734012233/jobs/6336146018#step:6:151