### PR TITLE
[ENG-8715][eas-cli] get channel:{view,list,edit} to play nice with rollouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Make new rollouts version available for internal dogfooding. ([#1966](https://github.com/expo/eas-cli/pull/1966) by [@quinlanj](https://github.com/quinlanj))
+- Get channel:{view,list,edit} to play nice with rollouts. ([#1974](https://github.com/expo/eas-cli/pull/1974) by [@quinlanj](https://github.com/quinlanj))
 
 ## [3.18.0](https://github.com/expo/eas-cli/releases/tag/v3.18.0) - 2023-08-02
 

--- a/packages/eas-cli/src/channel/__tests__/branch-mapping-test.ts
+++ b/packages/eas-cli/src/channel/__tests__/branch-mapping-test.ts
@@ -1,11 +1,23 @@
 import { rolloutBranchMapping, standardBranchMapping } from '../../rollout/__tests__/fixtures';
 import {
   BranchMappingValidationError,
+  assertVersion,
   getAlwaysTrueBranchMapping,
+  getBranchMapping,
   getStandardBranchId,
   isAlwaysTrueBranchMapping,
 } from '../branch-mapping';
 import { testChannelObject } from './fixtures';
+
+describe(assertVersion, () => {
+  it('throws if the branch mapping is not the correct version', () => {
+    expect(() => assertVersion(testChannelObject, 5)).toThrowError(BranchMappingValidationError);
+  });
+  it('asserts the correct version', () => {
+    assertVersion(testChannelObject, 0);
+    expect(getBranchMapping(testChannelObject.branchMapping).version).toBe(0);
+  });
+});
 
 describe(isAlwaysTrueBranchMapping, () => {
   it('detects always true branch mappings', () => {

--- a/packages/eas-cli/src/channel/branch-mapping.ts
+++ b/packages/eas-cli/src/channel/branch-mapping.ts
@@ -133,6 +133,19 @@ export function hashLtOperator(): BranchMappingOperator {
   return 'hash_lt';
 }
 
+function isVersion(branchMapping: BranchMapping, version: number): boolean {
+  return branchMapping.version === version;
+}
+
+export function assertVersion(channelInfo: UpdateChannelBasicInfoFragment, version: number): void {
+  const branchMapping = getBranchMapping(channelInfo.branchMapping);
+  if (!isVersion(branchMapping, version)) {
+    throw new BranchMappingValidationError(
+      `Expected branch mapping version ${version}. Received: ${JSON.stringify(branchMapping)}`
+    );
+  }
+}
+
 export function assertStatement(node: BranchMappingNode): asserts node is BranchMappingStatement {
   if (!isStatement(node)) {
     throw new BranchMappingValidationError(

--- a/packages/eas-cli/src/channel/print-utils.ts
+++ b/packages/eas-cli/src/channel/print-utils.ts
@@ -1,0 +1,52 @@
+import assert from 'assert';
+import chalk from 'chalk';
+
+import { UpdateChannelObject } from '../graphql/queries/ChannelQuery';
+import Log from '../log';
+import { getRollout, isRollout } from '../rollout/branch-mapping';
+import {
+  FormattedBranchDescription,
+  formatBranch,
+  getUpdateGroupDescriptionsWithBranch,
+} from '../update/utils';
+import { assertVersion, hasStandardBranchMap } from './branch-mapping';
+
+export function logChannelDetails(channel: UpdateChannelObject): void {
+  assertVersion(channel, 0);
+  assert(
+    hasStandardBranchMap(channel) || isRollout(channel),
+    'Only standard branch mappings and rollouts are supported.'
+  );
+
+  const branchDescription = channel.updateBranches.flatMap(branch => {
+    const updateGroupWithBranchDescriptions = getUpdateGroupDescriptionsWithBranch(
+      branch.updateGroups
+    );
+    const maybeRollout = isRollout(channel) ? getRollout(channel) : null;
+    let maybePercentOnBranch: number | undefined = undefined;
+    if (maybeRollout) {
+      maybePercentOnBranch =
+        maybeRollout.rolledOutBranchId === branch.id
+          ? maybeRollout.percentRolledOut
+          : 100 - maybeRollout.percentRolledOut;
+    }
+
+    return updateGroupWithBranchDescriptions.map(
+      ({ branch, ...updateGroup }): FormattedBranchDescription => ({
+        branch,
+        branchRolloutPercentage: maybePercentOnBranch,
+        update: updateGroup,
+      })
+    );
+  });
+
+  if (branchDescription.length === 0) {
+    Log.log(chalk.dim('No branches are pointed to this channel.'));
+  } else {
+    Log.log(
+      branchDescription
+        .map(description => formatBranch(description))
+        .join(`\n\n${chalk.dim('———')}\n\n`)
+    );
+  }
+}

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -21,7 +21,7 @@ import {
   paginatedQueryWithConfirmPromptAsync,
   paginatedQueryWithSelectPromptAsync,
 } from '../utils/queries';
-import { logChannelDetails } from './utils';
+import { logChannelDetails } from './print-utils';
 
 export const CHANNELS_LIMIT = 25;
 

--- a/packages/eas-cli/src/channel/utils.ts
+++ b/packages/eas-cli/src/channel/utils.ts
@@ -1,13 +1,6 @@
 import assert from 'assert';
-import chalk from 'chalk';
 
 import { UpdateBranchObject, UpdateChannelObject } from '../graphql/queries/ChannelQuery';
-import Log from '../log';
-import {
-  FormattedBranchDescription,
-  formatBranch,
-  getUpdateGroupDescriptionsWithBranch,
-} from '../update/utils';
 import { BranchMapping, assertNodeObject, assertNumber, isNodeObject } from './branch-mapping';
 
 /**
@@ -69,45 +62,6 @@ export function getBranchMapping(branchMappingString?: string): {
   }
 
   return { branchMapping, isRollout, rolloutPercent };
-}
-
-export function logChannelDetails(channel: UpdateChannelObject): void {
-  const { branchMapping, isRollout, rolloutPercent } = getBranchMapping(channel.branchMapping);
-  if (branchMapping.data.length > 2) {
-    throw new Error('Branch Mapping data must have length less than or equal to 2.');
-  }
-
-  const rolloutBranchIds = branchMapping.data.map(data => data.branchId);
-  const branchDescription = channel.updateBranches.flatMap(branch => {
-    const updateGroupWithBranchDescriptions = getUpdateGroupDescriptionsWithBranch(
-      branch.updateGroups
-    );
-
-    const isRolloutBranch = isRollout && rolloutBranchIds.includes(branch.id);
-    const isBaseBranch = rolloutBranchIds.length > 0 && rolloutBranchIds[0] === branch.id;
-    let rolloutPercentNumber: number | undefined = undefined;
-    if (isRolloutBranch) {
-      rolloutPercentNumber = isBaseBranch ? rolloutPercent! * 100 : (1 - rolloutPercent!) * 100;
-    }
-
-    return updateGroupWithBranchDescriptions.map(
-      ({ branch, ...updateGroup }): FormattedBranchDescription => ({
-        branch,
-        branchRolloutPercentage: rolloutPercentNumber,
-        update: updateGroup,
-      })
-    );
-  });
-
-  if (branchDescription.length === 0) {
-    Log.log(chalk.dim('No branches are pointed to this channel.'));
-  } else {
-    Log.log(
-      branchDescription
-        .map(description => formatBranch(description))
-        .join(`\n\n${chalk.dim('———')}\n\n`)
-    );
-  }
 }
 
 function getUpdateBranchNullable(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Fix these commands to play nice with `channel:rollout` and `channel:rollout-preview`:
- channel:view
- channel:list
- channel:edit
- channel:rollout

# How

use the new rollout branch-mapping primitives to detect if there is a rollout 

# Test Plan

- [x] new tests pass