### PR TITLE
[ENG-7981] use the eas-cli npm tag for eas-cli-local-build-plugin updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Use the `eas-cli` npm tag for checking for the local build plugin updates. ([#1759](https://github.com/expo/eas-cli/pull/1759) by [@dsokal](https://github.com/dsokal))
+
 ## [3.8.1](https://github.com/expo/eas-cli/releases/tag/v3.8.1) - 2023-03-16
 
 ### 🐛 Bug fixes

--- a/scripts/src/updateLocalPlugin.sh
+++ b/scripts/src/updateLocalPlugin.sh
@@ -5,9 +5,11 @@ set -eo pipefail
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )"
 LOCAL_TS_PATH="$ROOT_DIR/packages/eas-cli/src/build/local.ts"
 
+LOCAL_BUILD_PLUGIN_NPM_TAG="eas-cli"
+
 echo "Checking if eas-cli-local-build-plugin upgrade is available"
 
-plugin_version_latest=$(npm info eas-cli-local-build-plugin@latest version)
+plugin_version_latest=$(npm info eas-cli-local-build-plugin@$LOCAL_BUILD_PLUGIN_NPM_TAG version)
 plugin_version_current=$(grep 'const PLUGIN_PACKAGE_VERSION' $LOCAL_TS_PATH | cut -d"'" -f2)
 
 if [[ "$plugin_version_latest" == "$plugin_version_current" ]]; then


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Streamlines eas-cli / eas-build releases.

# How

Use the `eas-cli` tag for checking for `eas-cli-local-build-plugin`.

I tagged the 0.0.128 version with `eas-cli` so this PR doesn't change anything yet.
<img width="759" alt="Screenshot 2023-03-28 at 10 19 07" src="https://user-images.githubusercontent.com/5256730/228176992-cada068e-f6e4-4f36-98cc-82cc2da5e3a4.png">


# Test Plan

None.