### PR TITLE
[eas-cli] fix runtime logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Bump Expo package dependencies. ([#1911](https://github.com/expo/eas-cli/pull/1911) by [@brentvatne](https://github.com/brentvatne))
 - Better bare workflow runtimeVersion error. ([#1910](https://github.com/expo/eas-cli/pull/1910) by [@quinlanj](https://github.com/quinlanj))
+- Fix runtime version print logs. ([#1925](https://github.com/expo/eas-cli/pull/1925) by [@quinlanj](https://github.com/quinlanj))
 
 ## [3.15.0](https://github.com/expo/eas-cli/releases/tag/v3.15.0) - 2023-06-30
 

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -155,7 +155,9 @@ async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
   }
 }
 
-function printRuntimeVersion(runtimeVersion: NonNullable<ExpoConfig['runtimeVersion']>): string {
+function serializeRuntimeVersionToString(
+  runtimeVersion: NonNullable<ExpoConfig['runtimeVersion']>
+): string {
   if (typeof runtimeVersion === 'object') {
     return JSON.stringify(runtimeVersion);
   } else {
@@ -184,21 +186,21 @@ function logEasUpdatesAutoConfig({
     Log.withTick(
       `Configured runtimeVersion for ${appPlatformDisplayNames[AppPlatform.Android]} and ${
         appPlatformDisplayNames[AppPlatform.Ios]
-      } with "${printRuntimeVersion(androidRuntime)}"`
+      } with "${serializeRuntimeVersionToString(androidRuntime)}"`
     );
   } else {
     if (androidRuntime) {
       Log.withTick(
         `Configured runtimeVersion for ${
           appPlatformDisplayNames[AppPlatform.Android]
-        } with "${printRuntimeVersion(androidRuntime)}"`
+        } with "${serializeRuntimeVersionToString(androidRuntime)}"`
       );
     }
     if (iosRuntime) {
       Log.withTick(
         `Configured runtimeVersion for ${
           appPlatformDisplayNames[AppPlatform.Ios]
-        } with "${printRuntimeVersion(iosRuntime)}"`
+        } with "${serializeRuntimeVersionToString(iosRuntime)}"`
       );
     }
   }

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -155,6 +155,14 @@ async function ensureEASUpdatesIsConfiguredInExpoConfigAsync({
   }
 }
 
+function printRuntimeVersion(runtimeVersion: NonNullable<ExpoConfig['runtimeVersion']>): string {
+  if (typeof runtimeVersion === 'object') {
+    return JSON.stringify(runtimeVersion);
+  } else {
+    return runtimeVersion;
+  }
+}
+
 function logEasUpdatesAutoConfig({
   modifyConfig,
   exp,
@@ -176,21 +184,21 @@ function logEasUpdatesAutoConfig({
     Log.withTick(
       `Configured runtimeVersion for ${appPlatformDisplayNames[AppPlatform.Android]} and ${
         appPlatformDisplayNames[AppPlatform.Ios]
-      } with "${modifyConfig.android?.runtimeVersion ?? modifyConfig.runtimeVersion}"`
+      } with "${printRuntimeVersion(androidRuntime)}"`
     );
   } else {
     if (androidRuntime) {
       Log.withTick(
-        `Configured runtimeVersion for ${appPlatformDisplayNames[AppPlatform.Android]} with "${
-          modifyConfig.android?.runtimeVersion ?? modifyConfig.runtimeVersion
-        }"`
+        `Configured runtimeVersion for ${
+          appPlatformDisplayNames[AppPlatform.Android]
+        } with "${printRuntimeVersion(androidRuntime)}"`
       );
     }
     if (iosRuntime) {
       Log.withTick(
-        `Configured runtimeVersion for ${appPlatformDisplayNames[AppPlatform.Ios]} with "${
-          modifyConfig.ios?.runtimeVersion ?? modifyConfig.runtimeVersion
-        }"`
+        `Configured runtimeVersion for ${
+          appPlatformDisplayNames[AppPlatform.Ios]
+        } with "${printRuntimeVersion(iosRuntime)}"`
       );
     }
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
There is a bug when printing out runtime versions:

When it is an object:
```
✔ Configured runtimeVersion for Android and iOS with "[object Object]"
```

When it is a string
```
✔ Configured runtimeVersion for Android and iOS with "1.0.0"
```

# How

This PR checks if a runtimeVersion is an object or string, then formats it accordingly.

When it is an object:
```
✔ Configured runtimeVersion for Android and iOS with "{"policy":"sdkVersion"}"
```

When it is a string:
```
✔ Configured runtimeVersion for Android and iOS with "1.0.0"
```

# Test Plan

- [ ] manually tested `eas update:configure` on managed and bare projects
