### PR TITLE
[eas-cli] Ensure that re-thrown error includes original stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Update `eas build:configure` command to show the link of `eas.json` when generated. ([#1878](https://github.com/expo/eas-cli/pull/1878) by [@amandeepmittal](https://github.com/amandeepmittal))
+- Include the original stack in re-thrown errors thrown from EAS CLI commands. ([#1882](https://github.com/expo/eas-cli/pull/1882) by [@brentvatne](https://github.com/brentvatne))
 
 ## [3.13.3](https://github.com/expo/eas-cli/releases/tag/v3.13.3) - 2023-06-05
 

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -203,6 +203,8 @@ export default abstract class EasCommand extends Command {
       Log.error(err.message);
     }
     Log.debug(err);
-    throw new Error(baseMessage);
+    const sanitizedError = new Error(baseMessage);
+    sanitizedError.stack = err.stack;
+    throw sanitizedError;
   }
 }


### PR DESCRIPTION
# Why

Without this diff, all stack traces that you can see with `DEBUG=* eas [cmd]` will point to where we catch and sanitize the error `EasCommand.ts`, and not give you any indication of the original source of the error.

# How

Point the `stack` on the new error object to the original error stack.

# Test Plan

- Add an error somewhere inside a command
- Run `DEBUG=* easd [command]`
- You should see the appropriate stack