### PR TITLE
[eas-cli] builds from GitHub are never in a dirty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Ignore dirty workingdir when building from GitHub. ([#1842](https://github.com/expo/eas-cli/pull/1842) by [@wkozyra95](https://github.com/wkozyra95))
+
 ## [3.12.1](https://github.com/expo/eas-cli/releases/tag/v3.12.1) - 2023-05-15
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -19,6 +19,7 @@ import { getVcsClient } from '../vcs';
 import { maybeResolveVersionsAsync as maybeResolveAndroidVersionsAsync } from './android/version';
 import { BuildContext } from './context';
 import { maybeResolveVersionsAsync as maybeResolveIosVersionsAsync } from './ios/version';
+import { LocalBuildMode } from './local';
 
 export async function collectMetadataAsync<T extends Platform>(
   ctx: BuildContext<T>
@@ -47,7 +48,10 @@ export async function collectMetadataAsync<T extends Platform>(
     gitCommitMessage: truncateGitCommitMessage(
       (await vcsClient.getLastCommitMessageAsync()) ?? undefined
     ),
-    isGitWorkingTreeDirty: await vcsClient.hasUncommittedChangesAsync(),
+    isGitWorkingTreeDirty:
+      ctx.localBuildOptions.localBuildMode === LocalBuildMode.INTERNAL
+        ? false
+        : await vcsClient.hasUncommittedChangesAsync(),
     username: getUsername(ctx.exp, ctx.user),
     message: ctx.message,
     ...(ctx.platform === Platform.IOS && {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Builds from GitHub should never be in a dirty state, even if there are some local changes cause by e.g. pre-install hook.

# How

override isGitWorkingTreeDirty when localBuildMode is INTERNAL

# Test Plan

simple change, not tested