### PR TITLE
[eas-cli] Fix rollout-preview ending with republish with code signing

### DIFF
--- a/packages/eas-cli/src/commands/channel/rollout-preview.ts
+++ b/packages/eas-cli/src/commands/channel/rollout-preview.ts
@@ -7,6 +7,7 @@ import { NonInteractiveOptions as CreateRolloutNonInteractiveOptions } from '../
 import { NonInteractiveOptions as EditRolloutNonInteractiveOptions } from '../../rollout/actions/EditRollout';
 import {
   EndOutcome,
+  GeneralOptions as EndRolloutGeneralOptions,
   NonInteractiveOptions as EndRolloutNonInteractiveOptions,
 } from '../../rollout/actions/EndRollout';
 import { ManageRolloutActions } from '../../rollout/actions/ManageRollout';
@@ -30,6 +31,7 @@ type ChannelRolloutRawArgsAndFlags = {
   'non-interactive': boolean;
   branch?: string;
   'runtime-version'?: string;
+  'private-key-path'?: string;
   json?: boolean;
 };
 
@@ -40,6 +42,7 @@ type ChannelRolloutArgsAndFlags = {
   json?: boolean;
 } & Partial<EditRolloutNonInteractiveOptions> &
   Partial<EndRolloutNonInteractiveOptions> &
+  EndRolloutGeneralOptions &
   Partial<CreateRolloutNonInteractiveOptions>;
 
 export default class ChannelRolloutPreview extends EasCommand {
@@ -113,6 +116,10 @@ export default class ChannelRolloutPreview extends EasCommand {
       description: 'Runtime version to target. Use with --action=create',
       required: false,
     }),
+    'private-key-path': Flags.string({
+      description: `File containing the PEM-encoded private key corresponding to the certificate in expo-updates' configuration. Defaults to a file named "private-key.pem" in the certificate's directory.`,
+      required: false,
+    }),
     ...EasNonInteractiveAndJsonFlags,
   };
 
