### PR TITLE
[eas-cli][ENG-8763] Select default android keystore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+
 - Added support for SSO users. ([#1875](https://github.com/expo/eas-cli/pull/1875) by [@lzkb](https://github.com/lzkb))
 - Added new bundle identifier capabilities and entitlements from WWDC23. ([#1870](https://github.com/expo/eas-cli/pull/1870) by [@EvanBacon](https://github.com/EvanBacon))
+- Selecting default keystore via CLI. ([#1889](https://github.com/expo/eas-cli/pull/1889) by [@khamilowicz](https://github.com/khamilowicz))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-android.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-android.ts
@@ -151,6 +151,7 @@ export function getNewAndroidApiMock(): { [key in keyof typeof AndroidGraphqlCli
     updateAndroidAppCredentialsAsync: jest.fn(),
     updateAndroidAppBuildCredentialsAsync: jest.fn(),
     createAndroidAppBuildCredentialsAsync: jest.fn(),
+    setDefaultAndroidAppBuildCredentialsAsync: jest.fn(),
     getDefaultAndroidAppBuildCredentialsAsync: jest.fn(),
     getAndroidAppBuildCredentialsByNameAsync: jest.fn(),
     createOrUpdateAndroidAppBuildCredentialsByNameAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/android/api/GraphqlClient.ts
@@ -146,6 +146,16 @@ export async function updateAndroidAppBuildCredentialsAsync(
   );
 }
 
+export async function setDefaultAndroidAppBuildCredentialsAsync(
+  graphqlClient: ExpoGraphqlClient,
+  buildCredentials: AndroidAppBuildCredentialsFragment
+): Promise<AndroidAppBuildCredentialsFragment> {
+  return await AndroidAppBuildCredentialsMutation.setDefaultAndroidAppBuildCredentialsAsync(
+    graphqlClient,
+    buildCredentials.id
+  );
+}
+
 export async function createAndroidAppBuildCredentialsAsync(
   graphqlClient: ExpoGraphqlClient,
   appLookupParams: AppLookupParams,
@@ -164,14 +174,6 @@ export async function createAndroidAppBuildCredentialsAsync(
       graphqlClient,
       appLookupParams
     );
-  const buildCredentialsList = androidAppCredentials.androidAppBuildCredentialsList;
-  const existingDefaultBuildCredentials =
-    buildCredentialsList.find(buildCredentials => buildCredentials.isDefault) ?? null;
-  if (existingDefaultBuildCredentials && isDefault) {
-    throw new Error(
-      'Cannot create new default Android Build Credentials. A set of default credentials exists already.'
-    );
-  }
 
   return await AndroidAppBuildCredentialsMutation.createAndroidAppBuildCredentialsAsync(
     graphqlClient,

--- a/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppBuildCredentialsMutation.ts
+++ b/packages/eas-cli/src/credentials/android/api/graphql/mutations/AndroidAppBuildCredentialsMutation.ts
@@ -5,6 +5,7 @@ import gql from 'graphql-tag';
 import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
+  AndroidAppBuildCredentials,
   AndroidAppBuildCredentialsFragment,
   AndroidAppBuildCredentialsInput,
   CreateAndroidAppBuildCredentialsMutation,
@@ -54,6 +55,37 @@ export const AndroidAppBuildCredentialsMutation = {
       'GraphQL: `createAndroidAppBuildCredentials` not defined in server response'
     );
     return data.androidAppBuildCredentials.createAndroidAppBuildCredentials;
+  },
+  async setDefaultAndroidAppBuildCredentialsAsync(
+    graphqlClient: ExpoGraphqlClient,
+    androidAppBuildCredentialsId: string
+  ): Promise<AndroidAppBuildCredentialsFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<AndroidAppBuildCredentials>(
+          gql`
+            mutation AndroidAppBuildCredentialsMutation(
+              $androidAppBuildCredentialsId: ID!
+              $isDefault: Boolean!
+            ) {
+              androidAppBuildCredentials {
+                setDefault(id: $androidAppBuildCredentialsId, isDefault: $isDefault) {
+                  id
+                  ...AndroidAppBuildCredentialsFragment
+                }
+              }
+            }
+            ${print(AndroidAppBuildCredentialsFragmentNode)}
+          `,
+          {
+            androidAppBuildCredentialsId,
+            isDefault: true,
+          }
+        )
+        .toPromise()
+    );
+    assert(data, `GraphQL: 'setDefault' not defined in server response ${JSON.stringify(data)}}`);
+    return data;
   },
   async setKeystoreAsync(
     graphqlClient: ExpoGraphqlClient,

--- a/packages/eas-cli/src/credentials/manager/Actions.ts
+++ b/packages/eas-cli/src/credentials/manager/Actions.ts
@@ -18,6 +18,7 @@ export enum AndroidActionType {
   GoBackToCaller,
   GoBackToHighLevelActions,
   CreateKeystore,
+  SetDefaultKeystore,
   DownloadKeystore,
   RemoveKeystore,
   CreateFcm,

--- a/packages/eas-cli/src/credentials/manager/AndroidActions.ts
+++ b/packages/eas-cli/src/credentials/manager/AndroidActions.ts
@@ -53,6 +53,11 @@ export const buildCredentialsActions: ActionInfo[] = [
     scope: Scope.Project,
   },
   {
+    value: AndroidActionType.SetDefaultKeystore,
+    title: 'Change default keystore',
+    scope: Scope.Project,
+  },
+  {
     value: AndroidActionType.DownloadKeystore,
     title: 'Download existing keystore',
     scope: Scope.Project,

--- a/packages/eas-cli/src/credentials/manager/CreateAndroidBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/CreateAndroidBuildCredentials.ts
@@ -1,0 +1,42 @@
+import { AndroidAppBuildCredentialsFragment } from '../../graphql/generated';
+import Log from '../../log';
+import { confirmAsync } from '../../prompts';
+import { promptForNameAsync } from '../android/actions/BuildCredentialsUtils';
+import { CreateKeystore } from '../android/actions/CreateKeystore';
+import { AppLookupParams } from '../android/api/GraphqlClient';
+import { CredentialsContext } from '../context';
+
+export class CreateAndroidBuildCredentials {
+  constructor(private app: AppLookupParams) {}
+
+  async runAsync(ctx: CredentialsContext): Promise<AndroidAppBuildCredentialsFragment> {
+    const name = await promptForNameAsync();
+
+    const buildCredentialsList = await ctx.android.getAndroidAppBuildCredentialsListAsync(
+      ctx.graphqlClient,
+      this.app
+    );
+
+    let isDefault = true;
+    if (buildCredentialsList.length > 0) {
+      isDefault = await confirmAsync({
+        message: 'Do you want to set this as your default build credentials?',
+        initial: false,
+      });
+    }
+
+    const keystore = await new CreateKeystore(this.app.account).runAsync(ctx);
+    const createAndroidCredentials = await ctx.android.createAndroidAppBuildCredentialsAsync(
+      ctx.graphqlClient,
+      this.app,
+      {
+        name,
+        isDefault,
+        androidKeystoreId: keystore.id,
+      }
+    );
+
+    Log.succeed(`Created Android build credentials ${createAndroidCredentials.name}`);
+    return createAndroidCredentials;
+  }
+}

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -14,7 +14,6 @@ import {
 } from '../android/actions/BuildCredentialsUtils';
 import { CreateFcm } from '../android/actions/CreateFcm';
 import { CreateGoogleServiceAccountKey } from '../android/actions/CreateGoogleServiceAccountKey';
-import { CreateKeystore } from '../android/actions/CreateKeystore';
 import { DownloadKeystore } from '../android/actions/DownloadKeystore';
 import { RemoveFcm } from '../android/actions/RemoveFcm';
 import { SelectAndRemoveGoogleServiceAccountKey } from '../android/actions/RemoveGoogleServiceAccountKey';
@@ -36,13 +35,11 @@ import {
   gsaKeyActions,
   highLevelActions,
 } from './AndroidActions';
+import { CreateAndroidBuildCredentials } from './CreateAndroidBuildCredentials';
 import { Action, PressAnyKeyToContinue } from './HelperActions';
-import {
-  SelectAndroidBuildCredentials,
-  SelectAndroidBuildCredentialsResultType,
-  SelectExistingAndroidBuildCredentials,
-} from './SelectAndroidBuildCredentials';
+import { SelectExistingAndroidBuildCredentials } from './SelectAndroidBuildCredentials';
 import { SelectBuildProfileFromEasJson } from './SelectBuildProfileFromEasJson';
+import { SetDefaultAndroidKeystore } from './SetDefaultAndroidKeystore';
 
 export class ManageAndroid {
   constructor(private callingAction: Action, private projectDir: string) {}
@@ -163,31 +160,9 @@ export class ManageAndroid {
     );
     const appLookupParams = await getAppLookupParamsFromContextAsync(ctx, gradleContext);
     if (action === AndroidActionType.CreateKeystore) {
-      const selectBuildCredentialsResult = await new SelectAndroidBuildCredentials(
-        appLookupParams
-      ).runAsync(ctx);
-      const keystore = await new CreateKeystore(appLookupParams.account).runAsync(ctx);
-      if (
-        selectBuildCredentialsResult.resultType ===
-        SelectAndroidBuildCredentialsResultType.CREATE_REQUEST
-      ) {
-        await ctx.android.createAndroidAppBuildCredentialsAsync(
-          ctx.graphqlClient,
-          appLookupParams,
-          {
-            ...selectBuildCredentialsResult.result,
-            androidKeystoreId: keystore.id,
-          }
-        );
-      } else {
-        await ctx.android.updateAndroidAppBuildCredentialsAsync(
-          ctx.graphqlClient,
-          selectBuildCredentialsResult.result,
-          {
-            androidKeystoreId: keystore.id,
-          }
-        );
-      }
+      await new CreateAndroidBuildCredentials(appLookupParams).runAsync(ctx);
+    } else if (action === AndroidActionType.SetDefaultKeystore) {
+      await new SetDefaultAndroidKeystore(appLookupParams).runAsync(ctx);
     } else if (action === AndroidActionType.DownloadKeystore) {
       const buildCredentials = await new SelectExistingAndroidBuildCredentials(
         appLookupParams

--- a/packages/eas-cli/src/credentials/manager/SetDefaultAndroidKeystore.ts
+++ b/packages/eas-cli/src/credentials/manager/SetDefaultAndroidKeystore.ts
@@ -1,0 +1,45 @@
+import { AndroidAppBuildCredentialsFragment } from '../../graphql/generated';
+import Log from '../../log';
+import { promptAsync } from '../../prompts';
+import { sortBuildCredentials } from '../android/actions/BuildCredentialsUtils';
+import { AppLookupParams } from '../android/api/GraphqlClient';
+import { CredentialsContext } from '../context';
+
+export class SetDefaultAndroidKeystore {
+  constructor(private app: AppLookupParams) {}
+
+  async runAsync(ctx: CredentialsContext): Promise<AndroidAppBuildCredentialsFragment | undefined> {
+    const buildCredentialsList = await ctx.android.getAndroidAppBuildCredentialsListAsync(
+      ctx.graphqlClient,
+      this.app
+    );
+    if (buildCredentialsList.length === 0) {
+      Log.log(`You don't have any Android build credentials`);
+      return;
+    }
+    const sortedBuildCredentialsList = sortBuildCredentials(buildCredentialsList);
+    const sortedBuildCredentialsChoices = sortedBuildCredentialsList.map(buildCredentials => ({
+      title: buildCredentials.isDefault
+        ? `${buildCredentials.name} (Default)`
+        : buildCredentials.name,
+      value: buildCredentials,
+    }));
+
+    const { buildCredentialsResult } = await promptAsync({
+      type: 'select',
+      name: 'buildCredentialsResult',
+      message: 'Select build credentials',
+      choices: [...sortedBuildCredentialsChoices, { title: 'Cancel', value: null }],
+    });
+
+    if (!buildCredentialsResult?.androidKeystore) {
+      return;
+    }
+
+    Log.log('Updating the default build credentials for this project...');
+    return await ctx.android.setDefaultAndroidAppBuildCredentialsAsync(ctx.graphqlClient, {
+      ...buildCredentialsResult,
+      isDefault: true,
+    });
+  }
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Current workflow can lead to users unintentionally overwriting their Android keystore. We should make this mistake less likely.

# How

Change current flow to the following:
- Keystore: Manage everything needed to build your project
- Set up a new keystore
- Generate a new Android Keystore
- Assign a name to your build credentials
- Set this as your default build credentials (y/N)

Also, user can also change his default keystore via CLI.

<img width="472" alt="image" src="https://github.com/expo/eas-cli/assets/1774298/9620862a-4535-4eee-91cf-584476b875d4">

# Test Plan

1. Run `eas credentials -p android`
2. Select any profile
3. Select `Keystore: Manage everything needed to build your project`

Creating new keystore

4. Select `Set up a new keystore`
5. Follow the workflow

Selecting default keystore

4. Select `Change default keystore`
5. Select new default keystore
6. Check (via CLI or web) whether default keystore changed.


