### PR TITLE
fix(eas-cli): implement variadic `--platform` flag when creating EAS updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Add proper expo cli `--platform` flag handling when exporting updates. ([#1939](https://github.com/expo/eas-cli/pull/1939) by [@byCedric](https://github.com/byCedric))
+
 ### 🧹 Chores
 
 ## [5.0.1](https://github.com/expo/eas-cli/releases/tag/v5.0.1) - 2023-08-28

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -207,7 +207,7 @@ export async function buildBundlesAsync({
       '--non-interactive',
       '--dump-sourcemap',
       '--dump-assetmap',
-      ...platformFlag,
+      `--platform=${platformFlag}`,
       ...(clearCache ? ['--clear'] : []),
     ]);
   }
@@ -247,8 +247,7 @@ export async function buildBundlesAsync({
     inputDir,
     '--dump-sourcemap',
     '--dump-assetmap',
-    '--platform',
-    platformFlag,
+    `--platform=${platformFlag}`,
     ...(clearCache ? ['--clear'] : []),
   ]);
 }

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -56,7 +56,27 @@ export function shouldUseVersionedExpoCLIExpensive(
   return !!resolveFrom.silent(projectDir, '@expo/cli');
 }
 
+/**
+ * Determine if we can and should use `expo export` with multiple `--platform` flags.
+ * This is an issue related to `expo export --all` causing issues when users have Metro web configured.
+ * See: https://github.com/expo/expo/pull/23621
+ */
+export function shouldUseVersionedExpoCLIWithExplicitPlatformsExpensive(
+  projectDir: string
+): boolean {
+  const expoCliPath = resolveFrom.silent(projectDir, '@expo/cli/package.json');
+  if (!expoCliPath) {
+    return false;
+  }
+
+  // TODO(cedric): update the version to the patched `@expo/cli` version(s) once it's released
+  return gteSdkVersion(require(expoCliPath).version, '0.10.10');
+}
+
 export const shouldUseVersionedExpoCLI = memoize(shouldUseVersionedExpoCLIExpensive);
+export const shouldUseVersionedExpoCLIWithExplicitPlatforms = memoize(
+  shouldUseVersionedExpoCLIWithExplicitPlatformsExpensive
+);
 
 export async function expoCommandAsync(
   projectDir: string,

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -69,8 +69,7 @@ export function shouldUseVersionedExpoCLIWithExplicitPlatformsExpensive(
     return false;
   }
 
-  // TODO(cedric): update the version to the patched `@expo/cli` version(s) once it's released
-  return gteSdkVersion(require(expoCliPath).version, '0.10.10');
+  return gteSdkVersion(require(expoCliPath).version, '0.10.11');
 }
 
 export const shouldUseVersionedExpoCLI = memoize(shouldUseVersionedExpoCLIExpensive);


### PR DESCRIPTION
# Why

Fixes ENG-9308

> This PR assumes that https://github.com/expo/expo/pull/23621 is going to be merged and released.

# How

- Added warning when users create EAS update bundles with `expo.web.bundler = "metro"`
- Added version detection to use the new variadic `--platform` flag
- Added explicit `expo export --platform android --platform ios` flags when creating EAS update bundles

# Test Plan

- `$ yarn create expo ./test-updates -t tabs@49` (comes with Metro web)
- `$ cd ./test-updates`
- `$ eas update`
  → should create exports for `android` and `ios`, **_not_** `web`
