### PR TITLE
[ENG-9482][eas-cli] provide credentials for custom Android builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - .nvmrc support for setting node version. ([#1954](https://github.com/expo/eas-cli/pull/1954) by [@khamilowicz](https://github.com/khamilowicz))
+- Provide credentials for custom Android builds. ([#1969](https://github.com/expo/eas-cli/pull/1969) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -124,8 +124,7 @@ export async function prepareAndroidBuildAsync(
 }
 
 function shouldProvideCredentials(ctx: BuildContext<Platform.ANDROID>): boolean {
-  const isCustomBuild = ctx.buildProfile.config !== undefined;
-  return !ctx.buildProfile.withoutCredentials && !isCustomBuild;
+  return !ctx.buildProfile.withoutCredentials;
 }
 
 async function ensureAndroidCredentialsAsync(


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-9482/implement-utilsinject-android-credentials

# How

Provide credentials for custom Android builds

# Test Plan

Tests
