### PR TITLE
[Build] Print friendly error msg in case account doesn't have required permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Print friendly error msg in case account doesn't have required permission. ([#1867](https://github.com/expo/eas-cli/pull/1867) by [@firasrg](https://github.com/firasrg))
+
 ## [3.15.1](https://github.com/expo/eas-cli/releases/tag/v3.15.1) - 2023-07-11
 
 ### 🐛 Bug fixes
@@ -29,7 +31,6 @@ This is the log of notable changes to EAS CLI and related packages.
 - Better bare workflow runtimeVersion error. ([#1910](https://github.com/expo/eas-cli/pull/1910) by [@quinlanj](https://github.com/quinlanj))
 - Fix runtime version print logs. ([#1925](https://github.com/expo/eas-cli/pull/1925) by [@quinlanj](https://github.com/quinlanj))
 - Add info about new `macos-ventura-13.4-xcode-14.3.1` image to `eas.schema.json`. ([#1920](https://github.com/expo/eas-cli/pull/1920) by [@szdziedzic](https://github.com/szdziedzic))
-- Print friendly error msg in case account doesn't have required permission. ([#1867](https://github.com/expo/eas-cli/pull/1867) by [@firasrg](https://github.com/firasrg))
 
 ## [3.15.0](https://github.com/expo/eas-cli/releases/tag/v3.15.0) - 2023-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Better bare workflow runtimeVersion error. ([#1910](https://github.com/expo/eas-cli/pull/1910) by [@quinlanj](https://github.com/quinlanj))
 - Fix runtime version print logs. ([#1925](https://github.com/expo/eas-cli/pull/1925) by [@quinlanj](https://github.com/quinlanj))
 - Add info about new `macos-ventura-13.4-xcode-14.3.1` image to `eas.schema.json`. ([#1920](https://github.com/expo/eas-cli/pull/1920) by [@szdziedzic](https://github.com/szdziedzic))
+- Print friendly error msg in case account doesn't have required permission. ([#1867](https://github.com/expo/eas-cli/pull/1867) by [@firasrg](https://github.com/firasrg))
 
 ## [3.15.0](https://github.com/expo/eas-cli/releases/tag/v3.15.0) - 2023-06-30
 

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -200,7 +200,14 @@ export default abstract class EasCommand extends Command {
           const requestIdLine = graphQLError.extensions?.requestId
             ? `\nRequest ID: ${err.graphQLErrors[0].extensions.requestId}`
             : '';
-          return `${messageLine}${requestIdLine}`;
+
+          const defaultMsg = `${messageLine}${requestIdLine}`;
+
+          if (err?.graphQLErrors?.[0]?.extensions?.errorCode === 'UNAUTHORIZED_ERROR') {
+            return `You don't have the required permissions to perform this operation.\n\n${defaultMsg}`;
+          }
+
+          return defaultMsg;
         })
         .join('\n');
       Log.error(cleanMessage);

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -203,7 +203,7 @@ export default abstract class EasCommand extends Command {
 
           const defaultMsg = `${messageLine}${requestIdLine}`;
 
-          if (err?.graphQLErrors?.[0]?.extensions?.errorCode === 'UNAUTHORIZED_ERROR') {
+          if (graphQLError.extensions?.errorCode === 'UNAUTHORIZED_ERROR') {
             return `You don't have the required permissions to perform this operation.\n\n${defaultMsg}`;
           }
 


### PR DESCRIPTION

# Why
This is very useful when build credentials fails, in case user doesn't have permissions. See https://github.com/expo/expo/issues/22696

# Test Plan
Honestly, I didn't make any tests, except static analysis, as I'm still new to this project, I don't know how I can reproduce [the issue](https://github.com/expo/expo/issues/22696) in my local machine, so please analyse it with me and tell me whether this change is valid, or tell me how to test that out in my local machine where my app is (if it's absolutely required);

I'm very happy to find such opportunity to contribute in Expo

thank you