### PR TITLE
[eas-cli] [ENG-6945] Don't use capitalised base error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Unify how the command errors are displayed. ([#1738](https://github.com/expo/eas-cli/pull/1738) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+- Unify the case of base error messages for command failures. ([#1744](https://github.com/expo/eas-cli/pull/1744) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 
 ## [3.8.0](https://github.com/expo/eas-cli/releases/tag/v3.8.0) - 2023-03-13
 

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -186,7 +186,8 @@ export default abstract class EasCommand extends Command {
   }
 
   protected override catch(err: Error): Promise<any> {
-    let baseMessage = this.baseErrorMessage ?? `${this.id} command failed.`;
+    const commandId = (this.id as string).charAt(0).toUpperCase() + (this.id as string).slice(1);
+    let baseMessage = this.baseErrorMessage ?? `${commandId} command failed.`;
     if (err instanceof EasCommandError) {
       Log.error(err.message);
     } else if (err instanceof CombinedError && err?.graphQLErrors) {

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -120,8 +120,6 @@ export default abstract class EasCommand extends Command {
    */
   private analyticsInternal?: AnalyticsWithOrchestration;
 
-  protected baseErrorMessage?: string;
-
   /**
    * Execute the context in the contextDefinition to satisfy command prerequisites.
    */
@@ -186,8 +184,8 @@ export default abstract class EasCommand extends Command {
   }
 
   protected override catch(err: Error): Promise<any> {
-    const commandId = (this.id as string).charAt(0).toUpperCase() + (this.id as string).slice(1);
-    let baseMessage = this.baseErrorMessage ?? `${commandId} command failed.`;
+    const commandId = (this.id as string).charAt(0).toLowerCase() + (this.id as string).slice(1);
+    let baseMessage = `${commandId} command failed.`;
     if (err instanceof EasCommandError) {
       Log.error(err.message);
     } else if (err instanceof CombinedError && err?.graphQLErrors) {

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -184,8 +184,7 @@ export default abstract class EasCommand extends Command {
   }
 
   protected override catch(err: Error): Promise<any> {
-    const commandId = (this.id as string).charAt(0).toLowerCase() + (this.id as string).slice(1);
-    let baseMessage = `${commandId} command failed.`;
+    let baseMessage = `${this.id} command failed.`;
     if (err instanceof EasCommandError) {
       Log.error(err.message);
     } else if (err instanceof CombinedError && err?.graphQLErrors) {

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -39,13 +39,12 @@ beforeEach(() => {
   jest.mocked(createAnalyticsAsync).mockResolvedValue(analytics);
 });
 
-const createTestEasCommand = (baseErrorMessage?: string): typeof EasCommand => {
+const createTestEasCommand = (): typeof EasCommand => {
   class TestEasCommand extends EasCommand {
     async runAsync(): Promise<void> {}
-    protected override baseErrorMessage = baseErrorMessage;
   }
 
-  TestEasCommand.id = 'TestEasCommand'; // normally oclif will assign ids, but b/c this is located outside the commands folder it will not
+  TestEasCommand.id = 'testEasCommand'; // normally oclif will assign ids, but b/c this is located outside the commands folder it will not
   return TestEasCommand;
 };
 
@@ -138,21 +137,7 @@ describe(EasCommand.name, () => {
         expect(logDebugSpy).toBeCalledWith(error);
       });
 
-      it('re-throws the error with new message if provided', async () => {
-        const TestEasCommand = createTestEasCommand('New base error message');
-        const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
-        runAsyncMock.mockImplementation(() => {
-          throw new Error('Error message');
-        });
-        try {
-          await TestEasCommand.run();
-        } catch (caughtError) {
-          expect(caughtError).toBeInstanceOf(Error);
-          expect((caughtError as Error).message).toEqual('New base error message');
-        }
-      });
-
-      it('re-throws the error with default base message if new one not provided', async () => {
+      it('re-throws the error with default base message', async () => {
         const TestEasCommand = createTestEasCommand();
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
         runAsyncMock.mockImplementation(() => {
@@ -162,13 +147,13 @@ describe(EasCommand.name, () => {
           await TestEasCommand.run();
         } catch (caughtError) {
           expect(caughtError).toBeInstanceOf(Error);
-          expect((caughtError as Error).message).toEqual('TestEasCommand command failed.');
+          expect((caughtError as Error).message).toEqual('testEasCommand command failed.');
         }
       });
 
-      it('re-throws the error with default base message if new one not provided - command id is capitalized if needed', async () => {
+      it('re-throws the error with default base message, command id is decapitalized if needed', async () => {
         const TestEasCommand = createTestEasCommand();
-        TestEasCommand.id = 'testEasCommand';
+        TestEasCommand.id = 'TestEasCommand';
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
         runAsyncMock.mockImplementation(() => {
           throw new Error('Error message');
@@ -177,7 +162,7 @@ describe(EasCommand.name, () => {
           await TestEasCommand.run();
         } catch (caughtError) {
           expect(caughtError).toBeInstanceOf(Error);
-          expect((caughtError as Error).message).toEqual('TestEasCommand command failed.');
+          expect((caughtError as Error).message).toEqual('testEasCommand command failed.');
         }
       });
 

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -166,6 +166,21 @@ describe(EasCommand.name, () => {
         }
       });
 
+      it('re-throws the error with default base message if new one not provided - command id is capitalized if needed', async () => {
+        const TestEasCommand = createTestEasCommand();
+        TestEasCommand.id = 'testEasCommand';
+        const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
+        runAsyncMock.mockImplementation(() => {
+          throw new Error('Error message');
+        });
+        try {
+          await TestEasCommand.run();
+        } catch (caughtError) {
+          expect(caughtError).toBeInstanceOf(Error);
+          expect((caughtError as Error).message).toEqual('TestEasCommand command failed.');
+        }
+      });
+
       it('re-throws the error with a different default base message in case of graphQLError', async () => {
         const TestEasCommand = createTestEasCommand();
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -151,21 +151,6 @@ describe(EasCommand.name, () => {
         }
       });
 
-      it('re-throws the error with default base message, command id is decapitalized if needed', async () => {
-        const TestEasCommand = createTestEasCommand();
-        TestEasCommand.id = 'TestEasCommand';
-        const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');
-        runAsyncMock.mockImplementation(() => {
-          throw new Error('Error message');
-        });
-        try {
-          await TestEasCommand.run();
-        } catch (caughtError) {
-          expect(caughtError).toBeInstanceOf(Error);
-          expect((caughtError as Error).message).toEqual('testEasCommand command failed.');
-        }
-      });
-
       it('re-throws the error with a different default base message in case of graphQLError', async () => {
         const TestEasCommand = createTestEasCommand();
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype as any, 'runAsync');

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -37,7 +37,6 @@ interface RawBuildFlags {
 
 export default class Build extends EasCommand {
   static override description = 'start a build';
-  override baseErrorMessage = 'Build command failed.';
 
   static override flags = {
     platform: Flags.enum({


### PR DESCRIPTION
Removed the option to provide custom base error message, so that it always be lower case for command failures

See: https://linear.app/expo/issue/ENG-6945/improve-eas-cli-error-logging

<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

To unify the behaviour the base error message is no longer customisable and always has lower case command id for command failures

# How

Lower case command id is always used for command failures

# Test Plan

Updated the automatic tests
