### PR TITLE
Support variant detection for package*UniversalApk Gradle Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Support variant detection for package*UniversalApk Gradle Commands. ([#1708](https://github.com/expo/eas-cli/pull/1708) by [@frw](https://github.com/frw))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/project/android/gradleUtils.ts
+++ b/packages/eas-cli/src/project/android/gradleUtils.ts
@@ -74,7 +74,7 @@ export function parseGradleCommand(cmd: string, buildGradle: AppBuildGradle): Gr
   const [moduleName, taskName] =
     splitCmd.length > 1 ? [splitCmd[0], splitCmd[1]] : [undefined, splitCmd[0]];
 
-  const matchResult = taskName.match(/(build|bundle|assemble)(.*)(Release|Debug)/);
+  const matchResult = taskName.match(/(build|bundle|assemble|package)(.*)(Release|Debug)/);
   if (!matchResult) {
     throw new Error(`Failed to parse gradle command: ${cmd}`);
   }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

`package*UniversalApk` is a well-known (though undocumented) Gradle task to build just the universal APK. This is especially useful if `enableSeparateBuildPerCPUArchitecture` is set to true, but you just want to output the universal APK file without needing to specify `buildArtifactPaths`.

# How

Added `package` in addition to the other prefixes for Gradle commands.

# Test Plan
I have a config in my `eas.json` containing `"gradleCommand": ":app:packageDebugUniversalApk"`.
Running `eas-cli` resulted in the message:
```
Unable to read gradle project config: Failed to parse gradle command: :app:packageDebugUniversalApk.
Values from app/build.gradle might be resolved incorrectly.
```

I then made the changes in this PR to `eas-cli` in my local dev environment, and ensured that the message no longer shows up.
