### PR TITLE
fix local builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix incorrect exit code for successful local builds. ([#1649](https://github.com/expo/eas-cli/pull/1649) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [3.4.0](https://github.com/expo/eas-cli/releases/tag/v3.4.0) - 2023-01-20

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -16,14 +16,14 @@ export enum LocalBuildMode {
    *
    * Triggered when running `eas build --local`.
    */
-  LOCAL_BUILD_PLUGIN,
+  LOCAL_BUILD_PLUGIN = 'local-build-plugin',
   /**
    * Type of local build that is not accessible to users directly. When
    * cloud build is triggered by git based integration, we are running
    * in this mode. Instead of sending build request to EAS Servers it's
    * printing it to the stdout as JSON, so EAS Build worker can read it.
    */
-  INTERNAL,
+  INTERNAL = 'internal',
 }
 
 export interface LocalBuildOptions {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Fixes https://github.com/expo/eas-cli/issues/1648

https://github.com/expo/eas-cli/pull/1568/files#diff-4d125a745cc089a165745b3ab71732146c1bd1ac146f531cae4ea4824a27c6b0L224 introduced a bug with local builds. By default, enum values are 0, 1, 2, and so on. `0` is falsy.

# How

Use non-default values for the LocalBuildMode enum.

# Test Plan

Tested locally.