### PR TITLE
[eas-cli] Add account list to `eas whoami`/`eas account:view`

### DIFF
--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -1,8 +1,10 @@
 import chalk from 'chalk';
+import nullthrows from 'nullthrows';
 
 import EasCommand from '../../commandUtils/EasCommand';
+import { Role } from '../../graphql/generated';
 import Log from '../../log';
-import { getActorDisplayName } from '../../user/User';
+import { Actor, getActorDisplayName } from '../../user/User';
 
 export default class AccountView extends EasCommand {
   static override description = 'show the username you are logged in as';
@@ -18,9 +20,48 @@ export default class AccountView extends EasCommand {
     } = await this.getContextAsync(AccountView, { nonInteractive: true });
     if (actor) {
       Log.log(chalk.green(getActorDisplayName(actor)));
+
+      // personal account is included, only show if more accounts that personal account
+      // but do show personal account in list if there are more
+      const accountExcludingPersonalAccount = actor.accounts.filter(
+        account => !('username' in actor) || account.name !== actor.username
+      );
+      if (accountExcludingPersonalAccount.length > 0) {
+        Log.newLine();
+        Log.log('Accounts:');
+        actor.accounts.forEach(account => {
+          const roleOnAccount = AccountView.getRoleOnAccount(actor, account);
+          Log.log(`• ${account.name} (Role: ${AccountView.getLabelForRole(roleOnAccount)})`);
+        });
+      }
     } else {
       Log.warn('Not logged in');
       process.exit(1);
+    }
+  }
+
+  private static getRoleOnAccount(actor: Actor, account: Actor['accounts'][0]): Role {
+    if ('username' in actor && account.name === actor.username) {
+      return Role.Owner;
+    }
+
+    return nullthrows(account.users.find(user => user.actor.id === actor.id)?.role);
+  }
+
+  private static getLabelForRole(role: Role): string {
+    switch (role) {
+      case Role.Owner:
+        return 'Owner';
+      case Role.Admin:
+        return 'Admin';
+      case Role.Developer:
+        return 'Developer';
+      case Role.ViewOnly:
+        return 'Viewer';
+      case Role.Custom:
+      case Role.HasAdmin:
+      case Role.NotAdmin:
+        return 'Custom';
     }
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When looking into #1324, I realized there's nowhere in the CLI that we show all the accounts that the logged-in user has access to and their roles. 

I think it makes sense in this command, though I was hesitant at first to add it as there's a chance that people are programmatically parsing the output since it has historically been just a username. What do others think?

# How

Add output. Will add tests once others chime in about whether it makes sense here.

# Test Plan

Test manually:

```
$ neas whoami
fake_username

Accounts:
• fake_username (Role: Owner)
• fake_other_account (Role: Admin)
• test-org (Role: Developer)
```
