### PR TITLE
[eas-cli][eas-json] add `large` resource class for iOS as allowed value in `eas.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add account list to `eas whoami`/`eas account:view`. ([#1814](https://github.com/expo/eas-cli/pull/1814) by [@wschurman](https://github.com/wschurman))
+- Add `large` resource class for iOS as allowed value in `eas.json`. ([#1817](https://github.com/expo/eas-cli/pull/1817) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/utils/resourceClass.ts
+++ b/packages/eas-cli/src/build/utils/resourceClass.ts
@@ -96,10 +96,10 @@ function resolveIosResourceClass(
     );
   }
 
-  if (resourceClass === ResourceClass.M1_LARGE) {
+  if ([ResourceClass.M_LARGE, ResourceClass.M1_LARGE].includes(resourceClass)) {
     Log.warn(
-      `Resource class ${chalk.bold('m1-large')} is deprecated. Use ${chalk.bold(
-        'm-large'
+      `Resource class ${chalk.bold(resourceClass)} is deprecated. Use ${chalk.bold(
+        'large'
       )} instead.`
     );
   }

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -187,7 +187,7 @@
           "default": "default",
           "anyOf": [
             {
-              "enum": ["default", "medium"]
+              "enum": ["default", "medium", "large"]
             },
             {
               "type": "string"
@@ -361,7 +361,7 @@
           "default": "default",
           "anyOf": [
             {
-              "enum": ["default", "medium", "intel-medium", "m-medium"]
+              "enum": ["default", "medium", "large", "intel-medium", "m-medium"]
             },
             {
               "type": "string"

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -467,6 +467,23 @@ test('iOS-specific resourceClass', async () => {
   ).resolves.not.toThrow();
 });
 
+test('iOS-specific resourceClass', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      production: {
+        ios: {
+          resourceClass: 'large',
+        },
+      },
+    },
+  });
+
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
+  await expect(
+    EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production')
+  ).resolves.not.toThrow();
+});
+
 test('Android-specific resourceClass', async () => {
   await fs.writeJson('/project/eas.json', {
     build: {

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -467,13 +467,28 @@ test('iOS-specific resourceClass', async () => {
   ).resolves.not.toThrow();
 });
 
-test('iOS-specific resourceClass', async () => {
+test('iOS-specific `large` resourceClass', async () => {
   await fs.writeJson('/project/eas.json', {
     build: {
       production: {
         ios: {
           resourceClass: 'large',
         },
+      },
+    },
+  });
+
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
+  await expect(
+    EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'production')
+  ).resolves.not.toThrow();
+});
+
+test('`large` resourceClass in build profile root', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      production: {
+        resourceClass: 'large',
       },
     },
   });

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -3,12 +3,13 @@ import semver from 'semver';
 
 import { ResourceClass } from './types';
 
-const AllowedCommonResourceClasses: ResourceClass[] = [ResourceClass.DEFAULT, ResourceClass.MEDIUM];
-
-const AllowedAndroidResourceClasses: ResourceClass[] = [
-  ...AllowedCommonResourceClasses,
+const AllowedCommonResourceClasses: ResourceClass[] = [
+  ResourceClass.DEFAULT,
+  ResourceClass.MEDIUM,
   ResourceClass.LARGE,
 ];
+
+const AllowedAndroidResourceClasses: ResourceClass[] = AllowedCommonResourceClasses;
 
 const AllowedIosResourceClasses: ResourceClass[] = [
   ...AllowedCommonResourceClasses,

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -23,6 +23,9 @@ export enum ResourceClass {
   INTEL_MEDIUM = 'intel-medium',
   MEDIUM = 'medium',
   M_MEDIUM = 'm-medium',
+  /**
+   * @deprecated use LARGE instead
+   */
   M_LARGE = 'm-large',
 }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We want to make `large` iOS available for the users

# How

Add `large` as a valid option for the `resourceClass` field in `eas.json` (both for iOS-specific options and in build profile root). 

After this PR is merged users should be able to use the `large` resource class in the following ways:

Request `large` both for iOS and Android
```json
{
  "build": {
    "production": {
      "resourceClass": "large",
      ...
    },
    ...
  },
  ...
}
```

Request `large` for iOS only
```json
{
  "build": {
    "production": {
      "ios": {
        "resourceClass": "large",
        ...
      },
      ...
    },
    ...
  },
  ...
}
```

Request `large` for Android only
```json
{
  "build": {
    "production": {
      "android": {
        "resourceClass": "large",
        ...
      },
      ...
    },
    ...
  },
  ...
}
```

Deprecate experimental `m-large` resource class.

# Test Plan

Add tests.

Test manually

Deprecated `m-large` resource class:
<img width="725" alt="Screenshot 2023-04-28 at 10 30 04" src="https://user-images.githubusercontent.com/55145344/235099304-2b5c572f-7b3a-475c-bcd3-a10ae096c5e0.png">

[Build](https://expo.dev/accounts/szdziedzic/projects/testapp/builds/4f76d386-e247-49dd-ab5b-79cab4ba2ef9) with `large` resource class works fine:
<img width="822" alt="Screenshot 2023-04-28 at 10 24 01" src="https://user-images.githubusercontent.com/55145344/235099312-220c4bc8-35f7-4b3b-b88e-621f213b5726.png">

