### PR TITLE
[ci] fix release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eas": "packages/eas-cli/bin/run",
     "lint": "eslint .",
     "lint-changelog": "./scripts/bin/run lint-changelog",
-    "release": "./scripts/bin/run release",
+    "release": "rimraf ./packages/eas-cli/build ./packages/eas-json/build && yarn build && ./scripts/bin/run release",
     "test": "jest",
     "clean": "lerna run clean && rm -rf node_modules coverage"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eas": "packages/eas-cli/bin/run",
     "lint": "eslint .",
     "lint-changelog": "./scripts/bin/run lint-changelog",
-    "release": "rimraf ./packages/eas-cli/build ./packages/eas-json/build && yarn build && ./scripts/bin/run release",
+    "release": "lerna run rebuild && ./scripts/bin/run release",
     "test": "jest",
     "clean": "lerna run clean && rm -rf node_modules coverage"
   },

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -202,7 +202,8 @@
   "repository": "expo/eas-cli",
   "scripts": {
     "postpack": "rimraf oclif.manifest.json",
-    "prepack": "rimraf build && yarn build && node ./scripts/prepack.js",
+    "prepack": "yarn rebuild && node ./scripts/prepack.js",
+    "rebuild": "rimraf build && yarn build",
     "pretarball-ci": "./scripts/pretarball-ci.sh",
     "build": "tsc --project tsconfig.build.json",
     "watch": "yarn build --watch --preserveWatchOutput",

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -36,7 +36,8 @@
     "build": "tsc --project tsconfig.build.json",
     "watch": "yarn build --watch --preserveWatchOutput",
     "typecheck": "tsc",
-    "prepack": "rimraf build && yarn build",
+    "prepack": "yarn rebuild",
+    "rebuild": "rimraf build && yarn build",
     "test": "jest",
     "clean": "rimraf build node_modules yarn-error.log"
   },


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

The old release script wasn't cleaning `build` folders and therefore releases from my device were publishing `README` containing nonexisting commands `eas run`, and `eas run:run`.

https://github.com/expo/eas-cli/commit/bfa63f95fed5741f44009e8506143d38ce9fbc6b

# How

I modified it to delete the `build` folder contents before running the script

# Test Plan

I tested that it deletes the `build` folder and runs `yarn build`
