### PR TITLE
[eas-cli] Print assets that timed out during upload or processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add clear cache flag to eas update. ([#1839](https://github.com/expo/eas-cli/pull/1839) by [@quinlanj](https://github.com/quinlanj))
+- Print EAS Update assets that timed out during upload or processing. ([#1849](https://github.com/expo/eas-cli/pull/1849) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -571,7 +571,13 @@ describe(uploadAssetsAsync, () => {
 
     mockdate.set(0);
     await expect(
-      uploadAssetsAsync(graphqlClient, assetsForUpdateInfoGroup, testProjectId)
+      uploadAssetsAsync(
+        graphqlClient,
+        assetsForUpdateInfoGroup,
+        testProjectId,
+        { isCanceledOrFinished: false },
+        () => {}
+      )
     ).resolves.toEqual({
       assetCount: 6,
       launchAssetCount: 2,
@@ -609,7 +615,15 @@ describe(uploadAssetsAsync, () => {
 
     mockdate.set(0);
     await expect(
-      uploadAssetsAsync(graphqlClient, assetsForUpdateInfoGroup, testProjectId)
+      uploadAssetsAsync(
+        graphqlClient,
+        assetsForUpdateInfoGroup,
+        testProjectId,
+        {
+          isCanceledOrFinished: false,
+        },
+        () => {}
+      )
     ).resolves.toEqual({
       assetCount: 6,
       launchAssetCount: 2,
@@ -645,20 +659,16 @@ describe(uploadAssetsAsync, () => {
         }, // ios.code
       ];
     });
-    const updateSpinnerFn = jest.fn((_totalAssets, _missingAssets) => {});
+    const onAssetUploadResultsChangedFn = jest.fn(_assetUploadResults => {});
 
     mockdate.set(0);
     await uploadAssetsAsync(
       graphqlClient,
       assetsForUpdateInfoGroup,
       testProjectId,
-      updateSpinnerFn
+      { isCanceledOrFinished: false },
+      onAssetUploadResultsChangedFn
     );
-    const calls = updateSpinnerFn.mock.calls;
-    expect(calls).toEqual([
-      [3, 3],
-      [3, 2],
-      [3, 0],
-    ]);
+    expect(onAssetUploadResultsChangedFn).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Closes ENG-8515.

We recently had a customer ask why their assets were struggling to upload. It happened to be that it was a 30MB compressible asset and our system wasn't tuned to support that. We fixed it by increasing the memory of our processing cloud function. But, it would have made debugging faster if we knew which assets had stalled.

This PR adds logging to indicate which assets have stalled.

# How

Add race.

# Test Plan

In project with new unique assets, run `neas update --branch preview` after manually making the upload function time out.
See
```
✖ Failed to upload
Upload processing timed out for assets:
- /Users/wschurman/temp/lots-o-assets/dist/bundles/android-2031cfb5df244b2172589371d5afeaed.js,
- /assets/images/1590.jpg,
- /assets/images/1591.jpg,
- /assets/images/1592.jpg,
- /assets/images/1593.jpg,
- /assets/images/1594.jpg,
- /assets/images/1595.jpg,
- /assets/images/1596.jpg,
- /assets/images/1597.jpg,
- /assets/images/1598.jpg,
- /assets/images/1599.jpg,
- /Users/wschurman/temp/lots-o-assets/dist/bundles/ios-f51cf230c6c4b45af938d3663652210b.js
    Error: update command failed.
```
