### PR TITLE
[eas-cli] [ENG-8506] Handle pending cancel build status in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Short format for selecting devices prompt. ([#1840](https://github.com/expo/eas-cli/pull/1840) by [@khamilowicz](https://github.com/khamilowicz))
 - Improve typescript types for user display. ([#1851](https://github.com/expo/eas-cli/pull/1851) by [@wschurman](https://github.com/wschurman))
+- Add support for pending-cancel build status. ([#1855](https://github.com/expo/eas-cli/pull/1855) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 
 ## [3.13.0](https://github.com/expo/eas-cli/releases/tag/v3.13.0) - 2023-05-17
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -7520,6 +7520,22 @@
             "deprecationReason": null
           },
           {
+            "name": "insights",
+            "description": "App query field for querying EAS Insights about this app",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppInsights",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "iosAppCredentials",
             "description": "iOS app credentials for the project",
             "args": [
@@ -9193,6 +9209,112 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppInsights",
+        "description": null,
+        "fields": [
+          {
+            "name": "totalUniqueUsers",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUsersByAppVersionOverTime",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UniqueUsersOverTimeData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUsersByPlatformOverTime",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UniqueUsersOverTimeData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -21887,6 +22009,49 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "InsightsTimespan",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "end",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "Int",
         "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
@@ -24584,6 +24749,128 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "LineChartData",
+        "description": null,
+        "fields": [
+          {
+            "name": "datasets",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "LineDataset",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labels",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "LineDataset",
+        "description": null,
+        "fields": [
+          {
+            "name": "data",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -32285,6 +32572,33 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UniqueUsersOverTimeData",
+        "description": null,
+        "fields": [
+          {
+            "name": "data",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "LineChartData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -4882,6 +4882,39 @@
             "deprecationReason": null
           },
           {
+            "name": "deleteAndroidAppCredentials",
+            "description": "Delete a set of credentials for an Android app",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteAndroidAppCredentialsResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "setFcm",
             "description": "Set the FCM push key to be used in an Android app",
             "args": [
@@ -17981,6 +18014,33 @@
       },
       {
         "kind": "OBJECT",
+        "name": "DeleteAndroidAppCredentialsResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "DeleteAndroidKeystoreResult",
         "description": null,
         "fields": [
@@ -23494,50 +23554,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "IosAppCredentialsQuery",
-        "description": null,
-        "fields": [
-          {
-            "name": "byId",
-            "description": null,
-            "args": [
-              {
-                "name": "iosAppCredentialsId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "IosAppCredentials",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "ENUM",
         "name": "IosBuildType",
         "description": "@deprecated Use developmentClient option instead.",
@@ -28769,22 +28785,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "InvoiceQuery",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "iosAppCredentials",
-            "description": "Top-level query object for querying IosAppCredentials.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "IosAppCredentialsQuery",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -13500,6 +13500,22 @@
             "deprecationReason": null
           },
           {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "appBuildVersion",
             "description": null,
             "args": [],
@@ -16707,6 +16723,12 @@
           },
           {
             "name": "NEW",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PENDING_CANCEL",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -25363,6 +25385,12 @@
             "deprecationReason": null
           },
           {
+            "name": "BUILD_PLAN_CREDIT_THRESHOLD_EXCEEDED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "SUBMISSION_COMPLETE",
             "description": null,
             "isDeprecated": false,
@@ -32321,6 +32349,22 @@
             "deprecationReason": null
           },
           {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "awaitingCodeSigningInfo",
             "description": null,
             "args": [],
@@ -33556,6 +33600,26 @@
           },
           {
             "name": "runtimeVersions",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sdkVersions",
             "description": null,
             "type": {
               "kind": "LIST",

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -492,6 +492,7 @@ async function handleSingleBuildProgressAsync(
       }
       break;
     }
+    case BuildStatus.PendingCancel:
     case BuildStatus.Canceled:
       spinner.fail('Build canceled');
       return { refetch: false };
@@ -522,6 +523,7 @@ const statusToDisplayName: Record<BuildStatus, string> = {
   [BuildStatus.New]: 'waiting to enter the queue (concurrency limit reached)',
   [BuildStatus.InQueue]: 'in queue',
   [BuildStatus.InProgress]: 'in progress',
+  [BuildStatus.PendingCancel]: 'canceled',
   [BuildStatus.Canceled]: 'canceled',
   [BuildStatus.Finished]: 'finished',
   [BuildStatus.Errored]: 'failed',
@@ -540,7 +542,12 @@ async function handleMultipleBuildsProgressAsync(
     builds.filter(build => build.status === BuildStatus.Finished).length === buildCount;
   const allSettled =
     builds.filter(build =>
-      [BuildStatus.Finished, BuildStatus.Errored, BuildStatus.Canceled].includes(build.status)
+      [
+        BuildStatus.Finished,
+        BuildStatus.Errored,
+        BuildStatus.Canceled,
+        BuildStatus.PendingCancel,
+      ].includes(build.status)
     ).length === buildCount;
 
   if (allSettled) {

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -218,7 +218,9 @@ export async function runBuildAndSubmitAsync(
   }
 
   const haveAllBuildsFailedOrCanceled = builds.every(
-    build => build?.status && [BuildStatus.Errored, BuildStatus.Canceled].includes(build?.status)
+    build =>
+      build?.status &&
+      [BuildStatus.Errored, BuildStatus.Canceled, BuildStatus.PendingCancel].includes(build?.status)
   );
 
   await maybeDownloadAndRunSimulatorBuildsAsync(builds, flags);

--- a/packages/eas-cli/src/build/types.ts
+++ b/packages/eas-cli/src/build/types.ts
@@ -2,6 +2,7 @@ export enum BuildStatus {
   NEW = 'new',
   IN_QUEUE = 'in-queue',
   IN_PROGRESS = 'in-progress',
+  PENDING_CANCEL = 'pending-cancel',
   ERRORED = 'errored',
   FINISHED = 'finished',
   CANCELED = 'canceled',

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -27,6 +27,7 @@ export function formatGraphQLBuild(build: BuildFragment): string {
             return chalk.blue('in queue');
           case GraphQLBuildStatus.InProgress:
             return chalk.blue('in progress');
+          case GraphQLBuildStatus.PendingCancel:
           case GraphQLBuildStatus.Canceled:
             return chalk.gray('canceled');
           case GraphQLBuildStatus.Finished:
@@ -90,6 +91,7 @@ export function formatGraphQLBuild(build: BuildFragment): string {
           case GraphQLBuildStatus.InQueue:
           case GraphQLBuildStatus.InProgress:
             return '<in progress>';
+          case GraphQLBuildStatus.PendingCancel:
           case GraphQLBuildStatus.Canceled:
           case GraphQLBuildStatus.Errored:
             return null;

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -80,7 +80,7 @@ function printBuildResult(build: BuildFragment): void {
     }
     return;
   }
-  if (build.status === BuildStatus.Canceled) {
+  if (build.status === BuildStatus.Canceled || build.status === BuildStatus.PendingCancel) {
     Log.addNewLineIfNone();
     Log.error(
       `${appPlatformEmojis[build.platform]} ${

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -80,7 +80,7 @@ function printBuildResult(build: BuildFragment): void {
     }
     return;
   }
-  if (build.status === BuildStatus.Canceled || build.status === BuildStatus.PendingCancel) {
+  if ([BuildStatus.Canceled, BuildStatus.PendingCancel].includes(build.status)) {
     Log.addNewLineIfNone();
     Log.error(
       `${appPlatformEmojis[build.platform]} ${

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -174,7 +174,7 @@ export default class BuildCancel extends EasCommand {
     const spinner = ora().start('Canceling the build…');
     try {
       const { status } = await cancelBuildAsync(graphqlClient, buildId);
-      if (status === BuildStatus.Canceled) {
+      if (status === BuildStatus.Canceled || status === BuildStatus.PendingCancel) {
         spinner.succeed('Build canceled');
       } else {
         spinner.text = 'Build is already completed';

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -174,7 +174,7 @@ export default class BuildCancel extends EasCommand {
     const spinner = ora().start('Canceling the build…');
     try {
       const { status } = await cancelBuildAsync(graphqlClient, buildId);
-      if (status === BuildStatus.Canceled || status === BuildStatus.PendingCancel) {
+      if ([BuildStatus.Canceled, BuildStatus.PendingCancel].includes(status)) {
         spinner.succeed('Build canceled');
       } else {
         spinner.text = 'Build is already completed';

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -27,6 +27,7 @@ export default class BuildList extends EasCommand {
         BuildStatus.NEW,
         BuildStatus.IN_QUEUE,
         BuildStatus.IN_PROGRESS,
+        BuildStatus.PENDING_CANCEL,
         BuildStatus.ERRORED,
         BuildStatus.FINISHED,
         BuildStatus.CANCELED,
@@ -123,6 +124,8 @@ const toGraphQLBuildStatus = (buildStatus?: BuildStatus): GraphQLBuildStatus | u
     return GraphQLBuildStatus.InQueue;
   } else if (buildStatus === BuildStatus.IN_PROGRESS) {
     return GraphQLBuildStatus.InProgress;
+  } else if (buildStatus === BuildStatus.PENDING_CANCEL) {
+    return GraphQLBuildStatus.PendingCancel;
   } else if (buildStatus === BuildStatus.ERRORED) {
     return GraphQLBuildStatus.Errored;
   } else if (buildStatus === BuildStatus.FINISHED) {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1019,6 +1019,8 @@ export type App = Project & {
   /** @deprecated No longer supported */
   iconUrl?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
+  /** App query field for querying EAS Insights about this app */
+  insights: AppInsights;
   /** iOS app credentials for the project */
   iosAppCredentials: Array<IosAppCredentials>;
   /** Whether the latest classic update publish is using a deprecated SDK version */
@@ -1350,6 +1352,28 @@ export type AppInput = {
   appInfo?: InputMaybe<AppInfoInput>;
   privacy: AppPrivacy;
   projectName: Scalars['String'];
+};
+
+export type AppInsights = {
+  __typename?: 'AppInsights';
+  totalUniqueUsers?: Maybe<Scalars['Int']>;
+  uniqueUsersByAppVersionOverTime: UniqueUsersOverTimeData;
+  uniqueUsersByPlatformOverTime: UniqueUsersOverTimeData;
+};
+
+
+export type AppInsightsTotalUniqueUsersArgs = {
+  timespan: InsightsTimespan;
+};
+
+
+export type AppInsightsUniqueUsersByAppVersionOverTimeArgs = {
+  timespan: InsightsTimespan;
+};
+
+
+export type AppInsightsUniqueUsersByPlatformOverTimeArgs = {
+  timespan: InsightsTimespan;
 };
 
 export type AppMutation = {
@@ -1972,6 +1996,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   __typename?: 'Build';
   activityTimestamp: Scalars['DateTime'];
   actor?: Maybe<Actor>;
+  app: App;
   appBuildVersion?: Maybe<Scalars['String']>;
   appVersion?: Maybe<Scalars['String']>;
   artifacts?: Maybe<BuildArtifacts>;
@@ -2420,7 +2445,8 @@ export enum BuildStatus {
   Finished = 'FINISHED',
   InProgress = 'IN_PROGRESS',
   InQueue = 'IN_QUEUE',
-  New = 'NEW'
+  New = 'NEW',
+  PendingCancel = 'PENDING_CANCEL'
 }
 
 export enum BuildTrigger {
@@ -3162,6 +3188,11 @@ export type GoogleServiceAccountKeyMutationDeleteGoogleServiceAccountKeyArgs = {
   id: Scalars['ID'];
 };
 
+export type InsightsTimespan = {
+  end: Scalars['DateTime'];
+  start: Scalars['DateTime'];
+};
+
 export type Invoice = {
   __typename?: 'Invoice';
   /** The total amount due for the invoice, in cents */
@@ -3514,6 +3545,19 @@ export type LeaveAccountResult = {
   success: Scalars['Boolean'];
 };
 
+export type LineChartData = {
+  __typename?: 'LineChartData';
+  datasets: Array<LineDataset>;
+  labels: Array<Scalars['String']>;
+};
+
+export type LineDataset = {
+  __typename?: 'LineDataset';
+  data: Array<Maybe<Scalars['Int']>>;
+  id: Scalars['ID'];
+  label: Scalars['String'];
+};
+
 export enum MailchimpAudience {
   ExpoDevelopers = 'EXPO_DEVELOPERS'
 }
@@ -3666,6 +3710,7 @@ export type MeteredBillingStatus = {
 
 export enum NotificationEvent {
   BuildComplete = 'BUILD_COMPLETE',
+  BuildPlanCreditThresholdExceeded = 'BUILD_PLAN_CREDIT_THRESHOLD_EXCEEDED',
   SubmissionComplete = 'SUBMISSION_COMPLETE'
 }
 
@@ -4666,6 +4711,11 @@ export type TimelineActivityFilterInput = {
   types?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
 };
 
+export type UniqueUsersOverTimeData = {
+  __typename?: 'UniqueUsersOverTimeData';
+  data: LineChartData;
+};
+
 export type UnsubscribeFromNotificationResult = {
   __typename?: 'UnsubscribeFromNotificationResult';
   notificationSubscription: NotificationSubscription;
@@ -4675,6 +4725,7 @@ export type Update = ActivityTimelineProjectActivity & {
   __typename?: 'Update';
   activityTimestamp: Scalars['DateTime'];
   actor?: Maybe<Actor>;
+  app: App;
   awaitingCodeSigningInfo: Scalars['Boolean'];
   branch: UpdateBranch;
   branchId: Scalars['ID'];

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -50,16 +50,13 @@ export type AccessTokenMutation = {
   setAccessTokenRevoked: AccessToken;
 };
 
-
 export type AccessTokenMutationCreateAccessTokenArgs = {
   createAccessTokenData: CreateAccessTokenInput;
 };
 
-
 export type AccessTokenMutationDeleteAccessTokenArgs = {
   id: Scalars['ID'];
 };
-
 
 export type AccessTokenMutationSetAccessTokenRevokedArgs = {
   id: Scalars['ID'];
@@ -73,20 +70,20 @@ export type AccessTokenMutationSetAccessTokenRevokedArgs = {
 export type Account = {
   __typename?: 'Account';
   /** @deprecated Legacy access tokens are deprecated */
-  accessTokens: Array<Maybe<AccessToken>>;
+  accessTokens: Maybe<AccessToken>[];
   /** Coalesced project activity for all apps belonging to this account. */
-  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
+  activityTimelineProjectActivities: ActivityTimelineProjectActivity[];
   appCount: Scalars['Int'];
-  appStoreConnectApiKeys: Array<AppStoreConnectApiKey>;
-  appleAppIdentifiers: Array<AppleAppIdentifier>;
-  appleDevices: Array<AppleDevice>;
-  appleDistributionCertificates: Array<AppleDistributionCertificate>;
-  appleProvisioningProfiles: Array<AppleProvisioningProfile>;
-  applePushKeys: Array<ApplePushKey>;
+  appStoreConnectApiKeys: AppStoreConnectApiKey[];
+  appleAppIdentifiers: AppleAppIdentifier[];
+  appleDevices: AppleDevice[];
+  appleDistributionCertificates: AppleDistributionCertificate[];
+  appleProvisioningProfiles: AppleProvisioningProfile[];
+  applePushKeys: ApplePushKey[];
   /** iOS credentials for account */
-  appleTeams: Array<AppleTeam>;
+  appleTeams: AppleTeam[];
   /** Apps associated with this account */
-  apps: Array<App>;
+  apps: App[];
   /** Paginated list of apps associated with this account. By default sorted by name. Use filter to adjust the sorting order. */
   appsPaginated: AccountAppsConnection;
   /** @deprecated Build packs are no longer supported */
@@ -95,26 +92,26 @@ export type Account = {
   billing?: Maybe<Billing>;
   billingPeriod: BillingPeriod;
   /** Build Jobs associated with this account */
-  buildJobs: Array<BuildJob>;
+  buildJobs: BuildJob[];
   /**
    * Coalesced Build (EAS) or BuildJob (Classic) for all apps belonging to this account.
    * @deprecated Use activityTimelineProjectActivities with filterTypes instead
    */
-  buildOrBuildJobs: Array<BuildOrBuildJob>;
+  buildOrBuildJobs: BuildOrBuildJob[];
   /** (EAS Build) Builds associated with this account */
-  builds: Array<Build>;
+  builds: Build[];
   createdAt: Scalars['DateTime'];
   /** Environment secrets for an account */
-  environmentSecrets: Array<EnvironmentSecret>;
+  environmentSecrets: EnvironmentSecret[];
   /** GitHub App installations for an account */
-  githubAppInstallations: Array<GitHubAppInstallation>;
+  githubAppInstallations: GitHubAppInstallation[];
   /** Android credentials for account */
-  googleServiceAccountKeys: Array<GoogleServiceAccountKey>;
+  googleServiceAccountKeys: GoogleServiceAccountKey[];
   id: Scalars['ID'];
   isCurrent: Scalars['Boolean'];
   name: Scalars['String'];
   /** Offers set on this account */
-  offers?: Maybe<Array<Offer>>;
+  offers?: Maybe<Offer[]>;
   /** Owning User of this account if personal account */
   owner?: Maybe<User>;
   /** Owning UserActor of this account if personal account */
@@ -123,7 +120,7 @@ export type Account = {
   /** @deprecated Legacy access tokens are deprecated */
   requiresAccessTokenForPushSecurity: Scalars['Boolean'];
   /** Snacks associated with this account */
-  snacks: Array<Snack>;
+  snacks: Snack[];
   /** SSO configuration for this account */
   ssoConfiguration?: Maybe<AccountSsoConfiguration>;
   /** Subscription info visible to members that have VIEWER role */
@@ -143,13 +140,12 @@ export type Account = {
    */
   userActorOwner?: Maybe<UserActor>;
   /** Pending user invitations for this account */
-  userInvitations: Array<UserInvitation>;
+  userInvitations: UserInvitation[];
   /** Actors associated with this account and permissions they hold */
-  users: Array<UserPermission>;
+  users: UserPermission[];
   /** @deprecated Build packs are no longer supported */
   willAutoRenewBuilds?: Maybe<Scalars['Boolean']>;
 };
-
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -157,10 +153,9 @@ export type Account = {
  */
 export type AccountActivityTimelineProjectActivitiesArgs = {
   createdBefore?: InputMaybe<Scalars['DateTime']>;
-  filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
+  filterTypes?: InputMaybe<ActivityTimelineProjectActivityType[]>;
   limit: Scalars['Int'];
 };
-
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -169,7 +164,6 @@ export type AccountActivityTimelineProjectActivitiesArgs = {
 export type AccountAppleAppIdentifiersArgs = {
   bundleIdentifier?: InputMaybe<Scalars['String']>;
 };
-
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -181,7 +175,6 @@ export type AccountAppleDevicesArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -189,7 +182,6 @@ export type AccountAppleDevicesArgs = {
 export type AccountAppleProvisioningProfilesArgs = {
   appleAppIdentifierId?: InputMaybe<Scalars['ID']>;
 };
-
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -201,7 +193,6 @@ export type AccountAppleTeamsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -211,7 +202,6 @@ export type AccountAppsArgs = {
   limit: Scalars['Int'];
   offset: Scalars['Int'];
 };
-
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -225,7 +215,6 @@ export type AccountAppsPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']>;
 };
 
-
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -233,7 +222,6 @@ export type AccountAppsPaginatedArgs = {
 export type AccountBillingPeriodArgs = {
   date: Scalars['DateTime'];
 };
-
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -245,7 +233,6 @@ export type AccountBuildJobsArgs = {
   status?: InputMaybe<BuildJobStatus>;
 };
 
-
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -254,7 +241,6 @@ export type AccountBuildOrBuildJobsArgs = {
   createdBefore?: InputMaybe<Scalars['DateTime']>;
   limit: Scalars['Int'];
 };
-
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -267,15 +253,13 @@ export type AccountBuildsArgs = {
   status?: InputMaybe<BuildStatus>;
 };
 
-
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
  */
 export type AccountEnvironmentSecretsArgs = {
-  filterNames?: InputMaybe<Array<Scalars['String']>>;
+  filterNames?: InputMaybe<Scalars['String'][]>;
 };
-
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -285,7 +269,6 @@ export type AccountSnacksArgs = {
   limit: Scalars['Int'];
   offset: Scalars['Int'];
 };
-
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -301,7 +284,7 @@ export type AccountTimelineActivityArgs = {
 
 export type AccountAppsConnection = {
   __typename?: 'AccountAppsConnection';
-  edges: Array<AccountAppsEdge>;
+  edges: AccountAppsEdge[];
   pageInfo: PageInfo;
 };
 
@@ -321,7 +304,7 @@ export enum AccountAppsSortByField {
    * Name prefers the display name but falls back to full_name with @account/
    * part stripped.
    */
-  Name = 'NAME'
+  Name = 'NAME',
 }
 
 export type AccountDataInput = {
@@ -362,7 +345,6 @@ export type AccountMutation = {
   setPushSecurityEnabled: Account;
 };
 
-
 export type AccountMutationBuyProductArgs = {
   accountName: Scalars['ID'];
   autoRenew?: InputMaybe<Scalars['Boolean']>;
@@ -370,21 +352,17 @@ export type AccountMutationBuyProductArgs = {
   productId: Scalars['ID'];
 };
 
-
 export type AccountMutationCancelAllSubscriptionsImmediatelyArgs = {
   accountID: Scalars['ID'];
 };
-
 
 export type AccountMutationCancelScheduledSubscriptionChangeArgs = {
   accountID: Scalars['ID'];
 };
 
-
 export type AccountMutationCancelSubscriptionArgs = {
   accountName: Scalars['ID'];
 };
-
 
 export type AccountMutationChangePlanArgs = {
   accountID: Scalars['ID'];
@@ -392,19 +370,16 @@ export type AccountMutationChangePlanArgs = {
   newPlanIdentifier: Scalars['String'];
 };
 
-
 export type AccountMutationGrantActorPermissionsArgs = {
   accountID: Scalars['ID'];
   actorID: Scalars['ID'];
-  permissions?: InputMaybe<Array<InputMaybe<Permission>>>;
+  permissions?: InputMaybe<InputMaybe<Permission>[]>;
 };
-
 
 export type AccountMutationRenameArgs = {
   accountID: Scalars['ID'];
   newName: Scalars['String'];
 };
-
 
 export type AccountMutationRequestRefundArgs = {
   accountID: Scalars['ID'];
@@ -413,25 +388,21 @@ export type AccountMutationRequestRefundArgs = {
   reason?: InputMaybe<Scalars['String']>;
 };
 
-
 export type AccountMutationRevokeActorPermissionsArgs = {
   accountID: Scalars['ID'];
   actorID: Scalars['ID'];
-  permissions?: InputMaybe<Array<InputMaybe<Permission>>>;
+  permissions?: InputMaybe<InputMaybe<Permission>[]>;
 };
-
 
 export type AccountMutationSetBuildAutoRenewArgs = {
   accountName: Scalars['ID'];
   autoRenew?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type AccountMutationSetPaymentSourceArgs = {
   accountName: Scalars['ID'];
   paymentSource: Scalars['ID'];
 };
-
 
 export type AccountMutationSetPushSecurityEnabledArgs = {
   accountID: Scalars['ID'];
@@ -453,11 +424,9 @@ export type AccountQuery = {
   byName: Account;
 };
 
-
 export type AccountQueryByIdArgs = {
   accountId: Scalars['String'];
 };
-
 
 export type AccountQueryByNameArgs = {
   accountName: Scalars['String'];
@@ -506,17 +475,14 @@ export type AccountSsoConfigurationMutation = {
   updateAccountSSOConfiguration: AccountSsoConfiguration;
 };
 
-
 export type AccountSsoConfigurationMutationCreateAccountSsoConfigurationArgs = {
   accountId: Scalars['ID'];
   accountSSOConfigurationData: AccountSsoConfigurationData;
 };
 
-
 export type AccountSsoConfigurationMutationDeleteAccountSsoConfigurationArgs = {
   id: Scalars['ID'];
 };
-
 
 export type AccountSsoConfigurationMutationUpdateAccountSsoConfigurationArgs = {
   accountSSOConfigurationData: AccountSsoConfigurationData;
@@ -545,7 +511,6 @@ export type AccountSsoConfigurationPublicDataQuery = {
   publicDataByAccountName: AccountSsoConfigurationPublicData;
 };
 
-
 export type AccountSsoConfigurationPublicDataQueryPublicDataByAccountNameArgs = {
   accountName: Scalars['String'];
 };
@@ -570,15 +535,13 @@ export type AccountUsageMetric = {
 export type AccountUsageMetrics = {
   __typename?: 'AccountUsageMetrics';
   byBillingPeriod: UsageMetricTotal;
-  metricsForServiceMetric: Array<AccountUsageMetric>;
+  metricsForServiceMetric: AccountUsageMetric[];
 };
-
 
 export type AccountUsageMetricsByBillingPeriodArgs = {
   date: Scalars['DateTime'];
   service?: InputMaybe<EasService>;
 };
-
 
 export type AccountUsageMetricsMetricsForServiceMetricArgs = {
   filterParams?: InputMaybe<Scalars['JSONObject']>;
@@ -597,15 +560,15 @@ export enum ActivityTimelineProjectActivityType {
   Build = 'BUILD',
   BuildJob = 'BUILD_JOB',
   Submission = 'SUBMISSION',
-  Update = 'UPDATE'
+  Update = 'UPDATE',
 }
 
 /** A regular user, SSO user, or robot that can authenticate with Expo services and be a member of accounts. */
 export type Actor = {
   /** Access Tokens belonging to this actor */
-  accessTokens: Array<AccessToken>;
+  accessTokens: AccessToken[];
   /** Associated accounts */
-  accounts: Array<Account>;
+  accounts: Account[];
   created: Scalars['DateTime'];
   /**
    * Best-effort human readable name for this actor for use in user interfaces during action attribution.
@@ -622,10 +585,9 @@ export type Actor = {
   isExpoAdmin: Scalars['Boolean'];
 };
 
-
 /** A regular user, SSO user, or robot that can authenticate with Expo services and be a member of accounts. */
 export type ActorFeatureGatesArgs = {
-  filter?: InputMaybe<Array<Scalars['String']>>;
+  filter?: InputMaybe<Scalars['String'][]>;
 };
 
 export type ActorQuery = {
@@ -634,7 +596,6 @@ export type ActorQuery = {
   byId: Actor;
 };
 
-
 export type ActorQueryByIdArgs = {
   id: Scalars['ID'];
 };
@@ -642,7 +603,7 @@ export type ActorQueryByIdArgs = {
 export type AddUserInput = {
   audience?: InputMaybe<MailchimpAudience>;
   email: Scalars['String'];
-  tags?: InputMaybe<Array<MailchimpTag>>;
+  tags?: InputMaybe<MailchimpTag[]>;
 };
 
 export type AddUserPayload = {
@@ -651,7 +612,7 @@ export type AddUserPayload = {
   id?: Maybe<Scalars['String']>;
   list_id?: Maybe<Scalars['String']>;
   status?: Maybe<Scalars['String']>;
-  tags?: Maybe<Array<MailchimpTagPayload>>;
+  tags?: Maybe<MailchimpTagPayload[]>;
   timestamp_signup?: Maybe<Scalars['String']>;
 };
 
@@ -703,29 +664,24 @@ export type AndroidAppBuildCredentialsMutation = {
   setName: AndroidAppBuildCredentials;
 };
 
-
 export type AndroidAppBuildCredentialsMutationCreateAndroidAppBuildCredentialsArgs = {
   androidAppBuildCredentialsInput: AndroidAppBuildCredentialsInput;
   androidAppCredentialsId: Scalars['ID'];
 };
 
-
 export type AndroidAppBuildCredentialsMutationDeleteAndroidAppBuildCredentialsArgs = {
   id: Scalars['ID'];
 };
-
 
 export type AndroidAppBuildCredentialsMutationSetDefaultArgs = {
   id: Scalars['ID'];
   isDefault: Scalars['Boolean'];
 };
 
-
 export type AndroidAppBuildCredentialsMutationSetKeystoreArgs = {
   id: Scalars['ID'];
   keystoreId: Scalars['ID'];
 };
-
 
 export type AndroidAppBuildCredentialsMutationSetNameArgs = {
   id: Scalars['ID'];
@@ -735,8 +691,8 @@ export type AndroidAppBuildCredentialsMutationSetNameArgs = {
 export type AndroidAppCredentials = {
   __typename?: 'AndroidAppCredentials';
   /** @deprecated use androidAppBuildCredentialsList instead */
-  androidAppBuildCredentialsArray: Array<AndroidAppBuildCredentials>;
-  androidAppBuildCredentialsList: Array<AndroidAppBuildCredentials>;
+  androidAppBuildCredentialsArray: AndroidAppBuildCredentials[];
+  androidAppBuildCredentialsList: AndroidAppBuildCredentials[];
   androidFcm?: Maybe<AndroidFcm>;
   app: App;
   applicationIdentifier?: Maybe<Scalars['String']>;
@@ -765,19 +721,16 @@ export type AndroidAppCredentialsMutation = {
   setGoogleServiceAccountKeyForSubmissions: AndroidAppCredentials;
 };
 
-
 export type AndroidAppCredentialsMutationCreateAndroidAppCredentialsArgs = {
   androidAppCredentialsInput: AndroidAppCredentialsInput;
   appId: Scalars['ID'];
   applicationIdentifier: Scalars['String'];
 };
 
-
 export type AndroidAppCredentialsMutationSetFcmArgs = {
   fcmId: Scalars['ID'];
   id: Scalars['ID'];
 };
-
 
 export type AndroidAppCredentialsMutationSetGoogleServiceAccountKeyForSubmissionsArgs = {
   googleServiceAccountKeyId: Scalars['ID'];
@@ -788,7 +741,7 @@ export enum AndroidBuildType {
   Apk = 'APK',
   AppBundle = 'APP_BUNDLE',
   /** @deprecated Use developmentClient option instead. */
-  DevelopmentClient = 'DEVELOPMENT_CLIENT'
+  DevelopmentClient = 'DEVELOPMENT_CLIENT',
 }
 
 export type AndroidBuilderEnvironmentInput = {
@@ -828,12 +781,10 @@ export type AndroidFcmMutation = {
   deleteAndroidFcm: DeleteAndroidFcmResult;
 };
 
-
 export type AndroidFcmMutationCreateAndroidFcmArgs = {
   accountId: Scalars['ID'];
   androidFcmInput: AndroidFcmInput;
 };
-
 
 export type AndroidFcmMutationDeleteAndroidFcmArgs = {
   id: Scalars['ID'];
@@ -841,7 +792,7 @@ export type AndroidFcmMutationDeleteAndroidFcmArgs = {
 
 export enum AndroidFcmVersion {
   Legacy = 'LEGACY',
-  V1 = 'V1'
+  V1 = 'V1',
 }
 
 export type AndroidJobBuildCredentialsInput = {
@@ -852,7 +803,7 @@ export type AndroidJobInput = {
   applicationArchivePath?: InputMaybe<Scalars['String']>;
   /** @deprecated */
   artifactPath?: InputMaybe<Scalars['String']>;
-  buildArtifactPaths?: InputMaybe<Array<Scalars['String']>>;
+  buildArtifactPaths?: InputMaybe<Scalars['String'][]>;
   buildProfile?: InputMaybe<Scalars['String']>;
   buildType?: InputMaybe<AndroidBuildType>;
   builderEnvironment?: InputMaybe<AndroidBuilderEnvironmentInput>;
@@ -884,7 +835,7 @@ export type AndroidJobOverridesInput = {
   applicationArchivePath?: InputMaybe<Scalars['String']>;
   /** @deprecated */
   artifactPath?: InputMaybe<Scalars['String']>;
-  buildArtifactPaths?: InputMaybe<Array<Scalars['String']>>;
+  buildArtifactPaths?: InputMaybe<Scalars['String'][]>;
   buildProfile?: InputMaybe<Scalars['String']>;
   buildType?: InputMaybe<AndroidBuildType>;
   builderEnvironment?: InputMaybe<AndroidBuilderEnvironmentInput>;
@@ -941,12 +892,10 @@ export type AndroidKeystoreMutation = {
   deleteAndroidKeystore: DeleteAndroidKeystoreResult;
 };
 
-
 export type AndroidKeystoreMutationCreateAndroidKeystoreArgs = {
   accountId: Scalars['ID'];
   androidKeystoreInput: AndroidKeystoreInput;
 };
-
 
 export type AndroidKeystoreMutationDeleteAndroidKeystoreArgs = {
   id: Scalars['ID'];
@@ -955,7 +904,7 @@ export type AndroidKeystoreMutationDeleteAndroidKeystoreArgs = {
 export enum AndroidKeystoreType {
   Jks = 'JKS',
   Pkcs12 = 'PKCS12',
-  Unknown = 'UNKNOWN'
+  Unknown = 'UNKNOWN',
 }
 
 export type AndroidSubmissionConfig = {
@@ -982,33 +931,33 @@ export type AndroidSubmissionConfigInput = {
 export type App = Project & {
   __typename?: 'App';
   /** @deprecated Legacy access tokens are deprecated */
-  accessTokens: Array<Maybe<AccessToken>>;
+  accessTokens: Maybe<AccessToken>[];
   /** Coalesced project activity for an app */
-  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
+  activityTimelineProjectActivities: ActivityTimelineProjectActivity[];
   /** Android app credentials for the project */
-  androidAppCredentials: Array<AndroidAppCredentials>;
+  androidAppCredentials: AndroidAppCredentials[];
   /** ios.appStoreUrl field from most recent classic update manifest */
   appStoreUrl?: Maybe<Scalars['String']>;
   assetLimitPerUpdateGroup: Scalars['Int'];
   branchesPaginated: AppBranchesConnection;
-  buildJobs: Array<BuildJob>;
+  buildJobs: BuildJob[];
   /**
    * Coalesced Build (EAS) or BuildJob (Classic) items for this app.
    * @deprecated Use activityTimelineProjectActivities with filterTypes instead
    */
-  buildOrBuildJobs: Array<BuildOrBuildJob>;
+  buildOrBuildJobs: BuildOrBuildJob[];
   /** (EAS Build) Builds associated with this app */
-  builds: Array<Build>;
+  builds: Build[];
   buildsPaginated: AppBuildsConnection;
   /** Classic update release channel names that have at least one build */
-  buildsReleaseChannels: Array<Scalars['String']>;
+  buildsReleaseChannels: Scalars['String'][];
   channelsPaginated: AppChannelsConnection;
   deployment?: Maybe<Deployment>;
   /** Deployments associated with this app */
   deployments: DeploymentsConnection;
   description: Scalars['String'];
   /** Environment secrets for an app */
-  environmentSecrets: Array<EnvironmentSecret>;
+  environmentSecrets: EnvironmentSecret[];
   fullName: Scalars['String'];
   githubRepository?: Maybe<GitHubRepository>;
   githubRepositorySettings?: Maybe<GitHubRepositorySettings>;
@@ -1020,7 +969,7 @@ export type App = Project & {
   iconUrl?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   /** iOS app credentials for the project */
-  iosAppCredentials: Array<IosAppCredentials>;
+  iosAppCredentials: IosAppCredentials[];
   /** Whether the latest classic update publish is using a deprecated SDK version */
   isDeprecated: Scalars['Boolean'];
   /** @deprecated 'likes' have been deprecated. */
@@ -1036,7 +985,7 @@ export type App = Project & {
   /** @deprecated 'likes' have been deprecated. */
   likeCount: Scalars['Int'];
   /** @deprecated 'likes' have been deprecated. */
-  likedBy: Array<Maybe<User>>;
+  likedBy: Maybe<User>[];
   name: Scalars['String'];
   ownerAccount: Account;
   /** @deprecated No longer supported */
@@ -1052,7 +1001,7 @@ export type App = Project & {
   published: Scalars['Boolean'];
   pushSecurityEnabled: Scalars['Boolean'];
   /** Classic update release channel names (to be removed) */
-  releaseChannels: Array<Scalars['String']>;
+  releaseChannels: Scalars['String'][];
   /** @deprecated Legacy access tokens are deprecated */
   requiresAccessTokenForPushSecurity: Scalars['Boolean'];
   scopeKey: Scalars['String'];
@@ -1060,7 +1009,7 @@ export type App = Project & {
   sdkVersion: Scalars['String'];
   slug: Scalars['String'];
   /** EAS Submissions associated with this app */
-  submissions: Array<Submission>;
+  submissions: Submission[];
   submissionsPaginated: AppSubmissionsConnection;
   /** Coalesced project activity for an app using pagination */
   timelineActivity: TimelineActivityConnection;
@@ -1069,43 +1018,40 @@ export type App = Project & {
   /** get an EAS branch owned by the app by name */
   updateBranchByName?: Maybe<UpdateBranch>;
   /** EAS branches owned by an app */
-  updateBranches: Array<UpdateBranch>;
+  updateBranches: UpdateBranch[];
   /** get an EAS channel owned by the app by name */
   updateChannelByName?: Maybe<UpdateChannel>;
   /** EAS channels owned by an app */
-  updateChannels: Array<UpdateChannel>;
+  updateChannels: UpdateChannel[];
   /** EAS updates owned by an app grouped by update group */
-  updateGroups: Array<Array<Update>>;
+  updateGroups: Update[][];
   /** Time of last classic update publish */
   updated: Scalars['DateTime'];
   /** EAS updates owned by an app */
-  updates: Array<Update>;
+  updates: Update[];
   updatesPaginated: AppUpdatesConnection;
   /** @deprecated Use ownerAccount.name instead */
   username: Scalars['String'];
   /** @deprecated No longer supported */
-  users?: Maybe<Array<Maybe<User>>>;
+  users?: Maybe<Maybe<User>[]>;
   /** Webhooks for an app */
-  webhooks: Array<Webhook>;
+  webhooks: Webhook[];
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppActivityTimelineProjectActivitiesArgs = {
   createdBefore?: InputMaybe<Scalars['DateTime']>;
-  filterChannels?: InputMaybe<Array<Scalars['String']>>;
-  filterPlatforms?: InputMaybe<Array<AppPlatform>>;
-  filterReleaseChannels?: InputMaybe<Array<Scalars['String']>>;
-  filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
+  filterChannels?: InputMaybe<Scalars['String'][]>;
+  filterPlatforms?: InputMaybe<AppPlatform[]>;
+  filterReleaseChannels?: InputMaybe<Scalars['String'][]>;
+  filterTypes?: InputMaybe<ActivityTimelineProjectActivityType[]>;
   limit: Scalars['Int'];
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppAndroidAppCredentialsArgs = {
   filter?: InputMaybe<AndroidAppCredentialsFilter>;
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppBranchesPaginatedArgs = {
@@ -1115,7 +1061,6 @@ export type AppBranchesPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppBuildJobsArgs = {
   limit: Scalars['Int'];
@@ -1123,13 +1068,11 @@ export type AppBuildJobsArgs = {
   status?: InputMaybe<BuildStatus>;
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppBuildOrBuildJobsArgs = {
   createdBefore?: InputMaybe<Scalars['DateTime']>;
   limit: Scalars['Int'];
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppBuildsArgs = {
@@ -1140,7 +1083,6 @@ export type AppBuildsArgs = {
   status?: InputMaybe<BuildStatus>;
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppBuildsPaginatedArgs = {
   after?: InputMaybe<Scalars['String']>;
@@ -1150,7 +1092,6 @@ export type AppBuildsPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppChannelsPaginatedArgs = {
   after?: InputMaybe<Scalars['String']>;
@@ -1159,13 +1100,11 @@ export type AppChannelsPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppDeploymentArgs = {
   channel: Scalars['String'];
   runtimeVersion: Scalars['String'];
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppDeploymentsArgs = {
@@ -1175,18 +1114,15 @@ export type AppDeploymentsArgs = {
   last?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppEnvironmentSecretsArgs = {
-  filterNames?: InputMaybe<Array<Scalars['String']>>;
+  filterNames?: InputMaybe<Scalars['String'][]>;
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppIosAppCredentialsArgs = {
   filter?: InputMaybe<IosAppCredentialsFilter>;
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppLatestAppVersionByPlatformAndApplicationIdentifierArgs = {
@@ -1194,20 +1130,17 @@ export type AppLatestAppVersionByPlatformAndApplicationIdentifierArgs = {
   platform: AppPlatform;
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppLatestReleaseForReleaseChannelArgs = {
   platform: AppPlatform;
   releaseChannel: Scalars['String'];
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppLikedByArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppSubmissionsArgs = {
@@ -1216,7 +1149,6 @@ export type AppSubmissionsArgs = {
   offset: Scalars['Int'];
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppSubmissionsPaginatedArgs = {
   after?: InputMaybe<Scalars['String']>;
@@ -1224,7 +1156,6 @@ export type AppSubmissionsPaginatedArgs = {
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppTimelineActivityArgs = {
@@ -1235,12 +1166,10 @@ export type AppTimelineActivityArgs = {
   last?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateBranchByNameArgs = {
   name: Scalars['String'];
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateBranchesArgs = {
@@ -1248,19 +1177,16 @@ export type AppUpdateBranchesArgs = {
   offset: Scalars['Int'];
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateChannelByNameArgs = {
   name: Scalars['String'];
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateChannelsArgs = {
   limit: Scalars['Int'];
   offset: Scalars['Int'];
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateGroupsArgs = {
@@ -1269,13 +1195,11 @@ export type AppUpdateGroupsArgs = {
   offset: Scalars['Int'];
 };
 
-
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdatesArgs = {
   limit: Scalars['Int'];
   offset: Scalars['Int'];
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdatesPaginatedArgs = {
@@ -1284,7 +1208,6 @@ export type AppUpdatesPaginatedArgs = {
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWebhooksArgs = {
@@ -1299,7 +1222,7 @@ export type AppBranchEdge = {
 
 export type AppBranchesConnection = {
   __typename?: 'AppBranchesConnection';
-  edges: Array<AppBranchEdge>;
+  edges: AppBranchEdge[];
   pageInfo: PageInfo;
 };
 
@@ -1311,7 +1234,7 @@ export type AppBuildEdge = {
 
 export type AppBuildsConnection = {
   __typename?: 'AppBuildsConnection';
-  edges: Array<AppBuildEdge>;
+  edges: AppBuildEdge[];
   pageInfo: PageInfo;
 };
 
@@ -1323,7 +1246,7 @@ export type AppChannelEdge = {
 
 export type AppChannelsConnection = {
   __typename?: 'AppChannelsConnection';
-  edges: Array<AppChannelEdge>;
+  edges: AppChannelEdge[];
   pageInfo: PageInfo;
 };
 
@@ -1364,23 +1287,19 @@ export type AppMutation = {
   setPushSecurityEnabled: App;
 };
 
-
 export type AppMutationCreateAppArgs = {
   appInput: AppInput;
 };
-
 
 export type AppMutationGrantAccessArgs = {
   accessLevel?: InputMaybe<Scalars['String']>;
   toUser: Scalars['ID'];
 };
 
-
 export type AppMutationSetAppInfoArgs = {
   appId: Scalars['ID'];
   appInfo: AppInfoInput;
 };
-
 
 export type AppMutationSetPushSecurityEnabledArgs = {
   appId: Scalars['ID'];
@@ -1396,13 +1315,13 @@ export type AppNotificationSubscriptionInput = {
 
 export enum AppPlatform {
   Android = 'ANDROID',
-  Ios = 'IOS'
+  Ios = 'IOS',
 }
 
 export enum AppPrivacy {
   Hidden = 'HIDDEN',
   Public = 'PUBLIC',
-  Unlisted = 'UNLISTED'
+  Unlisted = 'UNLISTED',
 }
 
 export type AppQuery = {
@@ -1411,12 +1330,11 @@ export type AppQuery = {
    * Public apps in the app directory
    * @deprecated App directory no longer supported
    */
-  all: Array<App>;
+  all: App[];
   byFullName: App;
   /** Look up app by app id */
   byId: App;
 };
-
 
 export type AppQueryAllArgs = {
   filter: AppsFilter;
@@ -1425,11 +1343,9 @@ export type AppQueryAllArgs = {
   sort: AppSort;
 };
 
-
 export type AppQueryByFullNameArgs = {
   fullName: Scalars['String'];
 };
-
 
 export type AppQueryByIdArgs = {
   appId: Scalars['String'];
@@ -1453,7 +1369,7 @@ export enum AppSort {
   /** Sort by recently published */
   RecentlyPublished = 'RECENTLY_PUBLISHED',
   /** Sort by highest trendScore */
-  Viewed = 'VIEWED'
+  Viewed = 'VIEWED',
 }
 
 export type AppStoreConnectApiKey = {
@@ -1465,7 +1381,7 @@ export type AppStoreConnectApiKey = {
   issuerIdentifier: Scalars['String'];
   keyIdentifier: Scalars['String'];
   name?: Maybe<Scalars['String']>;
-  roles?: Maybe<Array<AppStoreConnectUserRole>>;
+  roles?: Maybe<AppStoreConnectUserRole[]>;
   updatedAt: Scalars['DateTime'];
 };
 
@@ -1475,7 +1391,7 @@ export type AppStoreConnectApiKeyInput = {
   keyIdentifier: Scalars['String'];
   keyP8: Scalars['String'];
   name?: InputMaybe<Scalars['String']>;
-  roles?: InputMaybe<Array<AppStoreConnectUserRole>>;
+  roles?: InputMaybe<AppStoreConnectUserRole[]>;
 };
 
 export type AppStoreConnectApiKeyMutation = {
@@ -1486,12 +1402,10 @@ export type AppStoreConnectApiKeyMutation = {
   deleteAppStoreConnectApiKey: DeleteAppStoreConnectApiKeyResult;
 };
 
-
 export type AppStoreConnectApiKeyMutationCreateAppStoreConnectApiKeyArgs = {
   accountId: Scalars['ID'];
   appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput;
 };
-
 
 export type AppStoreConnectApiKeyMutationDeleteAppStoreConnectApiKeyArgs = {
   id: Scalars['ID'];
@@ -1513,7 +1427,7 @@ export enum AppStoreConnectUserRole {
   ReadOnly = 'READ_ONLY',
   Sales = 'SALES',
   Technical = 'TECHNICAL',
-  Unknown = 'UNKNOWN'
+  Unknown = 'UNKNOWN',
 }
 
 export type AppSubmissionEdge = {
@@ -1524,7 +1438,7 @@ export type AppSubmissionEdge = {
 
 export type AppSubmissionsConnection = {
   __typename?: 'AppSubmissionsConnection';
-  edges: Array<AppSubmissionEdge>;
+  edges: AppSubmissionEdge[];
   pageInfo: PageInfo;
 };
 
@@ -1536,7 +1450,7 @@ export type AppUpdateEdge = {
 
 export type AppUpdatesConnection = {
   __typename?: 'AppUpdatesConnection';
-  edges: Array<AppUpdateEdge>;
+  edges: AppUpdateEdge[];
   pageInfo: PageInfo;
 };
 
@@ -1581,7 +1495,6 @@ export type AppVersionMutation = {
   createAppVersion: AppVersion;
 };
 
-
 export type AppVersionMutationCreateAppVersionArgs = {
   appVersionInput: AppVersionInput;
 };
@@ -1607,7 +1520,6 @@ export type AppleAppIdentifierMutation = {
   createAppleAppIdentifier: AppleAppIdentifier;
 };
 
-
 export type AppleAppIdentifierMutationCreateAppleAppIdentifierArgs = {
   accountId: Scalars['ID'];
   appleAppIdentifierInput: AppleAppIdentifierInput;
@@ -1628,7 +1540,7 @@ export type AppleDevice = {
 
 export enum AppleDeviceClass {
   Ipad = 'IPAD',
-  Iphone = 'IPHONE'
+  Iphone = 'IPHONE',
 }
 
 export type AppleDeviceInput = {
@@ -1651,17 +1563,14 @@ export type AppleDeviceMutation = {
   updateAppleDevice: AppleDevice;
 };
 
-
 export type AppleDeviceMutationCreateAppleDeviceArgs = {
   accountId: Scalars['ID'];
   appleDeviceInput: AppleDeviceInput;
 };
 
-
 export type AppleDeviceMutationDeleteAppleDeviceArgs = {
   id: Scalars['ID'];
 };
-
 
 export type AppleDeviceMutationUpdateAppleDeviceArgs = {
   appleDeviceUpdateInput: AppleDeviceUpdateInput;
@@ -1681,7 +1590,6 @@ export type AppleDeviceRegistrationRequestMutation = {
   createAppleDeviceRegistrationRequest: AppleDeviceRegistrationRequest;
 };
 
-
 export type AppleDeviceRegistrationRequestMutationCreateAppleDeviceRegistrationRequestArgs = {
   accountId: Scalars['ID'];
   appleTeamId: Scalars['ID'];
@@ -1691,7 +1599,6 @@ export type AppleDeviceRegistrationRequestQuery = {
   __typename?: 'AppleDeviceRegistrationRequestQuery';
   byId: AppleDeviceRegistrationRequest;
 };
-
 
 export type AppleDeviceRegistrationRequestQueryByIdArgs = {
   id: Scalars['ID'];
@@ -1711,7 +1618,7 @@ export type AppleDistributionCertificate = {
   createdAt: Scalars['DateTime'];
   developerPortalIdentifier?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
-  iosAppBuildCredentialsList: Array<IosAppBuildCredentials>;
+  iosAppBuildCredentialsList: IosAppBuildCredentials[];
   serialNumber: Scalars['String'];
   updatedAt: Scalars['DateTime'];
   validityNotAfter: Scalars['DateTime'];
@@ -1734,12 +1641,10 @@ export type AppleDistributionCertificateMutation = {
   deleteAppleDistributionCertificate: DeleteAppleDistributionCertificateResult;
 };
 
-
 export type AppleDistributionCertificateMutationCreateAppleDistributionCertificateArgs = {
   accountId: Scalars['ID'];
   appleDistributionCertificateInput: AppleDistributionCertificateInput;
 };
-
 
 export type AppleDistributionCertificateMutationDeleteAppleDistributionCertificateArgs = {
   id: Scalars['ID'];
@@ -1749,7 +1654,7 @@ export type AppleProvisioningProfile = {
   __typename?: 'AppleProvisioningProfile';
   account: Account;
   appleAppIdentifier: AppleAppIdentifier;
-  appleDevices: Array<AppleDevice>;
+  appleDevices: AppleDevice[];
   appleTeam?: Maybe<AppleTeam>;
   appleUUID: Scalars['String'];
   createdAt: Scalars['DateTime'];
@@ -1773,11 +1678,10 @@ export type AppleProvisioningProfileMutation = {
   /** Delete a Provisioning Profile */
   deleteAppleProvisioningProfile: DeleteAppleProvisioningProfileResult;
   /** Delete Provisioning Profiles */
-  deleteAppleProvisioningProfiles: Array<DeleteAppleProvisioningProfileResult>;
+  deleteAppleProvisioningProfiles: DeleteAppleProvisioningProfileResult[];
   /** Update a Provisioning Profile */
   updateAppleProvisioningProfile: AppleProvisioningProfile;
 };
-
 
 export type AppleProvisioningProfileMutationCreateAppleProvisioningProfileArgs = {
   accountId: Scalars['ID'];
@@ -1785,16 +1689,13 @@ export type AppleProvisioningProfileMutationCreateAppleProvisioningProfileArgs =
   appleProvisioningProfileInput: AppleProvisioningProfileInput;
 };
 
-
 export type AppleProvisioningProfileMutationDeleteAppleProvisioningProfileArgs = {
   id: Scalars['ID'];
 };
 
-
 export type AppleProvisioningProfileMutationDeleteAppleProvisioningProfilesArgs = {
-  ids: Array<Scalars['ID']>;
+  ids: Scalars['ID'][];
 };
-
 
 export type AppleProvisioningProfileMutationUpdateAppleProvisioningProfileArgs = {
   appleProvisioningProfileInput: AppleProvisioningProfileInput;
@@ -1807,7 +1708,7 @@ export type ApplePushKey = {
   appleTeam?: Maybe<AppleTeam>;
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
-  iosAppCredentialsList: Array<IosAppCredentials>;
+  iosAppCredentialsList: IosAppCredentials[];
   keyIdentifier: Scalars['String'];
   keyP8: Scalars['String'];
   updatedAt: Scalars['DateTime'];
@@ -1827,12 +1728,10 @@ export type ApplePushKeyMutation = {
   deleteApplePushKey: DeleteApplePushKeyResult;
 };
 
-
 export type ApplePushKeyMutationCreateApplePushKeyArgs = {
   accountId: Scalars['ID'];
   applePushKeyInput: ApplePushKeyInput;
 };
-
 
 export type ApplePushKeyMutationDeleteApplePushKeyArgs = {
   id: Scalars['ID'];
@@ -1841,27 +1740,24 @@ export type ApplePushKeyMutationDeleteApplePushKeyArgs = {
 export type AppleTeam = {
   __typename?: 'AppleTeam';
   account: Account;
-  appleAppIdentifiers: Array<AppleAppIdentifier>;
-  appleDevices: Array<AppleDevice>;
-  appleDistributionCertificates: Array<AppleDistributionCertificate>;
-  appleProvisioningProfiles: Array<AppleProvisioningProfile>;
-  applePushKeys: Array<ApplePushKey>;
+  appleAppIdentifiers: AppleAppIdentifier[];
+  appleDevices: AppleDevice[];
+  appleDistributionCertificates: AppleDistributionCertificate[];
+  appleProvisioningProfiles: AppleProvisioningProfile[];
+  applePushKeys: ApplePushKey[];
   appleTeamIdentifier: Scalars['String'];
   appleTeamName?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
 };
 
-
 export type AppleTeamAppleAppIdentifiersArgs = {
   bundleIdentifier?: InputMaybe<Scalars['String']>;
 };
-
 
 export type AppleTeamAppleDevicesArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 export type AppleTeamAppleProvisioningProfilesArgs = {
   appleAppIdentifierId?: InputMaybe<Scalars['ID']>;
@@ -1878,7 +1774,6 @@ export type AppleTeamMutation = {
   createAppleTeam: AppleTeam;
 };
 
-
 export type AppleTeamMutationCreateAppleTeamArgs = {
   accountId: Scalars['ID'];
   appleTeamInput: AppleTeamInput;
@@ -1889,7 +1784,6 @@ export type AppleTeamQuery = {
   byAppleTeamIdentifier?: Maybe<AppleTeam>;
 };
 
-
 export type AppleTeamQueryByAppleTeamIdentifierArgs = {
   accountId: Scalars['ID'];
   identifier: Scalars['String'];
@@ -1899,7 +1793,7 @@ export enum AppsFilter {
   /** Featured Projects */
   Featured = 'FEATURED',
   /** New Projects */
-  New = 'NEW'
+  New = 'NEW',
 }
 
 export type AscApiKeyInput = {
@@ -1916,7 +1810,7 @@ export type AssetMetadataResult = {
 
 export enum AssetMetadataStatus {
   DoesNotExist = 'DOES_NOT_EXIST',
-  Exists = 'EXISTS'
+  Exists = 'EXISTS',
 }
 
 export type AssetMutation = {
@@ -1928,31 +1822,29 @@ export type AssetMutation = {
   getSignedAssetUploadSpecifications: GetSignedAssetUploadSpecificationsResult;
 };
 
-
 export type AssetMutationGetSignedAssetUploadSpecificationsArgs = {
-  assetContentTypes: Array<InputMaybe<Scalars['String']>>;
+  assetContentTypes: InputMaybe<Scalars['String']>[];
 };
 
 /** Check to see if assets with given storageKeys exist */
 export type AssetQuery = {
   __typename?: 'AssetQuery';
-  metadata: Array<AssetMetadataResult>;
+  metadata: AssetMetadataResult[];
 };
-
 
 /** Check to see if assets with given storageKeys exist */
 export type AssetQueryMetadataArgs = {
-  storageKeys: Array<Scalars['String']>;
+  storageKeys: Scalars['String'][];
 };
 
 export enum AuthProtocolType {
-  Oidc = 'OIDC'
+  Oidc = 'OIDC',
 }
 
 export type Billing = {
   __typename?: 'Billing';
   /** History of invoices */
-  charges?: Maybe<Array<Maybe<Charge>>>;
+  charges?: Maybe<Maybe<Charge>[]>;
   id: Scalars['ID'];
   /** @deprecated No longer used */
   payment?: Maybe<PaymentDetails>;
@@ -1968,78 +1860,78 @@ export type BillingPeriod = {
 };
 
 /** Represents an EAS Build */
-export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
-  __typename?: 'Build';
-  activityTimestamp: Scalars['DateTime'];
-  actor?: Maybe<Actor>;
-  appBuildVersion?: Maybe<Scalars['String']>;
-  appVersion?: Maybe<Scalars['String']>;
-  artifacts?: Maybe<BuildArtifacts>;
-  buildMode?: Maybe<BuildMode>;
-  buildProfile?: Maybe<Scalars['String']>;
-  canRetry: Scalars['Boolean'];
-  cancelingActor?: Maybe<Actor>;
-  channel?: Maybe<Scalars['String']>;
-  childBuild?: Maybe<Build>;
-  completedAt?: Maybe<Scalars['DateTime']>;
-  createdAt: Scalars['DateTime'];
-  customWorkflowName?: Maybe<Scalars['String']>;
-  distribution?: Maybe<DistributionType>;
-  enqueuedAt?: Maybe<Scalars['DateTime']>;
-  error?: Maybe<BuildError>;
-  estimatedWaitTimeLeftSeconds?: Maybe<Scalars['Int']>;
-  expirationDate?: Maybe<Scalars['DateTime']>;
-  gitCommitHash?: Maybe<Scalars['String']>;
-  gitCommitMessage?: Maybe<Scalars['String']>;
-  gitRef?: Maybe<Scalars['String']>;
-  githubRepositoryOwnerAndName?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-  /** Queue position is 1-indexed */
-  initialQueuePosition?: Maybe<Scalars['Int']>;
-  initiatingActor?: Maybe<Actor>;
-  /** @deprecated User type is deprecated */
-  initiatingUser?: Maybe<User>;
-  iosEnterpriseProvisioning?: Maybe<BuildIosEnterpriseProvisioning>;
-  isGitWorkingTreeDirty?: Maybe<Scalars['Boolean']>;
-  logFiles: Array<Scalars['String']>;
-  maxBuildTimeSeconds: Scalars['Int'];
-  /** Retry time starts after completedAt */
-  maxRetryTimeMinutes?: Maybe<Scalars['Int']>;
-  message?: Maybe<Scalars['String']>;
-  metrics?: Maybe<BuildMetrics>;
-  parentBuild?: Maybe<Build>;
-  platform: AppPlatform;
-  priority: BuildPriority;
-  project: Project;
-  projectRootDirectory?: Maybe<Scalars['String']>;
-  provisioningStartedAt?: Maybe<Scalars['DateTime']>;
-  /** Queue position is 1-indexed */
-  queuePosition?: Maybe<Scalars['Int']>;
-  reactNativeVersion?: Maybe<Scalars['String']>;
-  releaseChannel?: Maybe<Scalars['String']>;
-  /**
-   * The builder resource class requested by the developer
-   * @deprecated Use resourceClassDisplayName instead
-   */
-  resourceClass: BuildResourceClass;
-  /** String describing the resource class used to run the build */
-  resourceClassDisplayName: Scalars['String'];
-  retryDisabledReason?: Maybe<BuildRetryDisabledReason>;
-  runFromCI?: Maybe<Scalars['Boolean']>;
-  runtimeVersion?: Maybe<Scalars['String']>;
-  sdkVersion?: Maybe<Scalars['String']>;
-  status: BuildStatus;
-  submissions: Array<Submission>;
-  updatedAt: Scalars['DateTime'];
-  workerStartedAt?: Maybe<Scalars['DateTime']>;
-};
-
+export type Build = ActivityTimelineProjectActivity &
+  BuildOrBuildJob & {
+    __typename?: 'Build';
+    activityTimestamp: Scalars['DateTime'];
+    actor?: Maybe<Actor>;
+    app: App;
+    appBuildVersion?: Maybe<Scalars['String']>;
+    appVersion?: Maybe<Scalars['String']>;
+    artifacts?: Maybe<BuildArtifacts>;
+    buildMode?: Maybe<BuildMode>;
+    buildProfile?: Maybe<Scalars['String']>;
+    canRetry: Scalars['Boolean'];
+    cancelingActor?: Maybe<Actor>;
+    channel?: Maybe<Scalars['String']>;
+    childBuild?: Maybe<Build>;
+    completedAt?: Maybe<Scalars['DateTime']>;
+    createdAt: Scalars['DateTime'];
+    customWorkflowName?: Maybe<Scalars['String']>;
+    distribution?: Maybe<DistributionType>;
+    enqueuedAt?: Maybe<Scalars['DateTime']>;
+    error?: Maybe<BuildError>;
+    estimatedWaitTimeLeftSeconds?: Maybe<Scalars['Int']>;
+    expirationDate?: Maybe<Scalars['DateTime']>;
+    gitCommitHash?: Maybe<Scalars['String']>;
+    gitCommitMessage?: Maybe<Scalars['String']>;
+    gitRef?: Maybe<Scalars['String']>;
+    githubRepositoryOwnerAndName?: Maybe<Scalars['String']>;
+    id: Scalars['ID'];
+    /** Queue position is 1-indexed */
+    initialQueuePosition?: Maybe<Scalars['Int']>;
+    initiatingActor?: Maybe<Actor>;
+    /** @deprecated User type is deprecated */
+    initiatingUser?: Maybe<User>;
+    iosEnterpriseProvisioning?: Maybe<BuildIosEnterpriseProvisioning>;
+    isGitWorkingTreeDirty?: Maybe<Scalars['Boolean']>;
+    logFiles: Scalars['String'][];
+    maxBuildTimeSeconds: Scalars['Int'];
+    /** Retry time starts after completedAt */
+    maxRetryTimeMinutes?: Maybe<Scalars['Int']>;
+    message?: Maybe<Scalars['String']>;
+    metrics?: Maybe<BuildMetrics>;
+    parentBuild?: Maybe<Build>;
+    platform: AppPlatform;
+    priority: BuildPriority;
+    project: Project;
+    projectRootDirectory?: Maybe<Scalars['String']>;
+    provisioningStartedAt?: Maybe<Scalars['DateTime']>;
+    /** Queue position is 1-indexed */
+    queuePosition?: Maybe<Scalars['Int']>;
+    reactNativeVersion?: Maybe<Scalars['String']>;
+    releaseChannel?: Maybe<Scalars['String']>;
+    /**
+     * The builder resource class requested by the developer
+     * @deprecated Use resourceClassDisplayName instead
+     */
+    resourceClass: BuildResourceClass;
+    /** String describing the resource class used to run the build */
+    resourceClassDisplayName: Scalars['String'];
+    retryDisabledReason?: Maybe<BuildRetryDisabledReason>;
+    runFromCI?: Maybe<Scalars['Boolean']>;
+    runtimeVersion?: Maybe<Scalars['String']>;
+    sdkVersion?: Maybe<Scalars['String']>;
+    status: BuildStatus;
+    submissions: Submission[];
+    updatedAt: Scalars['DateTime'];
+    workerStartedAt?: Maybe<Scalars['DateTime']>;
+  };
 
 /** Represents an EAS Build */
 export type BuildCanRetryArgs = {
   newMode?: InputMaybe<BuildMode>;
 };
-
 
 /** Represents an EAS Build */
 export type BuildRetryDisabledReasonArgs = {
@@ -2064,12 +1956,12 @@ export type BuildCacheInput = {
   clear?: InputMaybe<Scalars['Boolean']>;
   disabled?: InputMaybe<Scalars['Boolean']>;
   key?: InputMaybe<Scalars['String']>;
-  paths?: InputMaybe<Array<Scalars['String']>>;
+  paths?: InputMaybe<Scalars['String'][]>;
 };
 
 export enum BuildCredentialsSource {
   Local = 'LOCAL',
-  Remote = 'REMOTE'
+  Remote = 'REMOTE',
 }
 
 export type BuildError = {
@@ -2095,41 +1987,42 @@ export type BuildFilter = {
 
 export type BuildFilterInput = {
   channel?: InputMaybe<Scalars['String']>;
-  platforms?: InputMaybe<Array<AppPlatform>>;
+  platforms?: InputMaybe<AppPlatform[]>;
   releaseChannel?: InputMaybe<Scalars['String']>;
 };
 
 export enum BuildIosEnterpriseProvisioning {
   Adhoc = 'ADHOC',
-  Universal = 'UNIVERSAL'
+  Universal = 'UNIVERSAL',
 }
 
 /** Represents an Standalone App build job */
-export type BuildJob = ActivityTimelineProjectActivity & BuildOrBuildJob & {
-  __typename?: 'BuildJob';
-  accountUserActor?: Maybe<UserActor>;
-  activityTimestamp: Scalars['DateTime'];
-  actor?: Maybe<Actor>;
-  app?: Maybe<App>;
-  artifacts?: Maybe<BuildArtifact>;
-  config?: Maybe<Scalars['JSON']>;
-  created?: Maybe<Scalars['DateTime']>;
-  expirationDate?: Maybe<Scalars['DateTime']>;
-  fullExperienceName?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-  logs?: Maybe<BuildLogs>;
-  platform: AppPlatform;
-  release?: Maybe<AppRelease>;
-  releaseChannel?: Maybe<Scalars['String']>;
-  sdkVersion?: Maybe<Scalars['String']>;
-  status?: Maybe<BuildJobStatus>;
-  updated?: Maybe<Scalars['DateTime']>;
-  user?: Maybe<User>;
-};
+export type BuildJob = ActivityTimelineProjectActivity &
+  BuildOrBuildJob & {
+    __typename?: 'BuildJob';
+    accountUserActor?: Maybe<UserActor>;
+    activityTimestamp: Scalars['DateTime'];
+    actor?: Maybe<Actor>;
+    app?: Maybe<App>;
+    artifacts?: Maybe<BuildArtifact>;
+    config?: Maybe<Scalars['JSON']>;
+    created?: Maybe<Scalars['DateTime']>;
+    expirationDate?: Maybe<Scalars['DateTime']>;
+    fullExperienceName?: Maybe<Scalars['String']>;
+    id: Scalars['ID'];
+    logs?: Maybe<BuildLogs>;
+    platform: AppPlatform;
+    release?: Maybe<AppRelease>;
+    releaseChannel?: Maybe<Scalars['String']>;
+    sdkVersion?: Maybe<Scalars['String']>;
+    status?: Maybe<BuildJobStatus>;
+    updated?: Maybe<Scalars['DateTime']>;
+    user?: Maybe<User>;
+  };
 
 export enum BuildJobLogsFormat {
   Json = 'JSON',
-  Raw = 'RAW'
+  Raw = 'RAW',
 }
 
 export type BuildJobMutation = {
@@ -2143,10 +2036,9 @@ export type BuildJobQuery = {
    * get all build jobs by an optional filter
    * @deprecated Prefer Account.buildJobs or App.buildJobs
    */
-  all: Array<Maybe<BuildJob>>;
+  all: Maybe<BuildJob>[];
   byId: BuildJob;
 };
-
 
 export type BuildJobQueryAllArgs = {
   experienceSlug?: InputMaybe<Scalars['String']>;
@@ -2156,7 +2048,6 @@ export type BuildJobQueryAllArgs = {
   status?: InputMaybe<BuildJobStatus>;
   username?: InputMaybe<Scalars['String']>;
 };
-
 
 export type BuildJobQueryByIdArgs = {
   buildId: Scalars['ID'];
@@ -2168,7 +2059,7 @@ export enum BuildJobStatus {
   InProgress = 'IN_PROGRESS',
   Pending = 'PENDING',
   SentToQueue = 'SENT_TO_QUEUE',
-  Started = 'STARTED'
+  Started = 'STARTED',
 }
 
 export type BuildLogs = {
@@ -2215,7 +2106,7 @@ export type BuildMetrics = {
 export enum BuildMode {
   Build = 'BUILD',
   Custom = 'CUSTOM',
-  Resign = 'RESIGN'
+  Resign = 'RESIGN',
 }
 
 export type BuildMutation = {
@@ -2246,11 +2137,9 @@ export type BuildMutation = {
   updateBuildMetadata: Build;
 };
 
-
 export type BuildMutationCancelBuildArgs = {
   buildId: Scalars['ID'];
 };
-
 
 export type BuildMutationCreateAndroidBuildArgs = {
   appId: Scalars['ID'];
@@ -2259,7 +2148,6 @@ export type BuildMutationCreateAndroidBuildArgs = {
   metadata?: InputMaybe<BuildMetadataInput>;
 };
 
-
 export type BuildMutationCreateIosBuildArgs = {
   appId: Scalars['ID'];
   buildParams?: InputMaybe<BuildParamsInput>;
@@ -2267,28 +2155,23 @@ export type BuildMutationCreateIosBuildArgs = {
   metadata?: InputMaybe<BuildMetadataInput>;
 };
 
-
 export type BuildMutationDeleteBuildArgs = {
   buildId: Scalars['ID'];
 };
-
 
 export type BuildMutationRetryAndroidBuildArgs = {
   buildId: Scalars['ID'];
   jobOverrides?: InputMaybe<AndroidJobOverridesInput>;
 };
 
-
 export type BuildMutationRetryBuildArgs = {
   buildId: Scalars['ID'];
 };
-
 
 export type BuildMutationRetryIosBuildArgs = {
   buildId: Scalars['ID'];
   jobOverrides?: InputMaybe<IosJobOverridesInput>;
 };
-
 
 export type BuildMutationUpdateBuildMetadataArgs = {
   buildId: Scalars['ID'];
@@ -2305,7 +2188,6 @@ export type BuildOrBuildJobQuery = {
   byId: EasBuildOrClassicBuildJob;
 };
 
-
 export type BuildOrBuildJobQueryByIdArgs = {
   buildOrBuildJobId: Scalars['ID'];
 };
@@ -2319,7 +2201,7 @@ export type BuildParamsInput = {
 export enum BuildPriority {
   High = 'HIGH',
   Normal = 'NORMAL',
-  NormalPlus = 'NORMAL_PLUS'
+  NormalPlus = 'NORMAL_PLUS',
 }
 
 /** Publicly visible data for a Build. */
@@ -2339,7 +2221,6 @@ export type BuildPublicDataQuery = {
   byId?: Maybe<BuildPublicData>;
 };
 
-
 export type BuildPublicDataQueryByIdArgs = {
   id: Scalars['ID'];
 };
@@ -2351,25 +2232,23 @@ export type BuildQuery = {
    * By default, they are sorted from latest to oldest.
    * Available only for admin users.
    */
-  all: Array<Build>;
+  all: Build[];
   /**
    * Get all builds for a specific app.
    * They are sorted from latest to oldest.
    * @deprecated Use App.builds instead
    */
-  allForApp: Array<Maybe<Build>>;
+  allForApp: Maybe<Build>[];
   /** Look up EAS Build by build ID */
   byId: Build;
 };
-
 
 export type BuildQueryAllArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
   order?: InputMaybe<Order>;
-  statuses?: InputMaybe<Array<BuildStatus>>;
+  statuses?: InputMaybe<BuildStatus[]>;
 };
-
 
 export type BuildQueryAllForAppArgs = {
   appId: Scalars['String'];
@@ -2378,7 +2257,6 @@ export type BuildQueryAllForAppArgs = {
   platform?: InputMaybe<AppPlatform>;
   status?: InputMaybe<BuildStatus>;
 };
-
 
 export type BuildQueryByIdArgs = {
   buildId: Scalars['ID'];
@@ -2403,7 +2281,7 @@ export enum BuildResourceClass {
   IosMedium = 'IOS_MEDIUM',
   IosMLarge = 'IOS_M_LARGE',
   IosMMedium = 'IOS_M_MEDIUM',
-  Legacy = 'LEGACY'
+  Legacy = 'LEGACY',
 }
 
 export enum BuildRetryDisabledReason {
@@ -2411,7 +2289,7 @@ export enum BuildRetryDisabledReason {
   InvalidStatus = 'INVALID_STATUS',
   IsGithubBuild = 'IS_GITHUB_BUILD',
   NotCompletedYet = 'NOT_COMPLETED_YET',
-  TooMuchTimeElapsed = 'TOO_MUCH_TIME_ELAPSED'
+  TooMuchTimeElapsed = 'TOO_MUCH_TIME_ELAPSED',
 }
 
 export enum BuildStatus {
@@ -2420,12 +2298,13 @@ export enum BuildStatus {
   Finished = 'FINISHED',
   InProgress = 'IN_PROGRESS',
   InQueue = 'IN_QUEUE',
-  New = 'NEW'
+  New = 'NEW',
+  PendingCancel = 'PENDING_CANCEL',
 }
 
 export enum BuildTrigger {
   EasCli = 'EAS_CLI',
-  GitBasedIntegration = 'GIT_BASED_INTEGRATION'
+  GitBasedIntegration = 'GIT_BASED_INTEGRATION',
 }
 
 export type BuildUpdatesInput = {
@@ -2435,7 +2314,7 @@ export type BuildUpdatesInput = {
 export enum BuildWorkflow {
   Generic = 'GENERIC',
   Managed = 'MANAGED',
-  Unknown = 'UNKNOWN'
+  Unknown = 'UNKNOWN',
 }
 
 export type Card = {
@@ -2659,7 +2538,6 @@ export type Deployment = {
   runtime: Runtime;
 };
 
-
 /** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
 export type DeploymentBuildsArgs = {
   after?: InputMaybe<Scalars['String']>;
@@ -2677,7 +2555,7 @@ export type DeploymentBuildEdge = {
 /** Represents the connection over the builds edge of a Deployment */
 export type DeploymentBuildsConnection = {
   __typename?: 'DeploymentBuildsConnection';
-  edges: Array<DeploymentBuildEdge>;
+  edges: DeploymentBuildEdge[];
   pageInfo: PageInfo;
 };
 
@@ -2690,7 +2568,7 @@ export type DeploymentEdge = {
 /** Represents the connection over the deployments edge of an App */
 export type DeploymentsConnection = {
   __typename?: 'DeploymentsConnection';
-  edges: Array<DeploymentEdge>;
+  edges: DeploymentEdge[];
   pageInfo: PageInfo;
 };
 
@@ -2715,7 +2593,6 @@ export type DiscordUserMutation = {
   deleteDiscordUser: DeleteDiscordUserResult;
 };
 
-
 export type DiscordUserMutationDeleteDiscordUserArgs = {
   id: Scalars['ID'];
 };
@@ -2723,12 +2600,12 @@ export type DiscordUserMutationDeleteDiscordUserArgs = {
 export enum DistributionType {
   Internal = 'INTERNAL',
   Simulator = 'SIMULATOR',
-  Store = 'STORE'
+  Store = 'STORE',
 }
 
 export enum EasBuildBillingResourceClass {
   Large = 'LARGE',
-  Medium = 'MEDIUM'
+  Medium = 'MEDIUM',
 }
 
 export type EasBuildDeprecationInfo = {
@@ -2739,14 +2616,14 @@ export type EasBuildDeprecationInfo = {
 
 export enum EasBuildDeprecationInfoType {
   Internal = 'INTERNAL',
-  UserFacing = 'USER_FACING'
+  UserFacing = 'USER_FACING',
 }
 
 export type EasBuildOrClassicBuildJob = Build | BuildJob;
 
 export enum EasService {
   Builds = 'BUILDS',
-  Updates = 'UPDATES'
+  Updates = 'UPDATES',
 }
 
 export enum EasServiceMetric {
@@ -2755,7 +2632,7 @@ export enum EasServiceMetric {
   Builds = 'BUILDS',
   ManifestRequests = 'MANIFEST_REQUESTS',
   UniqueUpdaters = 'UNIQUE_UPDATERS',
-  UniqueUsers = 'UNIQUE_USERS'
+  UniqueUsers = 'UNIQUE_USERS',
 }
 
 export type EasTotalPlanEnablement = {
@@ -2770,7 +2647,7 @@ export enum EasTotalPlanEnablementUnit {
   Concurrency = 'CONCURRENCY',
   Request = 'REQUEST',
   Updater = 'UPDATER',
-  User = 'USER'
+  User = 'USER',
 }
 
 export type EditUpdateBranchInput = {
@@ -2784,7 +2661,6 @@ export type EmailSubscriptionMutation = {
   __typename?: 'EmailSubscriptionMutation';
   addUser: AddUserPayload;
 };
-
 
 export type EmailSubscriptionMutationAddUserArgs = {
   addUserInput: AddUserInput;
@@ -2809,18 +2685,15 @@ export type EnvironmentSecretMutation = {
   deleteEnvironmentSecret: DeleteEnvironmentSecretResult;
 };
 
-
 export type EnvironmentSecretMutationCreateEnvironmentSecretForAccountArgs = {
   accountId: Scalars['String'];
   environmentSecretData: CreateEnvironmentSecretInput;
 };
 
-
 export type EnvironmentSecretMutationCreateEnvironmentSecretForAppArgs = {
   appId: Scalars['String'];
   environmentSecretData: CreateEnvironmentSecretInput;
 };
-
 
 export type EnvironmentSecretMutationDeleteEnvironmentSecretArgs = {
   id: Scalars['String'];
@@ -2828,7 +2701,7 @@ export type EnvironmentSecretMutationDeleteEnvironmentSecretArgs = {
 
 export enum EnvironmentSecretType {
   FileBase64 = 'FILE_BASE64',
-  String = 'STRING'
+  String = 'STRING',
 }
 
 export type EstimatedOverageAndCost = {
@@ -2889,7 +2762,7 @@ export enum Feature {
   /** Top Tier Support */
   Support = 'SUPPORT',
   /** Share access to projects */
-  Teams = 'TEAMS'
+  Teams = 'TEAMS',
 }
 
 export type FutureSubscription = {
@@ -2903,13 +2776,13 @@ export type FutureSubscription = {
 
 export type GetSignedAssetUploadSpecificationsResult = {
   __typename?: 'GetSignedAssetUploadSpecificationsResult';
-  specifications: Array<Scalars['String']>;
+  specifications: Scalars['String'][];
 };
 
 export enum GitHubAppEnvironment {
   Development = 'DEVELOPMENT',
   Production = 'PRODUCTION',
-  Staging = 'STAGING'
+  Staging = 'STAGING',
 }
 
 export type GitHubAppInstallation = {
@@ -2921,7 +2794,6 @@ export type GitHubAppInstallation = {
   installationIdentifier: Scalars['Int'];
   metadata: GitHubAppInstallationMetadata;
 };
-
 
 export type GitHubAppInstallationAccessibleRepositoriesArgs = {
   page?: InputMaybe<Scalars['Int']>;
@@ -2955,11 +2827,9 @@ export type GitHubAppInstallationMutation = {
   deleteGitHubAppInstallation: GitHubAppInstallation;
 };
 
-
 export type GitHubAppInstallationMutationCreateGitHubAppInstallationForAccountArgs = {
   githubAppInstallationData: CreateGitHubAppInstallationInput;
 };
-
 
 export type GitHubAppInstallationMutationDeleteGitHubAppInstallationArgs = {
   githubAppInstallationId: Scalars['ID'];
@@ -2968,7 +2838,7 @@ export type GitHubAppInstallationMutationDeleteGitHubAppInstallationArgs = {
 export enum GitHubAppInstallationStatus {
   Active = 'ACTIVE',
   NotInstalled = 'NOT_INSTALLED',
-  Suspended = 'SUSPENDED'
+  Suspended = 'SUSPENDED',
 }
 
 export type GitHubAppMutation = {
@@ -2976,7 +2846,6 @@ export type GitHubAppMutation = {
   /** Create a GitHub build for an app */
   createGitHubBuild: Scalars['Boolean'];
 };
-
 
 export type GitHubAppMutationCreateGitHubBuildArgs = {
   buildInput: GitHubBuildInput;
@@ -2992,11 +2861,9 @@ export type GitHubAppQuery = {
   searchRepositories: GitHubRepositoryPaginationResult;
 };
 
-
 export type GitHubAppQueryInstallationArgs = {
   id: Scalars['ID'];
 };
-
 
 export type GitHubAppQuerySearchRepositoriesArgs = {
   githubAppInstallationId: Scalars['ID'];
@@ -3043,11 +2910,9 @@ export type GitHubRepositoryMutation = {
   deleteGitHubRepository: GitHubRepository;
 };
 
-
 export type GitHubRepositoryMutationCreateGitHubRepositoryArgs = {
   githubRepositoryData: CreateGitHubRepositoryInput;
 };
-
 
 export type GitHubRepositoryMutationDeleteGitHubRepositoryArgs = {
   githubRepositoryId: Scalars['ID'];
@@ -3063,7 +2928,7 @@ export type GitHubRepositoryOwner = {
 
 export type GitHubRepositoryPaginationResult = {
   __typename?: 'GitHubRepositoryPaginationResult';
-  repositories: Array<GitHubAppInstallationAccessibleRepository>;
+  repositories: GitHubAppInstallationAccessibleRepository[];
   totalCount: Scalars['Int'];
 };
 
@@ -3084,16 +2949,13 @@ export type GitHubRepositorySettingsMutation = {
   updateGitHubRepositorySettings: GitHubRepositorySettings;
 };
 
-
 export type GitHubRepositorySettingsMutationCreateGitHubRepositorySettingsArgs = {
   githubRepositorySettingsData: CreateGitHubRepositorySettingsInput;
 };
 
-
 export type GitHubRepositorySettingsMutationDeleteGitHubRepositorySettingsArgs = {
   githubRepositorySettingsId: Scalars['ID'];
 };
-
 
 export type GitHubRepositorySettingsMutationUpdateGitHubRepositorySettingsArgs = {
   githubRepositorySettingsData: UpdateGitHubRepositorySettingsInput;
@@ -3121,7 +2983,6 @@ export type GitHubUserMutation = {
   /** Delete a GitHub User by ID */
   deleteGitHubUser: DeleteGitHubUserResult;
 };
-
 
 export type GitHubUserMutationDeleteGitHubUserArgs = {
   id: Scalars['ID'];
@@ -3151,12 +3012,10 @@ export type GoogleServiceAccountKeyMutation = {
   deleteGoogleServiceAccountKey: DeleteGoogleServiceAccountKeyResult;
 };
 
-
 export type GoogleServiceAccountKeyMutationCreateGoogleServiceAccountKeyArgs = {
   accountId: Scalars['ID'];
   googleServiceAccountKeyInput: GoogleServiceAccountKeyInput;
 };
-
 
 export type GoogleServiceAccountKeyMutationDeleteGoogleServiceAccountKeyArgs = {
   id: Scalars['ID'];
@@ -3172,7 +3031,7 @@ export type Invoice = {
   amountRemaining: Scalars['Int'];
   discount?: Maybe<InvoiceDiscount>;
   id: Scalars['ID'];
-  lineItems: Array<InvoiceLineItem>;
+  lineItems: InvoiceLineItem[];
   period: InvoicePeriod;
   startingBalance: Scalars['Int'];
   subtotal: Scalars['Int'];
@@ -3193,7 +3052,7 @@ export type InvoiceDiscount = {
 
 export enum InvoiceDiscountType {
   Amount = 'AMOUNT',
-  Percentage = 'PERCENTAGE'
+  Percentage = 'PERCENTAGE',
 }
 
 export type InvoiceLineItem = {
@@ -3227,7 +3086,6 @@ export type InvoiceQuery = {
   previewInvoiceForSubscriptionUpdate: Invoice;
 };
 
-
 export type InvoiceQueryPreviewInvoiceForSubscriptionUpdateArgs = {
   accountId: Scalars['String'];
   couponCode?: InputMaybe<Scalars['String']>;
@@ -3237,7 +3095,7 @@ export type InvoiceQueryPreviewInvoiceForSubscriptionUpdateArgs = {
 export type IosAppBuildCredentials = {
   __typename?: 'IosAppBuildCredentials';
   /** @deprecated Get Apple Devices from AppleProvisioningProfile instead */
-  appleDevices?: Maybe<Array<Maybe<AppleDevice>>>;
+  appleDevices?: Maybe<Maybe<AppleDevice>[]>;
   distributionCertificate?: Maybe<AppleDistributionCertificate>;
   id: Scalars['ID'];
   iosAppCredentials: IosAppCredentials;
@@ -3267,23 +3125,19 @@ export type IosAppBuildCredentialsMutation = {
   setProvisioningProfile: IosAppBuildCredentials;
 };
 
-
 export type IosAppBuildCredentialsMutationCreateIosAppBuildCredentialsArgs = {
   iosAppBuildCredentialsInput: IosAppBuildCredentialsInput;
   iosAppCredentialsId: Scalars['ID'];
 };
 
-
 export type IosAppBuildCredentialsMutationDeleteIosAppBuildCredentialsArgs = {
   id: Scalars['ID'];
 };
-
 
 export type IosAppBuildCredentialsMutationSetDistributionCertificateArgs = {
   distributionCertificateId: Scalars['ID'];
   id: Scalars['ID'];
 };
-
 
 export type IosAppBuildCredentialsMutationSetProvisioningProfileArgs = {
   id: Scalars['ID'];
@@ -3298,16 +3152,14 @@ export type IosAppCredentials = {
   appleTeam?: Maybe<AppleTeam>;
   id: Scalars['ID'];
   /** @deprecated use iosAppBuildCredentialsList instead */
-  iosAppBuildCredentialsArray: Array<IosAppBuildCredentials>;
-  iosAppBuildCredentialsList: Array<IosAppBuildCredentials>;
+  iosAppBuildCredentialsArray: IosAppBuildCredentials[];
+  iosAppBuildCredentialsList: IosAppBuildCredentials[];
   pushKey?: Maybe<ApplePushKey>;
 };
-
 
 export type IosAppCredentialsIosAppBuildCredentialsArrayArgs = {
   filter?: InputMaybe<IosAppBuildCredentialsFilter>;
 };
-
 
 export type IosAppCredentialsIosAppBuildCredentialsListArgs = {
   filter?: InputMaybe<IosAppBuildCredentialsFilter>;
@@ -3335,24 +3187,20 @@ export type IosAppCredentialsMutation = {
   setPushKey: IosAppCredentials;
 };
 
-
 export type IosAppCredentialsMutationCreateIosAppCredentialsArgs = {
   appId: Scalars['ID'];
   appleAppIdentifierId: Scalars['ID'];
   iosAppCredentialsInput: IosAppCredentialsInput;
 };
 
-
 export type IosAppCredentialsMutationDeleteIosAppCredentialsArgs = {
   id: Scalars['ID'];
 };
-
 
 export type IosAppCredentialsMutationSetAppStoreConnectApiKeyForSubmissionsArgs = {
   ascApiKeyId: Scalars['ID'];
   id: Scalars['ID'];
 };
-
 
 export type IosAppCredentialsMutationSetPushKeyArgs = {
   id: Scalars['ID'];
@@ -3364,7 +3212,6 @@ export type IosAppCredentialsQuery = {
   byId: IosAppCredentials;
 };
 
-
 export type IosAppCredentialsQueryByIdArgs = {
   iosAppCredentialsId: Scalars['ID'];
 };
@@ -3372,7 +3219,7 @@ export type IosAppCredentialsQueryByIdArgs = {
 /** @deprecated Use developmentClient option instead. */
 export enum IosBuildType {
   DevelopmentClient = 'DEVELOPMENT_CLIENT',
-  Release = 'RELEASE'
+  Release = 'RELEASE',
 }
 
 export type IosBuilderEnvironmentInput = {
@@ -3390,7 +3237,7 @@ export enum IosDistributionType {
   AdHoc = 'AD_HOC',
   AppStore = 'APP_STORE',
   Development = 'DEVELOPMENT',
-  Enterprise = 'ENTERPRISE'
+  Enterprise = 'ENTERPRISE',
 }
 
 export type IosJobDistributionCertificateInput = {
@@ -3402,7 +3249,7 @@ export type IosJobInput = {
   applicationArchivePath?: InputMaybe<Scalars['String']>;
   /** @deprecated */
   artifactPath?: InputMaybe<Scalars['String']>;
-  buildArtifactPaths?: InputMaybe<Array<Scalars['String']>>;
+  buildArtifactPaths?: InputMaybe<Scalars['String'][]>;
   buildConfiguration?: InputMaybe<Scalars['String']>;
   buildProfile?: InputMaybe<Scalars['String']>;
   /** @deprecated */
@@ -3432,7 +3279,7 @@ export type IosJobOverridesInput = {
   applicationArchivePath?: InputMaybe<Scalars['String']>;
   /** @deprecated */
   artifactPath?: InputMaybe<Scalars['String']>;
-  buildArtifactPaths?: InputMaybe<Array<Scalars['String']>>;
+  buildArtifactPaths?: InputMaybe<Scalars['String'][]>;
   buildConfiguration?: InputMaybe<Scalars['String']>;
   buildProfile?: InputMaybe<Scalars['String']>;
   /** @deprecated */
@@ -3456,7 +3303,7 @@ export type IosJobOverridesInput = {
 };
 
 export type IosJobSecretsInput = {
-  buildCredentials?: InputMaybe<Array<InputMaybe<IosJobTargetCredentialsInput>>>;
+  buildCredentials?: InputMaybe<InputMaybe<IosJobTargetCredentialsInput>[]>;
   robotAccessToken?: InputMaybe<Scalars['String']>;
 };
 
@@ -3473,12 +3320,12 @@ export type IosJobVersionInput = {
 /** @deprecated Use developmentClient option instead. */
 export enum IosManagedBuildType {
   DevelopmentClient = 'DEVELOPMENT_CLIENT',
-  Release = 'RELEASE'
+  Release = 'RELEASE',
 }
 
 export enum IosSchemeBuildConfiguration {
   Debug = 'DEBUG',
-  Release = 'RELEASE'
+  Release = 'RELEASE',
 }
 
 export type IosSubmissionConfig = {
@@ -3515,12 +3362,12 @@ export type LeaveAccountResult = {
 };
 
 export enum MailchimpAudience {
-  ExpoDevelopers = 'EXPO_DEVELOPERS'
+  ExpoDevelopers = 'EXPO_DEVELOPERS',
 }
 
 export enum MailchimpTag {
   DevClientUsers = 'DEV_CLIENT_USERS',
-  EasMasterList = 'EAS_MASTER_LIST'
+  EasMasterList = 'EAS_MASTER_LIST',
 }
 
 export type MailchimpTagPayload = {
@@ -3569,90 +3416,73 @@ export type MeMutation = {
   updateSSOProfile: SsoUser;
 };
 
-
 export type MeMutationAddSecondFactorDeviceArgs = {
   deviceConfiguration: SecondFactorDeviceConfiguration;
   otp: Scalars['String'];
 };
 
-
 export type MeMutationCertifySecondFactorDeviceArgs = {
   otp: Scalars['String'];
 };
-
 
 export type MeMutationCreateAccountArgs = {
   accountData: AccountDataInput;
 };
 
-
 export type MeMutationDeleteAccountArgs = {
   accountId: Scalars['ID'];
 };
-
 
 export type MeMutationDeleteSecondFactorDeviceArgs = {
   otp: Scalars['String'];
   userSecondFactorDeviceId: Scalars['ID'];
 };
 
-
 export type MeMutationDeleteSnackArgs = {
   snackId: Scalars['ID'];
 };
-
 
 export type MeMutationDisableSecondFactorAuthenticationArgs = {
   otp: Scalars['String'];
 };
 
-
 export type MeMutationInitiateSecondFactorAuthenticationArgs = {
-  deviceConfigurations: Array<SecondFactorDeviceConfiguration>;
+  deviceConfigurations: SecondFactorDeviceConfiguration[];
   recaptchaResponseToken?: InputMaybe<Scalars['String']>;
 };
-
 
 export type MeMutationLeaveAccountArgs = {
   accountId: Scalars['ID'];
 };
 
-
 export type MeMutationRegenerateSecondFactorBackupCodesArgs = {
   otp: Scalars['String'];
 };
-
 
 export type MeMutationSendSmsotpToSecondFactorDeviceArgs = {
   userSecondFactorDeviceId: Scalars['ID'];
 };
 
-
 export type MeMutationSetPrimarySecondFactorDeviceArgs = {
   userSecondFactorDeviceId: Scalars['ID'];
 };
-
 
 export type MeMutationTransferAppArgs = {
   appId: Scalars['ID'];
   destinationAccountId: Scalars['ID'];
 };
 
-
 export type MeMutationUnpublishAppArgs = {
   appId: Scalars['ID'];
 };
-
 
 export type MeMutationUpdateAppArgs = {
   appData: AppDataInput;
 };
 
-
 export type MeMutationUpdateProfileArgs = {
   userData: UserDataInput;
 };
-
 
 export type MeMutationUpdateSsoProfileArgs = {
   userData: SsoUserDataInput;
@@ -3666,7 +3496,8 @@ export type MeteredBillingStatus = {
 
 export enum NotificationEvent {
   BuildComplete = 'BUILD_COMPLETE',
-  SubmissionComplete = 'SUBMISSION_COMPLETE'
+  BuildPlanCreditThresholdExceeded = 'BUILD_PLAN_CREDIT_THRESHOLD_EXCEEDED',
+  SubmissionComplete = 'SUBMISSION_COMPLETE',
 }
 
 export type NotificationSubscription = {
@@ -3694,28 +3525,25 @@ export type NotificationSubscriptionMutation = {
   unsubscribe: UnsubscribeFromNotificationResult;
 };
 
-
 export type NotificationSubscriptionMutationSubscribeToEventForAccountArgs = {
   input: AccountNotificationSubscriptionInput;
 };
 
-
 export type NotificationSubscriptionMutationSubscribeToEventForAppArgs = {
   input: AppNotificationSubscriptionInput;
 };
-
 
 export type NotificationSubscriptionMutationUnsubscribeArgs = {
   id: Scalars['ID'];
 };
 
 export enum NotificationType {
-  Email = 'EMAIL'
+  Email = 'EMAIL',
 }
 
 export type Offer = {
   __typename?: 'Offer';
-  features?: Maybe<Array<Maybe<Feature>>>;
+  features?: Maybe<Maybe<Feature>[]>;
   id: Scalars['ID'];
   prerequisite?: Maybe<OfferPrerequisite>;
   price: Scalars['Int'];
@@ -3727,7 +3555,7 @@ export type Offer = {
 
 export type OfferPrerequisite = {
   __typename?: 'OfferPrerequisite';
-  stripeIds: Array<Scalars['String']>;
+  stripeIds: Scalars['String'][];
   type: Scalars['String'];
 };
 
@@ -3737,12 +3565,12 @@ export enum OfferType {
   /** Advanced Purchase of Paid Resource */
   Prepaid = 'PREPAID',
   /** Term subscription */
-  Subscription = 'SUBSCRIPTION'
+  Subscription = 'SUBSCRIPTION',
 }
 
 export enum Order {
   Asc = 'ASC',
-  Desc = 'DESC'
+  Desc = 'DESC',
 }
 
 export type PageInfo = {
@@ -3754,7 +3582,7 @@ export type PageInfo = {
 };
 
 export type PartialManifest = {
-  assets: Array<InputMaybe<PartialManifestAsset>>;
+  assets: InputMaybe<PartialManifestAsset>[];
   extra?: InputMaybe<Scalars['JSONObject']>;
   launchAsset: PartialManifestAsset;
 };
@@ -3778,7 +3606,7 @@ export enum Permission {
   Admin = 'ADMIN',
   Own = 'OWN',
   Publish = 'PUBLISH',
-  View = 'VIEW'
+  View = 'VIEW',
 }
 
 export type PlanEnablement = Concurrencies | EasTotalPlanEnablement;
@@ -3809,7 +3637,7 @@ export enum ProjectArchiveSourceType {
   Git = 'GIT',
   None = 'NONE',
   S3 = 'S3',
-  Url = 'URL'
+  Url = 'URL',
 }
 
 export type ProjectPublicData = {
@@ -3822,28 +3650,25 @@ export type ProjectQuery = {
   __typename?: 'ProjectQuery';
   byAccountNameAndSlug: Project;
   /** @deprecated No longer supported */
-  byPaths: Array<Maybe<Project>>;
+  byPaths: Maybe<Project>[];
   /** @deprecated See byAccountNameAndSlug */
   byUsernameAndSlug: Project;
 };
 
-
 export type ProjectQueryByAccountNameAndSlugArgs = {
   accountName: Scalars['String'];
   platform?: InputMaybe<AppPlatform>;
-  sdkVersions?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  sdkVersions?: InputMaybe<InputMaybe<Scalars['String']>[]>;
   slug: Scalars['String'];
 };
 
-
 export type ProjectQueryByPathsArgs = {
-  paths?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  paths?: InputMaybe<InputMaybe<Scalars['String']>[]>;
 };
-
 
 export type ProjectQueryByUsernameAndSlugArgs = {
   platform?: InputMaybe<Scalars['String']>;
-  sdkVersions?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  sdkVersions?: InputMaybe<InputMaybe<Scalars['String']>[]>;
   slug: Scalars['String'];
   username: Scalars['String'];
 };
@@ -3857,7 +3682,7 @@ export type PublicArtifacts = {
 export type PublishUpdateGroupInput = {
   awaitingCodeSigningInfo?: InputMaybe<Scalars['Boolean']>;
   branchId: Scalars['String'];
-  excludedAssets?: InputMaybe<Array<PartialManifestAsset>>;
+  excludedAssets?: InputMaybe<PartialManifestAsset[]>;
   gitCommitHash?: InputMaybe<Scalars['String']>;
   isGitWorkingTreeDirty?: InputMaybe<Scalars['Boolean']>;
   message?: InputMaybe<Scalars['String']>;
@@ -3875,9 +3700,9 @@ export type RescindUserInvitationResult = {
 export type Robot = Actor & {
   __typename?: 'Robot';
   /** Access Tokens belonging to this actor */
-  accessTokens: Array<AccessToken>;
+  accessTokens: AccessToken[];
   /** Associated accounts */
-  accounts: Array<Account>;
+  accounts: Account[];
   created: Scalars['DateTime'];
   displayName: Scalars['String'];
   /**
@@ -3890,10 +3715,9 @@ export type Robot = Actor & {
   isExpoAdmin: Scalars['Boolean'];
 };
 
-
 /** Represents a robot (not human) actor. */
 export type RobotFeatureGatesArgs = {
-  filter?: InputMaybe<Array<Scalars['String']>>;
+  filter?: InputMaybe<Scalars['String'][]>;
 };
 
 export type RobotDataInput = {
@@ -3910,18 +3734,15 @@ export type RobotMutation = {
   updateRobot: Robot;
 };
 
-
 export type RobotMutationCreateRobotForAccountArgs = {
   accountID: Scalars['String'];
-  permissions: Array<InputMaybe<Permission>>;
+  permissions: InputMaybe<Permission>[];
   robotData?: InputMaybe<RobotDataInput>;
 };
-
 
 export type RobotMutationDeleteRobotArgs = {
   id: Scalars['String'];
 };
-
 
 export type RobotMutationUpdateRobotArgs = {
   id: Scalars['String'];
@@ -3935,7 +3756,7 @@ export enum Role {
   HasAdmin = 'HAS_ADMIN',
   NotAdmin = 'NOT_ADMIN',
   Owner = 'OWNER',
-  ViewOnly = 'VIEW_ONLY'
+  ViewOnly = 'VIEW_ONLY',
 }
 
 export type RootMutation = {
@@ -4026,21 +3847,17 @@ export type RootMutation = {
   webhook: WebhookMutation;
 };
 
-
 export type RootMutationAccountArgs = {
   accountName: Scalars['ID'];
 };
-
 
 export type RootMutationAppArgs = {
   appId?: InputMaybe<Scalars['ID']>;
 };
 
-
 export type RootMutationBuildArgs = {
   buildId?: InputMaybe<Scalars['ID']>;
 };
-
 
 export type RootMutationBuildJobArgs = {
   buildId: Scalars['ID'];
@@ -4063,7 +3880,7 @@ export type RootQuery = {
    * Public apps in the app directory
    * @deprecated Use 'all' field under 'app'.
    */
-  allPublicApps?: Maybe<Array<Maybe<App>>>;
+  allPublicApps?: Maybe<Maybe<App>[]>;
   app: AppQuery;
   /**
    * Look up app by app id
@@ -4111,7 +3928,7 @@ export type RootQuery = {
   statuspageService: StatuspageServiceQuery;
   submissions: SubmissionQuery;
   /** fetch all updates in a group */
-  updatesByGroup: Array<Update>;
+  updatesByGroup: Update[];
   /** Top-level query object for querying Users. */
   user: UserQuery;
   /** Top-level query object for querying UserActors. */
@@ -4131,7 +3948,6 @@ export type RootQuery = {
   webhook: WebhookQuery;
 };
 
-
 export type RootQueryAllPublicAppsArgs = {
   filter: AppsFilter;
   limit?: InputMaybe<Scalars['Int']>;
@@ -4139,21 +3955,17 @@ export type RootQueryAllPublicAppsArgs = {
   sort: AppSort;
 };
 
-
 export type RootQueryAppByAppIdArgs = {
   appId: Scalars['String'];
 };
-
 
 export type RootQueryUpdatesByGroupArgs = {
   group: Scalars['ID'];
 };
 
-
 export type RootQueryUserByUserIdArgs = {
   userId: Scalars['String'];
 };
-
 
 export type RootQueryUserByUsernameArgs = {
   username: Scalars['String'];
@@ -4168,55 +3980,54 @@ export type Runtime = {
 };
 
 /** Represents a human SSO (not robot) actor. */
-export type SsoUser = Actor & UserActor & {
-  __typename?: 'SSOUser';
-  /** Access Tokens belonging to this actor, none at present */
-  accessTokens: Array<AccessToken>;
-  accounts: Array<Account>;
-  /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
-  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
-  appCount: Scalars['Int'];
-  appetizeCode?: Maybe<Scalars['String']>;
-  /** Apps this user has published. If this user is the viewer, this field returns the apps the user has access to. */
-  apps: Array<App>;
-  bestContactEmail?: Maybe<Scalars['String']>;
-  created: Scalars['DateTime'];
-  /** Discord account linked to a user */
-  discordUser?: Maybe<DiscordUser>;
-  displayName: Scalars['String'];
-  /**
-   * Server feature gate values for this actor, optionally filtering by desired gates.
-   * Only resolves for the viewer.
-   */
-  featureGates: Scalars['JSONObject'];
-  firstName?: Maybe<Scalars['String']>;
-  fullName?: Maybe<Scalars['String']>;
-  /** GitHub account linked to a user */
-  githubUser?: Maybe<GitHubUser>;
-  githubUsername?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-  industry?: Maybe<Scalars['String']>;
-  isExpoAdmin: Scalars['Boolean'];
-  lastName?: Maybe<Scalars['String']>;
-  location?: Maybe<Scalars['String']>;
-  notificationSubscriptions: Array<NotificationSubscription>;
-  /** Associated accounts */
-  primaryAccount: Account;
-  profilePhoto: Scalars['String'];
-  /** Snacks associated with this account */
-  snacks: Array<Snack>;
-  twitterUsername?: Maybe<Scalars['String']>;
-  username: Scalars['String'];
-};
-
+export type SsoUser = Actor &
+  UserActor & {
+    __typename?: 'SSOUser';
+    /** Access Tokens belonging to this actor, none at present */
+    accessTokens: AccessToken[];
+    accounts: Account[];
+    /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
+    activityTimelineProjectActivities: ActivityTimelineProjectActivity[];
+    appCount: Scalars['Int'];
+    appetizeCode?: Maybe<Scalars['String']>;
+    /** Apps this user has published. If this user is the viewer, this field returns the apps the user has access to. */
+    apps: App[];
+    bestContactEmail?: Maybe<Scalars['String']>;
+    created: Scalars['DateTime'];
+    /** Discord account linked to a user */
+    discordUser?: Maybe<DiscordUser>;
+    displayName: Scalars['String'];
+    /**
+     * Server feature gate values for this actor, optionally filtering by desired gates.
+     * Only resolves for the viewer.
+     */
+    featureGates: Scalars['JSONObject'];
+    firstName?: Maybe<Scalars['String']>;
+    fullName?: Maybe<Scalars['String']>;
+    /** GitHub account linked to a user */
+    githubUser?: Maybe<GitHubUser>;
+    githubUsername?: Maybe<Scalars['String']>;
+    id: Scalars['ID'];
+    industry?: Maybe<Scalars['String']>;
+    isExpoAdmin: Scalars['Boolean'];
+    lastName?: Maybe<Scalars['String']>;
+    location?: Maybe<Scalars['String']>;
+    notificationSubscriptions: NotificationSubscription[];
+    /** Associated accounts */
+    primaryAccount: Account;
+    profilePhoto: Scalars['String'];
+    /** Snacks associated with this account */
+    snacks: Snack[];
+    twitterUsername?: Maybe<Scalars['String']>;
+    username: Scalars['String'];
+  };
 
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserActivityTimelineProjectActivitiesArgs = {
   createdBefore?: InputMaybe<Scalars['DateTime']>;
-  filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
+  filterTypes?: InputMaybe<ActivityTimelineProjectActivityType[]>;
   limit: Scalars['Int'];
 };
-
 
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserAppsArgs = {
@@ -4225,18 +4036,15 @@ export type SsoUserAppsArgs = {
   offset: Scalars['Int'];
 };
 
-
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserFeatureGatesArgs = {
-  filter?: InputMaybe<Array<Scalars['String']>>;
+  filter?: InputMaybe<Scalars['String'][]>;
 };
-
 
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserNotificationSubscriptionsArgs = {
   filter?: InputMaybe<NotificationSubscriptionFilter>;
 };
-
 
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserSnacksArgs = {
@@ -4261,11 +4069,9 @@ export type SsoUserQuery = {
   byUsername: SsoUser;
 };
 
-
 export type SsoUserQueryByIdArgs = {
   userId: Scalars['ID'];
 };
-
 
 export type SsoUserQueryByUsernameArgs = {
   username: Scalars['String'];
@@ -4292,20 +4098,20 @@ export type SecondFactorDeviceConfigurationResult = {
 
 export type SecondFactorInitiationResult = {
   __typename?: 'SecondFactorInitiationResult';
-  configurationResults: Array<SecondFactorDeviceConfigurationResult>;
-  plaintextBackupCodes: Array<Scalars['String']>;
+  configurationResults: SecondFactorDeviceConfigurationResult[];
+  plaintextBackupCodes: Scalars['String'][];
 };
 
 export enum SecondFactorMethod {
   /** Google Authenticator (TOTP) */
   Authenticator = 'AUTHENTICATOR',
   /** SMS */
-  Sms = 'SMS'
+  Sms = 'SMS',
 }
 
 export type SecondFactorRegenerateBackupCodesResult = {
   __typename?: 'SecondFactorRegenerateBackupCodesResult';
-  plaintextBackupCodes: Array<Scalars['String']>;
+  plaintextBackupCodes: Scalars['String'][];
 };
 
 export type ServerlessFunctionIdentifierInput = {
@@ -4318,12 +4124,10 @@ export type ServerlessFunctionMutation = {
   createUploadPresignedUrl: CreateServerlessFunctionUploadUrlResult;
 };
 
-
 export type ServerlessFunctionMutationCreateDeploymentArgs = {
   appId: Scalars['ID'];
   serverlessFunctionIdentifierInput: ServerlessFunctionIdentifierInput;
 };
-
 
 export type ServerlessFunctionMutationCreateUploadPresignedUrlArgs = {
   appId: Scalars['ID'];
@@ -4368,11 +4172,9 @@ export type SnackQuery = {
   byId: Snack;
 };
 
-
 export type SnackQueryByHashIdArgs = {
   hashId: Scalars['ID'];
 };
-
 
 export type SnackQueryByIdArgs = {
   id: Scalars['ID'];
@@ -4386,7 +4188,7 @@ export enum StandardOffer {
   /** $29 USD per month, 1 year trial */
   YcDeals = 'YC_DEALS',
   /** $348 USD per year, 30 day trial */
-  YearlySub = 'YEARLY_SUB'
+  YearlySub = 'YEARLY_SUB',
 }
 
 /** Incident for a given component from Expo status page API. */
@@ -4404,7 +4206,7 @@ export type StatuspageIncident = {
   status: StatuspageIncidentStatus;
   updatedAt: Scalars['DateTime'];
   /** List of all updates for an incident from Expo status page. */
-  updates: Array<StatuspageIncidentUpdate>;
+  updates: StatuspageIncidentUpdate[];
 };
 
 /** Possible Incident impact values from Expo status page API. */
@@ -4413,7 +4215,7 @@ export enum StatuspageIncidentImpact {
   Maintenance = 'MAINTENANCE',
   Major = 'MAJOR',
   Minor = 'MINOR',
-  None = 'NONE'
+  None = 'NONE',
 }
 
 /** Possible Incident statuses from Expo status page API. */
@@ -4425,7 +4227,7 @@ export enum StatuspageIncidentStatus {
   Monitoring = 'MONITORING',
   Resolved = 'RESOLVED',
   Scheduled = 'SCHEDULED',
-  Verifying = 'VERIFYING'
+  Verifying = 'VERIFYING',
 }
 
 /** Update for an Incident from Expo status page API. */
@@ -4449,7 +4251,7 @@ export type StatuspageService = {
    * List of last inicdents for a service from Expo status page (we always query for 50 latest incidents for all services)
    * sorted by createdAt field in descending order.
    */
-  incidents: Array<StatuspageIncident>;
+  incidents: StatuspageIncident[];
   /** Name of a service monitored by Expo status page. */
   name: StatuspageServiceName;
   /** Current status of a service from Expo status page. */
@@ -4460,18 +4262,17 @@ export type StatuspageService = {
 export enum StatuspageServiceName {
   EasBuild = 'EAS_BUILD',
   EasSubmit = 'EAS_SUBMIT',
-  EasUpdate = 'EAS_UPDATE'
+  EasUpdate = 'EAS_UPDATE',
 }
 
 export type StatuspageServiceQuery = {
   __typename?: 'StatuspageServiceQuery';
   /** Query services from Expo status page by names. */
-  byServiceNames: Array<StatuspageService>;
+  byServiceNames: StatuspageService[];
 };
 
-
 export type StatuspageServiceQueryByServiceNamesArgs = {
-  serviceNames: Array<StatuspageServiceName>;
+  serviceNames: StatuspageServiceName[];
 };
 
 /** Possible statuses for a service. */
@@ -4480,7 +4281,7 @@ export enum StatuspageServiceStatus {
   MajorOutage = 'MAJOR_OUTAGE',
   Operational = 'OPERATIONAL',
   PartialOutage = 'PARTIAL_OUTAGE',
-  UnderMaintenance = 'UNDER_MAINTENANCE'
+  UnderMaintenance = 'UNDER_MAINTENANCE',
 }
 
 export type StripeCoupon = {
@@ -4522,21 +4323,21 @@ export type Submission = ActivityTimelineProjectActivity & {
 
 export enum SubmissionAndroidArchiveType {
   Aab = 'AAB',
-  Apk = 'APK'
+  Apk = 'APK',
 }
 
 export enum SubmissionAndroidReleaseStatus {
   Completed = 'COMPLETED',
   Draft = 'DRAFT',
   Halted = 'HALTED',
-  InProgress = 'IN_PROGRESS'
+  InProgress = 'IN_PROGRESS',
 }
 
 export enum SubmissionAndroidTrack {
   Alpha = 'ALPHA',
   Beta = 'BETA',
   Internal = 'INTERNAL',
-  Production = 'PRODUCTION'
+  Production = 'PRODUCTION',
 }
 
 export type SubmissionArchiveSourceInput = {
@@ -4550,7 +4351,7 @@ export type SubmissionArchiveSourceInput = {
 export enum SubmissionArchiveSourceType {
   GcsBuildApplicationArchive = 'GCS_BUILD_APPLICATION_ARCHIVE',
   GcsSubmitArchive = 'GCS_SUBMIT_ARCHIVE',
-  Url = 'URL'
+  Url = 'URL',
 }
 
 export type SubmissionError = {
@@ -4576,21 +4377,17 @@ export type SubmissionMutation = {
   retrySubmission: CreateSubmissionResult;
 };
 
-
 export type SubmissionMutationCancelSubmissionArgs = {
   submissionId: Scalars['ID'];
 };
-
 
 export type SubmissionMutationCreateAndroidSubmissionArgs = {
   input: CreateAndroidSubmissionInput;
 };
 
-
 export type SubmissionMutationCreateIosSubmissionArgs = {
   input: CreateIosSubmissionInput;
 };
-
 
 export type SubmissionMutationRetrySubmissionArgs = {
   parentSubmissionId: Scalars['ID'];
@@ -4602,7 +4399,6 @@ export type SubmissionQuery = {
   byId: Submission;
 };
 
-
 export type SubmissionQueryByIdArgs = {
   submissionId: Scalars['ID'];
 };
@@ -4613,7 +4409,7 @@ export enum SubmissionStatus {
   Errored = 'ERRORED',
   Finished = 'FINISHED',
   InProgress = 'IN_PROGRESS',
-  InQueue = 'IN_QUEUE'
+  InQueue = 'IN_QUEUE',
 }
 
 export type SubscribeToNotificationResult = {
@@ -4623,7 +4419,7 @@ export type SubscribeToNotificationResult = {
 
 export type SubscriptionDetails = {
   __typename?: 'SubscriptionDetails';
-  addons: Array<AddonDetails>;
+  addons: AddonDetails[];
   cancelledAt?: Maybe<Scalars['DateTime']>;
   concurrencies?: Maybe<Concurrencies>;
   coupon?: Maybe<StripeCoupon>;
@@ -4642,14 +4438,13 @@ export type SubscriptionDetails = {
   willCancel?: Maybe<Scalars['Boolean']>;
 };
 
-
 export type SubscriptionDetailsPlanEnablementArgs = {
   serviceMetric: EasServiceMetric;
 };
 
 export type TimelineActivityConnection = {
   __typename?: 'TimelineActivityConnection';
-  edges: Array<TimelineActivityEdge>;
+  edges: TimelineActivityEdge[];
   pageInfo: PageInfo;
 };
 
@@ -4660,10 +4455,10 @@ export type TimelineActivityEdge = {
 };
 
 export type TimelineActivityFilterInput = {
-  channels?: InputMaybe<Array<Scalars['String']>>;
-  platforms?: InputMaybe<Array<AppPlatform>>;
-  releaseChannels?: InputMaybe<Array<Scalars['String']>>;
-  types?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
+  channels?: InputMaybe<Scalars['String'][]>;
+  platforms?: InputMaybe<AppPlatform[]>;
+  releaseChannels?: InputMaybe<Scalars['String'][]>;
+  types?: InputMaybe<ActivityTimelineProjectActivityType[]>;
 };
 
 export type UnsubscribeFromNotificationResult = {
@@ -4675,6 +4470,7 @@ export type Update = ActivityTimelineProjectActivity & {
   __typename?: 'Update';
   activityTimestamp: Scalars['DateTime'];
   actor?: Maybe<Actor>;
+  app: App;
   awaitingCodeSigningInfo: Scalars['Boolean'];
   branch: UpdateBranch;
   branchId: Scalars['ID'];
@@ -4701,18 +4497,16 @@ export type UpdateBranch = {
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
   name: Scalars['String'];
-  updateGroups: Array<Array<Update>>;
+  updateGroups: Update[][];
   updatedAt: Scalars['DateTime'];
-  updates: Array<Update>;
+  updates: Update[];
 };
-
 
 export type UpdateBranchUpdateGroupsArgs = {
   filter?: InputMaybe<UpdatesFilter>;
   limit: Scalars['Int'];
   offset: Scalars['Int'];
 };
-
 
 export type UpdateBranchUpdatesArgs = {
   filter?: InputMaybe<UpdatesFilter>;
@@ -4732,28 +4526,24 @@ export type UpdateBranchMutation = {
    */
   editUpdateBranch: UpdateBranch;
   /** Publish an update group to a branch */
-  publishUpdateGroups: Array<Update>;
+  publishUpdateGroups: Update[];
 };
-
 
 export type UpdateBranchMutationCreateUpdateBranchForAppArgs = {
   appId: Scalars['ID'];
   name: Scalars['String'];
 };
 
-
 export type UpdateBranchMutationDeleteUpdateBranchArgs = {
   branchId: Scalars['ID'];
 };
-
 
 export type UpdateBranchMutationEditUpdateBranchArgs = {
   input: EditUpdateBranchInput;
 };
 
-
 export type UpdateBranchMutationPublishUpdateGroupsArgs = {
-  publishUpdateGroupsInput: Array<PublishUpdateGroupInput>;
+  publishUpdateGroupsInput: PublishUpdateGroupInput[];
 };
 
 export type UpdateChannel = {
@@ -4763,10 +4553,9 @@ export type UpdateChannel = {
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
   name: Scalars['String'];
-  updateBranches: Array<UpdateBranch>;
+  updateBranches: UpdateBranch[];
   updatedAt: Scalars['DateTime'];
 };
-
 
 export type UpdateChannelUpdateBranchesArgs = {
   limit: Scalars['Int'];
@@ -4793,18 +4582,15 @@ export type UpdateChannelMutation = {
   editUpdateChannel: UpdateChannel;
 };
 
-
 export type UpdateChannelMutationCreateUpdateChannelForAppArgs = {
   appId: Scalars['ID'];
   branchMapping?: InputMaybe<Scalars['String']>;
   name: Scalars['String'];
 };
 
-
 export type UpdateChannelMutationDeleteUpdateChannelArgs = {
   channelId: Scalars['ID'];
 };
-
 
 export type UpdateChannelMutationEditUpdateChannelArgs = {
   branchMapping: Scalars['String'];
@@ -4829,11 +4615,9 @@ export type UpdateMutation = {
   setCodeSigningInfo: Update;
 };
 
-
 export type UpdateMutationDeleteUpdateGroupArgs = {
   group: Scalars['ID'];
 };
-
 
 export type UpdateMutationSetCodeSigningInfoArgs = {
   codeSigningInfo: CodeSigningInfoInput;
@@ -4848,7 +4632,8 @@ export type UpdateRollBackToEmbeddedGroup = {
 
 export type UpdatesFilter = {
   platform?: InputMaybe<AppPlatform>;
-  runtimeVersions?: InputMaybe<Array<Scalars['String']>>;
+  runtimeVersions?: InputMaybe<Scalars['String'][]>;
+  sdkVersions?: InputMaybe<Scalars['String'][]>;
 };
 
 export type UploadSession = {
@@ -4856,7 +4641,6 @@ export type UploadSession = {
   /** Create an Upload Session */
   createUploadSession: Scalars['JSONObject'];
 };
-
 
 export type UploadSessionCreateUploadSessionArgs = {
   type: UploadSessionType;
@@ -4866,15 +4650,15 @@ export enum UploadSessionType {
   EasBuildGcsProjectSources = 'EAS_BUILD_GCS_PROJECT_SOURCES',
   EasBuildProjectSources = 'EAS_BUILD_PROJECT_SOURCES',
   EasSubmitAppArchive = 'EAS_SUBMIT_APP_ARCHIVE',
-  EasSubmitGcsAppArchive = 'EAS_SUBMIT_GCS_APP_ARCHIVE'
+  EasSubmitGcsAppArchive = 'EAS_SUBMIT_GCS_APP_ARCHIVE',
 }
 
 export type UsageMetricTotal = {
   __typename?: 'UsageMetricTotal';
   billingPeriod: BillingPeriod;
   id: Scalars['ID'];
-  overageMetrics: Array<EstimatedOverageAndCost>;
-  planMetrics: Array<EstimatedUsage>;
+  overageMetrics: EstimatedOverageAndCost[];
+  planMetrics: EstimatedUsage[];
   /** Total cost of overages, in cents */
   totalCost: Scalars['Float'];
 };
@@ -4884,14 +4668,14 @@ export enum UsageMetricType {
   Build = 'BUILD',
   Request = 'REQUEST',
   Update = 'UPDATE',
-  User = 'USER'
+  User = 'USER',
 }
 
 export enum UsageMetricsGranularity {
   Day = 'DAY',
   Hour = 'HOUR',
   Minute = 'MINUTE',
-  Total = 'TOTAL'
+  Total = 'TOTAL',
 }
 
 export type UsageMetricsTimespan = {
@@ -4900,66 +4684,65 @@ export type UsageMetricsTimespan = {
 };
 
 /** Represents a human (not robot) actor. */
-export type User = Actor & UserActor & {
-  __typename?: 'User';
-  /** Access Tokens belonging to this actor */
-  accessTokens: Array<AccessToken>;
-  accounts: Array<Account>;
-  /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
-  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
-  appCount: Scalars['Int'];
-  appetizeCode?: Maybe<Scalars['String']>;
-  /** Apps this user has published */
-  apps: Array<App>;
-  bestContactEmail?: Maybe<Scalars['String']>;
-  created: Scalars['DateTime'];
-  /** Discord account linked to a user */
-  discordUser?: Maybe<DiscordUser>;
-  displayName: Scalars['String'];
-  email?: Maybe<Scalars['String']>;
-  emailVerified: Scalars['Boolean'];
-  /**
-   * Server feature gate values for this actor, optionally filtering by desired gates.
-   * Only resolves for the viewer.
-   */
-  featureGates: Scalars['JSONObject'];
-  firstName?: Maybe<Scalars['String']>;
-  fullName?: Maybe<Scalars['String']>;
-  /** GitHub account linked to a user */
-  githubUser?: Maybe<GitHubUser>;
-  githubUsername?: Maybe<Scalars['String']>;
-  /** Whether this user has any pending user invitations. Only resolves for the viewer. */
-  hasPendingUserInvitations: Scalars['Boolean'];
-  id: Scalars['ID'];
-  industry?: Maybe<Scalars['String']>;
-  isExpoAdmin: Scalars['Boolean'];
-  /** @deprecated This field no longer exists */
-  isLegacy: Scalars['Boolean'];
-  isSecondFactorAuthenticationEnabled: Scalars['Boolean'];
-  lastName?: Maybe<Scalars['String']>;
-  location?: Maybe<Scalars['String']>;
-  notificationSubscriptions: Array<NotificationSubscription>;
-  /** Pending UserInvitations for this user. Only resolves for the viewer. */
-  pendingUserInvitations: Array<UserInvitation>;
-  /** Associated accounts */
-  primaryAccount: Account;
-  profilePhoto: Scalars['String'];
-  /** Get all certified second factor authentication methods */
-  secondFactorDevices: Array<UserSecondFactorDevice>;
-  /** Snacks associated with this account */
-  snacks: Array<Snack>;
-  twitterUsername?: Maybe<Scalars['String']>;
-  username: Scalars['String'];
-};
-
+export type User = Actor &
+  UserActor & {
+    __typename?: 'User';
+    /** Access Tokens belonging to this actor */
+    accessTokens: AccessToken[];
+    accounts: Account[];
+    /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
+    activityTimelineProjectActivities: ActivityTimelineProjectActivity[];
+    appCount: Scalars['Int'];
+    appetizeCode?: Maybe<Scalars['String']>;
+    /** Apps this user has published */
+    apps: App[];
+    bestContactEmail?: Maybe<Scalars['String']>;
+    created: Scalars['DateTime'];
+    /** Discord account linked to a user */
+    discordUser?: Maybe<DiscordUser>;
+    displayName: Scalars['String'];
+    email?: Maybe<Scalars['String']>;
+    emailVerified: Scalars['Boolean'];
+    /**
+     * Server feature gate values for this actor, optionally filtering by desired gates.
+     * Only resolves for the viewer.
+     */
+    featureGates: Scalars['JSONObject'];
+    firstName?: Maybe<Scalars['String']>;
+    fullName?: Maybe<Scalars['String']>;
+    /** GitHub account linked to a user */
+    githubUser?: Maybe<GitHubUser>;
+    githubUsername?: Maybe<Scalars['String']>;
+    /** Whether this user has any pending user invitations. Only resolves for the viewer. */
+    hasPendingUserInvitations: Scalars['Boolean'];
+    id: Scalars['ID'];
+    industry?: Maybe<Scalars['String']>;
+    isExpoAdmin: Scalars['Boolean'];
+    /** @deprecated This field no longer exists */
+    isLegacy: Scalars['Boolean'];
+    isSecondFactorAuthenticationEnabled: Scalars['Boolean'];
+    lastName?: Maybe<Scalars['String']>;
+    location?: Maybe<Scalars['String']>;
+    notificationSubscriptions: NotificationSubscription[];
+    /** Pending UserInvitations for this user. Only resolves for the viewer. */
+    pendingUserInvitations: UserInvitation[];
+    /** Associated accounts */
+    primaryAccount: Account;
+    profilePhoto: Scalars['String'];
+    /** Get all certified second factor authentication methods */
+    secondFactorDevices: UserSecondFactorDevice[];
+    /** Snacks associated with this account */
+    snacks: Snack[];
+    twitterUsername?: Maybe<Scalars['String']>;
+    username: Scalars['String'];
+  };
 
 /** Represents a human (not robot) actor. */
 export type UserActivityTimelineProjectActivitiesArgs = {
   createdBefore?: InputMaybe<Scalars['DateTime']>;
-  filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
+  filterTypes?: InputMaybe<ActivityTimelineProjectActivityType[]>;
   limit: Scalars['Int'];
 };
-
 
 /** Represents a human (not robot) actor. */
 export type UserAppsArgs = {
@@ -4968,18 +4751,15 @@ export type UserAppsArgs = {
   offset: Scalars['Int'];
 };
 
-
 /** Represents a human (not robot) actor. */
 export type UserFeatureGatesArgs = {
-  filter?: InputMaybe<Array<Scalars['String']>>;
+  filter?: InputMaybe<Scalars['String'][]>;
 };
-
 
 /** Represents a human (not robot) actor. */
 export type UserNotificationSubscriptionsArgs = {
   filter?: InputMaybe<NotificationSubscriptionFilter>;
 };
-
 
 /** Represents a human (not robot) actor. */
 export type UserSnacksArgs = {
@@ -4990,17 +4770,17 @@ export type UserSnacksArgs = {
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActor = {
   /** Access Tokens belonging to this user actor */
-  accessTokens: Array<AccessToken>;
-  accounts: Array<Account>;
+  accessTokens: AccessToken[];
+  accounts: Account[];
   /**
    * Coalesced project activity for all apps belonging to all accounts this user actor belongs to.
    * Only resolves for the viewer.
    */
-  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
+  activityTimelineProjectActivities: ActivityTimelineProjectActivity[];
   appCount: Scalars['Int'];
   appetizeCode?: Maybe<Scalars['String']>;
   /** Apps this user has published */
-  apps: Array<App>;
+  apps: App[];
   bestContactEmail?: Maybe<Scalars['String']>;
   created: Scalars['DateTime'];
   /** Discord account linked to a user */
@@ -5025,24 +4805,22 @@ export type UserActor = {
   isExpoAdmin: Scalars['Boolean'];
   lastName?: Maybe<Scalars['String']>;
   location?: Maybe<Scalars['String']>;
-  notificationSubscriptions: Array<NotificationSubscription>;
+  notificationSubscriptions: NotificationSubscription[];
   /** Associated accounts */
   primaryAccount: Account;
   profilePhoto: Scalars['String'];
   /** Snacks associated with this user's personal account */
-  snacks: Array<Snack>;
+  snacks: Snack[];
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
 };
 
-
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorActivityTimelineProjectActivitiesArgs = {
   createdBefore?: InputMaybe<Scalars['DateTime']>;
-  filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
+  filterTypes?: InputMaybe<ActivityTimelineProjectActivityType[]>;
   limit: Scalars['Int'];
 };
-
 
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorAppsArgs = {
@@ -5051,18 +4829,15 @@ export type UserActorAppsArgs = {
   offset: Scalars['Int'];
 };
 
-
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorFeatureGatesArgs = {
-  filter?: InputMaybe<Array<Scalars['String']>>;
+  filter?: InputMaybe<Scalars['String'][]>;
 };
-
 
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorNotificationSubscriptionsArgs = {
   filter?: InputMaybe<NotificationSubscriptionFilter>;
 };
-
 
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorSnacksArgs = {
@@ -5078,11 +4853,9 @@ export type UserActorQuery = {
   byUsername: UserActor;
 };
 
-
 export type UserActorQueryByIdArgs = {
   id: Scalars['ID'];
 };
-
 
 export type UserActorQueryByUsernameArgs = {
   username: Scalars['String'];
@@ -5117,7 +4890,7 @@ export type UserInvitation = {
   /** If the invite is for an organization or a personal team */
   isForOrganization: Scalars['Boolean'];
   /** Account permissions to be granted upon acceptance of this invitation */
-  permissions: Array<Permission>;
+  permissions: Permission[];
   /** Role to be granted upon acceptance of this invitation */
   role: Role;
 };
@@ -5148,33 +4921,27 @@ export type UserInvitationMutation = {
   resendUserInvitation: UserInvitation;
 };
 
-
 export type UserInvitationMutationAcceptUserInvitationAsViewerArgs = {
   id: Scalars['ID'];
 };
-
 
 export type UserInvitationMutationAcceptUserInvitationByTokenAsViewerArgs = {
   token: Scalars['ID'];
 };
 
-
 export type UserInvitationMutationCreateUserInvitationForAccountArgs = {
   accountID: Scalars['ID'];
   email: Scalars['String'];
-  permissions: Array<InputMaybe<Permission>>;
+  permissions: InputMaybe<Permission>[];
 };
-
 
 export type UserInvitationMutationDeleteUserInvitationArgs = {
   id: Scalars['ID'];
 };
 
-
 export type UserInvitationMutationDeleteUserInvitationByTokenArgs = {
   token: Scalars['ID'];
 };
-
 
 export type UserInvitationMutationResendUserInvitationArgs = {
   id: Scalars['ID'];
@@ -5199,7 +4966,6 @@ export type UserInvitationPublicDataQuery = {
   byToken: UserInvitationPublicData;
 };
 
-
 export type UserInvitationPublicDataQueryByTokenArgs = {
   token: Scalars['ID'];
 };
@@ -5207,7 +4973,7 @@ export type UserInvitationPublicDataQueryByTokenArgs = {
 export type UserPermission = {
   __typename?: 'UserPermission';
   actor: Actor;
-  permissions: Array<Permission>;
+  permissions: Permission[];
   role: Role;
   /** @deprecated User type is deprecated */
   user?: Maybe<User>;
@@ -5222,11 +4988,9 @@ export type UserQuery = {
   byUsername: User;
 };
 
-
 export type UserQueryByIdArgs = {
   userId: Scalars['ID'];
 };
-
 
 export type UserQueryByUsernameArgs = {
   username: Scalars['String'];
@@ -5276,17 +5040,14 @@ export type WebhookMutation = {
   updateWebhook: Webhook;
 };
 
-
 export type WebhookMutationCreateWebhookArgs = {
   appId: Scalars['String'];
   webhookInput: WebhookInput;
 };
 
-
 export type WebhookMutationDeleteWebhookArgs = {
   webhookId: Scalars['ID'];
 };
-
 
 export type WebhookMutationUpdateWebhookArgs = {
   webhookId: Scalars['ID'];
@@ -5298,14 +5059,13 @@ export type WebhookQuery = {
   byId: Webhook;
 };
 
-
 export type WebhookQueryByIdArgs = {
   id: Scalars['ID'];
 };
 
 export enum WebhookType {
   Build = 'BUILD',
-  Submit = 'SUBMIT'
+  Submit = 'SUBMIT',
 }
 
 export type DeleteAndroidAppBuildCredentialsResult = {
@@ -5333,8 +5093,13 @@ export type CreateUpdateBranchForAppMutationVariables = Exact<{
   name: Scalars['String'];
 }>;
 
-
-export type CreateUpdateBranchForAppMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', createUpdateBranchForApp: { __typename?: 'UpdateBranch', id: string, name: string } } };
+export type CreateUpdateBranchForAppMutation = {
+  __typename?: 'RootMutation';
+  updateBranch: {
+    __typename?: 'UpdateBranchMutation';
+    createUpdateBranchForApp: { __typename?: 'UpdateBranch'; id: string; name: string };
+  };
+};
 
 export type CreateUpdateChannelOnAppMutationVariables = Exact<{
   appId: Scalars['ID'];
@@ -5342,82 +5107,188 @@ export type CreateUpdateChannelOnAppMutationVariables = Exact<{
   branchMapping: Scalars['String'];
 }>;
 
-
-export type CreateUpdateChannelOnAppMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', createUpdateChannelForApp: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
+export type CreateUpdateChannelOnAppMutation = {
+  __typename?: 'RootMutation';
+  updateChannel: {
+    __typename?: 'UpdateChannelMutation';
+    createUpdateChannelForApp: {
+      __typename?: 'UpdateChannel';
+      id: string;
+      name: string;
+      branchMapping: string;
+    };
+  };
+};
 
 export type GetBranchInfoQueryVariables = Exact<{
   appId: Scalars['String'];
   name: Scalars['String'];
 }>;
 
-
-export type GetBranchInfoQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, name: string } | null } } };
+export type GetBranchInfoQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      updateBranchByName?: { __typename?: 'UpdateBranch'; id: string; name: string } | null;
+    };
+  };
+};
 
 export type DeleteUpdateBranchMutationVariables = Exact<{
   branchId: Scalars['ID'];
 }>;
 
-
-export type DeleteUpdateBranchMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', deleteUpdateBranch: { __typename?: 'DeleteUpdateBranchResult', id: string } } };
+export type DeleteUpdateBranchMutation = {
+  __typename?: 'RootMutation';
+  updateBranch: {
+    __typename?: 'UpdateBranchMutation';
+    deleteUpdateBranch: { __typename?: 'DeleteUpdateBranchResult'; id: string };
+  };
+};
 
 export type EditUpdateBranchMutationVariables = Exact<{
   input: EditUpdateBranchInput;
 }>;
 
-
-export type EditUpdateBranchMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', editUpdateBranch: { __typename?: 'UpdateBranch', id: string, name: string } } };
+export type EditUpdateBranchMutation = {
+  __typename?: 'RootMutation';
+  updateBranch: {
+    __typename?: 'UpdateBranchMutation';
+    editUpdateBranch: { __typename?: 'UpdateBranch'; id: string; name: string };
+  };
+};
 
 export type CancelBuildMutationVariables = Exact<{
   buildId: Scalars['ID'];
 }>;
 
-
-export type CancelBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', cancel: { __typename?: 'Build', id: string, status: BuildStatus } } };
+export type CancelBuildMutation = {
+  __typename?: 'RootMutation';
+  build: {
+    __typename?: 'BuildMutation';
+    cancel: { __typename?: 'Build'; id: string; status: BuildStatus };
+  };
+};
 
 export type DeleteUpdateChannelMutationVariables = Exact<{
   channelId: Scalars['ID'];
 }>;
 
-
-export type DeleteUpdateChannelMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', deleteUpdateChannel: { __typename?: 'DeleteUpdateChannelResult', id: string } } };
+export type DeleteUpdateChannelMutation = {
+  __typename?: 'RootMutation';
+  updateChannel: {
+    __typename?: 'UpdateChannelMutation';
+    deleteUpdateChannel: { __typename?: 'DeleteUpdateChannelResult'; id: string };
+  };
+};
 
 export type UpdateChannelBranchMappingMutationVariables = Exact<{
   channelId: Scalars['ID'];
   branchMapping: Scalars['String'];
 }>;
 
-
-export type UpdateChannelBranchMappingMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', editUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
+export type UpdateChannelBranchMappingMutation = {
+  __typename?: 'RootMutation';
+  updateChannel: {
+    __typename?: 'UpdateChannelMutation';
+    editUpdateChannel: {
+      __typename?: 'UpdateChannel';
+      id: string;
+      name: string;
+      branchMapping: string;
+    };
+  };
+};
 
 export type AppInfoQueryVariables = Exact<{
   appId: Scalars['String'];
 }>;
 
-
-export type AppInfoQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, fullName: string } } };
+export type AppInfoQuery = {
+  __typename?: 'RootQuery';
+  app: { __typename?: 'AppQuery'; byId: { __typename?: 'App'; id: string; fullName: string } };
+};
 
 export type DeleteUpdateGroupMutationVariables = Exact<{
   group: Scalars['ID'];
 }>;
 
-
-export type DeleteUpdateGroupMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', deleteUpdateGroup: { __typename?: 'DeleteUpdateGroupResult', group: string } } };
+export type DeleteUpdateGroupMutation = {
+  __typename?: 'RootMutation';
+  update: {
+    __typename?: 'UpdateMutation';
+    deleteUpdateGroup: { __typename?: 'DeleteUpdateGroupResult'; group: string };
+  };
+};
 
 export type CreateAndroidAppBuildCredentialsMutationVariables = Exact<{
   androidAppBuildCredentialsInput: AndroidAppBuildCredentialsInput;
   androidAppCredentialsId: Scalars['ID'];
 }>;
 
-
-export type CreateAndroidAppBuildCredentialsMutation = { __typename?: 'RootMutation', androidAppBuildCredentials: { __typename?: 'AndroidAppBuildCredentialsMutation', createAndroidAppBuildCredentials: { __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null } } };
+export type CreateAndroidAppBuildCredentialsMutation = {
+  __typename?: 'RootMutation';
+  androidAppBuildCredentials: {
+    __typename?: 'AndroidAppBuildCredentialsMutation';
+    createAndroidAppBuildCredentials: {
+      __typename?: 'AndroidAppBuildCredentials';
+      id: string;
+      isDefault: boolean;
+      isLegacy: boolean;
+      name: string;
+      androidKeystore?: {
+        __typename?: 'AndroidKeystore';
+        id: string;
+        type: AndroidKeystoreType;
+        keystore: string;
+        keystorePassword: string;
+        keyAlias: string;
+        keyPassword?: string | null;
+        md5CertificateFingerprint?: string | null;
+        sha1CertificateFingerprint?: string | null;
+        sha256CertificateFingerprint?: string | null;
+        createdAt: any;
+        updatedAt: any;
+      } | null;
+    };
+  };
+};
 
 export type SetKeystoreMutationVariables = Exact<{
   androidAppBuildCredentialsId: Scalars['ID'];
   keystoreId: Scalars['ID'];
 }>;
 
-
-export type SetKeystoreMutation = { __typename?: 'RootMutation', androidAppBuildCredentials: { __typename?: 'AndroidAppBuildCredentialsMutation', setKeystore: { __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null } } };
+export type SetKeystoreMutation = {
+  __typename?: 'RootMutation';
+  androidAppBuildCredentials: {
+    __typename?: 'AndroidAppBuildCredentialsMutation';
+    setKeystore: {
+      __typename?: 'AndroidAppBuildCredentials';
+      id: string;
+      isDefault: boolean;
+      isLegacy: boolean;
+      name: string;
+      androidKeystore?: {
+        __typename?: 'AndroidKeystore';
+        id: string;
+        type: AndroidKeystoreType;
+        keystore: string;
+        keystorePassword: string;
+        keyAlias: string;
+        keyPassword?: string | null;
+        md5CertificateFingerprint?: string | null;
+        sha1CertificateFingerprint?: string | null;
+        sha256CertificateFingerprint?: string | null;
+        createdAt: any;
+        updatedAt: any;
+      } | null;
+    };
+  };
+};
 
 export type CreateAndroidAppCredentialsMutationVariables = Exact<{
   androidAppCredentialsInput: AndroidAppCredentialsInput;
@@ -5425,154 +5296,713 @@ export type CreateAndroidAppCredentialsMutationVariables = Exact<{
   applicationIdentifier: Scalars['String'];
 }>;
 
-
-export type CreateAndroidAppCredentialsMutation = { __typename?: 'RootMutation', androidAppCredentials: { __typename?: 'AndroidAppCredentialsMutation', createAndroidAppCredentials: { __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> } } };
+export type CreateAndroidAppCredentialsMutation = {
+  __typename?: 'RootMutation';
+  androidAppCredentials: {
+    __typename?: 'AndroidAppCredentialsMutation';
+    createAndroidAppCredentials: {
+      __typename?: 'AndroidAppCredentials';
+      id: string;
+      applicationIdentifier?: string | null;
+      isLegacy: boolean;
+      app: {
+        __typename?: 'App';
+        id: string;
+        fullName: string;
+        slug: string;
+        ownerAccount: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        };
+      };
+      androidFcm?: {
+        __typename?: 'AndroidFcm';
+        id: string;
+        credential: any;
+        version: AndroidFcmVersion;
+        createdAt: any;
+        updatedAt: any;
+        snippet:
+          | {
+              __typename?: 'FcmSnippetLegacy';
+              firstFourCharacters: string;
+              lastFourCharacters: string;
+            }
+          | {
+              __typename?: 'FcmSnippetV1';
+              projectId: string;
+              keyId: string;
+              serviceAccountEmail: string;
+              clientId?: string | null;
+            };
+      } | null;
+      googleServiceAccountKeyForSubmissions?: {
+        __typename?: 'GoogleServiceAccountKey';
+        id: string;
+        projectIdentifier: string;
+        privateKeyIdentifier: string;
+        clientEmail: string;
+        clientIdentifier: string;
+        createdAt: any;
+        updatedAt: any;
+      } | null;
+      androidAppBuildCredentialsList: {
+        __typename?: 'AndroidAppBuildCredentials';
+        id: string;
+        isDefault: boolean;
+        isLegacy: boolean;
+        name: string;
+        androidKeystore?: {
+          __typename?: 'AndroidKeystore';
+          id: string;
+          type: AndroidKeystoreType;
+          keystore: string;
+          keystorePassword: string;
+          keyAlias: string;
+          keyPassword?: string | null;
+          md5CertificateFingerprint?: string | null;
+          sha1CertificateFingerprint?: string | null;
+          sha256CertificateFingerprint?: string | null;
+          createdAt: any;
+          updatedAt: any;
+        } | null;
+      }[];
+    };
+  };
+};
 
 export type SetFcmMutationVariables = Exact<{
   androidAppCredentialsId: Scalars['ID'];
   fcmId: Scalars['ID'];
 }>;
 
-
-export type SetFcmMutation = { __typename?: 'RootMutation', androidAppCredentials: { __typename?: 'AndroidAppCredentialsMutation', setFcm: { __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> } } };
+export type SetFcmMutation = {
+  __typename?: 'RootMutation';
+  androidAppCredentials: {
+    __typename?: 'AndroidAppCredentialsMutation';
+    setFcm: {
+      __typename?: 'AndroidAppCredentials';
+      id: string;
+      applicationIdentifier?: string | null;
+      isLegacy: boolean;
+      app: {
+        __typename?: 'App';
+        id: string;
+        fullName: string;
+        slug: string;
+        ownerAccount: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        };
+      };
+      androidFcm?: {
+        __typename?: 'AndroidFcm';
+        id: string;
+        credential: any;
+        version: AndroidFcmVersion;
+        createdAt: any;
+        updatedAt: any;
+        snippet:
+          | {
+              __typename?: 'FcmSnippetLegacy';
+              firstFourCharacters: string;
+              lastFourCharacters: string;
+            }
+          | {
+              __typename?: 'FcmSnippetV1';
+              projectId: string;
+              keyId: string;
+              serviceAccountEmail: string;
+              clientId?: string | null;
+            };
+      } | null;
+      googleServiceAccountKeyForSubmissions?: {
+        __typename?: 'GoogleServiceAccountKey';
+        id: string;
+        projectIdentifier: string;
+        privateKeyIdentifier: string;
+        clientEmail: string;
+        clientIdentifier: string;
+        createdAt: any;
+        updatedAt: any;
+      } | null;
+      androidAppBuildCredentialsList: {
+        __typename?: 'AndroidAppBuildCredentials';
+        id: string;
+        isDefault: boolean;
+        isLegacy: boolean;
+        name: string;
+        androidKeystore?: {
+          __typename?: 'AndroidKeystore';
+          id: string;
+          type: AndroidKeystoreType;
+          keystore: string;
+          keystorePassword: string;
+          keyAlias: string;
+          keyPassword?: string | null;
+          md5CertificateFingerprint?: string | null;
+          sha1CertificateFingerprint?: string | null;
+          sha256CertificateFingerprint?: string | null;
+          createdAt: any;
+          updatedAt: any;
+        } | null;
+      }[];
+    };
+  };
+};
 
 export type SetGoogleServiceAccountKeyForSubmissionsMutationVariables = Exact<{
   androidAppCredentialsId: Scalars['ID'];
   googleServiceAccountKeyId: Scalars['ID'];
 }>;
 
-
-export type SetGoogleServiceAccountKeyForSubmissionsMutation = { __typename?: 'RootMutation', androidAppCredentials: { __typename?: 'AndroidAppCredentialsMutation', setGoogleServiceAccountKeyForSubmissions: { __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> } } };
+export type SetGoogleServiceAccountKeyForSubmissionsMutation = {
+  __typename?: 'RootMutation';
+  androidAppCredentials: {
+    __typename?: 'AndroidAppCredentialsMutation';
+    setGoogleServiceAccountKeyForSubmissions: {
+      __typename?: 'AndroidAppCredentials';
+      id: string;
+      applicationIdentifier?: string | null;
+      isLegacy: boolean;
+      app: {
+        __typename?: 'App';
+        id: string;
+        fullName: string;
+        slug: string;
+        ownerAccount: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        };
+      };
+      androidFcm?: {
+        __typename?: 'AndroidFcm';
+        id: string;
+        credential: any;
+        version: AndroidFcmVersion;
+        createdAt: any;
+        updatedAt: any;
+        snippet:
+          | {
+              __typename?: 'FcmSnippetLegacy';
+              firstFourCharacters: string;
+              lastFourCharacters: string;
+            }
+          | {
+              __typename?: 'FcmSnippetV1';
+              projectId: string;
+              keyId: string;
+              serviceAccountEmail: string;
+              clientId?: string | null;
+            };
+      } | null;
+      googleServiceAccountKeyForSubmissions?: {
+        __typename?: 'GoogleServiceAccountKey';
+        id: string;
+        projectIdentifier: string;
+        privateKeyIdentifier: string;
+        clientEmail: string;
+        clientIdentifier: string;
+        createdAt: any;
+        updatedAt: any;
+      } | null;
+      androidAppBuildCredentialsList: {
+        __typename?: 'AndroidAppBuildCredentials';
+        id: string;
+        isDefault: boolean;
+        isLegacy: boolean;
+        name: string;
+        androidKeystore?: {
+          __typename?: 'AndroidKeystore';
+          id: string;
+          type: AndroidKeystoreType;
+          keystore: string;
+          keystorePassword: string;
+          keyAlias: string;
+          keyPassword?: string | null;
+          md5CertificateFingerprint?: string | null;
+          sha1CertificateFingerprint?: string | null;
+          sha256CertificateFingerprint?: string | null;
+          createdAt: any;
+          updatedAt: any;
+        } | null;
+      }[];
+    };
+  };
+};
 
 export type CreateAndroidFcmMutationVariables = Exact<{
   androidFcmInput: AndroidFcmInput;
   accountId: Scalars['ID'];
 }>;
 
-
-export type CreateAndroidFcmMutation = { __typename?: 'RootMutation', androidFcm: { __typename?: 'AndroidFcmMutation', createAndroidFcm: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } } };
+export type CreateAndroidFcmMutation = {
+  __typename?: 'RootMutation';
+  androidFcm: {
+    __typename?: 'AndroidFcmMutation';
+    createAndroidFcm: {
+      __typename?: 'AndroidFcm';
+      id: string;
+      credential: any;
+      version: AndroidFcmVersion;
+      createdAt: any;
+      updatedAt: any;
+      snippet:
+        | {
+            __typename?: 'FcmSnippetLegacy';
+            firstFourCharacters: string;
+            lastFourCharacters: string;
+          }
+        | {
+            __typename?: 'FcmSnippetV1';
+            projectId: string;
+            keyId: string;
+            serviceAccountEmail: string;
+            clientId?: string | null;
+          };
+    };
+  };
+};
 
 export type DeleteAndroidFcmMutationVariables = Exact<{
   androidFcmId: Scalars['ID'];
 }>;
 
-
-export type DeleteAndroidFcmMutation = { __typename?: 'RootMutation', androidFcm: { __typename?: 'AndroidFcmMutation', deleteAndroidFcm: { __typename?: 'deleteAndroidFcmResult', id: string } } };
+export type DeleteAndroidFcmMutation = {
+  __typename?: 'RootMutation';
+  androidFcm: {
+    __typename?: 'AndroidFcmMutation';
+    deleteAndroidFcm: { __typename?: 'deleteAndroidFcmResult'; id: string };
+  };
+};
 
 export type CreateAndroidKeystoreMutationVariables = Exact<{
   androidKeystoreInput: AndroidKeystoreInput;
   accountId: Scalars['ID'];
 }>;
 
-
-export type CreateAndroidKeystoreMutation = { __typename?: 'RootMutation', androidKeystore: { __typename?: 'AndroidKeystoreMutation', createAndroidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null } };
+export type CreateAndroidKeystoreMutation = {
+  __typename?: 'RootMutation';
+  androidKeystore: {
+    __typename?: 'AndroidKeystoreMutation';
+    createAndroidKeystore?: {
+      __typename?: 'AndroidKeystore';
+      id: string;
+      type: AndroidKeystoreType;
+      keystore: string;
+      keystorePassword: string;
+      keyAlias: string;
+      keyPassword?: string | null;
+      md5CertificateFingerprint?: string | null;
+      sha1CertificateFingerprint?: string | null;
+      sha256CertificateFingerprint?: string | null;
+      createdAt: any;
+      updatedAt: any;
+    } | null;
+  };
+};
 
 export type DeleteAndroidKeystoreMutationVariables = Exact<{
   androidKeystoreId: Scalars['ID'];
 }>;
 
-
-export type DeleteAndroidKeystoreMutation = { __typename?: 'RootMutation', androidKeystore: { __typename?: 'AndroidKeystoreMutation', deleteAndroidKeystore: { __typename?: 'DeleteAndroidKeystoreResult', id: string } } };
+export type DeleteAndroidKeystoreMutation = {
+  __typename?: 'RootMutation';
+  androidKeystore: {
+    __typename?: 'AndroidKeystoreMutation';
+    deleteAndroidKeystore: { __typename?: 'DeleteAndroidKeystoreResult'; id: string };
+  };
+};
 
 export type CreateGoogleServiceAccountKeyMutationVariables = Exact<{
   googleServiceAccountKeyInput: GoogleServiceAccountKeyInput;
   accountId: Scalars['ID'];
 }>;
 
-
-export type CreateGoogleServiceAccountKeyMutation = { __typename?: 'RootMutation', googleServiceAccountKey: { __typename?: 'GoogleServiceAccountKeyMutation', createGoogleServiceAccountKey: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } } };
+export type CreateGoogleServiceAccountKeyMutation = {
+  __typename?: 'RootMutation';
+  googleServiceAccountKey: {
+    __typename?: 'GoogleServiceAccountKeyMutation';
+    createGoogleServiceAccountKey: {
+      __typename?: 'GoogleServiceAccountKey';
+      id: string;
+      projectIdentifier: string;
+      privateKeyIdentifier: string;
+      clientEmail: string;
+      clientIdentifier: string;
+      createdAt: any;
+      updatedAt: any;
+    };
+  };
+};
 
 export type DeleteGoogleServiceAccountKeyMutationVariables = Exact<{
   googleServiceAccountKeyId: Scalars['ID'];
 }>;
 
+export type DeleteGoogleServiceAccountKeyMutation = {
+  __typename?: 'RootMutation';
+  googleServiceAccountKey: {
+    __typename?: 'GoogleServiceAccountKeyMutation';
+    deleteGoogleServiceAccountKey: {
+      __typename?: 'DeleteGoogleServiceAccountKeyResult';
+      id: string;
+    };
+  };
+};
 
-export type DeleteGoogleServiceAccountKeyMutation = { __typename?: 'RootMutation', googleServiceAccountKey: { __typename?: 'GoogleServiceAccountKeyMutation', deleteGoogleServiceAccountKey: { __typename?: 'DeleteGoogleServiceAccountKeyResult', id: string } } };
+export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQueryVariables =
+  Exact<{
+    projectFullName: Scalars['String'];
+    applicationIdentifier?: InputMaybe<Scalars['String']>;
+    legacyOnly?: InputMaybe<Scalars['Boolean']>;
+  }>;
 
-export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQueryVariables = Exact<{
-  projectFullName: Scalars['String'];
-  applicationIdentifier?: InputMaybe<Scalars['String']>;
-  legacyOnly?: InputMaybe<Scalars['Boolean']>;
-}>;
-
-
-export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, androidAppCredentials: Array<{ __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> }> } } };
+export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byFullName: {
+      __typename?: 'App';
+      id: string;
+      androidAppCredentials: {
+        __typename?: 'AndroidAppCredentials';
+        id: string;
+        applicationIdentifier?: string | null;
+        isLegacy: boolean;
+        app: {
+          __typename?: 'App';
+          id: string;
+          fullName: string;
+          slug: string;
+          ownerAccount: {
+            __typename?: 'Account';
+            id: string;
+            name: string;
+            users: {
+              __typename?: 'UserPermission';
+              role: Role;
+              actor:
+                | { __typename?: 'Robot'; id: string }
+                | { __typename?: 'SSOUser'; id: string }
+                | { __typename?: 'User'; id: string };
+            }[];
+          };
+        };
+        androidFcm?: {
+          __typename?: 'AndroidFcm';
+          id: string;
+          credential: any;
+          version: AndroidFcmVersion;
+          createdAt: any;
+          updatedAt: any;
+          snippet:
+            | {
+                __typename?: 'FcmSnippetLegacy';
+                firstFourCharacters: string;
+                lastFourCharacters: string;
+              }
+            | {
+                __typename?: 'FcmSnippetV1';
+                projectId: string;
+                keyId: string;
+                serviceAccountEmail: string;
+                clientId?: string | null;
+              };
+        } | null;
+        googleServiceAccountKeyForSubmissions?: {
+          __typename?: 'GoogleServiceAccountKey';
+          id: string;
+          projectIdentifier: string;
+          privateKeyIdentifier: string;
+          clientEmail: string;
+          clientIdentifier: string;
+          createdAt: any;
+          updatedAt: any;
+        } | null;
+        androidAppBuildCredentialsList: {
+          __typename?: 'AndroidAppBuildCredentials';
+          id: string;
+          isDefault: boolean;
+          isLegacy: boolean;
+          name: string;
+          androidKeystore?: {
+            __typename?: 'AndroidKeystore';
+            id: string;
+            type: AndroidKeystoreType;
+            keystore: string;
+            keystorePassword: string;
+            keyAlias: string;
+            keyPassword?: string | null;
+            md5CertificateFingerprint?: string | null;
+            sha1CertificateFingerprint?: string | null;
+            sha256CertificateFingerprint?: string | null;
+            createdAt: any;
+            updatedAt: any;
+          } | null;
+        }[];
+      }[];
+    };
+  };
+};
 
 export type GoogleServiceAccountKeyByAccountQueryVariables = Exact<{
   accountName: Scalars['String'];
 }>;
 
-
-export type GoogleServiceAccountKeyByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, googleServiceAccountKeys: Array<{ __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any }> } } };
+export type GoogleServiceAccountKeyByAccountQuery = {
+  __typename?: 'RootQuery';
+  account: {
+    __typename?: 'AccountQuery';
+    byName: {
+      __typename?: 'Account';
+      id: string;
+      googleServiceAccountKeys: {
+        __typename?: 'GoogleServiceAccountKey';
+        id: string;
+        projectIdentifier: string;
+        privateKeyIdentifier: string;
+        clientEmail: string;
+        clientIdentifier: string;
+        createdAt: any;
+        updatedAt: any;
+      }[];
+    };
+  };
+};
 
 export type CreateAppStoreConnectApiKeyMutationVariables = Exact<{
   appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput;
   accountId: Scalars['ID'];
 }>;
 
-
-export type CreateAppStoreConnectApiKeyMutation = { __typename?: 'RootMutation', appStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKeyMutation', createAppStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } } };
+export type CreateAppStoreConnectApiKeyMutation = {
+  __typename?: 'RootMutation';
+  appStoreConnectApiKey: {
+    __typename?: 'AppStoreConnectApiKeyMutation';
+    createAppStoreConnectApiKey: {
+      __typename?: 'AppStoreConnectApiKey';
+      id: string;
+      issuerIdentifier: string;
+      keyIdentifier: string;
+      name?: string | null;
+      roles?: AppStoreConnectUserRole[] | null;
+      createdAt: any;
+      updatedAt: any;
+      appleTeam?: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      } | null;
+    };
+  };
+};
 
 export type DeleteAppStoreConnectApiKeyMutationVariables = Exact<{
   appStoreConnectApiKeyId: Scalars['ID'];
 }>;
 
-
-export type DeleteAppStoreConnectApiKeyMutation = { __typename?: 'RootMutation', appStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKeyMutation', deleteAppStoreConnectApiKey: { __typename?: 'deleteAppStoreConnectApiKeyResult', id: string } } };
+export type DeleteAppStoreConnectApiKeyMutation = {
+  __typename?: 'RootMutation';
+  appStoreConnectApiKey: {
+    __typename?: 'AppStoreConnectApiKeyMutation';
+    deleteAppStoreConnectApiKey: { __typename?: 'deleteAppStoreConnectApiKeyResult'; id: string };
+  };
+};
 
 export type CreateAppleAppIdentifierMutationVariables = Exact<{
   appleAppIdentifierInput: AppleAppIdentifierInput;
   accountId: Scalars['ID'];
 }>;
 
-
-export type CreateAppleAppIdentifierMutation = { __typename?: 'RootMutation', appleAppIdentifier: { __typename?: 'AppleAppIdentifierMutation', createAppleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } } };
+export type CreateAppleAppIdentifierMutation = {
+  __typename?: 'RootMutation';
+  appleAppIdentifier: {
+    __typename?: 'AppleAppIdentifierMutation';
+    createAppleAppIdentifier: {
+      __typename?: 'AppleAppIdentifier';
+      id: string;
+      bundleIdentifier: string;
+    };
+  };
+};
 
 export type CreateAppleDeviceMutationVariables = Exact<{
   appleDeviceInput: AppleDeviceInput;
   accountId: Scalars['ID'];
 }>;
 
-
-export type CreateAppleDeviceMutation = { __typename?: 'RootMutation', appleDevice: { __typename?: 'AppleDeviceMutation', createAppleDevice: { __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null } } };
+export type CreateAppleDeviceMutation = {
+  __typename?: 'RootMutation';
+  appleDevice: {
+    __typename?: 'AppleDeviceMutation';
+    createAppleDevice: {
+      __typename?: 'AppleDevice';
+      id: string;
+      identifier: string;
+      name?: string | null;
+      model?: string | null;
+      deviceClass?: AppleDeviceClass | null;
+    };
+  };
+};
 
 export type DeleteAppleDeviceMutationVariables = Exact<{
   deviceId: Scalars['ID'];
 }>;
 
-
-export type DeleteAppleDeviceMutation = { __typename?: 'RootMutation', appleDevice: { __typename?: 'AppleDeviceMutation', deleteAppleDevice: { __typename?: 'DeleteAppleDeviceResult', id: string } } };
+export type DeleteAppleDeviceMutation = {
+  __typename?: 'RootMutation';
+  appleDevice: {
+    __typename?: 'AppleDeviceMutation';
+    deleteAppleDevice: { __typename?: 'DeleteAppleDeviceResult'; id: string };
+  };
+};
 
 export type UpdateAppleDeviceMutationVariables = Exact<{
   id: Scalars['ID'];
   appleDeviceUpdateInput: AppleDeviceUpdateInput;
 }>;
 
-
-export type UpdateAppleDeviceMutation = { __typename?: 'RootMutation', appleDevice: { __typename?: 'AppleDeviceMutation', updateAppleDevice: { __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null } } };
+export type UpdateAppleDeviceMutation = {
+  __typename?: 'RootMutation';
+  appleDevice: {
+    __typename?: 'AppleDeviceMutation';
+    updateAppleDevice: {
+      __typename?: 'AppleDevice';
+      id: string;
+      identifier: string;
+      name?: string | null;
+      model?: string | null;
+      deviceClass?: AppleDeviceClass | null;
+    };
+  };
+};
 
 export type CreateAppleDeviceRegistrationRequestMutationVariables = Exact<{
   appleTeamId: Scalars['ID'];
   accountId: Scalars['ID'];
 }>;
 
-
-export type CreateAppleDeviceRegistrationRequestMutation = { __typename?: 'RootMutation', appleDeviceRegistrationRequest: { __typename?: 'AppleDeviceRegistrationRequestMutation', createAppleDeviceRegistrationRequest: { __typename?: 'AppleDeviceRegistrationRequest', id: string } } };
+export type CreateAppleDeviceRegistrationRequestMutation = {
+  __typename?: 'RootMutation';
+  appleDeviceRegistrationRequest: {
+    __typename?: 'AppleDeviceRegistrationRequestMutation';
+    createAppleDeviceRegistrationRequest: {
+      __typename?: 'AppleDeviceRegistrationRequest';
+      id: string;
+    };
+  };
+};
 
 export type CreateAppleDistributionCertificateMutationVariables = Exact<{
   appleDistributionCertificateInput: AppleDistributionCertificateInput;
   accountId: Scalars['ID'];
 }>;
 
-
-export type CreateAppleDistributionCertificateMutation = { __typename?: 'RootMutation', appleDistributionCertificate: { __typename?: 'AppleDistributionCertificateMutation', createAppleDistributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null } };
+export type CreateAppleDistributionCertificateMutation = {
+  __typename?: 'RootMutation';
+  appleDistributionCertificate: {
+    __typename?: 'AppleDistributionCertificateMutation';
+    createAppleDistributionCertificate?: {
+      __typename?: 'AppleDistributionCertificate';
+      id: string;
+      certificateP12?: string | null;
+      certificatePassword?: string | null;
+      serialNumber: string;
+      developerPortalIdentifier?: string | null;
+      validityNotBefore: any;
+      validityNotAfter: any;
+      updatedAt: any;
+      appleTeam?: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      } | null;
+      iosAppBuildCredentialsList: {
+        __typename?: 'IosAppBuildCredentials';
+        id: string;
+        iosAppCredentials: {
+          __typename?: 'IosAppCredentials';
+          id: string;
+          app: {
+            __typename?: 'App';
+            id: string;
+            fullName: string;
+            slug: string;
+            ownerAccount: {
+              __typename?: 'Account';
+              id: string;
+              name: string;
+              users: {
+                __typename?: 'UserPermission';
+                role: Role;
+                actor:
+                  | { __typename?: 'Robot'; id: string }
+                  | { __typename?: 'SSOUser'; id: string }
+                  | { __typename?: 'User'; id: string };
+              }[];
+            };
+          };
+          appleAppIdentifier: {
+            __typename?: 'AppleAppIdentifier';
+            id: string;
+            bundleIdentifier: string;
+          };
+        };
+        provisioningProfile?: {
+          __typename?: 'AppleProvisioningProfile';
+          id: string;
+          developerPortalIdentifier?: string | null;
+        } | null;
+      }[];
+    } | null;
+  };
+};
 
 export type DeleteAppleDistributionCertificateMutationVariables = Exact<{
   appleDistributionCertificateId: Scalars['ID'];
 }>;
 
-
-export type DeleteAppleDistributionCertificateMutation = { __typename?: 'RootMutation', appleDistributionCertificate: { __typename?: 'AppleDistributionCertificateMutation', deleteAppleDistributionCertificate: { __typename?: 'DeleteAppleDistributionCertificateResult', id: string } } };
+export type DeleteAppleDistributionCertificateMutation = {
+  __typename?: 'RootMutation';
+  appleDistributionCertificate: {
+    __typename?: 'AppleDistributionCertificateMutation';
+    deleteAppleDistributionCertificate: {
+      __typename?: 'DeleteAppleDistributionCertificateResult';
+      id: string;
+    };
+  };
+};
 
 export type CreateAppleProvisioningProfileMutationVariables = Exact<{
   appleProvisioningProfileInput: AppleProvisioningProfileInput;
@@ -5580,70 +6010,462 @@ export type CreateAppleProvisioningProfileMutationVariables = Exact<{
   appleAppIdentifierId: Scalars['ID'];
 }>;
 
-
-export type CreateAppleProvisioningProfileMutation = { __typename?: 'RootMutation', appleProvisioningProfile: { __typename?: 'AppleProvisioningProfileMutation', createAppleProvisioningProfile: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } } };
+export type CreateAppleProvisioningProfileMutation = {
+  __typename?: 'RootMutation';
+  appleProvisioningProfile: {
+    __typename?: 'AppleProvisioningProfileMutation';
+    createAppleProvisioningProfile: {
+      __typename?: 'AppleProvisioningProfile';
+      id: string;
+      expiration: any;
+      developerPortalIdentifier?: string | null;
+      provisioningProfile?: string | null;
+      updatedAt: any;
+      status: string;
+      appleTeam?: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      } | null;
+      appleDevices: {
+        __typename?: 'AppleDevice';
+        id: string;
+        identifier: string;
+        name?: string | null;
+        model?: string | null;
+        deviceClass?: AppleDeviceClass | null;
+      }[];
+    };
+  };
+};
 
 export type UpdateAppleProvisioningProfileMutationVariables = Exact<{
   appleProvisioningProfileId: Scalars['ID'];
   appleProvisioningProfileInput: AppleProvisioningProfileInput;
 }>;
 
-
-export type UpdateAppleProvisioningProfileMutation = { __typename?: 'RootMutation', appleProvisioningProfile: { __typename?: 'AppleProvisioningProfileMutation', updateAppleProvisioningProfile: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } } };
+export type UpdateAppleProvisioningProfileMutation = {
+  __typename?: 'RootMutation';
+  appleProvisioningProfile: {
+    __typename?: 'AppleProvisioningProfileMutation';
+    updateAppleProvisioningProfile: {
+      __typename?: 'AppleProvisioningProfile';
+      id: string;
+      expiration: any;
+      developerPortalIdentifier?: string | null;
+      provisioningProfile?: string | null;
+      updatedAt: any;
+      status: string;
+      appleTeam?: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      } | null;
+      appleDevices: {
+        __typename?: 'AppleDevice';
+        id: string;
+        identifier: string;
+        name?: string | null;
+        model?: string | null;
+        deviceClass?: AppleDeviceClass | null;
+      }[];
+    };
+  };
+};
 
 export type DeleteAppleProvisioningProfilesMutationVariables = Exact<{
-  appleProvisioningProfileIds: Array<Scalars['ID']> | Scalars['ID'];
+  appleProvisioningProfileIds: Scalars['ID'][] | Scalars['ID'];
 }>;
 
-
-export type DeleteAppleProvisioningProfilesMutation = { __typename?: 'RootMutation', appleProvisioningProfile: { __typename?: 'AppleProvisioningProfileMutation', deleteAppleProvisioningProfiles: Array<{ __typename?: 'DeleteAppleProvisioningProfileResult', id: string }> } };
+export type DeleteAppleProvisioningProfilesMutation = {
+  __typename?: 'RootMutation';
+  appleProvisioningProfile: {
+    __typename?: 'AppleProvisioningProfileMutation';
+    deleteAppleProvisioningProfiles: {
+      __typename?: 'DeleteAppleProvisioningProfileResult';
+      id: string;
+    }[];
+  };
+};
 
 export type CreateApplePushKeyMutationVariables = Exact<{
   applePushKeyInput: ApplePushKeyInput;
   accountId: Scalars['ID'];
 }>;
 
-
-export type CreateApplePushKeyMutation = { __typename?: 'RootMutation', applePushKey: { __typename?: 'ApplePushKeyMutation', createApplePushKey: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } } };
+export type CreateApplePushKeyMutation = {
+  __typename?: 'RootMutation';
+  applePushKey: {
+    __typename?: 'ApplePushKeyMutation';
+    createApplePushKey: {
+      __typename?: 'ApplePushKey';
+      id: string;
+      keyIdentifier: string;
+      updatedAt: any;
+      appleTeam?: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      } | null;
+      iosAppCredentialsList: {
+        __typename?: 'IosAppCredentials';
+        id: string;
+        app: {
+          __typename?: 'App';
+          id: string;
+          fullName: string;
+          slug: string;
+          ownerAccount: {
+            __typename?: 'Account';
+            id: string;
+            name: string;
+            users: {
+              __typename?: 'UserPermission';
+              role: Role;
+              actor:
+                | { __typename?: 'Robot'; id: string }
+                | { __typename?: 'SSOUser'; id: string }
+                | { __typename?: 'User'; id: string };
+            }[];
+          };
+        };
+        appleAppIdentifier: {
+          __typename?: 'AppleAppIdentifier';
+          id: string;
+          bundleIdentifier: string;
+        };
+      }[];
+    };
+  };
+};
 
 export type DeleteApplePushKeyMutationVariables = Exact<{
   applePushKeyId: Scalars['ID'];
 }>;
 
-
-export type DeleteApplePushKeyMutation = { __typename?: 'RootMutation', applePushKey: { __typename?: 'ApplePushKeyMutation', deleteApplePushKey: { __typename?: 'deleteApplePushKeyResult', id: string } } };
+export type DeleteApplePushKeyMutation = {
+  __typename?: 'RootMutation';
+  applePushKey: {
+    __typename?: 'ApplePushKeyMutation';
+    deleteApplePushKey: { __typename?: 'deleteApplePushKeyResult'; id: string };
+  };
+};
 
 export type CreateAppleTeamMutationVariables = Exact<{
   appleTeamInput: AppleTeamInput;
   accountId: Scalars['ID'];
 }>;
 
-
-export type CreateAppleTeamMutation = { __typename?: 'RootMutation', appleTeam: { __typename?: 'AppleTeamMutation', createAppleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null, account: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } } } };
+export type CreateAppleTeamMutation = {
+  __typename?: 'RootMutation';
+  appleTeam: {
+    __typename?: 'AppleTeamMutation';
+    createAppleTeam: {
+      __typename?: 'AppleTeam';
+      id: string;
+      appleTeamIdentifier: string;
+      appleTeamName?: string | null;
+      account: {
+        __typename?: 'Account';
+        id: string;
+        name: string;
+        users: {
+          __typename?: 'UserPermission';
+          role: Role;
+          actor:
+            | { __typename?: 'Robot'; id: string }
+            | { __typename?: 'SSOUser'; id: string }
+            | { __typename?: 'User'; id: string };
+        }[];
+      };
+    };
+  };
+};
 
 export type CreateIosAppBuildCredentialsMutationVariables = Exact<{
   iosAppBuildCredentialsInput: IosAppBuildCredentialsInput;
   iosAppCredentialsId: Scalars['ID'];
 }>;
 
-
-export type CreateIosAppBuildCredentialsMutation = { __typename?: 'RootMutation', iosAppBuildCredentials: { __typename?: 'IosAppBuildCredentialsMutation', createIosAppBuildCredentials: { __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null } } };
+export type CreateIosAppBuildCredentialsMutation = {
+  __typename?: 'RootMutation';
+  iosAppBuildCredentials: {
+    __typename?: 'IosAppBuildCredentialsMutation';
+    createIosAppBuildCredentials: {
+      __typename?: 'IosAppBuildCredentials';
+      id: string;
+      iosDistributionType: IosDistributionType;
+      distributionCertificate?: {
+        __typename?: 'AppleDistributionCertificate';
+        id: string;
+        certificateP12?: string | null;
+        certificatePassword?: string | null;
+        serialNumber: string;
+        developerPortalIdentifier?: string | null;
+        validityNotBefore: any;
+        validityNotAfter: any;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        iosAppBuildCredentialsList: {
+          __typename?: 'IosAppBuildCredentials';
+          id: string;
+          iosAppCredentials: {
+            __typename?: 'IosAppCredentials';
+            id: string;
+            app: {
+              __typename?: 'App';
+              id: string;
+              fullName: string;
+              slug: string;
+              ownerAccount: {
+                __typename?: 'Account';
+                id: string;
+                name: string;
+                users: {
+                  __typename?: 'UserPermission';
+                  role: Role;
+                  actor:
+                    | { __typename?: 'Robot'; id: string }
+                    | { __typename?: 'SSOUser'; id: string }
+                    | { __typename?: 'User'; id: string };
+                }[];
+              };
+            };
+            appleAppIdentifier: {
+              __typename?: 'AppleAppIdentifier';
+              id: string;
+              bundleIdentifier: string;
+            };
+          };
+          provisioningProfile?: {
+            __typename?: 'AppleProvisioningProfile';
+            id: string;
+            developerPortalIdentifier?: string | null;
+          } | null;
+        }[];
+      } | null;
+      provisioningProfile?: {
+        __typename?: 'AppleProvisioningProfile';
+        id: string;
+        expiration: any;
+        developerPortalIdentifier?: string | null;
+        provisioningProfile?: string | null;
+        updatedAt: any;
+        status: string;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        appleDevices: {
+          __typename?: 'AppleDevice';
+          id: string;
+          identifier: string;
+          name?: string | null;
+          model?: string | null;
+          deviceClass?: AppleDeviceClass | null;
+        }[];
+      } | null;
+    };
+  };
+};
 
 export type SetDistributionCertificateMutationVariables = Exact<{
   iosAppBuildCredentialsId: Scalars['ID'];
   distributionCertificateId: Scalars['ID'];
 }>;
 
-
-export type SetDistributionCertificateMutation = { __typename?: 'RootMutation', iosAppBuildCredentials: { __typename?: 'IosAppBuildCredentialsMutation', setDistributionCertificate: { __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null } } };
+export type SetDistributionCertificateMutation = {
+  __typename?: 'RootMutation';
+  iosAppBuildCredentials: {
+    __typename?: 'IosAppBuildCredentialsMutation';
+    setDistributionCertificate: {
+      __typename?: 'IosAppBuildCredentials';
+      id: string;
+      iosDistributionType: IosDistributionType;
+      distributionCertificate?: {
+        __typename?: 'AppleDistributionCertificate';
+        id: string;
+        certificateP12?: string | null;
+        certificatePassword?: string | null;
+        serialNumber: string;
+        developerPortalIdentifier?: string | null;
+        validityNotBefore: any;
+        validityNotAfter: any;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        iosAppBuildCredentialsList: {
+          __typename?: 'IosAppBuildCredentials';
+          id: string;
+          iosAppCredentials: {
+            __typename?: 'IosAppCredentials';
+            id: string;
+            app: {
+              __typename?: 'App';
+              id: string;
+              fullName: string;
+              slug: string;
+              ownerAccount: {
+                __typename?: 'Account';
+                id: string;
+                name: string;
+                users: {
+                  __typename?: 'UserPermission';
+                  role: Role;
+                  actor:
+                    | { __typename?: 'Robot'; id: string }
+                    | { __typename?: 'SSOUser'; id: string }
+                    | { __typename?: 'User'; id: string };
+                }[];
+              };
+            };
+            appleAppIdentifier: {
+              __typename?: 'AppleAppIdentifier';
+              id: string;
+              bundleIdentifier: string;
+            };
+          };
+          provisioningProfile?: {
+            __typename?: 'AppleProvisioningProfile';
+            id: string;
+            developerPortalIdentifier?: string | null;
+          } | null;
+        }[];
+      } | null;
+      provisioningProfile?: {
+        __typename?: 'AppleProvisioningProfile';
+        id: string;
+        expiration: any;
+        developerPortalIdentifier?: string | null;
+        provisioningProfile?: string | null;
+        updatedAt: any;
+        status: string;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        appleDevices: {
+          __typename?: 'AppleDevice';
+          id: string;
+          identifier: string;
+          name?: string | null;
+          model?: string | null;
+          deviceClass?: AppleDeviceClass | null;
+        }[];
+      } | null;
+    };
+  };
+};
 
 export type SetProvisioningProfileMutationVariables = Exact<{
   iosAppBuildCredentialsId: Scalars['ID'];
   provisioningProfileId: Scalars['ID'];
 }>;
 
-
-export type SetProvisioningProfileMutation = { __typename?: 'RootMutation', iosAppBuildCredentials: { __typename?: 'IosAppBuildCredentialsMutation', setProvisioningProfile: { __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null } } };
+export type SetProvisioningProfileMutation = {
+  __typename?: 'RootMutation';
+  iosAppBuildCredentials: {
+    __typename?: 'IosAppBuildCredentialsMutation';
+    setProvisioningProfile: {
+      __typename?: 'IosAppBuildCredentials';
+      id: string;
+      iosDistributionType: IosDistributionType;
+      distributionCertificate?: {
+        __typename?: 'AppleDistributionCertificate';
+        id: string;
+        certificateP12?: string | null;
+        certificatePassword?: string | null;
+        serialNumber: string;
+        developerPortalIdentifier?: string | null;
+        validityNotBefore: any;
+        validityNotAfter: any;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        iosAppBuildCredentialsList: {
+          __typename?: 'IosAppBuildCredentials';
+          id: string;
+          iosAppCredentials: {
+            __typename?: 'IosAppCredentials';
+            id: string;
+            app: {
+              __typename?: 'App';
+              id: string;
+              fullName: string;
+              slug: string;
+              ownerAccount: {
+                __typename?: 'Account';
+                id: string;
+                name: string;
+                users: {
+                  __typename?: 'UserPermission';
+                  role: Role;
+                  actor:
+                    | { __typename?: 'Robot'; id: string }
+                    | { __typename?: 'SSOUser'; id: string }
+                    | { __typename?: 'User'; id: string };
+                }[];
+              };
+            };
+            appleAppIdentifier: {
+              __typename?: 'AppleAppIdentifier';
+              id: string;
+              bundleIdentifier: string;
+            };
+          };
+          provisioningProfile?: {
+            __typename?: 'AppleProvisioningProfile';
+            id: string;
+            developerPortalIdentifier?: string | null;
+          } | null;
+        }[];
+      } | null;
+      provisioningProfile?: {
+        __typename?: 'AppleProvisioningProfile';
+        id: string;
+        expiration: any;
+        developerPortalIdentifier?: string | null;
+        provisioningProfile?: string | null;
+        updatedAt: any;
+        status: string;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        appleDevices: {
+          __typename?: 'AppleDevice';
+          id: string;
+          identifier: string;
+          name?: string | null;
+          model?: string | null;
+          deviceClass?: AppleDeviceClass | null;
+        }[];
+      } | null;
+    };
+  };
+};
 
 export type CreateIosAppCredentialsMutationVariables = Exact<{
   iosAppCredentialsInput: IosAppCredentialsInput;
@@ -5651,47 +6473,636 @@ export type CreateIosAppCredentialsMutationVariables = Exact<{
   appleAppIdentifierId: Scalars['ID'];
 }>;
 
-
-export type CreateIosAppCredentialsMutation = { __typename?: 'RootMutation', iosAppCredentials: { __typename?: 'IosAppCredentialsMutation', createIosAppCredentials: { __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null }>, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
+export type CreateIosAppCredentialsMutation = {
+  __typename?: 'RootMutation';
+  iosAppCredentials: {
+    __typename?: 'IosAppCredentialsMutation';
+    createIosAppCredentials: {
+      __typename?: 'IosAppCredentials';
+      id: string;
+      iosAppBuildCredentialsList: {
+        __typename?: 'IosAppBuildCredentials';
+        id: string;
+        iosDistributionType: IosDistributionType;
+        distributionCertificate?: {
+          __typename?: 'AppleDistributionCertificate';
+          id: string;
+          certificateP12?: string | null;
+          certificatePassword?: string | null;
+          serialNumber: string;
+          developerPortalIdentifier?: string | null;
+          validityNotBefore: any;
+          validityNotAfter: any;
+          updatedAt: any;
+          appleTeam?: {
+            __typename?: 'AppleTeam';
+            id: string;
+            appleTeamIdentifier: string;
+            appleTeamName?: string | null;
+          } | null;
+          iosAppBuildCredentialsList: {
+            __typename?: 'IosAppBuildCredentials';
+            id: string;
+            iosAppCredentials: {
+              __typename?: 'IosAppCredentials';
+              id: string;
+              app: {
+                __typename?: 'App';
+                id: string;
+                fullName: string;
+                slug: string;
+                ownerAccount: {
+                  __typename?: 'Account';
+                  id: string;
+                  name: string;
+                  users: {
+                    __typename?: 'UserPermission';
+                    role: Role;
+                    actor:
+                      | { __typename?: 'Robot'; id: string }
+                      | { __typename?: 'SSOUser'; id: string }
+                      | { __typename?: 'User'; id: string };
+                  }[];
+                };
+              };
+              appleAppIdentifier: {
+                __typename?: 'AppleAppIdentifier';
+                id: string;
+                bundleIdentifier: string;
+              };
+            };
+            provisioningProfile?: {
+              __typename?: 'AppleProvisioningProfile';
+              id: string;
+              developerPortalIdentifier?: string | null;
+            } | null;
+          }[];
+        } | null;
+        provisioningProfile?: {
+          __typename?: 'AppleProvisioningProfile';
+          id: string;
+          expiration: any;
+          developerPortalIdentifier?: string | null;
+          provisioningProfile?: string | null;
+          updatedAt: any;
+          status: string;
+          appleTeam?: {
+            __typename?: 'AppleTeam';
+            id: string;
+            appleTeamIdentifier: string;
+            appleTeamName?: string | null;
+          } | null;
+          appleDevices: {
+            __typename?: 'AppleDevice';
+            id: string;
+            identifier: string;
+            name?: string | null;
+            model?: string | null;
+            deviceClass?: AppleDeviceClass | null;
+          }[];
+        } | null;
+      }[];
+      app: {
+        __typename?: 'App';
+        id: string;
+        fullName: string;
+        slug: string;
+        ownerAccount: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        };
+      };
+      appleTeam?: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      } | null;
+      appleAppIdentifier: {
+        __typename?: 'AppleAppIdentifier';
+        id: string;
+        bundleIdentifier: string;
+      };
+      pushKey?: {
+        __typename?: 'ApplePushKey';
+        id: string;
+        keyIdentifier: string;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        iosAppCredentialsList: {
+          __typename?: 'IosAppCredentials';
+          id: string;
+          app: {
+            __typename?: 'App';
+            id: string;
+            fullName: string;
+            slug: string;
+            ownerAccount: {
+              __typename?: 'Account';
+              id: string;
+              name: string;
+              users: {
+                __typename?: 'UserPermission';
+                role: Role;
+                actor:
+                  | { __typename?: 'Robot'; id: string }
+                  | { __typename?: 'SSOUser'; id: string }
+                  | { __typename?: 'User'; id: string };
+              }[];
+            };
+          };
+          appleAppIdentifier: {
+            __typename?: 'AppleAppIdentifier';
+            id: string;
+            bundleIdentifier: string;
+          };
+        }[];
+      } | null;
+      appStoreConnectApiKeyForSubmissions?: {
+        __typename?: 'AppStoreConnectApiKey';
+        id: string;
+        issuerIdentifier: string;
+        keyIdentifier: string;
+        name?: string | null;
+        roles?: AppStoreConnectUserRole[] | null;
+        createdAt: any;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+      } | null;
+    };
+  };
+};
 
 export type SetPushKeyMutationVariables = Exact<{
   iosAppCredentialsId: Scalars['ID'];
   pushKeyId: Scalars['ID'];
 }>;
 
-
-export type SetPushKeyMutation = { __typename?: 'RootMutation', iosAppCredentials: { __typename?: 'IosAppCredentialsMutation', setPushKey: { __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null }>, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
+export type SetPushKeyMutation = {
+  __typename?: 'RootMutation';
+  iosAppCredentials: {
+    __typename?: 'IosAppCredentialsMutation';
+    setPushKey: {
+      __typename?: 'IosAppCredentials';
+      id: string;
+      iosAppBuildCredentialsList: {
+        __typename?: 'IosAppBuildCredentials';
+        id: string;
+        iosDistributionType: IosDistributionType;
+        distributionCertificate?: {
+          __typename?: 'AppleDistributionCertificate';
+          id: string;
+          certificateP12?: string | null;
+          certificatePassword?: string | null;
+          serialNumber: string;
+          developerPortalIdentifier?: string | null;
+          validityNotBefore: any;
+          validityNotAfter: any;
+          updatedAt: any;
+          appleTeam?: {
+            __typename?: 'AppleTeam';
+            id: string;
+            appleTeamIdentifier: string;
+            appleTeamName?: string | null;
+          } | null;
+          iosAppBuildCredentialsList: {
+            __typename?: 'IosAppBuildCredentials';
+            id: string;
+            iosAppCredentials: {
+              __typename?: 'IosAppCredentials';
+              id: string;
+              app: {
+                __typename?: 'App';
+                id: string;
+                fullName: string;
+                slug: string;
+                ownerAccount: {
+                  __typename?: 'Account';
+                  id: string;
+                  name: string;
+                  users: {
+                    __typename?: 'UserPermission';
+                    role: Role;
+                    actor:
+                      | { __typename?: 'Robot'; id: string }
+                      | { __typename?: 'SSOUser'; id: string }
+                      | { __typename?: 'User'; id: string };
+                  }[];
+                };
+              };
+              appleAppIdentifier: {
+                __typename?: 'AppleAppIdentifier';
+                id: string;
+                bundleIdentifier: string;
+              };
+            };
+            provisioningProfile?: {
+              __typename?: 'AppleProvisioningProfile';
+              id: string;
+              developerPortalIdentifier?: string | null;
+            } | null;
+          }[];
+        } | null;
+        provisioningProfile?: {
+          __typename?: 'AppleProvisioningProfile';
+          id: string;
+          expiration: any;
+          developerPortalIdentifier?: string | null;
+          provisioningProfile?: string | null;
+          updatedAt: any;
+          status: string;
+          appleTeam?: {
+            __typename?: 'AppleTeam';
+            id: string;
+            appleTeamIdentifier: string;
+            appleTeamName?: string | null;
+          } | null;
+          appleDevices: {
+            __typename?: 'AppleDevice';
+            id: string;
+            identifier: string;
+            name?: string | null;
+            model?: string | null;
+            deviceClass?: AppleDeviceClass | null;
+          }[];
+        } | null;
+      }[];
+      app: {
+        __typename?: 'App';
+        id: string;
+        fullName: string;
+        slug: string;
+        ownerAccount: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        };
+      };
+      appleTeam?: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      } | null;
+      appleAppIdentifier: {
+        __typename?: 'AppleAppIdentifier';
+        id: string;
+        bundleIdentifier: string;
+      };
+      pushKey?: {
+        __typename?: 'ApplePushKey';
+        id: string;
+        keyIdentifier: string;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        iosAppCredentialsList: {
+          __typename?: 'IosAppCredentials';
+          id: string;
+          app: {
+            __typename?: 'App';
+            id: string;
+            fullName: string;
+            slug: string;
+            ownerAccount: {
+              __typename?: 'Account';
+              id: string;
+              name: string;
+              users: {
+                __typename?: 'UserPermission';
+                role: Role;
+                actor:
+                  | { __typename?: 'Robot'; id: string }
+                  | { __typename?: 'SSOUser'; id: string }
+                  | { __typename?: 'User'; id: string };
+              }[];
+            };
+          };
+          appleAppIdentifier: {
+            __typename?: 'AppleAppIdentifier';
+            id: string;
+            bundleIdentifier: string;
+          };
+        }[];
+      } | null;
+      appStoreConnectApiKeyForSubmissions?: {
+        __typename?: 'AppStoreConnectApiKey';
+        id: string;
+        issuerIdentifier: string;
+        keyIdentifier: string;
+        name?: string | null;
+        roles?: AppStoreConnectUserRole[] | null;
+        createdAt: any;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+      } | null;
+    };
+  };
+};
 
 export type SetAppStoreConnectApiKeyForSubmissionsMutationVariables = Exact<{
   iosAppCredentialsId: Scalars['ID'];
   ascApiKeyId: Scalars['ID'];
 }>;
 
-
-export type SetAppStoreConnectApiKeyForSubmissionsMutation = { __typename?: 'RootMutation', iosAppCredentials: { __typename?: 'IosAppCredentialsMutation', setAppStoreConnectApiKeyForSubmissions: { __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null }>, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
+export type SetAppStoreConnectApiKeyForSubmissionsMutation = {
+  __typename?: 'RootMutation';
+  iosAppCredentials: {
+    __typename?: 'IosAppCredentialsMutation';
+    setAppStoreConnectApiKeyForSubmissions: {
+      __typename?: 'IosAppCredentials';
+      id: string;
+      iosAppBuildCredentialsList: {
+        __typename?: 'IosAppBuildCredentials';
+        id: string;
+        iosDistributionType: IosDistributionType;
+        distributionCertificate?: {
+          __typename?: 'AppleDistributionCertificate';
+          id: string;
+          certificateP12?: string | null;
+          certificatePassword?: string | null;
+          serialNumber: string;
+          developerPortalIdentifier?: string | null;
+          validityNotBefore: any;
+          validityNotAfter: any;
+          updatedAt: any;
+          appleTeam?: {
+            __typename?: 'AppleTeam';
+            id: string;
+            appleTeamIdentifier: string;
+            appleTeamName?: string | null;
+          } | null;
+          iosAppBuildCredentialsList: {
+            __typename?: 'IosAppBuildCredentials';
+            id: string;
+            iosAppCredentials: {
+              __typename?: 'IosAppCredentials';
+              id: string;
+              app: {
+                __typename?: 'App';
+                id: string;
+                fullName: string;
+                slug: string;
+                ownerAccount: {
+                  __typename?: 'Account';
+                  id: string;
+                  name: string;
+                  users: {
+                    __typename?: 'UserPermission';
+                    role: Role;
+                    actor:
+                      | { __typename?: 'Robot'; id: string }
+                      | { __typename?: 'SSOUser'; id: string }
+                      | { __typename?: 'User'; id: string };
+                  }[];
+                };
+              };
+              appleAppIdentifier: {
+                __typename?: 'AppleAppIdentifier';
+                id: string;
+                bundleIdentifier: string;
+              };
+            };
+            provisioningProfile?: {
+              __typename?: 'AppleProvisioningProfile';
+              id: string;
+              developerPortalIdentifier?: string | null;
+            } | null;
+          }[];
+        } | null;
+        provisioningProfile?: {
+          __typename?: 'AppleProvisioningProfile';
+          id: string;
+          expiration: any;
+          developerPortalIdentifier?: string | null;
+          provisioningProfile?: string | null;
+          updatedAt: any;
+          status: string;
+          appleTeam?: {
+            __typename?: 'AppleTeam';
+            id: string;
+            appleTeamIdentifier: string;
+            appleTeamName?: string | null;
+          } | null;
+          appleDevices: {
+            __typename?: 'AppleDevice';
+            id: string;
+            identifier: string;
+            name?: string | null;
+            model?: string | null;
+            deviceClass?: AppleDeviceClass | null;
+          }[];
+        } | null;
+      }[];
+      app: {
+        __typename?: 'App';
+        id: string;
+        fullName: string;
+        slug: string;
+        ownerAccount: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        };
+      };
+      appleTeam?: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      } | null;
+      appleAppIdentifier: {
+        __typename?: 'AppleAppIdentifier';
+        id: string;
+        bundleIdentifier: string;
+      };
+      pushKey?: {
+        __typename?: 'ApplePushKey';
+        id: string;
+        keyIdentifier: string;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        iosAppCredentialsList: {
+          __typename?: 'IosAppCredentials';
+          id: string;
+          app: {
+            __typename?: 'App';
+            id: string;
+            fullName: string;
+            slug: string;
+            ownerAccount: {
+              __typename?: 'Account';
+              id: string;
+              name: string;
+              users: {
+                __typename?: 'UserPermission';
+                role: Role;
+                actor:
+                  | { __typename?: 'Robot'; id: string }
+                  | { __typename?: 'SSOUser'; id: string }
+                  | { __typename?: 'User'; id: string };
+              }[];
+            };
+          };
+          appleAppIdentifier: {
+            __typename?: 'AppleAppIdentifier';
+            id: string;
+            bundleIdentifier: string;
+          };
+        }[];
+      } | null;
+      appStoreConnectApiKeyForSubmissions?: {
+        __typename?: 'AppStoreConnectApiKey';
+        id: string;
+        issuerIdentifier: string;
+        keyIdentifier: string;
+        name?: string | null;
+        roles?: AppStoreConnectUserRole[] | null;
+        createdAt: any;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+      } | null;
+    };
+  };
+};
 
 export type AppStoreConnectApiKeyByAccountQueryVariables = Exact<{
   accountName: Scalars['String'];
 }>;
 
-
-export type AppStoreConnectApiKeyByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appStoreConnectApiKeys: Array<{ __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null }> } } };
+export type AppStoreConnectApiKeyByAccountQuery = {
+  __typename?: 'RootQuery';
+  account: {
+    __typename?: 'AccountQuery';
+    byName: {
+      __typename?: 'Account';
+      id: string;
+      appStoreConnectApiKeys: {
+        __typename?: 'AppStoreConnectApiKey';
+        id: string;
+        issuerIdentifier: string;
+        keyIdentifier: string;
+        name?: string | null;
+        roles?: AppStoreConnectUserRole[] | null;
+        createdAt: any;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+      }[];
+    };
+  };
+};
 
 export type AppleAppIdentifierByBundleIdQueryVariables = Exact<{
   accountName: Scalars['String'];
   bundleIdentifier: Scalars['String'];
 }>;
 
-
-export type AppleAppIdentifierByBundleIdQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleAppIdentifiers: Array<{ __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }> } } };
+export type AppleAppIdentifierByBundleIdQuery = {
+  __typename?: 'RootQuery';
+  account: {
+    __typename?: 'AccountQuery';
+    byName: {
+      __typename?: 'Account';
+      id: string;
+      appleAppIdentifiers: {
+        __typename?: 'AppleAppIdentifier';
+        id: string;
+        bundleIdentifier: string;
+      }[];
+    };
+  };
+};
 
 export type AppleDevicesByAppleTeamQueryVariables = Exact<{
   accountId: Scalars['ID'];
   appleTeamIdentifier: Scalars['String'];
 }>;
 
-
-export type AppleDevicesByAppleTeamQuery = { __typename?: 'RootQuery', appleTeam: { __typename?: 'AppleTeamQuery', byAppleTeamIdentifier?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, appleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } }> } | null } };
+export type AppleDevicesByAppleTeamQuery = {
+  __typename?: 'RootQuery';
+  appleTeam: {
+    __typename?: 'AppleTeamQuery';
+    byAppleTeamIdentifier?: {
+      __typename?: 'AppleTeam';
+      id: string;
+      appleTeamIdentifier: string;
+      appleTeamName?: string | null;
+      appleDevices: {
+        __typename?: 'AppleDevice';
+        id: string;
+        identifier: string;
+        name?: string | null;
+        model?: string | null;
+        deviceClass?: AppleDeviceClass | null;
+        appleTeam: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        };
+      }[];
+    } | null;
+  };
+};
 
 export type AppleDevicesByTeamIdentifierQueryVariables = Exact<{
   accountName: Scalars['String'];
@@ -5700,16 +7111,62 @@ export type AppleDevicesByTeamIdentifierQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']>;
 }>;
 
-
-export type AppleDevicesByTeamIdentifierQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleTeams: Array<{ __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, deviceClass?: AppleDeviceClass | null, enabled?: boolean | null, model?: string | null }> }> } } };
+export type AppleDevicesByTeamIdentifierQuery = {
+  __typename?: 'RootQuery';
+  account: {
+    __typename?: 'AccountQuery';
+    byName: {
+      __typename?: 'Account';
+      id: string;
+      appleTeams: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+        appleDevices: {
+          __typename?: 'AppleDevice';
+          id: string;
+          identifier: string;
+          name?: string | null;
+          deviceClass?: AppleDeviceClass | null;
+          enabled?: boolean | null;
+          model?: string | null;
+        }[];
+      }[];
+    };
+  };
+};
 
 export type AppleDevicesByIdentifierQueryVariables = Exact<{
   accountName: Scalars['String'];
   identifier: Scalars['String'];
 }>;
 
-
-export type AppleDevicesByIdentifierQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, model?: string | null, identifier: string, name?: string | null, deviceClass?: AppleDeviceClass | null, enabled?: boolean | null, appleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } }> } } };
+export type AppleDevicesByIdentifierQuery = {
+  __typename?: 'RootQuery';
+  account: {
+    __typename?: 'AccountQuery';
+    byName: {
+      __typename?: 'Account';
+      id: string;
+      appleDevices: {
+        __typename?: 'AppleDevice';
+        id: string;
+        model?: string | null;
+        identifier: string;
+        name?: string | null;
+        deviceClass?: AppleDeviceClass | null;
+        enabled?: boolean | null;
+        appleTeam: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        };
+      }[];
+    };
+  };
+};
 
 export type AppleDistributionCertificateByAppQueryVariables = Exact<{
   projectFullName: Scalars['String'];
@@ -5717,15 +7174,147 @@ export type AppleDistributionCertificateByAppQueryVariables = Exact<{
   iosDistributionType: IosDistributionType;
 }>;
 
-
-export type AppleDistributionCertificateByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null }> }> } } };
+export type AppleDistributionCertificateByAppQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byFullName: {
+      __typename?: 'App';
+      id: string;
+      iosAppCredentials: {
+        __typename?: 'IosAppCredentials';
+        id: string;
+        iosAppBuildCredentialsList: {
+          __typename?: 'IosAppBuildCredentials';
+          id: string;
+          distributionCertificate?: {
+            __typename?: 'AppleDistributionCertificate';
+            id: string;
+            certificateP12?: string | null;
+            certificatePassword?: string | null;
+            serialNumber: string;
+            developerPortalIdentifier?: string | null;
+            validityNotBefore: any;
+            validityNotAfter: any;
+            updatedAt: any;
+            appleTeam?: {
+              __typename?: 'AppleTeam';
+              id: string;
+              appleTeamIdentifier: string;
+              appleTeamName?: string | null;
+            } | null;
+            iosAppBuildCredentialsList: {
+              __typename?: 'IosAppBuildCredentials';
+              id: string;
+              iosAppCredentials: {
+                __typename?: 'IosAppCredentials';
+                id: string;
+                app: {
+                  __typename?: 'App';
+                  id: string;
+                  fullName: string;
+                  slug: string;
+                  ownerAccount: {
+                    __typename?: 'Account';
+                    id: string;
+                    name: string;
+                    users: {
+                      __typename?: 'UserPermission';
+                      role: Role;
+                      actor:
+                        | { __typename?: 'Robot'; id: string }
+                        | { __typename?: 'SSOUser'; id: string }
+                        | { __typename?: 'User'; id: string };
+                    }[];
+                  };
+                };
+                appleAppIdentifier: {
+                  __typename?: 'AppleAppIdentifier';
+                  id: string;
+                  bundleIdentifier: string;
+                };
+              };
+              provisioningProfile?: {
+                __typename?: 'AppleProvisioningProfile';
+                id: string;
+                developerPortalIdentifier?: string | null;
+              } | null;
+            }[];
+          } | null;
+        }[];
+      }[];
+    };
+  };
+};
 
 export type AppleDistributionCertificateByAccountQueryVariables = Exact<{
   accountName: Scalars['String'];
 }>;
 
-
-export type AppleDistributionCertificateByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDistributionCertificates: Array<{ __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> }> } } };
+export type AppleDistributionCertificateByAccountQuery = {
+  __typename?: 'RootQuery';
+  account: {
+    __typename?: 'AccountQuery';
+    byName: {
+      __typename?: 'Account';
+      id: string;
+      appleDistributionCertificates: {
+        __typename?: 'AppleDistributionCertificate';
+        id: string;
+        certificateP12?: string | null;
+        certificatePassword?: string | null;
+        serialNumber: string;
+        developerPortalIdentifier?: string | null;
+        validityNotBefore: any;
+        validityNotAfter: any;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        iosAppBuildCredentialsList: {
+          __typename?: 'IosAppBuildCredentials';
+          id: string;
+          iosAppCredentials: {
+            __typename?: 'IosAppCredentials';
+            id: string;
+            app: {
+              __typename?: 'App';
+              id: string;
+              fullName: string;
+              slug: string;
+              ownerAccount: {
+                __typename?: 'Account';
+                id: string;
+                name: string;
+                users: {
+                  __typename?: 'UserPermission';
+                  role: Role;
+                  actor:
+                    | { __typename?: 'Robot'; id: string }
+                    | { __typename?: 'SSOUser'; id: string }
+                    | { __typename?: 'User'; id: string };
+                }[];
+              };
+            };
+            appleAppIdentifier: {
+              __typename?: 'AppleAppIdentifier';
+              id: string;
+              bundleIdentifier: string;
+            };
+          };
+          provisioningProfile?: {
+            __typename?: 'AppleProvisioningProfile';
+            id: string;
+            developerPortalIdentifier?: string | null;
+          } | null;
+        }[];
+      }[];
+    };
+  };
+};
 
 export type AppleProvisioningProfilesByAppQueryVariables = Exact<{
   projectFullName: Scalars['String'];
@@ -5733,15 +7322,107 @@ export type AppleProvisioningProfilesByAppQueryVariables = Exact<{
   iosDistributionType: IosDistributionType;
 }>;
 
-
-export type AppleProvisioningProfilesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }>, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } } | null }> }> } } };
+export type AppleProvisioningProfilesByAppQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byFullName: {
+      __typename?: 'App';
+      id: string;
+      iosAppCredentials: {
+        __typename?: 'IosAppCredentials';
+        id: string;
+        iosAppBuildCredentialsList: {
+          __typename?: 'IosAppBuildCredentials';
+          id: string;
+          provisioningProfile?: {
+            __typename?: 'AppleProvisioningProfile';
+            id: string;
+            expiration: any;
+            developerPortalIdentifier?: string | null;
+            provisioningProfile?: string | null;
+            updatedAt: any;
+            status: string;
+            appleTeam?: {
+              __typename?: 'AppleTeam';
+              id: string;
+              appleTeamIdentifier: string;
+              appleTeamName?: string | null;
+            } | null;
+            appleDevices: {
+              __typename?: 'AppleDevice';
+              id: string;
+              identifier: string;
+              name?: string | null;
+              model?: string | null;
+              deviceClass?: AppleDeviceClass | null;
+            }[];
+            appleAppIdentifier: {
+              __typename?: 'AppleAppIdentifier';
+              id: string;
+              bundleIdentifier: string;
+            };
+          } | null;
+        }[];
+      }[];
+    };
+  };
+};
 
 export type ApplePushKeyByAccountQueryVariables = Exact<{
   accountName: Scalars['String'];
 }>;
 
-
-export type ApplePushKeyByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, applePushKeys: Array<{ __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> }> } } };
+export type ApplePushKeyByAccountQuery = {
+  __typename?: 'RootQuery';
+  account: {
+    __typename?: 'AccountQuery';
+    byName: {
+      __typename?: 'Account';
+      id: string;
+      applePushKeys: {
+        __typename?: 'ApplePushKey';
+        id: string;
+        keyIdentifier: string;
+        updatedAt: any;
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        iosAppCredentialsList: {
+          __typename?: 'IosAppCredentials';
+          id: string;
+          app: {
+            __typename?: 'App';
+            id: string;
+            fullName: string;
+            slug: string;
+            ownerAccount: {
+              __typename?: 'Account';
+              id: string;
+              name: string;
+              users: {
+                __typename?: 'UserPermission';
+                role: Role;
+                actor:
+                  | { __typename?: 'Robot'; id: string }
+                  | { __typename?: 'SSOUser'; id: string }
+                  | { __typename?: 'User'; id: string };
+              }[];
+            };
+          };
+          appleAppIdentifier: {
+            __typename?: 'AppleAppIdentifier';
+            id: string;
+            bundleIdentifier: string;
+          };
+        }[];
+      }[];
+    };
+  };
+};
 
 export type AppleTeamsByAccountNameQueryVariables = Exact<{
   accountName: Scalars['String'];
@@ -5749,16 +7430,40 @@ export type AppleTeamsByAccountNameQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']>;
 }>;
 
-
-export type AppleTeamsByAccountNameQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleTeams: Array<{ __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null }> } } };
+export type AppleTeamsByAccountNameQuery = {
+  __typename?: 'RootQuery';
+  account: {
+    __typename?: 'AccountQuery';
+    byName: {
+      __typename?: 'Account';
+      id: string;
+      appleTeams: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      }[];
+    };
+  };
+};
 
 export type AppleTeamByIdentifierQueryVariables = Exact<{
   accountId: Scalars['ID'];
   appleTeamIdentifier: Scalars['String'];
 }>;
 
-
-export type AppleTeamByIdentifierQuery = { __typename?: 'RootQuery', appleTeam: { __typename?: 'AppleTeamQuery', byAppleTeamIdentifier?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } };
+export type AppleTeamByIdentifierQuery = {
+  __typename?: 'RootQuery';
+  appleTeam: {
+    __typename?: 'AppleTeamQuery';
+    byAppleTeamIdentifier?: {
+      __typename?: 'AppleTeam';
+      id: string;
+      appleTeamIdentifier: string;
+      appleTeamName?: string | null;
+    } | null;
+  };
+};
 
 export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQueryVariables = Exact<{
   projectFullName: Scalars['String'];
@@ -5766,8 +7471,102 @@ export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQueryVariabl
   iosDistributionType: IosDistributionType;
 }>;
 
-
-export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null }> }> } } };
+export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byFullName: {
+      __typename?: 'App';
+      id: string;
+      iosAppCredentials: {
+        __typename?: 'IosAppCredentials';
+        id: string;
+        iosAppBuildCredentialsList: {
+          __typename?: 'IosAppBuildCredentials';
+          id: string;
+          iosDistributionType: IosDistributionType;
+          distributionCertificate?: {
+            __typename?: 'AppleDistributionCertificate';
+            id: string;
+            certificateP12?: string | null;
+            certificatePassword?: string | null;
+            serialNumber: string;
+            developerPortalIdentifier?: string | null;
+            validityNotBefore: any;
+            validityNotAfter: any;
+            updatedAt: any;
+            appleTeam?: {
+              __typename?: 'AppleTeam';
+              id: string;
+              appleTeamIdentifier: string;
+              appleTeamName?: string | null;
+            } | null;
+            iosAppBuildCredentialsList: {
+              __typename?: 'IosAppBuildCredentials';
+              id: string;
+              iosAppCredentials: {
+                __typename?: 'IosAppCredentials';
+                id: string;
+                app: {
+                  __typename?: 'App';
+                  id: string;
+                  fullName: string;
+                  slug: string;
+                  ownerAccount: {
+                    __typename?: 'Account';
+                    id: string;
+                    name: string;
+                    users: {
+                      __typename?: 'UserPermission';
+                      role: Role;
+                      actor:
+                        | { __typename?: 'Robot'; id: string }
+                        | { __typename?: 'SSOUser'; id: string }
+                        | { __typename?: 'User'; id: string };
+                    }[];
+                  };
+                };
+                appleAppIdentifier: {
+                  __typename?: 'AppleAppIdentifier';
+                  id: string;
+                  bundleIdentifier: string;
+                };
+              };
+              provisioningProfile?: {
+                __typename?: 'AppleProvisioningProfile';
+                id: string;
+                developerPortalIdentifier?: string | null;
+              } | null;
+            }[];
+          } | null;
+          provisioningProfile?: {
+            __typename?: 'AppleProvisioningProfile';
+            id: string;
+            expiration: any;
+            developerPortalIdentifier?: string | null;
+            provisioningProfile?: string | null;
+            updatedAt: any;
+            status: string;
+            appleTeam?: {
+              __typename?: 'AppleTeam';
+              id: string;
+              appleTeamIdentifier: string;
+              appleTeamName?: string | null;
+            } | null;
+            appleDevices: {
+              __typename?: 'AppleDevice';
+              id: string;
+              identifier: string;
+              name?: string | null;
+              model?: string | null;
+              deviceClass?: AppleDeviceClass | null;
+            }[];
+          } | null;
+        }[];
+      }[];
+    };
+  };
+};
 
 export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQueryVariables = Exact<{
   projectFullName: Scalars['String'];
@@ -5775,30 +7574,397 @@ export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQueryVariables
   iosDistributionType?: InputMaybe<IosDistributionType>;
 }>;
 
-
-export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null }>, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null }> } } };
+export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byFullName: {
+      __typename?: 'App';
+      id: string;
+      iosAppCredentials: {
+        __typename?: 'IosAppCredentials';
+        id: string;
+        iosAppBuildCredentialsList: {
+          __typename?: 'IosAppBuildCredentials';
+          id: string;
+          iosDistributionType: IosDistributionType;
+          distributionCertificate?: {
+            __typename?: 'AppleDistributionCertificate';
+            id: string;
+            certificateP12?: string | null;
+            certificatePassword?: string | null;
+            serialNumber: string;
+            developerPortalIdentifier?: string | null;
+            validityNotBefore: any;
+            validityNotAfter: any;
+            updatedAt: any;
+            appleTeam?: {
+              __typename?: 'AppleTeam';
+              id: string;
+              appleTeamIdentifier: string;
+              appleTeamName?: string | null;
+            } | null;
+            iosAppBuildCredentialsList: {
+              __typename?: 'IosAppBuildCredentials';
+              id: string;
+              iosAppCredentials: {
+                __typename?: 'IosAppCredentials';
+                id: string;
+                app: {
+                  __typename?: 'App';
+                  id: string;
+                  fullName: string;
+                  slug: string;
+                  ownerAccount: {
+                    __typename?: 'Account';
+                    id: string;
+                    name: string;
+                    users: {
+                      __typename?: 'UserPermission';
+                      role: Role;
+                      actor:
+                        | { __typename?: 'Robot'; id: string }
+                        | { __typename?: 'SSOUser'; id: string }
+                        | { __typename?: 'User'; id: string };
+                    }[];
+                  };
+                };
+                appleAppIdentifier: {
+                  __typename?: 'AppleAppIdentifier';
+                  id: string;
+                  bundleIdentifier: string;
+                };
+              };
+              provisioningProfile?: {
+                __typename?: 'AppleProvisioningProfile';
+                id: string;
+                developerPortalIdentifier?: string | null;
+              } | null;
+            }[];
+          } | null;
+          provisioningProfile?: {
+            __typename?: 'AppleProvisioningProfile';
+            id: string;
+            expiration: any;
+            developerPortalIdentifier?: string | null;
+            provisioningProfile?: string | null;
+            updatedAt: any;
+            status: string;
+            appleTeam?: {
+              __typename?: 'AppleTeam';
+              id: string;
+              appleTeamIdentifier: string;
+              appleTeamName?: string | null;
+            } | null;
+            appleDevices: {
+              __typename?: 'AppleDevice';
+              id: string;
+              identifier: string;
+              name?: string | null;
+              model?: string | null;
+              deviceClass?: AppleDeviceClass | null;
+            }[];
+          } | null;
+        }[];
+        app: {
+          __typename?: 'App';
+          id: string;
+          fullName: string;
+          slug: string;
+          ownerAccount: {
+            __typename?: 'Account';
+            id: string;
+            name: string;
+            users: {
+              __typename?: 'UserPermission';
+              role: Role;
+              actor:
+                | { __typename?: 'Robot'; id: string }
+                | { __typename?: 'SSOUser'; id: string }
+                | { __typename?: 'User'; id: string };
+            }[];
+          };
+        };
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        appleAppIdentifier: {
+          __typename?: 'AppleAppIdentifier';
+          id: string;
+          bundleIdentifier: string;
+        };
+        pushKey?: {
+          __typename?: 'ApplePushKey';
+          id: string;
+          keyIdentifier: string;
+          updatedAt: any;
+          appleTeam?: {
+            __typename?: 'AppleTeam';
+            id: string;
+            appleTeamIdentifier: string;
+            appleTeamName?: string | null;
+          } | null;
+          iosAppCredentialsList: {
+            __typename?: 'IosAppCredentials';
+            id: string;
+            app: {
+              __typename?: 'App';
+              id: string;
+              fullName: string;
+              slug: string;
+              ownerAccount: {
+                __typename?: 'Account';
+                id: string;
+                name: string;
+                users: {
+                  __typename?: 'UserPermission';
+                  role: Role;
+                  actor:
+                    | { __typename?: 'Robot'; id: string }
+                    | { __typename?: 'SSOUser'; id: string }
+                    | { __typename?: 'User'; id: string };
+                }[];
+              };
+            };
+            appleAppIdentifier: {
+              __typename?: 'AppleAppIdentifier';
+              id: string;
+              bundleIdentifier: string;
+            };
+          }[];
+        } | null;
+        appStoreConnectApiKeyForSubmissions?: {
+          __typename?: 'AppStoreConnectApiKey';
+          id: string;
+          issuerIdentifier: string;
+          keyIdentifier: string;
+          name?: string | null;
+          roles?: AppStoreConnectUserRole[] | null;
+          createdAt: any;
+          updatedAt: any;
+          appleTeam?: {
+            __typename?: 'AppleTeam';
+            id: string;
+            appleTeamIdentifier: string;
+            appleTeamName?: string | null;
+          } | null;
+        } | null;
+      }[];
+    };
+  };
+};
 
 export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQueryVariables = Exact<{
   projectFullName: Scalars['String'];
   appleAppIdentifierId: Scalars['String'];
 }>;
 
-
-export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null }>, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null }> } } };
+export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byFullName: {
+      __typename?: 'App';
+      id: string;
+      iosAppCredentials: {
+        __typename?: 'IosAppCredentials';
+        id: string;
+        iosAppBuildCredentialsList: {
+          __typename?: 'IosAppBuildCredentials';
+          id: string;
+          iosDistributionType: IosDistributionType;
+          distributionCertificate?: {
+            __typename?: 'AppleDistributionCertificate';
+            id: string;
+            certificateP12?: string | null;
+            certificatePassword?: string | null;
+            serialNumber: string;
+            developerPortalIdentifier?: string | null;
+            validityNotBefore: any;
+            validityNotAfter: any;
+            updatedAt: any;
+            appleTeam?: {
+              __typename?: 'AppleTeam';
+              id: string;
+              appleTeamIdentifier: string;
+              appleTeamName?: string | null;
+            } | null;
+            iosAppBuildCredentialsList: {
+              __typename?: 'IosAppBuildCredentials';
+              id: string;
+              iosAppCredentials: {
+                __typename?: 'IosAppCredentials';
+                id: string;
+                app: {
+                  __typename?: 'App';
+                  id: string;
+                  fullName: string;
+                  slug: string;
+                  ownerAccount: {
+                    __typename?: 'Account';
+                    id: string;
+                    name: string;
+                    users: {
+                      __typename?: 'UserPermission';
+                      role: Role;
+                      actor:
+                        | { __typename?: 'Robot'; id: string }
+                        | { __typename?: 'SSOUser'; id: string }
+                        | { __typename?: 'User'; id: string };
+                    }[];
+                  };
+                };
+                appleAppIdentifier: {
+                  __typename?: 'AppleAppIdentifier';
+                  id: string;
+                  bundleIdentifier: string;
+                };
+              };
+              provisioningProfile?: {
+                __typename?: 'AppleProvisioningProfile';
+                id: string;
+                developerPortalIdentifier?: string | null;
+              } | null;
+            }[];
+          } | null;
+          provisioningProfile?: {
+            __typename?: 'AppleProvisioningProfile';
+            id: string;
+            expiration: any;
+            developerPortalIdentifier?: string | null;
+            provisioningProfile?: string | null;
+            updatedAt: any;
+            status: string;
+            appleTeam?: {
+              __typename?: 'AppleTeam';
+              id: string;
+              appleTeamIdentifier: string;
+              appleTeamName?: string | null;
+            } | null;
+            appleDevices: {
+              __typename?: 'AppleDevice';
+              id: string;
+              identifier: string;
+              name?: string | null;
+              model?: string | null;
+              deviceClass?: AppleDeviceClass | null;
+            }[];
+          } | null;
+        }[];
+        app: {
+          __typename?: 'App';
+          id: string;
+          fullName: string;
+          slug: string;
+          ownerAccount: {
+            __typename?: 'Account';
+            id: string;
+            name: string;
+            users: {
+              __typename?: 'UserPermission';
+              role: Role;
+              actor:
+                | { __typename?: 'Robot'; id: string }
+                | { __typename?: 'SSOUser'; id: string }
+                | { __typename?: 'User'; id: string };
+            }[];
+          };
+        };
+        appleTeam?: {
+          __typename?: 'AppleTeam';
+          id: string;
+          appleTeamIdentifier: string;
+          appleTeamName?: string | null;
+        } | null;
+        appleAppIdentifier: {
+          __typename?: 'AppleAppIdentifier';
+          id: string;
+          bundleIdentifier: string;
+        };
+        pushKey?: {
+          __typename?: 'ApplePushKey';
+          id: string;
+          keyIdentifier: string;
+          updatedAt: any;
+          appleTeam?: {
+            __typename?: 'AppleTeam';
+            id: string;
+            appleTeamIdentifier: string;
+            appleTeamName?: string | null;
+          } | null;
+          iosAppCredentialsList: {
+            __typename?: 'IosAppCredentials';
+            id: string;
+            app: {
+              __typename?: 'App';
+              id: string;
+              fullName: string;
+              slug: string;
+              ownerAccount: {
+                __typename?: 'Account';
+                id: string;
+                name: string;
+                users: {
+                  __typename?: 'UserPermission';
+                  role: Role;
+                  actor:
+                    | { __typename?: 'Robot'; id: string }
+                    | { __typename?: 'SSOUser'; id: string }
+                    | { __typename?: 'User'; id: string };
+                }[];
+              };
+            };
+            appleAppIdentifier: {
+              __typename?: 'AppleAppIdentifier';
+              id: string;
+              bundleIdentifier: string;
+            };
+          }[];
+        } | null;
+        appStoreConnectApiKeyForSubmissions?: {
+          __typename?: 'AppStoreConnectApiKey';
+          id: string;
+          issuerIdentifier: string;
+          keyIdentifier: string;
+          name?: string | null;
+          roles?: AppStoreConnectUserRole[] | null;
+          createdAt: any;
+          updatedAt: any;
+          appleTeam?: {
+            __typename?: 'AppleTeam';
+            id: string;
+            appleTeamIdentifier: string;
+            appleTeamName?: string | null;
+          } | null;
+        } | null;
+      }[];
+    };
+  };
+};
 
 export type CreateAppMutationVariables = Exact<{
   appInput: AppInput;
 }>;
 
-
-export type CreateAppMutation = { __typename?: 'RootMutation', app?: { __typename?: 'AppMutation', createApp: { __typename?: 'App', id: string } } | null };
+export type CreateAppMutation = {
+  __typename?: 'RootMutation';
+  app?: { __typename?: 'AppMutation'; createApp: { __typename?: 'App'; id: string } } | null;
+};
 
 export type CreateAppVersionMutationVariables = Exact<{
   appVersionInput: AppVersionInput;
 }>;
 
-
-export type CreateAppVersionMutation = { __typename?: 'RootMutation', appVersion: { __typename?: 'AppVersionMutation', createAppVersion: { __typename?: 'AppVersion', id: string } } };
+export type CreateAppVersionMutation = {
+  __typename?: 'RootMutation';
+  appVersion: {
+    __typename?: 'AppVersionMutation';
+    createAppVersion: { __typename?: 'AppVersion'; id: string };
+  };
+};
 
 export type CreateAndroidBuildMutationVariables = Exact<{
   appId: Scalars['ID'];
@@ -5807,8 +7973,73 @@ export type CreateAndroidBuildMutationVariables = Exact<{
   buildParams?: InputMaybe<BuildParamsInput>;
 }>;
 
-
-export type CreateAndroidBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createAndroidBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, resourceClass: BuildResourceClass, expirationDate?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }, deprecationInfo?: { __typename?: 'EASBuildDeprecationInfo', type: EasBuildDeprecationInfoType, message: string } | null } } };
+export type CreateAndroidBuildMutation = {
+  __typename?: 'RootMutation';
+  build: {
+    __typename?: 'BuildMutation';
+    createAndroidBuild: {
+      __typename?: 'CreateBuildResult';
+      build: {
+        __typename?: 'Build';
+        id: string;
+        status: BuildStatus;
+        platform: AppPlatform;
+        channel?: string | null;
+        releaseChannel?: string | null;
+        distribution?: DistributionType | null;
+        iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
+        buildProfile?: string | null;
+        sdkVersion?: string | null;
+        appVersion?: string | null;
+        appBuildVersion?: string | null;
+        runtimeVersion?: string | null;
+        gitCommitHash?: string | null;
+        gitCommitMessage?: string | null;
+        initialQueuePosition?: number | null;
+        queuePosition?: number | null;
+        estimatedWaitTimeLeftSeconds?: number | null;
+        priority: BuildPriority;
+        createdAt: any;
+        updatedAt: any;
+        message?: string | null;
+        completedAt?: any | null;
+        resourceClass: BuildResourceClass;
+        expirationDate?: any | null;
+        error?: {
+          __typename?: 'BuildError';
+          errorCode: string;
+          message: string;
+          docsUrl?: string | null;
+        } | null;
+        artifacts?: {
+          __typename?: 'BuildArtifacts';
+          buildUrl?: string | null;
+          xcodeBuildLogsUrl?: string | null;
+          applicationArchiveUrl?: string | null;
+        } | null;
+        initiatingActor?:
+          | { __typename: 'Robot'; id: string; displayName: string }
+          | { __typename: 'SSOUser'; id: string; displayName: string }
+          | { __typename: 'User'; id: string; displayName: string }
+          | null;
+        project:
+          | {
+              __typename: 'App';
+              id: string;
+              name: string;
+              slug: string;
+              ownerAccount: { __typename?: 'Account'; id: string; name: string };
+            }
+          | { __typename: 'Snack'; id: string; name: string; slug: string };
+      };
+      deprecationInfo?: {
+        __typename?: 'EASBuildDeprecationInfo';
+        type: EasBuildDeprecationInfoType;
+        message: string;
+      } | null;
+    };
+  };
+};
 
 export type CreateIosBuildMutationVariables = Exact<{
   appId: Scalars['ID'];
@@ -5817,74 +8048,338 @@ export type CreateIosBuildMutationVariables = Exact<{
   buildParams?: InputMaybe<BuildParamsInput>;
 }>;
 
-
-export type CreateIosBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createIosBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, resourceClass: BuildResourceClass, expirationDate?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }, deprecationInfo?: { __typename?: 'EASBuildDeprecationInfo', type: EasBuildDeprecationInfoType, message: string } | null } } };
+export type CreateIosBuildMutation = {
+  __typename?: 'RootMutation';
+  build: {
+    __typename?: 'BuildMutation';
+    createIosBuild: {
+      __typename?: 'CreateBuildResult';
+      build: {
+        __typename?: 'Build';
+        id: string;
+        status: BuildStatus;
+        platform: AppPlatform;
+        channel?: string | null;
+        releaseChannel?: string | null;
+        distribution?: DistributionType | null;
+        iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
+        buildProfile?: string | null;
+        sdkVersion?: string | null;
+        appVersion?: string | null;
+        appBuildVersion?: string | null;
+        runtimeVersion?: string | null;
+        gitCommitHash?: string | null;
+        gitCommitMessage?: string | null;
+        initialQueuePosition?: number | null;
+        queuePosition?: number | null;
+        estimatedWaitTimeLeftSeconds?: number | null;
+        priority: BuildPriority;
+        createdAt: any;
+        updatedAt: any;
+        message?: string | null;
+        completedAt?: any | null;
+        resourceClass: BuildResourceClass;
+        expirationDate?: any | null;
+        error?: {
+          __typename?: 'BuildError';
+          errorCode: string;
+          message: string;
+          docsUrl?: string | null;
+        } | null;
+        artifacts?: {
+          __typename?: 'BuildArtifacts';
+          buildUrl?: string | null;
+          xcodeBuildLogsUrl?: string | null;
+          applicationArchiveUrl?: string | null;
+        } | null;
+        initiatingActor?:
+          | { __typename: 'Robot'; id: string; displayName: string }
+          | { __typename: 'SSOUser'; id: string; displayName: string }
+          | { __typename: 'User'; id: string; displayName: string }
+          | null;
+        project:
+          | {
+              __typename: 'App';
+              id: string;
+              name: string;
+              slug: string;
+              ownerAccount: { __typename?: 'Account'; id: string; name: string };
+            }
+          | { __typename: 'Snack'; id: string; name: string; slug: string };
+      };
+      deprecationInfo?: {
+        __typename?: 'EASBuildDeprecationInfo';
+        type: EasBuildDeprecationInfoType;
+        message: string;
+      } | null;
+    };
+  };
+};
 
 export type UpdateBuildMetadataMutationVariables = Exact<{
   buildId: Scalars['ID'];
   metadata: BuildMetadataInput;
 }>;
 
-
-export type UpdateBuildMetadataMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', updateBuildMetadata: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, resourceClass: BuildResourceClass, expirationDate?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
+export type UpdateBuildMetadataMutation = {
+  __typename?: 'RootMutation';
+  build: {
+    __typename?: 'BuildMutation';
+    updateBuildMetadata: {
+      __typename?: 'Build';
+      id: string;
+      status: BuildStatus;
+      platform: AppPlatform;
+      channel?: string | null;
+      releaseChannel?: string | null;
+      distribution?: DistributionType | null;
+      iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
+      buildProfile?: string | null;
+      sdkVersion?: string | null;
+      appVersion?: string | null;
+      appBuildVersion?: string | null;
+      runtimeVersion?: string | null;
+      gitCommitHash?: string | null;
+      gitCommitMessage?: string | null;
+      initialQueuePosition?: number | null;
+      queuePosition?: number | null;
+      estimatedWaitTimeLeftSeconds?: number | null;
+      priority: BuildPriority;
+      createdAt: any;
+      updatedAt: any;
+      message?: string | null;
+      completedAt?: any | null;
+      resourceClass: BuildResourceClass;
+      expirationDate?: any | null;
+      error?: {
+        __typename?: 'BuildError';
+        errorCode: string;
+        message: string;
+        docsUrl?: string | null;
+      } | null;
+      artifacts?: {
+        __typename?: 'BuildArtifacts';
+        buildUrl?: string | null;
+        xcodeBuildLogsUrl?: string | null;
+        applicationArchiveUrl?: string | null;
+      } | null;
+      initiatingActor?:
+        | { __typename: 'Robot'; id: string; displayName: string }
+        | { __typename: 'SSOUser'; id: string; displayName: string }
+        | { __typename: 'User'; id: string; displayName: string }
+        | null;
+      project:
+        | {
+            __typename: 'App';
+            id: string;
+            name: string;
+            slug: string;
+            ownerAccount: { __typename?: 'Account'; id: string; name: string };
+          }
+        | { __typename: 'Snack'; id: string; name: string; slug: string };
+    };
+  };
+};
 
 export type RetryIosBuildMutationVariables = Exact<{
   buildId: Scalars['ID'];
   jobOverrides: IosJobOverridesInput;
 }>;
 
-
-export type RetryIosBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', retryIosBuild: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, resourceClass: BuildResourceClass, expirationDate?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
+export type RetryIosBuildMutation = {
+  __typename?: 'RootMutation';
+  build: {
+    __typename?: 'BuildMutation';
+    retryIosBuild: {
+      __typename?: 'Build';
+      id: string;
+      status: BuildStatus;
+      platform: AppPlatform;
+      channel?: string | null;
+      releaseChannel?: string | null;
+      distribution?: DistributionType | null;
+      iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
+      buildProfile?: string | null;
+      sdkVersion?: string | null;
+      appVersion?: string | null;
+      appBuildVersion?: string | null;
+      runtimeVersion?: string | null;
+      gitCommitHash?: string | null;
+      gitCommitMessage?: string | null;
+      initialQueuePosition?: number | null;
+      queuePosition?: number | null;
+      estimatedWaitTimeLeftSeconds?: number | null;
+      priority: BuildPriority;
+      createdAt: any;
+      updatedAt: any;
+      message?: string | null;
+      completedAt?: any | null;
+      resourceClass: BuildResourceClass;
+      expirationDate?: any | null;
+      error?: {
+        __typename?: 'BuildError';
+        errorCode: string;
+        message: string;
+        docsUrl?: string | null;
+      } | null;
+      artifacts?: {
+        __typename?: 'BuildArtifacts';
+        buildUrl?: string | null;
+        xcodeBuildLogsUrl?: string | null;
+        applicationArchiveUrl?: string | null;
+      } | null;
+      initiatingActor?:
+        | { __typename: 'Robot'; id: string; displayName: string }
+        | { __typename: 'SSOUser'; id: string; displayName: string }
+        | { __typename: 'User'; id: string; displayName: string }
+        | null;
+      project:
+        | {
+            __typename: 'App';
+            id: string;
+            name: string;
+            slug: string;
+            ownerAccount: { __typename?: 'Account'; id: string; name: string };
+          }
+        | { __typename: 'Snack'; id: string; name: string; slug: string };
+    };
+  };
+};
 
 export type CreateEnvironmentSecretForAccountMutationVariables = Exact<{
   input: CreateEnvironmentSecretInput;
   accountId: Scalars['String'];
 }>;
 
-
-export type CreateEnvironmentSecretForAccountMutation = { __typename?: 'RootMutation', environmentSecret: { __typename?: 'EnvironmentSecretMutation', createEnvironmentSecretForAccount: { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any } } };
+export type CreateEnvironmentSecretForAccountMutation = {
+  __typename?: 'RootMutation';
+  environmentSecret: {
+    __typename?: 'EnvironmentSecretMutation';
+    createEnvironmentSecretForAccount: {
+      __typename?: 'EnvironmentSecret';
+      id: string;
+      name: string;
+      type: EnvironmentSecretType;
+      createdAt: any;
+    };
+  };
+};
 
 export type CreateEnvironmentSecretForAppMutationVariables = Exact<{
   input: CreateEnvironmentSecretInput;
   appId: Scalars['String'];
 }>;
 
-
-export type CreateEnvironmentSecretForAppMutation = { __typename?: 'RootMutation', environmentSecret: { __typename?: 'EnvironmentSecretMutation', createEnvironmentSecretForApp: { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any } } };
+export type CreateEnvironmentSecretForAppMutation = {
+  __typename?: 'RootMutation';
+  environmentSecret: {
+    __typename?: 'EnvironmentSecretMutation';
+    createEnvironmentSecretForApp: {
+      __typename?: 'EnvironmentSecret';
+      id: string;
+      name: string;
+      type: EnvironmentSecretType;
+      createdAt: any;
+    };
+  };
+};
 
 export type DeleteEnvironmentSecretMutationVariables = Exact<{
   id: Scalars['String'];
 }>;
 
+export type DeleteEnvironmentSecretMutation = {
+  __typename?: 'RootMutation';
+  environmentSecret: {
+    __typename?: 'EnvironmentSecretMutation';
+    deleteEnvironmentSecret: { __typename?: 'DeleteEnvironmentSecretResult'; id: string };
+  };
+};
 
-export type DeleteEnvironmentSecretMutation = { __typename?: 'RootMutation', environmentSecret: { __typename?: 'EnvironmentSecretMutation', deleteEnvironmentSecret: { __typename?: 'DeleteEnvironmentSecretResult', id: string } } };
+export type CreateKeystoreGenerationUrlMutationVariables = Exact<{ [key: string]: never }>;
 
-export type CreateKeystoreGenerationUrlMutationVariables = Exact<{ [key: string]: never; }>;
-
-
-export type CreateKeystoreGenerationUrlMutation = { __typename?: 'RootMutation', keystoreGenerationUrl: { __typename?: 'KeystoreGenerationUrlMutation', createKeystoreGenerationUrl: { __typename?: 'KeystoreGenerationUrl', id: string, url: string } } };
+export type CreateKeystoreGenerationUrlMutation = {
+  __typename?: 'RootMutation';
+  keystoreGenerationUrl: {
+    __typename?: 'KeystoreGenerationUrlMutation';
+    createKeystoreGenerationUrl: { __typename?: 'KeystoreGenerationUrl'; id: string; url: string };
+  };
+};
 
 export type GetSignedUploadMutationVariables = Exact<{
-  contentTypes: Array<Scalars['String']> | Scalars['String'];
+  contentTypes: Scalars['String'][] | Scalars['String'];
 }>;
 
-
-export type GetSignedUploadMutation = { __typename?: 'RootMutation', asset: { __typename?: 'AssetMutation', getSignedAssetUploadSpecifications: { __typename?: 'GetSignedAssetUploadSpecificationsResult', specifications: Array<string> } } };
+export type GetSignedUploadMutation = {
+  __typename?: 'RootMutation';
+  asset: {
+    __typename?: 'AssetMutation';
+    getSignedAssetUploadSpecifications: {
+      __typename?: 'GetSignedAssetUploadSpecificationsResult';
+      specifications: string[];
+    };
+  };
+};
 
 export type UpdatePublishMutationVariables = Exact<{
-  publishUpdateGroupsInput: Array<PublishUpdateGroupInput> | PublishUpdateGroupInput;
+  publishUpdateGroupsInput: PublishUpdateGroupInput[] | PublishUpdateGroupInput;
 }>;
 
-
-export type UpdatePublishMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', publishUpdateGroups: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> } };
+export type UpdatePublishMutation = {
+  __typename?: 'RootMutation';
+  updateBranch: {
+    __typename?: 'UpdateBranchMutation';
+    publishUpdateGroups: {
+      __typename?: 'Update';
+      id: string;
+      group: string;
+      message?: string | null;
+      createdAt: any;
+      runtimeVersion: string;
+      platform: string;
+      manifestFragment: string;
+      isRollBackToEmbedded: boolean;
+      manifestPermalink: string;
+      gitCommitHash?: string | null;
+      actor?:
+        | { __typename: 'Robot'; firstName?: string | null; id: string }
+        | { __typename: 'SSOUser'; id: string }
+        | { __typename: 'User'; username: string; id: string }
+        | null;
+      branch: { __typename?: 'UpdateBranch'; id: string; name: string };
+      codeSigningInfo?: {
+        __typename?: 'CodeSigningInfo';
+        keyid: string;
+        sig: string;
+        alg: string;
+      } | null;
+    }[];
+  };
+};
 
 export type SetCodeSigningInfoMutationVariables = Exact<{
   updateId: Scalars['ID'];
   codeSigningInfo: CodeSigningInfoInput;
 }>;
 
-
-export type SetCodeSigningInfoMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', setCodeSigningInfo: { __typename?: 'Update', id: string, group: string, awaitingCodeSigningInfo: boolean, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, alg: string, sig: string } | null } } };
+export type SetCodeSigningInfoMutation = {
+  __typename?: 'RootMutation';
+  update: {
+    __typename?: 'UpdateMutation';
+    setCodeSigningInfo: {
+      __typename?: 'Update';
+      id: string;
+      group: string;
+      awaitingCodeSigningInfo: boolean;
+      codeSigningInfo?: {
+        __typename?: 'CodeSigningInfo';
+        keyid: string;
+        alg: string;
+        sig: string;
+      } | null;
+    };
+  };
+};
 
 export type CreateAndroidSubmissionMutationVariables = Exact<{
   appId: Scalars['ID'];
@@ -5893,8 +8388,45 @@ export type CreateAndroidSubmissionMutationVariables = Exact<{
   archiveSource?: InputMaybe<SubmissionArchiveSourceInput>;
 }>;
 
-
-export type CreateAndroidSubmissionMutation = { __typename?: 'RootMutation', submission: { __typename?: 'SubmissionMutation', createAndroidSubmission: { __typename?: 'CreateSubmissionResult', submission: { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null } } } };
+export type CreateAndroidSubmissionMutation = {
+  __typename?: 'RootMutation';
+  submission: {
+    __typename?: 'SubmissionMutation';
+    createAndroidSubmission: {
+      __typename?: 'CreateSubmissionResult';
+      submission: {
+        __typename?: 'Submission';
+        id: string;
+        status: SubmissionStatus;
+        platform: AppPlatform;
+        logsUrl?: string | null;
+        app: {
+          __typename?: 'App';
+          id: string;
+          name: string;
+          slug: string;
+          ownerAccount: { __typename?: 'Account'; id: string; name: string };
+        };
+        androidConfig?: {
+          __typename?: 'AndroidSubmissionConfig';
+          applicationIdentifier?: string | null;
+          track: SubmissionAndroidTrack;
+          releaseStatus?: SubmissionAndroidReleaseStatus | null;
+        } | null;
+        iosConfig?: {
+          __typename?: 'IosSubmissionConfig';
+          ascAppIdentifier: string;
+          appleIdUsername?: string | null;
+        } | null;
+        error?: {
+          __typename?: 'SubmissionError';
+          errorCode?: string | null;
+          message?: string | null;
+        } | null;
+      };
+    };
+  };
+};
 
 export type CreateIosSubmissionMutationVariables = Exact<{
   appId: Scalars['ID'];
@@ -5903,52 +8435,166 @@ export type CreateIosSubmissionMutationVariables = Exact<{
   archiveSource?: InputMaybe<SubmissionArchiveSourceInput>;
 }>;
 
-
-export type CreateIosSubmissionMutation = { __typename?: 'RootMutation', submission: { __typename?: 'SubmissionMutation', createIosSubmission: { __typename?: 'CreateSubmissionResult', submission: { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null } } } };
+export type CreateIosSubmissionMutation = {
+  __typename?: 'RootMutation';
+  submission: {
+    __typename?: 'SubmissionMutation';
+    createIosSubmission: {
+      __typename?: 'CreateSubmissionResult';
+      submission: {
+        __typename?: 'Submission';
+        id: string;
+        status: SubmissionStatus;
+        platform: AppPlatform;
+        logsUrl?: string | null;
+        app: {
+          __typename?: 'App';
+          id: string;
+          name: string;
+          slug: string;
+          ownerAccount: { __typename?: 'Account'; id: string; name: string };
+        };
+        androidConfig?: {
+          __typename?: 'AndroidSubmissionConfig';
+          applicationIdentifier?: string | null;
+          track: SubmissionAndroidTrack;
+          releaseStatus?: SubmissionAndroidReleaseStatus | null;
+        } | null;
+        iosConfig?: {
+          __typename?: 'IosSubmissionConfig';
+          ascAppIdentifier: string;
+          appleIdUsername?: string | null;
+        } | null;
+        error?: {
+          __typename?: 'SubmissionError';
+          errorCode?: string | null;
+          message?: string | null;
+        } | null;
+      };
+    };
+  };
+};
 
 export type CreateUploadSessionMutationVariables = Exact<{
   type: UploadSessionType;
 }>;
 
-
-export type CreateUploadSessionMutation = { __typename?: 'RootMutation', uploadSession: { __typename?: 'UploadSession', createUploadSession: any } };
+export type CreateUploadSessionMutation = {
+  __typename?: 'RootMutation';
+  uploadSession: { __typename?: 'UploadSession'; createUploadSession: any };
+};
 
 export type CreateWebhookMutationVariables = Exact<{
   appId: Scalars['String'];
   webhookInput: WebhookInput;
 }>;
 
-
-export type CreateWebhookMutation = { __typename?: 'RootMutation', webhook: { __typename?: 'WebhookMutation', createWebhook: { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any } } };
+export type CreateWebhookMutation = {
+  __typename?: 'RootMutation';
+  webhook: {
+    __typename?: 'WebhookMutation';
+    createWebhook: {
+      __typename?: 'Webhook';
+      id: string;
+      event: WebhookType;
+      url: string;
+      createdAt: any;
+      updatedAt: any;
+    };
+  };
+};
 
 export type UpdateWebhookMutationVariables = Exact<{
   webhookId: Scalars['ID'];
   webhookInput: WebhookInput;
 }>;
 
-
-export type UpdateWebhookMutation = { __typename?: 'RootMutation', webhook: { __typename?: 'WebhookMutation', updateWebhook: { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any } } };
+export type UpdateWebhookMutation = {
+  __typename?: 'RootMutation';
+  webhook: {
+    __typename?: 'WebhookMutation';
+    updateWebhook: {
+      __typename?: 'Webhook';
+      id: string;
+      event: WebhookType;
+      url: string;
+      createdAt: any;
+      updatedAt: any;
+    };
+  };
+};
 
 export type DeleteWebhookMutationVariables = Exact<{
   webhookId: Scalars['ID'];
 }>;
 
-
-export type DeleteWebhookMutation = { __typename?: 'RootMutation', webhook: { __typename?: 'WebhookMutation', deleteWebhook: { __typename?: 'DeleteWebhookResult', id: string } } };
+export type DeleteWebhookMutation = {
+  __typename?: 'RootMutation';
+  webhook: {
+    __typename?: 'WebhookMutation';
+    deleteWebhook: { __typename?: 'DeleteWebhookResult'; id: string };
+  };
+};
 
 export type AppByIdQueryVariables = Exact<{
   appId: Scalars['String'];
 }>;
 
-
-export type AppByIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } } } };
+export type AppByIdQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      fullName: string;
+      slug: string;
+      ownerAccount: {
+        __typename?: 'Account';
+        id: string;
+        name: string;
+        users: {
+          __typename?: 'UserPermission';
+          role: Role;
+          actor:
+            | { __typename?: 'Robot'; id: string }
+            | { __typename?: 'SSOUser'; id: string }
+            | { __typename?: 'User'; id: string };
+        }[];
+      };
+    };
+  };
+};
 
 export type AppByFullNameQueryVariables = Exact<{
   fullName: Scalars['String'];
 }>;
 
-
-export type AppByFullNameQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } } } };
+export type AppByFullNameQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byFullName: {
+      __typename?: 'App';
+      id: string;
+      fullName: string;
+      slug: string;
+      ownerAccount: {
+        __typename?: 'Account';
+        id: string;
+        name: string;
+        users: {
+          __typename?: 'UserPermission';
+          role: Role;
+          actor:
+            | { __typename?: 'Robot'; id: string }
+            | { __typename?: 'SSOUser'; id: string }
+            | { __typename?: 'User'; id: string };
+        }[];
+      };
+    };
+  };
+};
 
 export type LatestAppVersionQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5956,16 +8602,39 @@ export type LatestAppVersionQueryVariables = Exact<{
   applicationIdentifier: Scalars['String'];
 }>;
 
-
-export type LatestAppVersionQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, latestAppVersionByPlatformAndApplicationIdentifier?: { __typename?: 'AppVersion', id: string, storeVersion: string, buildVersion: string } | null } } };
+export type LatestAppVersionQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      latestAppVersionByPlatformAndApplicationIdentifier?: {
+        __typename?: 'AppVersion';
+        id: string;
+        storeVersion: string;
+        buildVersion: string;
+      } | null;
+    };
+  };
+};
 
 export type ViewBranchQueryVariables = Exact<{
   appId: Scalars['String'];
   name: Scalars['String'];
 }>;
 
-
-export type ViewBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, name: string } | null } } };
+export type ViewBranchQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      updateBranchByName?: { __typename?: 'UpdateBranch'; id: string; name: string } | null;
+    };
+  };
+};
 
 export type BranchesByAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5973,8 +8642,46 @@ export type BranchesByAppQueryVariables = Exact<{
   offset: Scalars['Int'];
 }>;
 
-
-export type BranchesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> }> } } };
+export type BranchesByAppQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      updateBranches: {
+        __typename?: 'UpdateBranch';
+        id: string;
+        name: string;
+        updates: {
+          __typename?: 'Update';
+          id: string;
+          group: string;
+          message?: string | null;
+          createdAt: any;
+          runtimeVersion: string;
+          platform: string;
+          manifestFragment: string;
+          isRollBackToEmbedded: boolean;
+          manifestPermalink: string;
+          gitCommitHash?: string | null;
+          actor?:
+            | { __typename: 'Robot'; firstName?: string | null; id: string }
+            | { __typename: 'SSOUser'; id: string }
+            | { __typename: 'User'; username: string; id: string }
+            | null;
+          branch: { __typename?: 'UpdateBranch'; id: string; name: string };
+          codeSigningInfo?: {
+            __typename?: 'CodeSigningInfo';
+            keyid: string;
+            sig: string;
+            alg: string;
+          } | null;
+        }[];
+      }[];
+    };
+  };
+};
 
 export type ViewBranchesOnUpdateChannelQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5983,22 +8690,208 @@ export type ViewBranchesOnUpdateChannelQueryVariables = Exact<{
   limit: Scalars['Int'];
 }>;
 
-
-export type ViewBranchesOnUpdateChannelQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> } | null } } };
+export type ViewBranchesOnUpdateChannelQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      updateChannelByName?: {
+        __typename?: 'UpdateChannel';
+        id: string;
+        updateBranches: {
+          __typename?: 'UpdateBranch';
+          id: string;
+          name: string;
+          updateGroups: {
+            __typename?: 'Update';
+            id: string;
+            group: string;
+            message?: string | null;
+            createdAt: any;
+            runtimeVersion: string;
+            platform: string;
+            manifestFragment: string;
+            isRollBackToEmbedded: boolean;
+            manifestPermalink: string;
+            gitCommitHash?: string | null;
+            actor?:
+              | { __typename: 'Robot'; firstName?: string | null; id: string }
+              | { __typename: 'SSOUser'; id: string }
+              | { __typename: 'User'; username: string; id: string }
+              | null;
+            branch: { __typename?: 'UpdateBranch'; id: string; name: string };
+            codeSigningInfo?: {
+              __typename?: 'CodeSigningInfo';
+              keyid: string;
+              sig: string;
+              alg: string;
+            } | null;
+          }[][];
+        }[];
+      } | null;
+    };
+  };
+};
 
 export type BuildsByIdQueryVariables = Exact<{
   buildId: Scalars['ID'];
 }>;
 
-
-export type BuildsByIdQuery = { __typename?: 'RootQuery', builds: { __typename?: 'BuildQuery', byId: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, resourceClass: BuildResourceClass, expirationDate?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
+export type BuildsByIdQuery = {
+  __typename?: 'RootQuery';
+  builds: {
+    __typename?: 'BuildQuery';
+    byId: {
+      __typename?: 'Build';
+      id: string;
+      status: BuildStatus;
+      platform: AppPlatform;
+      channel?: string | null;
+      releaseChannel?: string | null;
+      distribution?: DistributionType | null;
+      iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
+      buildProfile?: string | null;
+      sdkVersion?: string | null;
+      appVersion?: string | null;
+      appBuildVersion?: string | null;
+      runtimeVersion?: string | null;
+      gitCommitHash?: string | null;
+      gitCommitMessage?: string | null;
+      initialQueuePosition?: number | null;
+      queuePosition?: number | null;
+      estimatedWaitTimeLeftSeconds?: number | null;
+      priority: BuildPriority;
+      createdAt: any;
+      updatedAt: any;
+      message?: string | null;
+      completedAt?: any | null;
+      resourceClass: BuildResourceClass;
+      expirationDate?: any | null;
+      error?: {
+        __typename?: 'BuildError';
+        errorCode: string;
+        message: string;
+        docsUrl?: string | null;
+      } | null;
+      artifacts?: {
+        __typename?: 'BuildArtifacts';
+        buildUrl?: string | null;
+        xcodeBuildLogsUrl?: string | null;
+        applicationArchiveUrl?: string | null;
+      } | null;
+      initiatingActor?:
+        | { __typename: 'Robot'; id: string; displayName: string }
+        | { __typename: 'SSOUser'; id: string; displayName: string }
+        | { __typename: 'User'; id: string; displayName: string }
+        | null;
+      project:
+        | {
+            __typename: 'App';
+            id: string;
+            name: string;
+            slug: string;
+            ownerAccount: { __typename?: 'Account'; id: string; name: string };
+          }
+        | { __typename: 'Snack'; id: string; name: string; slug: string };
+    };
+  };
+};
 
 export type BuildsWithSubmissionsByIdQueryVariables = Exact<{
   buildId: Scalars['ID'];
 }>;
 
-
-export type BuildsWithSubmissionsByIdQuery = { __typename?: 'RootQuery', builds: { __typename?: 'BuildQuery', byId: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, resourceClass: BuildResourceClass, expirationDate?: any | null, submissions: Array<{ __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null }>, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
+export type BuildsWithSubmissionsByIdQuery = {
+  __typename?: 'RootQuery';
+  builds: {
+    __typename?: 'BuildQuery';
+    byId: {
+      __typename?: 'Build';
+      id: string;
+      status: BuildStatus;
+      platform: AppPlatform;
+      channel?: string | null;
+      releaseChannel?: string | null;
+      distribution?: DistributionType | null;
+      iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
+      buildProfile?: string | null;
+      sdkVersion?: string | null;
+      appVersion?: string | null;
+      appBuildVersion?: string | null;
+      runtimeVersion?: string | null;
+      gitCommitHash?: string | null;
+      gitCommitMessage?: string | null;
+      initialQueuePosition?: number | null;
+      queuePosition?: number | null;
+      estimatedWaitTimeLeftSeconds?: number | null;
+      priority: BuildPriority;
+      createdAt: any;
+      updatedAt: any;
+      message?: string | null;
+      completedAt?: any | null;
+      resourceClass: BuildResourceClass;
+      expirationDate?: any | null;
+      submissions: {
+        __typename?: 'Submission';
+        id: string;
+        status: SubmissionStatus;
+        platform: AppPlatform;
+        logsUrl?: string | null;
+        app: {
+          __typename?: 'App';
+          id: string;
+          name: string;
+          slug: string;
+          ownerAccount: { __typename?: 'Account'; id: string; name: string };
+        };
+        androidConfig?: {
+          __typename?: 'AndroidSubmissionConfig';
+          applicationIdentifier?: string | null;
+          track: SubmissionAndroidTrack;
+          releaseStatus?: SubmissionAndroidReleaseStatus | null;
+        } | null;
+        iosConfig?: {
+          __typename?: 'IosSubmissionConfig';
+          ascAppIdentifier: string;
+          appleIdUsername?: string | null;
+        } | null;
+        error?: {
+          __typename?: 'SubmissionError';
+          errorCode?: string | null;
+          message?: string | null;
+        } | null;
+      }[];
+      error?: {
+        __typename?: 'BuildError';
+        errorCode: string;
+        message: string;
+        docsUrl?: string | null;
+      } | null;
+      artifacts?: {
+        __typename?: 'BuildArtifacts';
+        buildUrl?: string | null;
+        xcodeBuildLogsUrl?: string | null;
+        applicationArchiveUrl?: string | null;
+      } | null;
+      initiatingActor?:
+        | { __typename: 'Robot'; id: string; displayName: string }
+        | { __typename: 'SSOUser'; id: string; displayName: string }
+        | { __typename: 'User'; id: string; displayName: string }
+        | null;
+      project:
+        | {
+            __typename: 'App';
+            id: string;
+            name: string;
+            slug: string;
+            ownerAccount: { __typename?: 'Account'; id: string; name: string };
+          }
+        | { __typename: 'Snack'; id: string; name: string; slug: string };
+    };
+  };
+};
 
 export type ViewBuildsOnAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -6007,16 +8900,122 @@ export type ViewBuildsOnAppQueryVariables = Exact<{
   filter?: InputMaybe<BuildFilter>;
 }>;
 
-
-export type ViewBuildsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, builds: Array<{ __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, resourceClass: BuildResourceClass, expirationDate?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }> } } };
+export type ViewBuildsOnAppQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      builds: {
+        __typename?: 'Build';
+        id: string;
+        status: BuildStatus;
+        platform: AppPlatform;
+        channel?: string | null;
+        releaseChannel?: string | null;
+        distribution?: DistributionType | null;
+        iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
+        buildProfile?: string | null;
+        sdkVersion?: string | null;
+        appVersion?: string | null;
+        appBuildVersion?: string | null;
+        runtimeVersion?: string | null;
+        gitCommitHash?: string | null;
+        gitCommitMessage?: string | null;
+        initialQueuePosition?: number | null;
+        queuePosition?: number | null;
+        estimatedWaitTimeLeftSeconds?: number | null;
+        priority: BuildPriority;
+        createdAt: any;
+        updatedAt: any;
+        message?: string | null;
+        completedAt?: any | null;
+        resourceClass: BuildResourceClass;
+        expirationDate?: any | null;
+        error?: {
+          __typename?: 'BuildError';
+          errorCode: string;
+          message: string;
+          docsUrl?: string | null;
+        } | null;
+        artifacts?: {
+          __typename?: 'BuildArtifacts';
+          buildUrl?: string | null;
+          xcodeBuildLogsUrl?: string | null;
+          applicationArchiveUrl?: string | null;
+        } | null;
+        initiatingActor?:
+          | { __typename: 'Robot'; id: string; displayName: string }
+          | { __typename: 'SSOUser'; id: string; displayName: string }
+          | { __typename: 'User'; id: string; displayName: string }
+          | null;
+        project:
+          | {
+              __typename: 'App';
+              id: string;
+              name: string;
+              slug: string;
+              ownerAccount: { __typename?: 'Account'; id: string; name: string };
+            }
+          | { __typename: 'Snack'; id: string; name: string; slug: string };
+      }[];
+    };
+  };
+};
 
 export type ViewUpdateChannelOnAppQueryVariables = Exact<{
   appId: Scalars['String'];
   channelName: Scalars['String'];
 }>;
 
-
-export type ViewUpdateChannelOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> } | null } } };
+export type ViewUpdateChannelOnAppQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      updateChannelByName?: {
+        __typename?: 'UpdateChannel';
+        id: string;
+        name: string;
+        createdAt: any;
+        branchMapping: string;
+        updateBranches: {
+          __typename?: 'UpdateBranch';
+          id: string;
+          name: string;
+          updateGroups: {
+            __typename?: 'Update';
+            id: string;
+            group: string;
+            message?: string | null;
+            createdAt: any;
+            runtimeVersion: string;
+            platform: string;
+            manifestFragment: string;
+            isRollBackToEmbedded: boolean;
+            manifestPermalink: string;
+            gitCommitHash?: string | null;
+            actor?:
+              | { __typename: 'Robot'; firstName?: string | null; id: string }
+              | { __typename: 'SSOUser'; id: string }
+              | { __typename: 'User'; username: string; id: string }
+              | null;
+            branch: { __typename?: 'UpdateBranch'; id: string; name: string };
+            codeSigningInfo?: {
+              __typename?: 'CodeSigningInfo';
+              keyid: string;
+              sig: string;
+              alg: string;
+            } | null;
+          }[][];
+        }[];
+      } | null;
+    };
+  };
+};
 
 export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -6024,43 +9023,179 @@ export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
   limit: Scalars['Int'];
 }>;
 
-
-export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> }> } } };
+export type ViewUpdateChannelsOnAppQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      updateChannels: {
+        __typename?: 'UpdateChannel';
+        id: string;
+        name: string;
+        branchMapping: string;
+        updateBranches: {
+          __typename?: 'UpdateBranch';
+          id: string;
+          name: string;
+          updateGroups: {
+            __typename?: 'Update';
+            id: string;
+            group: string;
+            message?: string | null;
+            createdAt: any;
+            runtimeVersion: string;
+            platform: string;
+            manifestFragment: string;
+            isRollBackToEmbedded: boolean;
+            manifestPermalink: string;
+            gitCommitHash?: string | null;
+            actor?:
+              | { __typename: 'Robot'; firstName?: string | null; id: string }
+              | { __typename: 'SSOUser'; id: string }
+              | { __typename: 'User'; username: string; id: string }
+              | null;
+            branch: { __typename?: 'UpdateBranch'; id: string; name: string };
+            codeSigningInfo?: {
+              __typename?: 'CodeSigningInfo';
+              keyid: string;
+              sig: string;
+              alg: string;
+            } | null;
+          }[][];
+        }[];
+      }[];
+    };
+  };
+};
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String'];
 }>;
 
-
-export type EnvironmentSecretsByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, ownerAccount: { __typename?: 'Account', id: string, environmentSecrets: Array<{ __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any }> }, environmentSecrets: Array<{ __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any }> } } };
+export type EnvironmentSecretsByAppIdQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      ownerAccount: {
+        __typename?: 'Account';
+        id: string;
+        environmentSecrets: {
+          __typename?: 'EnvironmentSecret';
+          id: string;
+          name: string;
+          type: EnvironmentSecretType;
+          createdAt: any;
+        }[];
+      };
+      environmentSecrets: {
+        __typename?: 'EnvironmentSecret';
+        id: string;
+        name: string;
+        type: EnvironmentSecretType;
+        createdAt: any;
+      }[];
+    };
+  };
+};
 
 export type GetAssetMetadataQueryVariables = Exact<{
-  storageKeys: Array<Scalars['String']> | Scalars['String'];
+  storageKeys: Scalars['String'][] | Scalars['String'];
 }>;
 
-
-export type GetAssetMetadataQuery = { __typename?: 'RootQuery', asset: { __typename?: 'AssetQuery', metadata: Array<{ __typename?: 'AssetMetadataResult', storageKey: string, status: AssetMetadataStatus }> } };
+export type GetAssetMetadataQuery = {
+  __typename?: 'RootQuery';
+  asset: {
+    __typename?: 'AssetQuery';
+    metadata: {
+      __typename?: 'AssetMetadataResult';
+      storageKey: string;
+      status: AssetMetadataStatus;
+    }[];
+  };
+};
 
 export type GetAssetLimitPerUpdateGroupForAppQueryVariables = Exact<{
   appId: Scalars['String'];
 }>;
 
-
-export type GetAssetLimitPerUpdateGroupForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, assetLimitPerUpdateGroup: number } } };
+export type GetAssetLimitPerUpdateGroupForAppQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: { __typename?: 'App'; id: string; assetLimitPerUpdateGroup: number };
+  };
+};
 
 export type StatuspageServiceByServiceNamesQueryVariables = Exact<{
-  serviceNames: Array<StatuspageServiceName> | StatuspageServiceName;
+  serviceNames: StatuspageServiceName[] | StatuspageServiceName;
 }>;
 
-
-export type StatuspageServiceByServiceNamesQuery = { __typename?: 'RootQuery', statuspageService: { __typename?: 'StatuspageServiceQuery', byServiceNames: Array<{ __typename?: 'StatuspageService', id: string, name: StatuspageServiceName, status: StatuspageServiceStatus, incidents: Array<{ __typename?: 'StatuspageIncident', id: string, status: StatuspageIncidentStatus, name: string, impact: StatuspageIncidentImpact, shortlink: string }> }> } };
+export type StatuspageServiceByServiceNamesQuery = {
+  __typename?: 'RootQuery';
+  statuspageService: {
+    __typename?: 'StatuspageServiceQuery';
+    byServiceNames: {
+      __typename?: 'StatuspageService';
+      id: string;
+      name: StatuspageServiceName;
+      status: StatuspageServiceStatus;
+      incidents: {
+        __typename?: 'StatuspageIncident';
+        id: string;
+        status: StatuspageIncidentStatus;
+        name: string;
+        impact: StatuspageIncidentImpact;
+        shortlink: string;
+      }[];
+    }[];
+  };
+};
 
 export type SubmissionsByIdQueryVariables = Exact<{
   submissionId: Scalars['ID'];
 }>;
 
-
-export type SubmissionsByIdQuery = { __typename?: 'RootQuery', submissions: { __typename?: 'SubmissionQuery', byId: { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null } } };
+export type SubmissionsByIdQuery = {
+  __typename?: 'RootQuery';
+  submissions: {
+    __typename?: 'SubmissionQuery';
+    byId: {
+      __typename?: 'Submission';
+      id: string;
+      status: SubmissionStatus;
+      platform: AppPlatform;
+      logsUrl?: string | null;
+      app: {
+        __typename?: 'App';
+        id: string;
+        name: string;
+        slug: string;
+        ownerAccount: { __typename?: 'Account'; id: string; name: string };
+      };
+      androidConfig?: {
+        __typename?: 'AndroidSubmissionConfig';
+        applicationIdentifier?: string | null;
+        track: SubmissionAndroidTrack;
+        releaseStatus?: SubmissionAndroidReleaseStatus | null;
+      } | null;
+      iosConfig?: {
+        __typename?: 'IosSubmissionConfig';
+        ascAppIdentifier: string;
+        appleIdUsername?: string | null;
+      } | null;
+      error?: {
+        __typename?: 'SubmissionError';
+        errorCode?: string | null;
+        message?: string | null;
+      } | null;
+    };
+  };
+};
 
 export type GetAllSubmissionsForAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -6070,15 +9205,79 @@ export type GetAllSubmissionsForAppQueryVariables = Exact<{
   platform?: InputMaybe<AppPlatform>;
 }>;
 
-
-export type GetAllSubmissionsForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, submissions: Array<{ __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null }> } } };
+export type GetAllSubmissionsForAppQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      submissions: {
+        __typename?: 'Submission';
+        id: string;
+        status: SubmissionStatus;
+        platform: AppPlatform;
+        logsUrl?: string | null;
+        app: {
+          __typename?: 'App';
+          id: string;
+          name: string;
+          slug: string;
+          ownerAccount: { __typename?: 'Account'; id: string; name: string };
+        };
+        androidConfig?: {
+          __typename?: 'AndroidSubmissionConfig';
+          applicationIdentifier?: string | null;
+          track: SubmissionAndroidTrack;
+          releaseStatus?: SubmissionAndroidReleaseStatus | null;
+        } | null;
+        iosConfig?: {
+          __typename?: 'IosSubmissionConfig';
+          ascAppIdentifier: string;
+          appleIdUsername?: string | null;
+        } | null;
+        error?: {
+          __typename?: 'SubmissionError';
+          errorCode?: string | null;
+          message?: string | null;
+        } | null;
+      }[];
+    };
+  };
+};
 
 export type ViewUpdatesByGroupQueryVariables = Exact<{
   groupId: Scalars['ID'];
 }>;
 
-
-export type ViewUpdatesByGroupQuery = { __typename?: 'RootQuery', updatesByGroup: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
+export type ViewUpdatesByGroupQuery = {
+  __typename?: 'RootQuery';
+  updatesByGroup: {
+    __typename?: 'Update';
+    id: string;
+    group: string;
+    message?: string | null;
+    createdAt: any;
+    runtimeVersion: string;
+    platform: string;
+    manifestFragment: string;
+    isRollBackToEmbedded: boolean;
+    manifestPermalink: string;
+    gitCommitHash?: string | null;
+    actor?:
+      | { __typename: 'Robot'; firstName?: string | null; id: string }
+      | { __typename: 'SSOUser'; id: string }
+      | { __typename: 'User'; username: string; id: string }
+      | null;
+    branch: { __typename?: 'UpdateBranch'; id: string; name: string };
+    codeSigningInfo?: {
+      __typename?: 'CodeSigningInfo';
+      keyid: string;
+      sig: string;
+      alg: string;
+    } | null;
+  }[];
+};
 
 export type ViewUpdateGroupsOnBranchQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -6088,8 +9287,45 @@ export type ViewUpdateGroupsOnBranchQueryVariables = Exact<{
   filter?: InputMaybe<UpdatesFilter>;
 }>;
 
-
-export type ViewUpdateGroupsOnBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> } | null } } };
+export type ViewUpdateGroupsOnBranchQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      updateBranchByName?: {
+        __typename?: 'UpdateBranch';
+        id: string;
+        updateGroups: {
+          __typename?: 'Update';
+          id: string;
+          group: string;
+          message?: string | null;
+          createdAt: any;
+          runtimeVersion: string;
+          platform: string;
+          manifestFragment: string;
+          isRollBackToEmbedded: boolean;
+          manifestPermalink: string;
+          gitCommitHash?: string | null;
+          actor?:
+            | { __typename: 'Robot'; firstName?: string | null; id: string }
+            | { __typename: 'SSOUser'; id: string }
+            | { __typename: 'User'; username: string; id: string }
+            | null;
+          branch: { __typename?: 'UpdateBranch'; id: string; name: string };
+          codeSigningInfo?: {
+            __typename?: 'CodeSigningInfo';
+            keyid: string;
+            sig: string;
+            alg: string;
+          } | null;
+        }[][];
+      } | null;
+    };
+  };
+};
 
 export type ViewUpdateGroupsOnAppQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -6098,79 +9334,1099 @@ export type ViewUpdateGroupsOnAppQueryVariables = Exact<{
   filter?: InputMaybe<UpdatesFilter>;
 }>;
 
+export type ViewUpdateGroupsOnAppQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      updateGroups: {
+        __typename?: 'Update';
+        id: string;
+        group: string;
+        message?: string | null;
+        createdAt: any;
+        runtimeVersion: string;
+        platform: string;
+        manifestFragment: string;
+        isRollBackToEmbedded: boolean;
+        manifestPermalink: string;
+        gitCommitHash?: string | null;
+        actor?:
+          | { __typename: 'Robot'; firstName?: string | null; id: string }
+          | { __typename: 'SSOUser'; id: string }
+          | { __typename: 'User'; username: string; id: string }
+          | null;
+        branch: { __typename?: 'UpdateBranch'; id: string; name: string };
+        codeSigningInfo?: {
+          __typename?: 'CodeSigningInfo';
+          keyid: string;
+          sig: string;
+          alg: string;
+        } | null;
+      }[][];
+    };
+  };
+};
 
-export type ViewUpdateGroupsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> } } };
+export type CurrentUserQueryVariables = Exact<{ [key: string]: never }>;
 
-export type CurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type CurrentUserQuery = { __typename?: 'RootQuery', meActor?: { __typename: 'Robot', firstName?: string | null, id: string, featureGates: any, isExpoAdmin: boolean, accounts: Array<{ __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | { __typename: 'SSOUser', username: string, id: string, featureGates: any, isExpoAdmin: boolean, accounts: Array<{ __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | { __typename: 'User', username: string, id: string, featureGates: any, isExpoAdmin: boolean, primaryAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, accounts: Array<{ __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | null };
+export type CurrentUserQuery = {
+  __typename?: 'RootQuery';
+  meActor?:
+    | {
+        __typename: 'Robot';
+        firstName?: string | null;
+        id: string;
+        featureGates: any;
+        isExpoAdmin: boolean;
+        accounts: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        }[];
+      }
+    | {
+        __typename: 'SSOUser';
+        username: string;
+        id: string;
+        featureGates: any;
+        isExpoAdmin: boolean;
+        accounts: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        }[];
+      }
+    | {
+        __typename: 'User';
+        username: string;
+        id: string;
+        featureGates: any;
+        isExpoAdmin: boolean;
+        primaryAccount: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        };
+        accounts: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        }[];
+      }
+    | null;
+};
 
 export type WebhooksByAppIdQueryVariables = Exact<{
   appId: Scalars['String'];
   webhookFilter?: InputMaybe<WebhookFilter>;
 }>;
 
-
-export type WebhooksByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, webhooks: Array<{ __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any }> } } };
+export type WebhooksByAppIdQuery = {
+  __typename?: 'RootQuery';
+  app: {
+    __typename?: 'AppQuery';
+    byId: {
+      __typename?: 'App';
+      id: string;
+      webhooks: {
+        __typename?: 'Webhook';
+        id: string;
+        event: WebhookType;
+        url: string;
+        createdAt: any;
+        updatedAt: any;
+      }[];
+    };
+  };
+};
 
 export type WebhookByIdQueryVariables = Exact<{
   webhookId: Scalars['ID'];
 }>;
 
+export type WebhookByIdQuery = {
+  __typename?: 'RootQuery';
+  webhook: {
+    __typename?: 'WebhookQuery';
+    byId: {
+      __typename?: 'Webhook';
+      id: string;
+      event: WebhookType;
+      url: string;
+      createdAt: any;
+      updatedAt: any;
+    };
+  };
+};
 
-export type WebhookByIdQuery = { __typename?: 'RootQuery', webhook: { __typename?: 'WebhookQuery', byId: { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any } } };
+export type AccountFragment = {
+  __typename?: 'Account';
+  id: string;
+  name: string;
+  users: {
+    __typename?: 'UserPermission';
+    role: Role;
+    actor:
+      | { __typename?: 'Robot'; id: string }
+      | { __typename?: 'SSOUser'; id: string }
+      | { __typename?: 'User'; id: string };
+  }[];
+};
 
-export type AccountFragment = { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> };
+export type AppFragment = {
+  __typename?: 'App';
+  id: string;
+  fullName: string;
+  slug: string;
+  ownerAccount: {
+    __typename?: 'Account';
+    id: string;
+    name: string;
+    users: {
+      __typename?: 'UserPermission';
+      role: Role;
+      actor:
+        | { __typename?: 'Robot'; id: string }
+        | { __typename?: 'SSOUser'; id: string }
+        | { __typename?: 'User'; id: string };
+    }[];
+  };
+};
 
-export type AppFragment = { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } };
+export type BuildFragment = {
+  __typename?: 'Build';
+  id: string;
+  status: BuildStatus;
+  platform: AppPlatform;
+  channel?: string | null;
+  releaseChannel?: string | null;
+  distribution?: DistributionType | null;
+  iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
+  buildProfile?: string | null;
+  sdkVersion?: string | null;
+  appVersion?: string | null;
+  appBuildVersion?: string | null;
+  runtimeVersion?: string | null;
+  gitCommitHash?: string | null;
+  gitCommitMessage?: string | null;
+  initialQueuePosition?: number | null;
+  queuePosition?: number | null;
+  estimatedWaitTimeLeftSeconds?: number | null;
+  priority: BuildPriority;
+  createdAt: any;
+  updatedAt: any;
+  message?: string | null;
+  completedAt?: any | null;
+  resourceClass: BuildResourceClass;
+  expirationDate?: any | null;
+  error?: {
+    __typename?: 'BuildError';
+    errorCode: string;
+    message: string;
+    docsUrl?: string | null;
+  } | null;
+  artifacts?: {
+    __typename?: 'BuildArtifacts';
+    buildUrl?: string | null;
+    xcodeBuildLogsUrl?: string | null;
+    applicationArchiveUrl?: string | null;
+  } | null;
+  initiatingActor?:
+    | { __typename: 'Robot'; id: string; displayName: string }
+    | { __typename: 'SSOUser'; id: string; displayName: string }
+    | { __typename: 'User'; id: string; displayName: string }
+    | null;
+  project:
+    | {
+        __typename: 'App';
+        id: string;
+        name: string;
+        slug: string;
+        ownerAccount: { __typename?: 'Account'; id: string; name: string };
+      }
+    | { __typename: 'Snack'; id: string; name: string; slug: string };
+};
 
-export type BuildFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, resourceClass: BuildResourceClass, expirationDate?: any | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } };
+export type BuildWithSubmissionsFragment = {
+  __typename?: 'Build';
+  id: string;
+  status: BuildStatus;
+  platform: AppPlatform;
+  channel?: string | null;
+  releaseChannel?: string | null;
+  distribution?: DistributionType | null;
+  iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
+  buildProfile?: string | null;
+  sdkVersion?: string | null;
+  appVersion?: string | null;
+  appBuildVersion?: string | null;
+  runtimeVersion?: string | null;
+  gitCommitHash?: string | null;
+  gitCommitMessage?: string | null;
+  initialQueuePosition?: number | null;
+  queuePosition?: number | null;
+  estimatedWaitTimeLeftSeconds?: number | null;
+  priority: BuildPriority;
+  createdAt: any;
+  updatedAt: any;
+  message?: string | null;
+  completedAt?: any | null;
+  resourceClass: BuildResourceClass;
+  expirationDate?: any | null;
+  submissions: {
+    __typename?: 'Submission';
+    id: string;
+    status: SubmissionStatus;
+    platform: AppPlatform;
+    logsUrl?: string | null;
+    app: {
+      __typename?: 'App';
+      id: string;
+      name: string;
+      slug: string;
+      ownerAccount: { __typename?: 'Account'; id: string; name: string };
+    };
+    androidConfig?: {
+      __typename?: 'AndroidSubmissionConfig';
+      applicationIdentifier?: string | null;
+      track: SubmissionAndroidTrack;
+      releaseStatus?: SubmissionAndroidReleaseStatus | null;
+    } | null;
+    iosConfig?: {
+      __typename?: 'IosSubmissionConfig';
+      ascAppIdentifier: string;
+      appleIdUsername?: string | null;
+    } | null;
+    error?: {
+      __typename?: 'SubmissionError';
+      errorCode?: string | null;
+      message?: string | null;
+    } | null;
+  }[];
+  error?: {
+    __typename?: 'BuildError';
+    errorCode: string;
+    message: string;
+    docsUrl?: string | null;
+  } | null;
+  artifacts?: {
+    __typename?: 'BuildArtifacts';
+    buildUrl?: string | null;
+    xcodeBuildLogsUrl?: string | null;
+    applicationArchiveUrl?: string | null;
+  } | null;
+  initiatingActor?:
+    | { __typename: 'Robot'; id: string; displayName: string }
+    | { __typename: 'SSOUser'; id: string; displayName: string }
+    | { __typename: 'User'; id: string; displayName: string }
+    | null;
+  project:
+    | {
+        __typename: 'App';
+        id: string;
+        name: string;
+        slug: string;
+        ownerAccount: { __typename?: 'Account'; id: string; name: string };
+      }
+    | { __typename: 'Snack'; id: string; name: string; slug: string };
+};
 
-export type BuildWithSubmissionsFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, releaseChannel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, resourceClass: BuildResourceClass, expirationDate?: any | null, submissions: Array<{ __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null }>, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } };
+export type EnvironmentSecretFragment = {
+  __typename?: 'EnvironmentSecret';
+  id: string;
+  name: string;
+  type: EnvironmentSecretType;
+  createdAt: any;
+};
 
-export type EnvironmentSecretFragment = { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any };
+export type StatuspageServiceFragment = {
+  __typename?: 'StatuspageService';
+  id: string;
+  name: StatuspageServiceName;
+  status: StatuspageServiceStatus;
+  incidents: {
+    __typename?: 'StatuspageIncident';
+    id: string;
+    status: StatuspageIncidentStatus;
+    name: string;
+    impact: StatuspageIncidentImpact;
+    shortlink: string;
+  }[];
+};
 
-export type StatuspageServiceFragment = { __typename?: 'StatuspageService', id: string, name: StatuspageServiceName, status: StatuspageServiceStatus, incidents: Array<{ __typename?: 'StatuspageIncident', id: string, status: StatuspageIncidentStatus, name: string, impact: StatuspageIncidentImpact, shortlink: string }> };
+export type SubmissionFragment = {
+  __typename?: 'Submission';
+  id: string;
+  status: SubmissionStatus;
+  platform: AppPlatform;
+  logsUrl?: string | null;
+  app: {
+    __typename?: 'App';
+    id: string;
+    name: string;
+    slug: string;
+    ownerAccount: { __typename?: 'Account'; id: string; name: string };
+  };
+  androidConfig?: {
+    __typename?: 'AndroidSubmissionConfig';
+    applicationIdentifier?: string | null;
+    track: SubmissionAndroidTrack;
+    releaseStatus?: SubmissionAndroidReleaseStatus | null;
+  } | null;
+  iosConfig?: {
+    __typename?: 'IosSubmissionConfig';
+    ascAppIdentifier: string;
+    appleIdUsername?: string | null;
+  } | null;
+  error?: {
+    __typename?: 'SubmissionError';
+    errorCode?: string | null;
+    message?: string | null;
+  } | null;
+};
 
-export type SubmissionFragment = { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null };
+export type UpdateFragment = {
+  __typename?: 'Update';
+  id: string;
+  group: string;
+  message?: string | null;
+  createdAt: any;
+  runtimeVersion: string;
+  platform: string;
+  manifestFragment: string;
+  isRollBackToEmbedded: boolean;
+  manifestPermalink: string;
+  gitCommitHash?: string | null;
+  actor?:
+    | { __typename: 'Robot'; firstName?: string | null; id: string }
+    | { __typename: 'SSOUser'; id: string }
+    | { __typename: 'User'; username: string; id: string }
+    | null;
+  branch: { __typename?: 'UpdateBranch'; id: string; name: string };
+  codeSigningInfo?: {
+    __typename?: 'CodeSigningInfo';
+    keyid: string;
+    sig: string;
+    alg: string;
+  } | null;
+};
 
-export type UpdateFragment = { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null };
+export type UpdateBranchFragment = {
+  __typename?: 'UpdateBranch';
+  id: string;
+  name: string;
+  updates: {
+    __typename?: 'Update';
+    id: string;
+    group: string;
+    message?: string | null;
+    createdAt: any;
+    runtimeVersion: string;
+    platform: string;
+    manifestFragment: string;
+    isRollBackToEmbedded: boolean;
+    manifestPermalink: string;
+    gitCommitHash?: string | null;
+    actor?:
+      | { __typename: 'Robot'; firstName?: string | null; id: string }
+      | { __typename: 'SSOUser'; id: string }
+      | { __typename: 'User'; username: string; id: string }
+      | null;
+    branch: { __typename?: 'UpdateBranch'; id: string; name: string };
+    codeSigningInfo?: {
+      __typename?: 'CodeSigningInfo';
+      keyid: string;
+      sig: string;
+      alg: string;
+    } | null;
+  }[];
+};
 
-export type UpdateBranchFragment = { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
+export type WebhookFragment = {
+  __typename?: 'Webhook';
+  id: string;
+  event: WebhookType;
+  url: string;
+  createdAt: any;
+  updatedAt: any;
+};
 
-export type WebhookFragment = { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any };
+export type AndroidAppBuildCredentialsFragment = {
+  __typename?: 'AndroidAppBuildCredentials';
+  id: string;
+  isDefault: boolean;
+  isLegacy: boolean;
+  name: string;
+  androidKeystore?: {
+    __typename?: 'AndroidKeystore';
+    id: string;
+    type: AndroidKeystoreType;
+    keystore: string;
+    keystorePassword: string;
+    keyAlias: string;
+    keyPassword?: string | null;
+    md5CertificateFingerprint?: string | null;
+    sha1CertificateFingerprint?: string | null;
+    sha256CertificateFingerprint?: string | null;
+    createdAt: any;
+    updatedAt: any;
+  } | null;
+};
 
-export type AndroidAppBuildCredentialsFragment = { __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null };
+export type CommonAndroidAppCredentialsFragment = {
+  __typename?: 'AndroidAppCredentials';
+  id: string;
+  applicationIdentifier?: string | null;
+  isLegacy: boolean;
+  app: {
+    __typename?: 'App';
+    id: string;
+    fullName: string;
+    slug: string;
+    ownerAccount: {
+      __typename?: 'Account';
+      id: string;
+      name: string;
+      users: {
+        __typename?: 'UserPermission';
+        role: Role;
+        actor:
+          | { __typename?: 'Robot'; id: string }
+          | { __typename?: 'SSOUser'; id: string }
+          | { __typename?: 'User'; id: string };
+      }[];
+    };
+  };
+  androidFcm?: {
+    __typename?: 'AndroidFcm';
+    id: string;
+    credential: any;
+    version: AndroidFcmVersion;
+    createdAt: any;
+    updatedAt: any;
+    snippet:
+      | { __typename?: 'FcmSnippetLegacy'; firstFourCharacters: string; lastFourCharacters: string }
+      | {
+          __typename?: 'FcmSnippetV1';
+          projectId: string;
+          keyId: string;
+          serviceAccountEmail: string;
+          clientId?: string | null;
+        };
+  } | null;
+  googleServiceAccountKeyForSubmissions?: {
+    __typename?: 'GoogleServiceAccountKey';
+    id: string;
+    projectIdentifier: string;
+    privateKeyIdentifier: string;
+    clientEmail: string;
+    clientIdentifier: string;
+    createdAt: any;
+    updatedAt: any;
+  } | null;
+  androidAppBuildCredentialsList: {
+    __typename?: 'AndroidAppBuildCredentials';
+    id: string;
+    isDefault: boolean;
+    isLegacy: boolean;
+    name: string;
+    androidKeystore?: {
+      __typename?: 'AndroidKeystore';
+      id: string;
+      type: AndroidKeystoreType;
+      keystore: string;
+      keystorePassword: string;
+      keyAlias: string;
+      keyPassword?: string | null;
+      md5CertificateFingerprint?: string | null;
+      sha1CertificateFingerprint?: string | null;
+      sha256CertificateFingerprint?: string | null;
+      createdAt: any;
+      updatedAt: any;
+    } | null;
+  }[];
+};
 
-export type CommonAndroidAppCredentialsFragment = { __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> };
+export type AndroidFcmFragment = {
+  __typename?: 'AndroidFcm';
+  id: string;
+  credential: any;
+  version: AndroidFcmVersion;
+  createdAt: any;
+  updatedAt: any;
+  snippet:
+    | { __typename?: 'FcmSnippetLegacy'; firstFourCharacters: string; lastFourCharacters: string }
+    | {
+        __typename?: 'FcmSnippetV1';
+        projectId: string;
+        keyId: string;
+        serviceAccountEmail: string;
+        clientId?: string | null;
+      };
+};
 
-export type AndroidFcmFragment = { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } };
+export type AndroidKeystoreFragment = {
+  __typename?: 'AndroidKeystore';
+  id: string;
+  type: AndroidKeystoreType;
+  keystore: string;
+  keystorePassword: string;
+  keyAlias: string;
+  keyPassword?: string | null;
+  md5CertificateFingerprint?: string | null;
+  sha1CertificateFingerprint?: string | null;
+  sha256CertificateFingerprint?: string | null;
+  createdAt: any;
+  updatedAt: any;
+};
 
-export type AndroidKeystoreFragment = { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any };
+export type AppStoreConnectApiKeyFragment = {
+  __typename?: 'AppStoreConnectApiKey';
+  id: string;
+  issuerIdentifier: string;
+  keyIdentifier: string;
+  name?: string | null;
+  roles?: AppStoreConnectUserRole[] | null;
+  createdAt: any;
+  updatedAt: any;
+  appleTeam?: {
+    __typename?: 'AppleTeam';
+    id: string;
+    appleTeamIdentifier: string;
+    appleTeamName?: string | null;
+  } | null;
+};
 
-export type AppStoreConnectApiKeyFragment = { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null };
+export type AppleAppIdentifierFragment = {
+  __typename?: 'AppleAppIdentifier';
+  id: string;
+  bundleIdentifier: string;
+};
 
-export type AppleAppIdentifierFragment = { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string };
+export type AppleDeviceFragment = {
+  __typename?: 'AppleDevice';
+  id: string;
+  identifier: string;
+  name?: string | null;
+  model?: string | null;
+  deviceClass?: AppleDeviceClass | null;
+};
 
-export type AppleDeviceFragment = { __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null };
+export type AppleDeviceRegistrationRequestFragment = {
+  __typename?: 'AppleDeviceRegistrationRequest';
+  id: string;
+};
 
-export type AppleDeviceRegistrationRequestFragment = { __typename?: 'AppleDeviceRegistrationRequest', id: string };
+export type AppleDistributionCertificateFragment = {
+  __typename?: 'AppleDistributionCertificate';
+  id: string;
+  certificateP12?: string | null;
+  certificatePassword?: string | null;
+  serialNumber: string;
+  developerPortalIdentifier?: string | null;
+  validityNotBefore: any;
+  validityNotAfter: any;
+  updatedAt: any;
+  appleTeam?: {
+    __typename?: 'AppleTeam';
+    id: string;
+    appleTeamIdentifier: string;
+    appleTeamName?: string | null;
+  } | null;
+  iosAppBuildCredentialsList: {
+    __typename?: 'IosAppBuildCredentials';
+    id: string;
+    iosAppCredentials: {
+      __typename?: 'IosAppCredentials';
+      id: string;
+      app: {
+        __typename?: 'App';
+        id: string;
+        fullName: string;
+        slug: string;
+        ownerAccount: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        };
+      };
+      appleAppIdentifier: {
+        __typename?: 'AppleAppIdentifier';
+        id: string;
+        bundleIdentifier: string;
+      };
+    };
+    provisioningProfile?: {
+      __typename?: 'AppleProvisioningProfile';
+      id: string;
+      developerPortalIdentifier?: string | null;
+    } | null;
+  }[];
+};
 
-export type AppleDistributionCertificateFragment = { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> };
+export type AppleProvisioningProfileFragment = {
+  __typename?: 'AppleProvisioningProfile';
+  id: string;
+  expiration: any;
+  developerPortalIdentifier?: string | null;
+  provisioningProfile?: string | null;
+  updatedAt: any;
+  status: string;
+  appleTeam?: {
+    __typename?: 'AppleTeam';
+    id: string;
+    appleTeamIdentifier: string;
+    appleTeamName?: string | null;
+  } | null;
+  appleDevices: {
+    __typename?: 'AppleDevice';
+    id: string;
+    identifier: string;
+    name?: string | null;
+    model?: string | null;
+    deviceClass?: AppleDeviceClass | null;
+  }[];
+};
 
-export type AppleProvisioningProfileFragment = { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> };
+export type AppleProvisioningProfileIdentifiersFragment = {
+  __typename?: 'AppleProvisioningProfile';
+  id: string;
+  developerPortalIdentifier?: string | null;
+};
 
-export type AppleProvisioningProfileIdentifiersFragment = { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null };
+export type ApplePushKeyFragment = {
+  __typename?: 'ApplePushKey';
+  id: string;
+  keyIdentifier: string;
+  updatedAt: any;
+  appleTeam?: {
+    __typename?: 'AppleTeam';
+    id: string;
+    appleTeamIdentifier: string;
+    appleTeamName?: string | null;
+  } | null;
+  iosAppCredentialsList: {
+    __typename?: 'IosAppCredentials';
+    id: string;
+    app: {
+      __typename?: 'App';
+      id: string;
+      fullName: string;
+      slug: string;
+      ownerAccount: {
+        __typename?: 'Account';
+        id: string;
+        name: string;
+        users: {
+          __typename?: 'UserPermission';
+          role: Role;
+          actor:
+            | { __typename?: 'Robot'; id: string }
+            | { __typename?: 'SSOUser'; id: string }
+            | { __typename?: 'User'; id: string };
+        }[];
+      };
+    };
+    appleAppIdentifier: { __typename?: 'AppleAppIdentifier'; id: string; bundleIdentifier: string };
+  }[];
+};
 
-export type ApplePushKeyFragment = { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> };
+export type AppleTeamFragment = {
+  __typename?: 'AppleTeam';
+  id: string;
+  appleTeamIdentifier: string;
+  appleTeamName?: string | null;
+};
 
-export type AppleTeamFragment = { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null };
+export type GoogleServiceAccountKeyFragment = {
+  __typename?: 'GoogleServiceAccountKey';
+  id: string;
+  projectIdentifier: string;
+  privateKeyIdentifier: string;
+  clientEmail: string;
+  clientIdentifier: string;
+  createdAt: any;
+  updatedAt: any;
+};
 
-export type GoogleServiceAccountKeyFragment = { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any };
+export type IosAppBuildCredentialsFragment = {
+  __typename?: 'IosAppBuildCredentials';
+  id: string;
+  iosDistributionType: IosDistributionType;
+  distributionCertificate?: {
+    __typename?: 'AppleDistributionCertificate';
+    id: string;
+    certificateP12?: string | null;
+    certificatePassword?: string | null;
+    serialNumber: string;
+    developerPortalIdentifier?: string | null;
+    validityNotBefore: any;
+    validityNotAfter: any;
+    updatedAt: any;
+    appleTeam?: {
+      __typename?: 'AppleTeam';
+      id: string;
+      appleTeamIdentifier: string;
+      appleTeamName?: string | null;
+    } | null;
+    iosAppBuildCredentialsList: {
+      __typename?: 'IosAppBuildCredentials';
+      id: string;
+      iosAppCredentials: {
+        __typename?: 'IosAppCredentials';
+        id: string;
+        app: {
+          __typename?: 'App';
+          id: string;
+          fullName: string;
+          slug: string;
+          ownerAccount: {
+            __typename?: 'Account';
+            id: string;
+            name: string;
+            users: {
+              __typename?: 'UserPermission';
+              role: Role;
+              actor:
+                | { __typename?: 'Robot'; id: string }
+                | { __typename?: 'SSOUser'; id: string }
+                | { __typename?: 'User'; id: string };
+            }[];
+          };
+        };
+        appleAppIdentifier: {
+          __typename?: 'AppleAppIdentifier';
+          id: string;
+          bundleIdentifier: string;
+        };
+      };
+      provisioningProfile?: {
+        __typename?: 'AppleProvisioningProfile';
+        id: string;
+        developerPortalIdentifier?: string | null;
+      } | null;
+    }[];
+  } | null;
+  provisioningProfile?: {
+    __typename?: 'AppleProvisioningProfile';
+    id: string;
+    expiration: any;
+    developerPortalIdentifier?: string | null;
+    provisioningProfile?: string | null;
+    updatedAt: any;
+    status: string;
+    appleTeam?: {
+      __typename?: 'AppleTeam';
+      id: string;
+      appleTeamIdentifier: string;
+      appleTeamName?: string | null;
+    } | null;
+    appleDevices: {
+      __typename?: 'AppleDevice';
+      id: string;
+      identifier: string;
+      name?: string | null;
+      model?: string | null;
+      deviceClass?: AppleDeviceClass | null;
+    }[];
+  } | null;
+};
 
-export type IosAppBuildCredentialsFragment = { __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null };
+export type CommonIosAppCredentialsWithoutBuildCredentialsFragment = {
+  __typename?: 'IosAppCredentials';
+  id: string;
+  app: {
+    __typename?: 'App';
+    id: string;
+    fullName: string;
+    slug: string;
+    ownerAccount: {
+      __typename?: 'Account';
+      id: string;
+      name: string;
+      users: {
+        __typename?: 'UserPermission';
+        role: Role;
+        actor:
+          | { __typename?: 'Robot'; id: string }
+          | { __typename?: 'SSOUser'; id: string }
+          | { __typename?: 'User'; id: string };
+      }[];
+    };
+  };
+  appleTeam?: {
+    __typename?: 'AppleTeam';
+    id: string;
+    appleTeamIdentifier: string;
+    appleTeamName?: string | null;
+  } | null;
+  appleAppIdentifier: { __typename?: 'AppleAppIdentifier'; id: string; bundleIdentifier: string };
+  pushKey?: {
+    __typename?: 'ApplePushKey';
+    id: string;
+    keyIdentifier: string;
+    updatedAt: any;
+    appleTeam?: {
+      __typename?: 'AppleTeam';
+      id: string;
+      appleTeamIdentifier: string;
+      appleTeamName?: string | null;
+    } | null;
+    iosAppCredentialsList: {
+      __typename?: 'IosAppCredentials';
+      id: string;
+      app: {
+        __typename?: 'App';
+        id: string;
+        fullName: string;
+        slug: string;
+        ownerAccount: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        };
+      };
+      appleAppIdentifier: {
+        __typename?: 'AppleAppIdentifier';
+        id: string;
+        bundleIdentifier: string;
+      };
+    }[];
+  } | null;
+  appStoreConnectApiKeyForSubmissions?: {
+    __typename?: 'AppStoreConnectApiKey';
+    id: string;
+    issuerIdentifier: string;
+    keyIdentifier: string;
+    name?: string | null;
+    roles?: AppStoreConnectUserRole[] | null;
+    createdAt: any;
+    updatedAt: any;
+    appleTeam?: {
+      __typename?: 'AppleTeam';
+      id: string;
+      appleTeamIdentifier: string;
+      appleTeamName?: string | null;
+    } | null;
+  } | null;
+};
 
-export type CommonIosAppCredentialsWithoutBuildCredentialsFragment = { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null };
-
-export type CommonIosAppCredentialsFragment = { __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null }> } | null }>, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null };
+export type CommonIosAppCredentialsFragment = {
+  __typename?: 'IosAppCredentials';
+  id: string;
+  iosAppBuildCredentialsList: {
+    __typename?: 'IosAppBuildCredentials';
+    id: string;
+    iosDistributionType: IosDistributionType;
+    distributionCertificate?: {
+      __typename?: 'AppleDistributionCertificate';
+      id: string;
+      certificateP12?: string | null;
+      certificatePassword?: string | null;
+      serialNumber: string;
+      developerPortalIdentifier?: string | null;
+      validityNotBefore: any;
+      validityNotAfter: any;
+      updatedAt: any;
+      appleTeam?: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      } | null;
+      iosAppBuildCredentialsList: {
+        __typename?: 'IosAppBuildCredentials';
+        id: string;
+        iosAppCredentials: {
+          __typename?: 'IosAppCredentials';
+          id: string;
+          app: {
+            __typename?: 'App';
+            id: string;
+            fullName: string;
+            slug: string;
+            ownerAccount: {
+              __typename?: 'Account';
+              id: string;
+              name: string;
+              users: {
+                __typename?: 'UserPermission';
+                role: Role;
+                actor:
+                  | { __typename?: 'Robot'; id: string }
+                  | { __typename?: 'SSOUser'; id: string }
+                  | { __typename?: 'User'; id: string };
+              }[];
+            };
+          };
+          appleAppIdentifier: {
+            __typename?: 'AppleAppIdentifier';
+            id: string;
+            bundleIdentifier: string;
+          };
+        };
+        provisioningProfile?: {
+          __typename?: 'AppleProvisioningProfile';
+          id: string;
+          developerPortalIdentifier?: string | null;
+        } | null;
+      }[];
+    } | null;
+    provisioningProfile?: {
+      __typename?: 'AppleProvisioningProfile';
+      id: string;
+      expiration: any;
+      developerPortalIdentifier?: string | null;
+      provisioningProfile?: string | null;
+      updatedAt: any;
+      status: string;
+      appleTeam?: {
+        __typename?: 'AppleTeam';
+        id: string;
+        appleTeamIdentifier: string;
+        appleTeamName?: string | null;
+      } | null;
+      appleDevices: {
+        __typename?: 'AppleDevice';
+        id: string;
+        identifier: string;
+        name?: string | null;
+        model?: string | null;
+        deviceClass?: AppleDeviceClass | null;
+      }[];
+    } | null;
+  }[];
+  app: {
+    __typename?: 'App';
+    id: string;
+    fullName: string;
+    slug: string;
+    ownerAccount: {
+      __typename?: 'Account';
+      id: string;
+      name: string;
+      users: {
+        __typename?: 'UserPermission';
+        role: Role;
+        actor:
+          | { __typename?: 'Robot'; id: string }
+          | { __typename?: 'SSOUser'; id: string }
+          | { __typename?: 'User'; id: string };
+      }[];
+    };
+  };
+  appleTeam?: {
+    __typename?: 'AppleTeam';
+    id: string;
+    appleTeamIdentifier: string;
+    appleTeamName?: string | null;
+  } | null;
+  appleAppIdentifier: { __typename?: 'AppleAppIdentifier'; id: string; bundleIdentifier: string };
+  pushKey?: {
+    __typename?: 'ApplePushKey';
+    id: string;
+    keyIdentifier: string;
+    updatedAt: any;
+    appleTeam?: {
+      __typename?: 'AppleTeam';
+      id: string;
+      appleTeamIdentifier: string;
+      appleTeamName?: string | null;
+    } | null;
+    iosAppCredentialsList: {
+      __typename?: 'IosAppCredentials';
+      id: string;
+      app: {
+        __typename?: 'App';
+        id: string;
+        fullName: string;
+        slug: string;
+        ownerAccount: {
+          __typename?: 'Account';
+          id: string;
+          name: string;
+          users: {
+            __typename?: 'UserPermission';
+            role: Role;
+            actor:
+              | { __typename?: 'Robot'; id: string }
+              | { __typename?: 'SSOUser'; id: string }
+              | { __typename?: 'User'; id: string };
+          }[];
+        };
+      };
+      appleAppIdentifier: {
+        __typename?: 'AppleAppIdentifier';
+        id: string;
+        bundleIdentifier: string;
+      };
+    }[];
+  } | null;
+  appStoreConnectApiKeyForSubmissions?: {
+    __typename?: 'AppStoreConnectApiKey';
+    id: string;
+    issuerIdentifier: string;
+    keyIdentifier: string;
+    name?: string | null;
+    roles?: AppStoreConnectUserRole[] | null;
+    createdAt: any;
+    updatedAt: any;
+    appleTeam?: {
+      __typename?: 'AppleTeam';
+      id: string;
+      appleTeamIdentifier: string;
+      appleTeamName?: string | null;
+    } | null;
+  } | null;
+};

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -759,6 +759,8 @@ export type AndroidAppCredentialsMutation = {
   __typename?: 'AndroidAppCredentialsMutation';
   /** Create a set of credentials for an Android app */
   createAndroidAppCredentials: AndroidAppCredentials;
+  /** Delete a set of credentials for an Android app */
+  deleteAndroidAppCredentials: DeleteAndroidAppCredentialsResult;
   /** Set the FCM push key to be used in an Android app */
   setFcm: AndroidAppCredentials;
   /** Set the Google Service Account Key to be used for submitting an Android app */
@@ -770,6 +772,11 @@ export type AndroidAppCredentialsMutationCreateAndroidAppCredentialsArgs = {
   androidAppCredentialsInput: AndroidAppCredentialsInput;
   appId: Scalars['ID'];
   applicationIdentifier: Scalars['String'];
+};
+
+
+export type AndroidAppCredentialsMutationDeleteAndroidAppCredentialsArgs = {
+  id: Scalars['ID'];
 };
 
 
@@ -2594,6 +2601,11 @@ export type DeleteAccountSsoConfigurationResult = {
   id: Scalars['ID'];
 };
 
+export type DeleteAndroidAppCredentialsResult = {
+  __typename?: 'DeleteAndroidAppCredentialsResult';
+  id: Scalars['ID'];
+};
+
 export type DeleteAndroidKeystoreResult = {
   __typename?: 'DeleteAndroidKeystoreResult';
   id: Scalars['ID'];
@@ -3390,16 +3402,6 @@ export type IosAppCredentialsMutationSetPushKeyArgs = {
   pushKeyId: Scalars['ID'];
 };
 
-export type IosAppCredentialsQuery = {
-  __typename?: 'IosAppCredentialsQuery';
-  byId: IosAppCredentials;
-};
-
-
-export type IosAppCredentialsQueryByIdArgs = {
-  iosAppCredentialsId: Scalars['ID'];
-};
-
 /** @deprecated Use developmentClient option instead. */
 export enum IosBuildType {
   DevelopmentClient = 'DEVELOPMENT_CLIENT',
@@ -4131,8 +4133,6 @@ export type RootQuery = {
   githubApp: GitHubAppQuery;
   /** Top-level query object for querying Stripe Invoices. */
   invoice: InvoiceQuery;
-  /** Top-level query object for querying IosAppCredentials. */
-  iosAppCredentials: IosAppCredentialsQuery;
   /**
    * If authenticated as a typical end user, this is the appropriate top-level
    * query object

--- a/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
@@ -1,7 +1,7 @@
 import { instance, mock } from 'ts-mockito';
 
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
-import { Runtime, UpdateBranch, UpdateChannel } from '../../graphql/generated';
+import { App, Runtime, UpdateBranch, UpdateChannel } from '../../graphql/generated';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
 import { getBranchNameFromChannelNameAsync } from '../getBranchNameFromChannelNameAsync';
 
@@ -149,6 +149,7 @@ function mockUpdateBranches(branchNames: string[]): UpdateBranch[] {
           },
           codeSigningInfo: null,
           __typename: 'Update' as const,
+          app: {} as App,
         },
       ],
     ],


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Adding new build status `PENDING_CANCEL` which is supposed to give workers time to perform cleanup and upload logs when the build is canceled before the worker gets terminated by the launcher. This status is only relevant to EAS and from the user's perspective builds in this status should be treated the same as the ones that are already canceled. This PRs adds support for that

# How

In all the places where the behaviour is dictated by the build status a change is introduced to mirror the behaviour for canceled builds.

# Test Plan

Manually tested with modified response from `www` returning a build in `PENDING_CANCEL` status ⬇️ 
<img width="1050" alt="Screenshot 2023-05-24 at 14 01 34" src="https://github.com/expo/eas-cli/assets/2974455/bf06c580-1dbe-4290-868b-ce7c99782b1b">
Build `9ae0d32f-9ed5-4eb8-a396-bfbbd4ca95e7` is actually `PENDING_CANCEL` but is displayed as `CANCELED`

Testing with the version of CLI from main shows the build as in `unknown` status, which seems indicative for this change to not be breaking
<img width="1050" alt="Screenshot 2023-05-24 at 14 12 16" src="https://github.com/expo/eas-cli/assets/2974455/6e864d47-cf6b-41a4-926e-7ee6a41f17f3">
