### PR TITLE
don't generate ios credentials for non-signable targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix building iOS projects with framework targets. ([#1835](https://github.com/expo/eas-cli/pull/1835) by [@dsokal](https://github.com/dsokal))
+
 ### 🧹 Chores
 
 ## [3.12.1](https://github.com/expo/eas-cli/releases/tag/v3.12.1) - 2023-05-15

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -11,7 +11,7 @@
     "@expo/apple-utils": "1.2.0",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "7.0.3",
-    "@expo/config-plugins": "5.0.4",
+    "@expo/config-plugins": "6.0.2",
     "@expo/config-types": "47.0.0",
     "@expo/eas-build-job": "1.0.12",
     "@expo/eas-json": "3.12.1",

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -163,6 +163,9 @@ async function resolveBareProjectDependenciesAsync({
 
   if (target.dependencies && target.dependencies.length > 0) {
     for (const dependency of target.dependencies) {
+      if (!dependency.signable) {
+        continue;
+      }
       const dependencyBundleIdentifier = await getBundleIdentifierAsync(projectDir, exp, {
         targetName: dependency.name,
         buildConfiguration,

--- a/packages/eas-cli/src/update/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/ios/UpdatesModule.ts
@@ -53,7 +53,7 @@ export async function readChannelSafelyAsync(projectDir: string): Promise<string
   try {
     const expoPlist = await readExpoPlistAsync(projectDir);
     const updatesRequestHeaders = expoPlist['EXUpdatesRequestHeaders'];
-    return updatesRequestHeaders['expo-channel-name'] ?? null;
+    return updatesRequestHeaders?.['expo-channel-name'] ?? null;
   } catch {
     return null;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,7 +1347,28 @@
     node-forge "^1.2.1"
     nullthrows "^1.1.1"
 
-"@expo/config-plugins@5.0.4", "@expo/config-plugins@~5.0.3":
+"@expo/config-plugins@6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-6.0.2.tgz#cf07319515022ba94d9aa9fa30e0cff43a14256f"
+  integrity sha512-Cn01fXMHwjU042EgO9oO3Mna0o/UCrW91MQLMbJa4pXM41CYGjNgVy1EVXiuRRx/upegHhvltBw5D+JaUm8aZQ==
+  dependencies:
+    "@expo/config-types" "^48.0.0"
+    "@expo/json-file" "~8.2.37"
+    "@expo/plist" "^0.0.20"
+    "@expo/sdk-runtime-versions" "^1.0.0"
+    "@react-native/normalize-color" "^2.0.0"
+    chalk "^4.1.2"
+    debug "^4.3.1"
+    find-up "~5.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    semver "^7.3.5"
+    slash "^3.0.0"
+    xcode "^3.0.1"
+    xml2js "0.4.23"
+
+"@expo/config-plugins@~5.0.3":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-5.0.4.tgz#216fea6558fe66615af1370de55193f4181cb23e"
   integrity sha512-vzUcVpqOMs3h+hyRdhGwk+eGIOhXa5xYdd92yO17RMNHav3v/+ekMbs7XA2c3lepMO8Yd4/5hqmRw9ZTL6jGzg==
@@ -1372,6 +1393,11 @@
   version "47.0.0"
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-47.0.0.tgz#99eeabe0bba7a776e0f252b78beb0c574692c38d"
   integrity sha512-r0pWfuhkv7KIcXMUiNACJmJKKwlTBGMw9VZHNdppS8/0Nve8HZMTkNRFQzTHW1uH3pBj8jEXpyw/2vSWDHex9g==
+
+"@expo/config-types@^48.0.0":
+  version "48.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-48.0.0.tgz#15a46921565ffeda3c3ba010701398f05193d5b3"
+  integrity sha512-DwyV4jTy/+cLzXGAo1xftS6mVlSiLIWZjl9DjTCLPFVgNYQxnh7htPilRv4rBhiNs7KaznWqKU70+4zQoKVT9A==
 
 "@expo/config@7.0.3", "@expo/config@~7.0.2":
   version "7.0.3"
@@ -1424,7 +1450,7 @@
     json5 "^1.0.1"
     write-file-atomic "^2.3.0"
 
-"@expo/json-file@8.2.37":
+"@expo/json-file@8.2.37", "@expo/json-file@~8.2.37":
   version "8.2.37"
   resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.37.tgz#9c02d3b42134907c69cc0a027b18671b69344049"
   integrity sha512-YaH6rVg11JoTS2P6LsW7ybS2CULjf40AbnAHw2F1eDPuheprNjARZMnyHFPkKv7GuxCy+B9GPcbOKgc4cgA80Q==
@@ -1489,7 +1515,7 @@
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
 
-"@expo/plist@0.0.20":
+"@expo/plist@0.0.20", "@expo/plist@^0.0.20":
   version "0.0.20"
   resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.20.tgz#a6b3124438031c02b762bad5a47b70584d3c0072"
   integrity sha512-UXQ4LXCfTZ580LDHGJ5q62jSTwJFFJ1GqBu8duQMThiHKWbMJ+gajJh6rsB6EJ3aLUr9wcauxneL5LVRFxwBEA==


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Companion to https://github.com/expo/expo/pull/22454
Fixes https://github.com/expo/eas-cli/issues/1812

# How

Don't generate credentials for non-signable targets. 

# Test Plan

Tested against the project from https://github.com/expo/eas-cli/issues/1812#issuecomment-1540282795

# TODO

Upgrade `config-plugins` here when it's published