### PR TITLE
[ENG-7070][eas-cli] fix issues with invisible build info in some terminals while using submit command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix issue with invisible build info in some terminals in the `eas build:run` and `eas build:resign` commands. ([#1602](https://github.com/expo/eas-cli/pull/1602) by [@szdziedzic](https://github.com/szdziedzic))
+- Fix issues with invisible build info in some terminals while using the `eas submit` command. ([#1603](https://github.com/expo/eas-cli/pull/1603) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/submit/ArchiveSource.ts
+++ b/packages/eas-cli/src/submit/ArchiveSource.ts
@@ -320,23 +320,22 @@ function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choi
   const { id, updatedAt, runtimeVersion, buildProfile, gitCommitHash, gitCommitMessage, channel } =
     build;
 
-  const formatValue = (field?: string | null): string =>
-    field ? chalk.bold(field) : chalk.dim('Unknown');
+  const formatValue = (field?: string | null): string => (field ? chalk.bold(field) : 'Unknown');
 
   const buildDate = new Date(updatedAt);
 
   const formattedCommitData =
     gitCommitHash && gitCommitMessage
-      ? `${chalk.dim(gitCommitHash.slice(0, 7))} "${chalk.bold(gitCommitMessage)}"`
+      ? `${gitCommitHash.slice(0, 7)} "${chalk.bold(gitCommitMessage)}"`
       : 'Unknown';
 
-  const title = `ID: ${chalk.dim(id)} (${chalk.dim(`${fromNow(buildDate)} ago`)})`;
+  const title = `${chalk.bold(`ID:`)} ${id} (${chalk.bold(`${fromNow(buildDate)} ago`)})`;
 
   const description = [
-    `\tProfile: ${formatValue(buildProfile)}`,
-    `\tChannel: ${formatValue(channel)}`,
-    `\tRuntime version: ${formatValue(runtimeVersion)}`,
-    `\tCommit: ${formattedCommitData}`,
+    `\t${chalk.bold(`Profile:`)} ${formatValue(buildProfile)}`,
+    `\t${chalk.bold(`Channel:`)} ${formatValue(channel)}`,
+    `\t${chalk.bold(`Runtime version:`)} ${formatValue(runtimeVersion)}`,
+    `\t${chalk.bold(`Commit:`)} ${formattedCommitData}`,
   ].join('\n');
 
   return {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

While working on https://github.com/expo/eas-cli/pull/1602 I forgot to apply the same changes for submit command.

https://linear.app/expo/issue/ENG-7070/unable-to-see-details-of-disabled-builds-when-selecting-the-build-to

# How

Don't use the dim effect. Use bold effect for all undimmed fragments.

# Test Plan

Test locally
