### PR TITLE
[eas-cli] add clear cache option to updates

### DIFF
--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -59,6 +59,7 @@ type RawUpdateFlags = {
   platform: string;
   'input-dir': string;
   'skip-bundler': boolean;
+  'clear-cache': boolean;
   'private-key-path'?: string;
   'non-interactive': boolean;
   json: boolean;
@@ -76,6 +77,7 @@ type UpdateFlags = {
   updateMessage?: string;
   inputDir: string;
   skipBundler: boolean;
+  clearCache: boolean;
   privateKeyPath?: string;
   json: boolean;
   nonInteractive: boolean;
@@ -112,6 +114,10 @@ export default class UpdatePublish extends EasCommand {
     }),
     'skip-bundler': Flags.boolean({
       description: `Skip running Expo CLI to bundle the app before publishing`,
+      default: false,
+    }),
+    'clear-cache': Flags.boolean({
+      description: `Clear the bundler cache before publishing`,
       default: false,
     }),
     platform: Flags.enum({
@@ -151,6 +157,7 @@ export default class UpdatePublish extends EasCommand {
       updateMessage: updateMessageArg,
       inputDir,
       skipBundler,
+      clearCache,
       privateKeyPath,
       json: jsonFlag,
       nonInteractive,
@@ -212,7 +219,7 @@ export default class UpdatePublish extends EasCommand {
     if (!skipBundler) {
       const bundleSpinner = ora().start('Exporting...');
       try {
-        await buildBundlesAsync({ projectDir, inputDir, exp, platformFlag });
+        await buildBundlesAsync({ projectDir, inputDir, exp, platformFlag, clearCache });
         bundleSpinner.succeed('Exported bundle(s)');
       } catch (e) {
         bundleSpinner.fail('Export failed');
@@ -488,6 +495,7 @@ export default class UpdatePublish extends EasCommand {
       updateMessage,
       inputDir: flags['input-dir'],
       skipBundler: flags['skip-bundler'],
+      clearCache: flags['clear-cache'],
       platform: flags.platform as RequestedPlatform,
       privateKeyPath: flags['private-key-path'],
       nonInteractive,

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -180,11 +180,13 @@ export async function buildBundlesAsync({
   inputDir,
   exp,
   platformFlag,
+  clearCache,
 }: {
   projectDir: string;
   inputDir: string;
   exp: Pick<ExpoConfig, 'sdkVersion'>;
   platformFlag: ExpoCLIExportPlatformFlag;
+  clearCache?: boolean;
 }): Promise<void> {
   const packageJSON = JsonFile.read(path.resolve(projectDir, 'package.json'));
   if (!packageJSON) {
@@ -200,6 +202,7 @@ export async function buildBundlesAsync({
       '--dump-assetmap',
       '--platform',
       platformFlag,
+      ...(clearCache ? ['--clear'] : []),
     ]);
   } else {
     // Legacy global Expo CLI
@@ -213,6 +216,7 @@ export async function buildBundlesAsync({
       '--dump-assetmap',
       '--platform',
       platformFlag,
+      ...(clearCache ? ['--clear'] : []),
     ]);
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The `clear-cache` option to remove the metro bundler cache exists for `eas build` and for the Classic Updates `expo publish` command, but it was overlooked for `eas update`. This PR adds the flag to `eas update` to bring it to parity with our other commands.

Fixes https://github.com/expo/eas-cli/issues/1123 . Also a bunch of other users reported issues with `eas update` that I suspect would be fixed by clearing the metro bundler too.

# How

`eas update` relies on the expo cli's `expo export` command to generate it's bundle. This PR plumb down the `clear-cache` flag to the `expo export` command. This should work with all released versions of `expo export` since support for the `clear` flag has always existed. 

# Test Plan

- [ ] tested manually `eas update --clear-cache`
