### PR TITLE
[eas-cli] Print error message sent from server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Remove unnecessary workaround for trailing backslash in .gitignore. ([#1622](https://github.com/expo/eas-cli/pull/1622) by [@wkozyra95](https://github.com/wkozyra95))
 - Internal command that will be run on EAS worker when building from GitHub. ([#1568](https://github.com/expo/eas-cli/pull/1568) by [@wkozyra95](https://github.com/wkozyra95))
 - Make the disabled tier error message more descriptive. ([#1635](https://github.com/expo/eas-cli/pull/1635) by [@dsokal](https://github.com/dsokal))
+- Control some of the EAS Build error messages server-side. ([#1639](https://github.com/expo/eas-cli/pull/1639) by [@wkozyra95](https://github.com/wkozyra95))
 
 ## [3.3.2](https://github.com/expo/eas-cli/releases/tag/v3.3.2) - 2023-01-12
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -215,7 +215,7 @@ export default class Build extends EasCommand {
   ): Promise<BuildFlags> {
     const requestedPlatform = await selectRequestedPlatformAsync(flags.requestedPlatform);
 
-    if (!flags.localBuildOptions.localBuildMode) {
+    if (flags.localBuildOptions.localBuildMode) {
       if (flags.autoSubmit) {
         // TODO: implement this
         Errors.error('Auto-submits are not yet supported when building locally', { exit: 1 });


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Often when reacting to a new situation, we do not have a way to send good error messages to users without an EAS CLI update. This change is making all error messages defined server side.

# How

- Print error returned from www
- Print entire raw error in debug mode

# Test Plan

enable kill switch and try to run build on staging

![20230119_12h19m11s_grim](https://user-images.githubusercontent.com/9753141/213438124-6bf276a7-95db-41a2-86ff-c986df751674.png)

