### PR TITLE
[ENG-9283][eas-cli] Throw error when project tarball exceeds 1GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Limit project file upload size to 1GB. ([#1928](https://github.com/expo/eas-cli/pull/1928) by [@khamilowicz](https://github.com/khamilowicz))
+- Limit project file upload size to 2GB. ([#1928](https://github.com/expo/eas-cli/pull/1928) by [@khamilowicz](https://github.com/khamilowicz))
 
 ## [3.15.1](https://github.com/expo/eas-cli/releases/tag/v3.15.1) - 2023-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Limit project file upload size to 1GB. ([#1928](https://github.com/expo/eas-cli/pull/1928) by [@khamilowicz](https://github.com/khamilowicz))
+
 ## [3.15.1](https://github.com/expo/eas-cli/releases/tag/v3.15.1) - 2023-07-11
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -255,7 +255,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
           );
         }
 
-        if (projectTarball.size > 1024 * 1024 * 1024) {
+        if (projectTarball.size > 2 * 1024 * 1024 * 1024) {
           throw new Error('Project archive is too big. Maximum allowed size is 1GB.');
         }
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -256,7 +256,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         }
 
         if (projectTarball.size > 2 * 1024 * 1024 * 1024) {
-          throw new Error('Project archive is too big. Maximum allowed size is 1GB.');
+          throw new Error('Project archive is too big. Maximum allowed size is 2GB.');
         }
 
         projectTarballPath = projectTarball.path;

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -255,6 +255,10 @@ async function uploadProjectAsync<TPlatform extends Platform>(
           );
         }
 
+        if (projectTarball.size > 1024 * 1024 * 1024) {
+          throw new Error('Project archive is too big. Maximum allowed size is 1GB.');
+        }
+
         projectTarballPath = projectTarball.path;
 
         const bucketKey = await uploadFileAtPathToGCSAsync(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

To prevent users from uploading too large projects.

 https://exponent-internal.slack.com/archives/C017N0N99RA/p1688825990360349

# How

Throw error when archive is over 2GB

# Test Plan

1. Create large project
2. Try building it