### PR TITLE
print disabled resource class labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Remove unnecessary workaround for trailing backslash in .gitignore. ([#1622](https://github.com/expo/eas-cli/pull/1622) by [@wkozyra95](https://github.com/wkozyra95))
 - Internal command that will be run on EAS worker when building from GitHub. ([#1568](https://github.com/expo/eas-cli/pull/1568) by [@wkozyra95](https://github.com/wkozyra95))
+- Make the disabled tier error message more descriptive. ([#1635](https://github.com/expo/eas-cli/pull/1635) by [@dsokal](https://github.com/dsokal))
 
 ## [3.3.2](https://github.com/expo/eas-cli/releases/tag/v3.3.2) - 2023-01-12
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -177,8 +177,12 @@ function handleBuildRequestError(error: any, platform: Platform): never {
   } else if (
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_FREE_TIER_DISABLED_IOS'
   ) {
+    const resourceClasses = error.graphQLErrors[0].extensions.metadata?.resourceClasses;
+    const resourceClassesString = resourceClasses
+      ? ` (resource class${resourceClasses.length > 1 ? 'es' : ''}: ${resourceClasses.join(', ')})`
+      : '';
     Log.error(
-      `EAS Build free tier is temporarily disabled for iOS and we are not accepting any new builds. Try again later. ${learnMore(
+      `EAS Build free tier is temporarily disabled for iOS${resourceClassesString} and we are not accepting any new builds. Try again later. ${learnMore(
         'https://expo.fyi/eas-build-queues'
       )}`
     );


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

iOS resource classes (M1, Intel) can be disabled independently. 

# How

When a particular resource class is disabled, mention which one.

# Test Plan

<img width="1333" alt="Screenshot 2023-01-18 at 10 24 29" src="https://user-images.githubusercontent.com/5256730/213135114-07cf0695-e863-4586-b2ba-fc581831b1f3.png">

Tested with changes in https://github.com/expo/universe/pull/11239
