### PR TITLE
[eas-cli] rollout relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Make new rollouts version available for internal dogfooding. ([#1966](https://github.com/expo/eas-cli/pull/1966) by [@quinlanj](https://github.com/quinlanj))
+- Add relationships flag to rollouts-preview. ([#1972](https://github.com/expo/eas-cli/pull/1972) by [@quinlanj](https://github.com/quinlanj))
 
 ## [3.18.0](https://github.com/expo/eas-cli/releases/tag/v3.18.0) - 2023-08-02
 

--- a/packages/eas-cli/src/commands/channel/rollout-preview.ts
+++ b/packages/eas-cli/src/commands/channel/rollout-preview.ts
@@ -58,6 +58,42 @@ export default class ChannelRolloutPreview extends EasCommand {
       description: 'Rollout action to perform',
       options: Object.values(ActionRawFlagValue),
       required: false,
+      relationships: [
+        {
+          type: 'all',
+          flags: [
+            {
+              name: 'percent',
+              // eslint-disable-next-line async-protect/async-suffix
+              when: async flags => {
+                return (
+                  !!flags['non-interactive'] &&
+                  (flags['action'] === ActionRawFlagValue.CREATE ||
+                    flags['action'] === ActionRawFlagValue.EDIT)
+                );
+              },
+            },
+            {
+              name: 'outcome',
+              // eslint-disable-next-line async-protect/async-suffix
+              when: async flags =>
+                !!flags['non-interactive'] && flags['action'] === ActionRawFlagValue.END,
+            },
+            {
+              name: 'branch',
+              // eslint-disable-next-line async-protect/async-suffix
+              when: async flags =>
+                !!flags['non-interactive'] && flags['action'] === ActionRawFlagValue.CREATE,
+            },
+            {
+              name: 'runtime-version',
+              // eslint-disable-next-line async-protect/async-suffix
+              when: async flags =>
+                !!flags['non-interactive'] && flags['action'] === ActionRawFlagValue.CREATE,
+            },
+          ],
+        },
+      ],
     }),
     percent: Flags.integer({
       description:


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Add cli flag relationships for rollouts. Followup from https://github.com/expo/eas-cli/pull/1966#discussion_r1281179912

# How

Specify relationships when the user is running in `non-interactive` mode, since any other missing flags in interactive mode can be selected for by the user

# Test Plan

- [x] manually tested
