### PR TITLE
[eas-cli] handle server side defined error for situation when `intel-medium` is not available and remove `intel-medium` for `eas.schema.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Added branch mapping utility functions. ([#1944](https://github.com/expo/eas-cli/pull/1944) by [@quinlanj](https://github.com/quinlanj))
 - Amend branch mapping utility functions. ([#1945](https://github.com/expo/eas-cli/pull/1945) by [@quinlanj](https://github.com/quinlanj))
+- Handle error thrown when `intel-medium` resource class is not available as server-side defined error. ([#1947](https://github.com/expo/eas-cli/pull/1947) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [3.16.0](https://github.com/expo/eas-cli/releases/tag/v3.16.0) - 2023-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Added branch mapping utility functions. ([#1944](https://github.com/expo/eas-cli/pull/1944) by [@quinlanj](https://github.com/quinlanj))
 - Amend branch mapping utility functions. ([#1945](https://github.com/expo/eas-cli/pull/1945) by [@quinlanj](https://github.com/quinlanj))
 - Handle error thrown when `intel-medium` resource class is not available as server-side defined error. ([#1947](https://github.com/expo/eas-cli/pull/1947) by [@szdziedzic](https://github.com/szdziedzic))
+- Remove `intel-medium` from `eas.schema.json`, so it's not suggested as a valid value by our VSCode plugin. ([#1947](https://github.com/expo/eas-cli/pull/1947) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [3.16.0](https://github.com/expo/eas-cli/releases/tag/v3.16.0) - 2023-07-18
 

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -45,6 +45,7 @@ import {
   EasBuildFreeTierDisabledIOSError,
   EasBuildFreeTierIosLimitExceededError,
   EasBuildFreeTierLimitExceededError,
+  EasBuildLegacyResourceClassNotAvailableError,
   EasBuildProjectArchiveUploadError,
   EasBuildResourceClassNotAvailableInFreeTierError,
   EasBuildTooManyPendingBuildsError,
@@ -190,6 +191,7 @@ const SERVER_SIDE_DEFINED_ERRORS: Record<string, typeof EasCommandError> = {
   EAS_BUILD_FREE_TIER_IOS_LIMIT_EXCEEDED: EasBuildFreeTierIosLimitExceededError,
   EAS_BUILD_RESOURCE_CLASS_NOT_AVAILABLE_IN_FREE_TIER:
     EasBuildResourceClassNotAvailableInFreeTierError,
+  EAS_BUILD_LEGACY_RESOURCE_CLASS_NOT_AVAILABLE: EasBuildLegacyResourceClassNotAvailableError,
   VALIDATION_ERROR: RequestValidationError,
 };
 

--- a/packages/eas-cli/src/build/errors.ts
+++ b/packages/eas-cli/src/build/errors.ts
@@ -14,6 +14,8 @@ export class EasBuildFreeTierIosLimitExceededError extends EasCommandError {}
 
 export class EasBuildResourceClassNotAvailableInFreeTierError extends EasCommandError {}
 
+export class EasBuildLegacyResourceClassNotAvailableError extends EasCommandError {}
+
 export class RequestValidationError extends EasCommandError {}
 
 export class EasBuildDownForMaintenanceError extends EasCommandError {}

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -363,7 +363,7 @@
           "default": "default",
           "anyOf": [
             {
-              "enum": ["default", "medium", "large", "intel-medium", "m-medium"]
+              "enum": ["default", "medium", "large", "m-medium"]
             },
             {
               "type": "string"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1689800401918099
Companion to https://github.com/expo/universe/pull/12949

# How

Handle the `EAS_BUILD_LEGACY_RESOURCE_CLASS_NOT_AVAILABLE` error as server-side defined error.

Remove the `intel-medium` option from `eas.schema.json` to not suggest using it in our VSCode plugin.

# Test Plan

Tested manually

After:
<img width="1092" alt="Screenshot 2023-07-24 at 10 03 56" src="https://github.com/expo/eas-cli/assets/55145344/b4534965-a0d8-4d3a-9908-d1bf0ce56f54">
Before:
<img width="1085" alt="Screenshot 2023-07-24 at 10 00 20" src="https://github.com/expo/eas-cli/assets/55145344/d4ca2ad8-7cb8-42ce-a5c6-626d256be4cf">

