### PR TITLE
Add json output option to listing webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Add `--channel` option to `update:republish`. ([#1580](https://github.com/expo/eas-cli/pull/1580) by [@byCedric](https://github.com/byCedric))
 - Use `appVersion` as default runtime version policy when running `eas update:configure`. ([#1588](https://github.com/expo/eas-cli/pull/1588) by [@jonsamp](https://github.com/jonsamp))
+- Support `--json` flag in webhook list command (https://github.com/expo/eas-cli/pull/1605) by [@sheddy7](https://github.com/sheddy7)
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Add `--channel` option to `update:republish`. ([#1580](https://github.com/expo/eas-cli/pull/1580) by [@byCedric](https://github.com/byCedric))
 - Use `appVersion` as default runtime version policy when running `eas update:configure`. ([#1588](https://github.com/expo/eas-cli/pull/1588) by [@jonsamp](https://github.com/jonsamp))
-- Support `--json` flag in webhook list command (https://github.com/expo/eas-cli/pull/1605) by [@sheddy7](https://github.com/sheddy7)
+- Support `--json` flag in webhook list command. ([#1605](https://github.com/expo/eas-cli/pull/1605) by [@sheddy7](https://github.com/sheddy7))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -19,7 +19,7 @@ export default class WebhookList extends EasCommand {
       description: 'Event type that triggers the webhook',
       options: [WebhookType.Build, WebhookType.Submit],
     }),
-    ...EasJsonOnlyFlag
+    ...EasJsonOnlyFlag,
   };
 
   static override contextDefinition = {

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -2,6 +2,7 @@ import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
 import EasCommand from '../../commandUtils/EasCommand';
+import { EasJsonOnlyFlag } from '../../commandUtils/flags';
 import { WebhookType } from '../../graphql/generated';
 import { WebhookQuery } from '../../graphql/queries/WebhookQuery';
 import Log from '../../log';
@@ -18,9 +19,7 @@ export default class WebhookList extends EasCommand {
       description: 'Event type that triggers the webhook',
       options: [WebhookType.Build, WebhookType.Submit],
     }),
-    json: Flags.boolean({
-      description: 'Enable JSON output, non-JSON messages will be printed to stderr',
-    }),
+    ...EasJsonOnlyFlag
   };
 
   static override contextDefinition = {
@@ -32,16 +31,16 @@ export default class WebhookList extends EasCommand {
     const {
       flags: { event, json },
     } = await this.parse(WebhookList);
+    if (json) {
+      enableJsonOutput();
+    }
+
     const {
       projectConfig: { projectId },
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(WebhookList, {
       nonInteractive: true,
     });
-
-    if (json) {
-      enableJsonOutput();
-    }
 
     const projectDisplayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This updates adds the option of outputting the result of the webhook list command in JSON to allow for easier parsing.

# How

This was discussed in the forum thread here https://forums.expo.dev/t/how-to-programmatically-delete-a-webhook/68354 and this PR was used as a guide: https://github.com/expo/eas-cli/pull/567

# Test Plan

Tested locally using an existing Expo project to confirm that the output can now be formatted in JSON.
