### PR TITLE
[ENG-7709][eas-cli][eas-json] add `m-medium` and `m-large` resource classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add new `m-medium` and `m-large` resource classes. ([#1739](https://github.com/expo/eas-cli/pull/1739) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1185,6 +1185,18 @@
             "deprecationReason": null
           },
           {
+            "name": "ownerUserActor",
+            "description": "Owning UserActor of this account if personal account",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "UserActor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "pushSecurityEnabled",
             "description": null,
             "args": [],
@@ -1443,8 +1455,8 @@
               "name": "UserActor",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Deprecated in favor of ownerUserActor"
           },
           {
             "name": "userInvitations",
@@ -6573,6 +6585,71 @@
             "deprecationReason": null
           },
           {
+            "name": "branchesPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppBranchesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildJobs",
             "description": null,
             "args": [
@@ -8027,6 +8104,71 @@
             "deprecationReason": null
           },
           {
+            "name": "updatesPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppUpdatesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "username",
             "description": null,
             "args": [],
@@ -8104,6 +8246,100 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppBranchEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UpdateBranch",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppBranchesConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppBranchEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -9417,6 +9653,100 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppUpdateEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Update",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppUpdatesConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppUpdateEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -12359,8 +12689,8 @@
               "name": "BuildResourceClass",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use resourceClassDisplayName instead"
           },
           {
             "name": "appBuildVersion",
@@ -12873,6 +13203,22 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "BuildResourceClass",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use resourceClassDisplayName instead"
+          },
+          {
+            "name": "resourceClassDisplayName",
+            "description": "String describing the resource class used to run the build",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -15299,8 +15645,8 @@
           {
             "name": "IOS_INTEL_LARGE",
             "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use IOS_INTEL_MEDIUM instead"
           },
           {
             "name": "IOS_INTEL_MEDIUM",
@@ -15317,8 +15663,8 @@
           {
             "name": "IOS_M1_LARGE",
             "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use IOS_M_MEDIUM instead"
           },
           {
             "name": "IOS_M1_MEDIUM",
@@ -15340,6 +15686,18 @@
           },
           {
             "name": "IOS_MEDIUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IOS_M_LARGE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IOS_M_MEDIUM",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -16366,7 +16724,7 @@
           },
           {
             "name": "baseDirectory",
-            "description": "The base directory is the directory to change to before starting a build. This string should be a properly formatted Unix path starting with '/', './', or the name of the directory relative to the root of the repository. Valid examples include: '/apps/expo-app', './apps/expo-app', and 'apps/expo-app'. This is intended for monorepos or apps that live in a subdirectory of a repository.",
+            "description": "The base directory is the directory to change to before starting a build. This string should be a properly formatted POSIX path starting with '/', './', or the name of the directory relative to the root of the repository. Valid examples include: '/apps/expo-app', './apps/expo-app', and 'apps/expo-app'. This is intended for monorepos or apps that live in a subdirectory of a repository.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -32053,6 +32411,22 @@
             "deprecationReason": null
           },
           {
+            "name": "isLegacy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "This field no longer exists"
+          },
+          {
             "name": "isSecondFactorAuthenticationEnabled",
             "description": null,
             "args": [],
@@ -33763,6 +34137,18 @@
             },
             "isDeprecated": true,
             "deprecationReason": "User type is deprecated"
+          },
+          {
+            "name": "userActor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "UserActor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -615,7 +615,7 @@ async function updateIosBuildProfilesToUseM1WorkersAsync(projectDir: string): Pr
     for (const profileName of profileNames) {
       easJsonRawObject.build[profileName].ios = {
         ...easJsonRawObject.build[profileName].ios,
-        resourceClass: ResourceClass.M1_MEDIUM,
+        resourceClass: ResourceClass.M_MEDIUM,
       };
     }
     return easJsonRawObject;

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -54,18 +54,18 @@ const EAS_JSON_MANAGED_DEFAULT: EasJson = {
       developmentClient: true,
       distribution: 'internal',
       ios: {
-        resourceClass: ResourceClass.M1_MEDIUM,
+        resourceClass: ResourceClass.M_MEDIUM,
       },
     },
     preview: {
       distribution: 'internal',
       ios: {
-        resourceClass: ResourceClass.M1_MEDIUM,
+        resourceClass: ResourceClass.M_MEDIUM,
       },
     },
     production: {
       ios: {
-        resourceClass: ResourceClass.M1_MEDIUM,
+        resourceClass: ResourceClass.M_MEDIUM,
       },
     },
   },
@@ -86,18 +86,18 @@ const EAS_JSON_BARE_DEFAULT: EasJson = {
       },
       ios: {
         buildConfiguration: 'Debug',
-        resourceClass: ResourceClass.M1_MEDIUM,
+        resourceClass: ResourceClass.M_MEDIUM,
       },
     },
     preview: {
       distribution: 'internal',
       ios: {
-        resourceClass: ResourceClass.M1_MEDIUM,
+        resourceClass: ResourceClass.M_MEDIUM,
       },
     },
     production: {
       ios: {
-        resourceClass: ResourceClass.M1_MEDIUM,
+        resourceClass: ResourceClass.M_MEDIUM,
       },
     },
   },

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -8,24 +8,30 @@ import { BuildResourceClass } from '../../graphql/generated';
 import Log from '../../log';
 import { getReactNativeVersionAsync } from '../metadata';
 
+type AndroidResourceClass = Exclude<
+  ResourceClass,
+  | ResourceClass.M1_EXPERIMENTAL
+  | ResourceClass.M1_MEDIUM
+  | ResourceClass.M1_LARGE
+  | ResourceClass.INTEL_MEDIUM
+  | ResourceClass.M_MEDIUM
+  | ResourceClass.M_LARGE
+>;
+
 const iosResourceClassToBuildResourceClassMapping: Record<ResourceClass, BuildResourceClass> = {
   [ResourceClass.DEFAULT]: BuildResourceClass.IosDefault,
   [ResourceClass.LARGE]: BuildResourceClass.IosLarge,
-  [ResourceClass.M1_EXPERIMENTAL]: BuildResourceClass.IosM1Large,
-  [ResourceClass.M1_MEDIUM]: BuildResourceClass.IosM1Medium,
+  [ResourceClass.M1_EXPERIMENTAL]: BuildResourceClass.IosMMedium,
+  [ResourceClass.M1_MEDIUM]: BuildResourceClass.IosMMedium,
   [ResourceClass.M1_LARGE]: BuildResourceClass.IosM1Large,
   [ResourceClass.INTEL_MEDIUM]: BuildResourceClass.IosIntelMedium,
   [ResourceClass.MEDIUM]: BuildResourceClass.IosMedium,
+  [ResourceClass.M_MEDIUM]: BuildResourceClass.IosMMedium,
+  [ResourceClass.M_LARGE]: BuildResourceClass.IosMLarge,
 };
 
 const androidResourceClassToBuildResourceClassMapping: Record<
-  Exclude<
-    ResourceClass,
-    | ResourceClass.M1_EXPERIMENTAL
-    | ResourceClass.M1_MEDIUM
-    | ResourceClass.M1_LARGE
-    | ResourceClass.INTEL_MEDIUM
-  >,
+  AndroidResourceClass,
   BuildResourceClass
 > = {
   [ResourceClass.DEFAULT]: BuildResourceClass.AndroidDefault,
@@ -70,15 +76,7 @@ function resolveAndroidResourceClass(selectedResourceClass?: ResourceClass): Bui
 
   const resourceClass = selectedResourceClass ?? ResourceClass.DEFAULT;
 
-  return androidResourceClassToBuildResourceClassMapping[
-    resourceClass as Exclude<
-      ResourceClass,
-      | ResourceClass.M1_EXPERIMENTAL
-      | ResourceClass.M1_MEDIUM
-      | ResourceClass.M1_LARGE
-      | ResourceClass.INTEL_MEDIUM
-    >
-  ];
+  return androidResourceClassToBuildResourceClassMapping[resourceClass as AndroidResourceClass];
 }
 
 async function resolveIosResourceClassAsync(
@@ -106,7 +104,7 @@ async function resolveIosDefaultRequestedResourceClassAsync(
     (sdkVersion && semver.satisfies(sdkVersion, '>=48')) ||
     (reactNativeVersion && semver.satisfies(reactNativeVersion, '>=0.71.0'))
   ) {
-    return ResourceClass.M1_MEDIUM;
+    return ResourceClass.M_MEDIUM;
   } else {
     return ResourceClass.DEFAULT;
   }

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -91,6 +91,10 @@ async function resolveIosResourceClassAsync(
     Log.warn(`Resource class ${chalk.bold('m1-experimental')} is deprecated.`);
   }
 
+  if (resourceClass === ResourceClass.M1_MEDIUM) {
+    Log.warn(`Resource class ${chalk.bold('m1-medium')} is deprecated.`);
+  }
+
   return iosResourceClassToBuildResourceClassMapping[resourceClass];
 }
 

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -88,11 +88,19 @@ async function resolveIosResourceClassAsync(
     selectedResourceClass ?? (await resolveIosDefaultRequestedResourceClassAsync(exp, projectDir));
 
   if (resourceClass === ResourceClass.M1_EXPERIMENTAL) {
-    Log.warn(`Resource class ${chalk.bold('m1-experimental')} is deprecated.`);
+    Log.warn(
+      `Resource class ${chalk.bold('m1-experimental')} is deprecated. Use ${chalk.bold(
+        'm-medium'
+      )} instead.`
+    );
   }
 
   if (resourceClass === ResourceClass.M1_MEDIUM) {
-    Log.warn(`Resource class ${chalk.bold('m1-medium')} is deprecated.`);
+    Log.warn(
+      `Resource class ${chalk.bold('m1-medium')} is deprecated. Use ${chalk.bold(
+        'm-medium'
+      )} instead.`
+    );
   }
 
   return iosResourceClassToBuildResourceClassMapping[resourceClass];

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -23,7 +23,7 @@ const iosResourceClassToBuildResourceClassMapping: Record<ResourceClass, BuildRe
   [ResourceClass.LARGE]: BuildResourceClass.IosLarge,
   [ResourceClass.M1_EXPERIMENTAL]: BuildResourceClass.IosMMedium,
   [ResourceClass.M1_MEDIUM]: BuildResourceClass.IosMMedium,
-  [ResourceClass.M1_LARGE]: BuildResourceClass.IosM1Large,
+  [ResourceClass.M1_LARGE]: BuildResourceClass.IosMLarge,
   [ResourceClass.INTEL_MEDIUM]: BuildResourceClass.IosIntelMedium,
   [ResourceClass.MEDIUM]: BuildResourceClass.IosMedium,
   [ResourceClass.M_MEDIUM]: BuildResourceClass.IosMMedium,
@@ -87,18 +87,18 @@ async function resolveIosResourceClassAsync(
   const resourceClass =
     selectedResourceClass ?? (await resolveIosDefaultRequestedResourceClassAsync(exp, projectDir));
 
-  if (resourceClass === ResourceClass.M1_EXPERIMENTAL) {
+  if ([ResourceClass.M1_EXPERIMENTAL, ResourceClass.M1_MEDIUM].includes(resourceClass)) {
     Log.warn(
-      `Resource class ${chalk.bold('m1-experimental')} is deprecated. Use ${chalk.bold(
+      `Resource class ${chalk.bold(resourceClass)} is deprecated. Use ${chalk.bold(
         'm-medium'
       )} instead.`
     );
   }
 
-  if (resourceClass === ResourceClass.M1_MEDIUM) {
+  if (resourceClass === ResourceClass.M1_LARGE) {
     Log.warn(
-      `Resource class ${chalk.bold('m1-medium')} is deprecated. Use ${chalk.bold(
-        'm-medium'
+      `Resource class ${chalk.bold('m1-large')} is deprecated. Use ${chalk.bold(
+        'm-large'
       )} instead.`
     );
   }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -115,6 +115,8 @@ export type Account = {
   offers?: Maybe<Array<Offer>>;
   /** Owning User of this account if personal account */
   owner?: Maybe<User>;
+  /** Owning UserActor of this account if personal account */
+  ownerUserActor?: Maybe<UserActor>;
   pushSecurityEnabled: Scalars['Boolean'];
   /** @deprecated Legacy access tokens are deprecated */
   requiresAccessTokenForPushSecurity: Scalars['Boolean'];
@@ -133,7 +135,10 @@ export type Account = {
   updatedAt: Scalars['DateTime'];
   /** Account query object for querying EAS usage metrics */
   usageMetrics: AccountUsageMetrics;
-  /** Owning UserActor of this account if personal account */
+  /**
+   * Owning UserActor of this account if personal account
+   * @deprecated Deprecated in favor of ownerUserActor
+   */
   userActorOwner?: Maybe<UserActor>;
   /** Pending user invitations for this account */
   userInvitations: Array<UserInvitation>;
@@ -940,6 +945,7 @@ export type App = Project & {
   /** ios.appStoreUrl field from most recent classic update manifest */
   appStoreUrl?: Maybe<Scalars['String']>;
   assetLimitPerUpdateGroup: Scalars['Int'];
+  branchesPaginated: AppBranchesConnection;
   buildJobs: Array<BuildJob>;
   /**
    * Coalesced Build (EAS) or BuildJob (Classic) items for this app.
@@ -1023,6 +1029,7 @@ export type App = Project & {
   updated: Scalars['DateTime'];
   /** EAS updates owned by an app */
   updates: Array<Update>;
+  updatesPaginated: AppUpdatesConnection;
   /** @deprecated Use ownerAccount.name instead */
   username: Scalars['String'];
   /** @deprecated No longer supported */
@@ -1046,6 +1053,15 @@ export type AppActivityTimelineProjectActivitiesArgs = {
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppAndroidAppCredentialsArgs = {
   filter?: InputMaybe<AndroidAppCredentialsFilter>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppBranchesPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -1183,8 +1199,29 @@ export type AppUpdatesArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
+export type AppUpdatesPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWebhooksArgs = {
   filter?: InputMaybe<WebhookFilter>;
+};
+
+export type AppBranchEdge = {
+  __typename?: 'AppBranchEdge';
+  cursor: Scalars['String'];
+  node: UpdateBranch;
+};
+
+export type AppBranchesConnection = {
+  __typename?: 'AppBranchesConnection';
+  edges: Array<AppBranchEdge>;
+  pageInfo: PageInfo;
 };
 
 export type AppDataInput = {
@@ -1375,6 +1412,18 @@ export enum AppStoreConnectUserRole {
   Technical = 'TECHNICAL',
   Unknown = 'UNKNOWN'
 }
+
+export type AppUpdateEdge = {
+  __typename?: 'AppUpdateEdge';
+  cursor: Scalars['String'];
+  node: Update;
+};
+
+export type AppUpdatesConnection = {
+  __typename?: 'AppUpdatesConnection';
+  edges: Array<AppUpdateEdge>;
+  pageInfo: PageInfo;
+};
 
 /** Represents Play Store/App Store version of an application */
 export type AppVersion = {
@@ -1796,7 +1845,10 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   __typename?: 'Build';
   activityTimestamp: Scalars['DateTime'];
   actor?: Maybe<Actor>;
-  /** The actual resource class of the builder assigned to the build job */
+  /**
+   * The actual resource class of the builder assigned to the build job
+   * @deprecated Use resourceClassDisplayName instead
+   */
   actualResourceClass?: Maybe<BuildResourceClass>;
   appBuildVersion?: Maybe<Scalars['String']>;
   appVersion?: Maybe<Scalars['String']>;
@@ -1839,8 +1891,13 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   queuePosition?: Maybe<Scalars['Int']>;
   reactNativeVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
-  /** The builder resource class requested by the developer */
+  /**
+   * The builder resource class requested by the developer
+   * @deprecated Use resourceClassDisplayName instead
+   */
   resourceClass: BuildResourceClass;
+  /** String describing the resource class used to run the build */
+  resourceClassDisplayName: Scalars['String'];
   runFromCI?: Maybe<Scalars['Boolean']>;
   runtimeVersion?: Maybe<Scalars['String']>;
   sdkVersion?: Maybe<Scalars['String']>;
@@ -2197,14 +2254,18 @@ export enum BuildResourceClass {
   AndroidLarge = 'ANDROID_LARGE',
   AndroidMedium = 'ANDROID_MEDIUM',
   IosDefault = 'IOS_DEFAULT',
+  /** @deprecated Use IOS_INTEL_MEDIUM instead */
   IosIntelLarge = 'IOS_INTEL_LARGE',
   IosIntelMedium = 'IOS_INTEL_MEDIUM',
   IosLarge = 'IOS_LARGE',
+  /** @deprecated Use IOS_M_MEDIUM instead */
   IosM1Large = 'IOS_M1_LARGE',
   IosM1Medium = 'IOS_M1_MEDIUM',
   IosM2Medium = 'IOS_M2_MEDIUM',
   IosM2ProMedium = 'IOS_M2_PRO_MEDIUM',
   IosMedium = 'IOS_MEDIUM',
+  IosMLarge = 'IOS_M_LARGE',
+  IosMMedium = 'IOS_M_MEDIUM',
   Legacy = 'LEGACY'
 }
 
@@ -2340,7 +2401,7 @@ export type CreateGitHubRepositoryInput = {
 
 export type CreateGitHubRepositorySettingsInput = {
   appId: Scalars['ID'];
-  /** The base directory is the directory to change to before starting a build. This string should be a properly formatted Unix path starting with '/', './', or the name of the directory relative to the root of the repository. Valid examples include: '/apps/expo-app', './apps/expo-app', and 'apps/expo-app'. This is intended for monorepos or apps that live in a subdirectory of a repository. */
+  /** The base directory is the directory to change to before starting a build. This string should be a properly formatted POSIX path starting with '/', './', or the name of the directory relative to the root of the repository. Valid examples include: '/apps/expo-app', './apps/expo-app', and 'apps/expo-app'. This is intended for monorepos or apps that live in a subdirectory of a repository. */
   baseDirectory: Scalars['String'];
 };
 
@@ -4597,6 +4658,8 @@ export type User = Actor & UserActor & {
   id: Scalars['ID'];
   industry?: Maybe<Scalars['String']>;
   isExpoAdmin: Scalars['Boolean'];
+  /** @deprecated This field no longer exists */
+  isLegacy: Scalars['Boolean'];
   isSecondFactorAuthenticationEnabled: Scalars['Boolean'];
   lastName?: Maybe<Scalars['String']>;
   location?: Maybe<Scalars['String']>;
@@ -4869,6 +4932,7 @@ export type UserPermission = {
   role?: Maybe<Role>;
   /** @deprecated User type is deprecated */
   user?: Maybe<User>;
+  userActor?: Maybe<UserActor>;
 };
 
 export type UserQuery = {

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -354,7 +354,7 @@
           "default": "default",
           "anyOf": [
             {
-              "enum": ["default", "medium", "m1-medium", "intel-medium"]
+              "enum": ["default", "medium", "intel-medium", "m-medium"]
             },
             {
               "type": "string"

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -14,6 +14,8 @@ const AllowedIosResourceClasses: ResourceClass[] = [
   ...AllowedCommonResourceClasses,
   ResourceClass.M1_MEDIUM,
   ResourceClass.INTEL_MEDIUM,
+  ResourceClass.M_MEDIUM,
+  ResourceClass.M_LARGE,
 ];
 
 const CacheSchema = Joi.object({

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -16,6 +16,9 @@ export enum ResourceClass {
    * @deprecated use M_MEDIUM instead
    */
   M1_MEDIUM = 'm1-medium',
+  /**
+   * @deprecated use M_LARGE instead
+   */
   M1_LARGE = 'm1-large',
   INTEL_MEDIUM = 'intel-medium',
   MEDIUM = 'medium',

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -9,15 +9,18 @@ export enum ResourceClass {
   DEFAULT = 'default',
   LARGE = 'large',
   /**
-   * @deprecated use M1_MEDIUM instead
-   * @experimental
-   * This resource class is not yet ready to be used in production. For testing purposes only. Might be deprecated / deleted at any time.
+   * @deprecated use M_MEDIUM instead
    */
   M1_EXPERIMENTAL = 'm1-experimental',
+  /**
+   * @deprecated use M_MEDIUM instead
+   */
   M1_MEDIUM = 'm1-medium',
   M1_LARGE = 'm1-large',
   INTEL_MEDIUM = 'intel-medium',
   MEDIUM = 'medium',
+  M_MEDIUM = 'm-medium',
+  M_LARGE = 'm-large',
 }
 
 export type DistributionType = 'store' | 'internal';


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7709/create-m-large-and-m-medium-resource-classes

# How

Add new `m-medium` and `m-large` resource classes.

Make `m1-medium` and `m1-experimental` point to `m-medium` on the server side.

Don't suggest `m1-medium` in the `eas.json` schema to users. Suggest `m-medium` instead.

I'm not adding `m-large` to `eas.schema.json`, because it's hidden behind the feature gate and it isn't publicly available.

# Test Plan

Run builds locally
