### PR TITLE
[eas-cli] validate chosen build in `eas build:run` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Validate chosen build in the `eas build:run` command. ([#1614](https://github.com/expo/eas-cli/pull/1614) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [3.2.0](https://github.com/expo/eas-cli/releases/tag/v3.2.0) - 2023-01-09

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -145,7 +145,7 @@ export async function getLatestBuildAsync(
     projectId: string;
     filter?: BuildFilter;
   }
-): Promise<BuildFragment> {
+): Promise<BuildFragment | null> {
   const builds = await BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
     appId: projectId,
     limit: 1,
@@ -154,7 +154,7 @@ export async function getLatestBuildAsync(
   });
 
   if (builds.length === 0) {
-    throw new Error('Found no build matching the provided criteria.');
+    return null;
   }
 
   return builds[0];

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -74,11 +74,11 @@ export async function listAndSelectBuildOnAppAsync(
     selectPromptDisabledFunction?: (build: BuildFragment) => boolean;
     selectPromptWarningMessage?: string;
   }
-): Promise<BuildFragment | void> {
+): Promise<BuildFragment | null> {
   if (paginatedQueryOptions.nonInteractive) {
     throw new Error('Unable to select a build in non-interactive mode.');
   } else {
-    return await paginatedQueryWithSelectPromptAsync({
+    const selectedBuild = await paginatedQueryWithSelectPromptAsync({
       limit: paginatedQueryOptions.limit ?? BUILDS_LIMIT,
       offset: paginatedQueryOptions.offset,
       queryToPerform: (limit, offset) =>
@@ -95,6 +95,7 @@ export async function listAndSelectBuildOnAppAsync(
         selectPromptWarningMessage,
       },
     });
+    return selectedBuild ?? null;
   }
 }
 

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -1,4 +1,5 @@
 import { Errors, Flags } from '@oclif/core';
+import assert from 'assert';
 import { pathExists } from 'fs-extra';
 import path from 'path';
 
@@ -181,8 +182,10 @@ async function maybeGetBuildAsync(
       selectPromptWarningMessage:
         'Artifacts for this build have expired and are no longer available, or this is not a simulator/emulator build.',
     });
-
-    return build ?? null;
+    if (!build) {
+      throw new Error('There are no simulator/emulator builds that can be run for this project.');
+    }
+    return build;
   } else if (flags.runArchiveFlags.latest) {
     return await getLatestBuildAsync(graphqlClient, {
       projectId,
@@ -251,9 +254,7 @@ async function getPathToSimulatorBuildAppAsync(
     );
   }
 
-  if (flags.runArchiveFlags.path) {
-    return flags.runArchiveFlags.path;
-  }
-
-  throw new Error('There are no simulator/emulator builds that can be run for this project.');
+  // this should never fail, due to the validation in sanitizeFlagsAsync
+  assert(flags.runArchiveFlags.path);
+  return flags.runArchiveFlags.path;
 }

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -187,7 +187,7 @@ async function maybeGetBuildAsync(
     }
     return build;
   } else if (flags.runArchiveFlags.latest) {
-    return await getLatestBuildAsync(graphqlClient, {
+    const latestBuild = await getLatestBuildAsync(graphqlClient, {
       projectId,
       filter: {
         platform: flags.selectedPlatform,
@@ -195,6 +195,10 @@ async function maybeGetBuildAsync(
         status: BuildStatus.Finished,
       },
     });
+    if (!latestBuild) {
+      throw new Error('There are no simulator/emulator builds that can be run for this project.');
+    }
+    return latestBuild;
   } else {
     return null;
   }

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -151,7 +151,7 @@ async function resolvePlatformAsync(platform?: string): Promise<AppPlatform> {
   return selectedPlatform;
 }
 
-function sanitizeChosenBuild(
+function validateChosenBuild(
   maybeBuild: BuildFragment | null,
   selectedPlatform: AppPlatform
 ): BuildFragment {
@@ -191,7 +191,7 @@ async function maybeGetBuildAsync(
 
   if (flags.runArchiveFlags.id) {
     const build = await BuildQuery.byIdAsync(graphqlClient, flags.runArchiveFlags.id);
-    return sanitizeChosenBuild(build, flags.selectedPlatform);
+    return validateChosenBuild(build, flags.selectedPlatform);
   } else if (
     !flags.runArchiveFlags.id &&
     !flags.runArchiveFlags.path &&
@@ -213,7 +213,7 @@ async function maybeGetBuildAsync(
       selectPromptWarningMessage:
         'Artifacts for this build have expired and are no longer available, or this is not a simulator/emulator build.',
     });
-    return sanitizeChosenBuild(build, flags.selectedPlatform);
+    return validateChosenBuild(build, flags.selectedPlatform);
   } else if (flags.runArchiveFlags.latest) {
     const latestBuild = await getLatestBuildAsync(graphqlClient, {
       projectId,
@@ -224,7 +224,7 @@ async function maybeGetBuildAsync(
       },
     });
 
-    return sanitizeChosenBuild(latestBuild, flags.selectedPlatform);
+    return validateChosenBuild(latestBuild, flags.selectedPlatform);
   } else {
     return null;
   }

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -1,5 +1,4 @@
 import { Errors, Flags } from '@oclif/core';
-import assert from 'assert';
 import { pathExists } from 'fs-extra';
 import path from 'path';
 
@@ -252,7 +251,9 @@ async function getPathToSimulatorBuildAppAsync(
     );
   }
 
-  // this should never fail, due to the validation in sanitizeFlagsAsync
-  assert(flags.runArchiveFlags.path);
-  return flags.runArchiveFlags.path;
+  if (flags.runArchiveFlags.path) {
+    return flags.runArchiveFlags.path;
+  }
+
+  throw new Error('There are no simulator/emulator builds that can be run for this project.');
 }

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -14,6 +14,7 @@ import {
 import { AppPlatform, BuildFragment, BuildStatus, DistributionType } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import Log from '../../log';
+import { appPlatformDisplayNames } from '../../platform';
 import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { RunArchiveFlags, runAsync } from '../../run/run';
@@ -40,11 +41,6 @@ interface RunCommandFlags {
   limit?: number;
   offset?: number;
 }
-
-const appPlatformToAppPlatformName: Record<AppPlatform, string> = {
-  [AppPlatform.Android]: 'Android',
-  [AppPlatform.Ios]: 'iOS',
-};
 
 export default class Run extends EasCommand {
   static override description = 'run simulator/emulator builds from eas-cli';
@@ -156,7 +152,7 @@ async function resolvePlatformAsync(platform?: string): Promise<AppPlatform> {
 }
 
 function sanitizeChosenBuild(
-  maybeBuild: BuildFragment | null | undefined | void,
+  maybeBuild: BuildFragment | null,
   selectedPlatform: AppPlatform
 ): BuildFragment {
   if (!maybeBuild) {
@@ -166,8 +162,8 @@ function sanitizeChosenBuild(
   if (selectedPlatform !== maybeBuild.platform) {
     throw new Error(
       `The selected build is for ${
-        appPlatformToAppPlatformName[maybeBuild.platform]
-      }, but you selected ${appPlatformToAppPlatformName[selectedPlatform]}`
+        appPlatformDisplayNames[maybeBuild.platform]
+      }, but you selected ${appPlatformDisplayNames[selectedPlatform]}`
     );
   }
 
@@ -204,7 +200,7 @@ async function maybeGetBuildAsync(
   ) {
     const build = await listAndSelectBuildOnAppAsync(graphqlClient, {
       projectId,
-      title: `Select ${appPlatformToAppPlatformName[flags.selectedPlatform]} ${
+      title: `Select ${appPlatformDisplayNames[flags.selectedPlatform]} ${
         flags.selectedPlatform === AppPlatform.Ios ? 'simulator' : 'emulator'
       } build to run for ${await getDisplayNameForProjectIdAsync(graphqlClient, projectId)} app`,
       filter: {

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -174,7 +174,8 @@ async function maybeGetBuildAsync(
     flags.selectedPlatform === AppPlatform.Ios ? DistributionType.Simulator : undefined;
 
   if (flags.runArchiveFlags.id) {
-    return BuildQuery.byIdAsync(graphqlClient, flags.runArchiveFlags.id);
+    const build = await BuildQuery.byIdAsync(graphqlClient, flags.runArchiveFlags.id);
+    return sanitizeChosenBuild(build);
   } else if (
     !flags.runArchiveFlags.id &&
     !flags.runArchiveFlags.path &&


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

When adding a paginated select prompt to the `eas build:run` I introduced a new bug.
<img width="460" alt="Screenshot 2023-01-09 at 11 22 26" src="https://user-images.githubusercontent.com/55145344/211286609-caf32c19-c354-4296-b0b6-586e74d1acda.png">
When you have no emulator/simulator builds in your project you will get this strange assertion error message.

EDIT: I noticed that I wasn't sanitizing builds selected by id or as latest. This is also fixed now.
Now I sanitize every selected build to make sure it is valid in the context of the `eas build:run` command.

# How
Throw a custom error if there are no simulator/emulator builds for a given platform.
<img width="537" alt="Screenshot 2023-01-09 at 11 23 35" src="https://user-images.githubusercontent.com/55145344/211286817-37b86f8f-c8f0-497e-bf6e-f46ca5148a77.png">


# Test Plan

Manual tests.
