### PR TITLE
[ENG-7070][eas-cli] Fix issues with invisible build info in some terminals in `build:run` and `build:resign` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix issue with invisible build info in some terminals in the `eas build:run` and `eas build:resign` commands. ([#1602](https://github.com/expo/eas-cli/pull/1602) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [3.1.1](https://github.com/expo/eas-cli/releases/tag/v3.1.1) - 2022-12-19

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -95,7 +95,7 @@ export async function listAndSelectBuildOnAppAsync(
 }
 
 function formatBuildChoiceValue(value: string | undefined | null): string {
-  return value ? chalk.bold(value) : chalk.dim('Unknown');
+  return value ? chalk.bold(value) : 'Unknown';
 }
 
 function formatBuildChoiceTitleAndDescription(build: BuildFragment): {
@@ -105,19 +105,21 @@ function formatBuildChoiceTitleAndDescription(build: BuildFragment): {
   const splitCommitMessage = build.gitCommitMessage?.split('\n');
   const formattedCommitData =
     build.gitCommitHash && splitCommitMessage && splitCommitMessage.length > 0
-      ? `${chalk.dim(build.gitCommitHash.slice(0, 7))} "${chalk.bold(
+      ? `${build.gitCommitHash.slice(0, 7)} "${chalk.bold(
           splitCommitMessage[0] + (splitCommitMessage.length > 1 ? '…' : '')
         )}"`
       : 'Unknown';
 
   return {
-    title: `ID: ${chalk.dim(build.id)} (${chalk.dim(`${fromNow(new Date(build.updatedAt))} ago`)})`,
+    title: `${chalk.bold(`ID:`)} ${build.id} (${chalk.bold(
+      `${fromNow(new Date(build.updatedAt))} ago`
+    )})`,
     description: [
-      `\tVersion: ${formatBuildChoiceValue(build.appVersion)}`,
-      `\t${
-        build.platform === AppPlatform.Ios ? 'Build number' : 'Version code'
-      }: ${formatBuildChoiceValue(build.appBuildVersion)}`,
-      `\tCommit: ${formattedCommitData}`,
+      `\t${chalk.bold(`Version:`)} ${formatBuildChoiceValue(build.appVersion)}`,
+      `\t${chalk.bold(
+        build.platform === AppPlatform.Ios ? 'Build number:' : 'Version code:'
+      )} ${formatBuildChoiceValue(build.appBuildVersion)}`,
+      `\t${chalk.bold(`Commit:`)} ${formattedCommitData}`,
     ].join('\n'),
   };
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7070/unable-to-see-details-of-disabled-builds-when-selecting-the-build-to

# How

Don't use the dim effect. Use bold effect for all undimmed fragments.

# Test Plan

Test locally
<img width="564" alt="Screenshot 2023-01-02 at 14 27 17" src="https://user-images.githubusercontent.com/55145344/210238078-28392002-757b-46bd-9887-c205bf83dc01.png">
