### PR TITLE
[eas-cli] Update apple utilities to avoid the maintenance error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Update apple utilities to work around the maintenance error
+
 ### 🧹 Chores
 
 - Don't use defaults for the `cache.cacheDefaultPaths` build profile field. ([#1769](https://github.com/expo/eas-cli/pull/1769) by [@szdziedzic](https://github.com/szdziedzic))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Update apple utilities to work around the maintenance error
+- Update apple utilities to work around the maintenance error ([#1780](https://github.com/expo/eas-cli/pull/1780) by [@byCedric](https://github.com/byCedric))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Update apple utilities to work around the maintenance error ([#1780](https://github.com/expo/eas-cli/pull/1780) by [@byCedric](https://github.com/byCedric))
+- Update apple utilities to work around the maintenance error. ([#1780](https://github.com/expo/eas-cli/pull/1780) by [@byCedric](https://github.com/byCedric))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eas-cli",
   "description": "EAS command line tool",
-  "version": "3.9.1",
+  "version": "3.9.0",
   "author": "Expo <support@expo.dev>",
   "bin": {
     "eas": "./bin/run"

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "eas-cli",
   "description": "EAS command line tool",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "author": "Expo <support@expo.dev>",
   "bin": {
     "eas": "./bin/run"
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "1.1.0",
+    "@expo/apple-utils": "1.2.0",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "7.0.3",
     "@expo/config-plugins": "5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,10 +1324,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@expo/apple-utils@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.1.0.tgz#62cd724436b8eaa9cafcc3648ea211af8409fc71"
-  integrity sha512-caw0o9HeQHX7xeXppkXI3B/PmPyVOkEjWgXdv0dYzgW/rwvZRLwtMNFXX5t+dJy2hd2UpZlrixaoYyvxuXPtbQ==
+"@expo/apple-utils@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.2.0.tgz#227d118089a4645b076162f3b513dfc68763ca21"
+  integrity sha512-MotvQqu8CNVlnl9nsISobXDjEzSMfT7U5Zk+1rhOFoJhaZhlEkARxumUFUgH6cYnK7J2mMd3YxM+G769arkEKQ==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

This updates our apple utilities to work around the `maintenance` error users encounter when logging in.

# How

- Updated to `@expo/apple-utils@1.2.0`

# Test Plan

- `eas credentials` and try to log in