### PR TITLE
Revert "[ENG-9422][eas-cli] Use .nvmrc to set node version (#1954)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Revert adding `.nvmrc` support for setting node version. ([#1976](https://github.com/expo/eas-cli/pull/1976) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [3.18.1](https://github.com/expo/eas-cli/releases/tag/v3.18.1) - 2023-08-03

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -117,7 +117,6 @@ export async function runBuildAndSubmitAsync(
     easJsonAccessor,
     platforms,
     profileName: flags.profile ?? undefined,
-    projectDir,
   });
   Log.log(
     `Loaded "env" configuration for the "${buildProfiles[0].profileName}" profile: ${
@@ -184,7 +183,6 @@ export async function runBuildAndSubmitAsync(
       platforms,
       profileName: flags.submitProfile,
       type: 'submit',
-      projectDir,
     });
     for (const startedBuild of startedBuilds) {
       const submitProfile = nullthrows(

--- a/packages/eas-cli/src/commands/build/version/get.ts
+++ b/packages/eas-cli/src/commands/build/version/get.ts
@@ -68,7 +68,6 @@ export default class BuildVersionGetView extends EasCommand {
       easJsonAccessor,
       platforms,
       profileName: flags.profile ?? undefined,
-      projectDir,
     });
     const results: { [key in Platform]?: string } = {};
     for (const { profile, platform } of buildProfiles) {

--- a/packages/eas-cli/src/commands/build/version/sync.ts
+++ b/packages/eas-cli/src/commands/build/version/sync.ts
@@ -80,7 +80,6 @@ export default class BuildVersionSyncView extends EasCommand {
       easJsonAccessor,
       platforms,
       profileName: flags.profile ?? undefined,
-      projectDir,
     });
     for (const profileInfo of buildProfiles) {
       const { exp, projectId } = await getDynamicPrivateProjectConfigAsync({

--- a/packages/eas-cli/src/commands/metadata/lint.ts
+++ b/packages/eas-cli/src/commands/metadata/lint.ts
@@ -47,7 +47,6 @@ export default class MetadataLint extends EasCommand {
       easJsonAccessor: EasJsonAccessor.fromProjectPath(projectDir),
       platforms: [Platform.IOS],
       profileName: flags.profile,
-      projectDir,
     });
 
     if (submitProfiles.length !== 1) {

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -49,7 +49,6 @@ export default class MetadataPull extends EasCommand {
       easJsonAccessor: EasJsonAccessor.fromProjectPath(projectDir),
       platforms: [Platform.IOS],
       profileName: flags.profile,
-      projectDir,
     });
 
     if (submitProfiles.length !== 1) {

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -47,7 +47,6 @@ export default class MetadataPush extends EasCommand {
       easJsonAccessor: EasJsonAccessor.fromProjectPath(projectDir),
       platforms: [Platform.IOS],
       profileName: flags.profile,
-      projectDir,
     });
 
     if (submitProfiles.length !== 1) {

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -118,7 +118,6 @@ export default class Submit extends EasCommand {
       easJsonAccessor: EasJsonAccessor.fromProjectPath(projectDir),
       platforms,
       profileName: flagsWithPlatform.profile,
-      projectDir,
     });
 
     const submissions: SubmissionFragment[] = [];

--- a/packages/eas-cli/src/utils/__tests__/profiles-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/profiles-test.ts
@@ -1,8 +1,5 @@
 import { Platform } from '@expo/eas-build-job';
 import { BuildProfile, EasJsonAccessor, EasJsonUtils, errors } from '@expo/eas-json';
-import fs from 'fs-extra';
-import { vol } from 'memfs';
-import os from 'os';
 
 import Log from '../../log';
 import { selectAsync } from '../../prompts';
@@ -12,7 +9,6 @@ import {
   maybePrintBuildProfileDeprecationWarningsAsync,
 } from '../profiles';
 
-jest.mock('fs');
 jest.mock('../../prompts');
 jest.mock('@expo/eas-json', () => {
   const actual = jest.requireActual('@expo/eas-json');
@@ -36,7 +32,6 @@ const getBuildProfileDeprecationWarningsAsync = jest.spyOn(
 );
 const newLineSpy = jest.spyOn(Log, 'newLine');
 const warnSpy = jest.spyOn(Log, 'warn');
-const projectDir = '/app';
 
 describe(getProfilesAsync, () => {
   afterEach(() => {
@@ -56,7 +51,6 @@ describe(getProfilesAsync, () => {
       platforms: [Platform.ANDROID, Platform.IOS],
       profileName: undefined,
       type: 'build',
-      projectDir,
     });
 
     expect(result[0].profileName).toBe('production');
@@ -77,7 +71,6 @@ describe(getProfilesAsync, () => {
         platforms: [Platform.ANDROID],
         profileName: undefined,
         type: 'build',
-        projectDir,
       })
     ).rejects.toThrowError(errors.MissingProfileError);
   });
@@ -93,7 +86,6 @@ describe(getProfilesAsync, () => {
       platforms: [Platform.ANDROID, Platform.IOS],
       profileName: 'custom-profile',
       type: 'build',
-      projectDir,
     });
 
     expect(result[0].profileName).toBe('custom-profile');
@@ -104,52 +96,6 @@ describe(getProfilesAsync, () => {
       'custom-profile'
     );
     expect(getBuildProfileAsync).toBeCalledWith(easJsonAccessor, Platform.IOS, 'custom-profile');
-  });
-
-  describe('node version', () => {
-    const nodeVersion = '14.17.1';
-
-    it('is read from profile', async () => {
-      const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
-      getBuildProfileAsync.mockImplementation(async () => {
-        return { node: nodeVersion } as BuildProfile<Platform.ANDROID>;
-      });
-      const result = await getProfilesAsync({
-        easJsonAccessor,
-        platforms: [Platform.ANDROID],
-        profileName: 'custom-profile',
-        type: 'build',
-        projectDir,
-      });
-
-      expect(result[0].profile.node).toBe(nodeVersion);
-    });
-
-    describe('with .nvmrc', () => {
-      beforeEach(async () => {
-        vol.reset();
-        await fs.mkdirp(os.tmpdir());
-
-        vol.fromJSON({ '.nvmrc': nodeVersion }, projectDir);
-      });
-
-      it('is read from .nvmrc', async () => {
-        const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
-        getBuildProfileAsync.mockImplementation(async () => {
-          return {} as BuildProfile<Platform.ANDROID>;
-        });
-
-        const result = await getProfilesAsync({
-          easJsonAccessor,
-          platforms: [Platform.ANDROID],
-          profileName: 'custom-profile',
-          type: 'build',
-          projectDir,
-        });
-
-        expect(result[0].profile.node).toBe(nodeVersion);
-      });
-    });
   });
 
   it('throws validation error if eas.json is invalid', async () => {
@@ -163,7 +109,6 @@ describe(getProfilesAsync, () => {
         platforms: [Platform.ANDROID, Platform.IOS],
         profileName: undefined,
         type: 'build',
-        projectDir,
       })
     ).rejects.toThrowError(/eas.json is not valid/);
   });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://github.com/expo/eas-cli/issues/1975

# How

Revert https://github.com/expo/eas-cli/pull/1954

# Test Plan

Tests

Run build locally and see that we don't read `.nvmrc`
