### PR TITLE
[eas-cli] always show logs from expo install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Show output of `expo install expo-updates`. ([#1782](https://github.com/expo/eas-cli/pull/1782) by [@wkozyra95](https://github.com/wkozyra95))
+
 ## [3.9.1](https://github.com/expo/eas-cli/releases/tag/v3.9.1) - 2023-04-10
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -343,7 +343,7 @@ export async function ensureEASUpdateIsConfiguredAsync(
     expWithoutUpdates.sdkVersion
   );
   if (!hasExpoUpdates) {
-    await installExpoUpdatesAsync(projectDir, { silent: !Log.isDebug });
+    await installExpoUpdatesAsync(projectDir, { silent: false });
     Log.withTick('Installed expo updates');
   }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

When reproducing unrelated issues I noticed that if global expo-cli is not installed then running `eas update` will trigger installing `expo-update` package but it will hang on a prompt that is never displayed because the output is not printed to a terminal.

The result of the above is that command hangs indefinitely unless users hits enter(but no prompt is displayed). It happens for SDK 45 and lower)

# How

Always show output install command

# Test Plan

before
![20230411_11h26m54s_grim](https://user-images.githubusercontent.com/9753141/231116966-71cdb96d-dc6d-4a58-900a-9377a6e81b9c.png)


after
![20230411_11h25m16s_grim](https://user-images.githubusercontent.com/9753141/231116737-101bcb85-cb07-42dc-8921-d6e18150cd9e.png)

