### PR TITLE
[eas-cli] make ora recognize CI env variable

### DIFF
--- a/packages/eas-cli/src/ora.ts
+++ b/packages/eas-cli/src/ora.ts
@@ -1,3 +1,4 @@
+import { boolish } from 'getenv';
 // eslint-disable-next-line
 import oraReal, { Options, Ora } from 'ora';
 
@@ -14,6 +15,8 @@ const warnReal = console.warn;
 // eslint-disable-next-line no-console
 const errorReal = console.error;
 
+const isCi = boolish('CI', false);
+
 /**
  * A custom ora spinner that sends the stream to stdout in CI, or non-TTY, instead of stderr (the default).
  *
@@ -22,7 +25,7 @@ const errorReal = console.error;
  */
 export function ora(options?: Options | string): Ora {
   const inputOptions = typeof options === 'string' ? { text: options } : options ?? {};
-  const disabled = Log.isDebug || !process.stdin.isTTY;
+  const disabled = Log.isDebug || !process.stdin.isTTY || isCi;
   const spinner = oraReal({
     // Ensure our non-interactive mode emulates CI mode.
     isEnabled: !disabled,


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why
Some users trigger `eas build` from their CI. I'm not sure if `isTTY` is intended to always trigger in this case, but a user recently reported EAS build CI output that looked like the output below, and we've added CI flag checks elsewhere to do the same thing.

```
Compressing project files and uploading to EAS Build. Learn more: https://expo.fyi/eas-build-archive
⠋ Compressing project files⠙ Compressing project files⠹ Compressing project files⠸ Compressing project files⠼ Compressing project files⠴ Compressing project files⠦ Compressing project files⠧ Compressing project files⠇ Compressing project files⠏ Compressing project files⠋ Compressing project files⠙ Compressing project files⠹ Compressing project files⠸ Compressing project files⠼ Compressing project files⠴ Compressing project files⠦ Compressing project files⠧ Compressing project files⠇ Compressing project files⠏ Compressing project files⠋ Compressing project files⠙ Compressing project files⠹ Compressing project files⠸ Compressing project files⠼ Compressing project files⠴ Compressing project files⠦ Compressing project files⠧ Compressing project files⠇ Compressing project files⠏ Compressing project files✔ Compressed project files 3s (14.1 MB)
⠋ Uploading to EAS Build (0 / 14.1 MB)⠙ Uploading to EAS Build (13.4 MB / 14.1 MB)⠹ Uploading to EAS Build (14.1 MB / 14.1 MB)⠸ Uploading to EAS Build (14.1 MB / 14.1 MB)✔ Uploaded to EAS 
```

# How

Added CI check similar to [here](https://github.com/expo/expo-cli/pull/4672)

# Test Plan
Tested `eas build` and `eas update`, both worked/ looked fine.

Output:
```
keith@andknuckles-2 just-kana % CI=1 ../eas-cli/bin/run build --profile preview --platform ios --non-interactive
Resource class m1-medium is deprecated. Use m-medium instead.
- Incrementing buildNumber from 20 to 21.
✔ Incremented buildNumber from 20 to 21.
✔ Using remote iOS credentials (Expo server)

Distribution Certificate is not validated for non-interactive builds.
Skipping Provisioning Profile validation on Apple Servers because we aren't authenticated.

...

Compressing project files and uploading to EAS Build. Learn more: https://expo.fyi/eas-build-archive
- Uploading to EAS Build (0 / 3.9 MB)
✔ Uploaded to EAS 4s
```


