### PR TITLE
[ENG-7351][eas-cli] set `m1-medium` resource class for builds which don't specify resource class for SDK 48 and RN 0.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Set `m1-medium` resource class for SDK version `>=48` and RN version `>=0.71` builds with unspecified resource class. ([#1655](https://github.com/expo/eas-cli/pull/1655) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -1,15 +1,14 @@
-import { ExpoConfig } from '@expo/config-types';
 import { Platform } from '@expo/eas-build-job';
-import { BuildProfile, EasJson } from '@expo/eas-json';
+import { BuildProfile, EasJson, ResourceClass } from '@expo/eas-json';
 import JsonFile from '@expo/json-file';
 import getenv from 'getenv';
 import resolveFrom from 'resolve-from';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Analytics, AnalyticsEventProperties, BuildEvent } from '../analytics/AnalyticsManager';
+import { DynamicConfigContextFn } from '../commandUtils/context/DynamicProjectConfigContextField';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { CredentialsContext } from '../credentials/context';
-import { BuildResourceClass } from '../graphql/generated';
 import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 import { resolveWorkflowAsync } from '../project/workflow';
 import { Actor } from '../user/User';
@@ -17,6 +16,7 @@ import { createAndroidContextAsync } from './android/build';
 import { BuildContext, CommonContext } from './context';
 import { createIosContextAsync } from './ios/build';
 import { LocalBuildOptions } from './local';
