### PR TITLE
[eas-cli] Makes eas.json configuration to only run on update:configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Makes eas.json configuration to only run on `update:configure`. ([#1598](https://github.com/expo/eas-cli/pull/1598) by [@jonsamp](https://github.com/jonsamp))
+
 ### 🧹 Chores
 
 ## [3.1.1](https://github.com/expo/eas-cli/releases/tag/v3.1.1) - 2022-12-19

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -5,7 +5,10 @@ import EasCommand from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import Log from '../../log';
 import { RequestedPlatform } from '../../platform';
-import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
+import {
+  ensureEASUpdateIsConfiguredAsync,
+  ensureEASUpdateIsConfiguredInEasJsonAsync,
+} from '../../update/configure';
 
 export default class UpdateConfigure extends EasCommand {
   static override description = 'configure the project to support EAS Update';
@@ -45,6 +48,8 @@ export default class UpdateConfigure extends EasCommand {
       projectDir,
       platform,
     });
+
+    await ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir);
 
     Log.addNewLineIfNone();
     Log.log(`🎉 Your app is configured with EAS Update!`);

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -258,7 +258,7 @@ async function ensureEASUpdateIsConfiguredNativelyAsync(
  * Make sure EAS Build profiles are configured to work with EAS Update by adding channels to build profiles.
  */
 
-async function ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir: string): Promise<void> {
+export async function ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir: string): Promise<void> {
   const easJsonPath = EasJsonAccessor.formatEasJsonPath(projectDir);
 
   if (!(await fs.pathExists(easJsonPath))) {
@@ -362,8 +362,6 @@ export async function ensureEASUpdateIsConfiguredAsync(
       platform,
       workflows,
     });
-
-  await ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir);
 
   if (projectChanged || !hasExpoUpdates) {
     await ensureEASUpdateIsConfiguredNativelyAsync(graphqlClient, {


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This PR is a bug fix. I landed a PR where when running `eas update:configure`, we set the `channel` property in build profiles. However, I placed that logic in a place that is also called when running `eas update ...`. (We want to set up expo-updates and configure app.json if needed when running `eas update`)

This is not the desired behavior for this configuration however. We _only_ want to set up channels in build profiles when a developer is running `eas update:configure`. By removing this from the `eas update` command, it allows developers to set a channel in their native code, then use EAS Build, and not have their native channel overwritten.

# How

- Takes the `ensureEASUpdateIsConfiguredInEasJsonAsync()` function out of the shared configuration and call it in the `update:configure` command.

# Test Plan

1. Create an app with `npc create-expo-app myApp`
2. Run `eas build:configure`
3. Run `eas update`. Expect that there will be no channels configured in eas.json, while app.json will be configured.
4. Run `eas update:configure`. Expect that eas.json is configured with channels.