### PR TITLE
[eas-cli] Load entitlements from prebuild config when `/ios` is gitignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Load iOS entitlements from prebuild config when `./ios` is gitignored. ([#1852](https://github.com/expo/eas-cli/pull/1852) by [@byCedric](https://github.com/byCedric))
+
 ### 🧹 Chores
 
 - Short format for selecting devices prompt. ([#1840](https://github.com/expo/eas-cli/pull/1840) by [@khamilowicz](https://github.com/khamilowicz))

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/capabilityIdentifiers-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/capabilityIdentifiers-test.ts
@@ -169,4 +169,8 @@ describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {
       })
     ).rejects.toThrow(/is not available. Enter a different string/);
   });
+
+  it(`ignores capabilities from "/ios" folder when gitignored`, async () => {
+    //
+  });
 });

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -11,7 +11,7 @@ import { resolveWorkflowAsync } from '../workflow';
 import { getBundleIdentifierAsync } from './bundleIdentifier';
 import {
   getManagedApplicationTargetEntitlementsAsync,
-  getNativeTargetEntitlementsAsync,
+  getNativeTargetEntitlementsUnlessGitIgnoredAsync,
 } from './entitlements';
 import { XcodeBuildContext } from './scheme';
 
@@ -89,6 +89,7 @@ export async function resolveBareProjectTargetsAsync({
   exp,
   projectDir,
   xcodeBuildContext,
+  env,
 }: ResolveTargetOptions): Promise<Target[]> {
   const { buildScheme, buildConfiguration } = xcodeBuildContext;
   const result: Target[] = [];
@@ -102,9 +103,12 @@ export async function resolveBareProjectTargetsAsync({
     targetName: applicationTarget.name,
     buildConfiguration,
   });
-  const entitlements = await getNativeTargetEntitlementsAsync(projectDir, {
-    targetName: applicationTarget.name,
-    buildConfiguration,
+  const entitlements = await getNativeTargetEntitlementsUnlessGitIgnoredAsync(projectDir, {
+    env: env ?? {},
+    target: {
+      targetName: applicationTarget.name,
+      buildConfiguration,
+    },
   });
   result.push({
     targetName: applicationTarget.name,
@@ -151,6 +155,7 @@ async function resolveBareProjectDependenciesAsync({
   target,
   bundleIdentifier,
   pbxProject,
+  env,
 }: {
   exp: ExpoConfig;
   projectDir: string;
@@ -158,6 +163,7 @@ async function resolveBareProjectDependenciesAsync({
   target: IOSConfig.Target.Target;
   bundleIdentifier: string;
   pbxProject: XcodeProject;
+  env?: ResolveTargetOptions['env'];
 }): Promise<Target[]> {
   const result: Target[] = [];
 
@@ -170,9 +176,12 @@ async function resolveBareProjectDependenciesAsync({
         targetName: dependency.name,
         buildConfiguration,
       });
-      const entitlements = await getNativeTargetEntitlementsAsync(projectDir, {
-        targetName: target.name,
-        buildConfiguration,
+      const entitlements = await getNativeTargetEntitlementsUnlessGitIgnoredAsync(projectDir, {
+        env: env ?? {},
+        target: {
+          targetName: target.name,
+          buildConfiguration,
+        },
       });
       result.push({
         targetName: dependency.name,
@@ -193,6 +202,7 @@ async function resolveBareProjectDependenciesAsync({
         target: dependency,
         bundleIdentifier: dependencyBundleIdentifier,
         pbxProject,
+        env,
       });
       if (dependencyDependencies.length > 0) {
         result.push(...dependencyDependencies);


### PR DESCRIPTION

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Fixes ENG-8481

# How

- Added a check before loading native ios capabilities
- Once `./ios` is gitignored, we load the capabilities from prebuild config (instead of native files)
- This behavior can be reverted by defining `EAS_SYNC_NATIVE_CAPABILITIES=1` (not sure if this is the best varname for it)

# Test Plan

- Create a new project
- Ignore `ios` folder
- Add more capabilities through xcode
- run `eas build`
- This should NOT include these new capabilities (only when adding them to app.json)