### PR TITLE
[eas-cli] Warn when project ID but no owner specified and mismatch logged in user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Use `sdkVersion` as default runtime version policy when running `eas update:configure`. ([#1669](https://github.com/expo/eas-cli/pull/1669) by [@jonsamp](https://github.com/jonsamp))
+- Warn when project ID but no owner specified and mismatch logged in user. ([#1667](https://github.com/expo/eas-cli/pull/1667) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -10,7 +10,7 @@ import { getExpoConfig } from '../../../project/expoConfig';
 import { fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync } from '../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 import { toAppPrivacy } from '../../../project/projectUtils';
 import SessionManager from '../../../user/SessionManager';
-import { Actor } from '../../../user/User';
+import { Actor, getActorUsername } from '../../../user/User';
 import { createGraphqlClient } from './createGraphqlClient';
 import { findProjectRootAsync } from './findProjectDirAndVerifyProjectSetupAsync';
 
@@ -93,9 +93,22 @@ export async function getProjectIdAsync(
     const appForProjectId = await AppQuery.byIdAsync(graphqlClient, localProjectId);
     if (exp.owner && exp.owner !== appForProjectId.ownerAccount.name) {
       throw new Error(
-        `Project config: Project identified by "extra.eas.projectId" (${
+        `Project config: Owner of project identified by "extra.eas.projectId" (${
           appForProjectId.ownerAccount.name
-        }) is not owned by owner specified in the "owner" field (${exp.owner}). ${learnMore(
+        }) does not match owner specified in the "owner" field (${exp.owner}). ${learnMore(
+          'https://expo.fyi/eas-project-id'
+        )}`
+      );
+    }
+
+    const actorUsername = getActorUsername(actor);
+    if (!exp.owner && appForProjectId.ownerAccount.name !== actorUsername) {
+      throw new Error(
+        `Project config: Owner of project identified by "extra.eas.projectId" (${
+          appForProjectId.ownerAccount.name
+        }) does not match the logged in user (${actorUsername}) and the "owner" field is not specified. To ensure all libraries work correctly, "owner": "${
+          appForProjectId.ownerAccount.name
+        }" should be added to the project config, which can be done automatically by re-running "eas init". ${learnMore(
           'https://expo.fyi/eas-project-id'
         )}`
       );

--- a/packages/eas-cli/src/user/User.ts
+++ b/packages/eas-cli/src/user/User.ts
@@ -7,15 +7,25 @@ export type Actor = NonNullable<CurrentUserQuery['meActor']>;
  * This should be used whenever the "current user" needs to be displayed.
  * The display name CANNOT be used as project owner.
  */
-export function getActorDisplayName(user?: Actor): string {
-  switch (user?.__typename) {
+export function getActorDisplayName(actor?: Actor): string {
+  switch (actor?.__typename) {
     case 'User':
-      return user.username;
+      return actor.username;
     case 'Robot':
-      return user.firstName ? `${user.firstName} (robot)` : 'robot';
+      return actor.firstName ? `${actor.firstName} (robot)` : 'robot';
     case 'SSOUser':
-      return user.username ? `${user.username} (sso user)` : 'sso user';
+      return actor.username ? `${actor.username} (sso user)` : 'sso user';
     default:
       return 'anonymous';
+  }
+}
+
+export function getActorUsername(actor?: Actor): string | null {
+  switch (actor?.__typename) {
+    case 'User':
+    case 'SSOUser':
+      return actor.username;
+    default:
+      return null;
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

A user reported an issue where they were operating on a organization project as another account. While this works for 99% of things, some legacy code still requires an owner field to work properly.

It is unlikely that many users end up in this state though since:
a) `eas init` sets owner and project ID
b) the instructions tell people to set owner when collaborating

But it might be missed sometimes. Therefore, this PR validates that when there is a project ID and no owner set, it will throw an error when the implicit owner for legacy tools (the currently-logged-in user) does not match the actual owner of the project identified by the ID.

Closes ENG-7474.

# How

Add check and test.

This commit also now verifies the project setup idempotently when `eas init` is re-run so that the command error added can give the user succinct instructions.

# Test Plan

Run tests.

Manual tests:
1. In project with project id but no owner field, run `eas init` (locally) and ensure it adds the owner field.