### PR TITLE
[eas-cli] [ENG-8957] Handle multiple GraphQLErrors in CombinedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Ensure useClassicUpdates is not set when using EAS Update commands. ([#1915](https://github.com/expo/eas-cli/pull/1915) by [@ide](https://github.com/ide))
+- Handle multiple GraphQLErrors when receiving a CombinedError. ([#1924](https://github.com/expo/eas-cli/pull/1924) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
+++ b/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
@@ -424,6 +424,29 @@ describe(Build.name, () => {
 
           assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
         });
+        it('throws base Error class with message including all error messages if combined error has multiple GraphQL errors', async () => {
+          const platform = Platform.ANDROID;
+          const graphQLErrors = [
+            getGraphQLError('Error 1', 'UNKNOWN_GRAPHQL_ERROR'),
+            getGraphQLError('Error 2', 'OTHER_GRAPHQL_ERROR'),
+            getGraphQLError('Error 3', 'YET_ANOTHER_GRAPHQL_ERROR'),
+          ];
+          const error = new CombinedError({ graphQLErrors });
+          const expectedMessage =
+            `${EXPECTED_GENERIC_MESSAGE}\n` +
+            `Request ID: ${mockRequestId}\n` +
+            'Error message: Error 1\n' +
+            `Request ID: ${mockRequestId}\n` +
+            'Error message: Error 2\n' +
+            `Request ID: ${mockRequestId}\n` +
+            'Error message: Error 3';
+
+          const handleBuildRequestErrorThrownError = getError<Error>(() => {
+            handleBuildRequestError(error, platform);
+          });
+
+          assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
+        });
         describe('without request ID', () => {
           it('throws base Error class with custom message without request ID line', async () => {
             const platform = Platform.ANDROID;
@@ -448,6 +471,29 @@ describe(Build.name, () => {
           const graphQLErrors = [graphQLError];
           const error = new CombinedError({ graphQLErrors });
           const expectedMessage = `${EXPECTED_GENERIC_MESSAGE}\nRequest ID: ${mockRequestId}\nError message: Error 1`;
+
+          const handleBuildRequestErrorThrownError = getError<Error>(() => {
+            handleBuildRequestError(error, platform);
+          });
+
+          assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
+        });
+        it('throws base Error class with message including all error messages if combined error has multiple GraphQL errors', async () => {
+          const platform = Platform.IOS;
+          const graphQLErrors = [
+            getGraphQLError('Error 1', 'UNKNOWN_GRAPHQL_ERROR'),
+            getGraphQLError('Error 2', 'OTHER_GRAPHQL_ERROR'),
+            getGraphQLError('Error 3', 'YET_ANOTHER_GRAPHQL_ERROR'),
+          ];
+          const error = new CombinedError({ graphQLErrors });
+          const expectedMessage =
+            `${EXPECTED_GENERIC_MESSAGE}\n` +
+            `Request ID: ${mockRequestId}\n` +
+            'Error message: Error 1\n' +
+            `Request ID: ${mockRequestId}\n` +
+            'Error message: Error 2\n' +
+            `Request ID: ${mockRequestId}\n` +
+            'Error message: Error 3';
 
           const handleBuildRequestErrorThrownError = getError<Error>(() => {
             handleBuildRequestError(error, platform);

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -113,9 +113,8 @@ export async function prepareAndroidBuildAsync(
     ): Promise<BuildResult> => {
       const graphqlMetadata = transformMetadata(metadata);
       const graphqlJob = transformJob(job);
-      console.log(appId);
       return await BuildMutation.createAndroidBuildAsync(ctx.graphqlClient, {
-        appId: 2 as unknown as string,
+        appId,
         job: graphqlJob,
         metadata: graphqlMetadata,
         buildParams,

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -113,8 +113,9 @@ export async function prepareAndroidBuildAsync(
     ): Promise<BuildResult> => {
       const graphqlMetadata = transformMetadata(metadata);
       const graphqlJob = transformJob(job);
+      console.log(appId);
       return await BuildMutation.createAndroidBuildAsync(ctx.graphqlClient, {
-        appId,
+        appId: 2 as unknown as string,
         job: graphqlJob,
         metadata: graphqlMetadata,
         buildParams,


### PR DESCRIPTION
CombinedError technically can have more than 1 GraphQLError inside it, even though for now we only use it with 1. In such a case it would be good for the eas-cli to be able to handle and properly log/display all the multiple error messages

See: https://linear.app/expo/issue/ENG-8957/improve-error-handling-in-eas-cli-to-support-case-when-combined-error

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

CombinedError technically can have more than 1 GraphQLError inside it, even though for now we only use it with 1. In such a case it would be good for the eas-cli to be able to handle and properly log/display all the multiple error messages

# How

Use all error messages from GraphQLErrors in the final message logged/displayed

# Test Plan

Tested manually as well as added automated tests