### PR TITLE
[ENG-9093][eas-cli] Throw if useClassicUpdates is set when the developer is trying to use EAS Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Show build profile when selecting a build for eas build:run. ([#1901](https://github.com/expo/eas-cli/pull/1901) by [@keith-kurak](https://github.com/keith-kurak))
-
 - Adds -m alias to --message in update/republish and removed README comment. ([#1905](https://github.com/expo/eas-cli/pull/1905) by [@pusongqi](https://github.com/pusongqi))
 
-
 ### 🐛 Bug fixes
+
+- Ensure useClassicUpdates is not set when using EAS Update commands. ([#1915](https://github.com/expo/eas-cli/pull/1915) by [@ide](https://github.com/ide))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
@@ -1,4 +1,4 @@
-import { getConfig, modifyConfigAsync } from '@expo/config';
+import { getConfig, getConfigFilePaths, modifyConfigAsync } from '@expo/config';
 import { vol } from 'memfs';
 import { anything, instance, mock, when } from 'ts-mockito';
 
@@ -26,6 +26,10 @@ describe(getProjectIdAsync, () => {
   let sessionManager: SessionManager;
 
   beforeEach(() => {
+    jest
+      .mocked(getConfigFilePaths)
+      .mockReturnValue({ staticConfigPath: null, dynamicConfigPath: null });
+
     const sessionManagerMock = mock<SessionManager>();
     when(sessionManagerMock.ensureLoggedInAsync(anything())).thenResolve({
       actor: {

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -63,6 +63,11 @@ export default class BuildConfigure extends EasCommand {
       nonInteractive: false,
     });
     if (didCreateEasJson && isUsingEASUpdate(exp, projectId)) {
+      if (exp.updates?.useClassicUpdates) {
+        throw new Error(
+          `Your app config sets "updates.useClassicUpdates" but is configured to use EAS Update in "updates.url". EAS Update does not support classic updates. Remove "useClassicUpdates" from your app config if you intend to use EAS Update and run this command again.`
+        );
+      }
       await ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir);
     }
 

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -11,7 +11,10 @@ import { isExpoUpdatesInstalled, isUsingEASUpdate } from '../../project/projectU
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { promptAsync } from '../../prompts';
 import { syncUpdatesConfigurationAsync as syncAndroidUpdatesConfigurationAsync } from '../../update/android/UpdatesModule';
-import { ensureEASUpdateIsConfiguredInEasJsonAsync } from '../../update/configure';
+import {
+  ensureEASUpdateIsConfiguredInEasJsonAsync,
+  ensureUseClassicUpdatesIsRemovedAsync,
+} from '../../update/configure';
 import { syncUpdatesConfigurationAsync as syncIosUpdatesConfigurationAsync } from '../../update/ios/UpdatesModule';
 import { getVcsClient } from '../../vcs';
 
@@ -64,10 +67,11 @@ export default class BuildConfigure extends EasCommand {
     });
     if (didCreateEasJson && isUsingEASUpdate(exp, projectId)) {
       if (exp.updates?.useClassicUpdates) {
-        throw new Error(
-          `Your app config sets "updates.useClassicUpdates" but is configured to use EAS Update in "updates.url". EAS Update does not support classic updates. Remove "useClassicUpdates" from your app config if you intend to use EAS Update and run this command again.`
-        );
+        // NOTE: this method modifies the Expo config; be sure to use this function's return value
+        // if the config object is used later in the future
+        await ensureUseClassicUpdatesIsRemovedAsync({ exp, projectDir });
       }
+
       await ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir);
     }
 

--- a/packages/eas-cli/src/commands/update/__tests__/configure.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/configure.test.ts
@@ -1,0 +1,27 @@
+import { ExpoConfig } from '@expo/config';
+import { instance, mock } from 'ts-mockito';
+
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { ensureEASUpdateIsConfiguredAsync } from '../../../update/configure';
+
+describe(ensureEASUpdateIsConfiguredAsync, () => {
+  it('errors with "useClassicUpdates" set', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>({}));
+    const exp: ExpoConfig = {
+      name: 'test',
+      slug: 'test',
+      updates: { useClassicUpdates: true },
+    };
+
+    await expect(async () => {
+      await ensureEASUpdateIsConfiguredAsync(graphqlClient, {
+        exp,
+        projectId: 'test',
+        projectDir: '/tmp/test',
+        platform: null,
+      });
+    }).rejects.toThrow(
+      `Your app config sets "updates.useClassicUpdates" but EAS Update does not support classic updates. Remove "useClassicUpdates" from your app config and run this command again.`
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/update/__tests__/configure.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/configure.test.ts
@@ -5,7 +5,7 @@ import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/cr
 import { ensureEASUpdateIsConfiguredAsync } from '../../../update/configure';
 
 describe(ensureEASUpdateIsConfiguredAsync, () => {
-  it('errors with "useClassicUpdates" set', async () => {
+  it('errors with "useClassicUpdates" set and no app.json', async () => {
     const graphqlClient = instance(mock<ExpoGraphqlClient>({}));
     const exp: ExpoConfig = {
       name: 'test',

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -92,20 +92,6 @@ describe(UpdatePublish.name, () => {
     );
   });
 
-  it.only('errors with "useClassicUpdates" set', async () => {
-    const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
-
-    mockTestProject({ expoConfig: { updates: { useClassicUpdates: true } } });
-    mockTestExport();
-
-    jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
-      branchId: 'branch123',
-      createdBranch: false,
-    });
-
-    await expect(new UpdatePublish(flags, commandOptions).run()).rejects.toThrow('xxx.');
-  });
-
   it('creates a new update with --non-interactive, --branch, and --message', async () => {
     const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
 

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -92,6 +92,20 @@ describe(UpdatePublish.name, () => {
     );
   });
 
+  it.only('errors with "useClassicUpdates" set', async () => {
+    const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
+
+    mockTestProject({ expoConfig: { updates: { useClassicUpdates: true } } });
+    mockTestExport();
+
+    jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
+      branchId: 'branch123',
+      createdBranch: false,
+    });
+
+    await expect(new UpdatePublish(flags, commandOptions).run()).rejects.toThrow('xxx.');
+  });
+
   it('creates a new update with --non-interactive, --branch, and --message', async () => {
     const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
 

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -41,7 +41,7 @@ export default class UpdateConfigure extends EasCommand {
     });
 
     Log.log(
-      '💡 The following process will configure your project to run EAS Update. These changes only apply to your local project files and you can safely revert them at any time.'
+      '💡 The following process will configure your project to use EAS Update. These changes only apply to your local project files and you can safely revert them at any time.'
     );
 
     await getVcsClient().ensureRepoExistsAsync();
@@ -56,7 +56,7 @@ export default class UpdateConfigure extends EasCommand {
     await ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir);
 
     Log.addNewLineIfNone();
-    Log.log(`🎉 Your app is configured with EAS Update!`);
+    Log.log(`🎉 Your app is configured to use EAS Update!`);
     Log.newLine();
     const easJsonExists = await easJsonExistsAsync(projectDir);
     if (!easJsonExists) {


### PR DESCRIPTION
Why
---
Fail fast with a clear message if the app config contradicts itself or the developer's behavior.

How
---
Throw if useClassicUpdates is set in the app config and the developer is running an EAS Update-related command or if the app config uses an EAS Update URL.

Test Plan
---
Added a unit test for ensureEASUpdateIsConfiguredAsync