### PR TITLE
[eas-cli] Changes for SSO user type and SSO login.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Added new bundle identifier capabilities and entitlements from WWDC23. ([#1870](https://github.com/expo/eas-cli/pull/1870) by [@EvanBacon](https://github.com/EvanBacon))
-- Add support for SSO user login. ([#1875](https://github.com/expo/eas-cli/pull/1875) by [@lzkb](https://github.com/lzkb))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-
+- Added support for SSO users. ([#1875](https://github.com/expo/eas-cli/pull/1875) by [@lzkb](https://github.com/lzkb))
 - Added new bundle identifier capabilities and entitlements from WWDC23. ([#1870](https://github.com/expo/eas-cli/pull/1870) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Added new bundle identifier capabilities and entitlements from WWDC23. ([#1870](https://github.com/expo/eas-cli/pull/1870) by [@EvanBacon](https://github.com/EvanBacon))
+- Add support for SSO user login. ([#1875](https://github.com/expo/eas-cli/pull/1875) by [@lzkb](https://github.com/lzkb))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -124,16 +124,13 @@ log in with your Expo account
 
 ```
 USAGE
-  $ eas account:login [--sso]
-
-FLAGS
-  -s, --sso  Log in with SSO
+  $ eas account:login
 
 DESCRIPTION
   log in with your Expo account
 
 ALIASES
-  $ eas login [-s]
+  $ eas login
 ```
 
 _See code: [src/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v3.13.3/packages/eas-cli/src/commands/account/login.ts)_

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -124,13 +124,16 @@ log in with your Expo account
 
 ```
 USAGE
-  $ eas account:login
+  $ eas account:login [--sso]
+
+FLAGS
+  -s, --sso  Log in with SSO
 
 DESCRIPTION
   log in with your Expo account
 
 ALIASES
-  $ eas login
+  $ eas login [-s]
 ```
 
 _See code: [src/commands/account/login.ts](https://github.com/expo/eas-cli/blob/v3.13.3/packages/eas-cli/src/commands/account/login.ts)_
@@ -906,7 +909,10 @@ log in with your Expo account
 
 ```
 USAGE
-  $ eas login
+  $ eas login [--sso]
+
+FLAGS
+  -s, --sso  Log in with SSO
 
 DESCRIPTION
   log in with your Expo account

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -13499,6 +13499,277 @@
       },
       {
         "kind": "OBJECT",
+        "name": "BackgroundJobReceipt",
+        "description": null,
+        "fields": [
+          {
+            "name": "account",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errorCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errorMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resultId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resultType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BackgroundJobResultType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "state",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BackgroundJobState",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tries",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "willRetry",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "BackgroundJobReceiptQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byId",
+            "description": "Look up background job receipt by ID",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceipt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BackgroundJobResultType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "GITHUB_BUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BackgroundJobState",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "FAILURE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IN_PROGRESS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "QUEUED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUCCESS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Billing",
         "description": null,
         "fields": [
@@ -20737,7 +21008,7 @@
         "fields": [
           {
             "name": "createGitHubBuild",
-            "description": "Create a GitHub build for an app",
+            "description": "Create a GitHub build for an app. Returns the ID of the background job receipt. Use BackgroundJobReceiptQuery to get the status of the job.",
             "args": [
               {
                 "name": "buildInput",
@@ -20760,8 +21031,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceipt",
                 "ofType": null
               }
             },
@@ -28731,6 +29002,22 @@
             "deprecationReason": null
           },
           {
+            "name": "backgroundJobReceipt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceiptQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildJobs",
             "description": null,
             "args": [],
@@ -32959,6 +33246,22 @@
         "description": null,
         "fields": [
           {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "appId",
             "description": null,
             "args": [],
@@ -33370,6 +33673,22 @@
         "name": "UpdateChannel",
         "description": null,
         "fields": [
+          {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "appId",
             "description": null,

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -7253,6 +7253,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ChannelFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "first",
                 "description": null,
                 "type": {
@@ -9250,6 +9262,22 @@
         "name": "AppInsights",
         "description": null,
         "fields": [
+          {
+            "name": "hasEventsFromExpoInsightsClientModule",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "totalUniqueUsers",
             "description": null,
@@ -17034,6 +17062,29 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ChannelFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "searchTerm",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -29314,8 +29365,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "apps",
@@ -29524,8 +29575,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "id",
@@ -29552,8 +29603,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "isExpoAdmin",
@@ -29592,8 +29643,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "notificationSubscriptions",
@@ -29730,8 +29781,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "username",
@@ -29785,55 +29836,7 @@
             "deprecationReason": null
           },
           {
-            "name": "githubUsername",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "industry",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "lastName",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "location",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "twitterUsername",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -34413,8 +34416,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "apps",
@@ -34651,8 +34654,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "hasPendingUserInvitations",
@@ -34695,8 +34698,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "isExpoAdmin",
@@ -34728,7 +34731,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "This field no longer exists"
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "isSecondFactorAuthenticationEnabled",
@@ -34767,8 +34770,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "notificationSubscriptions",
@@ -34953,8 +34956,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "username",
@@ -35140,8 +35143,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "apps",
@@ -35350,8 +35353,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "id",
@@ -35378,8 +35381,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "isExpoAdmin",
@@ -35418,8 +35421,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "notificationSubscriptions",
@@ -35556,8 +35559,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "username",
@@ -35682,18 +35685,6 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "appetizeCode",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "email",
             "description": null,
             "type": {
@@ -35730,35 +35721,11 @@
             "deprecationReason": null
           },
           {
-            "name": "githubUsername",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "id",
             "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "ID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "industry",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -35778,31 +35745,7 @@
             "deprecationReason": null
           },
           {
-            "name": "location",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "profilePhoto",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "twitterUsername",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -47,6 +47,7 @@
     "fast-glob": "3.2.12",
     "figures": "3.2.0",
     "form-data": "4.0.0",
+    "freeport-async": "2.0.0",
     "fs-extra": "10.1.0",
     "getenv": "1.0.0",
     "gradle-to-js": "2.0.1",

--- a/packages/eas-cli/src/api.ts
+++ b/packages/eas-cli/src/api.ts
@@ -2,6 +2,7 @@ import { JSONValue } from '@expo/json-file';
 
 import { ApiV2Error } from './ApiV2Error';
 import fetch, { RequestError, RequestInit } from './fetch';
+import { getFreePortAsync } from './utils/port';
 
 interface RequestOptions {
   body: JSONValue;
@@ -103,4 +104,15 @@ export function getEASUpdateURL(projectId: string): string {
   } else {
     return new URL(projectId, `https://u.expo.dev`).href;
   }
+}
+
+export async function getSsoLocalServerPortAsync(): Promise<number> {
+  let startPort: number;
+  if (process.env.SSO_LOCAL_SERVER_PORT) {
+    startPort = parseInt(process.env.SSO_LOCAL_SERVER_PORT, 10);
+  } else {
+    startPort = 19300;
+  }
+  const port = await getFreePortAsync(startPort);
+  return port;
 }

--- a/packages/eas-cli/src/api.ts
+++ b/packages/eas-cli/src/api.ts
@@ -109,7 +109,7 @@ export function getEASUpdateURL(projectId: string): string {
 export async function getSsoLocalServerPortAsync(): Promise<number> {
   let startPort: number;
   if (process.env.SSO_LOCAL_SERVER_PORT) {
-    startPort = parseInt(process.env.SSO_LOCAL_SERVER_PORT, 10);
+    startPort = Number(process.env.SSO_LOCAL_SERVER_PORT);
   } else {
     startPort = 19300;
   }

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -160,12 +160,12 @@ export async function getProjectIdAsync(
     switch (user.__typename) {
       case 'User':
         return user.username;
+      case 'SSOUser':
+        return user.username;
       case 'Robot':
         throw new Error(
           'The "owner" manifest property is required when using robot users. See: https://docs.expo.dev/versions/latest/config/app/#owner'
         );
-      case 'SSOUser':
-        throw new Error('SSO users are not supported yet.');
     }
   };
 

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -1,3 +1,5 @@
+import { Flags } from '@oclif/core';
+
 import EasCommand from '../../commandUtils/EasCommand';
 import Log from '../../log';
 
@@ -5,13 +7,26 @@ export default class AccountLogin extends EasCommand {
   static override description = 'log in with your Expo account';
   static override aliases = ['login'];
 
+  static override flags = {
+    // can pass either --sso or -s
+    sso: Flags.boolean({
+      description: 'Login with SSO',
+      char: 's',
+      default: false,
+    }),
+  };
+
   static override contextDefinition = {
     ...this.ContextOptions.SessionManagment,
   };
 
   async runAsync(): Promise<void> {
+    const {
+      flags: { sso },
+    } = await this.parse(AccountLogin);
+
     const { sessionManager } = await this.getContextAsync(AccountLogin, { nonInteractive: false });
-    await sessionManager.showLoginPromptAsync();
+    await sessionManager.showLoginPromptAsync({}, sso);
     Log.log('Logged in');
   }
 }

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -26,7 +26,7 @@ export default class AccountLogin extends EasCommand {
     } = await this.parse(AccountLogin);
 
     const { sessionManager } = await this.getContextAsync(AccountLogin, { nonInteractive: false });
-    await sessionManager.showLoginPromptAsync({}, sso);
+    await sessionManager.showLoginPromptAsync({ sso });
     Log.log('Logged in');
   }
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1982,6 +1982,43 @@ export enum AuthProtocolType {
   Oidc = 'OIDC'
 }
 
+export type BackgroundJobReceipt = {
+  __typename?: 'BackgroundJobReceipt';
+  account: Account;
+  createdAt: Scalars['DateTime'];
+  errorCode?: Maybe<Scalars['String']>;
+  errorMessage?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  resultId?: Maybe<Scalars['ID']>;
+  resultType: BackgroundJobResultType;
+  state: BackgroundJobState;
+  tries: Scalars['Int'];
+  updatedAt: Scalars['DateTime'];
+  willRetry: Scalars['Boolean'];
+};
+
+export type BackgroundJobReceiptQuery = {
+  __typename?: 'BackgroundJobReceiptQuery';
+  /** Look up background job receipt by ID */
+  byId: BackgroundJobReceipt;
+};
+
+
+export type BackgroundJobReceiptQueryByIdArgs = {
+  id: Scalars['ID'];
+};
+
+export enum BackgroundJobResultType {
+  GithubBuild = 'GITHUB_BUILD'
+}
+
+export enum BackgroundJobState {
+  Failure = 'FAILURE',
+  InProgress = 'IN_PROGRESS',
+  Queued = 'QUEUED',
+  Success = 'SUCCESS'
+}
+
 export type Billing = {
   __typename?: 'Billing';
   /** History of invoices */
@@ -3017,8 +3054,8 @@ export enum GitHubAppInstallationStatus {
 
 export type GitHubAppMutation = {
   __typename?: 'GitHubAppMutation';
-  /** Create a GitHub build for an app */
-  createGitHubBuild: Scalars['Boolean'];
+  /** Create a GitHub build for an app. Returns the ID of the background job receipt. Use BackgroundJobReceiptQuery to get the status of the job. */
+  createGitHubBuild: BackgroundJobReceipt;
 };
 
 
@@ -4128,6 +4165,7 @@ export type RootQuery = {
   /** Top-level query object for querying Apple Teams. */
   appleTeam: AppleTeamQuery;
   asset: AssetQuery;
+  backgroundJobReceipt: BackgroundJobReceiptQuery;
   buildJobs: BuildJobQuery;
   buildOrBuildJob: BuildOrBuildJobQuery;
   /** Top-level query object for querying BuildPublicData publicly. */
@@ -4755,6 +4793,7 @@ export type Update = ActivityTimelineProjectActivity & {
 
 export type UpdateBranch = {
   __typename?: 'UpdateBranch';
+  app: App;
   appId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
@@ -4816,6 +4855,7 @@ export type UpdateBranchMutationPublishUpdateGroupsArgs = {
 
 export type UpdateChannel = {
   __typename?: 'UpdateChannel';
+  app: App;
   appId: Scalars['ID'];
   branchMapping: Scalars['String'];
   createdAt: Scalars['DateTime'];

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1164,6 +1164,7 @@ export type AppBuildsPaginatedArgs = {
 export type AppChannelsPaginatedArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<ChannelFilterInput>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
 };
@@ -1363,6 +1364,7 @@ export type AppInput = {
 
 export type AppInsights = {
   __typename?: 'AppInsights';
+  hasEventsFromExpoInsightsClientModule: Scalars['Boolean'];
   totalUniqueUsers?: Maybe<Scalars['Int']>;
   uniqueUsersByAppVersionOverTime: UniqueUsersOverTimeData;
   uniqueUsersByPlatformOverTime: UniqueUsersOverTimeData;
@@ -2478,6 +2480,10 @@ export type Card = {
   expMonth?: Maybe<Scalars['Int']>;
   expYear?: Maybe<Scalars['Int']>;
   last4?: Maybe<Scalars['String']>;
+};
+
+export type ChannelFilterInput = {
+  searchTerm?: InputMaybe<Scalars['String']>;
 };
 
 export type Charge = {
@@ -4221,6 +4227,7 @@ export type SsoUser = Actor & UserActor & {
   /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int'];
+  /** @deprecated No longer supported */
   appetizeCode?: Maybe<Scalars['String']>;
   /** Apps this user has published. If this user is the viewer, this field returns the apps the user has access to. */
   apps: Array<App>;
@@ -4238,11 +4245,14 @@ export type SsoUser = Actor & UserActor & {
   fullName?: Maybe<Scalars['String']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
+  /** @deprecated No longer supported */
   githubUsername?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
+  /** @deprecated No longer supported */
   industry?: Maybe<Scalars['String']>;
   isExpoAdmin: Scalars['Boolean'];
   lastName?: Maybe<Scalars['String']>;
+  /** @deprecated No longer supported */
   location?: Maybe<Scalars['String']>;
   notificationSubscriptions: Array<NotificationSubscription>;
   /** Associated accounts */
@@ -4250,6 +4260,7 @@ export type SsoUser = Actor & UserActor & {
   profilePhoto: Scalars['String'];
   /** Snacks associated with this account */
   snacks: Array<Snack>;
+  /** @deprecated No longer supported */
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
 };
@@ -4291,11 +4302,7 @@ export type SsoUserSnacksArgs = {
 
 export type SsoUserDataInput = {
   firstName?: InputMaybe<Scalars['String']>;
-  githubUsername?: InputMaybe<Scalars['String']>;
-  industry?: InputMaybe<Scalars['String']>;
   lastName?: InputMaybe<Scalars['String']>;
-  location?: InputMaybe<Scalars['String']>;
-  twitterUsername?: InputMaybe<Scalars['String']>;
 };
 
 export type SsoUserQuery = {
@@ -4960,6 +4967,7 @@ export type User = Actor & UserActor & {
   /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int'];
+  /** @deprecated No longer supported */
   appetizeCode?: Maybe<Scalars['String']>;
   /** Apps this user has published */
   apps: Array<App>;
@@ -4979,16 +4987,19 @@ export type User = Actor & UserActor & {
   fullName?: Maybe<Scalars['String']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
+  /** @deprecated No longer supported */
   githubUsername?: Maybe<Scalars['String']>;
   /** Whether this user has any pending user invitations. Only resolves for the viewer. */
   hasPendingUserInvitations: Scalars['Boolean'];
   id: Scalars['ID'];
+  /** @deprecated No longer supported */
   industry?: Maybe<Scalars['String']>;
   isExpoAdmin: Scalars['Boolean'];
-  /** @deprecated This field no longer exists */
+  /** @deprecated No longer supported */
   isLegacy: Scalars['Boolean'];
   isSecondFactorAuthenticationEnabled: Scalars['Boolean'];
   lastName?: Maybe<Scalars['String']>;
+  /** @deprecated No longer supported */
   location?: Maybe<Scalars['String']>;
   notificationSubscriptions: Array<NotificationSubscription>;
   /** Pending UserInvitations for this user. Only resolves for the viewer. */
@@ -5000,6 +5011,7 @@ export type User = Actor & UserActor & {
   secondFactorDevices: Array<UserSecondFactorDevice>;
   /** Snacks associated with this account */
   snacks: Array<Snack>;
+  /** @deprecated No longer supported */
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
 };
@@ -5050,6 +5062,7 @@ export type UserActor = {
    */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int'];
+  /** @deprecated No longer supported */
   appetizeCode?: Maybe<Scalars['String']>;
   /** Apps this user has published */
   apps: Array<App>;
@@ -5071,11 +5084,14 @@ export type UserActor = {
   fullName?: Maybe<Scalars['String']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
+  /** @deprecated No longer supported */
   githubUsername?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
+  /** @deprecated No longer supported */
   industry?: Maybe<Scalars['String']>;
   isExpoAdmin: Scalars['Boolean'];
   lastName?: Maybe<Scalars['String']>;
+  /** @deprecated No longer supported */
   location?: Maybe<Scalars['String']>;
   notificationSubscriptions: Array<NotificationSubscription>;
   /** Associated accounts */
@@ -5083,6 +5099,7 @@ export type UserActor = {
   profilePhoto: Scalars['String'];
   /** Snacks associated with this user's personal account */
   snacks: Array<Snack>;
+  /** @deprecated No longer supported */
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
 };
@@ -5141,17 +5158,12 @@ export type UserActorQueryByUsernameArgs = {
 };
 
 export type UserDataInput = {
-  appetizeCode?: InputMaybe<Scalars['String']>;
   email?: InputMaybe<Scalars['String']>;
   firstName?: InputMaybe<Scalars['String']>;
   fullName?: InputMaybe<Scalars['String']>;
-  githubUsername?: InputMaybe<Scalars['String']>;
   id?: InputMaybe<Scalars['ID']>;
-  industry?: InputMaybe<Scalars['String']>;
   lastName?: InputMaybe<Scalars['String']>;
-  location?: InputMaybe<Scalars['String']>;
   profilePhoto?: InputMaybe<Scalars['String']>;
-  twitterUsername?: InputMaybe<Scalars['String']>;
   username?: InputMaybe<Scalars['String']>;
 };
 
@@ -6156,7 +6168,7 @@ export type ViewUpdateGroupsOnAppQuery = { __typename?: 'RootQuery', app: { __ty
 export type CurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type CurrentUserQuery = { __typename?: 'RootQuery', meActor?: { __typename: 'Robot', firstName?: string | null, id: string, featureGates: any, isExpoAdmin: boolean, accounts: Array<{ __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | { __typename: 'SSOUser', username: string, id: string, featureGates: any, isExpoAdmin: boolean, accounts: Array<{ __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | { __typename: 'User', username: string, id: string, featureGates: any, isExpoAdmin: boolean, primaryAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, accounts: Array<{ __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | null };
+export type CurrentUserQuery = { __typename?: 'RootQuery', meActor?: { __typename: 'Robot', firstName?: string | null, id: string, featureGates: any, isExpoAdmin: boolean, accounts: Array<{ __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | { __typename: 'SSOUser', username: string, id: string, featureGates: any, isExpoAdmin: boolean, primaryAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, accounts: Array<{ __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | { __typename: 'User', username: string, id: string, featureGates: any, isExpoAdmin: boolean, primaryAccount: { __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, accounts: Array<{ __typename?: 'Account', id: string, name: string, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | null };
 
 export type WebhooksByAppIdQueryVariables = Exact<{
   appId: Scalars['String'];

--- a/packages/eas-cli/src/graphql/queries/UserQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UserQuery.ts
@@ -28,6 +28,10 @@ export const UserQuery = {
                 }
                 ... on SSOUser {
                   username
+                  primaryAccount {
+                    id
+                    ...AccountFragment
+                  }
                 }
                 accounts {
                   id

--- a/packages/eas-cli/src/graphql/queries/UserQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UserQuery.ts
@@ -16,7 +16,7 @@ export const UserQuery = {
               meActor {
                 __typename
                 id
-                ... on User {
+                ... on UserActor {
                   username
                   primaryAccount {
                     id
@@ -25,13 +25,6 @@ export const UserQuery = {
                 }
                 ... on Robot {
                   firstName
-                }
-                ... on SSOUser {
-                  username
-                  primaryAccount {
-                    id
-                    ...AccountFragment
-                  }
                 }
                 accounts {
                   id
@@ -45,7 +38,7 @@ export const UserQuery = {
           `,
           {},
           {
-            additionalTypenames: ['User'],
+            additionalTypenames: ['User', 'SSOUser'],
           }
         )
         .toPromise()

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -16,6 +16,8 @@ export function getUsername(exp: ExpoConfig, user: Actor): string | undefined {
   switch (user.__typename) {
     case 'User':
       return user.username;
+    case 'SSOUser':
+      return user.username;
     case 'Robot':
       // owner field is necessary to run `expo prebuild`
       if (!exp.owner) {
@@ -25,8 +27,6 @@ export function getUsername(exp: ExpoConfig, user: Actor): string | undefined {
       }
       // robot users don't have usernames
       return undefined;
-    case 'SSOUser':
-      throw new Error('SSO users are not supported yet.');
   }
 }
 

--- a/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
@@ -94,6 +94,7 @@ function mockUpdateChannel({
 }): UpdateChannel {
   return {
     id: 'a2a1fa12-9d6a-433a-a432-49c64ef8439f',
+    app: {} as App,
     name: channelName ?? 'default-channel-name',
     createdAt: '2022-12-07T02:24:29.786Z',
     appId: '123',
@@ -109,6 +110,7 @@ function mockUpdateBranches(branchNames: string[]): UpdateBranch[] {
   return branchNames.map(branchName => ({
     id: 'f9dc4dbb-663f-4a19-8cf2-a783b484d2db',
     name: branchName ?? 'default-branch-name',
+    app: {} as App,
     appId: '123',
     createdAt: '2022-12-07T02:24:29.786Z',
     updatedAt: '2022-12-07T02:24:29.786Z',
@@ -140,6 +142,7 @@ function mockUpdateBranches(branchNames: string[]): UpdateBranch[] {
           branch: {
             id: 'f9dc4dbb-663f-4a19-8cf2-a783b484d2db',
             name: 'production3',
+            app: {} as App,
             appId: '123',
             createdAt: '2022-12-07T02:24:29.786Z',
             updatedAt: '2022-12-07T02:24:29.786Z',

--- a/packages/eas-cli/src/user/SessionManager.ts
+++ b/packages/eas-cli/src/user/SessionManager.ts
@@ -122,7 +122,7 @@ export default class SessionManager {
 
     if (!actor) {
       Log.warn('An Expo user account is required to proceed.');
-      await this.showLoginPromptAsync({ nonInteractive, printNewLine: true, sso: undefined });
+      await this.showLoginPromptAsync({ nonInteractive, printNewLine: true });
       actor = await this.getUserAsync();
     }
 
@@ -152,9 +152,7 @@ export default class SessionManager {
   } = {}): Promise<void> {
     if (nonInteractive) {
       Errors.error(
-        `Either log in with ${chalk.bold('eas login')} or ${chalk.bold(
-          'eas login --sso | -s'
-        )} or set the ${chalk.bold(
+        `Either log in with ${chalk.bold('eas login')} or set the ${chalk.bold(
           'EXPO_TOKEN'
         )} environment variable if you're using EAS CLI on CI (${learnMore(
           'https://docs.expo.dev/accounts/programmatic-access/',
@@ -166,12 +164,12 @@ export default class SessionManager {
       Log.newLine();
     }
 
-    if (sso === true) {
+    if (sso) {
       await this.ssoLoginAsync();
       return;
     }
 
-    Log.log('Use ctrl-c to exit and then run eas login for other login options');
+    Log.log(`For other login options, ctrl-c to exit and then run ${chalk.bold('eas login')}`);
     Log.log('Log in to EAS with email or username');
 
     const { username, password } = await promptAsync([

--- a/packages/eas-cli/src/user/SessionManager.ts
+++ b/packages/eas-cli/src/user/SessionManager.ts
@@ -169,7 +169,7 @@ export default class SessionManager {
       return;
     }
 
-    Log.log(`For other login options, ctrl-c to exit and then run ${chalk.bold('eas login')}`);
+    Log.log(`For other login options, ctrl-c to exit and then run ${chalk.bold('eas login')}.`);
     Log.log('Log in to EAS with email or username');
 
     const { username, password } = await promptAsync([

--- a/packages/eas-cli/src/user/SessionManager.ts
+++ b/packages/eas-cli/src/user/SessionManager.ts
@@ -169,8 +169,11 @@ export default class SessionManager {
       return;
     }
 
-    Log.log(`For other login options, ctrl-c to exit and then run ${chalk.bold('eas login')}.`);
-    Log.log('Log in to EAS with email or username');
+    Log.log(
+      `Log in to EAS with email or username (exit and run ${chalk.bold(
+        'eas login'
+      )} for other options)`
+    );
 
     const { username, password } = await promptAsync([
       {

--- a/packages/eas-cli/src/user/User.ts
+++ b/packages/eas-cli/src/user/User.ts
@@ -3,7 +3,7 @@ import { CurrentUserQuery, Robot, SsoUser, User } from '../graphql/generated';
 export type Actor = NonNullable<CurrentUserQuery['meActor']>;
 
 /**
- * Resolve the name of the actor, either normal user or robot user.
+ * Resolve the name of the actor, either normal user, sso user or robot user.
  * This should be used whenever the "current user" needs to be displayed.
  * The display name CANNOT be used as project owner.
  */

--- a/packages/eas-cli/src/user/__tests__/SessionManager-test.ts
+++ b/packages/eas-cli/src/user/__tests__/SessionManager-test.ts
@@ -287,10 +287,6 @@ describe(SessionManager, () => {
     });
 
     it('calls SSO login if the sso flag is true', async () => {
-      // jest
-      //   .mocked(promptAsync)
-      //   .mockImplementationOnce(async () => ({ username: 'USERNAME', password: 'PASSWORD' }));
-
       const sessionManager = new SessionManager(analytics);
 
       // SSO login

--- a/packages/eas-cli/src/user/__tests__/User-test.ts
+++ b/packages/eas-cli/src/user/__tests__/User-test.ts
@@ -21,6 +21,26 @@ const userStub: Actor = {
   featureGates: {},
 };
 
+const ssoUserStub: Actor = {
+  __typename: 'SSOUser',
+  id: 'ssoUserId',
+  username: 'ssoUsername',
+  primaryAccount: {
+    id: 'account_id_888',
+    name: 'ssoUsername',
+    users: [{ role: Role.Owner, actor: { id: 'ssoUserId' } }],
+  },
+  accounts: [
+    {
+      id: 'account_id_888',
+      name: 'ssoUsername',
+      users: [{ role: Role.Owner, actor: { id: 'ssoUserId' } }],
+    },
+  ],
+  isExpoAdmin: false,
+  featureGates: {},
+};
+
 const robotStub: Actor = {
   __typename: 'Robot',
   id: 'userId',
@@ -35,8 +55,12 @@ describe('getActorDisplayName', () => {
     expect(getActorDisplayName()).toBe('unknown');
   });
 
-  it('returns username for user actors', () => {
+  it('returns username for regular user actors', () => {
     expect(getActorDisplayName(userStub)).toBe(userStub.username);
+  });
+
+  it('returns username for SSO user actors', () => {
+    expect(getActorDisplayName(ssoUserStub)).toBe(`${ssoUserStub.username}`);
   });
 
   it('returns firstName with robot prefix for robot actors', () => {

--- a/packages/eas-cli/src/user/actions.ts
+++ b/packages/eas-cli/src/user/actions.ts
@@ -2,7 +2,7 @@ import { AccountFragment } from '../graphql/generated';
 import { Actor } from './User';
 
 export function ensureActorHasPrimaryAccount(user: Actor): AccountFragment {
-  if (user.__typename === 'User') {
+  if (user.__typename === 'User' || user.__typename === 'SSOUser') {
     return user.primaryAccount;
   }
   throw new Error('This action is not supported for robot users.');

--- a/packages/eas-cli/src/user/expoSsoLauncher.ts
+++ b/packages/eas-cli/src/user/expoSsoLauncher.ts
@@ -5,13 +5,13 @@ import querystring from 'querystring';
 
 import Log from '../log';
 
-export default (options: {
+export async function initiateAuthFlowAsync(options: {
   expoWebsiteUrl: string;
   serverPort: number;
-}): { executeAuthFlow: () => Promise<string> } => {
+}): Promise<string> {
   const { expoWebsiteUrl, serverPort } = options;
   if (!expoWebsiteUrl || !serverPort) {
-    throw new Error('Expo website URL and localserver port are required.');
+    throw new Error('Expo website URL and local server port are required.');
   }
   const scheme = 'http';
   const hostname = 'localhost';
@@ -35,13 +35,13 @@ export default (options: {
         (request: http.IncomingMessage, response: http.ServerResponse) => {
           try {
             if (!(request.method === 'GET' && request.url?.includes('/auth/callback'))) {
-              throw new Error('Unexpected SSO login response');
+              throw new Error('Unexpected SSO login response.');
             }
             const url = new URL(request.url, `http:${request.headers.host}`);
             const sessionSecret = url.searchParams.get('session_secret');
 
             if (!sessionSecret) {
-              throw new Error('Login in the website failed unexpectedly.');
+              throw new Error('Request missing session_secret search parameter.');
             }
             resolve(sessionSecret);
             response.writeHead(200, { 'Content-Type': 'text/plain' });
@@ -76,7 +76,5 @@ export default (options: {
     });
   };
 
-  return {
-    executeAuthFlow,
-  };
-};
+  return await executeAuthFlow();
+}

--- a/packages/eas-cli/src/user/expoSsoLauncher.ts
+++ b/packages/eas-cli/src/user/expoSsoLauncher.ts
@@ -5,7 +5,7 @@ import querystring from 'querystring';
 
 import Log from '../log';
 
-export async function initiateAuthFlowAsync(options: {
+export async function getSessionUsingBrowserAuthFlowAsync(options: {
   expoWebsiteUrl: string;
   serverPort: number;
 }): Promise<string> {
@@ -45,7 +45,7 @@ export async function initiateAuthFlowAsync(options: {
             }
             resolve(sessionSecret);
             response.writeHead(200, { 'Content-Type': 'text/plain' });
-            response.write(`Thank you, website login has completed. You can now close this tab.`);
+            response.write(`Website login has completed. You can now close this tab.`);
             response.end();
           } catch (error) {
             reject(error);
@@ -60,7 +60,7 @@ export async function initiateAuthFlowAsync(options: {
       );
 
       server.listen(serverPort, hostname, () => {
-        Log.log('Waiting for website login...');
+        Log.log('Waiting for browser login...');
       });
 
       server.on('connection', connection => {

--- a/packages/eas-cli/src/user/expoSsoLauncher.ts
+++ b/packages/eas-cli/src/user/expoSsoLauncher.ts
@@ -1,0 +1,82 @@
+import openBrowserAsync from 'better-opn';
+import http from 'http';
+import { Socket } from 'node:net';
+import querystring from 'querystring';
+
+import Log from '../log';
+
+export default (options: {
+  expoWebsiteUrl: string;
+  serverPort: number;
+}): { executeAuthFlow: () => Promise<string> } => {
+  const { expoWebsiteUrl, serverPort } = options;
+  if (!expoWebsiteUrl || !serverPort) {
+    throw new Error('Expo website URL and localserver port are required.');
+  }
+  const scheme = 'http';
+  const hostname = 'localhost';
+  const path = '/auth/callback';
+  const redirectUri = `${scheme}://${hostname}:${serverPort}${path}`;
+
+  const buildExpoSsoLoginUrl = (): string => {
+    const data = {
+      app_redirect_uri: redirectUri,
+    };
+    const params = querystring.stringify(data);
+    return `${expoWebsiteUrl}/sso-login?${params}`;
+  };
+
+  // Start server and begin auth flow
+  const executeAuthFlow = (): Promise<string> => {
+    return new Promise<string>(async (resolve, reject) => {
+      const connections = new Set<Socket>();
+
+      const server = http.createServer(
+        (request: http.IncomingMessage, response: http.ServerResponse) => {
+          try {
+            if (!(request.method === 'GET' && request.url?.includes('/auth/callback'))) {
+              throw new Error('Unexpected SSO login response');
+            }
+            const url = new URL(request.url, `http:${request.headers.host}`);
+            const sessionSecret = url.searchParams.get('session_secret');
+
+            if (!sessionSecret) {
+              throw new Error('Login in the website failed unexpectedly.');
+            }
+            resolve(sessionSecret);
+            response.writeHead(200, { 'Content-Type': 'text/plain' });
+            response.write(`Thank you, website login has completed. You can now close this tab.`);
+            response.end();
+          } catch (error) {
+            reject(error);
+          } finally {
+            server.close();
+            // Ensure that the server shuts down
+            for (const connection of connections) {
+              connection.destroy();
+            }
+          }
+        }
+      );
+
+      server.listen(serverPort, hostname, () => {
+        Log.log('Waiting for website login...');
+      });
+
+      server.on('connection', connection => {
+        connections.add(connection);
+
+        connection.on('close', () => {
+          connections.delete(connection);
+        });
+      });
+
+      const authorizeUrl = buildExpoSsoLoginUrl();
+      openBrowserAsync(authorizeUrl);
+    });
+  };
+
+  return {
+    executeAuthFlow,
+  };
+};

--- a/packages/eas-cli/src/user/fetchSessionSecretAndSsoUser.ts
+++ b/packages/eas-cli/src/user/fetchSessionSecretAndSsoUser.ts
@@ -1,0 +1,24 @@
+import { getExpoWebsiteBaseUrl, getSsoLocalServerPortAsync } from '../api';
+import expoSsoLauncher from './expoSsoLauncher';
+import { fetchUserAsync } from './fetchUser';
+
+export async function fetchSessionSecretAndSsoUserAsync(): Promise<{
+  sessionSecret: string;
+  id: string;
+  username: string;
+}> {
+  const config = {
+    expoWebsiteUrl: getExpoWebsiteBaseUrl(),
+    serverPort: await getSsoLocalServerPortAsync(),
+  };
+  const auth = expoSsoLauncher(config);
+  const sessionSecret = await auth.executeAuthFlow();
+
+  const userData = await fetchUserAsync({ sessionSecret });
+
+  return {
+    sessionSecret,
+    id: userData.id,
+    username: userData.username,
+  };
+}

--- a/packages/eas-cli/src/user/fetchSessionSecretAndSsoUser.ts
+++ b/packages/eas-cli/src/user/fetchSessionSecretAndSsoUser.ts
@@ -1,5 +1,5 @@
 import { getExpoWebsiteBaseUrl, getSsoLocalServerPortAsync } from '../api';
-import expoSsoLauncher from './expoSsoLauncher';
+import { initiateAuthFlowAsync } from './expoSsoLauncher';
 import { fetchUserAsync } from './fetchUser';
 
 export async function fetchSessionSecretAndSsoUserAsync(): Promise<{
@@ -11,8 +11,7 @@ export async function fetchSessionSecretAndSsoUserAsync(): Promise<{
     expoWebsiteUrl: getExpoWebsiteBaseUrl(),
     serverPort: await getSsoLocalServerPortAsync(),
   };
-  const auth = expoSsoLauncher(config);
-  const sessionSecret = await auth.executeAuthFlow();
+  const sessionSecret = await initiateAuthFlowAsync(config);
 
   const userData = await fetchUserAsync({ sessionSecret });
 

--- a/packages/eas-cli/src/user/fetchSessionSecretAndSsoUser.ts
+++ b/packages/eas-cli/src/user/fetchSessionSecretAndSsoUser.ts
@@ -1,5 +1,5 @@
 import { getExpoWebsiteBaseUrl, getSsoLocalServerPortAsync } from '../api';
-import { initiateAuthFlowAsync } from './expoSsoLauncher';
+import { getSessionUsingBrowserAuthFlowAsync } from './expoSsoLauncher';
 import { fetchUserAsync } from './fetchUser';
 
 export async function fetchSessionSecretAndSsoUserAsync(): Promise<{
@@ -11,7 +11,7 @@ export async function fetchSessionSecretAndSsoUserAsync(): Promise<{
     expoWebsiteUrl: getExpoWebsiteBaseUrl(),
     serverPort: await getSsoLocalServerPortAsync(),
   };
-  const sessionSecret = await initiateAuthFlowAsync(config);
+  const sessionSecret = await getSessionUsingBrowserAuthFlowAsync(config);
 
   const userData = await fetchUserAsync({ sessionSecret });
 

--- a/packages/eas-cli/src/user/fetchSessionSecretAndUser.ts
+++ b/packages/eas-cli/src/user/fetchSessionSecretAndUser.ts
@@ -1,7 +1,5 @@
-import gql from 'graphql-tag';
-
 import { ApiV2Client } from '../api';
-import { createGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { fetchUserAsync } from './fetchUser';
 
 export async function fetchSessionSecretAndUserAsync({
   username,
@@ -21,32 +19,10 @@ export async function fetchSessionSecretAndUserAsync({
     body: { username, password, otp },
   });
   const { sessionSecret } = body.data;
-  const graphqlClient = createGraphqlClient({ accessToken: null, sessionSecret: null });
-  const result = await graphqlClient
-    .query(
-      gql`
-        query UserQuery {
-          viewer {
-            id
-            username
-          }
-        }
-      `,
-      {},
-      {
-        fetchOptions: {
-          headers: {
-            'expo-session': sessionSecret,
-          },
-        },
-        additionalTypenames: [] /* UserQuery has immutable fields */,
-      }
-    )
-    .toPromise();
-  const { data } = result;
+  const userData = await fetchUserAsync({ sessionSecret });
   return {
     sessionSecret,
-    id: data.viewer.id,
-    username: data.viewer.username,
+    id: userData.id,
+    username: userData.username,
   };
 }

--- a/packages/eas-cli/src/user/fetchUser.ts
+++ b/packages/eas-cli/src/user/fetchUser.ts
@@ -7,7 +7,7 @@ export async function fetchUserAsync({
 }: {
   sessionSecret: string;
 }): Promise<{ id: string; username: string }> {
-  const graphqlClient = createGraphqlClient({ accessToken: null, sessionSecret: null });
+  const graphqlClient = createGraphqlClient({ accessToken: null, sessionSecret });
   const result = await graphqlClient
     .query(
       gql`
@@ -20,11 +20,6 @@ export async function fetchUserAsync({
       `,
       {},
       {
-        fetchOptions: {
-          headers: {
-            'expo-session': sessionSecret,
-          },
-        },
         additionalTypenames: [] /* UserQuery has immutable fields */,
       }
     )

--- a/packages/eas-cli/src/user/fetchUser.ts
+++ b/packages/eas-cli/src/user/fetchUser.ts
@@ -1,0 +1,38 @@
+import gql from 'graphql-tag';
+
+import { createGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+
+export async function fetchUserAsync({
+  sessionSecret,
+}: {
+  sessionSecret: string;
+}): Promise<{ id: string; username: string }> {
+  const graphqlClient = createGraphqlClient({ accessToken: null, sessionSecret: null });
+  const result = await graphqlClient
+    .query(
+      gql`
+        query UserQuery {
+          meUserActor {
+            id
+            username
+          }
+        }
+      `,
+      {},
+      {
+        fetchOptions: {
+          headers: {
+            'expo-session': sessionSecret,
+          },
+        },
+        additionalTypenames: [] /* UserQuery has immutable fields */,
+      }
+    )
+    .toPromise();
+
+  const { data } = result;
+  return {
+    id: data.meUserActor.id,
+    username: data.meUserActor.username,
+  };
+}

--- a/packages/eas-cli/src/utils/port.ts
+++ b/packages/eas-cli/src/utils/port.ts
@@ -1,0 +1,11 @@
+import freeportAsync from 'freeport-async';
+
+/** Get a free port or throw an error. */
+export async function getFreePortAsync(rangeStart: number): Promise<number> {
+  const port = await freeportAsync(rangeStart, { hostnames: [null, 'localhost'] });
+  if (!port) {
+    throw new Error('No available port found');
+  }
+
+  return port;
+}

--- a/ts-declarations/freeport-async/index.d.ts
+++ b/ts-declarations/freeport-async/index.d.ts
@@ -1,0 +1,8 @@
+declare module 'freeport-async' {
+  interface FreePortOptions {
+    hostnames?: (string | null)[];
+  }
+
+  function freePortAsync(rangeStart: number, options?: FreePortOptions): Promise<number>;
+  export = freePortAsync;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7455,6 +7455,11 @@ forwarded@0.2.0:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
+freeport-async@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/freeport-async/-/freeport-async-2.0.0.tgz#6adf2ec0c629d11abff92836acd04b399135bab4"
+  integrity sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"


### PR DESCRIPTION
# Why

These changes are to enable  an SSO user to log in with eas cli via the Expo website.

# How

Added a -sso, -s flag to the login command for a user to select logging in with SSO. The CLI then opens a browser window and redirects the user to the Expo website to log in. The website takes them through the auth flow with their Auth Provider and logs them in to Expo before returning.

This CLI SSO user login follows Expo Go login behavior (which also logs in via the Expo website):
- if no user is logged into the website, the user gets logged in and the session is returned to the CLI
- if a user is already logged into the website then that user session is returned
- once a user is logged into the website, in order to change the logged-in user in the CLI, the current user has to be manually logged out in the website.

Non-SSO user login behavior has not changed.

# Test Plan
Tested manually against the website running locally and with www also running locally. While testing, a couple of log lines were temporarily added to log the session information.

**A) With no user logged in to the website, tested logging in an SSO user:**
eas-cli % EXPO_LOCAL=1 easd login --sso
```
Log in to EAS
Listening for login response at http://localhost:19300
sessionSecret= {"id":"265cd840-2106-46ed-b7f6-6f1835b4e1f1","version":1,"expires_at":2001740400000}
Logged in
```
Website console logs:
```
Navigated to https://dev-49197392.okta.com/oauth2/v1/authorize?client_id=0oa4my0ckz8yKYZum5d7&scope=openid+profile+email+offline_access&response_type=code&redirect_uri=http%3A%2F%2Fexpo.test%2Fauth%2Fcallback%2Fokta&state=6z5w342e3i6y2q2r6i421hs164h1r4ra3b3hk3n3n564w573b5ku1z1i4o1n&nonce=2n3161g1b4h1vj2f6u305m6o4c20k673t5m4k1y2a505i3h3i3r

Navigated to http://expo.test/auth/callback/okta?code=M4XV4Ws6iUAgOwA7vxT3keMVwYOiBskzxiyWpQg1PUk&state=6z5w342e3i6y2q2r6i421hs164h1r4ra3b3hk3n3n564w573b5ku1z1i4o1n

Navigated to http://localhost:19300/auth/callback?username_or_email=liz-sso-viewer&session_secret={%22id%22:%22265cd840-2106-46ed-b7f6-6f1835b4e1f1%22,%22version%22:1,%22expires_at%22:2001740400000}
```

Website and eas-cli have the same user logged in.

**B) With the SSO user already logged in from the test above, tried logging in an SSO user again:**
eas-cli % EXPO_LOCAL=1 easd login --sso
```
Log in to EAS
Listening for login response at http://localhost:19300
sessionSecret= {"id":"265cd840-2106-46ed-b7f6-6f1835b4e1f1","version":1,"expires_at":2001740400000}
Logged in
```
Website immediately returns the session for the logged in user:
```
http://localhost:19300/auth/callback?username_or_email=liz-sso-viewer&session_secret=%7B%22id%22%3A%22265cd840-2106-46ed-b7f6-6f1835b4e1f1%22%2C%22version%22%3A1%2C%22expires_at%22%3A2001740400000%7D
```
Website and eas-cli have the same user logged in.

**C) Checked user identity**
EXPO_LOCAL=1 easd whoami
```
liz-sso-viewer

Accounts:
• liz-sso-viewer (Role: Owner)
• testssoorgforokta (Role: Viewer)
```

**D) Also, with the SSO user logged in, tried logging in a regular user in eas-cli:**
eas-cli % EXPO_LOCAL=1 easd login
```
Log in to EAS
✔ Email or username … lktest
✔ Password … *********
Logged in
```

After this:
eas-cli % EXPO_LOCAL=1 easd whoami

```
lktest

Accounts:
• lktest (Role: Owner)
• lktestorg (Role: Owner)
```

The CLI has a regular user logged in and the website still has the SSO user liz-sso-viewer logged in

It is also possible to log in a regular user with the new flow: 
**E) with nobody logged in to the website, tested logging in a regular user in the website, by clicking on Continue with Password in the website sso-login page:**
eas-cli % EXPO_LOCAL=1 easd login --sso
```
Log in to EAS
Listening for login response at http://localhost:19300
sessionSecret= {"id":"eca11b5d-f4d0-436f-9394-34783ae098a6","version":1,"expires_at":2001740400000}
Logged in
```

eas-cli % EXPO_LOCAL=1 easd whoami 
```
lktest

Accounts:
• lktest (Role: Owner)
• lktestorg (Role: Owner)
lizkaubisch@Lizs-MBP-2 eas-cli % 
```
The regular user is logged in to the CLI and in the website

**F) For latest commit addressing review comments, also tested against staging and tested:**

a) Attempting a command when not logged in, and got new login prompt:
EXPO_LOCAL=1 easd build -p ios --profile preview 

```
An Expo user account is required to proceed.

Use ctrl-c to exit and then run eas login for other login options
Log in to EAS with email or username
? Email or username › 

```

 b) creating an EAS build:
 EXPO_STAGING=1 easd build -p ios --profile preview

```
Compressing project files and uploading to EAS Build. Learn more: https://expo.fyi/eas-build-archive
✔ Uploaded to EAS 

Build details: https://staging.expo.dev/accounts/liz-sso-viewer/projects/liz-sso-viewer-proj1/builds/6e429e23-800b-47d8-b155-73fa9c33ef97

Waiting for build to complete. You can press Ctrl+C to exit.
  Build queued...

Start builds sooner in the priority queue.
Sign up for EAS Production or Enterprise at https://staging.expo.dev/accounts/liz-sso-viewer/settings/subscriptions

Waiting in Free tier queue
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 

⠹ Build in progress...
```