### PR TITLE
[ENG-7676][eas-cli] don't resolve default resource class for iOS based on metadata in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Add info about Xcode 14.3 image to `eas.schema.json`. ([#1808](https://github.com/expo/eas-cli/pull/1808) by [@szdziedzic](https://github.com/szdziedzic))
 - Allow users to select an app to run using the `build:run` command if multiple apps are found in the tarball. ([#1807](https://github.com/expo/eas-cli/pull/1807) by [@szdziedzic](https://github.com/szdziedzic))
+- Don't resolve `default` resource class for iOS in CLI. ([#1734](https://github.com/expo/eas-cli/pull/1734) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [3.10.1](https://github.com/expo/eas-cli/releases/tag/v3.10.1) - 2023-04-25
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -737,7 +737,7 @@
           },
           {
             "name": "appsPaginated",
-            "description": null,
+            "description": "Paginated list of apps associated with this account. By default sorted by name. Use filter to adjust the sorting order.",
             "args": [
               {
                 "name": "after",
@@ -757,6 +757,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AccountAppsFilterInput",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -1681,6 +1693,56 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AccountAppsFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "sortByField",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AccountAppsSortByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AccountAppsSortByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "LATEST_ACTIVITY_TIME",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NAME",
+            "description": "Name prefers the display name but falls back to full_name with @account/\npart stripped.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -14208,22 +14270,6 @@
             "deprecationReason": null
           },
           {
-            "name": "customPaths",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "disabled",
             "description": null,
             "type": {
@@ -14242,6 +14288,26 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "paths",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -80,9 +80,14 @@ interface Builder<TPlatform extends Platform, Credentials, TJob extends Job> {
 
 export type BuildRequestSender = () => Promise<BuildFragment | undefined>;
 
-function resolveBuildParamsInput<T extends Platform>(ctx: BuildContext<T>): BuildParamsInput {
+function resolveBuildParamsInput<T extends Platform>(
+  ctx: BuildContext<T>,
+  metadata: Metadata
+): BuildParamsInput {
   return {
     resourceClass: ctx.resourceClass,
+    sdkVersion: metadata.sdkVersion,
+    reactNativeVersion: metadata.reactNativeVersion,
   };
 }
 
@@ -142,7 +147,7 @@ export async function prepareBuildRequestForPlatformAsync<
   assert(projectArchive);
 
   const metadata = await collectMetadataAsync(ctx);
-  const buildParams = resolveBuildParamsInput(ctx);
+  const buildParams = resolveBuildParamsInput(ctx, metadata);
   const job = await builder.prepareJobAsync(ctx, {
     projectArchive,
     credentials: credentialsResult?.credentials,

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -1,5 +1,5 @@
 import { Platform, Workflow } from '@expo/eas-build-job';
-import { EasJson, EasJsonAccessor, ResourceClass } from '@expo/eas-json';
+import { EasJson, EasJsonAccessor } from '@expo/eas-json';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
@@ -53,21 +53,11 @@ const EAS_JSON_MANAGED_DEFAULT: EasJson = {
     development: {
       developmentClient: true,
       distribution: 'internal',
-      ios: {
-        resourceClass: ResourceClass.M_MEDIUM,
-      },
     },
     preview: {
       distribution: 'internal',
-      ios: {
-        resourceClass: ResourceClass.M_MEDIUM,
-      },
     },
-    production: {
-      ios: {
-        resourceClass: ResourceClass.M_MEDIUM,
-      },
-    },
+    production: {},
   },
   submit: {
     production: {},
@@ -86,20 +76,12 @@ const EAS_JSON_BARE_DEFAULT: EasJson = {
       },
       ios: {
         buildConfiguration: 'Debug',
-        resourceClass: ResourceClass.M_MEDIUM,
       },
     },
     preview: {
       distribution: 'internal',
-      ios: {
-        resourceClass: ResourceClass.M_MEDIUM,
-      },
     },
-    production: {
-      ios: {
-        resourceClass: ResourceClass.M_MEDIUM,
-      },
-    },
+    production: {},
   },
   submit: {
     production: {},

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -90,8 +90,6 @@ export async function createBuildContextAsync<T extends Platform>({
   const resourceClass = await resolveBuildResourceClassAsync(
     buildProfile,
     platform,
-    projectDir,
-    exp,
     resourceClassFlag
   );
 

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -52,7 +52,7 @@ export async function resolveBuildResourceClassAsync<T extends Platform>(
   const selectedResourceClass = resourceClassFlag ?? profileResourceClass;
 
   return platform === Platform.IOS
-    ? await resolveIosResourceClassAsync(resourceClassFlag, profileResourceClass)
+    ? resolveIosResourceClass(resourceClassFlag, profileResourceClass)
     : resolveAndroidResourceClass(selectedResourceClass);
 }
 
@@ -74,10 +74,10 @@ function resolveAndroidResourceClass(selectedResourceClass?: ResourceClass): Bui
   return androidResourceClassToBuildResourceClassMapping[resourceClass as AndroidResourceClass];
 }
 
-async function resolveIosResourceClassAsync(
+function resolveIosResourceClass(
   resourceClassFlag?: ResourceClass,
   profileResourceClass?: ResourceClass
-): Promise<BuildResourceClass> {
+): BuildResourceClass {
   const resourceClass = resourceClassFlag ?? profileResourceClass ?? ResourceClass.DEFAULT;
 
   if (resourceClassFlag === ResourceClass.LARGE) {

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -1,12 +1,9 @@
-import { ExpoConfig } from '@expo/config-types';
 import { Platform } from '@expo/eas-build-job';
 import { BuildProfile, ResourceClass } from '@expo/eas-json';
 import chalk from 'chalk';
-import semver from 'semver';
 
 import { BuildResourceClass } from '../../graphql/generated';
 import Log, { link } from '../../log';
-import { getReactNativeVersionAsync } from '../metadata';
 
 type AndroidResourceClass = Exclude<
   ResourceClass,
@@ -42,8 +39,6 @@ const androidResourceClassToBuildResourceClassMapping: Record<
 export async function resolveBuildResourceClassAsync<T extends Platform>(
   profile: BuildProfile<T>,
   platform: Platform,
-  projectDir: string,
-  exp: ExpoConfig,
   resourceClassFlag?: ResourceClass
 ): Promise<BuildResourceClass> {
   const profileResourceClass = profile.resourceClass;
@@ -57,7 +52,7 @@ export async function resolveBuildResourceClassAsync<T extends Platform>(
   const selectedResourceClass = resourceClassFlag ?? profileResourceClass;
 
   return platform === Platform.IOS
-    ? await resolveIosResourceClassAsync(exp, projectDir, resourceClassFlag, profileResourceClass)
+    ? await resolveIosResourceClassAsync(resourceClassFlag, profileResourceClass)
     : resolveAndroidResourceClass(selectedResourceClass);
 }
 
@@ -80,15 +75,10 @@ function resolveAndroidResourceClass(selectedResourceClass?: ResourceClass): Bui
 }
 
 async function resolveIosResourceClassAsync(
-  exp: ExpoConfig,
-  projectDir: string,
   resourceClassFlag?: ResourceClass,
   profileResourceClass?: ResourceClass
 ): Promise<BuildResourceClass> {
-  const resourceClass =
-    resourceClassFlag ??
-    profileResourceClass ??
-    (await resolveIosDefaultRequestedResourceClassAsync(exp, projectDir));
+  const resourceClass = resourceClassFlag ?? profileResourceClass ?? ResourceClass.DEFAULT;
 
   if (resourceClassFlag === ResourceClass.LARGE) {
     throw new Error(
@@ -115,20 +105,4 @@ async function resolveIosResourceClassAsync(
   }
 
   return iosResourceClassToBuildResourceClassMapping[resourceClass];
-}
-
-async function resolveIosDefaultRequestedResourceClassAsync(
-  exp: ExpoConfig,
-  projectDir: string
-): Promise<ResourceClass> {
-  const { sdkVersion } = exp;
-  const reactNativeVersion = await getReactNativeVersionAsync(projectDir);
-  if (
-    (sdkVersion && semver.satisfies(sdkVersion, '>=48')) ||
-    (reactNativeVersion && semver.satisfies(reactNativeVersion, '>=0.71.0'))
-  ) {
-    return ResourceClass.M_MEDIUM;
-  } else {
-    return ResourceClass.DEFAULT;
-  }
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -87,6 +87,7 @@ export type Account = {
   appleTeams: Array<AppleTeam>;
   /** Apps associated with this account */
   apps: Array<App>;
+  /** Paginated list of apps associated with this account. By default sorted by name. Use filter to adjust the sorting order. */
   appsPaginated: AccountAppsConnection;
   /** @deprecated Build packs are no longer supported */
   availableBuilds?: Maybe<Scalars['Int']>;
@@ -219,6 +220,7 @@ export type AccountAppsArgs = {
 export type AccountAppsPaginatedArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<AccountAppsFilterInput>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
 };
@@ -308,6 +310,19 @@ export type AccountAppsEdge = {
   cursor: Scalars['String'];
   node: App;
 };
+
+export type AccountAppsFilterInput = {
+  sortByField: AccountAppsSortByField;
+};
+
+export enum AccountAppsSortByField {
+  LatestActivityTime = 'LATEST_ACTIVITY_TIME',
+  /**
+   * Name prefers the display name but falls back to full_name with @account/
+   * part stripped.
+   */
+  Name = 'NAME'
+}
 
 export type AccountDataInput = {
   name: Scalars['String'];
@@ -2036,9 +2051,9 @@ export type BuildArtifacts = {
 
 export type BuildCacheInput = {
   clear?: InputMaybe<Scalars['Boolean']>;
-  customPaths?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   disabled?: InputMaybe<Scalars['Boolean']>;
   key?: InputMaybe<Scalars['String']>;
+  paths?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export enum BuildCredentialsSource {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7676/default-resource-class-m1-rollout
Companion to https://github.com/expo/universe/pull/11639

We want to move resolving the default iOS resource class to the server side so we can have more control over users.

# How

Don't resolve the iOS default resource class in CLI

Don't set `m1-medium` as default when running the `eas build:configure` command. 

Send `sdkVersion` and `reactNativeVersion` as build params to our server

# Test Plan

Should be merged after https://github.com/expo/universe/pull/11639

Test manually.
