### PR TITLE
[eas-cli] Remove workaround for gitignore parsing (fixed upstream)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Remove unnecessary workaround for trailing backslash in .gitignore. ([#1622](https://github.com/expo/eas-cli/pull/1622) by [@wkozyra95](https://github.com/wkozyra95))
+
 ## [3.3.2](https://github.com/expo/eas-cli/releases/tag/v3.3.2) - 2023-01-12
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -39,7 +39,7 @@ export class Ignore {
     if (await fs.pathExists(easIgnorePath)) {
       this.ignoreMapping = [
         ['', createIgnore().add(DEFAULT_IGNORE)],
-        ['', createIgnore().add(await this.readIgnoreFileAsync(easIgnorePath))],
+        ['', createIgnore().add(await fs.readFile(easIgnorePath, 'utf-8'))],
       ];
       return;
     }
@@ -57,7 +57,7 @@ export class Ignore {
       ignoreFilePaths.map(async filePath => {
         return [
           filePath.slice(0, filePath.length - GITIGNORE_FILENAME.length),
-          createIgnore().add(await this.readIgnoreFileAsync(path.join(this.rootDir, filePath))),
+          createIgnore().add(await fs.readFile(path.join(this.rootDir, filePath), 'utf-8')),
         ] as const;
       })
     );
@@ -71,16 +71,6 @@ export class Ignore {
       }
     }
     return false;
-  }
-
-  private async readIgnoreFileAsync(filePath: string): Promise<string> {
-    const fileContents = await fs.readFile(filePath, 'utf-8');
-    const lines = fileContents.split('\n');
-    // Strip trailing '\'. This logic can be removed after fix upstream is released.
-    // https://github.com/kaelzhang/node-ignore/issues/81
-    return lines
-      .map((line: string) => (line.slice(-1) === '\\' ? line.slice(0, -1) : line))
-      .join('\n');
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Remove workaround for some git ignore files. Issue was fixed upstream in https://github.com/kaelzhang/node-ignore/issues/81

# How

Remove workaround, package was updated in https://github.com/expo/eas-cli/pull/1617

# Test Plan

run build with a .gitignore including `test\` entry.