### PR TITLE
[eas-cli] make `large` resource class only available for paid tier users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Short format for selecting devices prompt. ([#1840](https://github.com/expo/eas-cli/pull/1840) by [@khamilowicz](https://github.com/khamilowicz))
 - Improve typescript types for user display. ([#1851](https://github.com/expo/eas-cli/pull/1851) by [@wschurman](https://github.com/wschurman))
+- Add error for `large` resource class not available on the free plan to server-side defined errors. ([#1848](https://github.com/expo/eas-cli/pull/1848) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [3.13.0](https://github.com/expo/eas-cli/releases/tag/v3.13.0) - 2023-05-17
 

--- a/packages/eas-cli/src/__tests__/commands/utils.ts
+++ b/packages/eas-cli/src/__tests__/commands/utils.ts
@@ -116,3 +116,25 @@ export function mockTestCommand<T extends Command>(
   (cmd as any).getContextAsync = jest.fn(() => ctx);
   return cmd;
 }
+
+export class NoErrorThrownError extends Error {}
+
+export const getErrorAsync = async <TError = any>(
+  call: () => unknown
+): Promise<TError | NoErrorThrownError> => {
+  try {
+    await call();
+    throw new NoErrorThrownError();
+  } catch (error: unknown) {
+    return error as TError;
+  }
+};
+
+export const getError = <TError = any>(call: () => unknown): TError | NoErrorThrownError => {
+  try {
+    call();
+    throw new NoErrorThrownError();
+  } catch (error: unknown) {
+    return error as TError;
+  }
+};

--- a/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
+++ b/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
@@ -3,6 +3,7 @@ import { CombinedError } from '@urql/core';
 import { GraphQLError } from 'graphql/error';
 import { v4 as uuidv4 } from 'uuid';
 
+import { getError } from '../../__tests__/commands/utils';
 import { EasCommandError } from '../../commandUtils/errors';
 import Build from '../../commands/build';
 import Log, { link } from '../../log';
@@ -126,11 +127,17 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
-              handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(caughtError as Error, TurtleDeprecatedJobFormatError, 'Error 1');
-            }
+            const handleBuildRequestErrorThrownError = getError<TurtleDeprecatedJobFormatError>(
+              () => {
+                handleBuildRequestError(error, platform);
+              }
+            );
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              TurtleDeprecatedJobFormatError,
+              'Error 1'
+            );
           });
 
           it('throws correct EasBuildResourceClassNotAvailableInFreeTierError', async () => {
@@ -142,15 +149,16 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
-              handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(
-                caughtError as Error,
-                EasBuildResourceClassNotAvailableInFreeTierError,
-                'Error 1'
-              );
-            }
+            const handleBuildRequestErrorThrownError =
+              getError<EasBuildResourceClassNotAvailableInFreeTierError>(() => {
+                handleBuildRequestError(error, platform);
+              });
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              EasBuildResourceClassNotAvailableInFreeTierError,
+              'Error 1'
+            );
           });
         });
         describe('with iOS', () => {
@@ -160,11 +168,17 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
-              handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(caughtError as Error, TurtleDeprecatedJobFormatError, 'Error 1');
-            }
+            const handleBuildRequestErrorThrownError = getError<TurtleDeprecatedJobFormatError>(
+              () => {
+                handleBuildRequestError(error, platform);
+              }
+            );
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              TurtleDeprecatedJobFormatError,
+              'Error 1'
+            );
           });
 
           it('throws correct EasBuildResourceClassNotAvailableInFreeTierError', async () => {
@@ -176,15 +190,16 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
-              handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(
-                caughtError as Error,
-                EasBuildResourceClassNotAvailableInFreeTierError,
-                'Error 1'
-              );
-            }
+            const handleBuildRequestErrorThrownError =
+              getError<EasBuildResourceClassNotAvailableInFreeTierError>(() => {
+                handleBuildRequestError(error, platform);
+              });
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              EasBuildResourceClassNotAvailableInFreeTierError,
+              'Error 1'
+            );
           });
         });
       });
