### PR TITLE
[eas-cli] Handle free user limit error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Better runtimeVersion output. ([#1894](https://github.com/expo/eas-cli/pull/1894) by [@quinlanj](https://github.com/quinlanj))
 - Print better error message when uploading project archive tarball fails. ([#1897](https://github.com/expo/eas-cli/pull/1897) by [@szdziedzic](https://github.com/szdziedzic))
+- Adds support for 2 new server-side errors related to build limits. ([#1921](https://github.com/expo/eas-cli/pull/1921) by [@sundeeppeswani](https://github.com/sundeeppeswani))
 
 ## [3.14.0](https://github.com/expo/eas-cli/releases/tag/v3.14.0) - 2023-06-20
 

--- a/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
+++ b/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
@@ -13,6 +13,8 @@ import {
   EasBuildFreeTierDisabledAndroidError,
   EasBuildFreeTierDisabledError,
   EasBuildFreeTierDisabledIOSError,
+  EasBuildFreeTierIosLimitExceededError,
+  EasBuildFreeTierLimitExceededError,
   EasBuildResourceClassNotAvailableInFreeTierError,
   EasBuildTooManyPendingBuildsError,
   RequestValidationError,
@@ -276,6 +278,45 @@ describe(Build.name, () => {
           assertReThrownError(
             handleBuildRequestErrorThrownError,
             EasBuildFreeTierDisabledAndroidError,
+            'Error 1'
+          );
+        });
+      });
+      describe('for EAS_BUILD_FREE_TIER_LIMIT_EXCEEDED', () => {
+        it('throws correct EasCommandError subclass', async () => {
+          const platform = Platform.ANDROID;
+          const graphQLError = getGraphQLError('Error 1', 'EAS_BUILD_FREE_TIER_LIMIT_EXCEEDED');
+          const graphQLErrors = [graphQLError];
+          const error = new CombinedError({ graphQLErrors });
+
+          const handleBuildRequestErrorThrownError = getError<EasBuildFreeTierLimitExceededError>(
+            () => {
+              handleBuildRequestError(error, platform);
+            }
+          );
+
+          assertReThrownError(
+            handleBuildRequestErrorThrownError,
+            EasBuildFreeTierLimitExceededError,
+            'Error 1'
+          );
+        });
+      });
+      describe('for EAS_BUILD_FREE_TIER_IOS_LIMIT_EXCEEDED', () => {
+        it('throws correct EasCommandError subclass', async () => {
+          const platform = Platform.ANDROID;
+          const graphQLError = getGraphQLError('Error 1', 'EAS_BUILD_FREE_TIER_IOS_LIMIT_EXCEEDED');
+          const graphQLErrors = [graphQLError];
+          const error = new CombinedError({ graphQLErrors });
+
+          const handleBuildRequestErrorThrownError =
+            getError<EasBuildFreeTierIosLimitExceededError>(() => {
+              handleBuildRequestError(error, platform);
+            });
+
+          assertReThrownError(
+            handleBuildRequestErrorThrownError,
+            EasBuildFreeTierIosLimitExceededError,
             'Error 1'
           );
         });

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -42,6 +42,8 @@ import {
   EasBuildFreeTierDisabledAndroidError,
   EasBuildFreeTierDisabledError,
   EasBuildFreeTierDisabledIOSError,
+  EasBuildFreeTierIosLimitExceededError,
+  EasBuildFreeTierLimitExceededError,
   EasBuildProjectArchiveUploadError,
   EasBuildResourceClassNotAvailableInFreeTierError,
   EasBuildTooManyPendingBuildsError,
@@ -183,6 +185,8 @@ const SERVER_SIDE_DEFINED_ERRORS: Record<string, typeof EasCommandError> = {
   EAS_BUILD_FREE_TIER_DISABLED: EasBuildFreeTierDisabledError,
   EAS_BUILD_FREE_TIER_DISABLED_IOS: EasBuildFreeTierDisabledIOSError,
   EAS_BUILD_FREE_TIER_DISABLED_ANDROID: EasBuildFreeTierDisabledAndroidError,
+  EAS_BUILD_FREE_TIER_LIMIT_EXCEEDED: EasBuildFreeTierLimitExceededError,
+  EAS_BUILD_FREE_TIER_IOS_LIMIT_EXCEEDED: EasBuildFreeTierIosLimitExceededError,
   EAS_BUILD_RESOURCE_CLASS_NOT_AVAILABLE_IN_FREE_TIER:
     EasBuildResourceClassNotAvailableInFreeTierError,
   VALIDATION_ERROR: RequestValidationError,

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -8,6 +8,10 @@ export class EasBuildFreeTierDisabledIOSError extends EasCommandError {}
 
 export class EasBuildFreeTierDisabledAndroidError extends EasCommandError {}
 
+export class EasBuildFreeTierLimitExceededError extends EasCommandError {}
+
+export class EasBuildFreeTierIosLimitExceededError extends EasCommandError {}
+
 export class EasBuildResourceClassNotAvailableInFreeTierError extends EasCommandError {}
 
 export class RequestValidationError extends EasCommandError {}

--- a/packages/eas-cli/src/graphql/client.ts
+++ b/packages/eas-cli/src/graphql/client.ts
@@ -6,7 +6,16 @@ export async function withErrorHandlingAsync<T>(promise: Promise<OperationResult
   const { data, error } = await promise;
 
   if (error) {
-    if (error.graphQLErrors.some(e => e?.extensions?.isTransient)) {
+    if (
+      error.graphQLErrors.some(
+        e =>
+          e?.extensions?.isTransient &&
+          ![
+            'EAS_BUILD_FREE_TIER_LIMIT_EXCEEDED',
+            'EAS_BUILD_FREE_TIER_IOS_LIMIT_EXCEEDED',
+          ].includes(e?.extensions?.errorCode as string)
+      )
+    ) {
       Log.error(`We've encountered a transient error. Try again shortly.`);
     }
     throw error;


### PR DESCRIPTION
# Why

Adds support for a new class of server-side errors related to build limits for free accounts.

# How

This uses existing support for server-side errors to render the error in the console: 
![Screenshot 2023-06-25 at 10 26 24 AM](https://github.com/expo/eas-cli/assets/50374605/2f0207cc-27e5-4a30-a477-6d678b9c6662)
