### PR TITLE
[eas-cli] Add missing key information about updates in json outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Add missing key information about updates in `eas update --json` and `eas update:view --json`. ([#1611](https://github.com/expo/eas-cli/pull/1611) by [@byCedric](https://github.com/byCedric))
+
 ### 🧹 Chores
 
 ## [3.2.1](https://github.com/expo/eas-cli/releases/tag/v3.2.1) - 2023-01-09

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -2045,6 +2045,81 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "AccountNotificationSubscriptionInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "accountId",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationEvent",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "AccountQuery",
         "description": "",
@@ -2239,9 +2314,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2402,9 +2481,13 @@
             "name": "issuer",
             "description": "",
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -2691,9 +2774,13 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8202,6 +8289,81 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "AppNotificationSubscriptionInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationEvent",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "AppPlatform",
         "description": "",
@@ -11899,6 +12061,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
                 "ofType": null
               }
             },
@@ -16982,6 +17160,92 @@
           },
           {
             "name": "UNIQUE_USERS",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EASTotalPlanEnablement",
+        "description": "",
+        "fields": [
+          {
+            "name": "total",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unit",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "EASTotalPlanEnablementUnit",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EASTotalPlanEnablementUnit",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILD",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BYTE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CONCURRENCY",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REQUEST",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UPDATER",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "USER",
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null
@@ -22598,6 +22862,326 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "NotificationEvent",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILD_COMPLETE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUBMISSION_COMPLETE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NotificationSubscription",
+        "description": "",
+        "fields": [
+          {
+            "name": "account",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "actor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationEvent",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "NotificationSubscriptionFilter",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "accountId",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appId",
+            "description": "",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "NotificationEvent",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "",
+            "type": {
+              "kind": "ENUM",
+              "name": "NotificationType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NotificationSubscriptionMutation",
+        "description": "",
+        "fields": [
+          {
+            "name": "subscribeToEventForAccount",
+            "description": "",
+            "args": [
+              {
+                "name": "input",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AccountNotificationSubscriptionInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SubscribeToNotificationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subscribeToEventForApp",
+            "description": "",
+            "args": [
+              {
+                "name": "input",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppNotificationSubscriptionInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SubscribeToNotificationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unsubscribe",
+            "description": "",
+            "args": [
+              {
+                "name": "id",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UnsubscribeFromNotificationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "NotificationType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "EMAIL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "Offer",
         "description": "",
@@ -23125,6 +23709,27 @@
           }
         ],
         "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "PlanEnablement",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Concurrencies",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "EASTotalPlanEnablement",
+            "ofType": null
+          }
+        ]
       },
       {
         "kind": "INTERFACE",
@@ -24767,6 +25372,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "MeMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notificationSubscription",
+            "description": "Mutations that modify a NotificationSubscription",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NotificationSubscriptionMutation",
                 "ofType": null
               }
             },
@@ -27809,6 +28430,33 @@
       },
       {
         "kind": "OBJECT",
+        "name": "SubscribeToNotificationResult",
+        "description": "",
+        "fields": [
+          {
+            "name": "notificationSubscription",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NotificationSubscription",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "SubscriptionDetails",
         "description": "",
         "fields": [
@@ -27965,6 +28613,35 @@
             "deprecationReason": null
           },
           {
+            "name": "planEnablement",
+            "description": "",
+            "args": [
+              {
+                "name": "serviceMetric",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "EASServiceMetric",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "UNION",
+              "name": "PlanEnablement",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "planId",
             "description": "",
             "args": [],
@@ -28024,6 +28701,33 @@
               "kind": "SCALAR",
               "name": "Boolean",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UnsubscribeFromNotificationResult",
+        "description": "",
+        "fields": [
+          {
+            "name": "notificationSubscription",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NotificationSubscription",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -30127,6 +30831,43 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notificationSubscriptions",
+            "description": "",
+            "args": [
+              {
+                "name": "filter",
+                "description": "",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NotificationSubscriptionFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "NotificationSubscription",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -12,6 +12,7 @@ import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/cr
 import FeatureGateEnvOverrides from '../../../commandUtils/gating/FeatureGateEnvOverrides';
 import FeatureGating from '../../../commandUtils/gating/FeatureGating';
 import { jester } from '../../../credentials/__tests__/fixtures-constants';
+import { UpdateFragment } from '../../../graphql/generated';
 import { PublishMutation } from '../../../graphql/mutations/PublishMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { collectAssetsAsync, uploadAssetsAsync } from '../../../project/publish';
@@ -19,6 +20,19 @@ import { getBranchNameFromChannelNameAsync } from '../../../update/getBranchName
 
 const projectRoot = '/test-project';
 const commandOptions = { root: projectRoot } as any;
+const updateStub: UpdateFragment = {
+  id: 'update-1234',
+  group: 'group-1234',
+  branch: { id: 'branch-1234', name: 'main' },
+  message: 'test message',
+  runtimeVersion: 'exposdk:47.0.0',
+  platform: 'ios',
+  gitCommitHash: 'commit',
+  manifestFragment: JSON.stringify({ fake: 'manifest' }),
+  manifestPermalink: 'https://expo.dev/fake/manifest/link',
+  codeSigningInfo: null,
+  createdAt: '2022-01-01T12:00:00Z',
+};
 
 jest.mock('fs');
 jest.mock('@expo/config');
@@ -81,15 +95,9 @@ describe(UpdatePublish.name, () => {
       createdBranch: false,
     });
 
-    jest.mocked(PublishMutation.publishUpdateGroupAsync).mockResolvedValue(
-      platforms.map(platform => ({
-        id: 'update123',
-        group: 'group123',
-        runtimeVersion,
-        platform,
-        manifestPermalink: 'https://example.com/update123/manifest',
-      }))
-    );
+    jest
+      .mocked(PublishMutation.publishUpdateGroupAsync)
+      .mockResolvedValue(platforms.map(platform => ({ ...updateStub, platform, runtimeVersion })));
 
     await new UpdatePublish(flags, commandOptions).run();
 
@@ -110,11 +118,9 @@ describe(UpdatePublish.name, () => {
 
     jest.mocked(PublishMutation.publishUpdateGroupAsync).mockResolvedValue(
       platforms.map(platform => ({
-        id: 'update123',
-        group: 'group123',
+        ...updateStub,
         runtimeVersion,
         platform,
-        manifestPermalink: 'https://example.com/update123/manifest',
       }))
     );
 

--- a/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
@@ -27,6 +27,7 @@ const updateStub: UpdateFragment = {
   platform: 'ios',
   gitCommitHash: 'commit',
   manifestFragment: JSON.stringify({ fake: 'manifest' }),
+  manifestPermalink: 'https://expo.dev/fake/manifest/link',
   codeSigningInfo: null,
   createdAt: '2022-01-01T12:00:00Z',
 };

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -39,7 +39,11 @@ import { resolveWorkflowAsync } from '../../project/workflow';
 import { promptAsync } from '../../prompts';
 import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
 import { getBranchNameFromChannelNameAsync } from '../../update/getBranchNameFromChannelNameAsync';
-import { formatUpdateMessage, truncateString as truncateUpdateMessage } from '../../update/utils';
+import {
+  formatUpdateMessage,
+  getUpdateGroupJson,
+  truncateString as truncateUpdateMessage,
+} from '../../update/utils';
 import {
   checkManifestBodyAgainstUpdateInfoGroup,
   getCodeSigningInfoAsync,
@@ -434,7 +438,7 @@ export default class UpdatePublish extends EasCommand {
     }
 
     if (jsonFlag) {
-      printJsonOnlyOutput(newUpdates);
+      printJsonOnlyOutput(getUpdateGroupJson(newUpdates));
     } else {
       if (new Set(newUpdates.map(update => update.group)).size > 1) {
         Log.addNewLineIfNone();

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -41,7 +41,7 @@ import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
 import { getBranchNameFromChannelNameAsync } from '../../update/getBranchNameFromChannelNameAsync';
 import {
   formatUpdateMessage,
-  getUpdateGroupJson,
+  getUpdateGroupJsonInfo,
   truncateString as truncateUpdateMessage,
 } from '../../update/utils';
 import {
@@ -438,7 +438,7 @@ export default class UpdatePublish extends EasCommand {
     }
 
     if (jsonFlag) {
-      printJsonOnlyOutput(getUpdateGroupJson(newUpdates));
+      printJsonOnlyOutput(getUpdateGroupJsonInfo(newUpdates));
     } else {
       if (new Set(newUpdates.map(update => update.group)).size > 1) {
         Log.addNewLineIfNone();

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -4,7 +4,11 @@ import EasCommand from '../../commandUtils/EasCommand';
 import { EasJsonOnlyFlag } from '../../commandUtils/flags';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import Log from '../../log';
-import { formatUpdateGroup, getUpdateGroupDescriptions, getUpdateGroupJson } from '../../update/utils';
+import {
+  formatUpdateGroup,
+  getUpdateGroupDescriptions,
+  getUpdateGroupJson,
+} from '../../update/utils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class UpdateView extends EasCommand {

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -7,7 +7,7 @@ import Log from '../../log';
 import {
   formatUpdateGroup,
   getUpdateGroupDescriptions,
-  getUpdateGroupJson,
+  getUpdateGroupJsonInfo,
 } from '../../update/utils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
@@ -47,7 +47,7 @@ export default class UpdateView extends EasCommand {
     const updatesByGroup = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, { groupId });
 
     if (jsonFlag) {
-      printJsonOnlyOutput(getUpdateGroupJson(updatesByGroup));
+      printJsonOnlyOutput(getUpdateGroupJsonInfo(updatesByGroup));
     } else {
       const [updateGroupDescription] = getUpdateGroupDescriptions([updatesByGroup]);
 

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -4,7 +4,7 @@ import EasCommand from '../../commandUtils/EasCommand';
 import { EasJsonOnlyFlag } from '../../commandUtils/flags';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import Log from '../../log';
-import { formatUpdateGroup, getUpdateGroupDescriptions } from '../../update/utils';
+import { formatUpdateGroup, getUpdateGroupDescriptions, getUpdateGroupJson } from '../../update/utils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class UpdateView extends EasCommand {
@@ -41,11 +41,12 @@ export default class UpdateView extends EasCommand {
     }
 
     const updatesByGroup = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, { groupId });
-    const [updateGroupDescription] = getUpdateGroupDescriptions([updatesByGroup]);
 
     if (jsonFlag) {
-      printJsonOnlyOutput(updateGroupDescription);
+      printJsonOnlyOutput(getUpdateGroupJson(updatesByGroup));
     } else {
+      const [updateGroupDescription] = getUpdateGroupDescriptions([updatesByGroup]);
+
       Log.log(chalk.bold('Update group:'));
 
       Log.log(formatUpdateGroup(updateGroupDescription));

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -370,6 +370,13 @@ export type AccountMutationSetPushSecurityEnabledArgs = {
   pushSecurityEnabled: Scalars['Boolean'];
 };
 
+export type AccountNotificationSubscriptionInput = {
+  accountId: Scalars['ID'];
+  event: NotificationEvent;
+  type: NotificationType;
+  userId: Scalars['ID'];
+};
+
 export type AccountQuery = {
   __typename?: 'AccountQuery';
   /** Query an Account by ID */
@@ -398,7 +405,7 @@ export type AccountSsoConfiguration = {
   clientSecret: Scalars['String'];
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
-  issuer?: Maybe<Scalars['String']>;
+  issuer: Scalars['String'];
   jwksEndpoint?: Maybe<Scalars['String']>;
   revokeEndpoint?: Maybe<Scalars['String']>;
   tokenEndpoint?: Maybe<Scalars['String']>;
@@ -412,7 +419,7 @@ export type AccountSsoConfigurationData = {
   authProviderIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
   clientSecret: Scalars['String'];
-  issuer?: InputMaybe<Scalars['String']>;
+  issuer: Scalars['String'];
   jwksEndpoint?: InputMaybe<Scalars['String']>;
   revokeEndpoint?: InputMaybe<Scalars['String']>;
   tokenEndpoint?: InputMaybe<Scalars['String']>;
@@ -454,7 +461,7 @@ export type AccountSsoConfigurationPublicData = {
   authProviderIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
   id: Scalars['ID'];
-  issuer?: Maybe<Scalars['String']>;
+  issuer: Scalars['String'];
   jwksEndpoint?: Maybe<Scalars['String']>;
   revokeEndpoint?: Maybe<Scalars['String']>;
   tokenEndpoint?: Maybe<Scalars['String']>;
@@ -1213,6 +1220,13 @@ export type AppMutationSetPushSecurityEnabledArgs = {
   pushSecurityEnabled: Scalars['Boolean'];
 };
 
+export type AppNotificationSubscriptionInput = {
+  appId: Scalars['ID'];
+  event: NotificationEvent;
+  type: NotificationType;
+  userId: Scalars['ID'];
+};
+
 export enum AppPlatform {
   Android = 'ANDROID',
   Ios = 'IOS'
@@ -1746,6 +1760,7 @@ export type BillingPeriod = {
   __typename?: 'BillingPeriod';
   anchor: Scalars['DateTime'];
   end: Scalars['DateTime'];
+  id: Scalars['ID'];
   start: Scalars['DateTime'];
 };
 
@@ -2465,6 +2480,21 @@ export enum EasServiceMetric {
   ManifestRequests = 'MANIFEST_REQUESTS',
   UniqueUpdaters = 'UNIQUE_UPDATERS',
   UniqueUsers = 'UNIQUE_USERS'
+}
+
+export type EasTotalPlanEnablement = {
+  __typename?: 'EASTotalPlanEnablement';
+  total: Scalars['Int'];
+  unit?: Maybe<EasTotalPlanEnablementUnit>;
+};
+
+export enum EasTotalPlanEnablementUnit {
+  Build = 'BUILD',
+  Byte = 'BYTE',
+  Concurrency = 'CONCURRENCY',
+  Request = 'REQUEST',
+  Updater = 'UPDATER',
+  User = 'USER'
 }
 
 export type EditUpdateBranchInput = {
@@ -3274,6 +3304,55 @@ export type MeteredBillingStatus = {
   EAS_UPDATE: Scalars['Boolean'];
 };
 
+export enum NotificationEvent {
+  BuildComplete = 'BUILD_COMPLETE',
+  SubmissionComplete = 'SUBMISSION_COMPLETE'
+}
+
+export type NotificationSubscription = {
+  __typename?: 'NotificationSubscription';
+  account?: Maybe<Account>;
+  actor?: Maybe<Actor>;
+  app?: Maybe<App>;
+  createdAt: Scalars['DateTime'];
+  event: NotificationEvent;
+  id: Scalars['ID'];
+  type: NotificationType;
+};
+
+export type NotificationSubscriptionFilter = {
+  accountId?: InputMaybe<Scalars['ID']>;
+  appId?: InputMaybe<Scalars['ID']>;
+  event?: InputMaybe<NotificationEvent>;
+  type?: InputMaybe<NotificationType>;
+};
+
+export type NotificationSubscriptionMutation = {
+  __typename?: 'NotificationSubscriptionMutation';
+  subscribeToEventForAccount: SubscribeToNotificationResult;
+  subscribeToEventForApp: SubscribeToNotificationResult;
+  unsubscribe: UnsubscribeFromNotificationResult;
+};
+
+
+export type NotificationSubscriptionMutationSubscribeToEventForAccountArgs = {
+  input: AccountNotificationSubscriptionInput;
+};
+
+
+export type NotificationSubscriptionMutationSubscribeToEventForAppArgs = {
+  input: AppNotificationSubscriptionInput;
+};
+
+
+export type NotificationSubscriptionMutationUnsubscribeArgs = {
+  id: Scalars['ID'];
+};
+
+export enum NotificationType {
+  Email = 'EMAIL'
+}
+
 export type Offer = {
   __typename?: 'Offer';
   features?: Maybe<Array<Maybe<Feature>>>;
@@ -3341,6 +3420,8 @@ export enum Permission {
   Publish = 'PUBLISH',
   View = 'VIEW'
 }
+
+export type PlanEnablement = Concurrencies | EasTotalPlanEnablement;
 
 export type Project = {
   description: Scalars['String'];
@@ -3558,6 +3639,8 @@ export type RootMutation = {
   keystoreGenerationUrl: KeystoreGenerationUrlMutation;
   /** Mutations that modify the currently authenticated User */
   me: MeMutation;
+  /** Mutations that modify a NotificationSubscription */
+  notificationSubscription: NotificationSubscriptionMutation;
   /** Mutations that create, update, and delete Robots */
   robot: RobotMutation;
   serverlessFunction: ServerlessFunctionMutation;
@@ -4051,6 +4134,11 @@ export enum SubmissionStatus {
   InQueue = 'IN_QUEUE'
 }
 
+export type SubscribeToNotificationResult = {
+  __typename?: 'SubscribeToNotificationResult';
+  notificationSubscription: NotificationSubscription;
+};
+
 export type SubscriptionDetails = {
   __typename?: 'SubscriptionDetails';
   addons: Array<AddonDetails>;
@@ -4064,11 +4152,22 @@ export type SubscriptionDetails = {
   meteredBillingStatus: MeteredBillingStatus;
   name?: Maybe<Scalars['String']>;
   nextInvoice?: Maybe<Scalars['DateTime']>;
+  planEnablement?: Maybe<PlanEnablement>;
   planId?: Maybe<Scalars['String']>;
   price: Scalars['Int'];
   status?: Maybe<Scalars['String']>;
   trialEnd?: Maybe<Scalars['DateTime']>;
   willCancel?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type SubscriptionDetailsPlanEnablementArgs = {
+  serviceMetric: EasServiceMetric;
+};
+
+export type UnsubscribeFromNotificationResult = {
+  __typename?: 'UnsubscribeFromNotificationResult';
+  notificationSubscription: NotificationSubscription;
 };
 
 export type Update = ActivityTimelineProjectActivity & {
@@ -4334,6 +4433,7 @@ export type User = Actor & {
   /** @deprecated 'likes' have been deprecated. */
   likes?: Maybe<Array<Maybe<App>>>;
   location?: Maybe<Scalars['String']>;
+  notificationSubscriptions: Array<NotificationSubscription>;
   /** Pending UserInvitations for this user. Only resolves for the viewer. */
   pendingUserInvitations: Array<UserInvitation>;
   /** Associated accounts */
@@ -4376,6 +4476,12 @@ export type UserFeatureGatesArgs = {
 export type UserLikesArgs = {
   limit: Scalars['Int'];
   offset: Scalars['Int'];
+};
+
+
+/** Represents a human (not robot) actor. */
+export type UserNotificationSubscriptionsArgs = {
+  filter?: InputMaybe<NotificationSubscriptionFilter>;
 };
 
 
@@ -5160,7 +5266,7 @@ export type UpdatePublishMutationVariables = Exact<{
 }>;
 
 
-export type UpdatePublishMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', publishUpdateGroups: Array<{ __typename?: 'Update', id: string, group: string, runtimeVersion: string, platform: string, manifestPermalink: string }> } };
+export type UpdatePublishMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', publishUpdateGroups: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> } };
 
 export type SetCodeSigningInfoMutationVariables = Exact<{
   updateId: Scalars['ID'];
@@ -5258,7 +5364,7 @@ export type BranchesByAppQueryVariables = Exact<{
 }>;
 
 
-export type BranchesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> }> } } };
+export type BranchesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> }> } } };
 
 export type ViewBranchesOnUpdateChannelQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5268,7 +5374,7 @@ export type ViewBranchesOnUpdateChannelQueryVariables = Exact<{
 }>;
 
 
-export type ViewBranchesOnUpdateChannelQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> } | null } } };
+export type ViewBranchesOnUpdateChannelQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> } | null } } };
 
 export type BuildsByIdQueryVariables = Exact<{
   buildId: Scalars['ID'];
@@ -5300,7 +5406,7 @@ export type ViewUpdateChannelOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> } | null } } };
+export type ViewUpdateChannelOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> } | null } } };
 
 export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5309,7 +5415,7 @@ export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> }> } } };
+export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> }> } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5362,7 +5468,7 @@ export type ViewUpdatesByGroupQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdatesByGroupQuery = { __typename?: 'RootQuery', updatesByGroup: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
+export type ViewUpdatesByGroupQuery = { __typename?: 'RootQuery', updatesByGroup: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
 
 export type ViewUpdateGroupsOnBranchQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5373,7 +5479,7 @@ export type ViewUpdateGroupsOnBranchQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateGroupsOnBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> } | null } } };
+export type ViewUpdateGroupsOnBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> } | null } } };
 
 export type ViewUpdateGroupsOnAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5383,7 +5489,7 @@ export type ViewUpdateGroupsOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateGroupsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> } } };
+export type ViewUpdateGroupsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> } } };
 
 export type CurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -5419,9 +5525,9 @@ export type StatuspageServiceFragment = { __typename?: 'StatuspageService', id: 
 
 export type SubmissionFragment = { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null };
 
-export type UpdateFragment = { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null };
+export type UpdateFragment = { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null };
 
-export type UpdateBranchFragment = { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
+export type UpdateBranchFragment = { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
 
 export type WebhookFragment = { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any };
 

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -48,10 +48,7 @@ export const PublishMutation = {
               updateBranch {
                 publishUpdateGroups(publishUpdateGroupsInput: $publishUpdateGroupsInput) {
                   id
-                  group
-                  runtimeVersion
-                  platform
-                  manifestPermalink
+                  ...UpdateFragment
                 }
               }
             }

--- a/packages/eas-cli/src/graphql/types/Update.ts
+++ b/packages/eas-cli/src/graphql/types/Update.ts
@@ -9,6 +9,7 @@ export const UpdateFragmentNode = gql`
     runtimeVersion
     platform
     manifestFragment
+    manifestPermalink
     gitCommitHash
     actor {
       __typename

--- a/packages/eas-cli/src/update/utils.ts
+++ b/packages/eas-cli/src/update/utils.ts
@@ -24,6 +24,18 @@ export type FormatUpdateParameter = Pick<Update, 'id' | 'createdAt' | 'message'>
   actor?: Maybe<Pick<User, 'username' | 'id'> | Pick<Robot, 'firstName' | 'id'>>;
 };
 
+export type UpdateJson = { branch: string } & Pick<
+  UpdateFragment,
+  | 'id'
+  | 'createdAt'
+  | 'group'
+  | 'message'
+  | 'runtimeVersion'
+  | 'platform'
+  | 'manifestPermalink'
+  | 'gitCommitHash'
+>;
+
 export type UpdateGroupDescription = FormatUpdateParameter & {
   branch: string;
   group: string;
@@ -179,6 +191,20 @@ export function formatUpdateTitle(update: UpdateFragment): string {
     createdAt,
     'mmm dd HH:MM'
   )} by ${actorName}, runtimeVersion: ${runtimeVersion}] ${message}`;
+}
+
+export function getUpdateGroupJson(updateGroups: UpdateFragment[]): UpdateJson[] {
+  return updateGroups.map(update => ({
+    id: update.id,
+    createdAt: update.createdAt,
+    group: update.group,
+    branch: update.branch.name,
+    message: update.message,
+    runtimeVersion: update.runtimeVersion,
+    platform: update.platform,
+    manifestPermalink: update.manifestPermalink,
+    gitCommitHash: update.gitCommitHash,
+  }));
 }
 
 export function getUpdateGroupDescriptions(

--- a/packages/eas-cli/src/update/utils.ts
+++ b/packages/eas-cli/src/update/utils.ts
@@ -24,7 +24,7 @@ export type FormatUpdateParameter = Pick<Update, 'id' | 'createdAt' | 'message'>
   actor?: Maybe<Pick<User, 'username' | 'id'> | Pick<Robot, 'firstName' | 'id'>>;
 };
 
-export type UpdateJson = { branch: string } & Pick<
+export type UpdateJsonInfo = { branch: string } & Pick<
   UpdateFragment,
   | 'id'
   | 'createdAt'
@@ -193,7 +193,7 @@ export function formatUpdateTitle(update: UpdateFragment): string {
   )} by ${actorName}, runtimeVersion: ${runtimeVersion}] ${message}`;
 }
 
-export function getUpdateGroupJson(updateGroups: UpdateFragment[]): UpdateJson[] {
+export function getUpdateGroupJsonInfo(updateGroups: UpdateFragment[]): UpdateJsonInfo[] {
   return updateGroups.map(update => ({
     id: update.id,
     createdAt: update.createdAt,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes ENG-7180

This information isn't necessarily useful when using `eas update ...` or `eas update:view ...`. However, it's useful if you use it programmatically with `--json`.

`eas update:view <group>` | `eas update:view <group> --json`
--- | ---
![image](https://user-images.githubusercontent.com/1203991/211152583-b3a27db8-f99a-451c-afb8-0a690d447b6a.png) | ![image](https://user-images.githubusercontent.com/1203991/211152589-45448e6a-eb97-44e6-8a9f-e38ee578cae3.png)


With this information, we can generate things like QR codes, branch links to expo.dev, and more. It also allows us to add support for EAS Update in [expo-github-action ](https://github.com/expo/expo-github-action) without implementing anything other than calling `expo config --json` and `eas update ... --json`.

# How

- Added `getUpdateGroupJson` next to helper functions we use to generate the non-json output
- Replaced custom partial mutation response with `UpdateFragment` when creating an update
- Implemented `getUpdateGroupJson` in `eas update --json`
- Implemented `getUpdateGroupJson` in `eas update:view --json`

# Test Plan

- `eas update:view <group>` should output a simplified list
- `eas update:view <group> --json` should output more details as JSON list
- `eas update` should output steps and a simplified list
- `eas update --json` should output steps and more details as JSON list
