### PR TITLE
[eas-cli] utils: amend rollouts definition

### DIFF
--- a/packages/eas-cli/src/rollout/__tests__/utils-test.ts
+++ b/packages/eas-cli/src/rollout/__tests__/utils-test.ts
@@ -60,23 +60,6 @@ describe(isRollout, () => {
     const customMapping1 = {
       version: 0,
       data: [
-        { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
-        {
-          branchId: uuidv4(),
-          branchMappingLogic: {
-            operand: 10 / 100,
-            clientKey: 'rolloutToken',
-            branchMappingOperator: hashLtOperator(),
-          },
-        },
-      ],
-    };
-    expect(isRollout(customMapping1)).toBe(true);
-
-    const customMapping2 = {
-      version: 0,
-      data: [
-        { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
         {
           branchId: uuidv4(),
           branchMappingLogic: andStatement([
@@ -92,9 +75,10 @@ describe(isRollout, () => {
             },
           ]),
         },
+        { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
       ],
     };
-    expect(isRollout(customMapping2)).toBe(true);
+    expect(isRollout(customMapping1)).toBe(true);
   });
   it('correctly classifies branchMappings that arent rollouts', () => {
     expect(isRollout(standardBranchMapping)).toBe(false);
@@ -196,5 +180,21 @@ describe(isRollout, () => {
       ],
     };
     expect(isRollout(customMapping5)).toBe(false);
+
+    const customMapping6 = {
+      version: 0,
+      data: [
+        { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
+        {
+          branchId: uuidv4(),
+          branchMappingLogic: {
+            operand: 10 / 100,
+            clientKey: 'rolloutToken',
+            branchMappingOperator: hashLtOperator(),
+          },
+        },
+      ],
+    };
+    expect(isRollout(customMapping6)).toBe(false);
   });
 });

--- a/packages/eas-cli/src/rollout/utils.ts
+++ b/packages/eas-cli/src/rollout/utils.ts
@@ -66,14 +66,10 @@ function isRtvConstrainedRollout(branchMapping: BranchMapping): boolean {
   if (branchMapping.data.length !== 2) {
     return false;
   }
-  const hasAlwaysTrueNode = branchMapping.data.some(wrappedNode =>
-    isAlwaysTrue(wrappedNode.branchMappingLogic)
-  );
-  const hasRtvRolloutNode = branchMapping.data.some(wrappedNode =>
-    isRtvConstrainedRolloutNode(wrappedNode.branchMappingLogic)
-  );
+  const hasRtvRolloutNode = isRtvConstrainedRolloutNode(branchMapping.data[0].branchMappingLogic);
+  const defaultsToAlwaysTrueNode = isAlwaysTrue(branchMapping.data[1].branchMappingLogic);
 
-  return hasAlwaysTrueNode && hasRtvRolloutNode;
+  return hasRtvRolloutNode && defaultsToAlwaysTrueNode;
 }
 
 function isRtvConstrainedRolloutNode(node: BranchMappingNode): boolean {
@@ -94,13 +90,9 @@ function isUnconstrainedRollout(branchMapping: BranchMapping): boolean {
   if (branchMapping.data.length !== 2) {
     return false;
   }
-  const hasAlwaysTrueNode = branchMapping.data.some(wrappedNode =>
-    isAlwaysTrue(wrappedNode.branchMappingLogic)
-  );
-  const hasRolloutNode = branchMapping.data.some(wrappedNode =>
-    isRolloutNode(wrappedNode.branchMappingLogic)
-  );
-  return hasAlwaysTrueNode && hasRolloutNode;
+  const hasRolloutNode = isRolloutNode(branchMapping.data[0].branchMappingLogic);
+  const defaultsToAlwaysTrueNode = isAlwaysTrue(branchMapping.data[1].branchMappingLogic);
+  return hasRolloutNode && defaultsToAlwaysTrueNode;
 }
 
 function isRuntimeVersionNode(node: BranchMappingNode): boolean {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Amend the definition of a rollout branch mapping to be position aware. For example, this is a valid rollout:
```
[
    {
      branchId: uuidv4(),
      branchMappingLogic: {
        operand: 10 / 100,
        clientKey: 'rolloutToken',
        branchMappingOperator: hashLtOperator(),
      },
    },
    { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
  ]
```

However, if the array items are switched, it should not be considered a rollout anymore. This is because we evaluate each item in the branch mapping like a switch statement. So in this example, it will always evaluate to true in the first statement and never evaluate the second: 

```
[
    { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
    {
      branchId: uuidv4(),
      branchMappingLogic: {
        operand: 10 / 100,
        clientKey: 'rolloutToken',
        branchMappingOperator: hashLtOperator(),
      },
    }
  ]
```

# Test Plan

- [ ] amended tests pass
