### PR TITLE
[eas-cli] [ENG-6945] Unify error display method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Unify how the command errors are displayed. ([#1738](https://github.com/expo/eas-cli/pull/1738) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+
 ## [3.7.2](https://github.com/expo/eas-cli/releases/tag/v3.7.2) - 2023-02-24
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
+++ b/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
@@ -1,0 +1,363 @@
+import { Platform } from '@expo/eas-build-job';
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql/error';
+
+import { EasCommandError } from '../../commandUtils/errors';
+import Build from '../../commands/build';
+import Log, { link } from '../../log';
+import { testExports } from '../build';
+import {
+  EasBuildDownForMaintenanceError,
+  EasBuildFreeTierDisabledAndroidError,
+  EasBuildFreeTierDisabledError,
+  EasBuildFreeTierDisabledIOSError,
+  EasBuildTooManyPendingBuildsError,
+  RequestValidationError,
+  TurtleDeprecatedJobFormatError,
+} from '../errors';
+const { handleBuildRequestError } = testExports;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+const EXPECTED_STRINGIFIED_GRAPHQL_ERROR_JSON = `[
+  {
+    "message": "Error 1"
+  },
+  {
+    "message": "Error 2"
+  },
+  {
+    "message": "Error 3"
+  }
+]`;
+
+const EXPECTED_EAS_BUILD_DOWN_MESSAGE = `EAS Build is down for maintenance. Try again later. Check ${link(
+  'https://status.expo.dev/'
+)} for updates.`;
+
+const EXPECTED_MAX_BUILD_COUNT_MESSAGE_ANDROID = `You have already reached the maximum number of pending Android builds for your account. Try again later.`;
+const EXPECTED_MAX_BUILD_COUNT_MESSAGE_IOS = `You have already reached the maximum number of pending iOS builds for your account. Try again later.`;
+
+const EXPECTED_GENERIC_MESSAGE =
+  'Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.';
+
+const getGraphQLError = (message: string, errorCode: string): GraphQLError => {
+  return new GraphQLError(message, null, null, null, null, null, {
+    errorCode,
+  });
+};
+
+const assertReThrownError = (
+  caughtError: CombinedError | Error,
+  expectedType: typeof EasCommandError,
+  expectedMessage: string = 'Error 1'
+): void => {
+  expect(caughtError).toBeInstanceOf(expectedType);
+  expect((caughtError as Error).message).toEqual(expectedMessage);
+};
+
+describe(Build.name, () => {
+  describe('handle build request errors', () => {
+    describe('logs graphQL errors to debug if present', () => {
+      it('does it with Android', async () => {
+        const platform = Platform.ANDROID;
+        const logDebugSpy = jest.spyOn(Log, 'debug');
+        const graphQLErrors = ['Error 1', 'Error 2', 'Error 3'];
+        const error = new CombinedError({ graphQLErrors });
+
+        try {
+          handleBuildRequestError(error, platform);
+        } catch {}
+
+        expect(logDebugSpy).toBeCalledWith(EXPECTED_STRINGIFIED_GRAPHQL_ERROR_JSON);
+      });
+
+      it('does it with iOS', async () => {
+        const platform = Platform.IOS;
+        const logDebugSpy = jest.spyOn(Log, 'debug');
+        const graphQLErrors = ['Error 1', 'Error 2', 'Error 3'];
+        const error = new CombinedError({ graphQLErrors });
+
+        try {
+          handleBuildRequestError(error, platform);
+        } catch {}
+
+        expect(logDebugSpy).toBeCalledWith(EXPECTED_STRINGIFIED_GRAPHQL_ERROR_JSON);
+      });
+    });
+
+    describe('logs nothing to debug if graphQLErrors not present', () => {
+      it('does it with Android', async () => {
+        const platform = Platform.ANDROID;
+        const logDebugSpy = jest.spyOn(Log, 'debug');
+        const error = new Error('Generic error');
+
+        try {
+          handleBuildRequestError(error, platform);
+        } catch {}
+
+        expect(logDebugSpy).toBeCalledWith(undefined);
+      });
+
+      it('does it with iOS', async () => {
+        const platform = Platform.IOS;
+        const logDebugSpy = jest.spyOn(Log, 'debug');
+        const error = new Error('Generic error');
+
+        try {
+          handleBuildRequestError(error, platform);
+        } catch {}
+
+        expect(logDebugSpy).toBeCalledWith(undefined);
+      });
+    });
+
+    describe('error is server-side defined error', () => {
+      describe('throws correct EasCommandError subclass', () => {
+        describe('for TURTLE_DEPRECATED_JOB_FORMAT', () => {
+          it('does it with Android', async () => {
+            const platform = Platform.ANDROID;
+            const graphQLError = getGraphQLError('Error 1', 'TURTLE_DEPRECATED_JOB_FORMAT');
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(caughtError as Error, TurtleDeprecatedJobFormatError);
+            }
+          });
+
+          it('does it with iOS', async () => {
+            const platform = Platform.IOS;
+            const graphQLError = getGraphQLError('Error 1', 'TURTLE_DEPRECATED_JOB_FORMAT');
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(caughtError as Error, TurtleDeprecatedJobFormatError);
+            }
+          });
+        });
+
+        describe('for EAS_BUILD_FREE_TIER_DISABLED', () => {
+          it('does it with Android', async () => {
+            const platform = Platform.ANDROID;
+            const graphQLError = getGraphQLError('Error 1', 'EAS_BUILD_FREE_TIER_DISABLED');
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(caughtError as Error, EasBuildFreeTierDisabledError);
+            }
+          });
+
+          it('does it with iOS', async () => {
+            const platform = Platform.IOS;
+            const graphQLError = getGraphQLError('Error 1', 'EAS_BUILD_FREE_TIER_DISABLED');
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(caughtError as Error, EasBuildFreeTierDisabledError);
+            }
+          });
+        });
+
+        it('does it for EAS_BUILD_FREE_TIER_DISABLED_IOS', async () => {
+          const platform = Platform.IOS;
+          const graphQLError = getGraphQLError('Error 1', 'EAS_BUILD_FREE_TIER_DISABLED_IOS');
+          const graphQLErrors = [graphQLError];
+          const error = new CombinedError({ graphQLErrors });
+
+          try {
+            handleBuildRequestError(error, platform);
+          } catch (caughtError) {
+            assertReThrownError(caughtError as Error, EasBuildFreeTierDisabledIOSError);
+          }
+        });
+
+        it('does it for EAS_BUILD_FREE_TIER_DISABLED_ANDROID', async () => {
+          const platform = Platform.ANDROID;
+          const graphQLError = getGraphQLError('Error 1', 'EAS_BUILD_FREE_TIER_DISABLED_ANDROID');
+          const graphQLErrors = [graphQLError];
+          const error = new CombinedError({ graphQLErrors });
+
+          try {
+            handleBuildRequestError(error, platform);
+          } catch (caughtError) {
+            assertReThrownError(caughtError as Error, EasBuildFreeTierDisabledAndroidError);
+          }
+        });
+
+        describe('for VALIDATION_ERROR', () => {
+          it('does it with Android', async () => {
+            const platform = Platform.ANDROID;
+            const graphQLError = getGraphQLError('Error 1', 'VALIDATION_ERROR');
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(caughtError as Error, RequestValidationError);
+            }
+          });
+
+          it('does it with iOS', async () => {
+            const platform = Platform.IOS;
+            const graphQLError = getGraphQLError('Error 1', 'VALIDATION_ERROR');
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(caughtError as Error, RequestValidationError);
+            }
+          });
+        });
+      });
+    });
+
+    describe('error is other expected graphQL-related error', () => {
+      describe('throws correct EasCommandError subclass', () => {
+        describe('for EAS_BUILD_DOWN_FOR_MAINTENANCE', () => {
+          it('does it with Android', async () => {
+            const platform = Platform.ANDROID;
+            const graphQLError = getGraphQLError('Error 1', 'EAS_BUILD_DOWN_FOR_MAINTENANCE');
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(
+                caughtError as Error,
+                EasBuildDownForMaintenanceError,
+                EXPECTED_EAS_BUILD_DOWN_MESSAGE
+              );
+            }
+          });
+
+          it('does it with iOS', async () => {
+            const platform = Platform.IOS;
+            const graphQLError = getGraphQLError('Error 1', 'EAS_BUILD_DOWN_FOR_MAINTENANCE');
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(
+                caughtError as Error,
+                EasBuildDownForMaintenanceError,
+                EXPECTED_EAS_BUILD_DOWN_MESSAGE
+              );
+            }
+          });
+        });
+
+        describe('for EAS_BUILD_TOO_MANY_PENDING_BUILDS', () => {
+          it('does it with Android', async () => {
+            const platform = Platform.ANDROID;
+            const graphQLError = getGraphQLError('Error 1', 'EAS_BUILD_TOO_MANY_PENDING_BUILDS');
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(
+                caughtError as Error,
+                EasBuildTooManyPendingBuildsError,
+                EXPECTED_MAX_BUILD_COUNT_MESSAGE_ANDROID
+              );
+            }
+          });
+
+          it('does it with iOS', async () => {
+            const platform = Platform.IOS;
+            const graphQLError = getGraphQLError('Error 1', 'EAS_BUILD_TOO_MANY_PENDING_BUILDS');
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(
+                caughtError as Error,
+                EasBuildTooManyPendingBuildsError,
+                EXPECTED_MAX_BUILD_COUNT_MESSAGE_IOS
+              );
+            }
+          });
+        });
+      });
+    });
+
+    describe('error is unexpected graphQL-related error', () => {
+      describe('throws base Error class with custom message', () => {
+        it('does it with Android', async () => {
+          const platform = Platform.ANDROID;
+          const graphQLError = getGraphQLError('Error 1', 'UNKNOWN_GRAPHQL_ERROR');
+          const graphQLErrors = [graphQLError];
+          const error = new CombinedError({ graphQLErrors });
+
+          try {
+            handleBuildRequestError(error, platform);
+          } catch (caughtError) {
+            assertReThrownError(caughtError as Error, Error, EXPECTED_GENERIC_MESSAGE);
+          }
+        });
+
+        it('does it with iOS', async () => {
+          const platform = Platform.IOS;
+          const graphQLError = getGraphQLError('Error 1', 'UNKNOWN_GRAPHQL_ERROR');
+          const graphQLErrors = [graphQLError];
+          const error = new CombinedError({ graphQLErrors });
+
+          try {
+            handleBuildRequestError(error, platform);
+          } catch (caughtError) {
+            assertReThrownError(caughtError as Error, Error, EXPECTED_GENERIC_MESSAGE);
+          }
+        });
+      });
+    });
+
+    describe('error is unexpected non-graphQL-related error', () => {
+      describe('throws base Error class with propagated message', () => {
+        it('does it with Android', async () => {
+          const platform = Platform.ANDROID;
+          const error = new Error('Non-graphQL-related error');
+
+          try {
+            handleBuildRequestError(error, platform);
+          } catch (caughtError) {
+            expect(caughtError).toStrictEqual(error);
+          }
+        });
+
+        it('does it with iOS', async () => {
+          const platform = Platform.IOS;
+          const error = new Error('Non-graphQL-related error');
+
+          try {
+            handleBuildRequestError(error, platform);
+          } catch (caughtError) {
+            expect(caughtError).toStrictEqual(error);
+          }
+        });
+      });
+    });
+  });
+});

