### PR TITLE
[eas-cli] update:configure less verbose output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+
 - Added support for SSO users. ([#1875](https://github.com/expo/eas-cli/pull/1875) by [@lzkb](https://github.com/lzkb))
 - Added new bundle identifier capabilities and entitlements from WWDC23. ([#1870](https://github.com/expo/eas-cli/pull/1870) by [@EvanBacon](https://github.com/EvanBacon))
 
@@ -20,6 +21,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Update `eas build:configure` command to show the link of `eas.json` when generated. ([#1878](https://github.com/expo/eas-cli/pull/1878) by [@amandeepmittal](https://github.com/amandeepmittal))
 - Create app.json or add the "expo" key if either are missing, before modifying or reading the file. ([#1881](https://github.com/expo/eas-cli/pull/1881) by [@brentvatne](https://github.com/brentvatne))
 - Include the original stack in re-thrown errors thrown from EAS CLI commands. ([#1882](https://github.com/expo/eas-cli/pull/1882) by [@brentvatne](https://github.com/brentvatne))
+- Make `update:configure` less verbose. ([#1888](https://github.com/expo/eas-cli/pull/1888) by [@quinlanj](https://github.com/quinlanj))
 
 ## [3.13.3](https://github.com/expo/eas-cli/releases/tag/v3.13.3) - 2023-06-05
 

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -14,6 +14,10 @@ interface ConfigureParams {
   nonInteractive: boolean;
 }
 
+export async function easJsonExistsAsync(projectDir: string): Promise<boolean> {
+  return await fs.pathExists(EasJsonAccessor.formatEasJsonPath(projectDir));
+}
+
 /**
  * Creates eas.json if it does not exist.
  *
@@ -24,7 +28,7 @@ interface ConfigureParams {
 export async function ensureProjectConfiguredAsync(
   configureParams: ConfigureParams
 ): Promise<boolean> {
-  if (await fs.pathExists(EasJsonAccessor.formatEasJsonPath(configureParams.projectDir))) {
+  if (await easJsonExistsAsync(configureParams.projectDir)) {
     return false;
   }
 

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -1,9 +1,10 @@
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
+import { easJsonExistsAsync } from '../../build/configure';
 import EasCommand from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
-import Log, { learnMore, link } from '../../log';
+import Log, { learnMore } from '../../log';
 import { RequestedPlatform } from '../../platform';
 import {
   ensureEASUpdateIsConfiguredAsync,
@@ -57,7 +58,10 @@ export default class UpdateConfigure extends EasCommand {
     Log.addNewLineIfNone();
     Log.log(`🎉 Your app is configured with EAS Update!`);
     Log.newLine();
-    Log.log(`- Run ${chalk.bold('eas build:configure')} to complete your installation`);
+    const easJsonExists = await easJsonExistsAsync(projectDir);
+    if (!easJsonExists) {
+      Log.log(`- Run ${chalk.bold('eas build:configure')} to complete your installation`);
+    }
     Log.log(
       `- ${learnMore('https://docs.expo.dev/eas-update/introduction/', {
         learnMoreMessage: 'Learn more about other capabilities of EAS Update',

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
-import Log from '../../log';
+import Log, { learnMore, link } from '../../log';
 import { RequestedPlatform } from '../../platform';
 import {
   ensureEASUpdateIsConfiguredAsync,
@@ -57,21 +57,11 @@ export default class UpdateConfigure extends EasCommand {
     Log.addNewLineIfNone();
     Log.log(`🎉 Your app is configured with EAS Update!`);
     Log.newLine();
-    Log.log(`${chalk.bold('Next steps')}:`);
-    Log.newLine();
-    Log.log('Update a production build:');
-    Log.log(`1. Create a new build. Example: ${chalk.bold('eas build --profile production')}.`);
-    Log.log('2. Make changes in your project.');
-    Log.log(`3. Publish an update. Example: ${chalk.bold('eas update --channel production')}.`);
-    Log.log('4. Force close and reopen the app at least twice to view the update.');
-
-    Log.newLine();
-    Log.log('Preview an update:');
+    Log.log(`- Run ${chalk.bold('eas build:configure')} to complete your installation`);
     Log.log(
-      `1. Publish an update to a branch. Example: ${chalk.bold('eas update --branch new-feature')}.`
-    );
-    Log.log(
-      '2. In Expo Go or a development build, navigate to Projects > [project name] > Branch > Open.'
+      `- ${learnMore('https://docs.expo.dev/eas-update/introduction/', {
+        learnMoreMessage: 'Learn more about other capabilities of EAS Update',
+      })}`
     );
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Make `eas update:configure` output less verbose and similar to `eas build:configure`

# UX

Before:
```
🎉 Your app is configured with EAS Update!

Next steps:

Update a production build:
1. Create a new build. Example: eas build --profile production.
2. Make changes in your project.
3. Publish an update. Example: eas update --channel production.
4. Force close and reopen the app at least twice to view the update.

Preview an update:
1. Publish an update to a branch. Example: eas update --branch new-feature.
2. In Expo Go or a development build, navigate to Projects > [project name] > Branch > Open.
```

After:
```
quins-MacBook-Pro:AwesomeProject2 quin$ ~/Documents/eas-cli/packages/eas-cli/bin/run update:configure
🎉 Your app is configured with EAS Update!

- Run eas build:configure to complete your installation
- Learn more about other capabilities of EAS Update: https://docs.expo.dev/eas-update/introduction/
```

# Test Plan

- [ ] tests still pass
