### PR TITLE
[ENG-7376][eas-cli] link to build phase in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Validate the platform for local builds earlier. ([#1698](https://github.com/expo/eas-cli/pull/1698) by [@wkozyra95](https://github.com/wkozyra95))
 - Display build message when picking build in `eas submit`, `eas build:resign`, and `eas build:run` commands. ([#1700](https://github.com/expo/eas-cli/pull/1700) by [@szdziedzic](https://github.com/szdziedzic))
+- Add a link directly to a build phase logs in the EAS CLI build error message. ([#1699](https://github.com/expo/eas-cli/pull/1699) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [3.6.0](https://github.com/expo/eas-cli/releases/tag/v3.6.0) - 2023-02-14
 

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -23,12 +23,12 @@ const errorCodeToErrorMessageOverride: Record<string, (build: BuildFragment) => 
   EAS_BUILD_UNKNOWN_FASTLANE_ERROR: build =>
     `The ${link(getBuildLogsUrl(build, 'run-fastlane'), {
       text: '"Run fastlane"',
-      fallback: terminalLinkFallback,
+      fallback: terminalLinkFallback(getBuildLogsUrl(build, 'run-fastlane'), '"Run fastlane"'),
     })} step failed with an unknown error. Refer to the ${link(
       getBuildLogsUrl(build, 'xcode-logs'),
       {
         text: '"Xcode logs"',
-        fallback: terminalLinkFallback,
+        fallback: terminalLinkFallback(getBuildLogsUrl(build, 'xcode-logs'), '"Xcode logs"'),
       }
     )} phase for additional, more detailed logs`,
   EAS_BUILD_UNKNOWN_GRADLE_ERROR: build =>
@@ -36,7 +36,7 @@ const errorCodeToErrorMessageOverride: Record<string, (build: BuildFragment) => 
       getBuildLogsUrl(build, 'run-gradlew'),
       {
         text: '"Run gradlew"',
-        fallback: terminalLinkFallback,
+        fallback: terminalLinkFallback(getBuildLogsUrl(build, 'run-gradlew'), '"Run gradlew"'),
       }
     )} phase for more information.`,
 };

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -15,6 +15,10 @@ import Log, { learnMore, link } from '../../log';
 import { appPlatformDisplayNames, appPlatformEmojis } from '../../platform';
 import { getBuildLogsUrl, getInternalDistributionInstallUrl } from './url';
 
+function terminalLinkFallback(url: string, text: string): string {
+  return `${text} (${url})`;
+}
+
 const errorCodeToErrorMessageOverride: Record<string, (build: BuildFragment) => string> = {
   EAS_BUILD_UNKNOWN_FASTLANE_ERROR: build =>
     `The ${link(getBuildLogsUrl(build, 'run-fastlane'), {
@@ -23,6 +27,7 @@ const errorCodeToErrorMessageOverride: Record<string, (build: BuildFragment) => 
       getBuildLogsUrl(build, 'xcode-logs'),
       {
         text: '"Xcode logs"',
+        fallback: terminalLinkFallback,
       }
     )} phase for additional, more detailed logs`,
   EAS_BUILD_UNKNOWN_GRADLE_ERROR: build =>
@@ -30,6 +35,7 @@ const errorCodeToErrorMessageOverride: Record<string, (build: BuildFragment) => 
       getBuildLogsUrl(build, 'run-gradlew'),
       {
         text: '"Run gradlew"',
+        fallback: terminalLinkFallback,
       }
     )} phase for more information.`,
 };

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -23,6 +23,7 @@ const errorCodeToErrorMessageOverride: Record<string, (build: BuildFragment) => 
   EAS_BUILD_UNKNOWN_FASTLANE_ERROR: build =>
     `The ${link(getBuildLogsUrl(build, 'run-fastlane'), {
       text: '"Run fastlane"',
+      fallback: terminalLinkFallback,
     })} step failed with an unknown error. Refer to the ${link(
       getBuildLogsUrl(build, 'xcode-logs'),
       {

--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -10,12 +10,14 @@ export function getProjectDashboardUrl(accountName: string, projectName: string)
   ).toString();
 }
 
-export function getBuildLogsUrl(build: BuildFragment): string {
+export function getBuildLogsUrl(build: BuildFragment, hash?: string): string {
   const { project } = build;
   const url =
     project.__typename !== 'App'
       ? `/builds/${build.id}`
-      : `/accounts/${project.ownerAccount.name}/projects/${project.slug}/builds/${build.id}`;
+      : `/accounts/${project.ownerAccount.name}/projects/${project.slug}/builds/${build.id}${
+          hash ? `#${hash}` : ''
+        }`;
 
   return new URL(url, getExpoWebsiteBaseUrl()).toString();
 }

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -94,7 +94,8 @@ export function link(
 ): string {
   // Links can be disabled via env variables https://github.com/jamestalmage/supports-hyperlinks/blob/master/index.js
   const output = terminalLink(text, url, {
-    fallback: () => fallback ?? `${text}: ${chalk.underline(url)}`,
+    fallback: () =>
+      fallback ?? (text === url ? chalk.underline(url) : `${text}: ${chalk.underline(url)}`),
   });
   return dim ? chalk.dim(output) : output;
 }

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -90,19 +90,12 @@ export default class Log {
  */
 export function link(
   url: string,
-  {
-    text = url,
-    dim = true,
-    fallback = (url: string, text: string) =>
-      text === url ? chalk.underline(url) : `${text}: ${chalk.underline(url)}`,
-  }: { text?: string; dim?: boolean; fallback?: (url: string, text: string) => string } = {}
+  { text = url, fallback, dim = true }: { text?: string; dim?: boolean; fallback?: string } = {}
 ): string {
-  if (!terminalLink.isSupported) {
-    const fallbackText = fallback(url, text);
-    return dim ? chalk.dim(fallbackText) : fallbackText;
-  }
   // Links can be disabled via env variables https://github.com/jamestalmage/supports-hyperlinks/blob/master/index.js
-  const output = terminalLink(text, url);
+  const output = terminalLink(text, url, {
+    fallback: () => fallback ?? `${text}: ${chalk.underline(url)}`,
+  });
   return dim ? chalk.dim(output) : output;
 }
 

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -97,10 +97,12 @@ export function link(
       text === url ? chalk.underline(url) : `${text}: ${chalk.underline(url)}`,
   }: { text?: string; dim?: boolean; fallback?: (url: string, text: string) => string } = {}
 ): string {
+  if (!terminalLink.isSupported) {
+    const fallbackText = fallback(url, text);
+    return dim ? chalk.dim(fallbackText) : fallbackText;
+  }
   // Links can be disabled via env variables https://github.com/jamestalmage/supports-hyperlinks/blob/master/index.js
-  const output = terminalLink(text, url, {
-    fallback: () => fallback(url, text),
-  });
+  const output = terminalLink(text, url);
   return dim ? chalk.dim(output) : output;
 }
 

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -90,11 +90,16 @@ export default class Log {
  */
 export function link(
   url: string,
-  { text = url, dim = true }: { text?: string; dim?: boolean } = {}
+  {
+    text = url,
+    dim = true,
+    fallback = (url: string, text: string) =>
+      text === url ? chalk.underline(url) : `${text}: ${chalk.underline(url)}`,
+  }: { text?: string; dim?: boolean; fallback?: (url: string, text: string) => string } = {}
 ): string {
   // Links can be disabled via env variables https://github.com/jamestalmage/supports-hyperlinks/blob/master/index.js
   const output = terminalLink(text, url, {
-    fallback: () => (text === url ? chalk.underline(url) : `${text}: ${chalk.underline(url)}`),
+    fallback: () => fallback(url, text),
   });
   return dim ? chalk.dim(output) : output;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7376/add-link-directly-to-log-build-phase-in-eas-cli-build-error-message

# How

Add overrides for certain error messages. Use changes from https://github.com/expo/universe/pull/11440 to link users directly to the error phase mentioned in the error message.

# Test Plan

Test locally.

https://user-images.githubusercontent.com/55145344/219015836-3d0db562-febc-40cd-93fe-1264f54d1580.mov


