### PR TITLE
Show build profile on `eas build:run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Show build profile when selecting a build for eas build:run. ([#1901](https://github.com/expo/eas-cli/pull/1901) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/queries.ts
+++ b/packages/eas-cli/src/build/queries.ts
@@ -132,6 +132,7 @@ function createBuildToPartialChoiceMaker(
         name: build.platform === AppPlatform.Ios ? 'Build number' : 'Version code',
         value: build.appBuildVersion ? chalk.bold(build.appBuildVersion) : null,
       },
+      { name: 'Profile', value: build.buildProfile ? chalk.bold(build.buildProfile) : null },
     ];
 
     const filteredDescriptionArray: string[] = descriptionItems

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -210,8 +210,9 @@ async function maybeGetBuildAsync(
       },
       paginatedQueryOptions,
       selectPromptDisabledFunction: build => !isRunnableOnSimulatorOrEmulator(build),
-      selectPromptWarningMessage:
-        'Artifacts for this build have expired and are no longer available, or this is not a simulator/emulator build.',
+      selectPromptWarningMessage: `Artifacts for this build have expired and are no longer available, or this is not ${
+        flags.selectedPlatform === AppPlatform.Ios ? 'a simulator' : 'an emulator'
+      } build.`,
     });
     return validateChosenBuild(build, flags.selectedPlatform);
   } else if (flags.runArchiveFlags.latest) {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
I love using `eas build:run` to quickly install a build on an emulator/ simulator, but found I had to go back to my project page to check the build ID, because I was occasionally building non-development builds for various test cases (especially when it comes to APK files), and I could't tell which one was which.

Adding build profile to the selected list item lets you match your build with something easily at-hand in your local dev environment (your **eas.json** file), so it's easy to tell if you're grabbing the latest development build, or a standalone internal test version, etc.

# How

Added build profile to the list of data that shows when you arrow down to a build in the list.

Also slightly compressed the not-available warning based on available information..

# Test Plan

<img width="765" alt="image" src="https://github.com/expo/eas-cli/assets/8053974/534b35fe-dcd6-4776-9ef4-b7cf4f7620a3">

