### PR TITLE
[ENG-7158] add resource class to eas.json

### DIFF
--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -12,13 +12,3 @@ export enum BuildDistributionType {
   INTERNAL = 'internal',
   SIMULATOR = 'simulator',
 }
-
-export enum UserInputResourceClass {
-  DEFAULT = 'default',
-  LARGE = 'large',
-  /**
-   * @experimental
-   * This resource class is not yet ready to be used in production. For testing purposes only. Might be deprecated / deleted at any time.
-   */
-  M1_EXPERIMENTAL = 'm1-experimental',
-}

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -1,5 +1,5 @@
 import { Platform } from '@expo/eas-build-job';
-import { EasJsonAccessor, EasJsonUtils } from '@expo/eas-json';
+import { EasJsonAccessor, EasJsonUtils, ResourceClass } from '@expo/eas-json';
 import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
 import figures from 'figures';
@@ -7,7 +7,6 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { BuildFlags, runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
-import { UserInputResourceClass } from '../../build/types';
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { StatuspageServiceName } from '../../graphql/generated';
@@ -31,7 +30,7 @@ interface RawBuildFlags {
   json: boolean;
   'auto-submit': boolean;
   'auto-submit-with-profile'?: string;
-  'resource-class'?: UserInputResourceClass;
+  'resource-class'?: ResourceClass;
   message?: string;
 }
 
@@ -85,7 +84,7 @@ export default class Build extends EasCommand {
       exclusive: ['auto-submit'],
     }),
     'resource-class': Flags.enum({
-      options: Object.values(UserInputResourceClass),
+      options: Object.values(ResourceClass),
       hidden: true,
       description: 'The instance type that will be used to run this build [experimental]',
     }),
@@ -157,11 +156,11 @@ export default class Build extends EasCommand {
       Errors.error('--json is allowed only when building in non-interactive mode', { exit: 1 });
     }
     if (
-      flags['resource-class'] === UserInputResourceClass.M1_EXPERIMENTAL &&
+      flags['resource-class'] === ResourceClass.M1_EXPERIMENTAL &&
       flags.platform !== Platform.IOS
     ) {
       Errors.error(
-        `Resource class ${UserInputResourceClass.M1_EXPERIMENTAL} is only available for iOS builds`,
+        `Resource class ${ResourceClass.M1_EXPERIMENTAL} is only available for iOS builds`,
         {
           exit: 1,
         }
@@ -213,7 +212,7 @@ export default class Build extends EasCommand {
       json: flags['json'],
       autoSubmit: flags['auto-submit'] || flags['auto-submit-with-profile'] !== undefined,
       submitProfile: flags['auto-submit-with-profile'] ?? profile,
-      userInputResourceClass: flags['resource-class'] ?? UserInputResourceClass.DEFAULT,
+      resourceClass: flags['resource-class'] ?? ResourceClass.DEFAULT,
       message,
     };
   }

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -349,3 +349,53 @@ test('get profile names', async () => {
   const allProfileNames = await EasJsonUtils.getBuildProfileNamesAsync(accessor);
   expect(allProfileNames.sort()).toEqual(['blah', 'production'].sort());
 });
+
+test('invalid resourceClass at build profile root', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      production: {
+        resourceClass: 'm1-experimental',
+      },
+    },
+  });
+
+  const accessor = new EasJsonAccessor('/project');
+
+  await expect(
+    EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production')
+  ).rejects.toThrowError(/build.production.resourceClass.*must be one of/);
+});
+
+test('iOS-specific resourceClass', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      production: {
+        ios: {
+          resourceClass: 'm1-experimental',
+        },
+      },
+    },
+  });
+
+  const accessor = new EasJsonAccessor('/project');
+  await expect(
+    EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production')
+  ).resolves.not.toThrow();
+});
+
+test('Android-specific resourceClass', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      production: {
+        android: {
+          resourceClass: 'large',
+        },
+      },
+    },
+  });
+
+  const accessor = new EasJsonAccessor('/project');
+  await expect(
+    EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'production')
+  ).resolves.not.toThrow();
+});

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -5,6 +5,16 @@ export enum CredentialsSource {
   REMOTE = 'remote',
 }
 
+export enum ResourceClass {
+  DEFAULT = 'default',
+  LARGE = 'large',
+  /**
+   * @experimental
+   * This resource class is not yet ready to be used in production. For testing purposes only. Might be deprecated / deleted at any time.
+   */
+  M1_EXPERIMENTAL = 'm1-experimental',
+}
+
 export type DistributionType = 'store' | 'internal';
 
 export type IosEnterpriseProvisioning = 'adhoc' | 'universal';
@@ -22,6 +32,7 @@ export interface CommonBuildProfile {
   developmentClient?: boolean;
   prebuildCommand?: string;
   autoIncrement?: boolean;
+  resourceClass?: ResourceClass;
   buildArtifactPaths?: string[];
 
   node?: string;

--- a/packages/eas-json/src/index.ts
+++ b/packages/eas-json/src/index.ts
@@ -8,6 +8,7 @@ export {
   DistributionType,
   IosEnterpriseProvisioning,
   IosVersionAutoIncrement,
+  ResourceClass,
 } from './build/types';
 export { EasJsonAccessor } from './accessor';
 export { EasJsonUtils } from './utils';


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7158/add-resourceclass-to-build-profile

# How

- Add `resourceClass` to eas.json.
- Print warning when resource class is defined both in eas.json and with flag.

# Test Plan

Tests + manual test.

<img width="867" alt="Screenshot 2023-01-05 at 16 21 08" src="https://user-images.githubusercontent.com/5256730/210815720-2e1b1faa-fe73-4508-8476-1948d2f1c0b6.png">


# Future work

Update eas.json schema when @szdziedzic updates resource class names.
