### PR TITLE
[eas-cli] display build message data when picking build in `submit`, `build:run` and `build:resign` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Validate the platform for local builds earlier. ([#1698](https://github.com/expo/eas-cli/pull/1698) by [@wkozyra95](https://github.com/wkozyra95))
+- Display build message when picking build in `eas submit`, `eas build:resign`, and `eas build:run` commands. ([#1700](https://github.com/expo/eas-cli/pull/1700) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [3.6.0](https://github.com/expo/eas-cli/releases/tag/v3.6.0) - 2023-02-14
 

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -120,7 +120,11 @@ function createBuildToPartialChoiceMaker(
     const descriptionItemNameToValue: Record<string, string | null> = {
       Version: build.appVersion ? chalk.bold(build.appVersion) : null,
       Commit: formattedCommitData,
-      Message: build.message ? chalk.bold(build.message) : null,
+      Message: build.message
+        ? chalk.bold(
+            build.message.length > 200 ? `${build.message.slice(0, 200)}...` : build.message
+          )
+        : null,
     };
     descriptionItemNameToValue[
       build.platform === AppPlatform.Ios ? 'Build number' : 'Version code'

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -131,6 +131,7 @@ function createBuildToPartialChoiceMaker(
           build.platform === AppPlatform.Ios ? 'Build number:' : 'Version code:'
         )} ${formatBuildChoiceValue(build.appBuildVersion)}`,
         `\t${chalk.bold(`Commit:`)} ${formattedCommitData}`,
+        `\t${chalk.bold(`Message:`)} ${formatBuildChoiceValue(build.message)}`,
       ].join('\n'),
       disabled: selectPromptDisabledFunction?.(build),
     };

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -117,28 +117,32 @@ function createBuildToPartialChoiceMaker(
           )}"`
         : null;
 
-    const descriptionItemNameToValue: Record<string, string | null> = {
-      Version: build.appVersion ? chalk.bold(build.appVersion) : null,
-      Commit: formattedCommitData,
-      Message: build.message
-        ? chalk.bold(
-            build.message.length > 200 ? `${build.message.slice(0, 200)}...` : build.message
-          )
-        : null,
-    };
-    descriptionItemNameToValue[
-      build.platform === AppPlatform.Ios ? 'Build number' : 'Version code'
-    ] = build.appBuildVersion ? chalk.bold(build.appBuildVersion) : null;
+    const descriptionItems: { name: string; value: string | null }[] = [
+      { name: 'Version', value: build.appVersion ? chalk.bold(build.appVersion) : null },
+      { name: 'Commit', value: formattedCommitData },
+      {
+        name: 'Message',
+        value: build.message
+          ? chalk.bold(
+              build.message.length > 200 ? `${build.message.slice(0, 200)}...` : build.message
+            )
+          : null,
+      },
+      {
+        name: build.platform === AppPlatform.Ios ? 'Build number' : 'Version code',
+        value: build.appBuildVersion ? chalk.bold(build.appBuildVersion) : null,
+      },
+    ];
 
-    const descriptionItems = Object.keys(descriptionItemNameToValue)
-      .filter(k => descriptionItemNameToValue[k])
-      .map(k => `${chalk.bold(k)}: ${descriptionItemNameToValue[k]}`);
+    const filteredDescriptionArray: string[] = descriptionItems
+      .filter(item => item.value)
+      .map(item => `${chalk.bold(item.name)}: ${item.value}`);
 
     return {
       title: `${chalk.bold(`ID:`)} ${build.id} (${chalk.bold(
         `${fromNow(new Date(build.completedAt))} ago`
       )})`,
-      description: descriptionItems.length > 0 ? descriptionItems.join('\n') : '',
+      description: filteredDescriptionArray.length > 0 ? filteredDescriptionArray.join('\n') : '',
       disabled: selectPromptDisabledFunction?.(build),
     };
   };

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -121,18 +121,25 @@ function createBuildToPartialChoiceMaker(
           )}"`
         : 'Unknown';
 
+    const descriptionItems = [
+      `\t${chalk.bold(`Version:`)} ${formatBuildChoiceValue(build.appVersion)}`,
+      `\t${chalk.bold(
+        build.platform === AppPlatform.Ios ? 'Build number:' : 'Version code:'
+      )} ${formatBuildChoiceValue(build.appBuildVersion)}`,
+      `\t${chalk.bold(`Commit:`)} ${formattedCommitData}`,
+    ];
+
+    if (build.message) {
+      descriptionItems.push(
+        `\t${chalk.bold(`Message:`)} ${formatBuildChoiceValue(build.message).slice(0, 200)}`
+      );
+    }
+
     return {
       title: `${chalk.bold(`ID:`)} ${build.id} (${chalk.bold(
         `${fromNow(new Date(build.completedAt))} ago`
       )})`,
-      description: [
-        `\t${chalk.bold(`Version:`)} ${formatBuildChoiceValue(build.appVersion)}`,
-        `\t${chalk.bold(
-          build.platform === AppPlatform.Ios ? 'Build number:' : 'Version code:'
-        )} ${formatBuildChoiceValue(build.appBuildVersion)}`,
-        `\t${chalk.bold(`Commit:`)} ${formattedCommitData}`,
-        `\t${chalk.bold(`Message:`)} ${formatBuildChoiceValue(build.message)}`,
-      ].join('\n'),
+      description: descriptionItems.join('\n'),
       disabled: selectPromptDisabledFunction?.(build),
     };
   };

--- a/packages/eas-cli/src/submit/ArchiveSource.ts
+++ b/packages/eas-cli/src/submit/ArchiveSource.ts
@@ -339,23 +339,26 @@ function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choi
 
   const title = `${chalk.bold(`ID:`)} ${id} (${chalk.bold(`${fromNow(buildDate)} ago`)})`;
 
-  const descriptionItemNameToValue: Record<string, string | null> = {
-    Profile: buildProfile ? chalk.bold(buildProfile) : null,
-    Channel: channel ? chalk.bold(channel) : null,
-    'Runtime version': runtimeVersion ? chalk.bold(runtimeVersion) : null,
-    Commit: formattedCommitData,
-    Message: message
-      ? chalk.bold(message.length > 200 ? `${message.slice(0, 200)}...` : message)
-      : null,
-  };
+  const descriptionItems: { name: string; value: string | null }[] = [
+    { name: 'Profile', value: buildProfile ? chalk.bold(buildProfile) : null },
+    { name: 'Channel', value: channel ? chalk.bold(channel) : null },
+    { name: 'Runtime version', value: runtimeVersion ? chalk.bold(runtimeVersion) : null },
+    { name: 'Commit', value: formattedCommitData },
+    {
+      name: 'Message',
+      value: message
+        ? chalk.bold(message.length > 200 ? `${message.slice(0, 200)}...` : message)
+        : null,
+    },
+  ];
 
-  const descriptionItems = Object.keys(descriptionItemNameToValue)
-    .filter(k => descriptionItemNameToValue[k])
-    .map(k => `${chalk.bold(k)}: ${descriptionItemNameToValue[k]}`);
+  const filteredDescriptionArray: string[] = descriptionItems
+    .filter(item => item.value)
+    .map(item => `${chalk.bold(item.name)}: ${item.value}`);
 
   return {
     title,
-    description: descriptionItems.length > 0 ? descriptionItems.join('\n') : '',
+    description: filteredDescriptionArray.length > 0 ? filteredDescriptionArray.join('\n') : '',
     value: build,
     disabled: buildDate < expiryDate,
   };

--- a/packages/eas-cli/src/submit/ArchiveSource.ts
+++ b/packages/eas-cli/src/submit/ArchiveSource.ts
@@ -344,7 +344,9 @@ function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choi
     Channel: channel ? chalk.bold(channel) : null,
     'Runtime version': runtimeVersion ? chalk.bold(runtimeVersion) : null,
     Commit: formattedCommitData,
-    Message: message ? chalk.bold(message) : null,
+    Message: message
+      ? chalk.bold(message.length > 200 ? `${message.slice(0, 200)}...` : message)
+      : null,
   };
 
   const descriptionItems = Object.keys(descriptionItemNameToValue)

--- a/packages/eas-cli/src/submit/ArchiveSource.ts
+++ b/packages/eas-cli/src/submit/ArchiveSource.ts
@@ -339,13 +339,18 @@ function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choi
 
   const title = `${chalk.bold(`ID:`)} ${id} (${chalk.bold(`${fromNow(buildDate)} ago`)})`;
 
-  const description = [
+  const descriptionItems = [
     `\t${chalk.bold(`Profile:`)} ${formatValue(buildProfile)}`,
     `\t${chalk.bold(`Channel:`)} ${formatValue(channel)}`,
     `\t${chalk.bold(`Runtime version:`)} ${formatValue(runtimeVersion)}`,
     `\t${chalk.bold(`Commit:`)} ${formattedCommitData}`,
-    `\t${chalk.bold(`Message:`)} ${formatValue(message)}`,
-  ].join('\n');
+  ];
+
+  if (message) {
+    descriptionItems.push(`\t${chalk.bold(`Message:`)} ${formatValue(message).slice(0, 200)}`);
+  }
+
+  const description = descriptionItems.join('\n');
 
   return {
     title,

--- a/packages/eas-cli/src/submit/ArchiveSource.ts
+++ b/packages/eas-cli/src/submit/ArchiveSource.ts
@@ -317,8 +317,16 @@ async function handleBuildListSourceAsync(
 }
 
 function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choice {
-  const { id, updatedAt, runtimeVersion, buildProfile, gitCommitHash, gitCommitMessage, channel } =
-    build;
+  const {
+    id,
+    updatedAt,
+    runtimeVersion,
+    buildProfile,
+    gitCommitHash,
+    gitCommitMessage,
+    channel,
+    message,
+  } = build;
 
   const formatValue = (field?: string | null): string => (field ? chalk.bold(field) : 'Unknown');
 
@@ -336,6 +344,7 @@ function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choi
     `\t${chalk.bold(`Channel:`)} ${formatValue(channel)}`,
     `\t${chalk.bold(`Runtime version:`)} ${formatValue(runtimeVersion)}`,
     `\t${chalk.bold(`Commit:`)} ${formattedCommitData}`,
+    `\t${chalk.bold(`Message:`)} ${formatValue(message)}`,
   ].join('\n');
 
   return {

--- a/packages/eas-cli/src/submit/ArchiveSource.ts
+++ b/packages/eas-cli/src/submit/ArchiveSource.ts
@@ -327,34 +327,33 @@ function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choi
     channel,
     message,
   } = build;
-
-  const formatValue = (field?: string | null): string => (field ? chalk.bold(field) : 'Unknown');
-
   const buildDate = new Date(updatedAt);
 
+  const splitCommitMessage = gitCommitMessage?.split('\n');
   const formattedCommitData =
-    gitCommitHash && gitCommitMessage
-      ? `${gitCommitHash.slice(0, 7)} "${chalk.bold(gitCommitMessage)}"`
-      : 'Unknown';
+    gitCommitHash && splitCommitMessage && splitCommitMessage.length > 0
+      ? `${gitCommitHash.slice(0, 7)} "${chalk.bold(
+          splitCommitMessage[0] + (splitCommitMessage.length > 1 ? '…' : '')
+        )}"`
+      : null;
 
   const title = `${chalk.bold(`ID:`)} ${id} (${chalk.bold(`${fromNow(buildDate)} ago`)})`;
 
-  const descriptionItems = [
-    `\t${chalk.bold(`Profile:`)} ${formatValue(buildProfile)}`,
-    `\t${chalk.bold(`Channel:`)} ${formatValue(channel)}`,
-    `\t${chalk.bold(`Runtime version:`)} ${formatValue(runtimeVersion)}`,
-    `\t${chalk.bold(`Commit:`)} ${formattedCommitData}`,
-  ];
+  const descriptionItemNameToValue: Record<string, string | null> = {
+    Profile: buildProfile ? chalk.bold(buildProfile) : null,
+    Channel: channel ? chalk.bold(channel) : null,
+    'Runtime version': runtimeVersion ? chalk.bold(runtimeVersion) : null,
+    Commit: formattedCommitData,
+    Message: message ? chalk.bold(message) : null,
+  };
 
-  if (message) {
-    descriptionItems.push(`\t${chalk.bold(`Message:`)} ${formatValue(message).slice(0, 200)}`);
-  }
-
-  const description = descriptionItems.join('\n');
+  const descriptionItems = Object.keys(descriptionItemNameToValue)
+    .filter(k => descriptionItemNameToValue[k])
+    .map(k => `${chalk.bold(k)}: ${descriptionItemNameToValue[k]}`);
 
   return {
     title,
-    description,
+    description: descriptionItems.length > 0 ? descriptionItems.join('\n') : '',
     value: build,
     disabled: buildDate < expiryDate,
   };


### PR DESCRIPTION


<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1676462063098759

# How

Display `build.message` data

# Test Plan

<img width="567" alt="Screenshot 2023-02-15 at 13 08 04" src="https://user-images.githubusercontent.com/55145344/219023918-27200d54-36ad-45d3-abfb-bd4f4dd86223.png">

