### PR TITLE
[eas-cli] fetch entire relay compliant dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Unify channel graphql query types. ([#1949](https://github.com/expo/eas-cli/pull/1949) by [@quinlanj](https://github.com/quinlanj))
+- Fetch entire relay compliant dataset. ([#1953](https://github.com/expo/eas-cli/pull/1953) by [@quinlanj](https://github.com/quinlanj))
 
 ## [3.17.0](https://github.com/expo/eas-cli/releases/tag/v3.17.0) - 2023-07-24
 

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -8,6 +8,8 @@ import { withErrorHandlingAsync } from '../graphql/client';
 import {
   CreateUpdateChannelOnAppMutation,
   CreateUpdateChannelOnAppMutationVariables,
+  PageInfo,
+  UpdateChannelBasicInfoFragment,
   ViewBranchesOnUpdateChannelQueryVariables,
   ViewUpdateChannelsOnAppQueryVariables,
 } from '../graphql/generated';
@@ -15,12 +17,14 @@ import { BranchQuery, UpdateBranchOnChannelObject } from '../graphql/queries/Bra
 import { ChannelQuery, UpdateChannelObject } from '../graphql/queries/ChannelQuery';
 import { UpdateChannelBasicInfoFragmentNode } from '../graphql/types/UpdateChannelBasicInfo';
 import Log from '../log';
+import { ora } from '../ora';
 import formatFields from '../utils/formatFields';
 import { printJsonOnlyOutput } from '../utils/json';
 import {
   paginatedQueryWithConfirmPromptAsync,
   paginatedQueryWithSelectPromptAsync,
 } from '../utils/queries';
+import { Connection, QueryParams, getPaginatedDatasetAsync } from '../utils/relay';
 import { logChannelDetails } from './utils';
 
 export const CHANNELS_LIMIT = 25;
@@ -263,4 +267,47 @@ export async function ensureChannelExistsAsync(
       throw e;
     }
   }
+}
+
+export async function getChannelsDatasetAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    appId,
+    filterPredicate,
+    batchSize = 100,
+  }: {
+    appId: string;
+    filterPredicate?: (channelInfo: UpdateChannelBasicInfoFragment) => boolean;
+    batchSize?: number;
+  }
+): Promise<UpdateChannelBasicInfoFragment[]> {
+  const queryAsync = async ({
+    first,
+    after,
+  }: QueryParams): Promise<Connection<UpdateChannelBasicInfoFragment>> =>
+    await ChannelQuery.viewUpdateChannelsBasicInfoPaginatedOnAppAsync(graphqlClient, {
+      appId,
+      first,
+      after,
+    });
+
+  const assetSpinner = ora().start('Fetching channels...');
+  const afterEachQuery = (
+    totalNodesFetched: number,
+    _dataset: UpdateChannelBasicInfoFragment[],
+    _batch: UpdateChannelBasicInfoFragment[],
+    pageInfo: PageInfo
+  ): void => {
+    if (pageInfo.hasNextPage) {
+      assetSpinner.text = `Fetched ${totalNodesFetched} channels`;
+    }
+  };
+  const dataset = await getPaginatedDatasetAsync({
+    queryAsync,
+    afterEachQuery,
+    filterPredicate,
+    batchSize,
+  });
+  assetSpinner.succeed(`Fetched all channels`);
+  return dataset;
 }

