### PR TITLE
[eas-cli] Fix republishing with code signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix republishing with code signing. ([#1973](https://github.com/expo/eas-cli/pull/1973) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 - Make new rollouts version available for internal dogfooding. ([#1966](https://github.com/expo/eas-cli/pull/1966) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
@@ -1,5 +1,5 @@
-import { AppJSONConfig, PackageJSONConfig, getConfig } from '@expo/config';
-import { vol } from 'memfs';
+import { AppJSONConfig, ExpoConfig, PackageJSONConfig, getConfig } from '@expo/config';
+import { DirectoryJSON, vol } from 'memfs';
 import { instance, mock } from 'ts-mockito';
 
 import LoggedInContextField from '../../../commandUtils/context/LoggedInContextField';
@@ -8,12 +8,17 @@ import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/cr
 import FeatureGateEnvOverrides from '../../../commandUtils/gating/FeatureGateEnvOverrides';
 import FeatureGating from '../../../commandUtils/gating/FeatureGating';
 import { jester } from '../../../credentials/__tests__/fixtures-constants';
-import { CodeSigningInfo, UpdateFragment } from '../../../graphql/generated';
+import { UpdateFragment } from '../../../graphql/generated';
 import { PublishMutation } from '../../../graphql/mutations/PublishMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { UpdateQuery } from '../../../graphql/queries/UpdateQuery';
 import { getBranchNameFromChannelNameAsync } from '../../../update/getBranchNameFromChannelNameAsync';
 import { selectUpdateGroupOnBranchAsync } from '../../../update/queries';
+import {
+  getCodeSigningInfoAsync,
+  getManifestBodyAsync,
+  signBody,
+} from '../../../utils/code-signing';
 import UpdateRepublish from '../republish';
 
 const projectRoot = '/test-project';
@@ -33,12 +38,6 @@ const updateStub: UpdateFragment = {
   createdAt: '2022-01-01T12:00:00Z',
 };
 
-const codeSigningStub: CodeSigningInfo = {
-  keyid: 'keyid',
-  alg: 'alg',
-  sig: 'sig',
-};
-
 jest.mock('fs');
 jest.mock('@expo/config');
 jest.mock('../../../commandUtils/context/contextUtils/getProjectIdAsync');
@@ -52,6 +51,8 @@ jest.mock('../../../ora', () => ({
     start: () => ({ succeed: () => {}, fail: () => {} }),
   }),
 }));
+jest.mock('../../../utils/code-signing');
+jest.mock('../../../fetch');
 
 describe(UpdateRepublish.name, () => {
   afterEach(() => vol.reset());
@@ -156,18 +157,45 @@ describe(UpdateRepublish.name, () => {
   });
 
   it('re-creates update using codesigning with --group and --message', async () => {
-    const flags = ['--group=1234', '--message=test-republish'];
+    const flags = [
+      '--group=1234',
+      '--message=test-republish',
+      `--private-key-path=./keys/test-private-key.pem`,
+    ];
     const codeSigning = {
-      alg: 'alg',
+      alg: 'rsa-v1_5-sha256',
       keyid: 'keyid',
       sig: 'sig',
     };
 
-    mockTestProject();
+    mockTestProject({
+      extraManifest: {
+        updates: {
+          codeSigningCertificate: './keys/test-certificate.pem',
+          codeSigningMetadata: {
+            alg: 'rsa-v1_5-sha256',
+            keyid: 'keyid',
+          },
+        },
+      },
+      extraVol: {
+        './keys/test-private-key.pem': 'testpemprivate',
+        './keys/test-certificate.pem': 'testpemcertificate',
+      },
+    });
+
+    jest.mocked(getCodeSigningInfoAsync).mockResolvedValue({
+      privateKey: '' as any,
+      certificate: '' as any,
+      codeSigningMetadata: { alg: 'rsa-v1_5-sha256', keyid: 'keyid' },
+    });
+    jest.mocked(getManifestBodyAsync).mockResolvedValue('test');
+    jest.mocked(signBody).mockReturnValue('sig');
+
     // Mock queries to retrieve the update and code signing info
     jest
       .mocked(UpdateQuery.viewUpdateGroupAsync)
-      .mockResolvedValue([{ ...updateStub, codeSigningInfo: codeSigningStub }]);
+      .mockResolvedValue([{ ...updateStub, codeSigningInfo: codeSigning }]);
     // Mock mutations to store the new update
     jest.mocked(PublishMutation.publishUpdateGroupAsync).mockResolvedValue([
       {
@@ -287,8 +315,12 @@ describe(UpdateRepublish.name, () => {
 /** Create a new in-memory project, based on src/commands/project/__tests__/init.test.ts */
 function mockTestProject({
   configuredProjectId = '1234',
+  extraManifest,
+  extraVol,
 }: {
   configuredProjectId?: string;
+  extraManifest?: Partial<ExpoConfig>;
+  extraVol?: DirectoryJSON;
 } = {}): void {
   const packageJSON: PackageJSONConfig = {
     name: 'testing123',
@@ -309,6 +341,7 @@ function mockTestProject({
           projectId: configuredProjectId,
         },
       },
+      ...extraManifest,
     },
   };
 
@@ -316,6 +349,7 @@ function mockTestProject({
     {
       'package.json': JSON.stringify(packageJSON),
       'app.json': JSON.stringify(appJSON),
+      ...extraVol,
     },
     projectRoot
   );


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This fixes the following issue:
- A republished update will have the same manifest info group but different generated metadata from the server (different groupId and potentially different branch name).
- Previously, this was using the same signature, but for the different blob. Therefore it would fail.

Closes ENG-9596.

# How

This fixes it by requiring providing the private key to republish when code signing is involved.

# Test Plan

1. Set up code signing: https://docs.expo.dev/eas-update/code-signing/
1. `eas update`, see it is signed
1. `eas update:republish`, see it signs correctly now
