### PR TITLE
[eas-cli][1/2] unify channel graphql query types

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -2573,18 +2573,6 @@
         "description": "Auth configuration data for an SSO account.",
         "fields": [
           {
-            "name": "authEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "authProtocol",
             "description": null,
             "args": [],
@@ -2665,18 +2653,6 @@
             "deprecationReason": null
           },
           {
-            "name": "endSessionEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "id",
             "description": null,
             "args": [],
@@ -2709,42 +2685,6 @@
             "deprecationReason": null
           },
           {
-            "name": "jwksEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "revokeEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tokenEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "updatedAt",
             "description": null,
             "args": [],
@@ -2756,18 +2696,6 @@
                 "name": "DateTime",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userInfoEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3089,18 +3017,6 @@
         "description": "Public auth configuration data for an SSO account.",
         "fields": [
           {
-            "name": "authEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "authProtocol",
             "description": null,
             "args": [],
@@ -3133,7 +3049,7 @@
             "deprecationReason": null
           },
           {
-            "name": "clientIdentifier",
+            "name": "authorizationUrl",
             "description": null,
             "args": [],
             "type": {
@@ -3144,18 +3060,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endSessionEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3188,54 +3092,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "jwksEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "revokeEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tokenEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userInfoEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
@@ -12,6 +13,7 @@ import {
 } from '../graphql/generated';
 import { BranchQuery, UpdateBranchOnChannelObject } from '../graphql/queries/BranchQuery';
 import { ChannelQuery, UpdateChannelObject } from '../graphql/queries/ChannelQuery';
+import { UpdateChannelBasicInfoFragmentNode } from '../graphql/types/UpdateChannelBasicInfo';
 import Log from '../log';
 import formatFields from '../utils/formatFields';
 import { printJsonOnlyOutput } from '../utils/json';
@@ -227,11 +229,11 @@ export async function createChannelOnAppAsync(
             updateChannel {
               createUpdateChannelForApp(appId: $appId, name: $name, branchMapping: $branchMapping) {
                 id
-                name
-                branchMapping
+                ...UpdateChannelBasicInfoFragment
               }
             }
           }
+          ${print(UpdateChannelBasicInfoFragmentNode)}
         `,
         {
           appId,

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -1,5 +1,6 @@
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { selectBranchOnAppAsync } from '../../branch/queries';
@@ -9,18 +10,20 @@ import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/creat
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { withErrorHandlingAsync } from '../../graphql/client';
 import {
+  UpdateChannelBasicInfoFragment,
   UpdateChannelBranchMappingMutation,
   UpdateChannelBranchMappingMutationVariables,
 } from '../../graphql/generated';
 import { BranchQuery } from '../../graphql/queries/BranchQuery';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import { UpdateChannelBasicInfoFragmentNode } from '../../graphql/types/UpdateChannelBasicInfo';
 import Log from '../../log';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export async function updateChannelBranchMappingAsync(
   graphqlClient: ExpoGraphqlClient,
   { channelId, branchMapping }: UpdateChannelBranchMappingMutationVariables
-): Promise<UpdateChannelBranchMappingMutation['updateChannel']['editUpdateChannel']> {
+): Promise<UpdateChannelBasicInfoFragment> {
   const data = await withErrorHandlingAsync(
     graphqlClient
       .mutation<UpdateChannelBranchMappingMutation, UpdateChannelBranchMappingMutationVariables>(
@@ -29,11 +32,11 @@ export async function updateChannelBranchMappingAsync(
             updateChannel {
               editUpdateChannel(channelId: $channelId, branchMapping: $branchMapping) {
                 id
-                name
-                branchMapping
+                ...UpdateChannelBasicInfoFragment
               }
             }
           }
+          ${print(UpdateChannelBasicInfoFragmentNode)}
         `,
         { channelId, branchMapping }
       )

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -15,7 +15,7 @@ import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/creat
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { UpdateBranch } from '../../graphql/generated';
 import { BranchQuery } from '../../graphql/queries/BranchQuery';
-import { ChannelQuery, UpdateChannelByNameObject } from '../../graphql/queries/ChannelQuery';
+import { ChannelQuery, UpdateChannelObject } from '../../graphql/queries/ChannelQuery';
 import Log from '../../log';
 import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync, selectAsync } from '../../prompts';
@@ -45,7 +45,7 @@ async function promptForRolloutPercentAsync({
   return rolloutPercent;
 }
 
-function getRolloutInfo(channel: UpdateChannelByNameObject): {
+function getRolloutInfo(channel: UpdateChannelObject): {
   newBranch: Pick<UpdateBranch, 'name' | 'id'>;
   oldBranch: Pick<UpdateBranch, 'name' | 'id'>;
   currentPercent: number;
@@ -84,7 +84,7 @@ async function startRolloutAsync(
     projectId: string;
     displayName: string;
     currentBranchMapping: BranchMapping;
-    channel: UpdateChannelByNameObject;
+    channel: UpdateChannelObject;
     nonInteractive: boolean;
   }
 ): Promise<{
@@ -165,7 +165,7 @@ async function editRolloutAsync(
     percent?: number;
     nonInteractive: boolean;
     currentBranchMapping: BranchMapping;
-    channel: UpdateChannelByNameObject;
+    channel: UpdateChannelObject;
   }
 ): Promise<{
   newChannelInfo: {
@@ -223,7 +223,7 @@ async function endRolloutAsync(
     branchName?: string;
     nonInteractive: boolean;
     projectId: string;
-    channel: UpdateChannelByNameObject;
+    channel: UpdateChannelObject;
   }
 ): Promise<{
   newChannelInfo: {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -468,20 +468,14 @@ export type AccountQueryByNameArgs = {
 /** Auth configuration data for an SSO account. */
 export type AccountSsoConfiguration = {
   __typename?: 'AccountSSOConfiguration';
-  authEndpoint?: Maybe<Scalars['String']>;
   authProtocol: AuthProtocolType;
   authProviderIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
   clientSecret: Scalars['String'];
   createdAt: Scalars['DateTime'];
-  endSessionEndpoint?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   issuer: Scalars['String'];
-  jwksEndpoint?: Maybe<Scalars['String']>;
-  revokeEndpoint?: Maybe<Scalars['String']>;
-  tokenEndpoint?: Maybe<Scalars['String']>;
   updatedAt: Scalars['DateTime'];
-  userInfoEndpoint?: Maybe<Scalars['String']>;
 };
 
 export type AccountSsoConfigurationData = {
@@ -528,17 +522,11 @@ export type AccountSsoConfigurationMutationUpdateAccountSsoConfigurationArgs = {
 /** Public auth configuration data for an SSO account. */
 export type AccountSsoConfigurationPublicData = {
   __typename?: 'AccountSSOConfigurationPublicData';
-  authEndpoint?: Maybe<Scalars['String']>;
   authProtocol: AuthProtocolType;
   authProviderIdentifier: Scalars['String'];
-  clientIdentifier: Scalars['String'];
-  endSessionEndpoint?: Maybe<Scalars['String']>;
+  authorizationUrl: Scalars['String'];
   id: Scalars['ID'];
   issuer: Scalars['String'];
-  jwksEndpoint?: Maybe<Scalars['String']>;
-  revokeEndpoint?: Maybe<Scalars['String']>;
-  tokenEndpoint?: Maybe<Scalars['String']>;
-  userInfoEndpoint?: Maybe<Scalars['String']>;
 };
 
 export type AccountSsoConfigurationPublicDataQuery = {
@@ -6197,7 +6185,16 @@ export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> }> } } };
+export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> }> }> } } };
+
+export type ViewUpdateChannelsPaginatedOnAppQueryVariables = Exact<{
+  appId: Scalars['String'];
+  first?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type ViewUpdateChannelsPaginatedOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, channelsPaginated: { __typename?: 'AppChannelsConnection', edges: Array<{ __typename?: 'AppChannelEdge', node: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -6310,6 +6307,10 @@ export type SubmissionFragment = { __typename?: 'Submission', id: string, status
 export type UpdateFragment = { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null };
 
 export type UpdateBranchFragment = { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }> };
+
+export type UpdateBranchWithCurrentGroupFragment = { __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null }>> };
+
+export type UpdateChannelBasicInfoFragment = { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string };
 
 export type WebhookFragment = { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any };
 

--- a/packages/eas-cli/src/graphql/types/UpdateBranchWithCurrentUpdate.ts
+++ b/packages/eas-cli/src/graphql/types/UpdateBranchWithCurrentUpdate.ts
@@ -1,0 +1,16 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { UpdateFragmentNode } from './Update';
+
+export const UpdateBranchWithCurrentGroupFragmentNode = gql`
+  fragment UpdateBranchWithCurrentGroupFragment on UpdateBranch {
+    id
+    name
+    updateGroups(offset: 0, limit: 1) {
+      id
+      ...UpdateFragment
+    }
+  }
+  ${print(UpdateFragmentNode)}
+`;

--- a/packages/eas-cli/src/graphql/types/UpdateChannelBasicInfo.ts
+++ b/packages/eas-cli/src/graphql/types/UpdateChannelBasicInfo.ts
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag';
+
+export const UpdateChannelBasicInfoFragmentNode = gql`
+  fragment UpdateChannelBasicInfoFragment on UpdateChannel {
+    id
+    name
+    branchMapping
+  }
+`;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

For graphql queries that have the same fields, unify them with fragments if possible. There is one exception:

```
  query FooQuery($appId: String!, $offset: Int!, $limit: Int!) {
    app {
      byId(appId: $appId) {
        id
        updateChannels(offset: $offset, limit: $limit) {
          updateBranches(offset: 0, limit: 5) { <---- We plan to parameterize these arguments instead of keeping it constant
            id
          }
        }
      }
    }
  }
```

Unfortunately, graphql does not allow for [parameterized fragments ](https://github.com/graphql/graphql-spec/issues/204) so I create an intersection type to unify the channel fields: `UpdateChannelObject = ViewUpdateChannelsOnAppObject & UpdateChannelByNameObject;`


# How

Create fragments and intersection types 

# Test Plan

- [ ] current tests pass
