### PR TITLE
[eas-cli] Initialize app.json if it does not exist, add expo key if missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Update `eas build:configure` command to show the link of `eas.json` when generated. ([#1878](https://github.com/expo/eas-cli/pull/1878) by [@amandeepmittal](https://github.com/amandeepmittal))
+- Create app.json or add the "expo" key if either are missing, before modifying or reading the file. ([#1881](https://github.com/expo/eas-cli/pull/1881) by [@brentvatne](https://github.com/brentvatne))
 
 ## [3.13.3](https://github.com/expo/eas-cli/releases/tag/v3.13.3) - 2023-06-05
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -1,4 +1,4 @@
-import { getProjectConfigDescription, modifyConfigAsync } from '@expo/config';
+import { getProjectConfigDescription } from '@expo/config';
 import { ExpoConfig } from '@expo/config-types';
 import { Env } from '@expo/eas-build-job';
 import chalk from 'chalk';
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import Log, { learnMore } from '../../../log';
 import { ora } from '../../../ora';
-import { getPrivateExpoConfig } from '../../../project/expoConfig';
+import { createOrModifyExpoConfigAsync, getPrivateExpoConfig } from '../../../project/expoConfig';
 import { fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync } from '../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 import { toAppPrivacy } from '../../../project/projectUtils';
 import SessionManager from '../../../user/SessionManager';
@@ -25,7 +25,7 @@ export async function saveProjectIdToAppConfigAsync(
   options: { env?: Env } = {}
 ): Promise<void> {
   const exp = getPrivateExpoConfig(projectDir, options);
-  const result = await modifyConfigAsync(
+  const result = await createOrModifyExpoConfigAsync(
     projectDir,
     {
       extra: { ...exp.extra, eas: { ...exp.extra?.eas, projectId } },

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -1,4 +1,4 @@
-import { getProjectConfigDescription, modifyConfigAsync } from '@expo/config';
+import { getProjectConfigDescription } from '@expo/config';
 import { ExpoConfig } from '@expo/config-types';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -13,7 +13,7 @@ import { AppMutation } from '../../graphql/mutations/AppMutation';
 import { AppQuery } from '../../graphql/queries/AppQuery';
 import Log, { link } from '../../log';
 import { ora } from '../../ora';
-import { getPrivateExpoConfig } from '../../project/expoConfig';
+import { createOrModifyExpoConfigAsync, getPrivateExpoConfig } from '../../project/expoConfig';
 import { findProjectIdByAccountNameAndSlugNullableAsync } from '../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 import { toAppPrivacy } from '../../project/projectUtils';
 import { confirmAsync, promptAsync } from '../../prompts';
@@ -60,7 +60,7 @@ export default class ProjectInit extends EasCommand {
     projectDir: string,
     modifications: Partial<ExpoConfig>
   ): Promise<void> {
-    const result = await modifyConfigAsync(projectDir, modifications);
+    const result = await createOrModifyExpoConfigAsync(projectDir, modifications);
     switch (result.type) {
       case 'success':
         break;

--- a/packages/eas-cli/src/project/__tests__/expoConfig.test.ts
+++ b/packages/eas-cli/src/project/__tests__/expoConfig.test.ts
@@ -1,0 +1,62 @@
+import { getConfigFilePaths, modifyConfigAsync } from '@expo/config';
+import JsonFile from '@expo/json-file';
+import { writeFileSync } from 'fs-extra';
+
+import { createOrModifyExpoConfigAsync } from '../expoConfig';
+
+jest.mock('fs-extra');
+jest.mock('@expo/config');
+jest.mock('@expo/json-file');
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('expoConfig', () => {
+  describe('createOrModifyExpoConfigAsync', () => {
+    it('should create a new app config file if it does not exist', async () => {
+      jest.mocked(getConfigFilePaths).mockReturnValue({
+        staticConfigPath: null,
+        dynamicConfigPath: null,
+      });
+
+      await createOrModifyExpoConfigAsync('/app', {});
+      expect(writeFileSync).toHaveBeenCalledWith('/app/app.json', '{\n  "expo": {}\n}');
+    });
+
+    it('should delegate to modifyConfigAsync if ', async () => {
+      jest.mocked(getConfigFilePaths).mockReturnValue({
+        staticConfigPath: '/app/app.json',
+        dynamicConfigPath: null,
+      });
+      jest.mocked(JsonFile.readAsync).mockResolvedValue({ expo: {} });
+
+      await createOrModifyExpoConfigAsync('/app', {});
+      // modifyConfigAsync is mocked so this shouldn't be called
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should modify an existing config file if it exists', async () => {
+      jest.mocked(getConfigFilePaths).mockReturnValue({
+        staticConfigPath: '/app/app.json',
+        dynamicConfigPath: null,
+      });
+      jest.mocked(JsonFile.readAsync).mockResolvedValue({ expo: {} });
+
+      await createOrModifyExpoConfigAsync('/app', { owner: 'ccheever' });
+      expect(modifyConfigAsync).toHaveBeenCalledWith('/app', { owner: 'ccheever' });
+    });
+
+    it('adds expo key if app.json is missing it', async () => {
+      jest.mocked(getConfigFilePaths).mockReturnValue({
+        staticConfigPath: '/app/app.json',
+        dynamicConfigPath: null,
+      });
+      jest.mocked(JsonFile.readAsync).mockResolvedValue({ name: 'App' });
+
+      await createOrModifyExpoConfigAsync('/app', { owner: 'ccheever' });
+      expect(JsonFile.writeAsync).toHaveBeenCalledWith('/app/app.json', { name: 'App', expo: {} });
+      expect(modifyConfigAsync).toHaveBeenCalledWith('/app', { owner: 'ccheever' });
+    });
+  });
+});

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -74,7 +74,7 @@ export function ensureExpoConfigExists(projectDir: string): void {
 
 async function ensureStaticExpoConfigIsValidAsync(projectDir: string): Promise<void> {
   const paths = getConfigFilePaths(projectDir);
-  if (paths?.staticConfigPath?.endsWith('app.json')) {
+  if (paths?.staticConfigPath?.endsWith('app.json') && !paths?.dynamicConfigPath) {
     const staticConfig = await JsonFile.readAsync(paths.staticConfigPath);
 
     // Add the "expo" key if it doesn't exist on app.json yet, such as in

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -25,7 +25,6 @@ interface ExpoConfigOptionsInternal extends ExpoConfigOptions {
 export async function createOrModifyExpoConfigAsync(
   projectDir: string,
   exp: Partial<ExpoConfig>,
-  // options is the same type as the third argument to modifyConfigAsync
   readOptions?: { skipSDKVersionRequirement?: boolean }
 ): ReturnType<typeof modifyConfigAsync> {
   ensureExpoConfigExists(projectDir);

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -1,5 +1,8 @@
-import { ExpoConfig, getConfig } from '@expo/config';
+import { ExpoConfig, getConfig, getConfigFilePaths, modifyConfigAsync } from '@expo/config';
 import { Env } from '@expo/eas-build-job';
+import JsonFile from '@expo/json-file';
+import fs from 'fs-extra';
+import path from 'path';
 
 export type PublicExpoConfig = Omit<
   ExpoConfig,
@@ -17,6 +20,22 @@ export interface ExpoConfigOptions {
 
 interface ExpoConfigOptionsInternal extends ExpoConfigOptions {
   isPublicConfig?: boolean;
+}
+
+export async function createOrModifyExpoConfigAsync(
+  projectDir: string,
+  exp: Partial<ExpoConfig>,
+  // options is the same type as the third argument to modifyConfigAsync
+  readOptions?: { skipSDKVersionRequirement?: boolean }
+): ReturnType<typeof modifyConfigAsync> {
+  ensureExpoConfigExists(projectDir);
+  await ensureStaticExpoConfigIsValidAsync(projectDir);
+
+  if (readOptions) {
+    return modifyConfigAsync(projectDir, exp, readOptions);
+  } else {
+    return modifyConfigAsync(projectDir, exp);
+  }
 }
 
 function getExpoConfigInternal(
@@ -40,12 +59,38 @@ function getExpoConfigInternal(
 }
 
 export function getPrivateExpoConfig(projectDir: string, opts: ExpoConfigOptions = {}): ExpoConfig {
+  ensureExpoConfigExists(projectDir);
+
   return getExpoConfigInternal(projectDir, { ...opts, isPublicConfig: false });
+}
+
+export function ensureExpoConfigExists(projectDir: string): void {
+  const paths = getConfigFilePaths(projectDir);
+  if (!paths?.staticConfigPath && !paths?.dynamicConfigPath) {
+    // eslint-disable-next-line node/no-sync
+    fs.writeFileSync(path.join(projectDir, 'app.json'), JSON.stringify({ expo: {} }, null, 2));
+  }
+}
+
+async function ensureStaticExpoConfigIsValidAsync(projectDir: string): Promise<void> {
+  const paths = getConfigFilePaths(projectDir);
+  if (paths?.staticConfigPath?.endsWith('app.json')) {
+    const staticConfig = await JsonFile.readAsync(paths.staticConfigPath);
+
+    // Add the "expo" key if it doesn't exist on app.json yet, such as in
+    // projects initialized with RNC CLI
+    if (!staticConfig?.expo) {
+      staticConfig.expo = {};
+      await JsonFile.writeAsync(paths.staticConfigPath, staticConfig);
+    }
+  }
 }
 
 export function getPublicExpoConfig(
   projectDir: string,
   opts: ExpoConfigOptions = {}
 ): PublicExpoConfig {
+  ensureExpoConfigExists(projectDir);
+
   return getExpoConfigInternal(projectDir, { ...opts, isPublicConfig: true });
 }

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -1,4 +1,3 @@
-import { modifyConfigAsync } from '@expo/config';
 import { ExpoConfig } from '@expo/config-types';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { EasJsonAccessor } from '@expo/eas-json';
@@ -10,6 +9,7 @@ import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGr
 import { AppPlatform } from '../graphql/generated';
 import Log, { learnMore } from '../log';
 import { RequestedPlatform, appPlatformDisplayNames } from '../platform';
+import { createOrModifyExpoConfigAsync } from '../project/expoConfig';
 import {
   installExpoUpdatesAsync,
   isExpoUpdatesInstalledOrAvailable,
@@ -128,7 +128,7 @@ async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
   }
 
   const mergedExp = mergeExpoConfig(exp, modifyConfig);
-  const result = await modifyConfigAsync(projectDir, mergedExp);
+  const result = await createOrModifyExpoConfigAsync(projectDir, mergedExp);
 
   switch (result.type) {
     case 'success':


### PR DESCRIPTION
# Why

It's unfortunate to have to tell people to manually create this file, we should do it automatically with `eas init` or `eas update:configure` or `eas build:configure`. Additionally, the current error is.. not very helpful: 

```
easd build:configure
EAS project not configured.
✔ Existing EAS project found for @brents/quin (id = 0f084c7f-d209-491d-97ac-c8c5c4c2c122). Configure this project? … yes
✖ Linking local project to EAS project 0f084c7f-d209-491d-97ac-c8c5c4c2c122
No config exists
    Error: build:configure command failed.
```

"No config exists"

# How

Wrap `modifyConfigAsync` and add some ensure calls where we read the app config.

# Test Plan

I tried this in a project without app.json, and with an app.json that does not have an `expo` key. Need to write actual unit tests to cover this behavior still