### PR TITLE
[eas-cli] fix update:republish group id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Pass correct group into `update:republish`. ([#1971](https://github.com/expo/eas-cli/pull/1971) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🧹 Chores
 
 - More branch mapping utility. ([#1957](https://github.com/expo/eas-cli/pull/1957) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/commands/update/republish.ts
+++ b/packages/eas-cli/src/commands/update/republish.ts
@@ -166,15 +166,15 @@ async function getOrAskUpdatesAsync(
   flags: UpdateRepublishFlags
 ): Promise<UpdateToRepublish[]> {
   if (flags.groupId) {
-    const updateGroups = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, {
+    const updateGroup = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, {
       groupId: flags.groupId,
     });
 
-    return updateGroups.map(group => ({
-      ...group,
-      groupId: group.group,
-      branchId: group.branch.id,
-      branchName: group.branch.name,
+    return updateGroup.map(update => ({
+      ...update,
+      groupId: update.group,
+      branchId: update.branch.id,
+      branchName: update.branch.name,
     }));
   }
 
@@ -211,17 +211,17 @@ async function askUpdatesFromBranchNameAsync(
     throw new Error('Must supply --group when in non-interactive mode');
   }
 
-  const updateGroups = await selectUpdateGroupOnBranchAsync(graphqlClient, {
+  const updateGroup = await selectUpdateGroupOnBranchAsync(graphqlClient, {
     projectId,
     branchName,
     paginatedQueryOptions: getPaginatedQueryOptions({ json, 'non-interactive': nonInteractive }),
   });
 
-  return updateGroups.map(group => ({
-    ...group,
-    groupId: group.id,
-    branchId: group.branch.id,
-    branchName: group.branch.name,
+  return updateGroup.map(update => ({
+    ...update,
+    groupId: update.group,
+    branchId: update.branch.id,
+    branchName: update.branch.name,
   }));
 }
 /** Ask the user which update needs to be republished by channel name, this requires interactive mode */

--- a/packages/eas-cli/src/update/republish.ts
+++ b/packages/eas-cli/src/update/republish.ts
@@ -111,19 +111,20 @@ export async function republishAsync({
     updatesRepublished.map(update => [update.platform, update])
   );
 
+  const arbitraryRepublishedUpdate = updatesRepublished[0];
   const updateGroupUrl = getUpdateGroupUrl(
     (await getOwnerAccountForProjectIdAsync(graphqlClient, app.projectId)).name,
     app.exp.slug,
-    updatesRepublished[0].group
+    arbitraryRepublishedUpdate.group
   );
 
   Log.addNewLineIfNone();
   Log.log(
     formatFields([
       { label: 'Branch', value: targetBranchName },
-      { label: 'Runtime version', value: updatesRepublished[0].runtimeVersion },
+      { label: 'Runtime version', value: arbitraryRepublishedUpdate.runtimeVersion },
       { label: 'Platform', value: updatesRepublished.map(update => update.platform).join(', ') },
-      { label: 'Update Group ID', value: updatesRepublished[0].id },
+      { label: 'Update Group ID', value: arbitraryRepublishedUpdate.group },
       ...(updatesRepublishedByPlatform.android
         ? [{ label: 'Android update ID', value: updatesRepublishedByPlatform.android.id }]
         : []),


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`update:republish` is broken, and as of https://github.com/expo/eas-cli/commit/8d57828f7e40c0be2ef6de74ee92857a3ceb9db9 it throws. I added some assertions to `republishAsync` that uncovered the bug where we were confusing `update.id` with its group ID (`update.group`).

# How

Use the correct group and rename some variables to make code clearer

# Test Plan

- [ ] manually tested `update:republish` with channel, branch and group flags
