### PR TITLE
[ENG-7968][eas-cli][eas-json] print deprecation warnings for deprecated `eas.json` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Print deprecation warnings for deprecated `eas.json` fields. ([#1768](https://github.com/expo/eas-cli/pull/1768) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [3.9.1](https://github.com/expo/eas-cli/releases/tag/v3.9.1) - 2023-04-10
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/utils/__tests__/profiles-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/profiles-test.ts
@@ -11,6 +11,7 @@ jest.mock('@expo/eas-json', () => {
   const EasJsonUtilsMock = {
     getBuildProfileAsync: jest.fn(),
     getBuildProfileNamesAsync: jest.fn(),
+    getBuildProfileDepreactionWarnings: jest.fn(() => []),
   };
   return {
     ...actual,

--- a/packages/eas-cli/src/utils/__tests__/profiles-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/profiles-test.ts
@@ -11,7 +11,7 @@ jest.mock('@expo/eas-json', () => {
   const EasJsonUtilsMock = {
     getBuildProfileAsync: jest.fn(),
     getBuildProfileNamesAsync: jest.fn(),
-    getBuildProfileDepreactionWarnings: jest.fn(() => []),
+    getBuildProfileDeprecationWarnings: jest.fn(() => []),
   };
   return {
     ...actual,

--- a/packages/eas-cli/src/utils/profiles.ts
+++ b/packages/eas-cli/src/utils/profiles.ts
@@ -65,19 +65,7 @@ async function readProfileAsync<T extends ProfileType>({
       profileName
     );
 
-    const deprecationWarnings = EasJsonUtils.getBuildProfileDepreactionWarnings(buildProfile);
-    if (deprecationWarnings.length > 0) {
-      Log.newLine();
-      Log.warn('Detected deprecated fields in eas.json:');
-      for (const warning of deprecationWarnings) {
-        const warnlog: string = warning.message.map(line => `\t${line}`).join('\n');
-        Log.warn(warnlog);
-        if (warning.docsUrl) {
-          Log.warn(`\t${learnMore(warning.docsUrl)}`);
-        }
-        Log.newLine();
-      }
-    }
+    maybePrintBuildProfileDeprecationWarnings(buildProfile, profileName);
 
     return buildProfile as EasProfile<T>;
   } else {
@@ -86,5 +74,27 @@ async function readProfileAsync<T extends ProfileType>({
       platform,
       profileName
     )) as EasProfile<T>;
+  }
+}
+
+function maybePrintBuildProfileDeprecationWarnings(
+  buildProfile: BuildProfile<Platform>,
+  profileName?: string
+): void {
+  const deprecationWarnings = EasJsonUtils.getBuildProfileDepreactionWarnings(
+    buildProfile,
+    profileName
+  );
+  if (deprecationWarnings.length > 0) {
+    Log.newLine();
+    Log.warn('Detected deprecated fields in eas.json:');
+    for (const warning of deprecationWarnings) {
+      const warnlog: string = warning.message.map(line => `\t${line}`).join('\n');
+      Log.warn(warnlog);
+      if (warning.docsUrl) {
+        Log.warn(`\t${learnMore(warning.docsUrl)}`);
+      }
+      Log.newLine();
+    }
   }
 }

--- a/packages/eas-cli/src/utils/profiles.ts
+++ b/packages/eas-cli/src/utils/profiles.ts
@@ -77,24 +77,31 @@ async function readProfileAsync<T extends ProfileType>({
   }
 }
 
+let hasPrintedDeprecationWarnings = false;
+
 function maybePrintBuildProfileDeprecationWarnings(
   buildProfile: BuildProfile<Platform>,
   profileName?: string
 ): void {
-  const deprecationWarnings = EasJsonUtils.getBuildProfileDepreactionWarnings(
+  if (hasPrintedDeprecationWarnings) {
+    return;
+  }
+  const deprecationWarnings = EasJsonUtils.getBuildProfileDeprecationWarnings(
     buildProfile,
     profileName
   );
-  if (deprecationWarnings.length > 0) {
-    Log.newLine();
-    Log.warn('Detected deprecated fields in eas.json:');
-    for (const warning of deprecationWarnings) {
-      const warnlog: string = warning.message.map(line => `\t${line}`).join('\n');
-      Log.warn(warnlog);
-      if (warning.docsUrl) {
-        Log.warn(`\t${learnMore(warning.docsUrl)}`);
-      }
-      Log.newLine();
-    }
+  if (deprecationWarnings.length === 0) {
+    return;
   }
+  Log.newLine();
+  Log.warn('Detected deprecated fields in eas.json:');
+  for (const warning of deprecationWarnings) {
+    const warnlog: string = warning.message.map(line => `\t${line}`).join('\n');
+    Log.warn(warnlog);
+    if (warning.docsUrl) {
+      Log.warn(`\t${learnMore(warning.docsUrl)}`);
+    }
+    Log.newLine();
+  }
+  hasPrintedDeprecationWarnings = true;
 }

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -256,7 +256,6 @@ test('valid profile extending other profile with platform specific caching', asy
         },
         android: {
           cache: {
-            cacheDefaultPaths: false,
             customPaths: ['somefakepath'],
           },
         },
@@ -287,7 +286,6 @@ test('valid profile extending other profile with platform specific caching', asy
     distribution: 'internal',
     credentialsSource: 'remote',
     cache: {
-      cacheDefaultPaths: false,
       customPaths: ['somefakepath'],
     },
   });

--- a/packages/eas-json/src/utils.ts
+++ b/packages/eas-json/src/utils.ts
@@ -23,6 +23,29 @@ export class EasJsonUtils {
     return resolveBuildProfile({ easJson, platform, profileName });
   }
 
+  public static getBuildProfileDepreactionWarnings(
+    buildProfile: BuildProfile,
+    profileName?: string
+  ): { message: string[]; docsUrl?: string }[] {
+    const warnings: { message: string[]; docsUrl?: string }[] = [];
+
+    if (buildProfile.cache?.cacheDefaultPaths !== undefined) {
+      warnings.push({
+        message: [
+          `The "build.${
+            profileName ?? 'production'
+          }.cache.cacheDefaultPaths" field in eas.json is deprecated and will be removed in the future.`,
+          `You can use "build.${
+            profileName ?? 'production'
+          }.cache.cachePaths" to manually select which paths you want to cache.`,
+        ],
+        docsUrl: 'https://docs.expo.dev/build-reference/caching/#ios-dependencies',
+      });
+    }
+
+    return warnings;
+  }
+
   public static async getCliConfigAsync(accessor: EasJsonAccessor): Promise<EasJson['cli'] | null> {
     try {
       const easJson = await accessor.readAsync();

--- a/packages/eas-json/src/utils.ts
+++ b/packages/eas-json/src/utils.ts
@@ -35,9 +35,6 @@ export class EasJsonUtils {
           `The "build.${
             profileName ?? 'production'
           }.cache.cacheDefaultPaths" field in eas.json is deprecated and will be removed in the future.`,
-          `You can use "build.${
-            profileName ?? 'production'
-          }.cache.cachePaths" to manually select which paths you want to cache.`,
         ],
         docsUrl: 'https://docs.expo.dev/build-reference/caching/#ios-dependencies',
       });

--- a/packages/eas-json/src/utils.ts
+++ b/packages/eas-json/src/utils.ts
@@ -8,6 +8,11 @@ import { resolveSubmitProfile } from './submit/resolver';
 import { SubmitProfile } from './submit/types';
 import { EasJson } from './types';
 
+interface EasJsonDeprecationWarning {
+  message: string[];
+  docsUrl?: string;
+}
+
 export class EasJsonUtils {
   public static async getBuildProfileNamesAsync(accessor: EasJsonAccessor): Promise<string[]> {
     const easJson = await accessor.readAsync();
@@ -23,11 +28,11 @@ export class EasJsonUtils {
     return resolveBuildProfile({ easJson, platform, profileName });
   }
 
-  public static getBuildProfileDepreactionWarnings(
+  public static getBuildProfileDeprecationWarnings(
     buildProfile: BuildProfile,
     profileName?: string
-  ): { message: string[]; docsUrl?: string }[] {
-    const warnings: { message: string[]; docsUrl?: string }[] = [];
+  ): EasJsonDeprecationWarning[] {
+    const warnings: EasJsonDeprecationWarning[] = [];
 
     if (buildProfile.cache?.cacheDefaultPaths !== undefined) {
       warnings.push({


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://linear.app/expo/issue/ENG-7968/do-not-cache-podfilelock-by-default

Companion to https://github.com/expo/turtle-v2/pull/1256.

# How

Add a method in `eas.json` which returns deprecation warnings. Print them in the EAS CLI.

# Test Plan

Test manually
<img width="862" alt="Screenshot 2023-04-06 at 16 35 39" src="https://user-images.githubusercontent.com/55145344/230411438-1a35b948-4431-4f31-860c-d338776bc236.png">



