### PR TITLE
[ENG-7069][eas-cli] Use pagianted select prompt for eas build:run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Make all URLs in logs clickable in terminals supporting hyperlinks. ([#1591](https://github.com/expo/eas-cli/pull/1591) by [@Simek](https://github.com/Simek))
+- Use paginated select prompt for the `eas build:run` command. ([#1601](https://github.com/expo/eas-cli/pull/1601) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [3.1.1](https://github.com/expo/eas-cli/releases/tag/v3.1.1) - 2022-12-19
 

--- a/packages/eas-cli/src/branch/queries.ts
+++ b/packages/eas-cli/src/branch/queries.ts
@@ -49,7 +49,7 @@ export async function selectBranchOnAppAsync(
     promptOptions: {
       title: promptTitle,
       getIdentifierForQueryItem: updateBranchFragment => updateBranchFragment.id,
-      createDisplayTextForSelectionPromptListItem: displayTextForListItem,
+      convertQueryItemToChoice: displayTextForListItem,
     },
   });
   if (!selectedBranch) {

--- a/packages/eas-cli/src/branch/queries.ts
+++ b/packages/eas-cli/src/branch/queries.ts
@@ -49,7 +49,7 @@ export async function selectBranchOnAppAsync(
     promptOptions: {
       title: promptTitle,
       getIdentifierForQueryItem: updateBranchFragment => updateBranchFragment.id,
-      convertQueryItemToChoice: displayTextForListItem,
+      makePartialChoiceObject: displayTextForListItem,
     },
   });
   if (!selectedBranch) {

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -91,7 +91,7 @@ export async function listAndSelectBuildOnAppAsync(
       promptOptions: {
         title,
         getIdentifierForQueryItem: build => build.id,
-        makePartialChoiceObject: createBuildToPartialChoiceFormatter(selectPromptDisabledFunction),
+        makePartialChoiceObject: createBuildToPartialChoiceMaker(selectPromptDisabledFunction),
         selectPromptWarningMessage,
       },
     });
@@ -102,7 +102,7 @@ function formatBuildChoiceValue(value: string | undefined | null): string {
   return value ? chalk.bold(value) : 'Unknown';
 }
 
-function createBuildToPartialChoiceFormatter(
+function createBuildToPartialChoiceMaker(
   selectPromptDisabledFunction?: (build: BuildFragment) => boolean
 ) {
   return (

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -91,9 +91,7 @@ export async function listAndSelectBuildOnAppAsync(
       promptOptions: {
         title,
         getIdentifierForQueryItem: build => build.id,
-        convertQueryItemToChoice: createFunctionToConvertBuildToChoice(
-          selectPromptDisabledFunction
-        ),
+        makePartialChoiceObject: createBuildToPartialChoiceFormatter(selectPromptDisabledFunction),
         selectPromptWarningMessage,
       },
     });
@@ -104,7 +102,7 @@ function formatBuildChoiceValue(value: string | undefined | null): string {
   return value ? chalk.bold(value) : 'Unknown';
 }
 
-function createFunctionToConvertBuildToChoice(
+function createBuildToPartialChoiceFormatter(
   selectPromptDisabledFunction?: (build: BuildFragment) => boolean
 ) {
   return (

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -46,7 +46,7 @@ export async function selectChannelOnAppAsync(
       queryChannelsOnAppAsync(graphqlClient, { appId: projectId, limit, offset }),
     promptOptions: {
       title: selectionPromptTitle,
-      createDisplayTextForSelectionPromptListItem: updateChannel => ({ title: updateChannel.name }),
+      convertQueryItemToChoice: updateChannel => ({ title: updateChannel.name }),
       getIdentifierForQueryItem: updateChannel => updateChannel.id,
     },
   });

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -46,7 +46,7 @@ export async function selectChannelOnAppAsync(
       queryChannelsOnAppAsync(graphqlClient, { appId: projectId, limit, offset }),
     promptOptions: {
       title: selectionPromptTitle,
-      convertQueryItemToChoice: updateChannel => ({ title: updateChannel.name }),
+      makePartialChoiceObject: updateChannel => ({ title: updateChannel.name }),
       getIdentifierForQueryItem: updateChannel => updateChannel.id,
     },
   });

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -167,23 +167,23 @@ async function maybeGetBuildAsync(
     !flags.runArchiveFlags.url &&
     !flags.runArchiveFlags.latest
   ) {
-    return (
-      (await listAndSelectBuildOnAppAsync(graphqlClient, {
-        projectId,
-        title: `Select ${flags.selectedPlatform === AppPlatform.Ios ? 'iOS' : 'Android'} ${
-          flags.selectedPlatform === AppPlatform.Ios ? 'simulator' : 'emulator'
-        } build to run for ${await getDisplayNameForProjectIdAsync(graphqlClient, projectId)} app`,
-        filter: {
-          platform: flags.selectedPlatform,
-          distribution: distributionType,
-          status: BuildStatus.Finished,
-        },
-        paginatedQueryOptions,
-        selectPromptDisabledFunction: build => !isRunnableOnSimulatorOrEmulator(build),
-        selectPromptWarningMessage:
-          'Artifacts for this build have expired and are no longer available, or this is not a simulator/emulator build.',
-      })) ?? null
-    );
+    const build = await listAndSelectBuildOnAppAsync(graphqlClient, {
+      projectId,
+      title: `Select ${flags.selectedPlatform === AppPlatform.Ios ? 'iOS' : 'Android'} ${
+        flags.selectedPlatform === AppPlatform.Ios ? 'simulator' : 'emulator'
+      } build to run for ${await getDisplayNameForProjectIdAsync(graphqlClient, projectId)} app`,
+      filter: {
+        platform: flags.selectedPlatform,
+        distribution: distributionType,
+        status: BuildStatus.Finished,
+      },
+      paginatedQueryOptions,
+      selectPromptDisabledFunction: build => !isRunnableOnSimulatorOrEmulator(build),
+      selectPromptWarningMessage:
+        'Artifacts for this build have expired and are no longer available, or this is not a simulator/emulator build.',
+    });
+
+    return build ?? null;
   } else if (flags.runArchiveFlags.latest) {
     return await getLatestBuildAsync(graphqlClient, {
       projectId,

--- a/packages/eas-cli/src/devices/queries.ts
+++ b/packages/eas-cli/src/devices/queries.ts
@@ -44,7 +44,7 @@ export async function selectAppleTeamOnAccountAsync(
         }),
       promptOptions: {
         title: selectionPromptTitle,
-        convertQueryItemToChoice: appleTeam => ({
+        makePartialChoiceObject: appleTeam => ({
           title: appleTeam.appleTeamName
             ? `${appleTeam.appleTeamName} (ID: ${appleTeam.appleTeamIdentifier})`
             : appleTeam.appleTeamIdentifier,
@@ -88,7 +88,7 @@ export async function selectAppleDeviceOnAppleTeamAsync(
         }),
       promptOptions: {
         title: selectionPromptTitle,
-        convertQueryItemToChoice: appleDevice => ({
+        makePartialChoiceObject: appleDevice => ({
           title: formatDeviceLabel(appleDevice),
         }),
         getIdentifierForQueryItem: appleTeam => appleTeam.id,

--- a/packages/eas-cli/src/devices/queries.ts
+++ b/packages/eas-cli/src/devices/queries.ts
@@ -44,7 +44,7 @@ export async function selectAppleTeamOnAccountAsync(
         }),
       promptOptions: {
         title: selectionPromptTitle,
-        createDisplayTextForSelectionPromptListItem: appleTeam => ({
+        convertQueryItemToChoice: appleTeam => ({
           title: appleTeam.appleTeamName
             ? `${appleTeam.appleTeamName} (ID: ${appleTeam.appleTeamIdentifier})`
             : appleTeam.appleTeamIdentifier,
@@ -88,7 +88,7 @@ export async function selectAppleDeviceOnAppleTeamAsync(
         }),
       promptOptions: {
         title: selectionPromptTitle,
-        createDisplayTextForSelectionPromptListItem: appleDevice => ({
+        convertQueryItemToChoice: appleDevice => ({
           title: formatDeviceLabel(appleDevice),
         }),
         getIdentifierForQueryItem: appleTeam => appleTeam.id,

--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -45,7 +45,8 @@ export async function confirmAsync(
 export async function selectAsync<T>(
   message: string,
   choices: ExpoChoice<T>[],
-  options?: Options
+  options?: Options,
+  warn?: string
 ): Promise<T> {
   const { value } = await promptAsync(
     {
@@ -53,6 +54,7 @@ export async function selectAsync<T>(
       choices,
       name: 'value',
       type: 'select',
+      warn,
     },
     options
   );

--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -45,8 +45,10 @@ export async function confirmAsync(
 export async function selectAsync<T>(
   message: string,
   choices: ExpoChoice<T>[],
-  options?: Options,
-  warn?: string
+  config?: {
+    options?: Options;
+    warningMessageForDisabledEntries?: string;
+  }
 ): Promise<T> {
   const { value } = await promptAsync(
     {
@@ -54,9 +56,9 @@ export async function selectAsync<T>(
       choices,
       name: 'value',
       type: 'select',
-      warn,
+      warn: config?.warningMessageForDisabledEntries,
     },
-    options
+    config?.options ?? {}
   );
   return value ?? null;
 }

--- a/packages/eas-cli/src/update/queries.ts
+++ b/packages/eas-cli/src/update/queries.ts
@@ -126,7 +126,7 @@ export async function selectUpdateGroupOnBranchAsync(
       }),
     promptOptions: {
       title: 'Load more update groups?',
-      createDisplayTextForSelectionPromptListItem: updateGroup => ({
+      convertQueryItemToChoice: updateGroup => ({
         title: formatUpdateTitle(updateGroup[0]),
       }),
       getIdentifierForQueryItem: updateGroup => updateGroup[0].group,

--- a/packages/eas-cli/src/update/queries.ts
+++ b/packages/eas-cli/src/update/queries.ts
@@ -126,7 +126,7 @@ export async function selectUpdateGroupOnBranchAsync(
       }),
     promptOptions: {
       title: 'Load more update groups?',
-      convertQueryItemToChoice: updateGroup => ({
+      makePartialChoiceObject: updateGroup => ({
         title: formatUpdateTitle(updateGroup[0]),
       }),
       getIdentifierForQueryItem: updateGroup => updateGroup[0].group,

--- a/packages/eas-cli/src/utils/__tests__/queries-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/queries-test.ts
@@ -129,7 +129,7 @@ describe(paginatedQueryWithSelectPromptAsync.name, () => {
         promptOptions: {
           title: '',
           getIdentifierForQueryItem: item => item.id,
-          createDisplayTextForSelectionPromptListItem: item => ({ title: 'item: ' + item.value }),
+          convertQueryItemToChoice: item => ({ title: 'item: ' + item.value }),
         },
       });
 
@@ -179,7 +179,7 @@ describe(paginatedQueryWithSelectPromptAsync.name, () => {
       promptOptions: {
         title: '',
         getIdentifierForQueryItem: item => item.id,
-        createDisplayTextForSelectionPromptListItem: item => ({ title: item.value }),
+        convertQueryItemToChoice: item => ({ title: item.value }),
       },
     });
 

--- a/packages/eas-cli/src/utils/__tests__/queries-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/queries-test.ts
@@ -129,7 +129,7 @@ describe(paginatedQueryWithSelectPromptAsync.name, () => {
         promptOptions: {
           title: '',
           getIdentifierForQueryItem: item => item.id,
-          convertQueryItemToChoice: item => ({ title: 'item: ' + item.value }),
+          makePartialChoiceObject: item => ({ title: 'item: ' + item.value }),
         },
       });
 
@@ -179,7 +179,7 @@ describe(paginatedQueryWithSelectPromptAsync.name, () => {
       promptOptions: {
         title: '',
         getIdentifierForQueryItem: item => item.id,
-        convertQueryItemToChoice: item => ({ title: item.value }),
+        makePartialChoiceObject: item => ({ title: item.value }),
       },
     });
 

--- a/packages/eas-cli/src/utils/queries.ts
+++ b/packages/eas-cli/src/utils/queries.ts
@@ -27,7 +27,7 @@ type PaginatedQueryWithSelectPromptArgs<QueryReturnType extends Record<string, a
   BasePaginatedQueryArgs<QueryReturnType> & {
     promptOptions: {
       readonly title: string;
-      convertQueryItemToChoice: (queryItem: QueryReturnType) => SelectPromptEntry;
+      makePartialChoiceObject: (queryItem: QueryReturnType) => SelectPromptEntry;
       getIdentifierForQueryItem: (queryItem: QueryReturnType) => string;
       readonly selectPromptWarningMessage?: string;
     };
@@ -107,7 +107,7 @@ async function paginatedQueryWithSelectPromptInternalAsync<
   const selectionPromptListItems = uniqBy(newAccumulator, queryItem =>
     promptOptions.getIdentifierForQueryItem(queryItem)
   ).map(queryItem => ({
-    ...promptOptions.convertQueryItemToChoice(queryItem),
+    ...promptOptions.makePartialChoiceObject(queryItem),
     value: promptOptions.getIdentifierForQueryItem(queryItem),
   }));
   if (areMorePagesAvailable) {
@@ -120,8 +120,9 @@ async function paginatedQueryWithSelectPromptInternalAsync<
   const valueOfUserSelectedListItem = await selectAsync<string>(
     promptOptions.title,
     selectionPromptListItems,
-    undefined,
-    promptOptions.selectPromptWarningMessage
+    {
+      warningMessageForDisabledEntries: promptOptions.selectPromptWarningMessage,
+    }
   );
 
   if (valueOfUserSelectedListItem === fetchMoreValue) {

--- a/packages/eas-cli/src/utils/queries.ts
+++ b/packages/eas-cli/src/utils/queries.ts
@@ -6,6 +6,7 @@ const fetchMoreValue = '_fetchMore';
 export interface SelectPromptEntry {
   title: string;
   description?: string;
+  disabled?: boolean;
 }
 
 type BasePaginatedQueryArgs<QueryReturnType extends Record<string, any>> = {
@@ -26,10 +27,9 @@ type PaginatedQueryWithSelectPromptArgs<QueryReturnType extends Record<string, a
   BasePaginatedQueryArgs<QueryReturnType> & {
     promptOptions: {
       readonly title: string;
-      createDisplayTextForSelectionPromptListItem: (
-        queryItem: QueryReturnType
-      ) => SelectPromptEntry;
+      convertQueryItemToChoice: (queryItem: QueryReturnType) => SelectPromptEntry;
       getIdentifierForQueryItem: (queryItem: QueryReturnType) => string;
+      readonly selectPromptWarningMessage?: string;
     };
   };
 
@@ -107,7 +107,7 @@ async function paginatedQueryWithSelectPromptInternalAsync<
   const selectionPromptListItems = uniqBy(newAccumulator, queryItem =>
     promptOptions.getIdentifierForQueryItem(queryItem)
   ).map(queryItem => ({
-    ...promptOptions.createDisplayTextForSelectionPromptListItem(queryItem),
+    ...promptOptions.convertQueryItemToChoice(queryItem),
     value: promptOptions.getIdentifierForQueryItem(queryItem),
   }));
   if (areMorePagesAvailable) {
@@ -119,7 +119,9 @@ async function paginatedQueryWithSelectPromptInternalAsync<
 
   const valueOfUserSelectedListItem = await selectAsync<string>(
     promptOptions.title,
-    selectionPromptListItems
+    selectionPromptListItems,
+    undefined,
+    promptOptions.selectPromptWarningMessage
   );
 
   if (valueOfUserSelectedListItem === fetchMoreValue) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7069/add-pagination-to-eas-buildrun-command

# How

Use the paginated list and select function created by @wkozyra95 for the `build:resign` command https://github.com/expo/eas-cli/pull/1575

# Test Plan

Test `build:run` locally
