### PR TITLE
[eas-cli] Add support for roll back to embedded updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add support for roll back to embedded updates. ([#1754](https://github.com/expo/eas-cli/pull/1754) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -2986,6 +2986,49 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AccountUsageEASBuildMetadata",
+        "description": null,
+        "fields": [
+          {
+            "name": "platform",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "AccountUsageMetadata",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "AccountUsageEASBuildMetadata",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
         "name": "AccountUsageMetric",
         "description": null,
         "fields": [
@@ -3047,129 +3090,6 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "value",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AccountUsageMetricAndCost",
-        "description": null,
-        "fields": [
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "limit",
-            "description": "The limit, in units, allowed by this plan",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "metricType",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "UsageMetricType",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "service",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "EASService",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "serviceMetric",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "EASServiceMetric",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "totalCost",
-            "description": "Total cost of this particular metric, in cents",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -6865,6 +6785,83 @@
             "deprecationReason": null
           },
           {
+            "name": "buildsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppBuildsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildsReleaseChannels",
             "description": "Classic update release channel names that have at least one build",
             "args": [],
@@ -6883,6 +6880,71 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "channelsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppChannelsConnection",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -7689,6 +7751,71 @@
             "deprecationReason": null
           },
           {
+            "name": "submissionsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppSubmissionsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "timelineActivity",
             "description": "Coalesced project activity for an app using pagination",
             "args": [
@@ -8313,6 +8440,194 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "AppBranchEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppBuildEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "BuildOrBuildJob",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppBuildsConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppBuildEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppChannelEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UpdateChannel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppChannelsConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppChannelEdge",
                     "ofType": null
                   }
                 }
@@ -9653,6 +9968,100 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppSubmissionEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Submission",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppSubmissionsConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppSubmissionEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -12681,18 +13090,6 @@
             "deprecationReason": null
           },
           {
-            "name": "actualResourceClass",
-            "description": "The actual resource class of the builder assigned to the build job",
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "BuildResourceClass",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Use resourceClassDisplayName instead"
-          },
-          {
             "name": "appBuildVersion",
             "description": null,
             "args": [],
@@ -13729,6 +14126,61 @@
             "type": {
               "kind": "ENUM",
               "name": "BuildStatus",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BuildFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "channel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppPlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -15185,6 +15637,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "reactNativeVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "resourceClass",
             "description": null,
             "type": {
@@ -15195,6 +15659,18 @@
                 "name": "BuildResourceClass",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sdkVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -15668,18 +16144,6 @@
           },
           {
             "name": "IOS_M1_MEDIUM",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "IOS_M2_MEDIUM",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "IOS_M2_PRO_MEDIUM",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -17120,6 +17584,33 @@
       },
       {
         "kind": "OBJECT",
+        "name": "DeleteDiscordUserResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "DeleteEnvironmentSecretResult",
         "description": null,
         "fields": [
@@ -17688,6 +18179,180 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DiscordUser",
+        "description": null,
+        "fields": [
+          {
+            "name": "discordIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "DiscordUserMetadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userActor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "UserActor",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DiscordUserMetadata",
+        "description": null,
+        "fields": [
+          {
+            "name": "discordAvatarUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discordDiscriminator",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discordUsername",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DiscordUserMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "deleteDiscordUser",
+            "description": "Delete a Discord User by ID",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteDiscordUserResult",
                 "ofType": null
               }
             },
@@ -18333,6 +18998,248 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EstimatedOverageAndCost",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limit",
+            "description": "The limit, in units, allowed by this plan",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "AccountUsageMetadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "UsageMetricType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "service",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASService",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "serviceMetric",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASServiceMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCost",
+            "description": "Total cost of this particular metric, in cents",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EstimatedUsage",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "UsageMetricType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "service",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASService",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "serviceMetric",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASServiceMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -19351,6 +20258,18 @@
                 "name": "Int",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubRepositoryUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -25175,6 +26094,18 @@
             "deprecationReason": null
           },
           {
+            "name": "rollBackToEmbeddedInfoGroup",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UpdateRollBackToEmbeddedGroup",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "runtimeVersion",
             "description": null,
             "type": {
@@ -25194,13 +26125,9 @@
             "name": "updateInfoGroup",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "UpdateInfoGroup",
-                "ofType": null
-              }
+              "kind": "INPUT_OBJECT",
+              "name": "UpdateInfoGroup",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -26037,6 +26964,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "BuildJobMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discordUser",
+            "description": "Mutations for Discord users",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DiscordUserMutation",
                 "ofType": null
               }
             },
@@ -30618,6 +31561,22 @@
             "deprecationReason": null
           },
           {
+            "name": "isRollBackToEmbedded",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "manifestFragment",
             "description": null,
             "args": [],
@@ -31636,6 +32595,53 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "UpdateRollBackToEmbeddedGroup",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "android",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ios",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "web",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "UpdatesFilter",
         "description": null,
         "fields": null,
@@ -31808,7 +32814,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "AccountUsageMetricAndCost",
+                    "name": "EstimatedOverageAndCost",
                     "ofType": null
                   }
                 }
@@ -31832,7 +32838,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "AccountUsageMetricAndCost",
+                    "name": "EstimatedUsage",
                     "ofType": null
                   }
                 }
@@ -32229,6 +33235,18 @@
                 "name": "DateTime",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discordUser",
+            "description": "Discord account linked to a user",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "DiscordUser",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -92,7 +92,7 @@ describe(UpdatePublish.name, () => {
     mockTestProject();
 
     await expect(new UpdatePublish(flags, commandOptions).run()).rejects.toThrow(
-      'Cannot specify both --channel and --branch. Specify either --channel, --branch, or --auto'
+      'Cannot specify both --channel and --branch. Specify either --channel, --branch, or --auto.'
     );
   });
 

--- a/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
@@ -27,6 +27,7 @@ const updateStub: UpdateFragment = {
   platform: 'ios',
   gitCommitHash: 'commit',
   manifestFragment: JSON.stringify({ fake: 'manifest' }),
+  isRollBackToEmbedded: false,
   manifestPermalink: 'https://expo.dev/fake/manifest/link',
   codeSigningInfo: null,
   createdAt: '2022-01-01T12:00:00Z',

--- a/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
@@ -73,7 +73,7 @@ describe(UpdateRollBackToEmbedded.name, () => {
     mockTestProject();
 
     await expect(new UpdateRollBackToEmbedded(flags, commandOptions).run()).rejects.toThrow(
-      'Cannot specify both --channel and --branch. Specify either --channel, --branch, or --auto'
+      'Cannot specify both --channel and --branch. Specify either --channel, --branch, or --auto.'
     );
   });
 

--- a/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
@@ -3,7 +3,6 @@ import {
   ExpoConfig,
   GetConfigOptions,
   PackageJSONConfig,
-  Platform,
   getConfig,
 } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
@@ -12,7 +11,6 @@ import nullthrows from 'nullthrows';
 import path from 'path';
 import { instance, mock } from 'ts-mockito';
 
-import UpdatePublish from '..';
 import { ensureBranchExistsAsync } from '../../../branch/queries';
 import { DynamicProjectConfigContextField } from '../../../commandUtils/context/DynamicProjectConfigContextField';
 import LoggedInContextField from '../../../commandUtils/context/LoggedInContextField';
@@ -23,8 +21,8 @@ import { jester } from '../../../credentials/__tests__/fixtures-constants';
 import { UpdateFragment } from '../../../graphql/generated';
 import { PublishMutation } from '../../../graphql/mutations/PublishMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
-import { collectAssetsAsync, uploadAssetsAsync } from '../../../project/publish';
 import { getBranchNameFromChannelNameAsync } from '../../../update/getBranchNameFromChannelNameAsync';
+import UpdateRollBackToEmbedded from '../roll-back-to-embedded';
 
 const projectRoot = '/test-project';
 const commandOptions = { root: projectRoot } as any;
@@ -66,41 +64,26 @@ jest.mock('../../../project/publish', () => ({
   uploadAssetsAsync: jest.fn(),
 }));
 
-describe(UpdatePublish.name, () => {
-  afterEach(() => {
-    vol.reset();
-    jest.mocked(PublishMutation.publishUpdateGroupAsync).mockClear();
-  });
-
-  // Deprecated and split to a new command: update:republish
-  it('errors with --republish', async () => {
-    await expect(new UpdatePublish(['--republish'], commandOptions).run()).rejects.toThrow(
-      '--group and --republish flags are deprecated'
-    );
-  });
-
-  // Deprecated and split to a new command: update:republish
-  it('errors with --group', async () => {
-    await expect(new UpdatePublish(['--group=abc123'], commandOptions).run()).rejects.toThrow(
-      '--group and --republish flags are deprecated'
-    );
-  });
+describe(UpdateRollBackToEmbedded.name, () => {
+  afterEach(() => vol.reset());
 
   it('errors with both --channel and --branch', async () => {
     const flags = ['--channel=channel123', '--branch=branch123'];
 
     mockTestProject();
 
-    await expect(new UpdatePublish(flags, commandOptions).run()).rejects.toThrow(
+    await expect(new UpdateRollBackToEmbedded(flags, commandOptions).run()).rejects.toThrow(
       'Cannot specify both --channel and --branch. Specify either --channel, --branch, or --auto'
     );
   });
 
-  it('creates a new update with --non-interactive, --branch, and --message', async () => {
+  it('creates a roll back to embedded with --non-interactive, --branch, and --message', async () => {
     const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
 
     mockTestProject();
-    const { platforms, runtimeVersion } = mockTestExport();
+    const platforms = ['android', 'ios'];
+    const runtimeVersion = 'exposdk:47.0.0';
+    jest.mocked(Updates.getRuntimeVersion).mockReturnValue(runtimeVersion);
 
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
       branchId: 'branch123',
@@ -111,16 +94,18 @@ describe(UpdatePublish.name, () => {
       .mocked(PublishMutation.publishUpdateGroupAsync)
       .mockResolvedValue(platforms.map(platform => ({ ...updateStub, platform, runtimeVersion })));
 
-    await new UpdatePublish(flags, commandOptions).run();
+    await new UpdateRollBackToEmbedded(flags, commandOptions).run();
 
     expect(PublishMutation.publishUpdateGroupAsync).toHaveBeenCalled();
   });
 
-  it('creates a new update with --non-interactive, --channel, and --message', async () => {
+  it('creates a roll back to embedded with --non-interactive, --channel, and --message', async () => {
     const flags = ['--non-interactive', '--channel=channel123', '--message=abc'];
 
     const { projectId } = mockTestProject();
-    const { platforms, runtimeVersion } = mockTestExport();
+    const platforms = ['android', 'ios'];
+    const runtimeVersion = 'exposdk:47.0.0';
+    jest.mocked(Updates.getRuntimeVersion).mockReturnValue(runtimeVersion);
 
     jest.mocked(getBranchNameFromChannelNameAsync).mockResolvedValue('branchFromChannel');
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
@@ -136,7 +121,7 @@ describe(UpdatePublish.name, () => {
       }))
     );
 
-    await new UpdatePublish(flags, commandOptions).run();
+    await new UpdateRollBackToEmbedded(flags, commandOptions).run();
 
     expect(ensureBranchExistsAsync).toHaveBeenCalledWith(
       expect.any(Object), // graphql client
@@ -149,11 +134,11 @@ describe(UpdatePublish.name, () => {
     expect(PublishMutation.publishUpdateGroupAsync).toHaveBeenCalled();
   });
 
-  it('creates a new update with the public expo config', async () => {
+  it('creates a roll back to embedded with the public expo config', async () => {
     const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
 
     // Add configuration to the project that should not be included in the update
-    const { appJson } = mockTestProject({
+    mockTestProject({
       expoConfig: {
         hooks: {
           postPublish: [
@@ -166,7 +151,9 @@ describe(UpdatePublish.name, () => {
       },
     });
 
-    const { platforms, runtimeVersion } = mockTestExport({ platforms: ['ios'] });
+    const platforms = ['ios'];
+    const runtimeVersion = 'exposdk:47.0.0';
+    jest.mocked(Updates.getRuntimeVersion).mockReturnValue(runtimeVersion);
 
     // Mock an existing branch, so we don't create a new one
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
@@ -178,22 +165,15 @@ describe(UpdatePublish.name, () => {
       .mocked(PublishMutation.publishUpdateGroupAsync)
       .mockResolvedValue(platforms.map(platform => ({ ...updateStub, platform, runtimeVersion })));
 
-    await new UpdatePublish(flags, commandOptions).run();
+    await new UpdateRollBackToEmbedded(flags, commandOptions).run();
 
     // Pull the publish data from the mocked publish function
     const publishData = jest.mocked(PublishMutation.publishUpdateGroupAsync).mock.calls[0][1][0];
-    // Pull the Expo config from the publish data
-    const expoConfig = nullthrows(publishData.updateInfoGroup).ios!.extra.expoClient;
-
-    // Ensure the basic properties are present
-    expect(expoConfig).toHaveProperty('name', appJson.expo.name);
-    expect(expoConfig).toHaveProperty('slug', appJson.expo.slug);
-    // Ensure non-public config is not present
-    expect(expoConfig).not.toHaveProperty('hooks');
+    expect(nullthrows(publishData.rollBackToEmbeddedInfoGroup).ios).toBe(true);
   });
 });
 
-/** Create a new in-memory project, copied from src/commands/update/__tests__/republish.test.ts */
+/** Create a new in-memory project, based on src/commands/project/__tests__/init.test.ts */
 function mockTestProject({
   configuredProjectId = '1234',
   expoConfig = {},
@@ -274,57 +254,4 @@ function mockTestProject({
   });
 
   return { projectId: configuredProjectId, appJson: appJSON };
-}
-
-/** Create a new in-memory export of the project */
-function mockTestExport({
-  exportDir = 'dist',
-  platforms = ['android', 'ios'],
-  runtimeVersion = 'exposdk:47.0.0',
-}: {
-  exportDir?: string;
-  platforms?: Platform[];
-  runtimeVersion?: string;
-} = {}): {
-  inputDir: string;
-  platforms: Platform[];
-  runtimeVersion: string;
-} {
-  /* eslint-disable node/no-sync */
-  vol.mkdirpSync(path.join(projectRoot, exportDir, 'bundles'));
-  for (const platform of platforms) {
-    vol.writeFileSync(
-      path.join(projectRoot, exportDir, 'bundles', `${platform}-fake.js`),
-      `console.log("fake bundle for ${platform}");`
-    );
-  }
-
-  jest.mocked(collectAssetsAsync).mockResolvedValue(
-    Object.fromEntries(
-      platforms.map(platform => [
-        platform,
-        {
-          assets: [],
-          launchAsset: {
-            contentType: 'application/javascript',
-            path: path.join(projectRoot, exportDir, 'bundles', `${platform}-fake.js`),
-          },
-        },
-      ])
-    )
-  );
-
-  jest.mocked(uploadAssetsAsync).mockResolvedValue({
-    // platforms are mocked all containing only the launch asset
-    assetCount: platforms.length,
-    uniqueAssetCount: platforms.length,
-    uniqueUploadedAssetCount: platforms.length,
-    assetLimitPerUpdateGroup: 9001,
-    launchAssetCount: 2,
-    uniqueUploadedAssetPaths: [],
-  });
-
-  jest.mocked(Updates.getRuntimeVersion).mockReturnValue(runtimeVersion);
-
-  return { inputDir: exportDir, platforms, runtimeVersion };
 }

--- a/packages/eas-cli/src/commands/update/republish.ts
+++ b/packages/eas-cli/src/commands/update/republish.ts
@@ -56,7 +56,7 @@ type UpdateToRepublish = {
 >;
 
 export default class UpdateRepublish extends EasCommand {
-  static override description = 'rollback to an existing update';
+  static override description = 'roll back to an existing update';
 
   static override flags = {
     channel: Flags.string({

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -500,25 +500,19 @@ export type AccountSsoConfigurationPublicDataQueryPublicDataByAccountNameArgs = 
   accountName: Scalars['String'];
 };
 
+export type AccountUsageEasBuildMetadata = {
+  __typename?: 'AccountUsageEASBuildMetadata';
+  platform: AppPlatform;
+};
+
+export type AccountUsageMetadata = AccountUsageEasBuildMetadata;
+
 export type AccountUsageMetric = {
   __typename?: 'AccountUsageMetric';
   id: Scalars['ID'];
   metricType: UsageMetricType;
   serviceMetric: EasServiceMetric;
   timestamp: Scalars['DateTime'];
-  value: Scalars['Float'];
-};
-
-export type AccountUsageMetricAndCost = {
-  __typename?: 'AccountUsageMetricAndCost';
-  id: Scalars['ID'];
-  /** The limit, in units, allowed by this plan */
-  limit: Scalars['Float'];
-  metricType: UsageMetricType;
-  service: EasService;
-  serviceMetric: EasServiceMetric;
-  /** Total cost of this particular metric, in cents */
-  totalCost: Scalars['Float'];
   value: Scalars['Float'];
 };
 
@@ -954,8 +948,10 @@ export type App = Project & {
   buildOrBuildJobs: Array<BuildOrBuildJob>;
   /** (EAS Build) Builds associated with this app */
   builds: Array<Build>;
+  buildsPaginated: AppBuildsConnection;
   /** Classic update release channel names that have at least one build */
   buildsReleaseChannels: Array<Scalars['String']>;
+  channelsPaginated: AppChannelsConnection;
   deployment?: Maybe<Deployment>;
   /** Deployments associated with this app */
   deployments: DeploymentsConnection;
@@ -1011,6 +1007,7 @@ export type App = Project & {
   slug: Scalars['String'];
   /** EAS Submissions associated with this app */
   submissions: Array<Submission>;
+  submissionsPaginated: AppSubmissionsConnection;
   /** Coalesced project activity for an app using pagination */
   timelineActivity: TimelineActivityConnection;
   /** @deprecated 'likes' have been deprecated. */
@@ -1091,6 +1088,25 @@ export type AppBuildsArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
+export type AppBuildsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<BuildFilterInput>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppChannelsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
 export type AppDeploymentArgs = {
   channel: Scalars['String'];
   runtimeVersion: Scalars['String'];
@@ -1144,6 +1160,15 @@ export type AppSubmissionsArgs = {
   filter: SubmissionFilter;
   limit: Scalars['Int'];
   offset: Scalars['Int'];
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppSubmissionsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -1221,6 +1246,30 @@ export type AppBranchEdge = {
 export type AppBranchesConnection = {
   __typename?: 'AppBranchesConnection';
   edges: Array<AppBranchEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AppBuildEdge = {
+  __typename?: 'AppBuildEdge';
+  cursor: Scalars['String'];
+  node: BuildOrBuildJob;
+};
+
+export type AppBuildsConnection = {
+  __typename?: 'AppBuildsConnection';
+  edges: Array<AppBuildEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AppChannelEdge = {
+  __typename?: 'AppChannelEdge';
+  cursor: Scalars['String'];
+  node: UpdateChannel;
+};
+
+export type AppChannelsConnection = {
+  __typename?: 'AppChannelsConnection';
+  edges: Array<AppChannelEdge>;
   pageInfo: PageInfo;
 };
 
@@ -1412,6 +1461,18 @@ export enum AppStoreConnectUserRole {
   Technical = 'TECHNICAL',
   Unknown = 'UNKNOWN'
 }
+
+export type AppSubmissionEdge = {
+  __typename?: 'AppSubmissionEdge';
+  cursor: Scalars['String'];
+  node: Submission;
+};
+
+export type AppSubmissionsConnection = {
+  __typename?: 'AppSubmissionsConnection';
+  edges: Array<AppSubmissionEdge>;
+  pageInfo: PageInfo;
+};
 
 export type AppUpdateEdge = {
   __typename?: 'AppUpdateEdge';
@@ -1845,11 +1906,6 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   __typename?: 'Build';
   activityTimestamp: Scalars['DateTime'];
   actor?: Maybe<Actor>;
-  /**
-   * The actual resource class of the builder assigned to the build job
-   * @deprecated Use resourceClassDisplayName instead
-   */
-  actualResourceClass?: Maybe<BuildResourceClass>;
   appBuildVersion?: Maybe<Scalars['String']>;
   appVersion?: Maybe<Scalars['String']>;
   artifacts?: Maybe<BuildArtifacts>;
@@ -1959,6 +2015,12 @@ export type BuildFilter = {
   runtimeVersion?: InputMaybe<Scalars['String']>;
   sdkVersion?: InputMaybe<Scalars['String']>;
   status?: InputMaybe<BuildStatus>;
+};
+
+export type BuildFilterInput = {
+  channel?: InputMaybe<Scalars['String']>;
+  platforms?: InputMaybe<Array<AppPlatform>>;
+  releaseChannel?: InputMaybe<Scalars['String']>;
 };
 
 export enum BuildIosEnterpriseProvisioning {
@@ -2174,7 +2236,9 @@ export type BuildOrBuildJobQueryByIdArgs = {
 };
 
 export type BuildParamsInput = {
+  reactNativeVersion?: InputMaybe<Scalars['String']>;
   resourceClass: BuildResourceClass;
+  sdkVersion?: InputMaybe<Scalars['String']>;
 };
 
 export enum BuildPriority {
@@ -2261,8 +2325,6 @@ export enum BuildResourceClass {
   /** @deprecated Use IOS_M_MEDIUM instead */
   IosM1Large = 'IOS_M1_LARGE',
   IosM1Medium = 'IOS_M1_MEDIUM',
-  IosM2Medium = 'IOS_M2_MEDIUM',
-  IosM2ProMedium = 'IOS_M2_PRO_MEDIUM',
   IosMedium = 'IOS_MEDIUM',
   IosMLarge = 'IOS_M_LARGE',
   IosMMedium = 'IOS_M_MEDIUM',
@@ -2464,6 +2526,11 @@ export type DeleteAppleProvisioningProfileResult = {
   id: Scalars['ID'];
 };
 
+export type DeleteDiscordUserResult = {
+  __typename?: 'DeleteDiscordUserResult';
+  id: Scalars['ID'];
+};
+
 export type DeleteEnvironmentSecretResult = {
   __typename?: 'DeleteEnvironmentSecretResult';
   id: Scalars['ID'];
@@ -2556,6 +2623,32 @@ export type DeploymentsConnection = {
   __typename?: 'DeploymentsConnection';
   edges: Array<DeploymentEdge>;
   pageInfo: PageInfo;
+};
+
+export type DiscordUser = {
+  __typename?: 'DiscordUser';
+  discordIdentifier: Scalars['String'];
+  id: Scalars['ID'];
+  metadata?: Maybe<DiscordUserMetadata>;
+  userActor: UserActor;
+};
+
+export type DiscordUserMetadata = {
+  __typename?: 'DiscordUserMetadata';
+  discordAvatarUrl: Scalars['String'];
+  discordDiscriminator: Scalars['String'];
+  discordUsername: Scalars['String'];
+};
+
+export type DiscordUserMutation = {
+  __typename?: 'DiscordUserMutation';
+  /** Delete a Discord User by ID */
+  deleteDiscordUser: DeleteDiscordUserResult;
+};
+
+
+export type DiscordUserMutationDeleteDiscordUserArgs = {
+  id: Scalars['ID'];
 };
 
 export enum DistributionType {
@@ -2663,6 +2756,30 @@ export enum EnvironmentSecretType {
   FileBase64 = 'FILE_BASE64',
   String = 'STRING'
 }
+
+export type EstimatedOverageAndCost = {
+  __typename?: 'EstimatedOverageAndCost';
+  id: Scalars['ID'];
+  /** The limit, in units, allowed by this plan */
+  limit: Scalars['Float'];
+  metadata?: Maybe<AccountUsageMetadata>;
+  metricType: UsageMetricType;
+  service: EasService;
+  serviceMetric: EasServiceMetric;
+  /** Total cost of this particular metric, in cents */
+  totalCost: Scalars['Int'];
+  value: Scalars['Float'];
+};
+
+export type EstimatedUsage = {
+  __typename?: 'EstimatedUsage';
+  id: Scalars['ID'];
+  limit: Scalars['Float'];
+  metricType: UsageMetricType;
+  service: EasService;
+  serviceMetric: EasServiceMetric;
+  value: Scalars['Float'];
+};
 
 export type ExperimentationQuery = {
   __typename?: 'ExperimentationQuery';
@@ -2806,6 +2923,7 @@ export type GitHubRepository = {
   app: App;
   githubAppInstallation: GitHubAppInstallation;
   githubRepositoryIdentifier: Scalars['Int'];
+  githubRepositoryUrl?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   metadata?: Maybe<GitHubRepositoryMetadata>;
   nodeIdentifier: Scalars['String'];
@@ -3616,8 +3734,9 @@ export type PublishUpdateGroupInput = {
   gitCommitHash?: InputMaybe<Scalars['String']>;
   isGitWorkingTreeDirty?: InputMaybe<Scalars['Boolean']>;
   message?: InputMaybe<Scalars['String']>;
+  rollBackToEmbeddedInfoGroup?: InputMaybe<UpdateRollBackToEmbeddedGroup>;
   runtimeVersion: Scalars['String'];
-  updateInfoGroup: UpdateInfoGroup;
+  updateInfoGroup?: InputMaybe<UpdateInfoGroup>;
 };
 
 export type RescindUserInvitationResult = {
@@ -3738,6 +3857,8 @@ export type RootMutation = {
   build: BuildMutation;
   /** Mutations that modify an BuildJob */
   buildJob: BuildJobMutation;
+  /** Mutations for Discord users */
+  discordUser: DiscordUserMutation;
   /** Mutations that modify an EmailSubscription */
   emailSubscription: EmailSubscriptionMutation;
   /** Mutations that create and delete EnvironmentSecrets */
@@ -4420,6 +4541,7 @@ export type Update = ActivityTimelineProjectActivity & {
   group: Scalars['String'];
   id: Scalars['ID'];
   isGitWorkingTreeDirty: Scalars['Boolean'];
+  isRollBackToEmbedded: Scalars['Boolean'];
   manifestFragment: Scalars['String'];
   manifestPermalink: Scalars['String'];
   message?: Maybe<Scalars['String']>;
@@ -4575,6 +4697,12 @@ export type UpdateMutationSetCodeSigningInfoArgs = {
   updateId: Scalars['ID'];
 };
 
+export type UpdateRollBackToEmbeddedGroup = {
+  android?: InputMaybe<Scalars['Boolean']>;
+  ios?: InputMaybe<Scalars['Boolean']>;
+  web?: InputMaybe<Scalars['Boolean']>;
+};
+
 export type UpdatesFilter = {
   platform?: InputMaybe<AppPlatform>;
   runtimeVersions?: InputMaybe<Array<Scalars['String']>>;
@@ -4602,8 +4730,8 @@ export type UsageMetricTotal = {
   __typename?: 'UsageMetricTotal';
   billingPeriod: BillingPeriod;
   id: Scalars['ID'];
-  overageMetrics: Array<AccountUsageMetricAndCost>;
-  planMetrics: Array<AccountUsageMetricAndCost>;
+  overageMetrics: Array<EstimatedOverageAndCost>;
+  planMetrics: Array<EstimatedUsage>;
   /** Total cost of overages, in cents */
   totalCost: Scalars['Float'];
 };
@@ -4642,6 +4770,8 @@ export type User = Actor & UserActor & {
   apps: Array<App>;
   bestContactEmail?: Maybe<Scalars['String']>;
   created: Scalars['DateTime'];
+  /** Discord account linked to a user */
+  discordUser?: Maybe<DiscordUser>;
   displayName: Scalars['String'];
   email?: Maybe<Scalars['String']>;
   emailVerified: Scalars['Boolean'];
@@ -5589,7 +5719,7 @@ export type UpdatePublishMutationVariables = Exact<{
 }>;
 
 
-export type UpdatePublishMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', publishUpdateGroups: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> } };
+export type UpdatePublishMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', publishUpdateGroups: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> } };
 
 export type SetCodeSigningInfoMutationVariables = Exact<{
   updateId: Scalars['ID'];
@@ -5687,7 +5817,7 @@ export type BranchesByAppQueryVariables = Exact<{
 }>;
 
 
-export type BranchesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> }> } } };
+export type BranchesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> }> } } };
 
 export type ViewBranchesOnUpdateChannelQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5697,7 +5827,7 @@ export type ViewBranchesOnUpdateChannelQueryVariables = Exact<{
 }>;
 
 
-export type ViewBranchesOnUpdateChannelQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> } | null } } };
+export type ViewBranchesOnUpdateChannelQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> } | null } } };
 
 export type BuildsByIdQueryVariables = Exact<{
   buildId: Scalars['ID'];
@@ -5729,7 +5859,7 @@ export type ViewUpdateChannelOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> } | null } } };
+export type ViewUpdateChannelOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> } | null } } };
 
 export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5738,7 +5868,7 @@ export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> }> } } };
+export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> }> } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5791,7 +5921,7 @@ export type ViewUpdatesByGroupQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdatesByGroupQuery = { __typename?: 'RootQuery', updatesByGroup: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
+export type ViewUpdatesByGroupQuery = { __typename?: 'RootQuery', updatesByGroup: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
 
 export type ViewUpdateGroupsOnBranchQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5802,7 +5932,7 @@ export type ViewUpdateGroupsOnBranchQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateGroupsOnBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> } | null } } };
+export type ViewUpdateGroupsOnBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> } | null } } };
 
 export type ViewUpdateGroupsOnAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5812,7 +5942,7 @@ export type ViewUpdateGroupsOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateGroupsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> } } };
+export type ViewUpdateGroupsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> } } };
 
 export type CurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -5848,9 +5978,9 @@ export type StatuspageServiceFragment = { __typename?: 'StatuspageService', id: 
 
 export type SubmissionFragment = { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null };
 
-export type UpdateFragment = { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null };
+export type UpdateFragment = { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null };
 
-export type UpdateBranchFragment = { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
+export type UpdateBranchFragment = { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
 
 export type WebhookFragment = { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any };
 

--- a/packages/eas-cli/src/graphql/types/Update.ts
+++ b/packages/eas-cli/src/graphql/types/Update.ts
@@ -9,6 +9,7 @@ export const UpdateFragmentNode = gql`
     runtimeVersion
     platform
     manifestFragment
+    isRollBackToEmbedded
     manifestPermalink
     gitCommitHash
     actor {

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -5,7 +5,6 @@ import { instance, mock } from 'ts-mockito';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
-import { defaultPublishPlatforms } from '../../commands/update';
 import { AssetMetadataStatus } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import { PublishQuery } from '../../graphql/queries/PublishQuery';
@@ -14,6 +13,7 @@ import {
   buildUnsortedUpdateInfoGroupAsync,
   collectAssetsAsync,
   convertAssetToUpdateInfoGroupFormatAsync,
+  defaultPublishPlatforms,
   filterExportedPlatformsByFlag,
   filterOutAssetsThatAlreadyExistAsync,
   getAssetHashFromPath,

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -487,7 +487,7 @@ export async function getBranchNameForCommandAsync({
 }): Promise<string> {
   if (channelNameArg && branchNameArg) {
     throw new Error(
-      'Cannot specify both --channel and --branch. Specify either --channel, --branch, or --auto'
+      'Cannot specify both --channel and --branch. Specify either --channel, --branch, or --auto.'
     );
   }
 
@@ -502,7 +502,7 @@ export async function getBranchNameForCommandAsync({
   if (autoFlag) {
     return await getDefaultBranchNameAsync();
   } else if (nonInteractive) {
-    throw new Error('Must supply --channel, --branch or --auto when in non-interactive mode');
+    throw new Error('Must supply --channel, --branch or --auto when in non-interactive mode.');
   } else {
     let branchName: string;
 
@@ -520,13 +520,14 @@ export async function getBranchNameForCommandAsync({
       branchName = branch.name;
     } catch {
       // unable to select a branch (network error or no branches for project)
-      ({ name: branchName } = await promptAsync({
+      const { name } = await promptAsync({
         type: 'text',
         name: 'name',
         message: 'No branches found. Provide a branch name:',
         initial: await getDefaultBranchNameAsync(),
         validate: value => (value ? true : 'Branch name may not be empty.'),
-      }));
+      });
+      branchName = name;
     }
 
     assert(branchName, 'Branch name must be specified.');
@@ -559,13 +560,14 @@ export async function getUpdateMessageForCommandAsync({
     if (jsonFlag) {
       throw new Error(validationMessage);
     }
-    ({ updateMessage } = await promptAsync({
+    const { updateMessageLocal } = await promptAsync({
       type: 'text',
-      name: 'updateMessage',
+      name: 'updateMessageLocal',
       message: `Provide an roll back message:`,
       initial: (await getVcsClient().getLastCommitMessageAsync())?.trim(),
       validate: (value: any) => (value ? true : validationMessage),
-    }));
+    });
+    updateMessage = updateMessageLocal;
   }
 
   assert(updateMessage, 'Update message must be specified.');
@@ -578,7 +580,7 @@ export async function getUpdateMessageForCommandAsync({
   return updateMessage;
 }
 
-export const defaultPublishPlatforms: Partial<Platform>[] = ['android', 'ios'];
+export const defaultPublishPlatforms: Platform[] = ['android', 'ios'];
 
 export function getRequestedPlatform(
   platform: ExpoCLIExportPlatformFlag

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -1,22 +1,36 @@
 import { ExpoConfig, Platform } from '@expo/config';
+import { Updates } from '@expo/config-plugins';
+import { Platform as EASBuildJobPlatform, Workflow } from '@expo/eas-build-job';
 import JsonFile from '@expo/json-file';
+import assert from 'assert';
+import chalk from 'chalk';
 import crypto from 'crypto';
 import fs from 'fs-extra';
 import Joi from 'joi';
 import mime from 'mime';
+import nullthrows from 'nullthrows';
 import path from 'path';
 import promiseLimit from 'promise-limit';
 
+import { selectBranchOnAppAsync } from '../branch/queries';
+import { getDefaultBranchNameAsync } from '../branch/utils';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { PaginatedQueryOptions } from '../commandUtils/pagination';
 import { AssetMetadataStatus, PartialManifestAsset } from '../graphql/generated';
 import { PublishMutation } from '../graphql/mutations/PublishMutation';
 import { PublishQuery } from '../graphql/queries/PublishQuery';
-import Log from '../log';
+import Log, { learnMore } from '../log';
+import { RequestedPlatform, requestedPlatformDisplayNames } from '../platform';
+import { promptAsync } from '../prompts';
+import { getBranchNameFromChannelNameAsync } from '../update/getBranchNameFromChannelNameAsync';
+import { formatUpdateMessage, truncateString as truncateUpdateMessage } from '../update/utils';
 import { PresignedPost, uploadWithPresignedPostWithRetryAsync } from '../uploads';
 import { expoCommandAsync, shouldUseVersionedExpoCLI } from '../utils/expoCli';
 import chunk from '../utils/expodash/chunk';
 import { truthy } from '../utils/expodash/filter';
 import uniqBy from '../utils/expodash/uniqBy';
+import { getVcsClient } from '../vcs';
+import { resolveWorkflowAsync } from './workflow';
 
 export type ExpoCLIExportPlatformFlag = Platform | 'all';
 
@@ -452,4 +466,187 @@ export function isUploadedAssetCountAboveWarningThreshold(
 ): boolean {
   const warningThreshold = Math.floor(assetLimitPerUpdateGroup * 0.75);
   return uploadedAssetCount > warningThreshold;
+}
+
+export async function getBranchNameForCommandAsync({
+  graphqlClient,
+  projectId,
+  channelNameArg,
+  branchNameArg,
+  autoFlag,
+  nonInteractive,
+  paginatedQueryOptions,
+}: {
+  graphqlClient: ExpoGraphqlClient;
+  projectId: string;
+  channelNameArg: string | undefined;
+  branchNameArg: string | undefined;
+  autoFlag: boolean;
+  nonInteractive: boolean;
+  paginatedQueryOptions: PaginatedQueryOptions;
+}): Promise<string> {
+  if (channelNameArg && branchNameArg) {
+    throw new Error(
+      'Cannot specify both --channel and --branch. Specify either --channel, --branch, or --auto'
+    );
+  }
+
+  if (channelNameArg) {
+    return await getBranchNameFromChannelNameAsync(graphqlClient, projectId, channelNameArg);
+  }
+
+  if (branchNameArg) {
+    return branchNameArg;
+  }
+
+  if (autoFlag) {
+    return await getDefaultBranchNameAsync();
+  } else if (nonInteractive) {
+    throw new Error('Must supply --channel, --branch or --auto when in non-interactive mode');
+  } else {
+    let branchName: string;
+
+    try {
+      const branch = await selectBranchOnAppAsync(graphqlClient, {
+        projectId,
+        promptTitle: `Which branch would you like to roll back to embedded on?`,
+        displayTextForListItem: updateBranch => ({
+          title: `${updateBranch.name} ${chalk.grey(
+            `- current update: ${formatUpdateMessage(updateBranch.updates[0])}`
+          )}`,
+        }),
+        paginatedQueryOptions,
+      });
+      branchName = branch.name;
+    } catch {
+      // unable to select a branch (network error or no branches for project)
+      ({ name: branchName } = await promptAsync({
+        type: 'text',
+        name: 'name',
+        message: 'No branches found. Provide a branch name:',
+        initial: await getDefaultBranchNameAsync(),
+        validate: value => (value ? true : 'Branch name may not be empty.'),
+      }));
+    }
+
+    assert(branchName, 'Branch name must be specified.');
+    return branchName;
+  }
+}
+
+export async function getUpdateMessageForCommandAsync({
+  updateMessageArg,
+  autoFlag,
+  nonInteractive,
+  jsonFlag,
+}: {
+  updateMessageArg: string | undefined;
+  autoFlag: boolean;
+  nonInteractive: boolean;
+  jsonFlag: boolean;
+}): Promise<string> {
+  let updateMessage = updateMessageArg;
+  if (!updateMessageArg && autoFlag) {
+    updateMessage = (await getVcsClient().getLastCommitMessageAsync())?.trim();
+  }
+
+  if (!updateMessage) {
+    if (nonInteractive) {
+      throw new Error('Must supply --message or use --auto when in non-interactive mode');
+    }
+
+    const validationMessage = 'publish message may not be empty.';
+    if (jsonFlag) {
+      throw new Error(validationMessage);
+    }
+    ({ updateMessage } = await promptAsync({
+      type: 'text',
+      name: 'updateMessage',
+      message: `Provide an roll back message:`,
+      initial: (await getVcsClient().getLastCommitMessageAsync())?.trim(),
+      validate: (value: any) => (value ? true : validationMessage),
+    }));
+  }
+
+  assert(updateMessage, 'Update message must be specified.');
+
+  const truncatedMessage = truncateUpdateMessage(updateMessage, 1024);
+  if (truncatedMessage !== updateMessage) {
+    Log.warn('Update message exceeds the allowed 1024 character limit. Truncating message...');
+  }
+
+  return updateMessage;
+}
+
+export const defaultPublishPlatforms: Partial<Platform>[] = ['android', 'ios'];
+
+export function getRequestedPlatform(
+  platform: ExpoCLIExportPlatformFlag
+): RequestedPlatform | null {
+  switch (platform) {
+    case 'android':
+      return RequestedPlatform.Android;
+    case 'ios':
+      return RequestedPlatform.Ios;
+    case 'web':
+      return null;
+    case 'all':
+      return RequestedPlatform.All;
+    default:
+      throw new Error(`Unsupported platform: ${platform}`);
+  }
+}
+
+/** Get runtime versions grouped by platform. Runtime version is always `null` on web where the platform is always backwards compatible. */
+export async function getRuntimeVersionObjectAsync(
+  exp: ExpoConfig,
+  platforms: Platform[],
+  projectDir: string
+): Promise<{ platform: string; runtimeVersion: string }[]> {
+  for (const platform of platforms) {
+    if (platform === 'web') {
+      continue;
+    }
+    const isPolicy = typeof (exp[platform]?.runtimeVersion ?? exp.runtimeVersion) === 'object';
+    if (isPolicy) {
+      const isManaged =
+        (await resolveWorkflowAsync(projectDir, platform as EASBuildJobPlatform)) ===
+        Workflow.MANAGED;
+      if (!isManaged) {
+        throw new Error(
+          'Runtime version policies are only supported in the managed workflow. In the bare workflow, runtime version needs to be set manually.'
+        );
+      }
+    }
+  }
+
+  return [...new Set(platforms)].map(platform => {
+    if (platform === 'web') {
+      return { platform: 'web', runtimeVersion: 'UNVERSIONED' };
+    }
+    return {
+      platform,
+      runtimeVersion: nullthrows(
+        Updates.getRuntimeVersion(exp, platform),
+        `Unable to determine runtime version for ${
+          requestedPlatformDisplayNames[platform]
+        }. ${learnMore('https://docs.expo.dev/eas-update/runtime-versions/')}`
+      ),
+    };
+  });
+}
+
+export function getRuntimeToPlatformMappingFromRuntimeVersions(
+  runtimeVersions: { platform: string; runtimeVersion: string }[]
+): { runtimeVersion: string; platforms: string[] }[] {
+  const runtimeToPlatformMapping: { runtimeVersion: string; platforms: string[] }[] = [];
+  for (const runtime of runtimeVersions) {
+    const platforms = runtimeVersions
+      .filter(({ runtimeVersion }) => runtimeVersion === runtime.runtimeVersion)
+      .map(({ platform }) => platform);
+    if (!runtimeToPlatformMapping.find(item => item.runtimeVersion === runtime.runtimeVersion)) {
+      runtimeToPlatformMapping.push({ runtimeVersion: runtime.runtimeVersion, platforms });
+    }
+  }
+  return runtimeToPlatformMapping;
 }

--- a/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
@@ -124,6 +124,7 @@ function mockUpdateBranches(branchNames: string[]): UpdateBranch[] {
           runtime: {} as Runtime, // Temporary fix to resolve type errors
           platform: 'ios',
           manifestFragment: '...',
+          isRollBackToEmbedded: false,
           activityTimestamp: '2022-12-07T02:24:43.487Z',
           branchId: '',
           awaitingCodeSigningInfo: false,

--- a/packages/eas-cli/src/utils/code-signing.ts
+++ b/packages/eas-cli/src/utils/code-signing.ts
@@ -16,8 +16,9 @@ import nullthrows from 'nullthrows';
 
 import { Response } from '../fetch';
 import { PartialManifest, PartialManifestAsset } from '../graphql/generated';
+import areSetsEqual from './expodash/areSetsEqual';
 
-type CodeSigningInfo = {
+export type CodeSigningInfo = {
   privateKey: PKI.rsa.PrivateKey;
   certificate: PKI.Certificate;
   codeSigningMetadata: { alg: string; keyid: string };
@@ -188,10 +189,6 @@ export function checkManifestBodyAgainstUpdateInfoGroup(
     }
     assertAssetParity(correspondingManifestResponseBodyAssetJSON, nullthrows(partialManifestAsset));
   }
-}
-
-function areSetsEqual<T>(a: Set<T>, b: Set<T>): boolean {
-  return a.size === b.size && [...a].every(value => b.has(value));
 }
 
 export function checkDirectiveBodyAgainstUpdateInfoGroup(directiveResponseBody: string): void {

--- a/packages/eas-cli/src/utils/expodash/__tests__/areSetsEqual-test.ts
+++ b/packages/eas-cli/src/utils/expodash/__tests__/areSetsEqual-test.ts
@@ -1,0 +1,17 @@
+import areSetsEqual from '../areSetsEqual';
+
+describe(areSetsEqual, () => {
+  it.each([
+    [new Set([1, 2]), new Set([1, 2])],
+    [new Set([1, 2]), new Set([2, 1])],
+  ])('equal cases: %p', (a, b) => {
+    expect(areSetsEqual(a, b)).toBe(true);
+  });
+
+  it.each([
+    [new Set([1, 2, 3]), new Set([1, 2])],
+    [new Set([1, 2]), new Set([1, 2, 3])],
+  ])('non-equal cases: %p', (a, b) => {
+    expect(areSetsEqual(a, b)).toBe(false);
+  });
+});

--- a/packages/eas-cli/src/utils/expodash/areSetsEqual.ts
+++ b/packages/eas-cli/src/utils/expodash/areSetsEqual.ts
@@ -1,0 +1,3 @@
+export default function areSetsEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  return a.size === b.size && [...a].every(value => b.has(value));
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This adds a new command, `eas update:roll-back-to-embedded` (name up for discussion), that creates a "roll back to embedded" update.

Server implementation: https://github.com/expo/universe/pull/11720
Client implementations: https://github.com/expo/expo/pull/21652, https://github.com/expo/expo/pull/21256
Protocol spec: https://www.notion.so/expo/Expo-Updates-directives-in-multipart-manifests-2dee4deac86241a4873ee2fdb3d83d9c

# How

I considered making this a flag, but it seems the trend is to have these be a separate command (see `update:republish`).

1. Create command
2. Factor out common code from index
3. Add test

# Test Plan

Run test.

Run:
```
~/expo/eas-cli/packages/eas-cli/bin/run update:roll-back-to-embedded --private-key-path keys/private-key.pem
```
(to check that a republish is created in staging and that it is signed)
