### PR TITLE
[ENG-7367][eas-cli] Fix using local credentials with enterprise provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix undefined branchMappingLogic. ([#1653](https://github.com/expo/eas-cli/pull/1653) by [@quinlanj](https://github.com/quinlanj))
+- Fix using local credentials for internal distribution builds with universal provisioning. ([#1657](https://github.com/expo/eas-cli/pull/1657) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -147,7 +147,7 @@ export default class IosCredentialsProvider {
     if (this.options.distribution === 'internal') {
       if (this.options.enterpriseProvisioning === 'universal' && !isEnterprise) {
         throw new Error(
-          `You must use an universal provisioning profile${
+          `You must use a universal provisioning profile${
             targetName ? ` (target '${targetName})'` : ''
           } for internal distribution if you specified "enterpriseProvisioning": "universal" in eas.json`
         );

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -17,7 +17,7 @@ import { getAppFromContextAsync } from './actions/BuildCredentialsUtils';
 import { SetUpBuildCredentials } from './actions/SetUpBuildCredentials';
 import { SetUpPushKey } from './actions/SetUpPushKey';
 import { App, IosCredentials, Target } from './types';
-import { isAdHocProfile } from './utils/provisioningProfile';
+import { isAdHocProfile, isEnterpriseUniversalProfile } from './utils/provisioningProfile';
 
 interface Options {
   app: App;
@@ -143,17 +143,32 @@ export default class IosCredentialsProvider {
 
   private assertProvisioningProfileType(provisioningProfile: string, targetName?: string): void {
     const isAdHoc = isAdHocProfile(provisioningProfile);
-    if (this.options.distribution === 'internal' && !isAdHoc) {
-      throw new Error(
-        `You must use an adhoc provisioning profile${
-          targetName ? ` (target '${targetName})'` : ''
-        } for internal distribution`
-      );
-    } else if (this.options.distribution !== 'internal' && isAdHoc) {
+    const isEnterprise = isEnterpriseUniversalProfile(provisioningProfile);
+    if (this.options.distribution === 'internal') {
+      if (this.options.enterpriseProvisioning === 'universal' && !isEnterprise) {
+        throw new Error(
+          `You must use an universal provisioning profile${
+            targetName ? ` (target '${targetName})'` : ''
+          } for internal distribution if you specified "enterpriseProvisioning": "universal" in eas.json`
+        );
+      } else if (this.options.enterpriseProvisioning === 'adhoc' && !isAdHoc) {
+        throw new Error(
+          `You must use an adhoc provisioning profile${
+            targetName ? ` (target '${targetName})'` : ''
+          } for internal distribution if you specified "enterpriseProvisioning": "adhoc" in eas.json`
+        );
+      } else if (!this.options.enterpriseProvisioning && !isEnterprise && !isAdHoc) {
+        throw new Error(
+          `You must use an adhoc provisioning profile${
+            targetName ? ` (target '${targetName})'` : ''
+          } for internal distribution.`
+        );
+      }
+    } else if (isAdHoc) {
       throw new Error(
         `You can't use an adhoc provisioning profile${
           targetName ? ` (target '${targetName}')` : ''
-        } for app store distribution`
+        } for app store distribution.`
       );
     }
   }

--- a/packages/eas-cli/src/credentials/ios/utils/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/provisioningProfile.ts
@@ -26,6 +26,11 @@ export function isAdHocProfile(dataBase64: string): boolean {
   return Array.isArray(provisionedDevices);
 }
 
+export function isEnterpriseUniversalProfile(dataBase64: string): boolean {
+  const profilePlist = parse(dataBase64);
+  return !!profilePlist['ProvisionsAllDevices'];
+}
+
 export function parse(dataBase64: string): PlistObject {
   try {
     const buffer = Buffer.from(dataBase64, 'base64');


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Closes #1656 

# How

Check if the provisioning profile is using universal provisioning for enterprise accounts when using local credentials.
Additionally, check more strictly if enterpriseProvisioning is specified in eas.json.

# Test Plan

Don't have access to the enterprise account at the moment(some policies need to be accepted), so I didn't test it, but I verfied with EAS Build sources that this is the way we validate on builider type of the Provisioning profile
