### PR TITLE
[eas-cli] better runtime output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Better runtimeVersion output. ([#1894](https://github.com/expo/eas-cli/pull/1894) by [@quinlanj](https://github.com/quinlanj))
+
 ## [3.14.0](https://github.com/expo/eas-cli/releases/tag/v3.14.0) - 2023-06-20
 
 ### 🎉 New features

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -169,22 +169,29 @@ function logEasUpdatesAutoConfig({
     );
   }
 
-  if (modifyConfig.android?.runtimeVersion ?? modifyConfig.runtimeVersion) {
+  const androidRuntime = modifyConfig.android?.runtimeVersion ?? modifyConfig.runtimeVersion;
+  const iosRuntime = modifyConfig.ios?.runtimeVersion ?? modifyConfig.runtimeVersion;
+  if (androidRuntime && iosRuntime && androidRuntime === iosRuntime) {
     Log.withTick(
-      `Configured runtimeVersion for ${
-        appPlatformDisplayNames[AppPlatform.Android]
-      } with "${JSON.stringify(
-        modifyConfig.android?.runtimeVersion ?? modifyConfig.runtimeVersion
-      )}"`
-    );
-  }
-
-  if (modifyConfig.ios?.runtimeVersion ?? modifyConfig.runtimeVersion) {
-    Log.withTick(
-      `Configured runtimeVersion for ${
+      `Configured runtimeVersion for ${appPlatformDisplayNames[AppPlatform.Android]} and ${
         appPlatformDisplayNames[AppPlatform.Ios]
-      } with "${JSON.stringify(modifyConfig.ios?.runtimeVersion ?? modifyConfig.runtimeVersion)}"`
+      } with "${modifyConfig.android?.runtimeVersion ?? modifyConfig.runtimeVersion}"`
     );
+  } else {
+    if (androidRuntime) {
+      Log.withTick(
+        `Configured runtimeVersion for ${appPlatformDisplayNames[AppPlatform.Android]} with "${
+          modifyConfig.android?.runtimeVersion ?? modifyConfig.runtimeVersion
+        }"`
+      );
+    }
+    if (iosRuntime) {
+      Log.withTick(
+        `Configured runtimeVersion for ${appPlatformDisplayNames[AppPlatform.Ios]} with "${
+          modifyConfig.ios?.runtimeVersion ?? modifyConfig.runtimeVersion
+        }"`
+      );
+    }
   }
 }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

In `eas update:configure`, we are double quoting the `runtimeVersion` and printing it for each platform even if they are the same. Example:

```
✔ Configured runtimeVersion for Android with ""1.0.0""
✔ Configured runtimeVersion for iOS with ""1.0.0""
```

# How

This PR fixes the double quote, and prints the platform runtimeVersion together if they are the same. Example:

if they are same:
```
✔ Configured runtimeVersion for Android and iOS with "1.0.0"
```

if they are different:
```
✔ Configured runtimeVersion for Android with "2.0.0"
✔ Configured runtimeVersion for iOS with "1.0.0"
```

# Test Plan

- [ ] tested manually 
