### PR TITLE
[eas-cli] Do not require commits in eas build:internal

### DIFF
--- a/packages/eas-cli/src/commandUtils/context/OptionalProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/OptionalProjectConfigContextField.ts
@@ -3,7 +3,7 @@ import { InvalidEasJsonError } from '@expo/eas-json/build/errors';
 
 import { getExpoConfig } from '../../project/expoConfig';
 import ContextField, { ContextOptions } from './ContextField';
-import { findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
+import { applyCliConfigAsync, findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
 import { getProjectIdAsync } from './contextUtils/getProjectIdAsync';
 
 export class OptionalProjectConfigContextField extends ContextField<
@@ -35,6 +35,7 @@ export class OptionalProjectConfigContextField extends ContextField<
       return undefined;
     }
 
+    await applyCliConfigAsync(projectDir);
     const expBefore = getExpoConfig(projectDir);
     const projectId = await getProjectIdAsync(sessionManager, expBefore, {
       nonInteractive,

--- a/packages/eas-cli/src/commandUtils/context/ProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/ProjectConfigContextField.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { getExpoConfig } from '../../project/expoConfig';
 import ContextField, { ContextOptions } from './ContextField';
-import { findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
+import { applyCliConfigAsync, findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
 import { getProjectIdAsync } from './contextUtils/getProjectIdAsync';
 
 export default class ProjectConfigContextField extends ContextField<{
@@ -16,6 +16,7 @@ export default class ProjectConfigContextField extends ContextField<{
     projectDir: string;
   }> {
     const projectDir = await findProjectDirAndVerifyProjectSetupAsync();
+    await applyCliConfigAsync(projectDir);
     const expBefore = getExpoConfig(projectDir);
     const projectId = await getProjectIdAsync(sessionManager, expBefore, {
       nonInteractive,

--- a/packages/eas-cli/src/commandUtils/context/ProjectDirContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/ProjectDirContextField.ts
@@ -1,8 +1,13 @@
 import ContextField from './ContextField';
-import { findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
+import {
+  applyCliConfigAsync,
+  findProjectDirAndVerifyProjectSetupAsync,
+} from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
 
 export default class ProjectDirContextField extends ContextField<string> {
   async getValueAsync(): Promise<string> {
-    return await findProjectDirAndVerifyProjectSetupAsync();
+    const projectDir = await findProjectDirAndVerifyProjectSetupAsync();
+    await applyCliConfigAsync(projectDir);
+    return projectDir;
   }
 }

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
@@ -11,7 +11,7 @@ import { easCliVersion } from '../../../utils/easCli';
 import { getVcsClient, setVcsClient } from '../../../vcs';
 import GitClient from '../../../vcs/clients/git';
 
-async function applyCliConfigAsync(projectDir: string): Promise<void> {
+export async function applyCliConfigAsync(projectDir: string): Promise<void> {
   const easJsonAccessor = new EasJsonAccessor(projectDir);
   const config = await EasJsonUtils.getCliConfigAsync(easJsonAccessor);
   if (config?.version && !semver.satisfies(easCliVersion, config.version)) {
@@ -112,7 +112,6 @@ export async function findProjectRootAsync({
  */
 export async function findProjectDirAndVerifyProjectSetupAsync(): Promise<string> {
   const projectDir = await findProjectRootAsync();
-  await applyCliConfigAsync(projectDir);
   await ensureEasCliIsNotInDependenciesAsync(projectDir);
   return projectDir;
 }

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -6,6 +6,8 @@ import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import EasCommand from '../../commandUtils/EasCommand';
 import { RequestedPlatform } from '../../platform';
 import { enableJsonOutput } from '../../utils/json';
+import { setVcsClient } from '../../vcs';
+import GitNoCommitClient from '../../vcs/clients/gitNoCommit';
 
 /**
  * This command will be run on the EAS Build workers, when building
@@ -50,6 +52,8 @@ export default class BuildInternal extends EasCommand {
     } = await this.getContextAsync(BuildInternal, {
       nonInteractive: true,
     });
+
+    setVcsClient(new GitNoCommitClient());
 
     await handleDeprecatedEasJsonAsync(projectDir, flags.nonInteractive);
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

When building from git with the option "requireCommit" set to true, if pre-install hooks or install itself are leaving the local repo in a dirty state, the `eas build:internal` fails while attempting to commit the changes.

# How

- applyCliConfigAsync is changing the global vcs client, so it shouldn't be run as a part of a DynamicProjectConfig, because it would be triggered at different parts of the build process. All calls to that function should finish before `getContextAsync` returns.
  - I considered 2 alternative approaches: 
     - wrapping call to applyCliConfigAsync in `once`
     - moving call to the findProjectDirAndVerifyProjectSetupAsync in a [DynamicProjectConfig](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/commandUtils/context/DynamicProjectConfigContextField.ts#L20) otside of the arrow function

- update vcs client to git no commit client after context was resolved in `build:internal` command.

# Test Plan


