### PR TITLE
[ci] commit release changelog update using Expo Bot PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,8 @@ jobs:
     needs: publish-to-npm
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.EXPO_BOT_PAT }}
       - uses: actions/setup-node@v2
         with:
           node-version: 18


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

In https://github.com/expo/eas-cli/pull/1640/files changed PR changelog workflow behavior, it commits changelog changes using Expo Bot's PAT. I forgot to do the same for the release changelog update workflow committing to `main`.

We also can see that after the merge queue was enabled main commits from this workflow failed with branch protected error. Maybe adding PAT will fix it as well.

# How

Do the same as in https://github.com/expo/eas-cli/pull/1640/files. It shouldn't break anything.

# Test Plan

Test on prod 😈 I will observe if the next release workflow succeeds or if we see branch protected error again.