--- a/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
+++ b/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
@@ -5,7 +5,7 @@ import { GraphQLError } from 'graphql/error';
 import { EasCommandError } from '../../commandUtils/errors';
 import Build from '../../commands/build';
 import Log, { link } from '../../log';
-import { testExports } from '../build';
+import { handleBuildRequestError } from '../build';
 import {
   EasBuildDownForMaintenanceError,
   EasBuildFreeTierDisabledAndroidError,
@@ -15,7 +15,6 @@ import {
   RequestValidationError,
   TurtleDeprecatedJobFormatError,
 } from '../errors';
-const { handleBuildRequestError } = testExports;
 
 beforeEach(() => {
   jest.resetAllMocks();

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -173,26 +173,23 @@ function handleBuildRequestError(error: any, platform: Platform): never {
   Log.debug(JSON.stringify(error.graphQLErrors, null, 2));
 
   if (SERVER_SIDE_DEFINED_ERRORS.includes(error?.graphQLErrors?.[0]?.extensions?.errorCode)) {
-    Log.error(error?.graphQLErrors?.[0]?.message);
-    throw new Error('Build request failed.');
+    throw new Error(error?.graphQLErrors?.[0]?.message);
   } else if (
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_DOWN_FOR_MAINTENANCE'
   ) {
-    Log.error(
+    throw new Error(
       `EAS Build is down for maintenance. Try again later. Check ${link(
         'https://status.expo.dev/'
       )} for updates.`
     );
-    throw new Error('Build request failed.');
   } else if (
     error?.graphQLErrors?.[0]?.extensions?.errorCode === 'EAS_BUILD_TOO_MANY_PENDING_BUILDS'
   ) {
-    Log.error(
+    throw new Error(
       `You have already reached the maximum number of pending ${requestedPlatformDisplayNames[platform]} builds for your account. Try again later.`
     );
-    throw new Error('Build request failed.');
   } else if (error?.graphQLErrors) {
-    Log.error(
+    throw new Error(
       'Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.'
     );
   }

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -179,7 +179,7 @@ const SERVER_SIDE_DEFINED_ERRORS: Record<string, typeof EasCommandError> = {
   VALIDATION_ERROR: RequestValidationError,
 };
 
-function handleBuildRequestError(error: any, platform: Platform): never {
+export function handleBuildRequestError(error: any, platform: Platform): never {
   Log.debug(JSON.stringify(error.graphQLErrors, null, 2));
 
   const graphQLErrorCode: string = error?.graphQLErrors?.[0]?.extensions?.errorCode;
@@ -628,7 +628,3 @@ async function updateIosBuildProfilesToUseM1WorkersAsync(projectDir: string): Pr
   await easJsonAccessor.writeAsync();
   Log.withTick('Updated eas.json. Your next builds will run on M1 workers.');
 }
-
-export const testExports = {
-  handleBuildRequestError,
-};

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -42,6 +42,7 @@ import {
   EasBuildFreeTierDisabledError,
   EasBuildFreeTierDisabledIOSError,
   EasBuildTooManyPendingBuildsError,
+  EasCommandError,
   GenericGraphQLError,
   RequestValidationError,
   TurtleDeprecatedJobFormatError,
@@ -171,7 +172,7 @@ export async function prepareBuildRequestForPlatformAsync<
   };
 }
 
-const SERVER_SIDE_DEFINED_ERRORS: { [key: string]: any } = {
+const SERVER_SIDE_DEFINED_ERRORS: Record<string, typeof EasCommandError> = {
   TURTLE_DEPRECATED_JOB_FORMAT: TurtleDeprecatedJobFormatError,
   EAS_BUILD_FREE_TIER_DISABLED: EasBuildFreeTierDisabledError,
   EAS_BUILD_FREE_TIER_DISABLED_IOS: EasBuildFreeTierDisabledIOSError,
@@ -184,7 +185,7 @@ function handleBuildRequestError(error: any, platform: Platform): never {
 
   const graphQLErrorCode: string = error?.graphQLErrors?.[0]?.extensions?.errorCode;
   if (graphQLErrorCode in SERVER_SIDE_DEFINED_ERRORS) {
-    const ErrorClass: typeof Error = SERVER_SIDE_DEFINED_ERRORS[graphQLErrorCode];
+    const ErrorClass: typeof EasCommandError = SERVER_SIDE_DEFINED_ERRORS[graphQLErrorCode];
     throw new ErrorClass(error?.graphQLErrors?.[0]?.message);
   } else if (graphQLErrorCode === 'EAS_BUILD_DOWN_FOR_MAINTENANCE') {
     throw new EasBuildDownForMaintenanceError(

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -10,6 +10,7 @@ import { BuildEvent } from '../analytics/AnalyticsManager';
 import { withAnalyticsAsync } from '../analytics/common';
 import { getExpoWebsiteBaseUrl } from '../api';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { EasCommandError } from '../commandUtils/errors';
 import {
   AppPlatform,
   BuildFragment,
@@ -42,7 +43,6 @@ import {
   EasBuildFreeTierDisabledError,
   EasBuildFreeTierDisabledIOSError,
   EasBuildTooManyPendingBuildsError,
-  EasCommandError,
   RequestValidationError,
   TurtleDeprecatedJobFormatError,
 } from './errors';

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -628,3 +628,7 @@ async function updateIosBuildProfilesToUseM1WorkersAsync(projectDir: string): Pr
   await easJsonAccessor.writeAsync();
   Log.withTick('Updated eas.json. Your next builds will run on M1 workers.');
 }
+
+export const testExports = {
+  handleBuildRequestError,
+};

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -183,7 +183,7 @@ function handleBuildRequestError(error: any, platform: Platform): never {
   Log.debug(JSON.stringify(error.graphQLErrors, null, 2));
 
   const graphQLErrorCode: string = error?.graphQLErrors?.[0]?.extensions?.errorCode;
-  if (Object.keys(SERVER_SIDE_DEFINED_ERRORS).includes(graphQLErrorCode)) {
+  if (graphQLErrorCode in SERVER_SIDE_DEFINED_ERRORS) {
     const ErrorClass: typeof Error = SERVER_SIDE_DEFINED_ERRORS[graphQLErrorCode];
     throw new ErrorClass(error?.graphQLErrors?.[0]?.message);
   } else if (graphQLErrorCode === 'EAS_BUILD_DOWN_FOR_MAINTENANCE') {

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -43,7 +43,6 @@ import {
   EasBuildFreeTierDisabledIOSError,
   EasBuildTooManyPendingBuildsError,
   EasCommandError,
-  GenericGraphQLError,
   RequestValidationError,
   TurtleDeprecatedJobFormatError,
 } from './errors';
@@ -198,7 +197,7 @@ function handleBuildRequestError(error: any, platform: Platform): never {
       `You have already reached the maximum number of pending ${requestedPlatformDisplayNames[platform]} builds for your account. Try again later.`
     );
   } else if (error?.graphQLErrors) {
-    throw new GenericGraphQLError(
+    throw new Error(
       'Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.'
     );
   }

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -6,19 +6,19 @@ export class TurtleDeprecatedJobFormatError extends Error {
 
 export class EasBuildFreeTierDisabledError extends Error {
   constructor(message?: string) {
-    super(message ?? 'Eas-build free tier is disabled.');
+    super(message ?? 'EAS Build free tier is disabled.');
   }
 }
 
 export class EasBuildFreeTierDisabledIOSError extends Error {
   constructor(message?: string) {
-    super(message ?? 'Eas-build free tier is disabled for iOS.');
+    super(message ?? 'EAS Build free tier is disabled for iOS.');
   }
 }
 
 export class EasBuildFreeTierDisabledAndroidError extends Error {
   constructor(message?: string) {
-    super(message ?? 'Eas-build free tier is disabled for Android.');
+    super(message ?? 'EAS Build free tier is disabled for Android.');
   }
 }
 
@@ -30,13 +30,13 @@ export class RequestValidationError extends Error {
 
 export class EasBuildDownForMaintenanceError extends Error {
   constructor(message?: string) {
-    super(message ?? 'Eas-build is currently down for maintenance.');
+    super(message ?? 'EAS Build is currently down for maintenance.');
   }
 }
 
 export class EasBuildTooManyPendingBuildsError extends Error {
   constructor(message?: string) {
-    super(message ?? 'Eas-build has too many pending builds at the moment.');
+    super(message ?? 'EAS Build has too many pending builds at the moment.');
   }
 }
 

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -1,43 +1,15 @@
 import { EasCommandError } from '../commandUtils/errors';
 
-export class TurtleDeprecatedJobFormatError extends EasCommandError {
-  constructor(message?: string) {
-    super(message ?? 'Deprecated job format.');
-  }
-}
+export class TurtleDeprecatedJobFormatError extends EasCommandError {}
 
-export class EasBuildFreeTierDisabledError extends EasCommandError {
-  constructor(message?: string) {
-    super(message ?? 'EAS Build free tier is disabled.');
-  }
-}
+export class EasBuildFreeTierDisabledError extends EasCommandError {}
 
-export class EasBuildFreeTierDisabledIOSError extends EasCommandError {
-  constructor(message?: string) {
-    super(message ?? 'EAS Build free tier is disabled for iOS.');
-  }
-}
+export class EasBuildFreeTierDisabledIOSError extends EasCommandError {}
 
-export class EasBuildFreeTierDisabledAndroidError extends EasCommandError {
-  constructor(message?: string) {
-    super(message ?? 'EAS Build free tier is disabled for Android.');
-  }
-}
+export class EasBuildFreeTierDisabledAndroidError extends EasCommandError {}
 
-export class RequestValidationError extends EasCommandError {
-  constructor(message?: string) {
-    super(message ?? 'Request validation error.');
-  }
-}
+export class RequestValidationError extends EasCommandError {}
 
-export class EasBuildDownForMaintenanceError extends EasCommandError {
-  constructor(message?: string) {
-    super(message ?? 'EAS Build is currently down for maintenance.');
-  }
-}
+export class EasBuildDownForMaintenanceError extends EasCommandError {}
 
-export class EasBuildTooManyPendingBuildsError extends EasCommandError {
-  constructor(message?: string) {
-    super(message ?? 'EAS Build has too many pending builds at the moment.');
-  }
-}
+export class EasBuildTooManyPendingBuildsError extends EasCommandError {}

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -1,8 +1,4 @@
-export class EasCommandError extends Error {
-  constructor(message?: string) {
-    super(message ?? 'Unknown EAS error occurred.');
-  }
-}
+import { EasCommandError } from '../commandUtils/errors';
 
 export class TurtleDeprecatedJobFormatError extends EasCommandError {
   constructor(message?: string) {

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -1,46 +1,52 @@
-export class TurtleDeprecatedJobFormatError extends Error {
+export class EasCommandError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Unknown EAS error occurred.');
+  }
+}
+
+export class TurtleDeprecatedJobFormatError extends EasCommandError {
   constructor(message?: string) {
     super(message ?? 'Deprecated job format.');
   }
 }
 
-export class EasBuildFreeTierDisabledError extends Error {
+export class EasBuildFreeTierDisabledError extends EasCommandError {
   constructor(message?: string) {
     super(message ?? 'EAS Build free tier is disabled.');
   }
 }
 
-export class EasBuildFreeTierDisabledIOSError extends Error {
+export class EasBuildFreeTierDisabledIOSError extends EasCommandError {
   constructor(message?: string) {
     super(message ?? 'EAS Build free tier is disabled for iOS.');
   }
 }
 
-export class EasBuildFreeTierDisabledAndroidError extends Error {
+export class EasBuildFreeTierDisabledAndroidError extends EasCommandError {
   constructor(message?: string) {
     super(message ?? 'EAS Build free tier is disabled for Android.');
   }
 }
 
-export class RequestValidationError extends Error {
+export class RequestValidationError extends EasCommandError {
   constructor(message?: string) {
     super(message ?? 'Request validation error.');
   }
 }
 
-export class EasBuildDownForMaintenanceError extends Error {
+export class EasBuildDownForMaintenanceError extends EasCommandError {
   constructor(message?: string) {
     super(message ?? 'EAS Build is currently down for maintenance.');
   }
 }
 
-export class EasBuildTooManyPendingBuildsError extends Error {
+export class EasBuildTooManyPendingBuildsError extends EasCommandError {
   constructor(message?: string) {
     super(message ?? 'EAS Build has too many pending builds at the moment.');
   }
 }
 
-export class GenericGraphQLError extends Error {
+export class GenericGraphQLError extends EasCommandError {
   constructor(message?: string) {
     super(message ?? 'GraphQL query failed.');
   }

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -1,0 +1,47 @@
+export class TurtleDeprecatedJobFormatError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Deprecated job format.');
+  }
+}
+
+export class EasBuildFreeTierDisabledError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Eas-build free tier is disabled.');
+  }
+}
+
+export class EasBuildFreeTierDisabledIOSError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Eas-build free tier is disabled for iOS.');
+  }
+}
+
+export class EasBuildFreeTierDisabledAndroidError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Eas-build free tier is disabled for Android.');
+  }
+}
+
+export class RequestValidationError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Request validation error.');
+  }
+}
+
+export class EasBuildDownForMaintenanceError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Eas-build is currently down for maintenance.');
+  }
+}
+
+export class EasBuildTooManyPendingBuildsError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Eas-build has too many pending builds at the moment.');
+  }
+}
+
+export class GenericGraphQLError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'GraphQL query failed.');
+  }
+}

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -45,9 +45,3 @@ export class EasBuildTooManyPendingBuildsError extends EasCommandError {
     super(message ?? 'EAS Build has too many pending builds at the moment.');
   }
 }
-
-export class GenericGraphQLError extends EasCommandError {
-  constructor(message?: string) {
-    super(message ?? 'GraphQL query failed.');
-  }
-}

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -43,7 +43,7 @@ export async function listAndRenderBuildsOnAppAsync(
       offset: paginatedQueryOptions.offset,
       queryToPerform: (limit, offset) =>
         BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
-          appId: 111 as unknown as string,
+          appId: projectId,
           limit,
           offset,
           filter,

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -43,7 +43,7 @@ export async function listAndRenderBuildsOnAppAsync(
       offset: paginatedQueryOptions.offset,
       queryToPerform: (limit, offset) =>
         BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
-          appId: projectId,
+          appId: 111 as unknown as string,
           limit,
           offset,
           filter,

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -185,20 +185,15 @@ export default abstract class EasCommand extends Command {
   }
 
   protected override catch(err: Error): Promise<any> {
-    let baseMessage: string;
+    let baseMessage = this.baseErrorMessage ?? `${this.id} command failed.`;
     if (err instanceof EasCommandError) {
       Log.error(err.message);
-      baseMessage = this.baseErrorMessage ?? `${this.id} command failed.`;
-    } else {
-      const cleanMessage =
-        err instanceof CombinedError && err?.graphQLErrors
-          ? err.message.replace('[GraphQL] ', '')
-          : err.message;
+    } else if (err instanceof CombinedError && err?.graphQLErrors) {
+      const cleanMessage = err.message.replace('[GraphQL] ', '')
       Log.error(cleanMessage);
-      baseMessage =
-        err instanceof CombinedError && err?.graphQLErrors
-          ? this.baseGraphQLErrorMessage
-          : this.baseErrorMessage ?? `${this.id} command failed.`;
+      baseMessage = this.baseGraphQLErrorMessage
+    } else {
+      Log.error(err.message);
     }
     Log.debug(err);
     throw new Error(baseMessage);

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -118,7 +118,7 @@ export default abstract class EasCommand extends Command {
    */
   private analyticsInternal?: AnalyticsWithOrchestration;
 
-  protected baseErrorMessage: string = '';
+  protected baseErrorMessage?: string;
   protected baseGraphQLErrorMessage: string = 'GraphQL request failed.';
 
   /**

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -178,7 +178,7 @@ export default abstract class EasCommand extends Command {
     return super.finally(err);
   }
 
-  protected baseErrorMessage = 'Request failed';
+  protected baseErrorMessage = 'Command failed';
   protected override catch(err: CommandError): Promise<any> {
     const cleanMessage = err.message.startsWith('[GraphQL] ')
       ? err.message.replace('[GraphQL] ', '')

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -178,13 +178,16 @@ export default abstract class EasCommand extends Command {
     return super.finally(err);
   }
 
-  protected baseErrorMessage = 'Command failed';
+  protected baseErrorMessage = 'Command failed.';
+  protected baseGraphQLErrorMessage = 'GraphQL request failed.';
   protected override catch(err: CommandError): Promise<any> {
     const isGraphQLError = (err: any): boolean => {
       return err?.graphQLErrors;
     };
-    const cleanMessage = isGraphQLError(err) ? err.message.replace('[GraphQL] ', '') : err.message;
+
+    const isGraphQL = isGraphQLError(err);
+    const cleanMessage = isGraphQL ? err.message.replace('[GraphQL] ', '') : err.message;
     Log.error(cleanMessage);
-    throw new Error(this.baseErrorMessage);
+    throw new Error(isGraphQL ? this.baseGraphQLErrorMessage : this.baseErrorMessage);
   }
 }

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -118,8 +118,8 @@ export default abstract class EasCommand extends Command {
    */
   private analyticsInternal?: AnalyticsWithOrchestration;
 
-  protected baseErrorMessage = 'Command failed.';
-  protected baseGraphQLErrorMessage = 'GraphQL request failed.';
+  protected baseErrorMessage: string = '';
+  protected baseGraphQLErrorMessage: string = 'GraphQL request failed.';
 
   /**
    * Execute the context in the contextDefinition to satisfy command prerequisites.
@@ -188,7 +188,8 @@ export default abstract class EasCommand extends Command {
     let baseMessage: string = '';
     if (err instanceof EasCommandError) {
       Log.error(err.message);
-      baseMessage = this.baseErrorMessage;
+      // baseMessage = this.baseErrorMessage;
+      baseMessage = this.baseErrorMessage || `${this.id} command failed.`;
     } else {
       const cleanMessage =
         err instanceof CombinedError && err?.graphQLErrors
@@ -198,7 +199,8 @@ export default abstract class EasCommand extends Command {
       baseMessage =
         err instanceof CombinedError && err?.graphQLErrors
           ? this.baseGraphQLErrorMessage
-          : this.baseErrorMessage;
+          : // : this.baseErrorMessage;
+            this.baseErrorMessage || `${this.id} command failed.`;
     }
     Log.debug(err);
     throw new Error(baseMessage);

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -7,7 +7,6 @@ import {
   CommandEvent,
   createAnalyticsAsync,
 } from '../analytics/AnalyticsManager';
-import { EasCommandError } from '../build/errors';
 import Log from '../log';
 import SessionManager from '../user/SessionManager';
 import AnalyticsContextField from './context/AnalyticsContextField';
@@ -19,6 +18,7 @@ import { OptionalProjectConfigContextField } from './context/OptionalProjectConf
 import ProjectConfigContextField from './context/ProjectConfigContextField';
 import ProjectDirContextField from './context/ProjectDirContextField';
 import SessionManagementContextField from './context/SessionManagementContextField';
+import { EasCommandError } from './errors';
 
 type ContextInput<
   T extends {

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -188,7 +188,6 @@ export default abstract class EasCommand extends Command {
     let baseMessage: string = '';
     if (err instanceof EasCommandError) {
       Log.error(err.message);
-      // baseMessage = this.baseErrorMessage;
       baseMessage = this.baseErrorMessage || `${this.id} command failed.`;
     } else {
       const cleanMessage =
@@ -199,8 +198,7 @@ export default abstract class EasCommand extends Command {
       baseMessage =
         err instanceof CombinedError && err?.graphQLErrors
           ? this.baseGraphQLErrorMessage
-          : // : this.baseErrorMessage;
-            this.baseErrorMessage || `${this.id} command failed.`;
+          : this.baseErrorMessage || `${this.id} command failed.`;
     }
     Log.debug(err);
     throw new Error(baseMessage);

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -188,6 +188,7 @@ export default abstract class EasCommand extends Command {
     const isGraphQL = isGraphQLError(err);
     const cleanMessage = isGraphQL ? err.message.replace('[GraphQL] ', '') : err.message;
     Log.error(cleanMessage);
+    Log.debug(err.message);
     throw new Error(isGraphQL ? this.baseGraphQLErrorMessage : this.baseErrorMessage);
   }
 }

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -185,10 +185,10 @@ export default abstract class EasCommand extends Command {
   }
 
   protected override catch(err: Error): Promise<any> {
-    let baseMessage: string = '';
+    let baseMessage: string;
     if (err instanceof EasCommandError) {
       Log.error(err.message);
-      baseMessage = this.baseErrorMessage || `${this.id} command failed.`;
+      baseMessage = this.baseErrorMessage ?? `${this.id} command failed.`;
     } else {
       const cleanMessage =
         err instanceof CombinedError && err?.graphQLErrors
@@ -198,7 +198,7 @@ export default abstract class EasCommand extends Command {
       baseMessage =
         err instanceof CombinedError && err?.graphQLErrors
           ? this.baseGraphQLErrorMessage
-          : this.baseErrorMessage || `${this.id} command failed.`;
+          : this.baseErrorMessage ?? `${this.id} command failed.`;
     }
     Log.debug(err);
     throw new Error(baseMessage);

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -1,4 +1,5 @@
 import { Command } from '@oclif/core';
+import { CommandError } from '@oclif/core/lib/interfaces';
 import nullthrows from 'nullthrows';
 
 import {
@@ -6,6 +7,7 @@ import {
   CommandEvent,
   createAnalyticsAsync,
 } from '../analytics/AnalyticsManager';
+import Log from '../log';
 import SessionManager from '../user/SessionManager';
 import AnalyticsContextField from './context/AnalyticsContextField';
 import ContextField from './context/ContextField';
@@ -174,5 +176,14 @@ export default abstract class EasCommand extends Command {
   override async finally(err: Error): Promise<any> {
     await this.analytics.flushAsync();
     return super.finally(err);
+  }
+
+  protected baseErrorMessage = 'Request failed';
+  protected override catch(err: CommandError): Promise<any> {
+    const cleanMessage = err.message.startsWith('[GraphQL] ')
+      ? err.message.replace('[GraphQL] ', '')
+      : err.message;
+    Log.error(cleanMessage);
+    throw new Error(this.baseErrorMessage);
   }
 }

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -188,7 +188,7 @@ export default abstract class EasCommand extends Command {
     const isGraphQL = isGraphQLError(err);
     const cleanMessage = isGraphQL ? err.message.replace('[GraphQL] ', '') : err.message;
     Log.error(cleanMessage);
-    Log.debug(err.message);
+    Log.debug(err);
     throw new Error(isGraphQL ? this.baseGraphQLErrorMessage : this.baseErrorMessage);
   }
 }

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -106,6 +106,21 @@ export default abstract class EasCommand extends Command {
   static contextDefinition: ContextInput = {};
 
   /**
+   * The user session manager. Responsible for coordinating all user session related state.
+   * If needed in a subclass, use the SessionManager ContextOption.
+   */
+  private sessionManagerInternal?: SessionManager;
+
+  /**
+   * The analytics manager. Used for logging analytics.
+   * It is set up here to ensure a consistent setup.
+   */
+  private analyticsInternal?: AnalyticsWithOrchestration;
+
+  protected baseErrorMessage = 'Command failed.';
+  protected baseGraphQLErrorMessage = 'GraphQL request failed.';
+
+  /**
    * Execute the context in the contextDefinition to satisfy command prerequisites.
    */
   protected async getContextAsync<
@@ -134,20 +149,10 @@ export default abstract class EasCommand extends Command {
     return Object.fromEntries(contextValuePairs);
   }
 
-  /**
-   * The user session manager. Responsible for coordinating all user session related state.
-   * If needed in a subclass, use the SessionManager ContextOption.
-   */
-  private sessionManagerInternal?: SessionManager;
   private get sessionManager(): SessionManager {
     return nullthrows(this.sessionManagerInternal);
   }
 
-  /**
-   * The analytics manager. Used for logging analytics.
-   * It is set up here to ensure a consistent set up.
-   */
-  private analyticsInternal?: AnalyticsWithOrchestration;
   private get analytics(): AnalyticsWithOrchestration {
     return nullthrows(this.analyticsInternal);
   }
@@ -178,8 +183,6 @@ export default abstract class EasCommand extends Command {
     return super.finally(err);
   }
 
-  protected baseErrorMessage = 'Command failed.';
-  protected baseGraphQLErrorMessage = 'GraphQL request failed.';
   protected override catch(err: Error): Promise<any> {
     const isGraphQLError = (err: any): boolean => {
       return err?.graphQLErrors;

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -36,6 +36,8 @@ type ContextOutput<
   [P in keyof T]: T[P];
 };
 
+const BASE_GRAPHQL_ERROR_MESSAGE: string = 'GraphQL request failed.';
+
 export default abstract class EasCommand extends Command {
   protected static readonly ContextOptions = {
     /**
@@ -119,7 +121,6 @@ export default abstract class EasCommand extends Command {
   private analyticsInternal?: AnalyticsWithOrchestration;
 
   protected baseErrorMessage?: string;
-  protected baseGraphQLErrorMessage: string = 'GraphQL request failed.';
 
   /**
    * Execute the context in the contextDefinition to satisfy command prerequisites.
@@ -189,9 +190,9 @@ export default abstract class EasCommand extends Command {
     if (err instanceof EasCommandError) {
       Log.error(err.message);
     } else if (err instanceof CombinedError && err?.graphQLErrors) {
-      const cleanMessage = err.message.replace('[GraphQL] ', '')
+      const cleanMessage = err.message.replace('[GraphQL] ', '');
       Log.error(cleanMessage);
-      baseMessage = this.baseGraphQLErrorMessage
+      baseMessage = BASE_GRAPHQL_ERROR_MESSAGE;
     } else {
       Log.error(err.message);
     }

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -180,9 +180,10 @@ export default abstract class EasCommand extends Command {
 
   protected baseErrorMessage = 'Command failed';
   protected override catch(err: CommandError): Promise<any> {
-    const cleanMessage = err.message.startsWith('[GraphQL] ')
-      ? err.message.replace('[GraphQL] ', '')
-      : err.message;
+    const isGraphQLError = (err: any): boolean => {
+      return err?.graphQLErrors;
+    };
+    const cleanMessage = isGraphQLError(err) ? err.message.replace('[GraphQL] ', '') : err.message;
     Log.error(cleanMessage);
     throw new Error(this.baseErrorMessage);
   }

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
 const createTestEasCommand = (baseErrorMessage?: string): typeof EasCommand => {
   class TestEasCommand extends EasCommand {
     async runAsync(): Promise<void> {}
-    protected override baseErrorMessage = baseErrorMessage || 'Command failed';
+    protected override baseErrorMessage = baseErrorMessage || '';
   }
 
   TestEasCommand.id = 'TestEasCommand'; // normally oclif will assign ids, but b/c this is located outside the commands folder it will not
@@ -162,7 +162,7 @@ describe(EasCommand.name, () => {
           await TestEasCommand.run();
         } catch (caughtError) {
           expect(caughtError).toBeInstanceOf(Error);
-          expect((caughtError as Error).message).toEqual('Command failed');
+          expect((caughtError as Error).message).toEqual('TestEasCommand command failed.');
         }
       });
 

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
 const createTestEasCommand = (baseErrorMessage?: string): typeof EasCommand => {
   class TestEasCommand extends EasCommand {
     async runAsync(): Promise<void> {}
-    protected override baseErrorMessage = baseErrorMessage ?? '';
+    protected override baseErrorMessage = baseErrorMessage;
   }
 
   TestEasCommand.id = 'TestEasCommand'; // normally oclif will assign ids, but b/c this is located outside the commands folder it will not

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -108,15 +108,16 @@ describe(EasCommand.name, () => {
         const logErrorSpy = jest.spyOn(Log, 'error');
         const logDebugSpy = jest.spyOn(Log, 'debug');
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
+        const error = new Error('Unexpected, internal error message');
         runAsyncMock.mockImplementation(() => {
-          throw new Error('Unexpected, internal error message');
+          throw error;
         });
         try {
           await TestEasCommand.run();
         } catch {}
 
         expect(logErrorSpy).toBeCalledWith('Unexpected, internal error message');
-        expect(logDebugSpy).toBeCalledWith('Unexpected, internal error message');
+        expect(logDebugSpy).toBeCalledWith(error);
       });
 
       it('logs the cleaned message if needed', async () => {
@@ -124,16 +125,17 @@ describe(EasCommand.name, () => {
         const logErrorSpy = jest.spyOn(Log, 'error');
         const logDebugSpy = jest.spyOn(Log, 'debug');
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
+        const graphQLErrors = ['Unexpected GraphQL error message'];
+        const error = new CombinedError({ graphQLErrors });
         runAsyncMock.mockImplementation(() => {
-          const graphQLErrors = ['Unexpected GraphQL error message'];
-          throw new CombinedError({ graphQLErrors });
+          throw error;
         });
         try {
           await TestEasCommand.run();
         } catch {}
 
         expect(logErrorSpy).toBeCalledWith('Unexpected GraphQL error message');
-        expect(logDebugSpy).toBeCalledWith('[GraphQL] Unexpected GraphQL error message');
+        expect(logDebugSpy).toBeCalledWith(error);
       });
 
       it('re-throws the error with new message if provided', async () => {

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -105,7 +105,8 @@ describe(EasCommand.name, () => {
     describe('catch', () => {
       it('logs the message', async () => {
         const TestEasCommand = createTestEasCommand();
-        const logSpy = jest.spyOn(Log, 'error');
+        const logErrorSpy = jest.spyOn(Log, 'error');
+        const logDebugSpy = jest.spyOn(Log, 'debug');
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
         runAsyncMock.mockImplementation(() => {
           throw new Error('Unexpected, internal error message');
@@ -114,12 +115,14 @@ describe(EasCommand.name, () => {
           await TestEasCommand.run();
         } catch {}
 
-        expect(logSpy).toBeCalledWith('Unexpected, internal error message');
+        expect(logErrorSpy).toBeCalledWith('Unexpected, internal error message');
+        expect(logDebugSpy).toBeCalledWith('Unexpected, internal error message');
       });
 
       it('logs the cleaned message if needed', async () => {
         const TestEasCommand = createTestEasCommand();
-        const logSpy = jest.spyOn(Log, 'error');
+        const logErrorSpy = jest.spyOn(Log, 'error');
+        const logDebugSpy = jest.spyOn(Log, 'debug');
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
         runAsyncMock.mockImplementation(() => {
           const graphQLErrors = ['Unexpected GraphQL error message'];
@@ -129,7 +132,8 @@ describe(EasCommand.name, () => {
           await TestEasCommand.run();
         } catch {}
 
-        expect(logSpy).toBeCalledWith('Unexpected GraphQL error message');
+        expect(logErrorSpy).toBeCalledWith('Unexpected GraphQL error message');
+        expect(logDebugSpy).toBeCalledWith('[GraphQL] Unexpected GraphQL error message');
       });
 
       it('re-throws the error with new message if provided', async () => {

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -115,6 +115,20 @@ describe(EasCommand.name, () => {
         expect(logSpy).toBeCalledWith('Unexpected, internal error message');
       });
 
+      it('logs the cleaned message if needed', async () => {
+        const TestEasCommand = createTestEasCommand();
+        const logSpy = jest.spyOn(Log, 'error');
+        const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
+        runAsyncMock.mockImplementation(() => {
+          throw new Error('[GraphQL] Unexpected GraphQL error message');
+        });
+        try {
+          await TestEasCommand.run();
+        } catch {}
+
+        expect(logSpy).toBeCalledWith('Unexpected GraphQL error message');
+      });
+
       it('re-throws the error with new message if provided', async () => {
         const TestEasCommand = createTestEasCommand('New base error message');
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
 const createTestEasCommand = (baseErrorMessage?: string): typeof EasCommand => {
   class TestEasCommand extends EasCommand {
     async runAsync(): Promise<void> {}
-    protected override baseErrorMessage = baseErrorMessage || '';
+    protected override baseErrorMessage = baseErrorMessage ?? '';
   }
 
   TestEasCommand.id = 'TestEasCommand'; // normally oclif will assign ids, but b/c this is located outside the commands folder it will not

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -2,6 +2,7 @@ import { AnalyticsWithOrchestration, createAnalyticsAsync } from '../../analytic
 import Log from '../../log';
 import SessionManager from '../../user/SessionManager';
 import EasCommand from '../EasCommand';
+import {CombinedError} from "@urql/core";
 
 jest.mock('../../user/User');
 jest.mock('../../user/SessionManager');
@@ -120,7 +121,8 @@ describe(EasCommand.name, () => {
         const logSpy = jest.spyOn(Log, 'error');
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
         runAsyncMock.mockImplementation(() => {
-          throw new Error('[GraphQL] Unexpected GraphQL error message');
+          const graphQLErrors = ['Unexpected GraphQL error message'];
+          throw new CombinedError({ graphQLErrors });
         });
         try {
           await TestEasCommand.run();

--- a/packages/eas-cli/src/commandUtils/errors.ts
+++ b/packages/eas-cli/src/commandUtils/errors.ts
@@ -1,0 +1,5 @@
+export class EasCommandError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Unknown EAS error occurred.');
+  }
+}

--- a/packages/eas-cli/src/commandUtils/errors.ts
+++ b/packages/eas-cli/src/commandUtils/errors.ts
@@ -1,4 +1,6 @@
 export class EasCommandError extends Error {
+  // constructor is not useless, since the constructor for Error allows for optional `message`
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(message: string) {
     super(message);
   }

--- a/packages/eas-cli/src/commandUtils/errors.ts
+++ b/packages/eas-cli/src/commandUtils/errors.ts
@@ -1,5 +1,5 @@
 export class EasCommandError extends Error {
-  constructor(message?: string) {
-    super(message ?? 'Unknown EAS error occurred.');
+  constructor(message: string) {
+    super(message);
   }
 }

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -37,6 +37,7 @@ interface RawBuildFlags {
 
 export default class Build extends EasCommand {
   static override description = 'start a build';
+  override baseErrorMessage = 'Build request failed.';
 
   static override flags = {
     platform: Flags.enum({

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -37,7 +37,7 @@ interface RawBuildFlags {
 
 export default class Build extends EasCommand {
   static override description = 'start a build';
-  override baseErrorMessage = 'Build request failed.';
+  override baseErrorMessage = 'Build command failed.';
 
   static override flags = {
     platform: Flags.enum({


### PR DESCRIPTION
Overriden the `Command`'s `catch` method to catch all the errors thrown by the commands, log the error message there the same way as it was previously handled in `src/build/build.ts` and re-throw generic `Error` instance with predefined base error message. To avoid duplication, old `Log.error()` calls have been removed from `src/build/build.ts`. Also added tests to see if the `catch()` method works as intended.

<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [x] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

There used to be a difference between how the expected/handled errors had been displayed by `eas-cli` when compared to these that were not expected. This change is meant to unify this behaviour
Expected:
<img width="672" alt="Screenshot 2023-03-09 at 16 25 16" src="https://user-images.githubusercontent.com/2974455/224071306-fc0cf592-6ac2-45f1-b31d-0303a50c8b11.png">
Unexpected:
<img width="672" alt="Screenshot 2023-03-09 at 16 25 29" src="https://user-images.githubusercontent.com/2974455/224071356-3b27a813-b1d3-4c87-ab8b-af097e21ae90.png">

See: https://linear.app/expo/issue/ENG-6945/improve-eas-cli-error-logging

# How

Utilised the `catch()` method of `oclif`'s `Command` class, which is extended by custom base class `EasCommand`, which in turn is extended by all the commands in `eas-cli`. `EasCommand`'s `catch()` now logs the caught error the same way as it was previously done in case of expected errors, and then re-throws a generic error with pre-defined base error message. Code fragments which used to log the errors previously and re-throw generic error now just throw the error and let the `catch()` do the logging for them.
Expected:
<img width="672" alt="Screenshot 2023-03-09 at 16 30 50" src="https://user-images.githubusercontent.com/2974455/224072899-75e0cbf8-9f49-407f-ac16-ae4502ed4564.png">
Unexpected:
<img width="672" alt="Screenshot 2023-03-09 at 16 31 04" src="https://user-images.githubusercontent.com/2974455/224072935-88c1313a-7918-4fb9-bb49-e807ff702817.png">

# Test Plan

Added automatic tests to check the `catch()` methods behaviour
<img width="672" alt="Screenshot 2023-03-09 at 16 32 27" src="https://user-images.githubusercontent.com/2974455/224073354-e5564143-fa14-4bf5-8a48-522ec2f5d21a.png">
Plus tested manually by breaking the project to intentionally cause errors and check how they are displayed
