### PR TITLE
[eas-cli] use 'roll out' instead of rollout for verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Add relationships flag to rollouts-preview. ([#1972](https://github.com/expo/eas-cli/pull/1972) by [@quinlanj](https://github.com/quinlanj))
 - Get channel:{view,list,edit} to play nice with rollouts. ([#1974](https://github.com/expo/eas-cli/pull/1974) by [@quinlanj](https://github.com/quinlanj))
+- Use 'roll out' instead of rollout for verbs. ([#1979](https://github.com/expo/eas-cli/pull/1979) by [@quinlanj](https://github.com/quinlanj))
 
 ## [3.18.2](https://github.com/expo/eas-cli/releases/tag/v3.18.2) - 2023-08-03
 

--- a/packages/eas-cli/src/commands/channel/rollout-preview.ts
+++ b/packages/eas-cli/src/commands/channel/rollout-preview.ts
@@ -106,7 +106,7 @@ export default class ChannelRolloutPreview extends EasCommand {
       required: false,
     }),
     branch: Flags.string({
-      description: 'Branch to rollout. Use with --action=create',
+      description: 'Branch to roll out. Use with --action=create',
       required: false,
     }),
     'runtime-version': Flags.string({

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -314,7 +314,7 @@ export default class ChannelRollout extends EasCommand {
 
   static override flags = {
     branch: Flags.string({
-      description: 'branch to rollout',
+      description: 'branch to roll out',
       required: false,
     }),
     percent: Flags.integer({

--- a/packages/eas-cli/src/rollout/actions/CreateRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/CreateRollout.ts
@@ -207,7 +207,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     defaultBranchId: string
   ): Promise<UpdateBranchBasicInfoFragment> {
     const selectBranchAction = new SelectBranch({
-      printedType: 'branch to rollout',
+      printedType: 'branch to roll out',
       // we don't want to show the default branch as an option
       filterPredicate: (branchInfo: UpdateBranchBasicInfoFragment) =>
         branchInfo.id !== defaultBranchId,

--- a/packages/eas-cli/src/rollout/actions/RolloutMainMenu.ts
+++ b/packages/eas-cli/src/rollout/actions/RolloutMainMenu.ts
@@ -95,7 +95,7 @@ export class RolloutMainMenu implements EASUpdateAction<void> {
     const selectChannelAction = new SelectChannel({ filterPredicate });
     const channelInfo = await selectChannelAction.runAsync(ctx);
     if (!channelInfo) {
-      throw new Error(`You dont have any channels. Create one with <TODO>`);
+      throw new Error(`You dont have any channels. Create one with \`eas channel:create\``);
     }
     return channelInfo;
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

grammar feedback

# Test Plan

- [ ] tests still pass