### PR TITLE
[eas-cli] select existing rollouts and channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - More branch mapping utility. ([#1957](https://github.com/expo/eas-cli/pull/1957) by [@quinlanj](https://github.com/quinlanj))
+- Utility classes to select existing rollouts and channels. ([#1958](https://github.com/expo/eas-cli/pull/1958) by [@quinlanj](https://github.com/quinlanj))
 
 ## [3.17.1](https://github.com/expo/eas-cli/releases/tag/v3.17.1) - 2023-07-27
 

--- a/packages/eas-cli/src/channel/__tests__/fixtures.ts
+++ b/packages/eas-cli/src/channel/__tests__/fixtures.ts
@@ -1,3 +1,7 @@
+import {
+  UpdateChannelBasicInfoFragment,
+  ViewUpdateChannelsPaginatedOnAppQuery,
+} from '../../graphql/generated';
 import { UpdateBranchObject, UpdateChannelObject } from '../../graphql/queries/ChannelQuery';
 
 export const testUpdateBranch1: UpdateBranchObject = {
@@ -128,3 +132,53 @@ export const testChannelObject: UpdateChannelObject = {
   updateBranches: [testUpdateBranch1, testUpdateBranch2],
   __typename: 'UpdateChannel',
 };
+
+export const testBasicChannelInfo: UpdateChannelBasicInfoFragment = {
+  id: '9309afc2-9752-40db-8ef7-4abc10744c61',
+  name: 'production',
+  branchMapping:
+    '{"data":[{"branchId":"754bf17f-efc0-46ab-8a59-a03f20e53e9b","branchMappingLogic":{"operand":0.1,"clientKey":"rolloutToken","branchMappingOperator":"hash_lt"}},{"branchId":"6941a8dd-5c0a-48bc-8876-f49c88ed419f","branchMappingLogic":"true"}],"version":0}',
+  __typename: 'UpdateChannel',
+};
+
+export const testBasicChannelInfo2: UpdateChannelBasicInfoFragment = {
+  id: '9d5c7bf0-d52d-474c-9140-c1bad7f0de9d',
+  name: 'staging',
+  branchMapping:
+    '{"data":[{"branchId":"d7d68e32-d9c9-4a8d-8d1b-21e53100a5e8","branchMappingLogic":{"operand":0.1,"clientKey":"rolloutToken","branchMappingOperator":"hash_lt"}},{"branchId":"f9f708c2-0c91-4360-b2a4-0b61834aef4a","branchMappingLogic":"true"}],"version":0}',
+  __typename: 'UpdateChannel',
+};
+
+export const paginatedChannels: ViewUpdateChannelsPaginatedOnAppQuery['app']['byId']['channelsPaginated'] =
+  {
+    edges: [
+      {
+        node: {
+          id: '9d5c7bf0-d52d-474c-9140-c1bad7f0de9d',
+          name: 'staging',
+          branchMapping:
+            '{"data":[{"branchId":"d7d68e32-d9c9-4a8d-8d1b-21e53100a5e8","branchMappingLogic":{"operand":0.1,"clientKey":"rolloutToken","branchMappingOperator":"hash_lt"}},{"branchId":"f9f708c2-0c91-4360-b2a4-0b61834aef4a","branchMappingLogic":"true"}],"version":0}',
+          __typename: 'UpdateChannel',
+        },
+        __typename: 'AppChannelEdge',
+      },
+      {
+        node: {
+          id: '95630b3c-5b91-48cb-bd31-a84315a13246',
+          name: 'gh/quinlanj/3/orig',
+          branchMapping:
+            '{"data":[{"branchId":"d7d68e32-d9c9-4a8d-8d1b-21e53100a5e8","branchMappingLogic":"true"}],"version":0}',
+          __typename: 'UpdateChannel',
+        },
+        __typename: 'AppChannelEdge',
+      },
+    ],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: 'IjlkNWM3YmYwLWQ1MmQtNDc0Yy05MTQwLWMxYmFkN2YwZGU5ZCI',
+      endCursor: 'ImE4Y2M5ZWVmLTFkZjMtNDNmZi05YTZkLTRmYTZjMTFlYmEwYiI',
+      __typename: 'PageInfo',
+    },
+    __typename: 'AppChannelsConnection',
+  };

--- a/packages/eas-cli/src/channel/actions/SelectChannel.ts
+++ b/packages/eas-cli/src/channel/actions/SelectChannel.ts
@@ -1,0 +1,53 @@
+import { EASUpdateAction, EASUpdateContext, NonInteractiveError } from '../../eas-update/utils';
+import { UpdateChannelBasicInfoFragment } from '../../graphql/generated';
+import { promptAsync } from '../../prompts';
+import { getChannelsDatasetAsync } from '../queries';
+
+/**
+ * Select a channel for the project.
+ *
+ * @constructor
+ * @param {function} options.filterPredicate - A predicate to filter the channels that are shown to the user. It takes a channelInfo object as a parameter and returns a boolean.
+ * @param {string} options.printedType - The type of channel printed to the user. Defaults to 'channel'.
+ */
+export class SelectChannel implements EASUpdateAction<UpdateChannelBasicInfoFragment | null> {
+  constructor(
+    private options: {
+      filterPredicate?: (channelInfo: UpdateChannelBasicInfoFragment) => boolean;
+      printedType?: string;
+    } = {}
+  ) {}
+  public async runAsync(ctx: EASUpdateContext): Promise<UpdateChannelBasicInfoFragment | null> {
+    const { nonInteractive, graphqlClient, app } = ctx;
+    const { projectId } = app;
+    const { filterPredicate } = this.options;
+    const printedType = this.options.printedType ?? 'channel';
+    if (nonInteractive) {
+      throw new NonInteractiveError(
+        `${printedType} selection cannot be run in non-interactive mode.`
+      );
+    }
+
+    const channels = await getChannelsDatasetAsync(graphqlClient, {
+      appId: projectId,
+      filterPredicate,
+    });
+
+    if (channels.length === 0) {
+      return null;
+    } else if (channels.length === 1) {
+      return channels[0];
+    }
+
+    const { channel: selectedChannel } = await promptAsync({
+      type: 'select',
+      name: 'channel',
+      message: `Select a ${printedType}`,
+      choices: channels.map(channel => ({
+        value: channel,
+        title: channel.name,
+      })),
+    });
+    return selectedChannel;
+  }
+}

--- a/packages/eas-cli/src/channel/actions/__tests__/SelectChannel-test.ts
+++ b/packages/eas-cli/src/channel/actions/__tests__/SelectChannel-test.ts
@@ -1,0 +1,49 @@
+import { createCtxMock } from '../../../eas-update/__tests__/fixtures';
+import { NonInteractiveError } from '../../../eas-update/utils';
+import { promptAsync } from '../../../prompts';
+import { testBasicChannelInfo, testBasicChannelInfo2 } from '../../__tests__/fixtures';
+import { getChannelsDatasetAsync } from '../../queries';
+import { SelectChannel } from '../SelectChannel';
+
+jest.mock('../../queries');
+jest.mock('../../../prompts');
+describe(SelectChannel, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it('returns null if project has no channels', async () => {
+    jest.mocked(getChannelsDatasetAsync).mockResolvedValue([]);
+    const ctx = createCtxMock();
+    const selectChannel = new SelectChannel();
+    const channel = await selectChannel.runAsync(ctx);
+    expect(channel).toBeNull();
+  });
+  it('returns the channel without prompting if project only one channel', async () => {
+    jest.mocked(getChannelsDatasetAsync).mockResolvedValue([testBasicChannelInfo]);
+    const ctx = createCtxMock();
+    const selectChannel = new SelectChannel();
+    const channel = await selectChannel.runAsync(ctx);
+    expect(channel).toBe(testBasicChannelInfo);
+  });
+  it('returns the selected channel', async () => {
+    jest
+      .mocked(getChannelsDatasetAsync)
+      .mockResolvedValue([testBasicChannelInfo, testBasicChannelInfo2]);
+    jest.mocked(promptAsync).mockImplementation(async () => ({
+      channel: testBasicChannelInfo,
+    }));
+    const ctx = createCtxMock();
+    const selectChannel = new SelectChannel();
+    const channel = await selectChannel.runAsync(ctx);
+    expect(channel).toBe(testBasicChannelInfo);
+  });
+  it('throws an error in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const selectChannel = new SelectChannel();
+
+    // dont fail if users are running in non-interactive mode
+    await expect(selectChannel.runAsync(ctx)).rejects.toThrowError(NonInteractiveError);
+  });
+});

--- a/packages/eas-cli/src/eas-update/__tests__/fixtures.ts
+++ b/packages/eas-cli/src/eas-update/__tests__/fixtures.ts
@@ -1,0 +1,10 @@
+import { testAppJson } from '../../credentials/__tests__/fixtures-constants';
+import { EASUpdateContext } from '../utils';
+
+export function createCtxMock(options: { nonInteractive?: boolean } = {}): EASUpdateContext {
+  return {
+    graphqlClient: jest.fn() as any,
+    nonInteractive: options.nonInteractive ?? false,
+    app: { exp: testAppJson, projectId: 'test-project-id' },
+  };
+}

--- a/packages/eas-cli/src/eas-update/utils.ts
+++ b/packages/eas-cli/src/eas-update/utils.ts
@@ -1,0 +1,15 @@
+import { ExpoConfig } from '@expo/config-types';
+
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+
+export type EASUpdateContext = {
+  graphqlClient: ExpoGraphqlClient;
+  nonInteractive: boolean;
+  app: { exp: ExpoConfig; projectId: string };
+};
+
+export interface EASUpdateAction<T = any> {
+  runAsync(ctx: EASUpdateContext): Promise<T>;
+}
+
+export class NonInteractiveError extends Error {}

--- a/packages/eas-cli/src/rollout/__tests__/branch-mapping-test.ts
+++ b/packages/eas-cli/src/rollout/__tests__/branch-mapping-test.ts
@@ -21,48 +21,11 @@ import {
   isLegacyRolloutInfo,
   isRollout,
 } from '../branch-mapping';
-
-const rolloutBranchMapping = {
-  version: 0,
-  data: [
-    {
-      branchId: uuidv4(),
-      branchMappingLogic: andStatement([
-        {
-          operand: '1.0.0',
-          clientKey: 'runtimeVersion',
-          branchMappingOperator: equalsOperator(),
-        },
-        {
-          operand: 10 / 100,
-          clientKey: 'rolloutToken',
-          branchMappingOperator: hashLtOperator(),
-        },
-      ]),
-    },
-    { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
-  ],
-};
-
-const rolloutBranchMappingLegacy = {
-  version: 0,
-  data: [
-    {
-      branchId: uuidv4(),
-      branchMappingLogic: {
-        operand: 10 / 100,
-        clientKey: 'rolloutToken',
-        branchMappingOperator: hashLtOperator(),
-      },
-    },
-    { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
-  ],
-};
-
-const standardBranchMapping = {
-  version: 0,
-  data: [{ branchId: uuidv4(), branchMappingLogic: alwaysTrue() }],
-};
+import {
+  rolloutBranchMapping,
+  rolloutBranchMappingLegacy,
+  standardBranchMapping,
+} from './fixtures';
 
 describe(isLegacyRolloutInfo, () => {
   it('classifies rollouts properly', () => {

--- a/packages/eas-cli/src/rollout/__tests__/fixtures.ts
+++ b/packages/eas-cli/src/rollout/__tests__/fixtures.ts
@@ -1,0 +1,50 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  alwaysTrue,
+  andStatement,
+  equalsOperator,
+  hashLtOperator,
+} from '../../channel/branch-mapping';
+
+export const rolloutBranchMapping = {
+  version: 0,
+  data: [
+    {
+      branchId: uuidv4(),
+      branchMappingLogic: andStatement([
+        {
+          operand: '1.0.0',
+          clientKey: 'runtimeVersion',
+          branchMappingOperator: equalsOperator(),
+        },
+        {
+          operand: 10 / 100,
+          clientKey: 'rolloutToken',
+          branchMappingOperator: hashLtOperator(),
+        },
+      ]),
+    },
+    { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
+  ],
+};
+
+export const rolloutBranchMappingLegacy = {
+  version: 0,
+  data: [
+    {
+      branchId: uuidv4(),
+      branchMappingLogic: {
+        operand: 10 / 100,
+        clientKey: 'rolloutToken',
+        branchMappingOperator: hashLtOperator(),
+      },
+    },
+    { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
+  ],
+};
+
+export const standardBranchMapping = {
+  version: 0,
+  data: [{ branchId: uuidv4(), branchMappingLogic: alwaysTrue() }],
+};

--- a/packages/eas-cli/src/rollout/actions/SelectRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/SelectRollout.ts
@@ -1,0 +1,22 @@
+import { SelectChannel } from '../../channel/actions/SelectChannel';
+import { getBranchMapping } from '../../channel/branch-mapping';
+import { EASUpdateAction, EASUpdateContext } from '../../eas-update/utils';
+import { UpdateChannelBasicInfoFragment } from '../../graphql/generated';
+import { isRollout } from '../branch-mapping';
+
+/**
+ * Select an existing rollout for the project.
+ */
+export class SelectRollout implements EASUpdateAction<UpdateChannelBasicInfoFragment | null> {
+  public async runAsync(ctx: EASUpdateContext): Promise<UpdateChannelBasicInfoFragment | null> {
+    const rolloutFilterPredicate = (channelInfo: UpdateChannelBasicInfoFragment): boolean => {
+      const branchMapping = getBranchMapping(channelInfo.branchMapping);
+      return isRollout(branchMapping);
+    };
+    const selectChannel = new SelectChannel({
+      printedType: 'rollout',
+      filterPredicate: rolloutFilterPredicate,
+    });
+    return await selectChannel.runAsync(ctx);
+  }
+}

--- a/packages/eas-cli/src/rollout/actions/__tests__/SelectRollout-test.ts
+++ b/packages/eas-cli/src/rollout/actions/__tests__/SelectRollout-test.ts
@@ -1,0 +1,63 @@
+import { testBasicChannelInfo, testBasicChannelInfo2 } from '../../../channel/__tests__/fixtures';
+import { getChannelsDatasetAsync } from '../../../channel/queries';
+import { createCtxMock } from '../../../eas-update/__tests__/fixtures';
+import { NonInteractiveError } from '../../../eas-update/utils';
+import { promptAsync } from '../../../prompts';
+import { standardBranchMapping } from '../../__tests__/fixtures';
+import { SelectRollout } from '../SelectRollout';
+
+jest.mock('../../../channel/queries');
+jest.mock('../../../prompts');
+describe(SelectRollout, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it('returns null if project has no rollouts', async () => {
+    jest.mocked(getChannelsDatasetAsync).mockResolvedValue([]);
+    const ctx = createCtxMock();
+    const selectRollout = new SelectRollout();
+    const rollout = await selectRollout.runAsync(ctx);
+    expect(rollout).toBeNull();
+  });
+  it('returns the rollout without prompting if project only one rollout', async () => {
+    jest.mocked(getChannelsDatasetAsync).mockResolvedValue([testBasicChannelInfo]);
+    const ctx = createCtxMock();
+    const selectRollout = new SelectRollout();
+    const rollout = await selectRollout.runAsync(ctx);
+    expect(rollout).toBe(testBasicChannelInfo);
+  });
+  it('returns the selected rollout', async () => {
+    jest
+      .mocked(getChannelsDatasetAsync)
+      .mockResolvedValue([testBasicChannelInfo, testBasicChannelInfo2]);
+    jest.mocked(promptAsync).mockImplementation(async () => ({
+      channel: testBasicChannelInfo,
+    }));
+    const ctx = createCtxMock();
+    const selectRollout = new SelectRollout();
+    const rollout = await selectRollout.runAsync(ctx);
+    expect(rollout).toBe(testBasicChannelInfo);
+  });
+  it('filters the channels for rollouts', async () => {
+    const standardBranchMappingChannel = { ...testBasicChannelInfo };
+    standardBranchMappingChannel.branchMapping = JSON.stringify(standardBranchMapping);
+    const mockDataset = [standardBranchMappingChannel];
+    jest.mocked(getChannelsDatasetAsync).mockImplementation((_gqlClient, args: any) => {
+      const filterPredicate = args.filterPredicate as any;
+      return mockDataset.filter(filterPredicate) as any;
+    });
+    const ctx = createCtxMock();
+    const selectRollout = new SelectRollout();
+    const rollout = await selectRollout.runAsync(ctx);
+    expect(rollout).toBeNull();
+  });
+  it('throws an error in Non-Interactive Mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const selectRollout = new SelectRollout();
+
+    // dont fail if users are running in non-interactive mode
+    await expect(selectRollout.runAsync(ctx)).rejects.toThrowError(NonInteractiveError);
+  });
+});


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This PR does the following:
- Defines our `Action` model in the `eas-update` folder.  Every action implements the `EASUpdateAction` interface. This  allows us to build our commands with these modular Actions.
- Makes utility classes to select existing channels and rollouts. `SelectChannel` and `SelectRollout` are a concrete example of these Actions

# Test Plan

- [ ] new tests pass