@@ -175,6 +182,7 @@ export default class ChannelRolloutPreview extends EasCommand {
       outcome: rawFlags.outcome,
       branchNameToRollout: rawFlags.branch,
       runtimeVersion: rawFlags['runtime-version'],
+      privateKeyPath: rawFlags['private-key-path'] ?? null,
       action: action ? this.getAction(action) : undefined,
       nonInteractive: rawFlags['non-interactive'],
       json: rawFlags.json,

--- a/packages/eas-cli/src/rollout/actions/ManageRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/ManageRollout.ts
@@ -11,7 +11,11 @@ import {
   EditRollout,
   NonInteractiveOptions as EditRolloutNonInteractiveOptions,
 } from './EditRollout';
-import { EndRollout, NonInteractiveOptions as EndRolloutNonInteractiveOptions } from './EndRollout';
+import {
+  EndRollout,
+  GeneralOptions as EndRolloutGeneralOptions,
+  NonInteractiveOptions as EndRolloutNonInteractiveOptions,
+} from './EndRollout';
 
 export enum ManageRolloutActions {
   EDIT = 'Edit',
@@ -29,7 +33,8 @@ export class ManageRollout implements EASUpdateAction<EASUpdateAction> {
       callingAction?: EASUpdateAction;
       action?: ManageRolloutActions.EDIT | ManageRolloutActions.END;
     } & Partial<EditRolloutNonInteractiveOptions> &
-      Partial<EndRolloutNonInteractiveOptions> = {}
+      Partial<EndRolloutNonInteractiveOptions> &
+      EndRolloutGeneralOptions
   ) {}
 
   public async runAsync(ctx: EASUpdateContext): Promise<EASUpdateAction> {

--- a/packages/eas-cli/src/rollout/actions/NonInteractiveRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/NonInteractiveRollout.ts
@@ -1,6 +1,7 @@
 import { EASUpdateAction, EASUpdateContext } from '../../eas-update/utils';
 import { UpdateChannelBasicInfoFragment } from '../../graphql/generated';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import { CodeSigningInfo } from '../../utils/code-signing';
 import {
   CreateRollout,
   NonInteractiveOptions as CreateRolloutNonInteractiveOptions,
@@ -9,7 +10,11 @@ import {
   EditRollout,
   NonInteractiveOptions as EditRolloutNonInteractiveOptions,
 } from './EditRollout';
-import { EndRollout, NonInteractiveOptions as EndRolloutNonInteractiveOptions } from './EndRollout';
+import {
+  EndRollout,
+  GeneralOptions as EndRolloutGeneralOptions,
+  NonInteractiveOptions as EndRolloutNonInteractiveOptions,
+} from './EndRollout';
 import { ManageRolloutActions } from './ManageRollout';
 import { MainMenuActions, RolloutActions } from './RolloutMainMenu';
 
@@ -20,10 +25,12 @@ export class NonInteractiveRollout implements EASUpdateAction<void> {
   constructor(
     private options: {
       channelName?: string;
+      codeSigningInfo?: CodeSigningInfo;
       action?: RolloutActions;
     } & Partial<EditRolloutNonInteractiveOptions> &
       Partial<EndRolloutNonInteractiveOptions> &
-      Partial<CreateRolloutNonInteractiveOptions> = {}
+      EndRolloutGeneralOptions &
+      Partial<CreateRolloutNonInteractiveOptions>
   ) {}
 
   public async runAsync(ctx: EASUpdateContext): Promise<void> {
@@ -55,6 +62,7 @@ export class NonInteractiveRollout implements EASUpdateAction<void> {
     channelInfo: UpdateChannelBasicInfoFragment,
     options: Partial<EditRolloutNonInteractiveOptions> &
       Partial<EndRolloutNonInteractiveOptions> &
+      EndRolloutGeneralOptions &
       Partial<CreateRolloutNonInteractiveOptions>
   ): Promise<UpdateChannelBasicInfoFragment> {
     switch (action) {

--- a/packages/eas-cli/src/rollout/actions/RolloutMainMenu.ts
+++ b/packages/eas-cli/src/rollout/actions/RolloutMainMenu.ts
@@ -12,7 +12,10 @@ import {
   NonInteractiveOptions as CreateRolloutNonInteractiveOptions,
 } from './CreateRollout';
 import { NonInteractiveOptions as EditRolloutNonInteractiveOptions } from './EditRollout';
-import { NonInteractiveOptions as EndRolloutNonInteractiveOptions } from './EndRollout';
+import {
+  GeneralOptions as EndRolloutGeneralOptions,
+  NonInteractiveOptions as EndRolloutNonInteractiveOptions,
+} from './EndRollout';
 import { ManageRollout, ManageRolloutActions } from './ManageRollout';
 import { SelectRollout } from './SelectRollout';
 
@@ -36,7 +39,8 @@ export class RolloutMainMenu implements EASUpdateAction<void> {
       action?: RolloutActions;
     } & Partial<EditRolloutNonInteractiveOptions> &
       Partial<EndRolloutNonInteractiveOptions> &
-      Partial<CreateRolloutNonInteractiveOptions> = {}
+      EndRolloutGeneralOptions &
+      Partial<CreateRolloutNonInteractiveOptions>
   ) {}
 
   public async runAsync(ctx: EASUpdateContext): Promise<void> {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Code signing info must be provided to republish updates that were previously signed.

# How

Add `private-key-path` arg to command, require it when using signed updates and the user chooses to end by republishing.

# Test Plan

Create app locally, add code signing, set up to build locally, build in xcode with release scheme.

```
$ neas channel:rollout-preview --private-key-path keys/private-key.pem

✨ This command is in Developer Preview and has not been released to production yet

✔ What would you like to do? › Manage an existing rollout

🚀 Rollout:
Channel          main
Runtime Version  1.0.0
Branches         wooooo (100%), main (0%)

✔ What would you like to do? › End
✔ Which Update Group would you like to serve? › 🍽️  Served by branch wooooo (100%)
    Message          "Initial commit

    Generated by create-expo-app 2.0.3." (32 minutes ago by wschurman)
    Runtime Version  1.0.0
    Platforms        android, ios
    Group ID         bd8a520c-7299-4e57-9268-350294064474

🍽️  The Update Group you chose is served by branch wooooo

Ending the rollout will do the following:
1.  🔁 Republish the Update Group from wooooo onto main
2.  ⬅️  Route all users back to main
✔ Continue? … yes
✔ The republished update will be signed
🔒 Signing republished update
✔ Republished update

Branch             main
Runtime version    1.0.0
Platform           android, ios
Update Group ID    f9dd2abc-edf8-49c3-b770-a1fdcd0aacc4
Android update ID  a5712201-ab50-467c-a68d-59a5b2dc125f
iOS update ID      a83fd501-da7f-40d9-a248-bd5ac7867ba5
Message            Republish "Initial commit

Generated by create-expo-app 2.0.3." - group: bd8a520c-7299-4e57-9268-350294064474
Website link       https://expo.dev/accounts/wschurman/projects/watwathuh/updates/f9dd2abc-edf8-49c3-b770-a1fdcd0aacc4

🚗 Routed all traffic back to branch main
✅ Successfully ended rollout
```
