### PR TITLE
[eas-cli] [ENG-8153] Print requestId and original error message on unexpected graphQL-related error

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -202,8 +202,16 @@ export function handleBuildRequestError(error: any, platform: Platform): never {
       `You have already reached the maximum number of pending ${requestedPlatformDisplayNames[platform]} builds for your account. Try again later.`
     );
   } else if (error?.graphQLErrors) {
+    const requestIdLine = error?.graphQLErrors?.[0]?.extensions?.requestId
+      ? `\nRequest ID: ${error.graphQLErrors[0].extensions.requestId}`
+      : '';
+    const originalMessageLine = error?.graphQLErrors?.[0]?.message
+      ? `\nOriginal error: ${error.graphQLErrors[0].message}`
+      : '';
     throw new Error(
-      'Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.'
+      'Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.' +
+        requestIdLine +
+        originalMessageLine
     );
   }
   throw error;


### PR DESCRIPTION
Upon unexpected GraphQL-related error a new message is printed to the user. Now it also has the request ID (if returned with the error from `www`) and the original error message. This hopefully will help to identify the issues users have when unsuccessfully submitting build requests

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When users encounter an unexpected graphQL-related error when submitting build requests they receive a truthful, but rather generic message
<img width="1131" alt="Screenshot 2023-04-26 at 14 44 21" src="https://user-images.githubusercontent.com/2974455/234578483-09f55fd0-6368-48d6-a75e-99886ba5776e.png">
which suggests to report the issue if the problem persists, so they do, but identifying their build request and the issue with it is challenging. Having a request ID and the original error message from `www` should make this easier.

See: https://linear.app/expo/issue/ENG-8153/if-the-build-request-fails-with-unknown-error-print-request-id

# How

When an unexpected graphQL-related error is encountered, the error message printed to the user is the same, but contains up to 2 new lines - first contains the request ID, and the second contains the original error message from `www`'s graphQL

# Test Plan

Updated automated tests for error handling, as well as tested manually.
Current error message looks as follows
<img width="1131" alt="Screenshot 2023-04-26 at 14 38 28" src="https://user-images.githubusercontent.com/2974455/234579584-87662a2c-41b6-40c5-b339-81eec5797fcf.png">
