### PR TITLE
feat(eas-cli): add new public entitlements from wwdc23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Added new bundle identifier capabilities and entitlements from WWDC23. ([#1870](https://github.com/expo/eas-cli/pull/1870) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "1.2.0",
+    "@expo/apple-utils": "1.3.1",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "7.0.3",
     "@expo/config-plugins": "6.0.2",

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -514,6 +514,20 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     getOptions: getDefinedOptions,
   },
   {
+    name: 'Apple Pay Later Merchandising',
+    entitlement: 'com.apple.developer.pay-later-merchandising',
+    capability: CapabilityType.APPLE_PAY_LATER_MERCHANDISING,
+    validateOptions: createValidateStringArrayOptions(['payinfour-merchandising']),
+    getOptions: getDefinedOptions,
+  },
+  {
+    name: 'Sensitive Content Analysis',
+    entitlement: 'com.apple.developer.sensitivecontentanalysis.client',
+    capability: CapabilityType.SENSITIVE_CONTENT_ANALYSIS,
+    validateOptions: createValidateStringArrayOptions(['analysis']),
+    getOptions: getDefinedOptions,
+  },
+  {
     // Not in Xcode
     // https://developer-mdn.apple.com/documentation/devicecheck/preparing_to_use_the_app_attest_service
     // https://developer-mdn.apple.com/documentation/bundleresources/entitlements/com_apple_developer_devicecheck_appattest-environment
@@ -698,6 +712,36 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     validateOptions: validateBooleanOptions,
     getOptions: getBooleanOptions,
   },
+  {
+    entitlement: 'com.apple.developer.shared-with-you.collaboration',
+    name: 'Messages Collaboration',
+    capability: CapabilityType.MESSAGES_COLLABORATION,
+    validateOptions: validateBooleanOptions,
+    getOptions: getBooleanOptions,
+  },
+  {
+    entitlement: 'com.apple.developer.submerged-shallow-depth-and-pressure',
+    name: 'Shallow Depth and Pressure',
+    capability: CapabilityType.SHALLOW_DEPTH_PRESSURE,
+    validateOptions: validateBooleanOptions,
+    getOptions: getBooleanOptions,
+  },
+  {
+    entitlement: 'com.apple.developer.proximity-reader.identity.display',
+    name: 'Tap to Present ID on iPhone (Display Only)',
+    capability: CapabilityType.TAP_TO_DISPLAY_ID,
+    validateOptions: validateBooleanOptions,
+    getOptions: getBooleanOptions,
+  },
+  {
+    entitlement: 'com.apple.developer.matter.allow-setup-payload',
+    name: 'Matter Allow Setup Payload',
+    capability: CapabilityType.MATTER_ALLOW_SETUP_PAYLOAD,
+    validateOptions: validateBooleanOptions,
+    getOptions: getBooleanOptions,
+  },
+
+  // VMNET
 
   // These don't appear to have entitlements, so it's unclear how we can automatically enable / disable them at this time.
   // TODO: Maybe add a warning about manually enabling features?

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,10 +1324,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@expo/apple-utils@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.2.0.tgz#227d118089a4645b076162f3b513dfc68763ca21"
-  integrity sha512-MotvQqu8CNVlnl9nsISobXDjEzSMfT7U5Zk+1rhOFoJhaZhlEkARxumUFUgH6cYnK7J2mMd3YxM+G769arkEKQ==
+"@expo/apple-utils@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.3.1.tgz#99a2627c167af138722af9806a09a35f87115a39"
+  integrity sha512-ADPHXIpTWlt9tIg9yhwyuxQ6UMICWMfHgoCE1v8zzyYsa3BcKvawgkAGApYNxp2IYUKiNMqRYzViEKgq+Svk3w==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

- WWDC 23 update.

# How

- Add the new bundle identifier capabilities from WWDC 23. Only the values there show up on the [dashboard](https://developer.apple.com/account/resources/identifiers/bundleId) are added.
- Updated apple-utils with new version that contains new capabilities.
- Got the entitlement IDs from the new Xcode: Version 15.0 beta (15A5160n)

# Test Plan

- Tested API directly with apple utils.