### PR TITLE
[eas-cli] fix issue with the `eas.json` envs being not available when resolving local config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix the issue with the `eas.json` envs being not available when resolving dynamic config. ([#1666](https://github.com/expo/eas-cli/pull/1666) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [3.5.0](https://github.com/expo/eas-cli/releases/tag/v3.5.0) - 2023-01-31

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -51,7 +51,7 @@ export async function createBuildContextAsync<T extends Platform>({
   analytics: Analytics;
   getDynamicProjectConfigAsync: DynamicConfigContextFn;
 }): Promise<BuildContext<T>> {
-  const { exp, projectId } = await getDynamicProjectConfigAsync(buildProfile.env);
+  const { exp, projectId } = await getDynamicProjectConfigAsync({ env: buildProfile.env });
   const projectName = exp.slug;
   const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
   const workflow = await resolveWorkflowAsync(projectDir, platform);

--- a/packages/eas-cli/src/commandUtils/context/DynamicProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/DynamicProjectConfigContextField.ts
@@ -5,7 +5,7 @@ import ContextField, { ContextOptions } from './ContextField';
 import { findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
 import { getProjectIdAsync } from './contextUtils/getProjectIdAsync';
 
-export type DynamicConfigContextFn = (options?: ExpoConfigOptions) => Promise<{
+export type DynamicConfigContextFn = (options: ExpoConfigOptions) => Promise<{
   projectId: string;
   exp: ExpoConfig;
   projectDir: string;

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -211,7 +211,7 @@ export default class UpdatePublish extends EasCommand {
       projectId,
     });
 
-    const { exp } = await getDynamicProjectConfigAsync();
+    const { exp } = await getDynamicProjectConfigAsync({});
     const codeSigningInfo = await getCodeSigningInfoAsync(expPrivate, privateKeyPath);
 
     let realizedPlatforms: PublishPlatform[] = [];


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1675204277962559?thread_ts=1675197740.345569&cid=C017N0N99RA

# How

Revert change which caused this bug https://github.com/expo/eas-cli/commit/7fc3e3fcdbfaf8678f74a381ae29906d363ff33a#diff-c63107e3aba5b4b07dc44257b5a0d13751a25aa74279e996419d1e35a5955acf

# Test Plan

Tested locally
