### PR TITLE
[eas-cli] Add test case to ensure public config is used as update

### DIFF
--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -211,7 +211,7 @@ export default class UpdatePublish extends EasCommand {
       projectId,
     });
 
-    const { exp } = await getDynamicProjectConfigAsync({});
+    const { exp } = await getDynamicProjectConfigAsync({ isPublicConfig: true });
     const codeSigningInfo = await getCodeSigningInfoAsync(expPrivate, privateKeyPath);
 
     let realizedPlatforms: PublishPlatform[] = [];


### PR DESCRIPTION
# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Make sure we are only using the public config when creating updates.

# How

Added test case.

# Test Plan

- See tests
- `$ yarn create expo-app ./test-update && cd ./test-update`
- `$ eas update --auto`
- _Make sure this works as expected_
- Modify the `app.json` to create code-signed updates
- `$ eas update --auto`
- _Make sure code signing works as expected_