### PR TITLE
[eas-cli] use appVersion instead of sdkVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add `--channel` option to `update:republish`. ([#1580](https://github.com/expo/eas-cli/pull/1580) by [@byCedric](https://github.com/byCedric))
+- Use `appVersion` as default runtime version policy when running `eas update:configure`. ([#1588](https://github.com/expo/eas-cli/pull/1588) by [@jonsamp](https://github.com/jonsamp))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -18,7 +18,7 @@ import { resolveWorkflowPerPlatformAsync } from '../project/workflow';
 import { syncUpdatesConfigurationAsync as syncAndroidUpdatesConfigurationAsync } from './android/UpdatesModule';
 import { syncUpdatesConfigurationAsync as syncIosUpdatesConfigurationAsync } from './ios/UpdatesModule';
 
-export const DEFAULT_MANAGED_RUNTIME_VERSION = { policy: 'sdkVersion' } as const;
+export const DEFAULT_MANAGED_RUNTIME_VERSION = { policy: 'appVersion' } as const;
 export const DEFAULT_BARE_RUNTIME_VERSION = '1.0.0' as const;
 
 function getDefaultRuntimeVersion(workflow: Workflow): NonNullable<ExpoConfig['runtimeVersion']> {


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

The `appVersion` runtime version policy is easier to understand and read than `sdkVersion`, and now that android correctly parses values like `1.10`, we can make this the default policy.

In addition, the `appVersion` policy will work better with upcoming EAS website dashboards.

# Test Plan

Run `eas update:configure` and make sure the runtime version policy is `appVersion`.