--- a/packages/eas-cli/src/utils/__tests__/relay-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/relay-test.ts
@@ -1,0 +1,94 @@
+import { getPaginatedDatasetAsync } from '../relay';
+
+describe('getPaginatedDatasetAsync', () => {
+  const mockQueryAsync = jest.fn(({ first, after }) =>
+    Promise.resolve({
+      edges: Array(first).fill({ node: 'node', cursor: 'cursor' }),
+      pageInfo: {
+        hasNextPage: after !== 'next',
+        endCursor: after ? null : 'next',
+        hasPreviousPage: false,
+      },
+    })
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should query data page by page until no more data', async () => {
+    const dataset = await getPaginatedDatasetAsync({
+      queryAsync: mockQueryAsync,
+      batchSize: 1,
+    });
+
+    expect(mockQueryAsync).toHaveBeenCalledTimes(2);
+    expect(mockQueryAsync).toHaveBeenCalledWith({ first: 1, after: undefined });
+    expect(mockQueryAsync).toHaveBeenCalledWith({ first: 1, after: 'next' });
+    expect(dataset).toHaveLength(2);
+  });
+
+  it('should call beforeEachQuery and afterEachQuery with correct parameters', async () => {
+    // dataset is pass by reference, so we make a copy at each call
+    const datasetAtNthCall_beforeEachQuery = [] as any;
+    const mockBeforeEachQuery = jest.fn((totalNodesFetched, dataset) => {
+      datasetAtNthCall_beforeEachQuery.push([...dataset]);
+    });
+
+    // dataset is pass by reference, so we make a copy at each call
+    const datasetAtNthCall_afterEachQuery = [] as any;
+    const mockAfterEachQuery = jest.fn((totalNodesFetched, dataset, batch, pageInfo) => {
+      datasetAtNthCall_afterEachQuery.push([...dataset]);
+    });
+
+    await getPaginatedDatasetAsync({
+      queryAsync: mockQueryAsync,
+      beforeEachQuery: mockBeforeEachQuery,
+      afterEachQuery: mockAfterEachQuery,
+      batchSize: 1,
+    });
+
+    expect(mockBeforeEachQuery).toHaveBeenCalledTimes(2);
+    expect(mockBeforeEachQuery).toHaveBeenNthCalledWith(1, 0, expect.any(Array));
+    expect(datasetAtNthCall_beforeEachQuery[0]).toStrictEqual([]);
+    expect(mockBeforeEachQuery).toHaveBeenNthCalledWith(2, 1, expect.any(Array));
+    expect(datasetAtNthCall_beforeEachQuery[1]).toStrictEqual(['node']);
+
+    expect(mockAfterEachQuery).toHaveBeenCalledTimes(2);
+    expect(mockAfterEachQuery).toHaveBeenNthCalledWith(1, 1, expect.any(Array), ['node'], {
+      hasNextPage: true,
+      endCursor: 'next',
+      hasPreviousPage: false,
+    });
+    expect(datasetAtNthCall_afterEachQuery[0]).toStrictEqual(['node']);
+    expect(mockAfterEachQuery).toHaveBeenNthCalledWith(2, 2, expect.any(Array), ['node'], {
+      hasNextPage: false,
+      endCursor: null,
+      hasPreviousPage: false,
+    });
+    expect(datasetAtNthCall_afterEachQuery[1]).toStrictEqual(['node', 'node']);
+  });
+
+  it('should filter nodes if filterPredicate is provided', async () => {
+    const filterPredicate = (node: string): boolean => node !== 'node';
+
+    const dataset = await getPaginatedDatasetAsync({
+      queryAsync: mockQueryAsync,
+      filterPredicate,
+      batchSize: 1,
+    });
+
+    expect(dataset).toEqual([]); // expecting an empty array because our filterPredicate will filter out 'node'
+  });
+
+  it('should stop fetching when maxNodesFetched limit is reached', async () => {
+    const dataset = await getPaginatedDatasetAsync({
+      queryAsync: mockQueryAsync,
+      batchSize: 2,
+      maxNodesFetched: 2,
+    });
+
+    expect(dataset).toHaveLength(2);
+    expect(mockQueryAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/eas-cli/src/utils/relay.ts
+++ b/packages/eas-cli/src/utils/relay.ts
@@ -1,0 +1,73 @@
+import { PageInfo } from '../graphql/generated';
+
+export type Connection<T> = {
+  edges: Edge<T>[];
+  pageInfo: PageInfo;
+};
+
+type Edge<T> = {
+  node: T;
+};
+
+export type QueryParams = {
+  first: number;
+  after?: string;
+};
+
+/**
+ * Fetches dataset in paginated manner (batch by batch) using GraphQL queries.
+ *
+ * @param queryAsync A promise based function for querying.
+ * @param beforeEachQuery Optional. A callback function to be called before each query
+ * @param afterEachQuery Optional. A callback function to be called after each query.
+ * @param filterPredicate Optional. A predicate function to filter the node.
+ * @param batchSize Optional. The batch size of the pagination. Defaults to 100.
+ *
+ * @return {Promise<T[]>} - A promise that resolves to an array (the dataset).
+ * @throws {Error} - If an error occurs during execution of the query or pagination.
+ */
+export async function getPaginatedDatasetAsync<T>({
+  queryAsync,
+  beforeEachQuery,
+  afterEachQuery,
+  filterPredicate,
+  batchSize = 100,
+  maxNodesFetched = 10_000,
+}: {
+  queryAsync: ({ first, after }: QueryParams) => Promise<Connection<T>>;
+  beforeEachQuery?: (totalNodesFetched: number, dataset: T[]) => void;
+  afterEachQuery?: (
+    totalNodesFetched: number,
+    dataset: T[],
+    batch: T[],
+    pageInfo: PageInfo
+  ) => void;
+  filterPredicate?: (node: T) => boolean;
+  batchSize?: number;
+  maxNodesFetched?: number;
+}): Promise<T[]> {
+  const dataset = [];
+  let hasMore = true;
+  let after: string | undefined;
+  let totalNodesFetched = 0;
+  while (hasMore) {
+    if (beforeEachQuery) {
+      beforeEachQuery(totalNodesFetched, dataset);
+    }
+    const result = await queryAsync({ first: batchSize, after });
+    const { edges, pageInfo } = result;
+    const nodes = edges.map(edge => edge.node);
+    const batch = filterPredicate ? nodes.filter(filterPredicate) : nodes;
+    dataset.push(...batch);
+    hasMore = pageInfo.hasNextPage;
+    after = pageInfo.endCursor ?? undefined;
+    totalNodesFetched += nodes.length;
+    if (afterEachQuery) {
+      afterEachQuery(totalNodesFetched, dataset, batch, pageInfo);
+    }
+    if (totalNodesFetched >= maxNodesFetched) {
+      return dataset;
+    }
+  }
+  return dataset;
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

A utility function to fetch a complete dataset from a Relay compliant endpoint in a batched way. See a concrete usage of it in `getChannelsDatasetAsync`.

# Test Plan

- [ ] new tests pass
