### PR TITLE
[eas-cli] Add support for asset excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add support for EAS Update asset excludes. ([#1526](https://github.com/expo/eas-cli/pull/1526) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -225,8 +225,8 @@ function mockTestExport({
     );
   }
 
-  jest.mocked(collectAssetsAsync).mockResolvedValue(
-    Object.fromEntries(
+  jest.mocked(collectAssetsAsync).mockResolvedValue({
+    collectedAssets: new Map(
       platforms.map(platform => [
         platform,
         {
@@ -237,8 +237,9 @@ function mockTestExport({
           },
         },
       ])
-    )
-  );
+    ),
+    excludedAssets: [],
+  });
 
   jest.mocked(uploadAssetsAsync).mockResolvedValue({
     // platforms are mocked all containing only the launch asset

--- a/packages/eas-cli/src/utils/expodash/__tests__/partition-test.ts
+++ b/packages/eas-cli/src/utils/expodash/__tests__/partition-test.ts
@@ -1,0 +1,13 @@
+import { truthy } from '../filter';
+import partition from '../partition';
+
+describe(partition, () => {
+  it('partitions', () => {
+    expect(partition([true, false], truthy)).toMatchObject([[true], [false]]);
+
+    expect(partition([1, 2, 3, 4], e => e <= 2)).toMatchObject([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+});

--- a/packages/eas-cli/src/utils/expodash/mapMap.ts
+++ b/packages/eas-cli/src/utils/expodash/mapMap.ts
@@ -1,0 +1,10 @@
+export default function mapMap<K, V, M>(
+  map: ReadonlyMap<K, V>,
+  mapper: (value: V, key: K) => M
+): Map<K, M> {
+  const resultingMap = new Map();
+  for (const [k, v] of map) {
+    resultingMap.set(k, mapper(v, k));
+  }
+  return resultingMap;
+}

--- a/packages/eas-cli/src/utils/expodash/mapMapAsync.ts
+++ b/packages/eas-cli/src/utils/expodash/mapMapAsync.ts
@@ -1,0 +1,14 @@
+export default async function mapMapAsync<K, V, M>(
+  map: ReadonlyMap<K, V>,
+  mapper: (value: V, key: K) => Promise<M>
+): Promise<Map<K, M>> {
+  const resultingMap: Map<K, M> = new Map();
+  await Promise.all(
+    Array.from(map.keys()).map(async k => {
+      const initialValue = map.get(k) as V;
+      const result = await mapper(initialValue, k);
+      resultingMap.set(k, result);
+    })
+  );
+  return resultingMap;
+}

--- a/packages/eas-cli/src/utils/expodash/partition.ts
+++ b/packages/eas-cli/src/utils/expodash/partition.ts
@@ -1,0 +1,14 @@
+export default function partition<T>(arr: T[], predicate: (item: T) => boolean): [T[], T[]] {
+  const trueItems: T[] = [];
+  const falseItems: T[] = [];
+
+  for (const item of arr) {
+    if (predicate(item)) {
+      trueItems.push(item);
+    } else {
+      falseItems.push(item);
+    }
+  }
+
+  return [trueItems, falseItems];
+}

--- a/packages/eas-json/src/schema.ts
+++ b/packages/eas-json/src/schema.ts
@@ -13,4 +13,7 @@ export const EasJsonSchema = Joi.object({
   }),
   build: Joi.object().pattern(Joi.string(), BuildProfileSchema),
   submit: Joi.object().pattern(Joi.string(), SubmitProfileSchema),
+  update: Joi.object({
+    assetExcludePatterns: Joi.array().items(Joi.string()),
+  }),
 });

--- a/packages/eas-json/src/types.ts
+++ b/packages/eas-json/src/types.ts
@@ -25,4 +25,7 @@ export interface EasJson {
   };
   build?: { [profileName: string]: EasJsonBuildProfile };
   submit?: { [profileName: string]: EasJsonSubmitProfile };
+  update?: {
+    assetExcludePatterns?: string[];
+  };
 }

--- a/packages/eas-json/src/utils.ts
+++ b/packages/eas-json/src/utils.ts
@@ -48,4 +48,18 @@ export class EasJsonUtils {
     const easJson = await accessor.readAsync();
     return resolveSubmitProfile({ easJson, platform, profileName });
   }
+
+  public static async getUpdatesConfigAsync(
+    accessor: EasJsonAccessor
+  ): Promise<EasJson['update'] | null> {
+    try {
+      const easJson = await accessor.readAsync();
+      return easJson.update ?? null;
+    } catch (err: any) {
+      if (err instanceof MissingEasJsonError) {
+        return null;
+      }
+      throw err;
+    }
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This is a second try of https://github.com/expo/eas-cli/pull/1526 which "removes" assets from the exported bundle (almost as if we were to pass a assetExcludeGlobs to `expo export`).

# How

Exclude excluded assets from `dist` folder when building update.

# Test Plan

Note that this fails (client doesn't work):

1. create app with two images, one of which is included in the EAS asset exclude patterns
2. build app
3. update app to not use either image in App.tsx, publish update
4. reload app, see neither image is shown
5. update app to use both images, publish update, see one is excluded
6. reload app, see only the non-excluded image is shown (this is the issue, it should show both since the excluded image is in the bundle)

