### PR TITLE
print meaningful error message if extra.eas.projectId is not a string

### DIFF
--- a/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
@@ -252,4 +252,26 @@ describe(getProjectIdAsync, () => {
       getProjectIdAsync(sessionManager, { name: 'test', slug: 'test' }, { nonInteractive: false })
     ).rejects.toThrow();
   });
+
+  it('throws if extra.eas.projectId is not a string', async () => {
+    jest.mocked(getConfig).mockReturnValue({
+      exp: { name: 'test', slug: 'test', extra: { eas: { projectId: 1234 } } },
+    } as any);
+    jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
+      id: '1234',
+      fullName: '@notnotbrent/test',
+      slug: 'test',
+      ownerAccount: { name: 'notnotbrent' } as any,
+    });
+
+    await expect(
+      getProjectIdAsync(
+        sessionManager,
+        { name: 'test', slug: 'wat', extra: { eas: { projectId: 1234 } } },
+        { nonInteractive: false }
+      )
+    ).rejects.toThrow(
+      `Project config: "extra.eas.projectId" must be a string, found number. If you're not sure how to set it up on your own, remove the property entirely and it will be automatically configured on the next EAS CLI run.`
+    );
+  });
 });

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -89,6 +89,12 @@ export async function getProjectIdAsync(
 
   const localProjectId = exp.extra?.eas?.projectId;
   if (localProjectId) {
+    if (typeof localProjectId !== 'string') {
+      throw new Error(
+        `Project config: "extra.eas.projectId" must be a string, found ${typeof localProjectId}. If you're not sure how to set it up on your own, remove the property entirely and it will be automatically configured on the next EAS CLI run.`
+      );
+    }
+
     // check that the local project ID matches account and slug
     const appForProjectId = await AppQuery.byIdAsync(graphqlClient, localProjectId);
     if (exp.owner && exp.owner !== appForProjectId.ownerAccount.name) {


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

@kbrandwijk reported that people are getting a cryptic error around the `appId`. I repro'd the issue by setting `extra.eas.projectId` to a non-string value.

# How

- Validate whether `extra.eas.projectId` is a string before sending a server request.
- Print an error message with the potential solution (removing the value from app config).

# Test Plan

- Test case
- Manual test:
<img width="1547" alt="Screenshot 2023-04-13 at 10 53 55" src="https://user-images.githubusercontent.com/5256730/231709742-fc71cc01-b6a0-4c1b-896f-86f08b26def6.png">

