### PR TITLE
[eas-cli] error gracefully if expo pkg not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Error gracefully if expo pkg not installed. ([#1883](https://github.com/expo/eas-cli/pull/1883) by [@quinlanj](https://github.com/quinlanj))
+
 ## [3.13.3](https://github.com/expo/eas-cli/releases/tag/v3.13.3) - 2023-06-05
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -70,7 +70,7 @@ export async function expoCommandAsync(
   } catch (e: any) {
     if (e.code === 'MODULE_NOT_FOUND') {
       throw new Error(
-        `The \`expo\` package was not found. Please follow the installation directions at ${link(
+        `The \`expo\` package was not found. Follow the installation directions at ${link(
           'https://docs.expo.dev/bare/installing-expo-modules/'
         )}`
       );

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -5,7 +5,7 @@ import { boolish } from 'getenv';
 import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
 import semver from 'semver';
 
-import Log from '../log';
+import Log, { link } from '../log';
 import { memoize } from './expodash/memoize';
 
 // Aggressively returns `true` (UNVERSIONED, invalid SDK version format) to push users towards the versioned CLI.
@@ -63,8 +63,21 @@ export async function expoCommandAsync(
   args: string[],
   { silent = false }: { silent?: boolean } = {}
 ): Promise<void> {
-  const expoCliPath =
-    silentResolveFrom(projectDir, 'expo/bin/cli') ?? resolveFrom(projectDir, 'expo/bin/cli.js');
+  let expoCliPath;
+  try {
+    expoCliPath =
+      silentResolveFrom(projectDir, 'expo/bin/cli') ?? resolveFrom(projectDir, 'expo/bin/cli.js');
+  } catch (e: any) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        `The \`expo\` package was not found. Please follow the installation directions at ${link(
+          'https://docs.expo.dev/bare/installing-expo-modules/'
+        )}`
+      );
+    }
+    throw e;
+  }
+
   const spawnPromise = spawnAsync(expoCliPath, args, {
     stdio: ['inherit', 'pipe', 'pipe'], // inherit stdin so user can install a missing expo-cli from inside this command
   });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Fail gracefully on commands that call `npx expo install` if the expo package is not installed

# UX

Before:
```
quins-MacBook-Pro:AwesomeProject2 quin$ ~/Documents/eas-cli/packages/eas-cli/bin/run update:configure
💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.
> npx expo install expo-updates
Error: Cannot find module 'expo/bin/cli.js'
Require stack:
- /Users/quin/AwesomeProject2/noop.js
```

After:
```
quins-MacBook-Pro:AwesomeProject2 quin$ ~/Documents/eas-cli/packages/eas-cli/bin/run update:configure
💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.
> npx expo install expo-updates
`expo` package is not installed. Please follow the installation directions at https://docs.expo.dev/bare/installing-expo-modules/
    Error: update:configure command failed.
```

# Test Plan

- [x] manually ran `eas update:configure`