@@ -197,11 +212,17 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
-              handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(caughtError as Error, EasBuildFreeTierDisabledError, 'Error 1');
-            }
+            const handleBuildRequestErrorThrownError = getError<EasBuildFreeTierDisabledError>(
+              () => {
+                handleBuildRequestError(error, platform);
+              }
+            );
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              EasBuildFreeTierDisabledError,
+              'Error 1'
+            );
           });
         });
         describe('with iOS', () => {
@@ -211,11 +232,17 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
-              handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(caughtError as Error, EasBuildFreeTierDisabledError, 'Error 1');
-            }
+            const handleBuildRequestErrorThrownError = getError<EasBuildFreeTierDisabledError>(
+              () => {
+                handleBuildRequestError(error, platform);
+              }
+            );
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              EasBuildFreeTierDisabledError,
+              'Error 1'
+            );
           });
         });
       });
@@ -240,15 +267,17 @@ describe(Build.name, () => {
           const graphQLErrors = [graphQLError];
           const error = new CombinedError({ graphQLErrors });
 
-          try {
-            handleBuildRequestError(error, platform);
-          } catch (caughtError) {
-            assertReThrownError(
-              caughtError as Error,
-              EasBuildFreeTierDisabledAndroidError,
-              'Error 1'
-            );
-          }
+          const handleBuildRequestErrorThrownError = getError<EasBuildFreeTierDisabledAndroidError>(
+            () => {
+              handleBuildRequestError(error, platform);
+            }
+          );
+
+          assertReThrownError(
+            handleBuildRequestErrorThrownError,
+            EasBuildFreeTierDisabledAndroidError,
+            'Error 1'
+          );
         });
       });
 
@@ -260,11 +289,15 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
+            const handleBuildRequestErrorThrownError = getError<RequestValidationError>(() => {
               handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(caughtError as Error, RequestValidationError, 'Error 1');
-            }
+            });
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              RequestValidationError,
+              'Error 1'
+            );
           });
         });
         describe('with iOS', () => {
@@ -274,11 +307,15 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
+            const handleBuildRequestErrorThrownError = getError<RequestValidationError>(() => {
               handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(caughtError as Error, RequestValidationError, 'Error 1');
-            }
+            });
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              RequestValidationError,
+              'Error 1'
+            );
           });
         });
       });
@@ -293,15 +330,17 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
-              handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(
-                caughtError as Error,
-                EasBuildDownForMaintenanceError,
-                EXPECTED_EAS_BUILD_DOWN_MESSAGE
-              );
-            }
+            const handleBuildRequestErrorThrownError = getError<EasBuildDownForMaintenanceError>(
+              () => {
+                handleBuildRequestError(error, platform);
+              }
+            );
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              EasBuildDownForMaintenanceError,
+              EXPECTED_EAS_BUILD_DOWN_MESSAGE
+            );
           });
         });
         describe('with iOS', () => {
@@ -311,15 +350,17 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
-              handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(
-                caughtError as Error,
-                EasBuildDownForMaintenanceError,
-                EXPECTED_EAS_BUILD_DOWN_MESSAGE
-              );
-            }
+            const handleBuildRequestErrorThrownError = getError<EasBuildDownForMaintenanceError>(
+              () => {
+                handleBuildRequestError(error, platform);
+              }
+            );
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              EasBuildDownForMaintenanceError,
+              EXPECTED_EAS_BUILD_DOWN_MESSAGE
+            );
           });
         });
       });
@@ -332,15 +373,17 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
-              handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(
-                caughtError as Error,
-                EasBuildTooManyPendingBuildsError,
-                EXPECTED_MAX_BUILD_COUNT_MESSAGE_ANDROID
-              );
-            }
+            const handleBuildRequestErrorThrownError = getError<EasBuildTooManyPendingBuildsError>(
+              () => {
+                handleBuildRequestError(error, platform);
+              }
+            );
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              EasBuildTooManyPendingBuildsError,
+              EXPECTED_MAX_BUILD_COUNT_MESSAGE_ANDROID
+            );
           });
         });
         describe('with iOS', () => {
@@ -350,15 +393,17 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
-              handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(
-                caughtError as Error,
-                EasBuildTooManyPendingBuildsError,
-                EXPECTED_MAX_BUILD_COUNT_MESSAGE_IOS
-              );
-            }
+            const handleBuildRequestErrorThrownError = getError<EasBuildTooManyPendingBuildsError>(
+              () => {
+                handleBuildRequestError(error, platform);
+              }
+            );
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              EasBuildTooManyPendingBuildsError,
+              EXPECTED_MAX_BUILD_COUNT_MESSAGE_IOS
+            );
           });
         });
       });
