### PR TITLE
[eas-cli] Change sso flag display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Change sso flag display. ([#1890](https://github.com/expo/eas-cli/pull/1890) by [@lzkb](https://github.com/lzkb))
 - Build:configure -- add channels to eas.json if using eas updates. ([#1887](https://github.com/expo/eas-cli/pull/1887) by [@quinlanj](https://github.com/quinlanj))
 - Eas update: Error gracefully if no git repo. ([#1884](https://github.com/expo/eas-cli/pull/1884) by [@quinlanj](https://github.com/quinlanj))
 - Error gracefully if expo pkg not installed. ([#1883](https://github.com/expo/eas-cli/pull/1883) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -906,10 +906,7 @@ log in with your Expo account
 
 ```
 USAGE
-  $ eas login [--sso]
-
-FLAGS
-  -s, --sso  Log in with SSO
+  $ eas login
 
 DESCRIPTION
   log in with your Expo account

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -13,6 +13,7 @@ export default class AccountLogin extends EasCommand {
       description: 'Login with SSO',
       char: 's',
       default: false,
+      hidden: true,
     }),
   };
 


### PR DESCRIPTION
# Why
This makes 2 minor changes which are not to display the login -sso flag in the help text and not to list it in the README, as SSO is in beta stage.

# How
Added 'hidden' to the sso flag definition, and deleted the remaining mention of it in the README.

# Test Plan
Manually tested that easd login --help does not list the sso flag.
