### PR TITLE
[ui] Rename "queue" to "Free tier queue"

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -423,8 +423,8 @@ async function handleSingleBuildProgressAsync(
 }
 
 const priorityToQueueDisplayName: Record<BuildPriority, string> = {
-  [BuildPriority.Normal]: 'Free-tier queue',
-  [BuildPriority.NormalPlus]: 'Free-tier queue',
+  [BuildPriority.Normal]: 'Free tier queue',
+  [BuildPriority.NormalPlus]: 'Free tier queue',
   [BuildPriority.High]: 'priority queue',
 };
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -423,8 +423,8 @@ async function handleSingleBuildProgressAsync(
 }
 
 const priorityToQueueDisplayName: Record<BuildPriority, string> = {
-  [BuildPriority.Normal]: 'queue',
-  [BuildPriority.NormalPlus]: 'queue',
+  [BuildPriority.Normal]: 'Free-tier queue',
+  [BuildPriority.NormalPlus]: 'Free-tier queue',
   [BuildPriority.High]: 'priority queue',
 };
 


### PR DESCRIPTION
Why
---
Builds under the Free tier use spare capacity amongst the builders and have shorter timeouts. To communicate the priority of these builds more clearly and that they are not given the same level of service that customer builds receive, write out "Free-tier queue" instead of just "queue". Note: I capitalized "Free" since that is how "Free tier" is written in other contexts.

How
---
Searched the entire code base for "normal" and "standard" (case-insensitive). Found the one place where the search results affected human-facing text about the queues.

Test Plan
---
Just made sure the code built
