### PR TITLE
[eas-cli] Add styling to SSO auth redirect completion page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add styling to SSO auth redirect completion page. ([#1929](https://github.com/expo/eas-cli/pull/1929) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/user/expoSsoLauncher.ts
+++ b/packages/eas-cli/src/user/expoSsoLauncher.ts
@@ -5,6 +5,36 @@ import querystring from 'querystring';
 
 import Log from '../log';
 
+const successBody = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Expo SSO Login</title>
+  <meta charset="utf-8">
+  <style type="text/css">
+    html {
+      margin: 0;
+      padding: 0
+    }
+
+    body {
+      background-color: #fff;
+      font-family: Tahoma,Verdana;
+      font-size: 16px;
+      color: #000;
+      max-width: 100%;
+      box-sizing: border-box;
+      padding: .5rem;
+      margin: 1em;
+      overflow-wrap: break-word
+    }
+  </style>
+</head>
+<body>
+  SSO login complete. You may now close this tab and return to the command prompt.
+</body>
+</html>`;
+
 export async function getSessionUsingBrowserAuthFlowAsync(options: {
   expoWebsiteUrl: string;
   serverPort: number;
@@ -44,8 +74,8 @@ export async function getSessionUsingBrowserAuthFlowAsync(options: {
               throw new Error('Request missing session_secret search parameter.');
             }
             resolve(sessionSecret);
-            response.writeHead(200, { 'Content-Type': 'text/plain' });
-            response.write(`Website login has completed. You can now close this tab.`);
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.write(successBody);
             response.end();
           } catch (error) {
             reject(error);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Same as https://github.com/expo/expo/pull/23477 but for eas-cli. Closes ENG-8924.