### PR TITLE
[eas-cli] Automatically promote new cli release to staging on EAS Build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
           yarn pretarball-ci
           yarn oclif pack:tarballs --no-xz --targets linux-x64,linux-arm
       - id: x64
-        run: echo "::set-output name=filename::$(ls eas-*-x64.tar.gz)"
+        run: echo "filename=$(ls eas-*-x64.tar.gz)" >> $GITHUB_OUTPUT
         working-directory: ${{ github.workspace }}/packages/eas-cli/dist
       - id: arm
-        run: echo "::set-output name=filename::$(ls eas-*-arm.tar.gz)"
+        run: echo "filename=$(ls eas-*-arm.tar.gz)" >> $GITHUB_OUTPUT
         working-directory: ${{ github.workspace }}/packages/eas-cli/dist
       - name: Upload linux-x64 tarball
         uses: actions/upload-release-asset@v1
@@ -77,7 +77,7 @@ jobs:
           yarn pretarball-ci
           yarn oclif pack:tarballs --no-xz --targets darwin-x64
       - id: x64
-        run: echo "::set-output name=filename::$(ls eas-*-x64.tar.gz)"
+        run: echo "filename=$(ls eas-*-x64.tar.gz)" >> $GITHUB_OUTPUT
         working-directory: ${{ github.workspace }}/packages/eas-cli/dist
       - name: Upload darwin-x64 tarball
         uses: actions/upload-release-asset@v1
@@ -105,10 +105,10 @@ jobs:
           yarn oclif pack:win
         working-directory: ${{ github.workspace }}/packages/eas-cli
       - id: x64
-        run: echo "::set-output name=filename::$(ls eas-*-x64.exe)"
+        run: echo "filename=$(ls eas-*-x64.exe)" >> $GITHUB_OUTPUT
         working-directory: ${{ github.workspace }}/packages/eas-cli/dist/win32
       - id: x86
-        run: echo "::set-output name=filename::$(ls eas-*-x86.exe)"
+        run: echo "filename=$(ls eas-*-x86.exe)" >> $GITHUB_OUTPUT
         working-directory: ${{ github.workspace }}/packages/eas-cli/dist/win32
       - name: Upload x64 installer
         uses: actions/upload-release-asset@v1
@@ -145,6 +145,14 @@ jobs:
         run: yarn build
       - name: Publish packages to npm
         run: yarn lerna publish from-package --yes --no-verify-access
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+      - name: Add latest-eas-build-staging tag
+        run: |
+          VERSION=$(cat lerna.json | jq -r .version)
+          echo //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN > ~/.npmrc
+          npm dist-tag add eas-cli@$VERSION latest-eas-build-staging
+          echo "Run \"npm dist-tag add eas-cli@$VERSION latest-eas-build\" to promote it to production."
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
   release-changelog:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,3 +12,7 @@ The algorithm works as follows:
 - If there are any entries in the "🛠 Breaking changes" section, bump the MAJOR version.
 - Otherwise, if there are any entries in the "🎉 New features", bump the MINOR version.
 - Otherwise, bump the PATCH version.
+
+## Updating EAS CLI version on EAS Build
+
+Release process will automatically promote new version to staging. After verifying if it works there, you can promote it to production with `npm dist-tag add eas-cli@{version} latest-eas-build`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,4 +15,4 @@ The algorithm works as follows:
 
 ## Updating EAS CLI version on EAS Build
 
-Release process will automatically promote new version to staging. After verifying if it works there, you can promote it to production with `npm dist-tag add eas-cli@{version} latest-eas-build`.
+The release process promotes the new version to staging. After verifying it works there, you can promote it to production with `npm dist-tag add eas-cli@{version} latest-eas-build`.


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

For builds from GitHub we will need to run cli on the workers.

# How

- Automatically promote the new release to staging, and print instructions on how to promote it to production.
- Replace deprecated set-output syntax.

# Test Plan

Run code-promoting packages as part of the test suite.
