### PR TITLE
[eas-cli] Fix suggested identifiers to match owning account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix suggested application identifier to match owning account name. ([#1670](https://github.com/expo/eas-cli/pull/1670) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 ## [3.5.2](https://github.com/expo/eas-cli/releases/tag/v3.5.2) - 2023-02-05

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -62,7 +62,7 @@ This means that it will most likely produce an AAB and you will not be able to i
   const gradleContext = await resolveGradleBuildContextAsync(ctx.projectDir, buildProfile);
 
   if (ctx.workflow === Workflow.MANAGED) {
-    await ensureApplicationIdIsDefinedForManagedProjectAsync(ctx.projectDir, ctx.exp, ctx.user);
+    await ensureApplicationIdIsDefinedForManagedProjectAsync(ctx);
   }
 
   const applicationId = await getApplicationIdAsync(ctx.projectDir, ctx.exp, gradleContext);

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -27,7 +27,7 @@ export async function createIosContextAsync(
   const { buildProfile } = ctx;
 
   if (ctx.workflow === Workflow.MANAGED) {
-    await ensureBundleIdentifierIsDefinedForManagedProjectAsync(ctx.projectDir, ctx.exp, ctx.user);
+    await ensureBundleIdentifierIsDefinedForManagedProjectAsync(ctx);
   }
 
   checkNodeEnvVariable(ctx);

--- a/packages/eas-cli/src/commands/build/version/set.ts
+++ b/packages/eas-cli/src/commands/build/version/set.ts
@@ -46,7 +46,7 @@ export default class BuildVersionSetView extends EasCommand {
   public async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildVersionSetView);
     const {
-      loggedIn: { actor, graphqlClient },
+      loggedIn: { graphqlClient },
       getDynamicProjectConfigAsync,
       projectDir,
     } = await this.getContextAsync(BuildVersionSetView, {
@@ -67,13 +67,14 @@ export default class BuildVersionSetView extends EasCommand {
 
     validateAppConfigForRemoteVersionSource(exp, platform);
 
-    const applicationIdentifier = await getApplicationIdentifierAsync(
+    const applicationIdentifier = await getApplicationIdentifierAsync({
+      graphqlClient,
       projectDir,
+      projectId,
       exp,
-      profile,
+      buildProfile: profile,
       platform,
-      actor
-    );
+    });
     const remoteVersions = await AppVersionQuery.latestVersionAsync(
       graphqlClient,
       projectId,

--- a/packages/eas-cli/src/commands/build/version/sync.ts
+++ b/packages/eas-cli/src/commands/build/version/sync.ts
@@ -63,7 +63,7 @@ export default class BuildVersionSyncView extends EasCommand {
   public async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildVersionSyncView);
     const {
-      loggedIn: { actor, graphqlClient },
+      loggedIn: { graphqlClient },
       getDynamicProjectConfigAsync,
       projectDir,
     } = await this.getContextAsync(BuildVersionSyncView, {
@@ -89,13 +89,14 @@ export default class BuildVersionSyncView extends EasCommand {
       validateAppConfigForRemoteVersionSource(exp, profileInfo.platform);
       const platformDisplayName = appPlatformDisplayNames[toAppPlatform(profileInfo.platform)];
 
-      const applicationIdentifier = await getApplicationIdentifierAsync(
+      const applicationIdentifier = await getApplicationIdentifierAsync({
+        graphqlClient,
         projectDir,
+        projectId,
         exp,
-        profileInfo.profile,
-        profileInfo.platform,
-        actor
-      );
+        buildProfile: profileInfo.profile,
+        platform: profileInfo.platform,
+      });
       const remoteVersions = await AppVersionQuery.latestVersionAsync(
         graphqlClient,
         projectId,

--- a/packages/eas-cli/src/project/applicationIdentifier.ts
+++ b/packages/eas-cli/src/project/applicationIdentifier.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { BuildProfile } from '@expo/eas-json';
 
-import { Actor } from '../user/User';
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   ensureApplicationIdIsDefinedForManagedProjectAsync,
   getApplicationIdAsync,
@@ -16,19 +16,32 @@ import { resolveXcodeBuildContextAsync } from './ios/scheme';
 import { findApplicationTarget, resolveTargetsAsync } from './ios/target';
 import { resolveWorkflowAsync } from './workflow';
 
-export async function getApplicationIdentifierAsync(
-  projectDir: string,
-  exp: ExpoConfig,
-  buildProfile: BuildProfile,
-  platform: Platform,
-  actor: Actor
-): Promise<string> {
+export async function getApplicationIdentifierAsync({
+  graphqlClient,
+  projectDir,
+  projectId,
+  exp,
+  buildProfile,
+  platform,
+}: {
+  graphqlClient: ExpoGraphqlClient;
+  projectDir: string;
+  projectId: string;
+  exp: ExpoConfig;
+  buildProfile: BuildProfile;
+  platform: Platform;
+}): Promise<string> {
   if (platform === Platform.ANDROID) {
     const profile = buildProfile as BuildProfile<Platform.ANDROID>;
     const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID);
 
     if (workflow === Workflow.MANAGED) {
-      return await ensureApplicationIdIsDefinedForManagedProjectAsync(projectDir, exp, actor);
+      return await ensureApplicationIdIsDefinedForManagedProjectAsync({
+        graphqlClient,
+        projectDir,
+        projectId,
+        exp,
+      });
     }
 
     const gradleContext = await resolveGradleBuildContextAsync(projectDir, profile);
@@ -37,7 +50,12 @@ export async function getApplicationIdentifierAsync(
     const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS);
     const profile = buildProfile as BuildProfile<Platform.IOS>;
     if (workflow === Workflow.MANAGED) {
-      return await ensureBundleIdentifierIsDefinedForManagedProjectAsync(projectDir, exp, actor);
+      return await ensureBundleIdentifierIsDefinedForManagedProjectAsync({
+        graphqlClient,
+        projectDir,
+        projectId,
+        exp,
+      });
     }
 
     const xcodeBuildContext = await resolveXcodeBuildContextAsync(


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Noticed that when I have an application that belongs to an org it still suggests my logged-in username as the application identifier part. This changes it to use the owner account name.

Closes ENG-7475.

# How

Update logic.

# Test Plan

Before:
```
$ eas build -p android
✔ Generated eas.json

📝  Android application id Learn more
✖ What would you like your Android application id to be? … com.wschurman.pouidapoidaw
```

After:
```
$ ~/expo/eas-cli/packages/eas-cli/bin/run build -p android

📝  Android application id Learn more
✖ What would you like your Android application id to be? … com.myneworg.pouidapoidaw
```
