### PR TITLE
[eas-cli] Add info about code signing and roll back to embedded in update info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- Add support for roll back to embedded updates. ([#1754](https://github.com/expo/eas-cli/pull/1754) by [@wschurman](https://github.com/wschurman))
+- Add support for roll back to embedded updates. ([#1754](https://github.com/expo/eas-cli/pull/1754), [#1755](https://github.com/expo/eas-cli/pull/1755) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -68,6 +68,7 @@ type UpdateFlags = {
 };
 
 export default class UpdateRollBackToEmbedded extends EasCommand {
+  static override hidden = true; // until we launch
   static override description = 'roll back to the embedded update';
 
   static override flags = {

--- a/packages/eas-cli/src/update/utils.ts
+++ b/packages/eas-cli/src/update/utils.ts
@@ -48,6 +48,8 @@ export type FormattedUpdateGroupDescription = {
   group: string;
   platforms: string;
   runtimeVersion: string;
+  codeSigningKey: string | undefined;
+  isRollBackToEmbedded: boolean;
 };
 
 export type FormattedBranchDescription = {
@@ -74,6 +76,8 @@ export function formatUpdateGroup(update: FormattedUpdateGroupDescription): stri
     { label: 'Platforms', value: update.platforms },
     { label: 'Runtime Version', value: update.runtimeVersion },
     { label: 'Message', value: update.message },
+    { label: 'Code Signing Key', value: update.codeSigningKey ?? 'N/A' },
+    { label: 'Is Roll Back to Embedded', value: update.isRollBackToEmbedded ? 'Yes' : 'No' },
     { label: 'Group ID', value: update.group },
   ]);
 }
@@ -203,6 +207,7 @@ export function getUpdateGroupJsonInfo(updateGroups: UpdateFragment[]): UpdateJs
     runtimeVersion: update.runtimeVersion,
     platform: update.platform,
     manifestPermalink: update.manifestPermalink,
+    isRollBackToEmbedded: update.isRollBackToEmbedded,
     gitCommitHash: update.gitCommitHash,
   }));
 }
@@ -213,6 +218,8 @@ export function getUpdateGroupDescriptions(
   return updateGroups.map(updateGroup => ({
     message: formatUpdateMessage(updateGroup[0]),
     runtimeVersion: updateGroup[0].runtimeVersion,
+    isRollBackToEmbedded: updateGroup[0].isRollBackToEmbedded,
+    codeSigningKey: updateGroup[0].codeSigningInfo?.keyid,
     group: updateGroup[0].group,
     platforms: formatPlatformForUpdateGroup(updateGroup),
   }));
@@ -225,6 +232,8 @@ export function getUpdateGroupDescriptionsWithBranch(
     branch: updateGroup[0].branch.name,
     message: formatUpdateMessage(updateGroup[0]),
     runtimeVersion: updateGroup[0].runtimeVersion,
+    isRollBackToEmbedded: updateGroup[0].isRollBackToEmbedded,
+    codeSigningKey: updateGroup[0].codeSigningInfo?.keyid,
     group: updateGroup[0].group,
     platforms: formatPlatformForUpdateGroup(updateGroup),
   }));
@@ -241,6 +250,8 @@ export function getBranchDescription(branch: UpdateBranchFragment): FormattedBra
     update: {
       message: formatUpdateMessage(latestUpdate),
       runtimeVersion: latestUpdate.runtimeVersion,
+      isRollBackToEmbedded: latestUpdate.isRollBackToEmbedded,
+      codeSigningKey: latestUpdate.codeSigningInfo?.keyid,
       group: latestUpdate.group,
       platforms: getPlatformsForGroup({
         group: latestUpdate.group,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This adds more info about updates into the table. We (do or will soon) show these in the website.

# How

Add info.

# Test Plan

```
$ ~/expo/eas-cli/packages/eas-cli/bin/run update:list
✔ Which branch would you like to view? › main

Branch:
Name  main
ID    eb778b09-83b4-4b45-9c82-c9e4332e424b

Recent update groups:

Platforms                 android, ios
Runtime Version           exposdk:48.0.0
Message                   "Initial commit

Generated by create-expo-app 1.3.2." (14 minutes ago by wschurman)
Code Signing Key          main
Is Roll Back to Embedded  Yes
Group ID                  4c3d99e4-40cf-49eb-9c75-eeee7652e309

———

Platforms                 android, ios
Runtime Version           exposdk:48.0.0
Message                   "Initial commit

Generated by create-expo-app 1.3.2." (16 minutes ago by wschurman)
Code Signing Key          N/A
Is Roll Back to Embedded  Yes
Group ID                  fe0f9616-fc9f-4e99-8901-463a297c20b9
```
