### PR TITLE
print graphql error message

### DIFF
--- a/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
+++ b/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
@@ -416,7 +416,7 @@ describe(Build.name, () => {
           const graphQLError = getGraphQLError('Error 1', 'UNKNOWN_GRAPHQL_ERROR');
           const graphQLErrors = [graphQLError];
           const error = new CombinedError({ graphQLErrors });
-          const expectedMessage = EXPECTED_GENERIC_MESSAGE + `\nRequest ID: ${mockRequestId}`;
+          const expectedMessage = `${EXPECTED_GENERIC_MESSAGE}\nRequest ID: ${mockRequestId}\nError message: Error 1`;
 
           const handleBuildRequestErrorThrownError = getError<Error>(() => {
             handleBuildRequestError(error, platform);
@@ -431,16 +431,13 @@ describe(Build.name, () => {
             delete graphQLError.extensions.requestId;
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
+            const expectedMessage = `${EXPECTED_GENERIC_MESSAGE}\nError message: Error 1`;
 
             const handleBuildRequestErrorThrownError = getError<Error>(() => {
               handleBuildRequestError(error, platform);
             });
 
-            assertReThrownError(
-              handleBuildRequestErrorThrownError,
-              Error,
-              EXPECTED_GENERIC_MESSAGE
-            );
+            assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
           });
         });
       });
@@ -450,7 +447,7 @@ describe(Build.name, () => {
           const graphQLError = getGraphQLError('Error 1', 'UNKNOWN_GRAPHQL_ERROR');
           const graphQLErrors = [graphQLError];
           const error = new CombinedError({ graphQLErrors });
-          const expectedMessage = EXPECTED_GENERIC_MESSAGE + `\nRequest ID: ${mockRequestId}`;
+          const expectedMessage = `${EXPECTED_GENERIC_MESSAGE}\nRequest ID: ${mockRequestId}\nError message: Error 1`;
 
           const handleBuildRequestErrorThrownError = getError<Error>(() => {
             handleBuildRequestError(error, platform);
@@ -465,16 +462,13 @@ describe(Build.name, () => {
             delete graphQLError.extensions.requestId;
             const graphQLErrors = [graphQLError];
             const error = new CombinedError({ graphQLErrors });
+            const expectedMessage = `${EXPECTED_GENERIC_MESSAGE}\nError message: Error 1`;
 
             const handleBuildRequestErrorThrownError = getError<Error>(() => {
               handleBuildRequestError(error, platform);
             });
 
-            assertReThrownError(
-              handleBuildRequestErrorThrownError,
-              Error,
-              EXPECTED_GENERIC_MESSAGE
-            );
+            assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
           });
         });
       });

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -205,12 +205,15 @@ export function handleBuildRequestError(error: any, platform: Platform): never {
       `You have already reached the maximum number of pending ${requestedPlatformDisplayNames[platform]} builds for your account. Try again later.`
     );
   } else if (error?.graphQLErrors) {
-    const requestIdLine = error?.graphQLErrors?.[0]?.extensions?.requestId
-      ? `\nRequest ID: ${error.graphQLErrors[0].extensions.requestId}`
+    const graphQLError = error.graphQLErrors[0];
+    const requestIdLine = graphQLError?.extensions?.requestId
+      ? `\nRequest ID: ${graphQLError.extensions.requestId}`
+      : '';
+    const originalErrorMessage = graphQLError?.message
+      ? `\nError message: ${graphQLError.message}`
       : '';
     throw new Error(
-      'Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.' +
-        requestIdLine
+      `Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.${requestIdLine}${originalErrorMessage}`
     );
   }
   throw error;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Follow-up to https://github.com/expo/eas-cli/pull/1813
In the case where users hit errors that are not listed in `SERVER_SIDE_DEFINED_ERRORS`, we don't print any information besides the request ID. Sometimes, the GraphQL error includes a meaningful error.

Could be related to the problem reported by Brent: https://exponent-internal.slack.com/archives/C02123T524U/p1685136530740159

Also, today I came across an issue where I was logged in as a user that didn't have access to build a project. I didn't get any hints on what I can do.

# How

Unhide GraphQL error message.

# Test Plan

<img width="1138" alt="Screenshot 2023-05-29 at 11 10 05" src="https://github.com/expo/eas-cli/assets/5256730/8b276936-faf5-403f-af18-a784f3effda1">
