### PR TITLE
[eas-cli][ENG-8528] Don't print all selected devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Short format for selecting devices prompt. ([#1840](https://github.com/expo/eas-cli/pull/1840) by [@khamilowicz](https://github.com/khamilowicz))
 - Ignore dirty workingdir when building from GitHub. ([#1842](https://github.com/expo/eas-cli/pull/1842) by [@wkozyra95](https://github.com/wkozyra95))
 
 ## [3.12.1](https://github.com/expo/eas-cli/releases/tag/v3.12.1) - 2023-05-15

--- a/packages/eas-cli/src/credentials/ios/actions/DeviceUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DeviceUtils.ts
@@ -13,6 +13,7 @@ export async function chooseDevicesAsync(
   const { devices } = await promptAsync({
     type: 'multiselect',
     name: 'devices',
+    selectionFormat: '<num> devices selected',
     message: 'Select devices for the ad hoc build:',
     hint: '- Space to select. Return to submit',
     choices: allDevices.map(device => ({

--- a/packages/eas-cli/src/easMultiselect.ts
+++ b/packages/eas-cli/src/easMultiselect.ts
@@ -1,0 +1,53 @@
+import { Choice, PromptObject } from 'prompts';
+import { MultiselectPrompt } from 'prompts/lib/elements';
+
+const noop = (): void => {};
+
+export type Question<T extends string = string> = PromptObject<T> & {
+  selectionFormat?: string;
+};
+
+/**
+ * Customized multiselect prompt.
+ *
+ * Additional parameters:
+ *
+ * @param selectionFormat
+ *   String indicating number of selected options. Should contain `<num>` substring.
+ *
+ *   Example:
+ *     'Selected <num> devices'
+ *
+ *   Short format is used when more than one option is selected.
+ *
+ **/
+
+export default class EasMultiselect extends MultiselectPrompt {
+  constructor(opts: Question) {
+    super(opts);
+    this.selectionFormat = opts.selectionFormat;
+  }
+  override renderDoneOrInstructions(): string {
+    if (this.done && this.selectionFormat && this.value) {
+      const selectedOptionsCount = this.value.filter(e => e.selected).length;
+
+      if (selectedOptionsCount > 1) {
+        return this.selectionFormat.replace('<num>', selectedOptionsCount.toString());
+      }
+    }
+    return super.renderDoneOrInstructions();
+  }
+}
+
+export const easMultiselect = (args: Question): Promise<Choice[]> => {
+  const toSelected = (items: Choice[]): Choice[] =>
+    items.filter(item => item.selected).map(item => item.value);
+
+  return new Promise((res, rej) => {
+    const p = new EasMultiselect(args);
+    const onAbort = toSelected || noop;
+    const onSubmit = toSelected || noop;
+    p.on('submit', x => res(onSubmit(x)));
+    p.on('abort', x => rej(onAbort(x)));
+  });
+};

--- a/packages/eas-cli/src/prompts.ts
+++ b/packages/eas-cli/src/prompts.ts
@@ -1,7 +1,12 @@
 import { constants } from 'os';
-import prompts, { Answers, Choice, Options, PromptType, PromptObject as Question } from 'prompts';
+import prompts, { Answers, Choice, Options, prompts as PromptElements, PromptType } from 'prompts';
 
+import { Question, easMultiselect } from './easMultiselect';
 export { PromptType, Question, Choice };
+
+if (PromptElements) {
+  PromptElements.multiselect = easMultiselect;
+}
 
 export interface ExpoChoice<T> extends Choice {
   value: T;

--- a/packages/eas-cli/tsconfig.json
+++ b/packages/eas-cli/tsconfig.json
@@ -14,8 +14,8 @@
     "outDir": "build",
     "rootDir": "src",
     "typeRoots": [
-      "../../node_modules/@types",
       "../../ts-declarations",
+      "../../node_modules/@types",
       "./node_modules/@types"
     ]
   },

--- a/ts-declarations/prompts/index.d.ts
+++ b/ts-declarations/prompts/index.d.ts
@@ -1,0 +1,11 @@
+declare module 'prompts/lib/elements' {
+  class MultiselectPrompt {
+    selectionFormat: string | undefined;
+    done: boolean | undefined;
+    value: any[] | undefined;
+
+    constructor(parameters: any);
+    on(event: string, callback: (args: any) => any): any;
+    renderDoneOrInstructions(): string;
+  }
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Select devices prompt is a bit messy when there are many selected devices. Instead of printing all of their names and identifiers, simply the number of selected devices should be displayed.

<img width="445" alt="image" src="https://github.com/expo/eas-cli/assets/1774298/66a8f47a-6f1a-473e-99a4-afc5fa55245f">

# How

Since `prompts` library does not make it easy to customize default prompts, default multiselect is overriden by new `EasMultiselect`. New prompt can customize output message via `selectionFormat` option.

# Test Plan

It can be tested by issuing new/editing existing adhoc provisioning profile with `eas credentials` command.