### PR TITLE
[ENG-9093][eas-cli] remove useClassicUpdates upon configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Show build profile when selecting a build for eas build:run. ([#1901](https://github.com/expo/eas-cli/pull/1901) by [@keith-kurak](https://github.com/keith-kurak))
-
 - Adds -m alias to --message in update/republish and removed README comment. ([#1905](https://github.com/expo/eas-cli/pull/1905) by [@pusongqi](https://github.com/pusongqi))
-
 
 ### 🐛 Bug fixes
 
@@ -19,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Better runtimeVersion output. ([#1894](https://github.com/expo/eas-cli/pull/1894) by [@quinlanj](https://github.com/quinlanj))
 - Print better error message when uploading project archive tarball fails. ([#1897](https://github.com/expo/eas-cli/pull/1897) by [@szdziedzic](https://github.com/szdziedzic))
+- Set useClassicUpdates to false on `eas update` and `eas update:configure`. ([#1914](https://github.com/expo/eas-cli/pull/1914) by [@quinlanj](https://github.com/quinlanj))
 
 ## [3.14.0](https://github.com/expo/eas-cli/releases/tag/v3.14.0) - 2023-06-20
 

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -84,6 +84,17 @@ export function isExpoUpdatesInstalledOrAvailable(
   return isExpoUpdatesInstalled(projectDir);
 }
 
+/**
+ * Projects on SDK 49+ are required to set `updates.useClassicUpdates` to `true` to use Classic Updates.
+ */
+export function isDefinitelyUsingClassicUpdates(exp: ExpoConfig): boolean {
+  return !!exp.updates?.useClassicUpdates;
+}
+
+export function isUsingClassicUpdates(exp: ExpoConfig, projectId: string): boolean {
+  return exp.updates?.url === getEASUpdateURL(projectId);
+}
+
 export function isUsingEASUpdate(exp: ExpoConfig, projectId: string): boolean {
   return exp.updates?.url === getEASUpdateURL(projectId);
 }

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -85,7 +85,7 @@ export function isExpoUpdatesInstalledOrAvailable(
 }
 
 /**
- * Projects on SDK 49+ are required to set `updates.useClassicUpdates` to `true` to use Classic Updates.
+ * Projects on SDK 49 are required to set `updates.useClassicUpdates` to `true` to use Classic Updates.
  */
 export function isDefinitelyUsingClassicUpdates(exp: ExpoConfig): boolean {
   return !!exp.updates?.useClassicUpdates;

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -91,10 +91,6 @@ export function isDefinitelyUsingClassicUpdates(exp: ExpoConfig): boolean {
   return !!exp.updates?.useClassicUpdates;
 }
 
-export function isUsingClassicUpdates(exp: ExpoConfig, projectId: string): boolean {
-  return exp.updates?.url === getEASUpdateURL(projectId);
-}
-
 export function isUsingEASUpdate(exp: ExpoConfig, projectId: string): boolean {
   return exp.updates?.url === getEASUpdateURL(projectId);
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Make sure a user isn't using Classic Updates and EAS Update at the same time. If a user has Classic Updates, set `useClassicUpdates` to false if a user runs `eas update:configure` or `eas update`.

# How

on `eas update:configure`: 
```
quins-MacBook-Pro:updates-test-4 quin$ ~/Documents/eas-cli/packages/eas-cli/bin/run update:configure
💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.
✔ Configured updates.useClassicUpdates to "false". You cannot use EAS Update and Classic Updates at the same time.
```

on `eas update`:
```
quins-MacBook-Pro:updates-test-4 quin$ ~/Documents/eas-cli/packages/eas-cli/bin/run update
✔ Configured updates.useClassicUpdates to "false". You cannot be using both EAS Update and Classic Updates.
```


# Test Plan

- [ ] manually tested
