### PR TITLE
[eas-cli] Disable analytics for environments behind proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Disable analytics when running behind a proxy. ([#1696](https://github.com/expo/eas-cli/pull/1696) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 🧹 Chores
 
 ## [3.6.0](https://github.com/expo/eas-cli/releases/tag/v3.6.0) - 2023-02-14

--- a/packages/eas-cli/src/analytics/AnalyticsManager.ts
+++ b/packages/eas-cli/src/analytics/AnalyticsManager.ts
@@ -133,7 +133,9 @@ export async function createAnalyticsAsync(): Promise<AnalyticsWithOrchestration
     await UserSettings.setAsync(USER_SETTINGS_KEY_ANALYTICS_ENABLED, false);
   }
 
-  const analyticsEnabled = await UserSettings.getAsync(USER_SETTINGS_KEY_ANALYTICS_ENABLED, true);
+  const analyticsEnabled =
+    !process.env.https_proxy && // disable analytics if running behind proxy
+    (await UserSettings.getAsync(USER_SETTINGS_KEY_ANALYTICS_ENABLED, true));
   if (!analyticsEnabled) {
     return new NoOpAnalytics();
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Closes #1684 

The analytics library does not respect proxy configuration, and it is causing cli to hang before exiting.

# How

Disable analytics if CLI is running behind a proxy.

# Test Plan