@@ -373,11 +418,11 @@ describe(Build.name, () => {
           const error = new CombinedError({ graphQLErrors });
           const expectedMessage = EXPECTED_GENERIC_MESSAGE + `\nRequest ID: ${mockRequestId}`;
 
-          try {
+          const handleBuildRequestErrorThrownError = getError<Error>(() => {
             handleBuildRequestError(error, platform);
-          } catch (caughtError) {
-            assertReThrownError(caughtError as Error, Error, expectedMessage);
-          }
+          });
+
+          assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
         });
         describe('without request ID', () => {
           it('throws base Error class with custom message without request ID line', async () => {
@@ -387,11 +432,15 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
+            const handleBuildRequestErrorThrownError = getError<Error>(() => {
               handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(caughtError as Error, Error, EXPECTED_GENERIC_MESSAGE);
-            }
+            });
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              Error,
+              EXPECTED_GENERIC_MESSAGE
+            );
           });
         });
       });
@@ -403,11 +452,11 @@ describe(Build.name, () => {
           const error = new CombinedError({ graphQLErrors });
           const expectedMessage = EXPECTED_GENERIC_MESSAGE + `\nRequest ID: ${mockRequestId}`;
 
-          try {
+          const handleBuildRequestErrorThrownError = getError<Error>(() => {
             handleBuildRequestError(error, platform);
-          } catch (caughtError) {
-            assertReThrownError(caughtError as Error, Error, expectedMessage);
-          }
+          });
+
+          assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
         });
         describe('without request ID', () => {
           it('throws base Error class with custom message without request ID line', async () => {
@@ -417,11 +466,15 @@ describe(Build.name, () => {
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
 
-            try {
+            const handleBuildRequestErrorThrownError = getError<Error>(() => {
               handleBuildRequestError(error, platform);
-            } catch (caughtError) {
-              assertReThrownError(caughtError as Error, Error, EXPECTED_GENERIC_MESSAGE);
-            }
+            });
+
+            assertReThrownError(
+              handleBuildRequestErrorThrownError,
+              Error,
+              EXPECTED_GENERIC_MESSAGE
+            );
           });
         });
       });
@@ -433,11 +486,11 @@ describe(Build.name, () => {
           const platform = Platform.ANDROID;
           const error = new Error('Non-graphQL-related error');
 
-          try {
+          const handleBuildRequestErrorThrownError = getError<Error>(() => {
             handleBuildRequestError(error, platform);
-          } catch (caughtError) {
-            expect(caughtError).toStrictEqual(error);
-          }
+          });
+
+          expect(handleBuildRequestErrorThrownError).toStrictEqual(error);
         });
       });
       describe('with iOS', () => {
@@ -445,11 +498,11 @@ describe(Build.name, () => {
           const platform = Platform.IOS;
           const error = new Error('Non-graphQL-related error');
 
-          try {
+          const handleBuildRequestErrorThrownError = getError<Error>(() => {
             handleBuildRequestError(error, platform);
-          } catch (caughtError) {
-            expect(caughtError).toStrictEqual(error);
-          }
+          });
+
+          expect(handleBuildRequestErrorThrownError).toStrictEqual(error);
         });
       });
     });

--- a/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
+++ b/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
@@ -12,6 +12,7 @@ import {
   EasBuildFreeTierDisabledAndroidError,
   EasBuildFreeTierDisabledError,
   EasBuildFreeTierDisabledIOSError,
+  EasBuildResourceClassNotAvailableInFreeTierError,
   EasBuildTooManyPendingBuildsError,
   RequestValidationError,
   TurtleDeprecatedJobFormatError,
@@ -131,6 +132,26 @@ describe(Build.name, () => {
               assertReThrownError(caughtError as Error, TurtleDeprecatedJobFormatError, 'Error 1');
             }
           });
