### PR TITLE
[eas-cli] Ignore the existing entitlements when ios is gitignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add styling to SSO auth redirect completion page. ([#1929](https://github.com/expo/eas-cli/pull/1929) by [@wschurman](https://github.com/wschurman))
+- Ignore entitlements from native template when `/ios` is gitignored. ([#1906](https://github.com/expo/eas-cli/pull/1906) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -3,6 +3,7 @@ import { JSONObject } from '@expo/json-file';
 import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 
 import { readPlistAsync } from '../../utils/plist';
+import { hasIgnoredIosProjectAsync } from '../workflow';
 
 interface Target {
   buildConfiguration?: string;
@@ -13,6 +14,7 @@ export async function getManagedApplicationTargetEntitlementsAsync(
   env: Record<string, string>
 ): Promise<JSONObject> {
   const originalProcessEnv: NodeJS.ProcessEnv = process.env;
+
   try {
     process.env = {
       ...process.env,
@@ -24,6 +26,7 @@ export async function getManagedApplicationTargetEntitlementsAsync(
       projectRoot: projectDir,
       platforms: ['ios'],
       introspect: true,
+      ignoreExistingNativeFiles: await hasIgnoredIosProjectAsync(projectDir),
     });
     return expWithMods.ios?.entitlements || {};
   } finally {

--- a/packages/eas-cli/src/project/workflow.ts
+++ b/packages/eas-cli/src/project/workflow.ts
@@ -44,3 +44,15 @@ export async function resolveWorkflowPerPlatformAsync(
   ]);
   return { android, ios };
 }
+
+export async function hasIgnoredIosProjectAsync(projectDir: string): Promise<boolean> {
+  const vcsClient = getVcsClient();
+  const vcsRootPath = path.normalize(await vcsClient.getRootPathAsync());
+
+  try {
+    const pbxProjectPath = IOSConfig.Paths.getPBXProjectPath(projectDir);
+    return await vcsClient.isFileIgnoredAsync(path.relative(vcsRootPath, pbxProjectPath));
+  } finally {
+    return false;
+  }
+}


### PR DESCRIPTION
# Why

Fixes ENG-8481
Supersedes #1852

# How

This change depends on https://github.com/expo/expo/pull/23165, and uses the new `ignoreExistingNativeFiles` when using CNG/managed.

# Todos

There are still a couple of things to do before we can merge this PR.

- [x] Wait for new `@expo/config-plugins` release with feature from https://github.com/expo/expo/pull/23165
- [ ] How do we communicate this "change" in behavior to our users?
- [ ] How can we let users opt-out of this new behavior?

Optionally:

- [ ] Define in clear terms when EAS CLI considers projects to be managed, or bare/generic

# Test Plan

TBD
