### PR TITLE
[ENG-7198][build] deprecate --resource-class flag

### DIFF
--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -86,6 +86,11 @@ export default class Build extends EasCommand {
     'resource-class': Flags.enum({
       options: Object.values(ResourceClass),
       hidden: true,
+      deprecated: {
+        message: chalk.yellow(
+          'The --resource-class flag has been deprecated. Define the resource class in eas.json.'
+        ),
+      },
       description: 'The instance type that will be used to run this build [experimental]',
     }),
     message: Flags.string({

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -88,7 +88,7 @@ export default class Build extends EasCommand {
       hidden: true,
       deprecated: {
         message: chalk.yellow(
-          'The --resource-class flag has been deprecated. Define the resource class in eas.json.'
+          'The --resource-class flag has been deprecated. Define the resource class in eas.json.\nLearn more: https://docs.expo.dev/build-reference/eas-json/'
         ),
       },
       description: 'The instance type that will be used to run this build [experimental]',


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7198/deprecate-resource-class-flag

# How

Deprecate the `--resource-class` flag.

# Test Plan

<img width="909" alt="Screenshot 2023-01-10 at 11 13 37" src="https://user-images.githubusercontent.com/5256730/211523916-07867aad-5515-4ccd-92ba-4a995484f28a.png">
