### PR TITLE
[ENG-8790][eas-cli] Fix updates synchronization of native files to include strings.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Show original GraphQL error message in case of an unexpected error. ([#1862](https://github.com/expo/eas-cli/pull/1862) by [@dsokal](https://github.com/dsokal))
+- Fix updates synchronization of native files to include strings.xml for bare projects. ([#1865](https://github.com/expo/eas-cli/pull/1865) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -18,8 +18,6 @@ export async function syncUpdatesConfigurationAsync(
   ensureValidVersions(exp, RequestedPlatform.Android);
   const accountName = (await getOwnerAccountForProjectIdAsync(graphqlClient, projectId)).name;
 
-  AndroidConfig.Updates.withUpdates(exp, { expoUsername: null });
-
   // sync AndroidManifest.xml
   const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
   const androidManifest = await getAndroidManifestAsync(projectDir);

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -1,11 +1,14 @@
 import { ExpoConfig } from '@expo/config';
-import { AndroidConfig, AndroidManifest } from '@expo/config-plugins';
+import { AndroidConfig, AndroidManifest, XML } from '@expo/config-plugins';
 
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { RequestedPlatform } from '../../platform';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { ensureValidVersions } from '../utils';
 
+/**
+ * Synchronize updates configuration to native files. This needs to do essentially the same thing as `withUpdates`
+ */
 export async function syncUpdatesConfigurationAsync(
   graphqlClient: ExpoGraphqlClient,
   projectDir: string,
@@ -15,9 +18,11 @@ export async function syncUpdatesConfigurationAsync(
   ensureValidVersions(exp, RequestedPlatform.Android);
   const accountName = (await getOwnerAccountForProjectIdAsync(graphqlClient, projectId)).name;
 
+  AndroidConfig.Updates.withUpdates(exp, { expoUsername: null });
+
+  // sync AndroidManifest.xml
   const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
   const androidManifest = await getAndroidManifestAsync(projectDir);
-
   const updatedAndroidManifest = AndroidConfig.Updates.setUpdatesConfig(
     projectDir,
     exp,
@@ -28,6 +33,17 @@ export async function syncUpdatesConfigurationAsync(
     androidManifestPath,
     updatedAndroidManifest
   );
+
+  // sync strings.xml
+  const stringsJSONPath = await AndroidConfig.Strings.getProjectStringsXMLPathAsync(projectDir);
+  const stringsResourceXML = await AndroidConfig.Resources.readResourcesXMLAsync({
+    path: stringsJSONPath,
+  });
+  const updatedStringsResourceXML = AndroidConfig.Updates.applyRuntimeVersionFromConfig(
+    exp,
+    stringsResourceXML
+  );
+  await XML.writeXMLAsync({ path: stringsJSONPath, xml: updatedStringsResourceXML });
 }
 
 export async function readReleaseChannelSafelyAsync(projectDir: string): Promise<string | null> {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://github.com/expo/expo/commit/166385e28b75d11684bacdcace0c4abb92434adb added this to the config plugin.

This code in eas-cli is supposed to emulate the config plugin, but for bare projects.

# How

Make the config plugin emulation also do the new synchronization of strings.xml.

# Test Plan

- npx create expo-app
- npx expo prebuild
- add runtime version to app.json
- install expo-updates
- commit everything 
- eas build (current prod version)
  - it added `<meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"`
  - but there were no changes in strings.xml
- neas build (with this PR)
  - it added `<meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"`
  - it added `<string name="expo_runtime_version">1.0</string>` to strings.xml