+
+          it('throws correct EasBuildResourceClassNotAvailableInFreeTierError', async () => {
+            const platform = Platform.ANDROID;
+            const graphQLError = getGraphQLError(
+              'Error 1',
+              'EAS_BUILD_RESOURCE_CLASS_NOT_AVAILABLE_IN_FREE_TIER'
+            );
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(
+                caughtError as Error,
+                EasBuildResourceClassNotAvailableInFreeTierError,
+                'Error 1'
+              );
+            }
+          });
         });
         describe('with iOS', () => {
           it('throws correct EasCommandError subclass', async () => {
@@ -143,6 +164,26 @@ describe(Build.name, () => {
               handleBuildRequestError(error, platform);
             } catch (caughtError) {
               assertReThrownError(caughtError as Error, TurtleDeprecatedJobFormatError, 'Error 1');
+            }
+          });
+
+          it('throws correct EasBuildResourceClassNotAvailableInFreeTierError', async () => {
+            const platform = Platform.IOS;
+            const graphQLError = getGraphQLError(
+              'Error 1',
+              'EAS_BUILD_RESOURCE_CLASS_NOT_AVAILABLE_IN_FREE_TIER'
+            );
+            const graphQLErrors = [graphQLError];
+            const error = new CombinedError({ graphQLErrors });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch (caughtError) {
+              assertReThrownError(
+                caughtError as Error,
+                EasBuildResourceClassNotAvailableInFreeTierError,
+                'Error 1'
+              );
             }
           });
         });

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -42,6 +42,7 @@ import {
   EasBuildFreeTierDisabledAndroidError,
   EasBuildFreeTierDisabledError,
   EasBuildFreeTierDisabledIOSError,
+  EasBuildResourceClassNotAvailableInFreeTierError,
   EasBuildTooManyPendingBuildsError,
   RequestValidationError,
   TurtleDeprecatedJobFormatError,
@@ -181,6 +182,8 @@ const SERVER_SIDE_DEFINED_ERRORS: Record<string, typeof EasCommandError> = {
   EAS_BUILD_FREE_TIER_DISABLED: EasBuildFreeTierDisabledError,
   EAS_BUILD_FREE_TIER_DISABLED_IOS: EasBuildFreeTierDisabledIOSError,
   EAS_BUILD_FREE_TIER_DISABLED_ANDROID: EasBuildFreeTierDisabledAndroidError,
+  EAS_BUILD_RESOURCE_CLASS_NOT_AVAILABLE_IN_FREE_TIER:
+    EasBuildResourceClassNotAvailableInFreeTierError,
   VALIDATION_ERROR: RequestValidationError,
 };
 

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -8,6 +8,8 @@ export class EasBuildFreeTierDisabledIOSError extends EasCommandError {}
 
 export class EasBuildFreeTierDisabledAndroidError extends EasCommandError {}
 
+export class EasBuildResourceClassNotAvailableInFreeTierError extends EasCommandError {}
+
 export class RequestValidationError extends EasCommandError {}
 
 export class EasBuildDownForMaintenanceError extends EasCommandError {}

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -187,12 +187,7 @@
           "default": "default",
           "anyOf": [
             {
-              "enum": ["default", "medium", "large"],
-              "markdownEnumDescriptions": [
-                "Maps to `\"default\"` for both Android and iOS",
-                "Maps to `\"medium\"` for both Android and iOS",
-                "Maps to `\"large\"` for both Android and iOS. Not available on free plan."
-              ]
+              "enum": ["default", "medium", "large"]
             },
             {
               "type": "string"
@@ -246,17 +241,12 @@
           ]
         },
         "resourceClass": {
-          "description": "The Android-specific resource class that will be used to run this build. Learn more: https://docs.expo.dev/build-reference/infrastructure/#android-build-server-configurations",
-          "markdownDescription": "The Android-specific resource class that will be used to run this build. [Learn more](https://docs.expo.dev/build-reference/infrastructure/#android-build-server-configurations)",
+          "description": "The Android-specific resource class that will be used to run this build. Learn more: https://docs.expo.dev/build-reference/infrastructure/",
+          "markdownDescription": "The Android-specific resource class that will be used to run this build. [Learn more](https://docs.expo.dev/build-reference/infrastructure/)",
           "default": "default",
           "anyOf": [
             {
-              "enum": ["default", "medium", "large"],
-              "markdownEnumDescriptions": [
-                "Maps to \"medium\"",
-                "[Learn more](https://docs.expo.dev/build-reference/infrastructure/#android-build-server-configurations)",
-                "[Learn more](https://docs.expo.dev/build-reference/infrastructure/#android-build-server-configurations). Not available on free plan."
-              ]
+              "enum": ["default", "medium", "large"]
             },
             {
               "type": "string"
@@ -366,17 +356,12 @@
           ]
         },
         "resourceClass": {
-          "description": "The iOS-specific resource class that will be used to run this build. Learn more: https://docs.expo.dev/build-reference/infrastructure/#ios-build-server-configurations",
-          "markdownDescription": "The iOS-specific resource class that will be used to run this build. [Learn more](https://docs.expo.dev/build-reference/infrastructure/#ios-build-server-configurations)",
+          "description": "The iOS-specific resource class that will be used to run this build. Learn more: https://docs.expo.dev/build-reference/infrastructure/",
+          "markdownDescription": "The iOS-specific resource class that will be used to run this build. [Learn more](https://docs.expo.dev/build-reference/infrastructure/)",
           "default": "default",
           "anyOf": [
             {
-              "enum": ["default", "medium", "large", "intel-medium", "m-medium"],
-              "markdownEnumDescriptions": [
-                "Maps to \"medium\"",
-                "[Learn more](https://docs.expo.dev/build-reference/infrastructure/#ios-build-server-configurations)",
-                "[Learn more](https://docs.expo.dev/build-reference/infrastructure/#ios-build-server-configurations). Not available on free plan."
-              ]
+              "enum": ["default", "medium", "large", "intel-medium", "m-medium"]
             },
             {
               "type": "string"

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -187,7 +187,12 @@
           "default": "default",
           "anyOf": [
             {
-              "enum": ["default", "medium", "large"]
+              "enum": ["default", "medium", "large"],
+              "markdownEnumDescriptions": [
+                "Maps to `\"default\"` for both Android and iOS",
+                "Maps to `\"medium\"` for both Android and iOS",
+                "Maps to `\"large\"` for both Android and iOS. Not available on free plan."
+              ]
             },
             {
               "type": "string"
@@ -241,12 +246,17 @@
           ]
         },
         "resourceClass": {
-          "description": "The Android-specific resource class that will be used to run this build. Learn more: https://docs.expo.dev/build-reference/infrastructure/",
-          "markdownDescription": "The Android-specific resource class that will be used to run this build. [Learn more](https://docs.expo.dev/build-reference/infrastructure/)",
+          "description": "The Android-specific resource class that will be used to run this build. Learn more: https://docs.expo.dev/build-reference/infrastructure/#android-build-server-configurations",
+          "markdownDescription": "The Android-specific resource class that will be used to run this build. [Learn more](https://docs.expo.dev/build-reference/infrastructure/#android-build-server-configurations)",
           "default": "default",
           "anyOf": [
             {
-              "enum": ["default", "medium", "large"]
+              "enum": ["default", "medium", "large"],
+              "markdownEnumDescriptions": [
+                "Maps to \"medium\"",
+                "[Learn more](https://docs.expo.dev/build-reference/infrastructure/#android-build-server-configurations)",
+                "[Learn more](https://docs.expo.dev/build-reference/infrastructure/#android-build-server-configurations). Not available on free plan."
+              ]
             },
             {
               "type": "string"
@@ -356,12 +366,17 @@
           ]
         },
         "resourceClass": {
-          "description": "The iOS-specific resource class that will be used to run this build. Learn more: https://docs.expo.dev/build-reference/infrastructure/",
-          "markdownDescription": "The iOS-specific resource class that will be used to run this build. [Learn more](https://docs.expo.dev/build-reference/infrastructure/)",
+          "description": "The iOS-specific resource class that will be used to run this build. Learn more: https://docs.expo.dev/build-reference/infrastructure/#ios-build-server-configurations",
+          "markdownDescription": "The iOS-specific resource class that will be used to run this build. [Learn more](https://docs.expo.dev/build-reference/infrastructure/#ios-build-server-configurations)",
           "default": "default",
           "anyOf": [
             {
-              "enum": ["default", "medium", "large", "intel-medium", "m-medium"]
+              "enum": ["default", "medium", "large", "intel-medium", "m-medium"],
+              "markdownEnumDescriptions": [
+                "Maps to \"medium\"",
+                "[Learn more](https://docs.expo.dev/build-reference/infrastructure/#ios-build-server-configurations)",
+                "[Learn more](https://docs.expo.dev/build-reference/infrastructure/#ios-build-server-configurations). Not available on free plan."
+              ]
             },
             {
               "type": "string"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Companion to https://github.com/expo/universe/pull/12375

# How

Handle newly defined error thrown when a free tier user tries to use a `large` resource class as other server-side defined errors in EAS CLI.

# Test Plan

Add tests
