### PR TITLE
[eas-cli] bump apple-utils to support hashcash for authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Implement Apple's proprietary Hashcash algorithm for signing authentication requests. ([#1719](https://github.com/expo/eas-cli/pull/1719) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🧹 Chores
 
 ## [3.7.1](https://github.com/expo/eas-cli/releases/tag/v3.7.1) - 2023-02-23

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "1.0.0",
+    "@expo/apple-utils": "1.1.0",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "7.0.3",
     "@expo/config-plugins": "5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,10 +1324,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@expo/apple-utils@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.0.0.tgz#1c8d1a4db674d0469777a13402afe6fffe171263"
-  integrity sha512-V8gMy1C63oAYlvkSjhfGYOET7sOmRIUAYv/wVcKJZiVAMZ5MQ2geeXCpLGC4+vuOQe2Hs3+qAgl4y0/b8OUO+A==
+"@expo/apple-utils@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.1.0.tgz#62cd724436b8eaa9cafcc3648ea211af8409fc71"
+  integrity sha512-caw0o9HeQHX7xeXppkXI3B/PmPyVOkEjWgXdv0dYzgW/rwvZRLwtMNFXX5t+dJy2hd2UpZlrixaoYyvxuXPtbQ==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

- fix https://github.com/expo/eas-cli/issues/1714 🤞 
- implements Apple's proprietary implementation of hashcash for signing authentication requests.
- Tested on all my accounts at a rate that would surely trigger rate limit issues otherwise. Didn't get a single failure. 