### PR TITLE
[eas-cli] add free tier limit exceeded errors to server-side defined errors

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -42,6 +42,8 @@ import {
   EasBuildFreeTierDisabledAndroidError,
   EasBuildFreeTierDisabledError,
   EasBuildFreeTierDisabledIOSError,
+  EasBuildFreeTierIOSLimitExceededError,
+  EasBuildFreeTierLimitExceededError,
   EasBuildProjectArchiveUploadError,
   EasBuildResourceClassNotAvailableInFreeTierError,
   EasBuildTooManyPendingBuildsError,
@@ -186,6 +188,8 @@ const SERVER_SIDE_DEFINED_ERRORS: Record<string, typeof EasCommandError> = {
   EAS_BUILD_RESOURCE_CLASS_NOT_AVAILABLE_IN_FREE_TIER:
     EasBuildResourceClassNotAvailableInFreeTierError,
   VALIDATION_ERROR: RequestValidationError,
+  EAS_BUILD_FREE_TIER_LIMIT_EXCEEDED_ERROR: EasBuildFreeTierLimitExceededError,
+  EAS_BUILD_FREE_TIER_IOS_LIMIT_EXCEEDED_ERROR: EasBuildFreeTierIOSLimitExceededError,
 };
 
 export function handleBuildRequestError(error: any, platform: Platform): never {

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -17,3 +17,7 @@ export class EasBuildDownForMaintenanceError extends EasCommandError {}
 export class EasBuildTooManyPendingBuildsError extends EasCommandError {}
 
 export class EasBuildProjectArchiveUploadError extends EasCommandError {}
+
+export class EasBuildFreeTierLimitExceededError extends EasCommandError {}
+
+export class EasBuildFreeTierIOSLimitExceededError extends EasCommandError {}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://github.com/expo/universe/pull/10819#discussion_r1250520568

# How

Add free tier limit exceeded errors to server-side defined errors

# Test Plan

Tests