### PR TITLE
[gha] add PR changelog check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,8 +1,5 @@
-<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
-
-# Checklist
-
-- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/eas-cli/blob/main/CHANGELOG.md#main) if necessary. You can comment this pull request with `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]` and CHANGELOG.md will be updated automatically.
+<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
+<!-- You can skip the changelog check by labeling the PR with "no changelog". -->
 
 # Why
 

--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -1,0 +1,48 @@
+name: Changelog bot
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  pr-commented:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request && github.event.issue.user.login == github.event.comment.user.login && startsWith(github.event.comment.body, '/changelog-entry ') }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.EXPO_BOT_PAT }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 18
+      - name: Checkout Pull Request
+        run: hub pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        working-directory: ./scripts
+        run: yarn install --frozen-lockfile --check-files
+      - name: Add changelog entry
+        working-directory: ./scripts
+        run: |
+          PARAMS=${PR_COMMENT_BODY#/changelog-entry }
+          if [[ ! "$PARAMS" =~ " " ]]; then
+            echo "Invalid /changelog-entry command"
+            exit 1
+          fi
+          CATEGORY=$( cut -d ' ' -f 1 <<< "$PARAMS" | sed -e 's/^[[:space:]]*//' )
+          MESSAGE=$( cut -d ' ' -f 2- <<< "$PARAMS" | sed -e 's/^[[:space:]]*//' )
+          yarn changelog-entry "$CATEGORY" "$MESSAGE"
+        env:
+          GITHUB_PR_AUTHOR: ${{ github.event.issue.user.login }}
+          GITHUB_PR_NUMBER: ${{ github.event.issue.number }}
+          PR_COMMENT_BODY: ${{ github.event.comment.body }}
+      - name: Commit and push
+        run: |
+          # use the last commit author name and email
+          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+
+          git add CHANGELOG.md
+          git commit -m "update CHANGELOG.md"
+          git push

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,48 +1,37 @@
-on:
-  issue_comment:
-    types: [created]
+name: CHANGELOG.md PR check
 
-name: Changelog
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+      - unlabeled
 
 jobs:
-  pr-commented:
+  pr-changelog-entry:
+    name: Check CHANGELOG.md updated
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request && github.event.issue.user.login == github.event.comment.user.login && startsWith(github.event.comment.body, '/changelog-entry ') }}
     steps:
       - uses: actions/checkout@v2
+      - name: Check if CHANGELOG.md was updated
+        id: changelog-updated
+        uses: tj-actions/changed-files@v35
         with:
-          token: ${{ secrets.EXPO_BOT_PAT }}
-      - uses: actions/setup-node@v2
+          files: CHANGELOG.md
+      - name: Fail if CHANGELOG.md was not updated and the "no changelog" label is absent
+        if: steps.changelog-updated.outputs.any_changed == 'false' && !contains(github.event.pull_request.labels.*.name, 'no changelog')
+        uses: actions/github-script@v6
         with:
-          node-version: 18
-      - name: Checkout Pull Request
-        run: hub pr checkout ${{ github.event.issue.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install dependencies
-        working-directory: ./scripts
-        run: yarn install --frozen-lockfile --check-files
-      - name: Add changelog entry
-        working-directory: ./scripts
-        run: |
-          PARAMS=${PR_COMMENT_BODY#/changelog-entry }
-          if [[ ! "$PARAMS" =~ " " ]]; then
-            echo "Invalid /changelog-entry command"
-            exit 1
-          fi
-          CATEGORY=$( cut -d ' ' -f 1 <<< "$PARAMS" | sed -e 's/^[[:space:]]*//' )
-          MESSAGE=$( cut -d ' ' -f 2- <<< "$PARAMS" | sed -e 's/^[[:space:]]*//' )
-          yarn changelog-entry "$CATEGORY" "$MESSAGE"
-        env:
-          GITHUB_PR_AUTHOR: ${{ github.event.issue.user.login }}
-          GITHUB_PR_NUMBER: ${{ github.event.issue.number }}
-          PR_COMMENT_BODY: ${{ github.event.comment.body }}
-      - name: Commit and push
-        run: |
-          # use the last commit author name and email
-          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
-          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-
-          git add CHANGELOG.md
-          git commit -m "update CHANGELOG.md"
-          git push
+          script: |
+            core.setFailed('Please add a changelog entry!')
+      - uses: mshick/add-pr-comment@v2.1.0
+        if: always()
+        with:
+          message-id: changelog-entry-check
+          refresh-message-position: true
+          message: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') && '⏩ The changelog entry check has been skipped since the "no changelog" label is present.' || '✅ Thank you for adding the changelog entry!' }}
+          message-failure: |
+            ❌ It looks like a changelog entry is missing for this PR. You have two options: you can add it manually, or you can use the changelog bot to do it for you.
+            🤖 To use the bot, simply comment on this PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`.
+            ⏩ If this PR doesn't require a changelog entry, such as if it's an internal change that doesn't affect the user experience, you can add the "no changelog" label to the PR.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: Run tests
+
 on:
   push:
     branches: [main]
@@ -34,11 +35,12 @@ jobs:
       - run: yarn lint --max-warnings=0
       - run: yarn install --frozen-lockfile --check-files
         working-directory: ./scripts
-      - run: yarn lint-changelog
       - uses: codecov/codecov-action@v1
         if: ${{ matrix.coverage }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - run: yarn lint-changelog
+
   notify-slack:
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
<!-- Thanks for contributing to _EAS CLI_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Why

This PR implements my idea on how to make skipping adding the changelog entry less likely.

# How

- Add a workflow that fails if the PR didn't modify CHANGELOG.md.
- The check is skipped if "no changelog" label is added to the PR.
- Comment PR with the check status.

# Test Plan

<img width="1021" alt="Screenshot 2023-04-19 at 15 58 42" src="https://user-images.githubusercontent.com/5256730/233100806-bedd29ed-d8c4-4ace-90fa-da5289b817e0.png">
<img width="1051" alt="Screenshot 2023-04-19 at 15 59 32" src="https://user-images.githubusercontent.com/5256730/233100810-d9107c69-a031-4aaa-baee-f44ee1d21273.png">
<img width="1068" alt="Screenshot 2023-04-19 at 16 00 04" src="https://user-images.githubusercontent.com/5256730/233100814-86cf4f70-27de-4611-b060-475fbd93909b.png">
