### PR TITLE
[ENG-9165][eas-cli] print the list of environment variables that we load in EAS CLI when evaluating app config for a build

### DIFF
--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -24,7 +24,7 @@ import {
 } from '../graphql/generated';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
 import { toAppPlatform, toPlatform } from '../graphql/types/AppPlatform';
-import Log from '../log';
+import Log, { learnMore } from '../log';
 import {
   RequestedPlatform,
   appPlatformDisplayNames,
@@ -118,6 +118,13 @@ export async function runBuildAndSubmitAsync(
     platforms,
     profileName: flags.profile ?? undefined,
   });
+  Log.log(
+    `Loaded "env" configuration for the "${buildProfiles[0].profileName}" profile: ${
+      buildProfiles[0].profile.env
+        ? Object.keys(buildProfiles[0].profile.env).join(', ')
+        : 'no environment variables specified'
+    }. ${learnMore('https://docs.expo.dev/build-reference/variables/')}`
+  );
 
   await ensureExpoDevClientInstalledForDevClientBuildsAsync({
     projectDir,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-9165/print-the-list-of-environment-variables-that-we-load-in-eas-cli-when

# How

Print list of env vars we load in EAS CLI and which can be used when evaluating app config for a build.

**Note**: This log will be always printed not only when evaluating `app.config.js`.

# Test Plan

Tested manually
<img width="1079" alt="Screenshot 2023-06-30 at 11 31 37" src="https://github.com/expo/eas-cli/assets/55145344/394299c8-469e-41c7-987b-ee015f8cc531">
<img width="1092" alt="Screenshot 2023-06-30 at 11 30 26" src="https://github.com/expo/eas-cli/assets/55145344/5b4353da-c5cc-4ead-9c42-ba6ff1a914c5">
<img width="1041" alt="Screenshot 2023-06-30 at 11 29 20" src="https://github.com/expo/eas-cli/assets/55145344/10d3fedf-beb8-46c6-8639-04777d8e7915">
