### PR TITLE
[eas-cli] throw error if somebody tries to run iOS with `large` resource class selected using deprecated `--resource-class` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Throw an error if somebody tries to start iOS build with the `large` resource class selected using the deprecated `--resource-class` flag. ([#1795](https://github.com/expo/eas-cli/pull/1795) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [3.9.3](https://github.com/expo/eas-cli/releases/tag/v3.9.3) - 2023-04-18
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import semver from 'semver';
 
 import { BuildResourceClass } from '../../graphql/generated';
-import Log, { learnMore } from '../../log';
+import Log, { link } from '../../log';
 import { getReactNativeVersionAsync } from '../metadata';
 
 type AndroidResourceClass = Exclude<
@@ -50,7 +50,7 @@ export async function resolveBuildResourceClassAsync<T extends Platform>(
 
   if (profileResourceClass && resourceClassFlag && resourceClassFlag !== profileResourceClass) {
     Log.warn(
-      `Build profile specifies the "${profileResourceClass}" resource class but you passed "${resourceClassFlag}" to --resource-class.\nUsing the  "${resourceClassFlag}" as the override.`
+      `Build profile specifies the "${profileResourceClass}" resource class but you passed "${resourceClassFlag}" to --resource-class.\nUsing "${resourceClassFlag}" as the override.`
     );
   }
 
@@ -92,7 +92,7 @@ async function resolveIosResourceClassAsync(
 
   if (resourceClassFlag === ResourceClass.LARGE) {
     throw new Error(
-      `The experimental "large" resource class for Intel iOS workers is no longer available. Define the avaliable resource class, which you want to use for your builds in eas.json. ${learnMore(
+      `Experimental "large" resource class for Intel iOS workers is no longer available. If you want to use a non-default resource class, check the available resource classes at ${link(
         'https://docs.expo.dev/build-reference/eas-json/'
       )}`
     );

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -92,7 +92,7 @@ async function resolveIosResourceClassAsync(
 
   if (resourceClassFlag === ResourceClass.LARGE) {
     throw new Error(
-      `Experimental "large" resource class for Intel iOS workers is no longer available. If you want to use a non-default resource class, check the available resource classes at ${link(
+      `Experimental "large" resource class for Intel iOS workers is no longer available. Remove the specified resource class to use the default, or learn more about all available resource classes: ${link(
         'https://docs.expo.dev/build-reference/eas-json/'
       )}`
     );


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.

# Why

https://exponent-internal.slack.com/archives/CHZKBDRN1/p1681788787056429

# How

Throw an error if somebody tries to run an iOS build using the `large` resource class specified using experimental and deprecated `--resource-class` flag.

# Test Plan

## Build with `large` resource class just for iOS
<img width="1054" alt="Screenshot 2023-04-18 at 14 39 45" src="https://user-images.githubusercontent.com/55145344/232781737-5d5969ed-c15a-4e56-b7e0-793b04e2a7f1.png">

## Build with `large` resource class just for Android
<img width="800" alt="Screenshot 2023-04-18 at 14 40 09" src="https://user-images.githubusercontent.com/55145344/232781916-a63cea6d-ec39-4d57-a3d1-4a63f2b5db08.png">

## Build with `large` resource class for both platforms
<img width="1067" alt="Screenshot 2023-04-18 at 14 40 37" src="https://user-images.githubusercontent.com/55145344/232782132-849d1289-61b2-4e66-9553-48a1af18c540.png">



