### PR TITLE
[ENG-8616][eas-cli] change update default runtime policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - More branch mapping utility. ([#1957](https://github.com/expo/eas-cli/pull/1957) by [@quinlanj](https://github.com/quinlanj))
 - Utility classes to select existing rollouts and channels. ([#1958](https://github.com/expo/eas-cli/pull/1958) by [@quinlanj](https://github.com/quinlanj))
+- Change default runtime version policy for EAS Update to appVersion. ([#1968](https://github.com/expo/eas-cli/pull/1968) by [@quinlanj](https://github.com/quinlanj))
 
 ## [3.17.1](https://github.com/expo/eas-cli/releases/tag/v3.17.1) - 2023-07-27
 

--- a/packages/eas-cli/src/update/__tests__/configure-test.ts
+++ b/packages/eas-cli/src/update/__tests__/configure-test.ts
@@ -1,0 +1,52 @@
+import { Workflow } from '@expo/eas-build-job';
+
+import {
+  DEFAULT_BARE_RUNTIME_VERSION,
+  DEFAULT_MANAGED_RUNTIME_VERSION_GTE_SDK_49,
+  DEFAULT_MANAGED_RUNTIME_VERSION_LTE_SDK_48,
+  getDefaultRuntimeVersion,
+} from '../configure';
+
+describe(getDefaultRuntimeVersion, () => {
+  it('gets the right rtv version/policy', () => {
+    expect(getDefaultRuntimeVersion(Workflow.MANAGED, '48.0.0')).toBe(
+      DEFAULT_MANAGED_RUNTIME_VERSION_LTE_SDK_48
+    );
+    expect(getDefaultRuntimeVersion(Workflow.MANAGED, '49.0.0')).toBe(
+      DEFAULT_MANAGED_RUNTIME_VERSION_GTE_SDK_49
+    );
+    expect(getDefaultRuntimeVersion(Workflow.MANAGED, '50.0.0')).toBe(
+      DEFAULT_MANAGED_RUNTIME_VERSION_GTE_SDK_49
+    );
+    expect(getDefaultRuntimeVersion(Workflow.MANAGED, 'sdf')).toBe(
+      DEFAULT_MANAGED_RUNTIME_VERSION_LTE_SDK_48
+    );
+    expect(getDefaultRuntimeVersion(Workflow.MANAGED, undefined)).toBe(
+      DEFAULT_MANAGED_RUNTIME_VERSION_LTE_SDK_48
+    );
+
+    expect(getDefaultRuntimeVersion(Workflow.UNKNOWN, '48.0.0')).toBe(
+      DEFAULT_MANAGED_RUNTIME_VERSION_LTE_SDK_48
+    );
+    expect(getDefaultRuntimeVersion(Workflow.UNKNOWN, '49.0.0')).toBe(
+      DEFAULT_MANAGED_RUNTIME_VERSION_GTE_SDK_49
+    );
+    expect(getDefaultRuntimeVersion(Workflow.UNKNOWN, '50.0.0')).toBe(
+      DEFAULT_MANAGED_RUNTIME_VERSION_GTE_SDK_49
+    );
+    expect(getDefaultRuntimeVersion(Workflow.UNKNOWN, 'sdf')).toBe(
+      DEFAULT_MANAGED_RUNTIME_VERSION_LTE_SDK_48
+    );
+    expect(getDefaultRuntimeVersion(Workflow.UNKNOWN, undefined)).toBe(
+      DEFAULT_MANAGED_RUNTIME_VERSION_LTE_SDK_48
+    );
+
+    expect(getDefaultRuntimeVersion(Workflow.GENERIC, '48.0.0')).toBe(DEFAULT_BARE_RUNTIME_VERSION);
+    expect(getDefaultRuntimeVersion(Workflow.GENERIC, '49.0.0')).toBe(DEFAULT_BARE_RUNTIME_VERSION);
+    expect(getDefaultRuntimeVersion(Workflow.GENERIC, '50.0.0')).toBe(DEFAULT_BARE_RUNTIME_VERSION);
+    expect(getDefaultRuntimeVersion(Workflow.GENERIC, 'sdf')).toBe(DEFAULT_BARE_RUNTIME_VERSION);
+    expect(getDefaultRuntimeVersion(Workflow.GENERIC, undefined)).toBe(
+      DEFAULT_BARE_RUNTIME_VERSION
+    );
+  });
+});


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Whenever someone tries to setup EAS Update, we used to default them to the `sdkVersion` runtime policy because Expo Go for 48 and below would not load any other policy. However, we've changed this in 49 and we can now switch folks over to the more expressive `appVersion`. 

# How

Detect if someone is setting up EAS Update on sdk 49.0.0 or higher. If they are, default them to `appVersion` runtime policy.

# Test Plan

- [x] new unit tests pass
- [x] manually tested
