### PR TITLE
[ENG-7094][eas-cli] move image validation to server side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Move image validation to the server side and better handle server validation errors in the eas-cli/. ([#1650](https://github.com/expo/eas-cli/pull/1650) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [3.4.1](https://github.com/expo/eas-cli/releases/tag/v3.4.1) - 2023-01-23
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/config": "7.0.3",
     "@expo/config-plugins": "5.0.4",
     "@expo/config-types": "47.0.0",
-    "@expo/eas-build-job": "0.2.102",
+    "@expo/eas-build-job": "0.2.103",
     "@expo/eas-json": "3.3.2",
     "@expo/json-file": "8.2.37",
     "@expo/multipart-body-parser": "1.1.0",

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -185,6 +185,8 @@ function handleBuildRequestError(error: any, platform: Platform): never {
       `You have already reached the maximum number of pending ${requestedPlatformDisplayNames[platform]} builds for your account. Try again later.`
     );
     throw new Error('Build request failed.');
+  } else if (error?.graphQLErrors?.[0]?.extensions?.errorCode === 'VALIDATION_ERROR') {
+    Log.error('Your request is invalid. Check the error message below.');
   } else if (error?.graphQLErrors) {
     Log.error(
       'Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.'

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -161,6 +161,7 @@ const SERVER_SIDE_DEFINED_ERRORS = [
   'EAS_BUILD_FREE_TIER_DISABLED',
   'EAS_BUILD_FREE_TIER_DISABLED_IOS',
   'EAS_BUILD_FREE_TIER_DISABLED_ANDROID',
+  'VALIDATION_ERROR',
 ];
 
 function handleBuildRequestError(error: any, platform: Platform): never {
@@ -185,8 +186,6 @@ function handleBuildRequestError(error: any, platform: Platform): never {
       `You have already reached the maximum number of pending ${requestedPlatformDisplayNames[platform]} builds for your account. Try again later.`
     );
     throw new Error('Build request failed.');
-  } else if (error?.graphQLErrors?.[0]?.extensions?.errorCode === 'VALIDATION_ERROR') {
-    Log.error('Build request is invalid. Check the error message below.');
   } else if (error?.graphQLErrors) {
     Log.error(
       'Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.'

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -186,7 +186,7 @@ function handleBuildRequestError(error: any, platform: Platform): never {
     );
     throw new Error('Build request failed.');
   } else if (error?.graphQLErrors?.[0]?.extensions?.errorCode === 'VALIDATION_ERROR') {
-    Log.error('Your request is invalid. Check the error message below.');
+    Log.error('Build request is invalid. Check the error message below.');
   } else if (error?.graphQLErrors) {
     Log.error(
       'Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.'

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -1,4 +1,3 @@
-import { Android, Ios } from '@expo/eas-build-job';
 import Joi from 'joi';
 import semver from 'semver';
 
@@ -48,7 +47,7 @@ const AndroidBuildProfileSchema = CommonBuildProfileSchema.concat(
     distribution: Joi.string().valid('store', 'internal'),
     withoutCredentials: Joi.boolean(),
 
-    image: Joi.string().valid(...Android.builderBaseImages),
+    image: Joi.string(),
     ndk: Joi.string().empty(null).custom(semverCheck),
     autoIncrement: Joi.alternatives().try(
       Joi.boolean(),
@@ -77,7 +76,7 @@ const IosBuildProfileSchema = CommonBuildProfileSchema.concat(
     simulator: Joi.boolean(),
     resourceClass: Joi.string().valid(...AllowedIosResourceClasses),
 
-    image: Joi.string().valid(...Ios.builderBaseImages),
+    image: Joi.string(),
     bundler: Joi.string().empty(null).custom(semverCheck),
     fastlane: Joi.string().empty(null).custom(semverCheck),
     cocoapods: Joi.string().empty(null).custom(semverCheck),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,6 +1398,14 @@
     joi "^17.4.2"
     semver "^7.3.5"
 
+"@expo/eas-build-job@0.2.103":
+  version "0.2.103"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.103.tgz#0b587ada854570bc664f59dcd43dc3ca4221d451"
+  integrity sha512-cstgN8sVIYjq37xHm/4E6jnAlYf1gndvWfuVzRicUjp1TVyGjV9IbilSOxJp8AEqgPZK6+bZOcMRXT634M0Nmg==
+  dependencies:
+    joi "^17.4.2"
+    semver "^7.3.5"
+
 "@expo/image-utils@0.3.22":
   version "0.3.22"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.22.tgz#3a45fb2e268d20fcc761c87bca3aca7fd8e24260"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7094/better-error-handling-when-image-is-valid-but-doesnt-exist-on

We recently moved `image` validation to the server side from the `eas-build-job` package https://github.com/expo/eas-build/pull/182. We need to move validating `image` in `eas-json` to the server side. To achieve this we also need to improve handling validation errors from WWW in `eas-cli`

# How

Improve handling of `VALIDATION_ERROR` errors and don't validate `image` in `eas-json`.

# Test Plan

Test locally with https://github.com/expo/turtle-v2/pull/1179 and https://github.com/expo/universe/pull/11284

<img width="710" alt="Screenshot 2023-01-23 at 16 16 57" src="https://user-images.githubusercontent.com/55145344/214082919-16a86c62-475b-48f8-920b-c957ad580cd5.png">
