### PR TITLE
[eas-cli] Update eas build:configure command to show link of eas.json when generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Update `eas build:configure` command to show the link of `eas.json` when generated. ([#1878](https://github.com/expo/eas-cli/pull/1878) by [@amandeepmittal](https://github.com/amandeepmittal))
+
 ## [3.13.3](https://github.com/expo/eas-cli/releases/tag/v3.13.3) - 2023-06-05
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -103,9 +103,6 @@ async function createEasJsonAsync(projectDir: string): Promise<void> {
   await fs.writeFile(easJsonPath, `${JSON.stringify(easJson, null, 2)}\n`);
   await getVcsClient().trackFileAsync(easJsonPath);
   Log.withTick(
-    `Generated ${chalk.bold('eas.json')} ${learnMore(
-      'https://docs.expo.dev/build-reference/eas-json/',
-      { learnMoreMessage: '(learn more)' }
-    )}`
+    `Generated ${chalk.bold('eas.json')}. ${learnMore('https://docs.expo.dev/build-reference/eas-json/')}`
   );
 }

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -103,6 +103,8 @@ async function createEasJsonAsync(projectDir: string): Promise<void> {
   await fs.writeFile(easJsonPath, `${JSON.stringify(easJson, null, 2)}\n`);
   await getVcsClient().trackFileAsync(easJsonPath);
   Log.withTick(
-    `Generated ${chalk.bold('eas.json')}. ${learnMore('https://docs.expo.dev/build-reference/eas-json/')}`
+    `Generated ${chalk.bold('eas.json')}. ${learnMore(
+      'https://docs.expo.dev/build-reference/eas-json/'
+    )}`
   );
 }

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -3,7 +3,7 @@ import { EasJson, EasJsonAccessor } from '@expo/eas-json';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
-import Log from '../log';
+import Log, { learnMore } from '../log';
 import { resolveWorkflowAsync } from '../project/workflow';
 import { easCliVersion } from '../utils/easCli';
 import { getVcsClient } from '../vcs';
@@ -102,5 +102,10 @@ async function createEasJsonAsync(projectDir: string): Promise<void> {
 
   await fs.writeFile(easJsonPath, `${JSON.stringify(easJson, null, 2)}\n`);
   await getVcsClient().trackFileAsync(easJsonPath);
-  Log.withTick(`Generated ${chalk.bold('eas.json')}`);
+  Log.withTick(
+    `Generated ${chalk.bold('eas.json')} ${learnMore(
+      'https://docs.expo.dev/build-reference/eas-json/',
+      { learnMoreMessage: '(learn more)' }
+    )}`
+  );
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This came up when talking to @brentvatne about improving user experience when they are running `eas build:configure` by linking to the [eas.json schema doc](https://docs.expo.dev/build-reference/eas-json/).

# How

By updating the message when it outputs "Generated eas.json" to use `learnMore()` to display a "(learn more)" 
 message with a link to eas.json schema doc.

# Test Plan

- In one terminal window, Inside `eas-cli` directory, run `yarn start`.
- In another terminal window,  create a new project with `npx create-expo` and navigate to the project directory.
- Inside the project directory, run `easd build:configure` and follow the prompts.

One success, you will get the following result with "(learn more)" link:

![CleanShot 2023-06-13 at 01 50 36@2x](https://github.com/expo/eas-cli/assets/10234615/446eeb60-4732-4628-9d95-0cce504d1e39)

