### PR TITLE
[eas-cli] Device delete not disabling on Apple side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix `device:delete` not disabling on Apple. ([#1803](https://github.com/expo/eas-cli/pull/1803) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 🧹 Chores
 
 - Throw an error if somebody tries to start iOS build with the `large` resource class selected using the deprecated `--resource-class` flag. ([#1795](https://github.com/expo/eas-cli/pull/1795) by [@szdziedzic](https://github.com/szdziedzic))

--- a/packages/eas-cli/src/commands/device/delete.ts
+++ b/packages/eas-cli/src/commands/device/delete.ts
@@ -112,11 +112,17 @@ export default class DeviceDelete extends EasCommand {
     const removeAppleSpinner = ora('Disabling device on Apple').start();
     try {
       const appleValidatedDevices = await Device.getAsync(context);
-      const appleValidatedDevice = appleValidatedDevices.find(d => d.id === device.id);
+      const appleValidatedDevice = appleValidatedDevices.find(
+        d => d.attributes.udid === device.identifier
+      );
       if (appleValidatedDevice) {
         await appleValidatedDevice.updateAsync({ status: DeviceStatus.DISABLED });
+        removeAppleSpinner.succeed('Disabled device on Apple');
+      } else {
+        removeAppleSpinner.warn(
+          'Device not found on Apple Developer Portal. Expo-registered devices will not appear there until they are chosen for an internal distribution build.'
+        );
       }
-      removeAppleSpinner.succeed('Disabled device on Apple');
     } catch (err) {
       removeAppleSpinner.fail();
       throw err;

--- a/packages/eas-cli/src/devices/actions/create/inputMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/inputMethod.ts
@@ -81,7 +81,9 @@ async function collectDeviceDataAsync(
   Log.newLine();
   Log.log(
     `We are going to register the following device in our database.
-This will ${chalk.bold('not')} register the device on the Apple Developer Portal yet.`
+This device will ${chalk.bold(
+      'not'
+    )} be registered on the Apple Developer Portal until it is chosen for an internal distribution build.`
   );
   Log.newLine();
   Log.log(formatNewDevice({ ...deviceData, identifier: deviceData.udid }, appleTeam));


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
For https://github.com/expo/eas-cli/pull/1787, I copied the Expo-to-Apple device cross-reference from `eas device:delete`. During testing, I discovered that it never found the device on Apple, and then when I went back to try out delete, it turned out that delete wasn't finding the device either, and thus never disabling it on the Apple Developer Portal.

# How
The previous `find` was comparing Expo GUID to an Apple 9-character alphanumeric ID. Updated to compare `udid` to `udid`.

Here's what the objects look like:

`AppleDevice` (Expo entity):
```
{
  id: 'f8108da4-d62b-4325-8f0d-b646133c2d16',
  identifier: '00008110-ABCDEFD12345678',
  name: 'keiths ipad',
  deviceClass: 'IPAD',
  enabled: true,
  model: null,
}
```

`Device` (from `@expo/apple-utils`):
```
{
  context: { providerId: 12345678, teamId: 'ABCDEF1234' },
  id: '12345678K6',
  attributes: {
    addedDate: '2023-04-20T14:33:24.000+00:00',
    serialNumber: null,
    inEligibilityDuration: 0,
    description: null,
    platform: 'IOS',
    name: 'keiths ipad',
    deviceClass: 'IPAD',
    model: 'iPad mini (6th generation)',
    udid: '00008110-ABCDEFD12345678',
    platformName: 'iOS',
    responseId: 'fd66367c-a738-4104-bd4b-41e69c41a9c2',
    status: 'ENABLED',
    devicePlatformLabel: 'iPad'
  }
}
```

Also added a bit more context when manually creating a device as to when the device is actually created on the Apple side when I realized that, in my haste when testing renames and deletes, I wasn't actually taking the steps to create the device on Apple.

# Test Plan
- [x] Tested `eas device:delete` with a device created on Apple, and it successfully disabled the device
- [x] Tested `eas device:delete` with a device not created on Apple, it it warned that it wasn't found on the Apple side. 
