### PR TITLE
[ENG-7565] add basic support for custom builds

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1310,6 +1310,83 @@
             "deprecationReason": "No longer needed"
           },
           {
+            "name": "timelineActivity",
+            "description": "Coalesced project activity for an app using pagination",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TimelineActivityFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TimelineActivityConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "unlimitedBuilds",
             "description": null,
             "args": [],
@@ -6755,18 +6832,6 @@
                 "deprecationReason": null
               },
               {
-                "name": "options",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "DeploymentOptions",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
                 "name": "runtimeVersion",
                 "description": null,
                 "type": {
@@ -6792,118 +6857,8 @@
             "deprecationReason": null
           },
           {
-            "name": "deploymentNew",
-            "description": null,
-            "args": [
-              {
-                "name": "channel",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "runtimeVersion",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "DeploymentNew",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "deployments",
             "description": "Deployments associated with this app",
-            "args": [
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "mostRecentlyUpdatedAt",
-                "description": "Offset the query",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "DateTime",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "options",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "DeploymentOptions",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Deployment",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deploymentsNew",
-            "description": null,
             "args": [
               {
                 "name": "after",
@@ -15372,6 +15327,18 @@
             "deprecationReason": null
           },
           {
+            "name": "IOS_M2_MEDIUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IOS_M2_PRO_MEDIUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "IOS_MEDIUM",
             "description": null,
             "isDeprecated": false,
@@ -17069,27 +17036,80 @@
         "description": "Represents a Deployment - a set of Builds with the same Runtime Version and Channel",
         "fields": [
           {
-            "name": "channel",
+            "name": "builds",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
-              "kind": "OBJECT",
-              "name": "UpdateChannel",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeploymentBuildsConnection",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "channelName",
-            "description": "The name of this deployment's associated channel. It is specified separately from the `channel`\nfield to allow specifying a deployment before an EAS Update channel has been created.",
+            "name": "channel",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "UpdateChannel",
                 "ofType": null
               }
             },
@@ -17113,55 +17133,15 @@
             "deprecationReason": null
           },
           {
-            "name": "mostRecentlyUpdatedAt",
+            "name": "runtime",
             "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "recentBuilds",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Build",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "runtimeVersion",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "Runtime",
                 "ofType": null
               }
             },
@@ -17298,7 +17278,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "DeploymentNew",
+                "name": "Deployment",
                 "ofType": null
               }
             },
@@ -17308,160 +17288,13 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DeploymentNew",
-        "description": "Represents a Deployment - a set of Builds with the same Runtime Version and Channel",
-        "fields": [
-          {
-            "name": "builds",
-            "description": null,
-            "args": [
-              {
-                "name": "after",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "before",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "last",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DeploymentBuildsConnection",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "channel",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UpdateChannel",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "runtime",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Runtime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "DeploymentOptions",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "buildListMaxSize",
-            "description": "Max number of associated builds to return",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
       {
         "kind": "OBJECT",
         "name": "DeploymentsConnection",
-        "description": "Represents the connection over the deploymentsNew edge of an App",
+        "description": "Represents the connection over the deployments edge of an App",
         "fields": [
           {
             "name": "edges",

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1358,6 +1358,18 @@
             "deprecationReason": null
           },
           {
+            "name": "userActorOwner",
+            "description": "Owning UserActor of this account if personal account",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "UserActor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userInvitations",
             "description": "Pending user invitations for this account",
             "args": [],
@@ -5171,6 +5183,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "customBuildConfig",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomBuildConfigInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -13444,6 +13468,18 @@
         "description": "Represents an Standalone App build job",
         "fields": [
           {
+            "name": "accountUserActor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "UserActor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "activityTimestamp",
             "description": null,
             "args": [],
@@ -14329,6 +14365,12 @@
         "enumValues": [
           {
             "name": "BUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CUSTOM",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -16522,6 +16564,33 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CustomBuildConfigInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "path",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -21743,6 +21812,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "BuildCacheInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "customBuildConfig",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomBuildConfigInput",
               "ofType": null
             },
             "defaultValue": null,

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/config": "7.0.3",
     "@expo/config-plugins": "5.0.4",
     "@expo/config-types": "47.0.0",
-    "@expo/eas-build-job": "0.2.103",
+    "@expo/eas-build-job": "0.2.106",
     "@expo/eas-json": "3.6.1",
     "@expo/json-file": "8.2.37",
     "@expo/multipart-body-parser": "1.1.0",

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -124,7 +124,8 @@ export async function prepareAndroidBuildAsync(
 }
 
 function shouldProvideCredentials(ctx: BuildContext<Platform.ANDROID>): boolean {
-  return !ctx.buildProfile.withoutCredentials;
+  const isCustomBuild = ctx.buildProfile.config !== undefined;
+  return !ctx.buildProfile.withoutCredentials && !isCustomBuild;
 }
 
 async function ensureAndroidCredentialsAsync(

--- a/packages/eas-cli/src/build/android/graphql.ts
+++ b/packages/eas-cli/src/build/android/graphql.ts
@@ -1,7 +1,12 @@
 import { Android } from '@expo/eas-build-job';
 
 import { AndroidBuildType, AndroidJobInput } from '../../graphql/generated';
-import { transformBuildTrigger, transformProjectArchive, transformWorkflow } from '../graphql';
+import {
+  transformBuildMode,
+  transformBuildTrigger,
+  transformProjectArchive,
+  transformWorkflow,
+} from '../graphql';
 
 export function transformJob(job: Android.Job): AndroidJobInput {
   return {
@@ -22,6 +27,8 @@ export function transformJob(job: Android.Job): AndroidJobInput {
     buildType: job.buildType && transformBuildType(job.buildType),
     developmentClient: job.developmentClient,
     experimental: job.experimental,
+    mode: transformBuildMode(job.mode),
+    customBuildConfig: job.customBuildConfig,
   };
 }
 

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -55,8 +55,8 @@ export async function prepareJobAsync(
     buildType = Android.BuildType.APK;
   }
 
-  const maybeCustomBuildConfigPath = ctx.buildProfile.config
-    ? getCustomBuildConfigPath(ctx.buildProfile.config)
+  const maybeCustomBuildConfigPath = buildProfile.config
+    ? getCustomBuildConfigPath(buildProfile.config)
     : undefined;
 
   const job: Android.Job = {

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -12,6 +12,7 @@ import path from 'path';
 import slash from 'slash';
 
 import { AndroidCredentials } from '../../credentials/android/AndroidCredentialsProvider';
+import { getCustomBuildConfigPath } from '../../project/customBuildConfig';
 import { getUsername } from '../../project/projectUtils';
 import { getVcsClient } from '../../vcs';
 import { BuildContext } from '../context';
@@ -55,7 +56,7 @@ export async function prepareJobAsync(
   }
 
   const maybeCustomBuildConfigPath = ctx.buildProfile.config
-    ? path.join('.eas/build', ctx.buildProfile.config)
+    ? getCustomBuildConfigPath(ctx.buildProfile.config)
     : undefined;
 
   const job: Android.Job = {

--- a/packages/eas-cli/src/build/graphql.ts
+++ b/packages/eas-cli/src/build/graphql.ts
@@ -91,11 +91,16 @@ export function transformIosEnterpriseProvisioning(
   }
 }
 
-export function transformBuildMode(buildMode: Metadata['buildMode']): BuildMode {
+// TODO: check what in metadata
+export function transformBuildMode(buildMode: string): BuildMode {
   if (buildMode === 'build') {
     return BuildMode.Build;
-  } else {
+  } else if (buildMode === 'resign') {
     return BuildMode.Resign;
+  } else if (buildMode === 'custom') {
+    return BuildMode.Custom;
+  } else {
+    throw new Error(`Unsupported build mode: ${buildMode}`);
   }
 }
 

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -55,5 +55,6 @@ export async function ensureIosCredentialsForBuildResignAsync(
 }
 
 function shouldProvideCredentials(buildCtx: BuildContext<Platform.IOS>): boolean {
-  return !buildCtx.buildProfile.simulator;
+  const isCustomBuild = buildCtx.buildProfile.config !== undefined;
+  return !buildCtx.buildProfile.simulator && !isCustomBuild;
 }

--- a/packages/eas-cli/src/build/ios/graphql.ts
+++ b/packages/eas-cli/src/build/ios/graphql.ts
@@ -2,7 +2,12 @@ import { Ios } from '@expo/eas-build-job';
 import nullthrows from 'nullthrows';
 
 import { IosJobInput, IosJobSecretsInput } from '../../graphql/generated';
-import { transformBuildTrigger, transformProjectArchive, transformWorkflow } from '../graphql';
+import {
+  transformBuildMode,
+  transformBuildTrigger,
+  transformProjectArchive,
+  transformWorkflow,
+} from '../graphql';
 
 export function transformJob(job: Ios.Job): IosJobInput {
   return {
@@ -12,7 +17,7 @@ export function transformJob(job: Ios.Job): IosJobInput {
     projectRootDirectory: nullthrows(job.projectRootDirectory),
     releaseChannel: job.releaseChannel,
     updates: job.updates,
-    secrets: transformIosSecrets(job.secrets),
+    secrets: job.secrets ? transformIosSecrets(job.secrets) : undefined,
     builderEnvironment: job.builderEnvironment,
     cache: job.cache,
     version: job.version?.buildNumber ? { buildNumber: job.version.buildNumber } : undefined,
@@ -24,6 +29,8 @@ export function transformJob(job: Ios.Job): IosJobInput {
     developmentClient: job.developmentClient,
     simulator: job.simulator,
     experimental: job.experimental,
+    mode: transformBuildMode(job.mode),
+    customBuildConfig: job.customBuildConfig,
   };
 }
 

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -13,6 +13,7 @@ import slash from 'slash';
 
 import { IosCredentials, TargetCredentials } from '../../credentials/ios/types';
 import { IosJobSecretsInput } from '../../graphql/generated';
+import { getCustomBuildConfigPath } from '../../project/customBuildConfig';
 import { getUsername } from '../../project/projectUtils';
 import { getVcsClient } from '../../vcs';
 import { BuildContext } from '../context';
@@ -45,7 +46,7 @@ export async function prepareJobAsync(
   }
 
   const maybeCustomBuildConfigPath = ctx.buildProfile.config
-    ? path.join('.eas/build', ctx.buildProfile.config)
+    ? getCustomBuildConfigPath(ctx.buildProfile.config)
     : undefined;
 
   const job: Ios.Job = {

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -7,6 +7,7 @@ import {
   Platform,
   sanitizeJob,
 } from '@expo/eas-build-job';
+import { BuildProfile } from '@expo/eas-json';
 import nullthrows from 'nullthrows';
 import path from 'path';
 import slash from 'slash';
@@ -34,9 +35,10 @@ export async function prepareJobAsync(
   ctx: BuildContext<Platform.IOS>,
   jobData: JobData
 ): Promise<Job> {
+  const username = getUsername(ctx.exp, ctx.user);
+  const buildProfile: BuildProfile<Platform.IOS> = ctx.buildProfile;
   const projectRootDirectory =
     slash(path.relative(await getVcsClient().getRootPathAsync(), ctx.projectDir)) || '.';
-  const username = getUsername(ctx.exp, ctx.user);
   const buildCredentials: Ios.BuildSecrets['buildCredentials'] = {};
   if (jobData.credentials) {
     const targetNames = Object.keys(jobData.credentials);
@@ -45,8 +47,8 @@ export async function prepareJobAsync(
     }
   }
 
-  const maybeCustomBuildConfigPath = ctx.buildProfile.config
-    ? getCustomBuildConfigPath(ctx.buildProfile.config)
+  const maybeCustomBuildConfigPath = buildProfile.config
+    ? getCustomBuildConfigPath(buildProfile.config)
     : undefined;
 
   const job: Ios.Job = {
@@ -55,32 +57,31 @@ export async function prepareJobAsync(
     projectArchive: jobData.projectArchive,
     projectRootDirectory,
     builderEnvironment: {
-      image: ctx.buildProfile.image,
-      node: ctx.buildProfile.node,
-      yarn: ctx.buildProfile.yarn,
-      bundler: ctx.buildProfile.bundler,
-      cocoapods: ctx.buildProfile.cocoapods,
-      fastlane: ctx.buildProfile.fastlane,
-      expoCli: ctx.buildProfile.expoCli,
-      env: ctx.buildProfile.env,
+      image: buildProfile.image,
+      node: buildProfile.node,
+      yarn: buildProfile.yarn,
+      bundler: buildProfile.bundler,
+      cocoapods: buildProfile.cocoapods,
+      fastlane: buildProfile.fastlane,
+      expoCli: buildProfile.expoCli,
+      env: buildProfile.env,
     },
     cache: {
       ...cacheDefaults,
-      ...ctx.buildProfile.cache,
+      ...buildProfile.cache,
       clear: ctx.clearCache,
     },
     secrets: {
       buildCredentials,
     },
-    releaseChannel: ctx.buildProfile.releaseChannel,
-    updates: { channel: ctx.buildProfile.channel },
-    developmentClient: ctx.buildProfile.developmentClient,
-    simulator: ctx.buildProfile.simulator,
+    releaseChannel: buildProfile.releaseChannel,
+    updates: { channel: buildProfile.channel },
+    developmentClient: buildProfile.developmentClient,
+    simulator: buildProfile.simulator,
     scheme: jobData.buildScheme,
-    buildConfiguration: ctx.buildProfile.buildConfiguration,
-    applicationArchivePath:
-      ctx.buildProfile.applicationArchivePath ?? ctx.buildProfile.artifactPath,
-    buildArtifactPaths: ctx.buildProfile.buildArtifactPaths,
+    buildConfiguration: buildProfile.buildConfiguration,
+    applicationArchivePath: buildProfile.applicationArchivePath ?? buildProfile.artifactPath,
+    buildArtifactPaths: buildProfile.buildArtifactPaths,
     username,
     ...(ctx.ios.buildNumberOverride && {
       version: {
@@ -88,9 +89,9 @@ export async function prepareJobAsync(
       },
     }),
     experimental: {
-      prebuildCommand: ctx.buildProfile.prebuildCommand,
+      prebuildCommand: buildProfile.prebuildCommand,
     },
-    mode: ctx.buildProfile.config ? BuildMode.CUSTOM : BuildMode.BUILD,
+    mode: buildProfile.config ? BuildMode.CUSTOM : BuildMode.BUILD,
     triggeredBy: BuildTrigger.EAS_CLI,
     ...(maybeCustomBuildConfigPath && {
       customBuildConfig: {

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,5 +1,5 @@
 import { Updates } from '@expo/config-plugins';
-import { Metadata, Platform, sanitizeMetadata } from '@expo/eas-build-job';
+import { BuildMode, Metadata, Platform, sanitizeMetadata } from '@expo/eas-build-job';
 import { IosEnterpriseProvisioning } from '@expo/eas-json';
 import fs from 'fs-extra';
 import resolveFrom from 'resolve-from';
@@ -57,6 +57,7 @@ export async function collectMetadataAsync<T extends Platform>(
     }),
     runWithNoWaitFlag: ctx.noWait,
     runFromCI: ctx.runFromCI,
+    buildMode: ctx.buildProfile.config ? BuildMode.CUSTOM : BuildMode.BUILD,
   };
   return sanitizeMetadata(metadata);
 }

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -31,6 +31,7 @@ import {
   appPlatformEmojis,
   toPlatforms,
 } from '../platform';
+import { validateCustomBuildConfigAsync } from '../project/customBuildConfig';
 import { checkExpoSdkIsSupportedAsync } from '../project/expoSdk';
 import { validateMetroConfigForManagedWorkflowAsync } from '../project/metroConfig';
 import { validateAppVersionRuntimePolicySupportAsync } from '../project/projectUtils';
@@ -118,6 +119,7 @@ export async function runBuildAndSubmitAsync(
 
   for (const buildProfile of buildProfiles) {
     validateBuildProfileVersionSettings(buildProfile, easJsonCliConfig);
+    await validateCustomBuildConfigAsync(projectDir, buildProfile.profile);
   }
 
   const startedBuilds: {

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -109,13 +109,13 @@ function printBuildResult(build: BuildFragment): void {
   } else {
     // TODO: it looks like buildUrl could possibly be undefined, based on the code below.
     // we should account for this case better if it is possible
-    const url = build.artifacts?.buildUrl ?? '';
-    if (url !== '') {
+    const url = build.artifacts?.buildUrl;
+    if (url) {
       Log.addNewLineIfNone();
       Log.log(
         `${appPlatformEmojis[build.platform]} ${appPlatformDisplayNames[build.platform]} app:`
       );
-      Log.log(`${link(url)}`);
+      Log.log(link(url));
     }
   }
 }

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -57,7 +57,6 @@ export function printLogsUrls(builds: BuildFragment[]): void {
 }
 
 export function printBuildResults(builds: (BuildFragment | null)[]): void {
-  Log.newLine();
   if (builds.length === 1) {
     const [build] = builds;
     assert(build, 'Build should be defined');
@@ -68,8 +67,8 @@ export function printBuildResults(builds: (BuildFragment | null)[]): void {
 }
 
 function printBuildResult(build: BuildFragment): void {
-  Log.addNewLineIfNone();
   if (build.status === BuildStatus.Errored) {
+    Log.addNewLineIfNone();
     const userError = build.error;
     Log.error(
       `${appPlatformEmojis[build.platform]} ${
@@ -82,6 +81,7 @@ function printBuildResult(build: BuildFragment): void {
     return;
   }
   if (build.status === BuildStatus.Canceled) {
+    Log.addNewLineIfNone();
     Log.error(
       `${appPlatformEmojis[build.platform]} ${
         appPlatformDisplayNames[build.platform]
@@ -91,6 +91,7 @@ function printBuildResult(build: BuildFragment): void {
   }
 
   if (build.distribution === DistributionType.Internal) {
+    Log.addNewLineIfNone();
     const logsUrl = getBuildLogsUrl(build);
     // It's tricky to install the .apk file directly on Android so let's fallback
     // to the build details page and let people press the button to download there
@@ -109,8 +110,13 @@ function printBuildResult(build: BuildFragment): void {
     // TODO: it looks like buildUrl could possibly be undefined, based on the code below.
     // we should account for this case better if it is possible
     const url = build.artifacts?.buildUrl ?? '';
-    Log.log(`${appPlatformEmojis[build.platform]} ${appPlatformDisplayNames[build.platform]} app:`);
-    Log.log(`${link(url)}`);
+    if (url !== '') {
+      Log.addNewLineIfNone();
+      Log.log(
+        `${appPlatformEmojis[build.platform]} ${appPlatformDisplayNames[build.platform]} app:`
+      );
+      Log.log(`${link(url)}`);
+    }
   }
 }
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -131,6 +131,8 @@ export type Account = {
   updatedAt: Scalars['DateTime'];
   /** Account query object for querying EAS usage metrics */
   usageMetrics: AccountUsageMetrics;
+  /** Owning UserActor of this account if personal account */
+  userActorOwner?: Maybe<UserActor>;
   /** Pending user invitations for this account */
   userInvitations: Array<UserInvitation>;
   /** Actors associated with this account and permissions they hold */
@@ -790,6 +792,7 @@ export type AndroidJobInput = {
   buildType?: InputMaybe<AndroidBuildType>;
   builderEnvironment?: InputMaybe<AndroidBuilderEnvironmentInput>;
   cache?: InputMaybe<BuildCacheInput>;
+  customBuildConfig?: InputMaybe<CustomBuildConfigInput>;
   developmentClient?: InputMaybe<Scalars['Boolean']>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
   gradleCommand?: InputMaybe<Scalars['String']>;
@@ -1912,6 +1915,7 @@ export enum BuildIosEnterpriseProvisioning {
 /** Represents an Standalone App build job */
 export type BuildJob = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   __typename?: 'BuildJob';
+  accountUserActor?: Maybe<UserActor>;
   activityTimestamp: Scalars['DateTime'];
   actor?: Maybe<Actor>;
   app?: Maybe<App>;
@@ -2019,6 +2023,7 @@ export type BuildMetrics = {
 
 export enum BuildMode {
   Build = 'BUILD',
+  Custom = 'CUSTOM',
   Resign = 'RESIGN'
 }
 
@@ -2358,6 +2363,10 @@ export type CreateSubmissionResult = {
   __typename?: 'CreateSubmissionResult';
   /** Created submission */
   submission: Submission;
+};
+
+export type CustomBuildConfigInput = {
+  path: Scalars['String'];
 };
 
 export type DeleteAccessTokenResult = {
@@ -3122,6 +3131,7 @@ export type IosJobInput = {
   buildType?: InputMaybe<IosBuildType>;
   builderEnvironment?: InputMaybe<IosBuilderEnvironmentInput>;
   cache?: InputMaybe<BuildCacheInput>;
+  customBuildConfig?: InputMaybe<CustomBuildConfigInput>;
   developmentClient?: InputMaybe<Scalars['Boolean']>;
   /** @deprecated */
   distribution?: InputMaybe<DistributionType>;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -126,6 +126,8 @@ export type Account = {
   subscription?: Maybe<SubscriptionDetails>;
   /** @deprecated No longer needed */
   subscriptionChangesPending?: Maybe<Scalars['Boolean']>;
+  /** Coalesced project activity for an app using pagination */
+  timelineActivity: TimelineActivityConnection;
   /** @deprecated See isCurrent */
   unlimitedBuilds: Scalars['Boolean'];
   updatedAt: Scalars['DateTime'];
@@ -262,6 +264,19 @@ export type AccountEnvironmentSecretsArgs = {
 export type AccountSnacksArgs = {
   limit: Scalars['Int'];
   offset: Scalars['Int'];
+};
+
+
+/**
+ * An account is a container owning projects, credentials, billing and other organization
+ * data and settings. Actors may own and be members of accounts.
+ */
+export type AccountTimelineActivityArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<TimelineActivityFilterInput>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 export type AccountDataInput = {
@@ -936,10 +951,8 @@ export type App = Project & {
   /** Classic update release channel names that have at least one build */
   buildsReleaseChannels: Array<Scalars['String']>;
   deployment?: Maybe<Deployment>;
-  deploymentNew?: Maybe<DeploymentNew>;
   /** Deployments associated with this app */
-  deployments: Array<Deployment>;
-  deploymentsNew: DeploymentsConnection;
+  deployments: DeploymentsConnection;
   description: Scalars['String'];
   /** Environment secrets for an app */
   environmentSecrets: Array<EnvironmentSecret>;
@@ -1064,28 +1077,12 @@ export type AppBuildsArgs = {
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppDeploymentArgs = {
   channel: Scalars['String'];
-  options?: InputMaybe<DeploymentOptions>;
-  runtimeVersion: Scalars['String'];
-};
-
-
-/** Represents an Exponent App (or Experience in legacy terms) */
-export type AppDeploymentNewArgs = {
-  channel: Scalars['String'];
   runtimeVersion: Scalars['String'];
 };
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppDeploymentsArgs = {
-  limit: Scalars['Int'];
-  mostRecentlyUpdatedAt?: InputMaybe<Scalars['DateTime']>;
-  options?: InputMaybe<DeploymentOptions>;
-};
-
-
-/** Represents an Exponent App (or Experience in legacy terms) */
-export type AppDeploymentsNewArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
@@ -2205,6 +2202,8 @@ export enum BuildResourceClass {
   IosLarge = 'IOS_LARGE',
   IosM1Large = 'IOS_M1_LARGE',
   IosM1Medium = 'IOS_M1_MEDIUM',
+  IosM2Medium = 'IOS_M2_MEDIUM',
+  IosM2ProMedium = 'IOS_M2_PRO_MEDIUM',
   IosMedium = 'IOS_MEDIUM',
   Legacy = 'LEGACY'
 }
@@ -2457,16 +2456,19 @@ export type DeployServerlessFunctionResult = {
 /** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
 export type Deployment = {
   __typename?: 'Deployment';
-  channel?: Maybe<UpdateChannel>;
-  /**
-   * The name of this deployment's associated channel. It is specified separately from the `channel`
-   * field to allow specifying a deployment before an EAS Update channel has been created.
-   */
-  channelName: Scalars['String'];
+  builds: DeploymentBuildsConnection;
+  channel: UpdateChannel;
   id: Scalars['ID'];
-  mostRecentlyUpdatedAt: Scalars['DateTime'];
-  recentBuilds: Array<Build>;
-  runtimeVersion: Scalars['String'];
+  runtime: Runtime;
+};
+
+
+/** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
+export type DeploymentBuildsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 export type DeploymentBuildEdge = {
@@ -2485,33 +2487,10 @@ export type DeploymentBuildsConnection = {
 export type DeploymentEdge = {
   __typename?: 'DeploymentEdge';
   cursor: Scalars['String'];
-  node: DeploymentNew;
+  node: Deployment;
 };
 
-/** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
-export type DeploymentNew = {
-  __typename?: 'DeploymentNew';
-  builds: DeploymentBuildsConnection;
-  channel: UpdateChannel;
-  id: Scalars['ID'];
-  runtime: Runtime;
-};
-
-
-/** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
-export type DeploymentNewBuildsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-};
-
-export type DeploymentOptions = {
-  /** Max number of associated builds to return */
-  buildListMaxSize?: InputMaybe<Scalars['Int']>;
-};
-
-/** Represents the connection over the deploymentsNew edge of an App */
+/** Represents the connection over the deployments edge of an App */
 export type DeploymentsConnection = {
   __typename?: 'DeploymentsConnection';
   edges: Array<DeploymentEdge>;

--- a/packages/eas-cli/src/project/customBuildConfig.ts
+++ b/packages/eas-cli/src/project/customBuildConfig.ts
@@ -1,0 +1,26 @@
+import { Platform } from '@expo/eas-build-job';
+import { BuildProfile } from '@expo/eas-json';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+
+export async function validateCustomBuildConfigAsync(
+  projectDir: string,
+  profile: BuildProfile<Platform>
+): Promise<void> {
+  if (!profile.config) {
+    return;
+  }
+
+  const relativeBuildConfigPath = getCustomBuildConfigPath(profile.config);
+  const buildConfigPath = path.join(projectDir, relativeBuildConfigPath);
+  if (!(await fs.pathExists(buildConfigPath))) {
+    throw new Error(
+      `Custom build configuration file ${chalk.bold(relativeBuildConfigPath)} does not exist.`
+    );
+  }
+}
+
+export function getCustomBuildConfigPath(configFilename: string): string {
+  return path.join('.eas/build', configFilename);
+}

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
     "@babel/code-frame": "7.18.6",
-    "@expo/eas-build-job": "0.2.102",
+    "@expo/eas-build-job": "0.2.106",
     "chalk": "4.1.2",
     "env-string": "1.0.1",
     "fs-extra": "10.1.0",

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -400,7 +400,7 @@ test('Android-specific resourceClass', async () => {
   ).resolves.not.toThrow();
 });
 
-test('build profile with platform-specifc custom build config', async () => {
+test('build profile with platform-specific custom build config', async () => {
   await fs.writeJson('/project/eas.json', {
     build: {
       production: {

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -399,3 +399,64 @@ test('Android-specific resourceClass', async () => {
     EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'production')
   ).resolves.not.toThrow();
 });
+
+test('build profile with platform-specifc custom build config', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      production: {
+        android: {
+          config: 'production.android.yml',
+        },
+        ios: {
+          config: 'production.ios.yml',
+        },
+      },
+    },
+  });
+
+  const accessor = new EasJsonAccessor('/project');
+  const androidProfile = await EasJsonUtils.getBuildProfileAsync(
+    accessor,
+    Platform.ANDROID,
+    'production'
+  );
+  const iosProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production');
+  expect(androidProfile).toEqual({
+    config: 'production.android.yml',
+    distribution: 'store',
+    credentialsSource: 'remote',
+  });
+  expect(iosProfile).toEqual({
+    config: 'production.ios.yml',
+    distribution: 'store',
+    credentialsSource: 'remote',
+  });
+});
+
+test('build profiles with both platform build config', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      production: {
+        config: 'production.yml',
+      },
+    },
+  });
+
+  const accessor = new EasJsonAccessor('/project');
+  const androidProfile = await EasJsonUtils.getBuildProfileAsync(
+    accessor,
+    Platform.ANDROID,
+    'production'
+  );
+  const iosProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production');
+  expect(androidProfile).toEqual({
+    config: 'production.yml',
+    distribution: 'store',
+    credentialsSource: 'remote',
+  });
+  expect(iosProfile).toEqual({
+    config: 'production.yml',
+    distribution: 'store',
+    credentialsSource: 'remote',
+  });
+});

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -39,6 +39,9 @@ const CommonBuildProfileSchema = Joi.object({
   env: Joi.object().pattern(Joi.string(), Joi.string().empty(null)),
   autoIncrement: Joi.alternatives().try(Joi.boolean()),
   resourceClass: Joi.string().valid(...AllowedCommonResourceClasses),
+
+  // TODO: add validation
+  config: Joi.string(),
 });
 
 const AndroidBuildProfileSchema = CommonBuildProfileSchema.concat(

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -24,72 +24,98 @@ const CacheSchema = Joi.object({
 });
 
 const CommonBuildProfileSchema = Joi.object({
-  credentialsSource: Joi.string().valid('local', 'remote').default('remote'),
-  distribution: Joi.string().valid('store', 'internal').default('store'),
-  cache: CacheSchema,
-  releaseChannel: Joi.string().regex(/^[a-z\d][a-z\d._-]*$/),
-  channel: Joi.string().regex(/^[a-z\d][a-z\d._-]*$/),
-  developmentClient: Joi.boolean(),
-  prebuildCommand: Joi.string(),
-  buildArtifactPaths: Joi.array().items(Joi.string()),
+  // builder
+  resourceClass: Joi.string().valid(...AllowedCommonResourceClasses),
 
+  // build environment
+  env: Joi.object().pattern(Joi.string(), Joi.string().empty(null)),
   node: Joi.string().empty(null).custom(semverCheck),
   yarn: Joi.string().empty(null).custom(semverCheck),
   expoCli: Joi.string().empty(null).custom(semverCheck),
-  env: Joi.object().pattern(Joi.string(), Joi.string().empty(null)),
-  autoIncrement: Joi.alternatives().try(Joi.boolean()),
-  resourceClass: Joi.string().valid(...AllowedCommonResourceClasses),
 
-  // TODO: add validation
+  // credentials
+  credentialsSource: Joi.string().valid('local', 'remote').default('remote'),
+  distribution: Joi.string().valid('store', 'internal').default('store'),
+
+  // updates
+  releaseChannel: Joi.string().regex(/^[a-z\d][a-z\d._-]*$/),
+  channel: Joi.string().regex(/^[a-z\d][a-z\d._-]*$/),
+
+  // build configuration
+  developmentClient: Joi.boolean(),
+  prebuildCommand: Joi.string(),
+
+  // versions
+  autoIncrement: Joi.alternatives().try(Joi.boolean()),
+
+  // artifacts
+  buildArtifactPaths: Joi.array().items(Joi.string()),
+
+  // cache
+  cache: CacheSchema,
+
+  // custom build configuration
   config: Joi.string(),
 });
 
-const AndroidBuildProfileSchema = CommonBuildProfileSchema.concat(
+const PlatformBuildProfileSchema = CommonBuildProfileSchema.concat(
   Joi.object({
-    credentialsSource: Joi.string().valid('local', 'remote'),
-    distribution: Joi.string().valid('store', 'internal'),
+    // build environment
+    image: Joi.string(),
+
+    // artifacts
+    artifactPath: Joi.string(),
+    applicationArchivePath: Joi.string(),
+  }).oxor('artifactPath', 'applicationArchivePath')
+);
+
+const AndroidBuildProfileSchema = PlatformBuildProfileSchema.concat(
+  Joi.object({
+    // builder
+    resourceClass: Joi.string().valid(...AllowedAndroidResourceClasses),
+
+    // build environment
+    ndk: Joi.string().empty(null).custom(semverCheck),
+
+    // credentials
     withoutCredentials: Joi.boolean(),
 
-    image: Joi.string(),
-    ndk: Joi.string().empty(null).custom(semverCheck),
+    // build configuration
+    gradleCommand: Joi.string(),
+    buildType: Joi.string().valid('apk', 'app-bundle'),
+
+    // versions
     autoIncrement: Joi.alternatives().try(
       Joi.boolean(),
       Joi.string().valid('version', 'versionCode')
     ),
-    resourceClass: Joi.string().valid(...AllowedAndroidResourceClasses),
-
-    artifactPath: Joi.string(),
-    applicationArchivePath: Joi.string(),
-    buildArtifactPaths: Joi.array().items(Joi.string()),
-    gradleCommand: Joi.string(),
-
-    buildType: Joi.string().valid('apk', 'app-bundle'),
-  }).oxor('artifactPath', 'applicationArchivePath')
+  })
 );
 
-const IosBuildProfileSchema = CommonBuildProfileSchema.concat(
+const IosBuildProfileSchema = PlatformBuildProfileSchema.concat(
   Joi.object({
-    credentialsSource: Joi.string().valid('local', 'remote'),
-    distribution: Joi.string().valid('store', 'internal'),
-    enterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
-    autoIncrement: Joi.alternatives().try(
-      Joi.boolean(),
-      Joi.string().valid('version', 'buildNumber')
-    ),
-    simulator: Joi.boolean(),
+    // builder
     resourceClass: Joi.string().valid(...AllowedIosResourceClasses),
 
-    image: Joi.string(),
+    // build environment
     bundler: Joi.string().empty(null).custom(semverCheck),
     fastlane: Joi.string().empty(null).custom(semverCheck),
     cocoapods: Joi.string().empty(null).custom(semverCheck),
 
-    artifactPath: Joi.string(),
-    applicationArchivePath: Joi.string(),
-    buildArtifactPaths: Joi.array().items(Joi.string()),
+    // credentials
+    enterpriseProvisioning: Joi.string().valid('adhoc', 'universal'),
+
+    // build configuration
+    simulator: Joi.boolean(),
     scheme: Joi.string(),
     buildConfiguration: Joi.string(),
-  }).oxor('artifactPath', 'applicationArchivePath')
+
+    // versions
+    autoIncrement: Joi.alternatives().try(
+      Joi.boolean(),
+      Joi.string().valid('version', 'buildNumber')
+    ),
+  })
 );
 
 export const BuildProfileSchema = CommonBuildProfileSchema.concat(

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -39,6 +39,7 @@ export interface CommonBuildProfile {
   autoIncrement?: boolean;
   resourceClass?: ResourceClass;
   buildArtifactPaths?: string[];
+  config?: string;
 
   node?: string;
   yarn?: string;

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -29,33 +29,42 @@ export type IosVersionAutoIncrement = VersionAutoIncrement | 'buildNumber';
 export type AndroidVersionAutoIncrement = VersionAutoIncrement | 'versionCode';
 
 export interface CommonBuildProfile {
-  credentialsSource: CredentialsSource;
-  distribution: DistributionType;
-  cache?: Omit<Cache, 'clear'>;
-  releaseChannel?: string;
-  channel?: string;
-  developmentClient?: boolean;
-  prebuildCommand?: string;
-  autoIncrement?: boolean;
+  // builder
   resourceClass?: ResourceClass;
-  buildArtifactPaths?: string[];
-  config?: string;
 
+  // build environment
+  env?: Record<string, string>;
   node?: string;
   yarn?: string;
   expoCli?: string;
-  env?: Record<string, string>;
+
+  // credentials
+  credentialsSource: CredentialsSource;
+  distribution: DistributionType;
+
+  // updates
+  releaseChannel?: string;
+  channel?: string;
+
+  // build configuration
+  developmentClient?: boolean;
+  prebuildCommand?: string;
+
+  // versions
+  autoIncrement?: boolean;
+
+  // artifacts
+  buildArtifactPaths?: string[];
+
+  // cache
+  cache?: Omit<Cache, 'clear'>;
+
+  // custom build configuration
+  config?: string;
 }
 
-export interface AndroidBuildProfile extends Omit<CommonBuildProfile, 'autoIncrement'> {
-  withoutCredentials?: boolean;
-  image?: Android.BuilderEnvironment['image'];
-  ndk?: string;
-  autoIncrement?: AndroidVersionAutoIncrement;
-
-  buildType?: Android.BuildType.APK | Android.BuildType.APP_BUNDLE;
-
-  gradleCommand?: string;
+interface PlatformBuildProfile extends Omit<CommonBuildProfile, 'autoIncrement'> {
+  // artifacts
   /**
    * @deprecated use applicationArchivePath
    */
@@ -63,22 +72,39 @@ export interface AndroidBuildProfile extends Omit<CommonBuildProfile, 'autoIncre
   applicationArchivePath?: string;
 }
 
-export interface IosBuildProfile extends Omit<CommonBuildProfile, 'autoIncrement'> {
-  enterpriseProvisioning?: IosEnterpriseProvisioning;
-  autoIncrement?: IosVersionAutoIncrement;
-  simulator?: boolean;
+export interface AndroidBuildProfile extends PlatformBuildProfile {
+  // build environment
+  image?: Android.BuilderEnvironment['image'];
+  ndk?: string;
+
+  // credentials
+  withoutCredentials?: boolean;
+
+  // build configuration
+  gradleCommand?: string;
+  buildType?: Android.BuildType.APK | Android.BuildType.APP_BUNDLE;
+
+  // versions
+  autoIncrement?: AndroidVersionAutoIncrement;
+}
+
+export interface IosBuildProfile extends PlatformBuildProfile {
+  // build environment
   image?: Ios.BuilderEnvironment['image'];
   bundler?: string;
   fastlane?: string;
   cocoapods?: string;
 
-  /**
-   * @deprecated use applicationArchivePath
-   */
-  artifactPath?: string;
-  applicationArchivePath?: string;
+  // credentials
+  enterpriseProvisioning?: IosEnterpriseProvisioning;
+
+  // build configuration
+  simulator?: boolean;
   scheme?: string;
   buildConfiguration?: string;
+
+  // versions
+  autoIncrement?: IosVersionAutoIncrement;
 }
 
 export type BuildProfile<TPlatform extends Platform = Platform> = TPlatform extends Platform.ANDROID

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,21 +1390,13 @@
     slugify "^1.3.4"
     sucrase "^3.20.0"
 
-"@expo/eas-build-job@0.2.102":
-  version "0.2.102"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.102.tgz#6c23388a7ac12d60a46d2a9ef779075f5c1a874b"
-  integrity sha512-1gav4gHhZCnRDIscd0/sat/fjts543QmexiWXUWDv15uzCxx/NnewN13tcmOwMV0K3Z3agOlJLRPN2t6UvIMAg==
+"@expo/eas-build-job@0.2.106":
+  version "0.2.106"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.106.tgz#a10f791986bfa9777a13b2b0e9c820673e9e38ba"
+  integrity sha512-V7ihSFNFaATM31P1b/tGrGG7sjuXBT5ZAzKnybTWr5Xl1ODOdEpSC1c9bzs9SUr2iWUFVsxyd2/7+f2+7r/l4A==
   dependencies:
-    joi "^17.4.2"
-    semver "^7.3.5"
-
-"@expo/eas-build-job@0.2.103":
-  version "0.2.103"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.2.103.tgz#0b587ada854570bc664f59dcd43dc3ca4221d451"
-  integrity sha512-cstgN8sVIYjq37xHm/4E6jnAlYf1gndvWfuVzRicUjp1TVyGjV9IbilSOxJp8AEqgPZK6+bZOcMRXT634M0Nmg==
-  dependencies:
-    joi "^17.4.2"
-    semver "^7.3.5"
+    joi "^17.7.0"
+    semver "^7.3.8"
 
 "@expo/image-utils@0.3.22":
   version "0.3.22"
@@ -3985,13 +3977,6 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
-"@sideway/address@^4.1.0":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
-  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
 "@sideway/address@^4.1.3":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27"
@@ -4003,6 +3988,11 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
   integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/formula@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.1.tgz#80fcbcbaf7ce031e0ef2dd29b1bfc7c3f583611f"
+  integrity sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==
 
 "@sideway/pinpoint@^2.0.0":
   version "2.0.0"
@@ -9328,15 +9318,15 @@ joi@17.7.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
-joi@^17.4.2:
-  version "17.4.2"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.2.tgz#02f4eb5cf88e515e614830239379dcbbe28ce7f7"
-  integrity sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==
+joi@^17.7.0:
+  version "17.8.3"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.8.3.tgz#d772fe27a87a5cda21aace5cf11eee8671ca7e6f"
+  integrity sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==
   dependencies:
     "@hapi/hoek" "^9.0.0"
     "@hapi/topo" "^5.0.0"
-    "@sideway/address" "^4.1.0"
-    "@sideway/formula" "^3.0.0"
+    "@sideway/address" "^4.1.3"
+    "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
 join-component@^1.1.0:


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This PR adds very basic support for custom builds.

# How

- Add `config` field to build profile that points at a .yml file in the **.eas/build** directory. 
- Validate if the custom build config file exists.
- If `config` is set, consider build custom.
- Don't configure credentials for custom builds (this is temporary until there is a way to read credentials from custom builds).
- Custom builds don't support uploading artifacts yet. Don't print application archive URL if it doesn't exist for a build.
- Set `buildMode` in metadata - build / custom.

# Test Plan

Configuration file does not exist in `.eas/build` directory:
<img width="753" alt="Screenshot 2023-02-22 at 16 16 28" src="https://user-images.githubusercontent.com/5256730/220676275-92a83786-8190-425e-8ed1-45a82d1e927d.png">

Failed build:
<img width="873" alt="Screenshot 2023-02-22 at 16 43 20" src="https://user-images.githubusercontent.com/5256730/220676350-606b57c7-7bf9-4df1-bd83-743dc266d591.png">

Successful build:
<img width="874" alt="Screenshot 2023-02-22 at 16 44 14" src="https://user-images.githubusercontent.com/5256730/220676362-03f2bea1-45b0-4017-b203-75966ceceb82.png">