### PR TITLE
[eas-cli] Print warning about EAS_NO_VCS option to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix running commands with `--json` flag when EAS_NO_VCS is set. ([#1641](https://github.com/expo/eas-cli/pull/1641) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 - Remove unnecessary workaround for trailing backslash in .gitignore. ([#1622](https://github.com/expo/eas-cli/pull/1622) by [@wkozyra95](https://github.com/wkozyra95))

--- a/packages/eas-cli/src/vcs/index.ts
+++ b/packages/eas-cli/src/vcs/index.ts
@@ -1,4 +1,5 @@
-import log from '../log';
+import chalk from 'chalk';
+
 import GitNoCommitClient from './clients/gitNoCommit';
 import NoVcsClient from './clients/noVcs';
 import { Client } from './vcs';
@@ -10,7 +11,11 @@ let vcsClient = resolveDefaultVcsClient();
 function resolveDefaultVcsClient(): Client {
   if (process.env.EAS_NO_VCS) {
     if (process.env.NODE_ENV !== 'test') {
-      log.warn(NO_VCS_WARNING);
+      // This log might be printed before cli arguments are evaluated,
+      // so it needs to go to stderr in case command is run in JSON
+      // only mode.
+      // eslint-disable-next-line no-console
+      console.error(chalk.yellow(NO_VCS_WARNING));
     }
     return new NoVcsClient();
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Closes #1636

# How

Always print warning about EAS_NO_VCS to stderr to avoid issues when command is run in json only mode

# Test Plan

`EAS_NO_VCS=1 eas_dev build:list --json --non-interactive | jq .`
