### PR TITLE
[eas-cli] Validate platform for local builds earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Validate the platform for local builds earlier. ([#1698](https://github.com/expo/eas-cli/pull/1698) by [@wkozyra95](https://github.com/wkozyra95))
+
 ## [3.6.0](https://github.com/expo/eas-cli/releases/tag/v3.6.0) - 2023-02-14
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -227,6 +227,13 @@ export default class Build extends EasCommand {
         });
       } else if (process.platform !== 'darwin' && requestedPlatform === RequestedPlatform.Ios) {
         Errors.error('Unsupported platform, macOS is required to build apps for iOS', { exit: 1 });
+      } else if (
+        !['linux', 'darwin'].includes(process.platform) &&
+        requestedPlatform === RequestedPlatform.Android
+      ) {
+        Errors.error('Unsupported platform, macOS or Linux is required to build apps for Android', {
+          exit: 1,
+        });
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://github.com/expo/eas-cli/issues/1685

Sometimes running local builds on windows fails before we even validate the platform, so to users it looks like a bug.
In the above case validation was never reached because spawning a process for local buld plugin failed.

# How

Validate platform in eas-cli before local plugin is executed.

# Test Plan

Not tested, copied the check from the local build plugin