+import { resolveBuildResourceClassAsync } from './utils/resourceClass';
 
 export async function createBuildContextAsync<T extends Platform>({
   buildProfileName,
@@ -28,13 +28,12 @@ export async function createBuildContextAsync<T extends Platform>({
   noWait,
   platform,
   projectDir,
-  resourceClass,
+  resourceClassFlag,
   message,
   actor,
   graphqlClient,
   analytics,
-  exp,
-  projectId,
+  getDynamicProjectConfigAsync,
 }: {
   buildProfileName: string;
   buildProfile: BuildProfile<T>;
@@ -45,14 +44,14 @@ export async function createBuildContextAsync<T extends Platform>({
   noWait: boolean;
   platform: T;
   projectDir: string;
-  resourceClass: BuildResourceClass;
+  resourceClassFlag?: ResourceClass;
   message?: string;
   actor: Actor;
   graphqlClient: ExpoGraphqlClient;
   analytics: Analytics;
-  exp: ExpoConfig;
-  projectId: string;
+  getDynamicProjectConfigAsync: DynamicConfigContextFn;
 }): Promise<BuildContext<T>> {
+  const { exp, projectId } = await getDynamicProjectConfigAsync(buildProfile.env);
   const projectName = exp.slug;
   const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
   const workflow = await resolveWorkflowAsync(projectDir, platform);
@@ -87,6 +86,14 @@ export async function createBuildContextAsync<T extends Platform>({
     run_from_ci: runFromCI,
   };
   analytics.logEvent(BuildEvent.BUILD_COMMAND, analyticsEventProperties);
+
+  const resourceClass = await resolveBuildResourceClassAsync(
+    buildProfile,
+    platform,
+    projectDir,
+    exp,
+    resourceClassFlag
+  );
 
   const commonContext: CommonContext<T> = {
     accountName: account.name,

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -1,3 +1,4 @@
+import { ExpoConfig } from '@expo/config-types';
 import { Platform } from '@expo/eas-build-job';
 import { BuildProfile, EasJson } from '@expo/eas-json';
 import JsonFile from '@expo/json-file';
@@ -6,7 +7,6 @@ import resolveFrom from 'resolve-from';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Analytics, AnalyticsEventProperties, BuildEvent } from '../analytics/AnalyticsManager';
-import { DynamicConfigContextFn } from '../commandUtils/context/DynamicProjectConfigContextField';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { CredentialsContext } from '../credentials/context';
 import { BuildResourceClass } from '../graphql/generated';
@@ -33,7 +33,8 @@ export async function createBuildContextAsync<T extends Platform>({
   actor,
   graphqlClient,
   analytics,
-  getDynamicProjectConfigAsync,
+  exp,
+  projectId,
 }: {
   buildProfileName: string;
   buildProfile: BuildProfile<T>;
@@ -49,10 +50,9 @@ export async function createBuildContextAsync<T extends Platform>({
   actor: Actor;
   graphqlClient: ExpoGraphqlClient;
   analytics: Analytics;
-  getDynamicProjectConfigAsync: DynamicConfigContextFn;
+  exp: ExpoConfig;
+  projectId: string;
 }): Promise<BuildContext<T>> {
-  const { exp, projectId } = await getDynamicProjectConfigAsync({ env: buildProfile.env });
-
   const projectName = exp.slug;
   const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
   const workflow = await resolveWorkflowAsync(projectDir, platform);

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -37,7 +37,7 @@ export async function collectMetadataAsync<T extends Platform>(
     credentialsSource: ctx.buildProfile.credentialsSource,
     sdkVersion: ctx.exp.sdkVersion,
     runtimeVersion: Updates.getRuntimeVersionNullable(ctx.exp, ctx.platform) ?? undefined,
-    reactNativeVersion: await getReactNativeVersionAsync(ctx),
+    reactNativeVersion: await getReactNativeVersionAsync(ctx.projectDir),
     ...channelOrReleaseChannel,
     distribution,
     appName: ctx.exp.name,
@@ -155,11 +155,9 @@ async function getNativeChannelAsync<T extends Platform>(
   return undefined;
 }
 
-async function getReactNativeVersionAsync(
-  ctx: BuildContext<Platform>
-): Promise<string | undefined> {
+export async function getReactNativeVersionAsync(projectDir: string): Promise<string | undefined> {
   try {
-    const reactNativePackageJsonPath = resolveFrom(ctx.projectDir, 'react-native/package.json');
+    const reactNativePackageJsonPath = resolveFrom(projectDir, 'react-native/package.json');
     return (await fs.readJson(reactNativePackageJsonPath)).version;
   } catch (err) {
     Log.debug('Failed to resolve react-native version:');

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -93,12 +93,6 @@ async function resolveIosResourceClassAsync(
     Log.warn(`Resource class ${chalk.bold('m1-experimental')} is deprecated.`);
   }
 
-  if ([ResourceClass.LARGE, ResourceClass.M1_LARGE].includes(resourceClass)) {
-    Log.warn(
-      `Large resource classes are not available for iOS builds yet. Your build will use the medium resource class.`
-    );
-  }
-
   return iosResourceClassToBuildResourceClassMapping[resourceClass];
 }
 

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -1,0 +1,124 @@
+import { Platform } from '@expo/eas-build-job';
+import { ResourceClass } from '@expo/eas-json';
+import chalk from 'chalk';
+import semver from 'semver';
+
+import { DynamicConfigContextFn } from '../../commandUtils/context/DynamicProjectConfigContextField';
+import { BuildResourceClass } from '../../graphql/generated';
+import Log from '../../log';
+import { ProfileData } from '../../utils/profiles';
+import { getReactNativeVersionAsync } from '../metadata';
+
+const iosResourceClassToBuildResourceClassMapping: Record<ResourceClass, BuildResourceClass> = {
+  [ResourceClass.DEFAULT]: BuildResourceClass.IosDefault,
+  [ResourceClass.LARGE]: BuildResourceClass.IosLarge,
+  [ResourceClass.M1_EXPERIMENTAL]: BuildResourceClass.IosM1Large,
+  [ResourceClass.M1_MEDIUM]: BuildResourceClass.IosM1Medium,
+  [ResourceClass.M1_LARGE]: BuildResourceClass.IosM1Large,
+  [ResourceClass.INTEL_MEDIUM]: BuildResourceClass.IosIntelMedium,
+  [ResourceClass.MEDIUM]: BuildResourceClass.IosMedium,
+};
+
+const androidResourceClassToBuildResourceClassMapping: Record<
+  Exclude<
+    ResourceClass,
+    | ResourceClass.M1_EXPERIMENTAL
+    | ResourceClass.M1_MEDIUM
+    | ResourceClass.M1_LARGE
+    | ResourceClass.INTEL_MEDIUM
+  >,
+  BuildResourceClass
+> = {
+  [ResourceClass.DEFAULT]: BuildResourceClass.AndroidDefault,
+  [ResourceClass.LARGE]: BuildResourceClass.AndroidLarge,
+  [ResourceClass.MEDIUM]: BuildResourceClass.AndroidMedium,
+};
+
+async function resolveDefaultResourceFlagAsync(
+  platform: Platform,
+  buildProfile: ProfileData<'build'>,
+  projectDir: string,
+  getDynamicProjectConfigAsync: DynamicConfigContextFn
+): Promise<ResourceClass> {
+  const { exp } = await getDynamicProjectConfigAsync({ env: buildProfile.profile.env });
+  const { sdkVersion } = exp;
+  const reactNativeVersion = await getReactNativeVersionAsync(projectDir);
+  return platform === Platform.IOS
+    ? resolveIosDefaultRequestedResourceClass(sdkVersion, reactNativeVersion)
+    : ResourceClass.DEFAULT;
+}
+
+function resolveIosDefaultRequestedResourceClass(
+  sdkVersion?: string,
+  reactNativeVersion?: string
+): ResourceClass {
+  if (
+    (sdkVersion && semver.satisfies(sdkVersion, '>=48')) ||
+    (reactNativeVersion && semver.satisfies(reactNativeVersion, '>=0.71.0'))
+  ) {
+    return ResourceClass.M1_MEDIUM;
+  } else {
+    return ResourceClass.DEFAULT;
+  }
+}
+
+export async function resolveBuildResourceClassAsync(
+  profile: ProfileData<'build'>,
+  projectDir: string,
+  getDynamicProjectConfigAsync: DynamicConfigContextFn,
+  resourceClassFlag?: ResourceClass
+): Promise<BuildResourceClass> {
+  if (
+    profile.platform !== Platform.IOS &&
+    resourceClassFlag &&
+    [
+      ResourceClass.M1_EXPERIMENTAL,
+      ResourceClass.M1_MEDIUM,
+      ResourceClass.M1_LARGE,
+      ResourceClass.INTEL_MEDIUM,
+    ].includes(resourceClassFlag)
+  ) {
+    throw new Error(`Resource class ${resourceClassFlag} is only available for iOS builds`);
+  }
+
+  const profileResourceClass = profile.profile.resourceClass;
+  if (profileResourceClass && resourceClassFlag && resourceClassFlag !== profileResourceClass) {
+    Log.warn(
+      `Build profile specifies the "${profileResourceClass}" resource class but you passed "${resourceClassFlag}" to --resource-class.\nUsing the  "${resourceClassFlag}" as the override.`
+    );
+  }
+
+  const resourceClass =
+    resourceClassFlag ??
+    profileResourceClass ??
+    (await resolveDefaultResourceFlagAsync(
+      profile.platform,
+      profile,
+      projectDir,
+      getDynamicProjectConfigAsync
+    ));
+
+  if (profile.platform === Platform.IOS && resourceClass === ResourceClass.M1_EXPERIMENTAL) {
+    Log.warn(`Resource class ${chalk.bold('m1-experimental')} is deprecated.`);
+  }
+  if (
+    profile.platform === Platform.IOS &&
+    [ResourceClass.LARGE, ResourceClass.M1_LARGE].includes(resourceClass)
+  ) {
+    Log.warn(
+      `Large resource classes are not available for iOS builds yet. Your build will use the medium resource class.`
+    );
+  }
+
+  return profile.platform === Platform.ANDROID
+    ? androidResourceClassToBuildResourceClassMapping[
+        resourceClass as Exclude<
+          ResourceClass,
+          | ResourceClass.M1_EXPERIMENTAL
+          | ResourceClass.M1_MEDIUM
+          | ResourceClass.M1_LARGE
+          | ResourceClass.INTEL_MEDIUM
+        >
+      ]
+    : iosResourceClassToBuildResourceClassMapping[resourceClass];
+}

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -1,9 +1,9 @@
+import { ExpoConfig } from '@expo/config-types';
 import { Platform } from '@expo/eas-build-job';
 import { ResourceClass } from '@expo/eas-json';
 import chalk from 'chalk';
 import semver from 'semver';
 
-import { DynamicConfigContextFn } from '../../commandUtils/context/DynamicProjectConfigContextField';
 import { BuildResourceClass } from '../../graphql/generated';
 import Log from '../../log';
 import { ProfileData } from '../../utils/profiles';
@@ -34,41 +34,41 @@ const androidResourceClassToBuildResourceClassMapping: Record<
   [ResourceClass.MEDIUM]: BuildResourceClass.AndroidMedium,
 };
 
-async function resolveIosDefaultRequestedResourceClassAsync(
-  getDynamicProjectConfigAsync: DynamicConfigContextFn,
+export async function resolveBuildResourceClassAsync(
+  profile: ProfileData<'build'>,
   projectDir: string,
-  buildProfile: ProfileData<'build'>
-): Promise<ResourceClass> {
-  const { exp } = await getDynamicProjectConfigAsync({ env: buildProfile.profile.env });
-  const { sdkVersion } = exp;
-  const reactNativeVersion = await getReactNativeVersionAsync(projectDir);
-  if (
-    (sdkVersion && semver.satisfies(sdkVersion, '>=48')) ||
-    (reactNativeVersion && semver.satisfies(reactNativeVersion, '>=0.71.0'))
-  ) {
-    return ResourceClass.M1_MEDIUM;
-  } else {
-    return ResourceClass.DEFAULT;
+  exp: ExpoConfig,
+  resourceClassFlag?: ResourceClass
+): Promise<BuildResourceClass> {
+  const profileResourceClass = profile.profile.resourceClass;
+
+  if (profileResourceClass && resourceClassFlag && resourceClassFlag !== profileResourceClass) {
+    Log.warn(
+      `Build profile specifies the "${profileResourceClass}" resource class but you passed "${resourceClassFlag}" to --resource-class.\nUsing the  "${resourceClassFlag}" as the override.`
+    );
   }
+
+  const selectedResourceClass = resourceClassFlag ?? profileResourceClass;
+
+  return profile.platform === Platform.IOS
+    ? await resolveIosResourceClassAsync(exp, projectDir, resourceClassFlag ?? profileResourceClass)
+    : resolveAndroidResourceClass(selectedResourceClass);
 }
 
-function resolveAndroidResourceClass(
-  profileResourceClass?: ResourceClass,
-  resourceClassFlag?: ResourceClass
-): BuildResourceClass {
+function resolveAndroidResourceClass(selectedResourceClass?: ResourceClass): BuildResourceClass {
   if (
-    resourceClassFlag &&
+    selectedResourceClass &&
     [
       ResourceClass.M1_EXPERIMENTAL,
       ResourceClass.M1_MEDIUM,
       ResourceClass.M1_LARGE,
       ResourceClass.INTEL_MEDIUM,
-    ].includes(resourceClassFlag)
+    ].includes(selectedResourceClass)
   ) {
-    throw new Error(`Resource class ${resourceClassFlag} is only available for iOS builds`);
+    throw new Error(`Resource class ${selectedResourceClass} is only available for iOS builds`);
   }
 
-  const resourceClass = resourceClassFlag ?? profileResourceClass ?? ResourceClass.DEFAULT;
+  const resourceClass = selectedResourceClass ?? ResourceClass.DEFAULT;
 
   return androidResourceClassToBuildResourceClassMapping[
     resourceClass as Exclude<
@@ -82,20 +82,12 @@ function resolveAndroidResourceClass(
 }
 
 async function resolveIosResourceClassAsync(
-  buildProfile: ProfileData<'build'>,
-  getDynamicProjectConfigAsync: DynamicConfigContextFn,
+  exp: ExpoConfig,
   projectDir: string,
-  profileResourceClass?: ResourceClass,
-  resourceClassFlag?: ResourceClass
+  selectedResourceClass?: ResourceClass
 ): Promise<BuildResourceClass> {
   const resourceClass =
-    resourceClassFlag ??
-    profileResourceClass ??
-    (await resolveIosDefaultRequestedResourceClassAsync(
-      getDynamicProjectConfigAsync,
-      projectDir,
-      buildProfile
-    ));
+    selectedResourceClass ?? (await resolveIosDefaultRequestedResourceClassAsync(exp, projectDir));
 
   if (resourceClass === ResourceClass.M1_EXPERIMENTAL) {
     Log.warn(`Resource class ${chalk.bold('m1-experimental')} is deprecated.`);
@@ -110,26 +102,18 @@ async function resolveIosResourceClassAsync(
   return iosResourceClassToBuildResourceClassMapping[resourceClass];
 }
 
-export async function resolveBuildResourceClassAsync(
-  profile: ProfileData<'build'>,
-  projectDir: string,
-  getDynamicProjectConfigAsync: DynamicConfigContextFn,
-  resourceClassFlag?: ResourceClass
-): Promise<BuildResourceClass> {
-  const profileResourceClass = profile.profile.resourceClass;
-  if (profileResourceClass && resourceClassFlag && resourceClassFlag !== profileResourceClass) {
-    Log.warn(
-      `Build profile specifies the "${profileResourceClass}" resource class but you passed "${resourceClassFlag}" to --resource-class.\nUsing the  "${resourceClassFlag}" as the override.`
-    );
+async function resolveIosDefaultRequestedResourceClassAsync(
+  exp: ExpoConfig,
+  projectDir: string
+): Promise<ResourceClass> {
+  const { sdkVersion } = exp;
+  const reactNativeVersion = await getReactNativeVersionAsync(projectDir);
+  if (
+    (sdkVersion && semver.satisfies(sdkVersion, '>=48')) ||
+    (reactNativeVersion && semver.satisfies(reactNativeVersion, '>=0.71.0'))
+  ) {
+    return ResourceClass.M1_MEDIUM;
+  } else {
+    return ResourceClass.DEFAULT;
   }
-
-  return profile.platform === Platform.IOS
-    ? await resolveIosResourceClassAsync(
-        profile,
-        getDynamicProjectConfigAsync,
-        projectDir,
-        profileResourceClass,
-        resourceClassFlag
-      )
-    : resolveAndroidResourceClass(profileResourceClass, resourceClassFlag);
 }

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -1,12 +1,11 @@
 import { ExpoConfig } from '@expo/config-types';
 import { Platform } from '@expo/eas-build-job';
-import { ResourceClass } from '@expo/eas-json';
+import { BuildProfile, ResourceClass } from '@expo/eas-json';
 import chalk from 'chalk';
 import semver from 'semver';
 
 import { BuildResourceClass } from '../../graphql/generated';
 import Log from '../../log';
-import { ProfileData } from '../../utils/profiles';
 import { getReactNativeVersionAsync } from '../metadata';
 
 const iosResourceClassToBuildResourceClassMapping: Record<ResourceClass, BuildResourceClass> = {
@@ -34,13 +33,14 @@ const androidResourceClassToBuildResourceClassMapping: Record<
   [ResourceClass.MEDIUM]: BuildResourceClass.AndroidMedium,
 };
 
-export async function resolveBuildResourceClassAsync(
-  profile: ProfileData<'build'>,
+export async function resolveBuildResourceClassAsync<T extends Platform>(
+  profile: BuildProfile<T>,
+  platform: Platform,
   projectDir: string,
   exp: ExpoConfig,
   resourceClassFlag?: ResourceClass
 ): Promise<BuildResourceClass> {
-  const profileResourceClass = profile.profile.resourceClass;
+  const profileResourceClass = profile.resourceClass;
 
   if (profileResourceClass && resourceClassFlag && resourceClassFlag !== profileResourceClass) {
     Log.warn(
@@ -50,7 +50,7 @@ export async function resolveBuildResourceClassAsync(
 
   const selectedResourceClass = resourceClassFlag ?? profileResourceClass;
 
-  return profile.platform === Platform.IOS
+  return platform === Platform.IOS
     ? await resolveIosResourceClassAsync(exp, projectDir, resourceClassFlag ?? profileResourceClass)
     : resolveAndroidResourceClass(selectedResourceClass);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7351/switch-the-default-resourceclass-to-m1-for-sdk-48-projects

# How

If the resource class is unspecified, and the project is using SDK 48 / React Native 0.71, use the `m1-medium` resource class for the build.

# Test Plan

Test locally.
