### PR TITLE
[eas-cli] Add EAS update properties that were removed from templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix suggested application identifier to match owning account name. ([#1670](https://github.com/expo/eas-cli/pull/1670) by [@wschurman](https://github.com/wschurman))
-- "Modify update:configure to add possibly missing EAS update config properties". ([#1686](https://github.com/expo/eas-cli/pull/1686) by [@douglowder](https://github.com/douglowder))
+- Modify update:configure to add possibly missing EAS update config properties. ([#1686](https://github.com/expo/eas-cli/pull/1686) by [@douglowder](https://github.com/douglowder))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix suggested application identifier to match owning account name. ([#1670](https://github.com/expo/eas-cli/pull/1670) by [@wschurman](https://github.com/wschurman))
+- "Modify update:configure to add possibly missing EAS update config properties". ([#1686](https://github.com/expo/eas-cli/pull/1686) by [@douglowder](https://github.com/douglowder))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -65,10 +65,6 @@ function mergeExpoConfig(exp: ExpoConfig, modifyExp: Partial<ExpoConfig>): Parti
     updates: {
       ...exp.updates,
       url: modifyExp?.updates?.url || exp.updates?.url,
-      fallbackToCacheTimeout:
-        modifyExp?.updates?.fallbackToCacheTimeout !== undefined
-          ? modifyExp?.updates?.fallbackToCacheTimeout
-          : exp?.updates?.fallbackToCacheTimeout,
     },
     android: {
       ...exp.android,
@@ -105,10 +101,6 @@ async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
 
   if (exp.updates?.url !== getEASUpdateURL(projectId)) {
     modifyConfig.updates = { url: getEASUpdateURL(projectId) };
-  }
-
-  if (exp.updates?.fallbackToCacheTimeout === undefined) {
-    modifyConfig.updates = { url: modifyConfig?.updates?.url, fallbackToCacheTimeout: 0 };
   }
 
   if (!exp.assetBundlePatterns) {
@@ -205,12 +197,6 @@ function logEasUpdatesAutoConfig({
   if (modifyConfig?.assetBundlePatterns) {
     Log.withTick(
       `Configured assetBundlePatterns to ${JSON.stringify(modifyConfig.assetBundlePatterns)}`
-    );
-  }
-
-  if (modifyConfig?.updates?.fallbackToCacheTimeout !== undefined) {
-    Log.withTick(
-      `Configured updates.fallbackToCacheTimeout to ${modifyConfig?.updates?.fallbackToCacheTimeout}`
     );
   }
 }

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -61,7 +61,15 @@ function replaceUndefinedObjectValues(
 function mergeExpoConfig(exp: ExpoConfig, modifyExp: Partial<ExpoConfig>): Partial<ExpoConfig> {
   return {
     runtimeVersion: modifyExp.runtimeVersion ?? exp.runtimeVersion,
-    updates: { ...exp.updates, ...modifyExp.updates },
+    assetBundlePatterns: modifyExp.assetBundlePatterns ?? exp.assetBundlePatterns,
+    updates: {
+      ...exp.updates,
+      url: modifyExp?.updates?.url || exp.updates?.url,
+      fallbackToCacheTimeout:
+        modifyExp?.updates?.fallbackToCacheTimeout !== undefined
+          ? modifyExp?.updates?.fallbackToCacheTimeout
+          : exp?.updates?.fallbackToCacheTimeout,
+    },
     android: {
       ...exp.android,
       ...modifyExp.android,
@@ -97,6 +105,14 @@ async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
 
   if (exp.updates?.url !== getEASUpdateURL(projectId)) {
     modifyConfig.updates = { url: getEASUpdateURL(projectId) };
+  }
+
+  if (exp.updates?.fallbackToCacheTimeout === undefined) {
+    modifyConfig.updates = { url: modifyConfig?.updates?.url, fallbackToCacheTimeout: 0 };
+  }
+
+  if (!exp.assetBundlePatterns) {
+    modifyConfig.assetBundlePatterns = ['*/**'];
   }
 
   let androidRuntimeVersion = exp.android?.runtimeVersion ?? exp.runtimeVersion;
@@ -183,6 +199,18 @@ function logEasUpdatesAutoConfig({
       `Configured runtimeVersion for ${
         appPlatformDisplayNames[AppPlatform.Ios]
       } with "${JSON.stringify(modifyConfig.ios?.runtimeVersion ?? modifyConfig.runtimeVersion)}"`
+    );
+  }
+
+  if (modifyConfig?.assetBundlePatterns) {
+    Log.withTick(
+      `Configured assetBundlePatterns to ${JSON.stringify(modifyConfig.assetBundlePatterns)}`
+    );
+  }
+
+  if (modifyConfig?.updates?.fallbackToCacheTimeout !== undefined) {
+    Log.withTick(
+      `Configured updates.fallbackToCacheTimeout to ${modifyConfig?.updates?.fallbackToCacheTimeout}`
     );
   }
 }


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Certain properties used in EAS Update, that were previously included by default in Expo templates, were removed in https://github.com/expo/expo/pull/21126 .

This PR modifies `eas update:configure` to check for those properties in the Expo config, and add the correct default values if they are not present.

# Test Plan

Tested with an app created with `yarn create expo-app`.

- If `assetBundlePatterns` or `fallbackToCacheTimeout` are removed from `app.json`, `eas update:configure` adds them back.
- If they are present, `eas update:configure` does not attempt to modify them.
- Overwriting the correct update URL still works as before.
