### PR TITLE
[eas-cli] print better error message when uploading the project archive tarball fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Better runtimeVersion output. ([#1894](https://github.com/expo/eas-cli/pull/1894) by [@quinlanj](https://github.com/quinlanj))
+- Print better error message when uploading project archive tarball fails. ([#1897](https://github.com/expo/eas-cli/pull/1897) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [3.14.0](https://github.com/expo/eas-cli/releases/tag/v3.14.0) - 2023-06-20
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -42,6 +42,7 @@ import {
   EasBuildFreeTierDisabledAndroidError,
   EasBuildFreeTierDisabledError,
   EasBuildFreeTierDisabledIOSError,
+  EasBuildProjectArchiveUploadError,
   EasBuildResourceClassNotAvailableInFreeTierError,
   EasBuildTooManyPendingBuildsError,
   RequestValidationError,
@@ -274,7 +275,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
     if (err.message) {
       errMessage += `\n\nReason: ${err.message}`;
     }
-    throw new EasCommandError(errMessage);
+    throw new EasBuildProjectArchiveUploadError(errMessage);
   } finally {
     if (projectTarballPath) {
       await fs.remove(projectTarballPath);

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -269,6 +269,12 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         properties: ctx.analyticsEventProperties,
       }
     );
+  } catch (err: any) {
+    let errMessage = 'Failed to upload the project tarball to EAS Build';
+    if (err.message) {
+      errMessage += `\n\nReason: ${err.message}`;
+    }
+    throw new EasCommandError(errMessage);
   } finally {
     if (projectTarballPath) {
       await fs.remove(projectTarballPath);

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -15,3 +15,5 @@ export class RequestValidationError extends EasCommandError {}
 export class EasBuildDownForMaintenanceError extends EasCommandError {}
 
 export class EasBuildTooManyPendingBuildsError extends EasCommandError {}
+
+export class EasBuildProjectArchiveUploadError extends EasCommandError {}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1687487381876689

# How

Improve error message

# Test Plan

Test locally
<img width="445" alt="Screenshot 2023-06-23 at 10 36 24" src="https://github.com/expo/eas-cli/assets/55145344/d2092e77-b5db-4ecf-bd24-45cfbd031878">
