### PR TITLE
[ENG-7183][eas-cli] validate that `expo-updates` are in project dependencies when somebody tries to run a build with channel set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Include the original stack in re-thrown errors thrown from EAS CLI commands. ([#1882](https://github.com/expo/eas-cli/pull/1882) by [@brentvatne](https://github.com/brentvatne))
 - Make `update:configure` less verbose. ([#1888](https://github.com/expo/eas-cli/pull/1888) by [@quinlanj](https://github.com/quinlanj))
 - Improve validation for values from app config. ([#1893](https://github.com/expo/eas-cli/pull/1893) by [@wkozyra95](https://github.com/wkozyra95))
+- Improve `expo-updates` validation for builds with `channel` property set. ([#1885](https://github.com/expo/eas-cli/pull/1885) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [3.13.3](https://github.com/expo/eas-cli/releases/tag/v3.13.3) - 2023-06-05
 

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -1,3 +1,4 @@
+import { ExpoConfig } from '@expo/config-types';
 import { Platform } from '@expo/eas-build-job';
 import { BuildProfile, EasJson, ResourceClass } from '@expo/eas-json';
 import JsonFile from '@expo/json-file';
@@ -6,7 +7,6 @@ import resolveFrom from 'resolve-from';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Analytics, AnalyticsEventProperties, BuildEvent } from '../analytics/AnalyticsManager';
-import { DynamicConfigContextFn } from '../commandUtils/context/DynamicProjectConfigContextField';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { CredentialsContext } from '../credentials/context';
 import { CustomBuildConfigMetadata } from '../project/customBuildConfig';
@@ -34,8 +34,9 @@ export async function createBuildContextAsync<T extends Platform>({
   actor,
   graphqlClient,
   analytics,
-  getDynamicPrivateProjectConfigAsync,
   customBuildConfigMetadata,
+  exp,
+  projectId,
 }: {
   buildProfileName: string;
   buildProfile: BuildProfile<T>;
@@ -51,10 +52,10 @@ export async function createBuildContextAsync<T extends Platform>({
   actor: Actor;
   graphqlClient: ExpoGraphqlClient;
   analytics: Analytics;
-  getDynamicPrivateProjectConfigAsync: DynamicConfigContextFn;
   customBuildConfigMetadata?: CustomBuildConfigMetadata;
+  exp: ExpoConfig;
+  projectId: string;
 }): Promise<BuildContext<T>> {
-  const { exp, projectId } = await getDynamicPrivateProjectConfigAsync({ env: buildProfile.env });
   const projectName = exp.slug;
   const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
   const workflow = await resolveWorkflowAsync(projectDir, platform);

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -1,4 +1,3 @@
-import { ExpoConfig } from '@expo/config-types';
 import { Platform } from '@expo/eas-build-job';
 import { BuildProfile, EasJson, ResourceClass } from '@expo/eas-json';
 import JsonFile from '@expo/json-file';
@@ -7,6 +6,7 @@ import resolveFrom from 'resolve-from';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Analytics, AnalyticsEventProperties, BuildEvent } from '../analytics/AnalyticsManager';
+import { DynamicConfigContextFn } from '../commandUtils/context/DynamicProjectConfigContextField';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { CredentialsContext } from '../credentials/context';
 import { CustomBuildConfigMetadata } from '../project/customBuildConfig';
@@ -34,9 +34,8 @@ export async function createBuildContextAsync<T extends Platform>({
   actor,
   graphqlClient,
   analytics,
+  getDynamicPrivateProjectConfigAsync,
   customBuildConfigMetadata,
-  exp,
-  projectId,
 }: {
   buildProfileName: string;
   buildProfile: BuildProfile<T>;
@@ -52,10 +51,10 @@ export async function createBuildContextAsync<T extends Platform>({
   actor: Actor;
   graphqlClient: ExpoGraphqlClient;
   analytics: Analytics;
+  getDynamicPrivateProjectConfigAsync: DynamicConfigContextFn;
   customBuildConfigMetadata?: CustomBuildConfigMetadata;
-  exp: ExpoConfig;
-  projectId: string;
 }): Promise<BuildContext<T>> {
+  const { exp, projectId } = await getDynamicPrivateProjectConfigAsync({ env: buildProfile.env });
   const projectName = exp.slug;
   const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
   const workflow = await resolveWorkflowAsync(projectDir, platform);

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -465,7 +465,7 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
     );
   }
   Log.warn(
-    'Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but expo-updates is not installed.'
+    `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but expo-updates is not installed.`
   );
   const installExpoUpdates = await confirmAsync({
     message: `Would you like to install expo-updates?`,

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -456,18 +456,18 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
 
   if (isExpoUpdatesInstalledAsDevDependency(projectDir)) {
     Log.warn(
-      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but "expo-updates" package is installed as dev dependency. Remove "expo-updates" from your dev dependencies and add it as dependency to your project to use channels for your builds.`
+      `The build profile "${buildProfile.profileName}" uses the channel "${buildProfile.profile.channel}", but you've added "expo-updates" as a dev dependency. To make channels work for your builds, move "expo-updates" from dev dependencies to the main dependencies in your project.`
     );
   } else if (nonInteractive) {
     Log.warn(
-      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but "expo-updates" package is not installed. Install "expo-updates" package to use channels for your builds. Run "npx expo install expo-updates" to install expo-updates package.`
+      `The build profile "${buildProfile.profileName}" has specified the channel "${buildProfile.profile.channel}", but the "expo-updates" package hasn't been installed. To use channels for your builds, install the "expo-updates" package by running "npx expo install expo-updates".`
     );
   } else {
     Log.warn(
-      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but "expo-updates" package is not installed. Install "expo-updates" package to use channels for your builds.`
+      `The build profile "${buildProfile.profileName}" specifies the channel "${buildProfile.profile.channel}", but the "expo-updates" package is missing. To use channels in your builds, install the "expo-updates" package.`
     );
     const installExpoUpdates = await confirmAsync({
-      message: `Would you like to install "expo-updates" package?`,
+      message: `Would you like to install the "expo-updates" package?`,
     });
     if (installExpoUpdates) {
       await installExpoUpdatesAsync(projectDir, { silent: false });

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -455,26 +455,23 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
   }
 
   if (isExpoUpdatesInstalledAsDevDependency(projectDir)) {
-    throw new Error(
+    Log.warn(
       `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but expo-updates is installed as dev dependency. Please remove expo-updates from your dev dependencies and add it as dependency to your project.`
     );
-  }
-  if (nonInteractive) {
-    throw new Error(
+  } else if (nonInteractive) {
+    Log.warn(
       `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but expo-updates is not installed. Please install expo-updates to use channels for your builds. Run "npx expo install expo-updates" to install expo-updates package.`
     );
-  }
-  Log.warn(
-    `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but expo-updates is not installed.`
-  );
-  const installExpoUpdates = await confirmAsync({
-    message: `Would you like to install expo-updates?`,
-  });
-  if (!installExpoUpdates) {
-    throw new Error(
-      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but expo-updates is not installed. Please install expo-updates to use channels for your builds. Run "npx expo install expo-updates" to install expo-updates package.`
+  } else {
+    Log.warn(
+      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but expo-updates is not installed.`
     );
+    const installExpoUpdates = await confirmAsync({
+      message: `Would you like to install expo-updates?`,
+    });
+    if (installExpoUpdates) {
+      await installExpoUpdatesAsync(projectDir, { silent: false });
+      Log.withTick('Installed expo updates');
+    }
   }
-  await installExpoUpdatesAsync(projectDir, { silent: false });
-  Log.withTick('Installed expo updates');
 }

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -456,18 +456,18 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
 
   if (isExpoUpdatesInstalledAsDevDependency(projectDir)) {
     Log.warn(
-      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but expo-updates is installed as dev dependency. Please remove expo-updates from your dev dependencies and add it as dependency to your project.`
+      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but "expo-updates" package is installed as dev dependency. Remove "expo-updates" from your dev dependencies and add it as dependency to your project to use channels for your builds.`
     );
   } else if (nonInteractive) {
     Log.warn(
-      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but expo-updates is not installed. Please install expo-updates to use channels for your builds. Run "npx expo install expo-updates" to install expo-updates package.`
+      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but "expo-updates" package is not installed. Install "expo-updates" package to use channels for your builds. Run "npx expo install expo-updates" to install expo-updates package.`
     );
   } else {
     Log.warn(
-      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but expo-updates is not installed.`
+      `Channel "${buildProfile.profile.channel}" is specified for build profile "${buildProfile.profileName}" but "expo-updates" package is not installed. Install "expo-updates" package to use channels for your builds.`
     );
     const installExpoUpdates = await confirmAsync({
-      message: `Would you like to install expo-updates?`,
+      message: `Would you like to install "expo-updates" package?`,
     });
     if (installExpoUpdates) {
       await installExpoUpdatesAsync(projectDir, { silent: false });

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -471,7 +471,7 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
     });
     if (installExpoUpdates) {
       await installExpoUpdatesAsync(projectDir, { silent: false });
-      Log.withTick('Installed expo updates');
+      Log.withTick('Installed expo-updates');
     }
   }
 }

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -291,8 +291,8 @@ async function prepareAndStartBuildAsync({
     actor,
     graphqlClient,
     analytics,
-    customBuildConfigMetadata,
     getDynamicPrivateProjectConfigAsync,
+    customBuildConfigMetadata,
   });
 
   if (moreBuilds) {

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -67,6 +67,11 @@ export function isExpoUpdatesInstalled(projectDir: string): boolean {
   return !!(packageJson.dependencies && 'expo-updates' in packageJson.dependencies);
 }
 
+export function isExpoUpdatesInstalledAsDevDependency(projectDir: string): boolean {
+  const packageJson = getPackageJson(projectDir);
+  return !!(packageJson.devDependencies && 'expo-updates' in packageJson.devDependencies);
+}
+
 export function isExpoUpdatesInstalledOrAvailable(
   projectDir: string,
   sdkVersion?: string

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -12,6 +12,7 @@ import { RequestedPlatform, appPlatformDisplayNames } from '../platform';
 import { createOrModifyExpoConfigAsync } from '../project/expoConfig';
 import {
   installExpoUpdatesAsync,
+  isExpoUpdatesInstalledAsDevDependency,
   isExpoUpdatesInstalledOrAvailable,
 } from '../project/projectUtils';
 import { resolveWorkflowPerPlatformAsync } from '../project/workflow';
@@ -340,9 +341,14 @@ export async function ensureEASUpdateIsConfiguredAsync(
     projectDir,
     expWithoutUpdates.sdkVersion
   );
-  if (!hasExpoUpdates) {
+  const hasExpoUpdatesInDevDependencies = isExpoUpdatesInstalledAsDevDependency(projectDir);
+  if (!hasExpoUpdates && !hasExpoUpdatesInDevDependencies) {
     await installExpoUpdatesAsync(projectDir, { silent: false });
     Log.withTick('Installed expo-updates');
+  } else if (hasExpoUpdatesInDevDependencies) {
+    Log.warn(
+      `The "expo-updates" package is installed as a dev dependency. This is not recommended. Move "expo-updates" to your dependencies.`
+    );
   }
 
   // Bail out if using a platform that doesn't require runtime versions

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -347,7 +347,7 @@ export async function ensureEASUpdateIsConfiguredAsync(
     Log.withTick('Installed expo-updates');
   } else if (hasExpoUpdatesInDevDependencies) {
     Log.warn(
-      `The "expo-updates" package is installed as a dev dependency. This is not recommended. Move "expo-updates" to your dependencies.`
+      `The "expo-updates" package is installed as a dev dependency. This is not recommended. Move "expo-updates" to your main dependencies.`
     );
   }
 

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -342,7 +342,7 @@ export async function ensureEASUpdateIsConfiguredAsync(
   );
   if (!hasExpoUpdates) {
     await installExpoUpdatesAsync(projectDir, { silent: false });
-    Log.withTick('Installed expo updates');
+    Log.withTick('Installed expo-updates');
   }
 
   // Bail out if using a platform that doesn't require runtime versions


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-7183/improve-detection-of-expo-updates-in-devdependencies

Currently, we don't perform any check in the `eas build` command to verify if a user has `expo-updates` installed when `channel` is set for the build profile.

# How

If a user has a `channel` set for their build profile warn if they don't have `expo-updates` installed. Detect when `expo-updates` are installed as a dev dependency and print a warning suggesting them moving it to dependencies.

Print a warning if `expo-updates` are installed as a dev dependency in `update` commands.

# Test Plan

Tested manually

<img width="668" alt="Screenshot 2023-06-16 at 13 31 42" src="https://github.com/expo/eas-cli/assets/55145344/e80425b2-8749-48a5-8a83-2ec3a814b3b7">
<img width="1083" alt="Screenshot 2023-06-16 at 13 32 14" src="https://github.com/expo/eas-cli/assets/55145344/b81ecce7-3367-4962-af8d-aaea84fdca55">
<img width="1090" alt="Screenshot 2023-06-16 at 13 32 57" src="https://github.com/expo/eas-cli/assets/55145344/458986b6-3bfd-4790-917c-ec659550d061">
