### PR TITLE
Remove direct `@types/bunyan` dependency

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -88,7 +88,6 @@
     "@graphql-codegen/introspection": "2.2.3",
     "@graphql-codegen/typescript": "2.8.7",
     "@graphql-codegen/typescript-operations": "2.5.12",
-    "@types/bunyan": "1.8.8",
     "@types/cli-progress": "3.11.0",
     "@types/dateformat": "3.0.1",
     "@types/envinfo": "7.8.1",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -27,7 +27,7 @@
     "@expo/results": "1.0.0",
     "@expo/rudder-sdk-node": "1.1.1",
     "@expo/spawn-async": "1.7.0",
-    "@expo/steps": "1.0.20",
+    "@expo/steps": "1.0.21",
     "@expo/timeago.js": "1.0.0",
     "@oclif/core": "1.23.2",
     "@oclif/plugin-autocomplete": "1.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4154,13 +4154,6 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/bunyan@1.8.8":
-  version "1.8.8"
-  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.8.tgz#8d6d33f090f37c07e2a80af30ae728450a101008"
-  integrity sha512-Cblq+Yydg3u+sGiz2mjHjC5MPmdjY+No4qvHrF+BUhblsmSfMvsHLbOG62tPbonsqBj6sbWv1LHcsoe5Jw+/Ow==
-  dependencies:
-    "@types/node" "*"
-
 "@types/cacheable-request@^6.0.1":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz#a430b3260466ca7b5ca5bfd735693b36e7a9d183"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,11 +1459,12 @@
     json5 "^2.2.2"
     write-file-atomic "^2.3.0"
 
-"@expo/logger@1.0.19":
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/@expo/logger/-/logger-1.0.19.tgz#f6066fe124822665e9e4cda1aed380f419ab341b"
-  integrity sha512-i997kA/gwNLernDSLxucnQTFX00rp2gBn/86QAqVI7N9YSfwBjPR2TiOyNWjS6YNhP/oO6WoSn73qXGiB4+xRA==
+"@expo/logger@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@expo/logger/-/logger-1.0.21.tgz#9271b52b8e27159cbbe3385b9a01fca3317b37c2"
+  integrity sha512-Vz+LHDGWUfowAwL10nBKqxrMYvO4qdZ8hLKcqUYc5mXBt+jmv7RP+8fcsMIejJEMWmYC2meO5eeCMLKKhEIgMA==
   dependencies:
+    "@types/bunyan" "^1.8.8"
     bunyan "^1.8.15"
 
 "@expo/multipart-body-parser@1.1.0":
@@ -1605,12 +1606,12 @@
   dependencies:
     cross-spawn "^7.0.3"
 
-"@expo/steps@1.0.20":
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/@expo/steps/-/steps-1.0.20.tgz#98d9d43013e6fd55516193d2a5caf8a09a157db7"
-  integrity sha512-K5lyILOQDYTTRQTYkGyk4lKWzjNWsSAEfS2tErGbcAPGG4ykx9XJa/Xd5Go/Uj/qaTN+Bsym7fyapySlwNXaBw==
+"@expo/steps@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@expo/steps/-/steps-1.0.21.tgz#606f1b6eefed4d6a86cf98d6286101c4a75f12c7"
+  integrity sha512-fojpxwPO4xrCqanZzKZZJTQUSxaX4YrfV2jEfoiBvt9EZqLMcYkJgOCowzgJqz4cXFG4f0yFb9mqvMg+6a4JxA==
   dependencies:
-    "@expo/logger" "1.0.19"
+    "@expo/logger" "1.0.21"
     "@expo/spawn-async" "^1.7.0"
     arg "^5.0.2"
     joi "^17.7.0"
@@ -4152,6 +4153,13 @@
   integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
   dependencies:
     "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/bunyan@^1.8.8":
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.8.tgz#8d6d33f090f37c07e2a80af30ae728450a101008"
+  integrity sha512-Cblq+Yydg3u+sGiz2mjHjC5MPmdjY+No4qvHrF+BUhblsmSfMvsHLbOG62tPbonsqBj6sbWv1LHcsoe5Jw+/Ow==
+  dependencies:
     "@types/node" "*"
 
 "@types/cacheable-request@^6.0.1":


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Cleanup after https://github.com/expo/eas-build/pull/233.

# How

Upgraded `@expo/steps` package. It is the only `eas-build` package in here.

# Test Plan

It's a type-only change so CI success will be enough.