### PR TITLE
[eas-cli] Switch to using M1 by default when running build:configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add `--json` flag to `eas config` command. ([#1568](https://github.com/expo/eas-cli/pull/1568) by [@wkozyra95](https://github.com/wkozyra95))
+- Add M1 resource class configuration to default eas.json when running eas build:configure on a new project. ([#1637](https://github.com/expo/eas-cli/pull/1637) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -1,5 +1,5 @@
 import { Platform, Workflow } from '@expo/eas-build-job';
-import { EasJson, EasJsonAccessor } from '@expo/eas-json';
+import { EasJson, EasJsonAccessor, ResourceClass } from '@expo/eas-json';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
@@ -53,11 +53,21 @@ const EAS_JSON_MANAGED_DEFAULT: EasJson = {
     development: {
       developmentClient: true,
       distribution: 'internal',
+      ios: {
+        resourceClass: ResourceClass.M1_MEDIUM,
+      },
     },
     preview: {
       distribution: 'internal',
+      ios: {
+        resourceClass: ResourceClass.M1_MEDIUM,
+      },
     },
-    production: {},
+    production: {
+      ios: {
+        resourceClass: ResourceClass.M1_MEDIUM,
+      },
+    },
   },
   submit: {
     production: {},
@@ -76,12 +86,20 @@ const EAS_JSON_BARE_DEFAULT: EasJson = {
       },
       ios: {
         buildConfiguration: 'Debug',
+        resourceClass: ResourceClass.M1_MEDIUM,
       },
     },
     preview: {
       distribution: 'internal',
+      ios: {
+        resourceClass: ResourceClass.M1_MEDIUM,
+      },
     },
-    production: {},
+    production: {
+      ios: {
+        resourceClass: ResourceClass.M1_MEDIUM,
+      },
+    },
   },
   submit: {
     production: {},


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

For new apps adopting EAS Build, they should be using M1, and this should be explicit until we change the default across the board.

# How

Add M1 resource class configuration to **eas.json**. We should remove this as M1 adoption increases, likely around the SDK 48 release where we hope to make it default.

# Test Plan

I ran `easd build:configure` on a new project
