### PR TITLE
[eas-json] Add support for running on server

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -612,7 +612,7 @@ function formatAccountSubscriptionsUrl(accountName: string): string {
 }
 
 async function updateIosBuildProfilesToUseM1WorkersAsync(projectDir: string): Promise<void> {
-  const easJsonAccessor = new EasJsonAccessor(projectDir);
+  const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
   await easJsonAccessor.readRawJsonAsync();
 
   const profileNames = await EasJsonUtils.getBuildProfileNamesAsync(easJsonAccessor);

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -99,7 +99,7 @@ export async function runBuildAndSubmitAsync(
     projectDir,
     nonInteractive: flags.nonInteractive,
   });
-  const easJsonAccessor = new EasJsonAccessor(projectDir);
+  const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
   const easJsonCliConfig: EasJson['cli'] =
     (await EasJsonUtils.getCliConfigAsync(easJsonAccessor)) ?? {};
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
@@ -12,7 +12,7 @@ import { getVcsClient, setVcsClient } from '../../../vcs';
 import GitClient from '../../../vcs/clients/git';
 
 async function applyCliConfigAsync(projectDir: string): Promise<void> {
-  const easJsonAccessor = new EasJsonAccessor(projectDir);
+  const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
   const config = await EasJsonUtils.getCliConfigAsync(easJsonAccessor);
   if (config?.version && !semver.satisfies(easCliVersion, config.version)) {
     throw new Error(

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -251,7 +251,7 @@ export async function handleDeprecatedEasJsonAsync(
   if (!(await fs.pathExists(EasJsonAccessor.formatEasJsonPath(projectDir)))) {
     return;
   }
-  const easJsonAccessor = new EasJsonAccessor(projectDir);
+  const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
   const profileNames = await EasJsonUtils.getBuildProfileNamesAsync(easJsonAccessor);
   const platformAndProfileNames: [Platform, string][] = profileNames.flatMap(profileName => [
     [Platform.ANDROID, profileName],

--- a/packages/eas-cli/src/commands/build/resign.ts
+++ b/packages/eas-cli/src/commands/build/resign.ts
@@ -121,7 +121,7 @@ export default class BuildResign extends EasCommand {
     await handleDeprecatedEasJsonAsync(projectDir, flags.nonInteractive);
 
     await maybeWarnAboutEasOutagesAsync(graphqlClient, [StatuspageServiceName.EasBuild]);
-    const easJsonAccessor = new EasJsonAccessor(projectDir);
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
     const easJsonCliConfig: EasJson['cli'] =
       (await EasJsonUtils.getCliConfigAsync(easJsonAccessor)) ?? {};
 

--- a/packages/eas-cli/src/commands/build/version/set.ts
+++ b/packages/eas-cli/src/commands/build/version/set.ts
@@ -54,7 +54,7 @@ export default class BuildVersionSetView extends EasCommand {
     });
 
     const platform = await selectPlatformAsync(flags.platform);
-    const easJsonAccessor = new EasJsonAccessor(projectDir);
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
     await ensureVersionSourceIsRemoteAsync(easJsonAccessor);
     const profile = await EasJsonUtils.getBuildProfileAsync(
       easJsonAccessor,

--- a/packages/eas-cli/src/commands/build/version/sync.ts
+++ b/packages/eas-cli/src/commands/build/version/sync.ts
@@ -71,7 +71,7 @@ export default class BuildVersionSyncView extends EasCommand {
     });
 
     const requestedPlatform = await selectRequestedPlatformAsync(flags.platform);
-    const easJsonAccessor = new EasJsonAccessor(projectDir);
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
     await ensureVersionSourceIsRemoteAsync(easJsonAccessor);
 
     const platforms = toPlatforms(requestedPlatform);

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -45,7 +45,7 @@ export default class Config extends EasCommand {
       nonInteractive: false,
     });
 
-    const accessor = new EasJsonAccessor(projectDir);
+    const accessor = EasJsonAccessor.fromProjectPath(projectDir);
     const profileName =
       maybeProfile ??
       (await selectAsync(

--- a/packages/eas-cli/src/commands/metadata/lint.ts
+++ b/packages/eas-cli/src/commands/metadata/lint.ts
@@ -44,7 +44,7 @@ export default class MetadataLint extends EasCommand {
 
     const submitProfiles = await getProfilesAsync({
       type: 'submit',
-      easJsonAccessor: new EasJsonAccessor(projectDir),
+      easJsonAccessor: EasJsonAccessor.fromProjectPath(projectDir),
       platforms: [Platform.IOS],
       profileName: flags.profile,
     });

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -46,7 +46,7 @@ export default class MetadataPull extends EasCommand {
 
     const submitProfiles = await getProfilesAsync({
       type: 'submit',
-      easJsonAccessor: new EasJsonAccessor(projectDir),
+      easJsonAccessor: EasJsonAccessor.fromProjectPath(projectDir),
       platforms: [Platform.IOS],
       profileName: flags.profile,
     });

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -44,7 +44,7 @@ export default class MetadataPush extends EasCommand {
 
     const submitProfiles = await getProfilesAsync({
       type: 'submit',
-      easJsonAccessor: new EasJsonAccessor(projectDir),
+      easJsonAccessor: EasJsonAccessor.fromProjectPath(projectDir),
       platforms: [Platform.IOS],
       profileName: flags.profile,
     });

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -115,7 +115,7 @@ export default class Submit extends EasCommand {
     const platforms = toPlatforms(flagsWithPlatform.requestedPlatform);
     const submissionProfiles = await getProfilesAsync({
       type: 'submit',
-      easJsonAccessor: new EasJsonAccessor(projectDir),
+      easJsonAccessor: EasJsonAccessor.fromProjectPath(projectDir),
       platforms,
       profileName: flagsWithPlatform.profile,
     });

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -128,7 +128,7 @@ export default class IosCredentialsProvider {
   private async disablePushNotificationsSetupInEasJsonAsync(
     ctx: CredentialsContext
   ): Promise<void> {
-    const easJsonAccessor = new EasJsonAccessor(ctx.projectDir);
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath(ctx.projectDir);
     await easJsonAccessor.readRawJsonAsync();
     easJsonAccessor.patch(easJsonRawObject => {
       easJsonRawObject.cli = {

--- a/packages/eas-cli/src/credentials/manager/SelectBuildProfileFromEasJson.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectBuildProfileFromEasJson.ts
@@ -8,7 +8,7 @@ export class SelectBuildProfileFromEasJson<T extends Platform> {
   private easJsonAccessor: EasJsonAccessor;
 
   constructor(projectDir: string, private platform: T) {
-    this.easJsonAccessor = new EasJsonAccessor(projectDir);
+    this.easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
   }
 
   async runAsync(): Promise<BuildProfile<T>> {

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -273,7 +273,7 @@ export async function ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir: stri
   }
 
   try {
-    const easJsonAccessor = new EasJsonAccessor(projectDir);
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
     await easJsonAccessor.readRawJsonAsync();
 
     easJsonAccessor.patch(easJsonRawObject => {

--- a/packages/eas-cli/src/utils/__tests__/profiles-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/profiles-test.ts
@@ -29,7 +29,7 @@ describe(getProfilesAsync, () => {
   });
 
   it('defaults to production profile', async () => {
-    const easJsonAccessor = new EasJsonAccessor('/fake');
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath('/fake');
     const result = await getProfilesAsync({
       easJsonAccessor,
       platforms: [Platform.ANDROID, Platform.IOS],
@@ -51,7 +51,7 @@ describe(getProfilesAsync, () => {
 
     await expect(
       getProfilesAsync({
-        easJsonAccessor: new EasJsonAccessor('/fake'),
+        easJsonAccessor: EasJsonAccessor.fromProjectPath('/fake'),
         platforms: [Platform.ANDROID],
         profileName: undefined,
         type: 'build',
@@ -60,7 +60,7 @@ describe(getProfilesAsync, () => {
   });
 
   it('gets a specific profile', async () => {
-    const easJsonAccessor = new EasJsonAccessor('/fake');
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath('/fake');
     const result = await getProfilesAsync({
       easJsonAccessor,
       platforms: [Platform.ANDROID, Platform.IOS],
@@ -85,7 +85,7 @@ describe(getProfilesAsync, () => {
 
     await expect(
       getProfilesAsync({
-        easJsonAccessor: new EasJsonAccessor('/fake'),
+        easJsonAccessor: EasJsonAccessor.fromProjectPath('/fake'),
         platforms: [Platform.ANDROID, Platform.IOS],
         profileName: undefined,
         type: 'build',

--- a/packages/eas-json/src/__tests__/__snapshots__/accessor-test.ts.snap
+++ b/packages/eas-json/src/__tests__/__snapshots__/accessor-test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EasJsonAccessor patching JSON file 1`] = `
+exports[`fromProjectPath patching JSON file 1`] = `
 "{
   "build": {
     "production": {
@@ -14,7 +14,7 @@ exports[`EasJsonAccessor patching JSON file 1`] = `
 "
 `;
 
-exports[`EasJsonAccessor patching JSON5 file (preserves comments) 1`] = `
+exports[`fromProjectPath patching JSON5 file (preserves comments) 1`] = `
 "{
   "build": {
     "production": {

--- a/packages/eas-json/src/__tests__/accessor-test.ts
+++ b/packages/eas-json/src/__tests__/accessor-test.ts
@@ -15,7 +15,7 @@ beforeEach(async () => {
   vol.reset();
 });
 
-describe(EasJsonAccessor, () => {
+describe(EasJsonAccessor.fromProjectPath, () => {
   test('patching JSON file', async () => {
     vol.fromJSON(
       {
@@ -24,7 +24,7 @@ describe(EasJsonAccessor, () => {
       fakeAppPath
     );
 
-    const accessor = new EasJsonAccessor(fakeAppPath);
+    const accessor = EasJsonAccessor.fromProjectPath(fakeAppPath);
     await accessor.readAsync();
     accessor.patch(o => {
       o.build.production.env.ABC = '456';
@@ -44,7 +44,7 @@ describe(EasJsonAccessor, () => {
       fakeAppPath
     );
 
-    const accessor = new EasJsonAccessor(fakeAppPath);
+    const accessor = EasJsonAccessor.fromProjectPath(fakeAppPath);
     await accessor.readAsync();
     accessor.patch(o => {
       o.build.production.env.ABC = '456';
@@ -67,7 +67,7 @@ describe(EasJsonAccessor, () => {
       fakeAppPath
     );
 
-    const accessor = new EasJsonAccessor(fakeAppPath);
+    const accessor = EasJsonAccessor.fromProjectPath(fakeAppPath);
     await expect(accessor.readAsync()).rejects.toThrowError(InvalidEasJsonError);
     await expect(accessor.readAsync()).rejects.toThrowError(
       /^Found invalid character in .*eas\.json.+/
@@ -82,7 +82,57 @@ describe(EasJsonAccessor, () => {
       fakeAppPath
     );
 
-    const accessor = new EasJsonAccessor(fakeAppPath);
+    const accessor = EasJsonAccessor.fromProjectPath(fakeAppPath);
+    await expect(accessor.readAsync()).rejects.toThrowError(InvalidEasJsonError);
+    await expect(accessor.readAsync()).rejects.toThrowError(/^.*eas\.json.* is empty\.$/g);
+  });
+});
+
+describe(EasJsonAccessor.fromRawString, () => {
+  test('patching JSON file', async () => {
+    const accessor = EasJsonAccessor.fromRawString(
+      await fsReal.readFile(path.join(fixturesDir, 'eas-json.json'), 'utf-8')
+    );
+    await accessor.readAsync();
+    expect(() =>
+      accessor.patch(o => {
+        o.build.production.env.ABC = '456';
+        return o;
+      })
+    ).toThrowError();
+  });
+
+  test('reading invalid JSON5 object', async () => {
+    vol.fromJSON(
+      {
+        './eas.json': await fsReal.readFile(
+          path.join(fixturesDir, 'eas-invalid-json5.json'),
+          'utf-8'
+        ),
+      },
+      fakeAppPath
+    );
+
+    const accessor = EasJsonAccessor.fromRawString(
+      await fsReal.readFile(path.join(fixturesDir, 'eas-invalid-json5.json'), 'utf-8')
+    );
+    await expect(accessor.readAsync()).rejects.toThrowError(InvalidEasJsonError);
+    await expect(accessor.readAsync()).rejects.toThrowError(
+      /^Found invalid character in .*eas\.json.+/
+    );
+  });
+
+  test('reading empty JSON file', async () => {
+    vol.fromJSON(
+      {
+        './eas.json': await fsReal.readFile(path.join(fixturesDir, 'eas-empty.json'), 'utf-8'),
+      },
+      fakeAppPath
+    );
+
+    const accessor = EasJsonAccessor.fromRawString(
+      await fsReal.readFile(path.join(fixturesDir, 'eas-empty.json'), 'utf-8')
+    );
     await expect(accessor.readAsync()).rejects.toThrowError(InvalidEasJsonError);
     await expect(accessor.readAsync()).rejects.toThrowError(/^.*eas\.json.* is empty\.$/g);
   });

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -20,7 +20,33 @@ test('minimal valid eas.json for both platforms', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
+  const iosProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production');
+  const androidProfile = await EasJsonUtils.getBuildProfileAsync(
+    accessor,
+    Platform.ANDROID,
+    'production'
+  );
+
+  expect(androidProfile).toEqual({
+    distribution: 'store',
+    credentialsSource: 'remote',
+  });
+
+  expect(iosProfile).toEqual({
+    distribution: 'store',
+    credentialsSource: 'remote',
+  });
+});
+
+test('minimal valid eas.json for both platforms when reading eas.json from string', async () => {
+  const accessor = EasJsonAccessor.fromRawString(
+    JSON.stringify({
+      build: {
+        production: {},
+      },
+    })
+  );
   const iosProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production');
   const androidProfile = await EasJsonUtils.getBuildProfileAsync(
     accessor,
@@ -52,7 +78,7 @@ test('valid eas.json for development client builds', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const iosProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'debug');
   const androidProfile = await EasJsonUtils.getBuildProfileAsync(
     accessor,
@@ -82,7 +108,7 @@ test(`valid eas.json with autoIncrement flag at build profile root`, async () =>
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const iosProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production');
   const androidProfile = await EasJsonUtils.getBuildProfileAsync(
     accessor,
@@ -111,7 +137,7 @@ test('valid profile for internal distribution on Android', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const profile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'internal');
   expect(profile).toEqual({
     distribution: 'internal',
@@ -133,7 +159,7 @@ test('valid profile extending other profile', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const baseProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'base');
   const extendedProfile = await EasJsonUtils.getBuildProfileAsync(
     accessor,
@@ -176,7 +202,7 @@ test('valid profile extending other profile with platform specific envs', async 
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const baseProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'base');
   const extendedAndroidProfile = await EasJsonUtils.getBuildProfileAsync(
     accessor,
@@ -238,7 +264,7 @@ test('valid profile extending other profile with platform specific caching', asy
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const baseProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'base');
   const extendedAndroidProfile = await EasJsonUtils.getBuildProfileAsync(
     accessor,
@@ -282,7 +308,7 @@ test('valid eas.json with missing profile', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const promise = EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'debug');
   await expect(promise).rejects.toThrowError('Missing build profile in eas.json: debug');
 });
@@ -294,7 +320,7 @@ test('invalid eas.json when using wrong buildType', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const promise = EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'production');
   await expect(promise).rejects.toThrowError(InvalidEasJsonError);
   await expect(promise).rejects.toThrowError(
@@ -305,7 +331,7 @@ test('invalid eas.json when using wrong buildType', async () => {
 test('empty json', async () => {
   await fs.writeJson('/project/eas.json', {});
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const promise = EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'production');
   await expect(promise).rejects.toThrowError('Missing build profile in eas.json: production');
 });
@@ -317,7 +343,7 @@ test('invalid semver value', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const promise = EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'production');
   await expect(promise).rejects.toThrowError(InvalidEasJsonError);
   await expect(promise).rejects.toThrowError(
@@ -332,7 +358,7 @@ test('invalid release channel', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const promise = EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'production');
   await expect(promise).rejects.toThrowError(/fails to match the required pattern/);
 });
@@ -345,7 +371,7 @@ test('get profile names', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const allProfileNames = await EasJsonUtils.getBuildProfileNamesAsync(accessor);
   expect(allProfileNames.sort()).toEqual(['blah', 'production'].sort());
 });
@@ -359,7 +385,7 @@ test('invalid resourceClass at build profile root', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
 
   await expect(
     EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production')
@@ -377,7 +403,7 @@ test('iOS-specific resourceClass', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   await expect(
     EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production')
   ).resolves.not.toThrow();
@@ -394,7 +420,7 @@ test('Android-specific resourceClass', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   await expect(
     EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'production')
   ).resolves.not.toThrow();
@@ -414,7 +440,7 @@ test('build profile with platform-specific custom build config', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const androidProfile = await EasJsonUtils.getBuildProfileAsync(
     accessor,
     Platform.ANDROID,
@@ -442,7 +468,7 @@ test('build profiles with both platform build config', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const androidProfile = await EasJsonUtils.getBuildProfileAsync(
     accessor,
     Platform.ANDROID,

--- a/packages/eas-json/src/__tests__/submitProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/submitProfiles-test.ts
@@ -19,7 +19,7 @@ test('minimal allowed eas.json for both platforms', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const iosProfile = await EasJsonUtils.getSubmitProfileAsync(accessor, Platform.IOS, 'production');
   const androidProfile = await EasJsonUtils.getSubmitProfileAsync(
     accessor,
@@ -50,7 +50,7 @@ test('android config with all required values', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const androidProfile = await EasJsonUtils.getSubmitProfileAsync(
     accessor,
     Platform.ANDROID,
@@ -80,7 +80,7 @@ test('android config with serviceAccountKeyPath set to env var', async () => {
 
   try {
     process.env.GOOGLE_SERVICE_ACCOUNT = './path.json';
-    const accessor = new EasJsonAccessor('/project');
+    const accessor = EasJsonAccessor.fromProjectPath('/project');
     const androidProfile = await EasJsonUtils.getSubmitProfileAsync(
       accessor,
       Platform.ANDROID,
@@ -114,7 +114,7 @@ test('ios config with all required values', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const iosProfile = await EasJsonUtils.getSubmitProfileAsync(accessor, Platform.IOS, 'production');
 
   expect(iosProfile).toEqual({
@@ -148,7 +148,7 @@ test('ios config with ascApiKey fields set to env var', async () => {
     process.env.ASC_API_KEY_PATH = './path-ABCD.p8';
     process.env.ASC_API_KEY_ISSUER_ID = 'abc-123-def-456';
     process.env.ASC_API_KEY_ID = 'ABCD';
-    const accessor = new EasJsonAccessor('/project');
+    const accessor = EasJsonAccessor.fromProjectPath('/project');
     const iosProfile = await EasJsonUtils.getSubmitProfileAsync(accessor, Platform.IOS, 'release');
 
     expect(iosProfile).toEqual({
@@ -189,7 +189,7 @@ test('valid profile extending other profile', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const baseProfile = await EasJsonUtils.getSubmitProfileAsync(accessor, Platform.IOS, 'base');
   const extendedProfile = await EasJsonUtils.getSubmitProfileAsync(
     accessor,
@@ -233,7 +233,7 @@ test('get profile names', async () => {
     },
   });
 
-  const accessor = new EasJsonAccessor('/project');
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
   const allProfileNames = await EasJsonUtils.getSubmitProfileNamesAsync(accessor);
   expect(allProfileNames.sort()).toEqual(['production', 'blah'].sort());
 });

--- a/packages/eas-json/src/index.ts
+++ b/packages/eas-json/src/index.ts
@@ -1,6 +1,7 @@
 export { AndroidReleaseStatus, AndroidReleaseTrack, SubmitProfile } from './submit/types';
 export { getDefaultProfile as getDefaultSubmitProfile } from './submit/resolver';
 export { EasJson, ProfileType, AppVersionSource } from './types';
+export { Platform } from '@expo/eas-build-job';
 export {
   AndroidVersionAutoIncrement,
   BuildProfile,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Modify eas-json package to run on server.

# How

- Make the constructor private and use 2 static methods to create EasJsonAccessor class
- Use `easJsonPath` field to distinguish accessor from file and from string
- Throw in any method that modifies eas.json when using EasJsonAccessor.fromRawString

# Test Plan

Add some tests
