### PR TITLE
[ENG-9603][eas-cli] rollout edit edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Handle rollout edit edge case. ([#1981](https://github.com/expo/eas-cli/pull/1981) by [@quinlanj](https://github.com/quinlanj))
+
 ## [3.18.3](https://github.com/expo/eas-cli/releases/tag/v3.18.3) - 2023-08-03
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/rollout/actions/EditRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/EditRollout.ts
@@ -16,7 +16,6 @@ import {
   isRollout,
 } from '../branch-mapping';
 import { promptForRolloutPercentAsync } from '../utils';
-import { EndOutcome, EndRollout } from './EndRollout';
 
 export type NonInteractiveOptions = {
   percent: number;

--- a/packages/eas-cli/src/rollout/actions/EditRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/EditRollout.ts
@@ -55,13 +55,9 @@ export class EditRollout implements EASUpdateAction<UpdateChannelBasicInfoFragme
     const promptMessage = `What percent of users should be sent to the ${rolledOutBranch.name} branch ?`;
     const percent = this.options.percent ?? (await promptForRolloutPercentAsync({ promptMessage }));
 
-    if (percent === 0) {
+    if (percent === 0 || percent === 100) {
       Log.warn(
-        `Editing the percent to 0 will not end the rollout. You'll need to end the rollout from the main menu.`
-      );
-    } else if (percent === 100) {
-      Log.warn(
-        `Editing the percent to 100 will not end the rollout. You'll need to end the rollout from the main menu.`
+        `Editing the percent to ${percent} will not end the rollout. You'll need to end the rollout from the main menu.`
       );
     }
 

--- a/packages/eas-cli/src/rollout/actions/EditRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/EditRollout.ts
@@ -56,12 +56,9 @@ export class EditRollout implements EASUpdateAction<UpdateChannelBasicInfoFragme
     const percent = this.options.percent ?? (await promptForRolloutPercentAsync({ promptMessage }));
 
     if (percent === 0) {
-      Log.log(`📝 Editing the percent to 0 will end the rollout.`);
-      const endAction = await new EndRollout(this.channelInfo, {
-        outcome: EndOutcome.ROUTE_BACK,
-        privateKeyPath: null,
-      });
-      return await endAction.runAsync(ctx);
+      Log.warn(
+        `Editing the percent to 0 will not end the rollout. You'll need to end the rollout from the main menu.`
+      );
     } else if (percent === 100) {
       Log.warn(
         `Editing the percent to 100 will not end the rollout. You'll need to end the rollout from the main menu.`


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

warn the user if they edit their rollout to 0 or 100 that it wont end the rollout. They'll need to end the rollout from the main menu


# Test Plan

- [ ] tests still pass
