### PR TITLE
[eas-cli] Fix expoCommandAsync to support the new cli bin path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Update expoCommandAsync to support the new cli bin path. ([#1772](https://github.com/expo/eas-cli/pull/1772) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🧹 Chores
 
 - Use the `eas-cli` npm tag for checking for the local build plugin updates. ([#1759](https://github.com/expo/eas-cli/pull/1759) by [@dsokal](https://github.com/dsokal))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Update expoCommandAsync to support the new cli bin path. ([#1772](https://github.com/expo/eas-cli/pull/1772) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Update `expoCommandAsync` to support the new Expo CLI bin path. ([#1772](https://github.com/expo/eas-cli/pull/1772) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import { boolish } from 'getenv';
-import resolveFrom from 'resolve-from';
+import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
 import semver from 'semver';
 
 import Log from '../log';
@@ -63,7 +63,8 @@ export async function expoCommandAsync(
   args: string[],
   { silent = false }: { silent?: boolean } = {}
 ): Promise<void> {
-  const expoCliPath = resolveFrom(projectDir, 'expo/bin/cli.js');
+  const expoCliPath =
+    silentResolveFrom(projectDir, 'expo/bin/cli') || resolveFrom(projectDir, 'expo/bin/cli.js');
   const spawnPromise = spawnAsync(expoCliPath, args, {
     stdio: ['inherit', 'pipe', 'pipe'], // inherit stdin so user can install a missing expo-cli from inside this command
   });

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -64,7 +64,7 @@ export async function expoCommandAsync(
   { silent = false }: { silent?: boolean } = {}
 ): Promise<void> {
   const expoCliPath =
-    silentResolveFrom(projectDir, 'expo/bin/cli') || resolveFrom(projectDir, 'expo/bin/cli.js');
+    silentResolveFrom(projectDir, 'expo/bin/cli') ?? resolveFrom(projectDir, 'expo/bin/cli.js');
   const spawnPromise = spawnAsync(expoCliPath, args, {
     stdio: ['inherit', 'pipe', 'pipe'], // inherit stdin so user can install a missing expo-cli from inside this command
   });


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

Since https://github.com/expo/expo/pull/21388 was merged we've been experiencing failures in the `Publish Native Component List Website & Update` workflow on [expo/expo](https://github.com/expo/expo) due to the `eas update` command failing to find the module 'expo/bin/cli.js'
 
E.g. https://github.com/expo/expo/actions/runs/4620498308/jobs/8170689606

![image](https://user-images.githubusercontent.com/11707729/230143837-017b0077-1fc3-4f57-a32c-c1bfffd049d5.png)


# How

This PR updates the `expoCommandAsync` function to resolve the CLI path from the new path, `expo/bin/cli`, using `expo/bin/cli.js` as a fallback

# Test Plan

Run the cli locally
