### PR TITLE
[eas-cli] fix incorrect handling of valid `inProgress` release status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix incorrect handling of valid `inProgress` Android submission release status. ([#1934](https://github.com/expo/eas-cli/pull/1934) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 - Limit project file upload size to 2GB. ([#1928](https://github.com/expo/eas-cli/pull/1928) by [@khamilowicz](https://github.com/khamilowicz))

--- a/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts
@@ -12,7 +12,7 @@ import {
   AmbiguousApplicationIdError,
   getApplicationIdAsync,
 } from '../../project/android/applicationId';
-import capitalize from '../../utils/expodash/capitalize';
+import capitalizeFirstLetter from '../../utils/expodash/capitalize';
 import { ArchiveSource } from '../ArchiveSource';
 import { resolveArchiveSource } from '../commons';
 import { SubmissionContext } from '../context';
@@ -73,7 +73,7 @@ export default class AndroidSubmitCommand {
     if (!track) {
       return result(SubmissionAndroidTrack.Internal);
     }
-    const capitalizedTrack = capitalize(track);
+    const capitalizedTrack = capitalizeFirstLetter(track);
     if (capitalizedTrack in SubmissionAndroidTrack) {
       return result(
         SubmissionAndroidTrack[capitalizedTrack as keyof typeof SubmissionAndroidTrack]
@@ -94,7 +94,7 @@ export default class AndroidSubmitCommand {
     if (!releaseStatus) {
       return result(SubmissionAndroidReleaseStatus.Completed);
     }
-    const capitalizedReleaseStatus = capitalize(releaseStatus);
+    const capitalizedReleaseStatus = capitalizeFirstLetter(releaseStatus);
     if (capitalizedReleaseStatus in SubmissionAndroidReleaseStatus) {
       return result(
         SubmissionAndroidReleaseStatus[

--- a/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
@@ -145,6 +145,46 @@ describe(AndroidSubmitCommand, () => {
       });
     });
 
+    it('sends a request to EAS Submit when using inProgress status', async () => {
+      const projectId = uuidv4();
+      const graphqlClient = {} as any as ExpoGraphqlClient;
+      const analytics = instance(mock<Analytics>());
+
+      const ctx = await createSubmissionContextAsync({
+        platform: Platform.ANDROID,
+        projectDir: testProject.projectRoot,
+        archiveFlags: {
+          url: 'http://expo.dev/fake.apk',
+        },
+        profile: {
+          serviceAccountKeyPath: '/google-service-account.json',
+          track: AndroidReleaseTrack.internal,
+          releaseStatus: AndroidReleaseStatus.inProgress,
+          changesNotSentForReview: false,
+        },
+        nonInteractive: false,
+        actor: mockJester,
+        graphqlClient,
+        analytics,
+        exp: testProject.appJSON.expo,
+        projectId,
+      });
+
+      const command = new AndroidSubmitCommand(ctx);
+      await command.runAsync();
+
+      expect(SubmissionMutation.createAndroidSubmissionAsync).toHaveBeenCalledWith(graphqlClient, {
+        appId: projectId,
+        archiveSource: { type: SubmissionArchiveSourceType.Url, url: 'http://expo.dev/fake.apk' },
+        config: {
+          googleServiceAccountKeyJson: fakeFiles['/google-service-account.json'],
+          releaseStatus: SubmissionAndroidReleaseStatus.InProgress,
+          track: SubmissionAndroidTrack.Internal,
+          changesNotSentForReview: false,
+        },
+      });
+    });
+
     it('assigns the build ID to submission', async () => {
       const projectId = uuidv4();
       const graphqlClient = {} as any as ExpoGraphqlClient;

--- a/packages/eas-cli/src/utils/expodash/__tests__/capitalize-test.ts
+++ b/packages/eas-cli/src/utils/expodash/__tests__/capitalize-test.ts
@@ -1,10 +1,13 @@
-import capitalize from '../capitalize';
+import capitalizeFirstLetter from '../capitalize';
 
-describe(capitalize, () => {
+describe(capitalizeFirstLetter, () => {
   it('capitalizes the string', () => {
-    expect(capitalize('dominik')).toBe('Dominik');
+    expect(capitalizeFirstLetter('dominik')).toBe('Dominik');
   });
   it('works with an empty string', () => {
-    expect(capitalize('')).toBe('');
+    expect(capitalizeFirstLetter('')).toBe('');
+  });
+  it('does not change the case of other letters', () => {
+    expect(capitalizeFirstLetter('inProgress')).toBe('InProgress');
   });
 });

--- a/packages/eas-cli/src/utils/expodash/capitalize.ts
+++ b/packages/eas-cli/src/utils/expodash/capitalize.ts
@@ -1,3 +1,3 @@
-export default function capitalize(s: string): string {
-  return s ? s.charAt(0).toUpperCase() + s.slice(1).toLowerCase() : '';
+export default function capitalizeFirstLetter(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
 }


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1689605257077099

Previously the `capitalize` function made the first letter upper case and other letters of the string lower case. So if we run `capitalize('inProgress')` we will get `'Inprogress'`.

This is the code that checks if the release status is supported
https://github.com/expo/eas-cli/blob/57dd372957d5f18da232c3efca5716a691e1f903/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts#L97-L112
https://github.com/expo/eas-cli/blob/57dd372957d5f18da232c3efca5716a691e1f903/packages/eas-cli/src/graphql/generated.ts#L4618-L4623

As you can see `'Inprogress'` is not a key of the `SubmissionAndroidReleaseStatus` enum, therefore the error will be thrown, which is incorrect behavior because it is a valid option.

# How

Change the `capitalize` function to `capitalizeFirstLetter` and make it work like `capitalizeFirstLetter('inProgress') => 'InProgress'`.

# Test Plan

Tested manually and added unit tests.

## Before
<img width="669" alt="Screenshot 2023-07-18 at 10 06 38" src="https://github.com/expo/eas-cli/assets/55145344/b11b44eb-e938-45b0-9c87-0c41d282d3ff">

## After
<img width="716" alt="Screenshot 2023-07-18 at 10 07 15" src="https://github.com/expo/eas-cli/assets/55145344/5a2345bb-fcbc-429d-9437-e6a312179f48">
