### PR TITLE
[ENG-9614][eas-cli] rollout ux improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Fixing more grammar errors. ([#1980](https://github.com/expo/eas-cli/pull/1980) by [@quinlanj](https://github.com/quinlanj))
 - Handle rollout edit edge case. ([#1981](https://github.com/expo/eas-cli/pull/1981) by [@quinlanj](https://github.com/quinlanj))
+- Rollout ux improvements. ([#1984](https://github.com/expo/eas-cli/pull/1984) by [@quinlanj](https://github.com/quinlanj))
 
 ## [3.18.3](https://github.com/expo/eas-cli/releases/tag/v3.18.3) - 2023-08-03
 

--- a/packages/eas-cli/src/branch/actions/__tests__/SelectBranch-test.ts
+++ b/packages/eas-cli/src/branch/actions/__tests__/SelectBranch-test.ts
@@ -25,7 +25,7 @@ describe(SelectBranch, () => {
     const branch = await selectBranch.runAsync(ctx);
     expect(branch).toBeNull();
   });
-  it('returns the branch without prompting if project only one branch', async () => {
+  it('still prompts if project has only one branch', async () => {
     const ctx = createCtxMock();
     jest.mocked(BranchQuery.listBranchesBasicInfoPaginatedOnAppAsync).mockResolvedValue({
       edges: [{ node: testBasicBranchInfo, cursor: 'cursor' }],
@@ -34,9 +34,13 @@ describe(SelectBranch, () => {
         hasNextPage: false,
       },
     });
+    jest.mocked(promptAsync).mockImplementation(async () => ({
+      item: testBasicBranchInfo,
+    }));
     const selectBranch = new SelectBranch();
     const branch = await selectBranch.runAsync(ctx);
     expect(branch).toBe(testBasicBranchInfo);
+    expect(promptAsync).toHaveBeenCalledTimes(1);
   });
   it('returns the selected branch', async () => {
     jest.mocked(BranchQuery.listBranchesBasicInfoPaginatedOnAppAsync).mockResolvedValue({

--- a/packages/eas-cli/src/channel/actions/__tests__/SelectChannel-test.ts
+++ b/packages/eas-cli/src/channel/actions/__tests__/SelectChannel-test.ts
@@ -25,7 +25,7 @@ describe(SelectChannel, () => {
     const channel = await selectChannel.runAsync(ctx);
     expect(channel).toBeNull();
   });
-  it('returns the channel without prompting if project only one channel', async () => {
+  it('still prompts if project has only one channel', async () => {
     const ctx = createCtxMock();
     jest.mocked(ChannelQuery.viewUpdateChannelsBasicInfoPaginatedOnAppAsync).mockResolvedValue({
       edges: [{ node: testBasicChannelInfo, cursor: 'cursor' }],
@@ -34,9 +34,13 @@ describe(SelectChannel, () => {
         hasNextPage: false,
       },
     });
+    jest.mocked(promptAsync).mockImplementation(async () => ({
+      item: testBasicChannelInfo,
+    }));
     const selectChannel = new SelectChannel();
     const channel = await selectChannel.runAsync(ctx);
     expect(channel).toBe(testBasicChannelInfo);
+    expect(promptAsync).toHaveBeenCalledTimes(1);
   });
   it('returns the selected channel', async () => {
     jest.mocked(ChannelQuery.viewUpdateChannelsBasicInfoPaginatedOnAppAsync).mockResolvedValue({

--- a/packages/eas-cli/src/rollout/actions/EndRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/EndRollout.ts
@@ -67,7 +67,7 @@ export class EndRollout implements EASUpdateAction<UpdateChannelBasicInfoFragmen
     const rolledOutUpdateGroup = rolledOutBranch.updateGroups[0];
     let outcome: EndOutcome;
     if (!rolledOutUpdateGroup) {
-      Log.log(`⚠️  There is no update group being served on ${rolledOutBranch.name}.`);
+      Log.log(`⚠️  There is no update group being served on the ${rolledOutBranch.name} branch.`);
       assert(
         this.options.outcome !== EndOutcome.REPUBLISH_AND_REVERT,
         `The only valid outcome for this rollout is to revert users back to the ${rollout.defaultBranch.name} branch. `

--- a/packages/eas-cli/src/rollout/actions/__tests__/SelectRollout-test.ts
+++ b/packages/eas-cli/src/rollout/actions/__tests__/SelectRollout-test.ts
@@ -25,7 +25,7 @@ describe(SelectRollout, () => {
     const rollout = await selectRollout.runAsync(ctx);
     expect(rollout).toBeNull();
   });
-  it('returns the rollout without prompting if project only one rollout', async () => {
+  it('still prompts if project has only one rollout', async () => {
     const ctx = createCtxMock();
     jest.mocked(ChannelQuery.viewUpdateChannelsBasicInfoPaginatedOnAppAsync).mockResolvedValue({
       edges: [{ node: testBasicChannelInfo, cursor: 'cursor' }],
@@ -34,9 +34,13 @@ describe(SelectRollout, () => {
         hasNextPage: false,
       },
     });
+    jest.mocked(promptAsync).mockImplementation(async () => ({
+      item: testBasicChannelInfo,
+    }));
     const selectRollout = new SelectRollout();
     const rollout = await selectRollout.runAsync(ctx);
     expect(rollout).toBe(testBasicChannelInfo);
+    expect(promptAsync).toHaveBeenCalledTimes(1);
   });
   it('returns the selected rollout', async () => {
     jest.mocked(ChannelQuery.viewUpdateChannelsBasicInfoPaginatedOnAppAsync).mockResolvedValue({

--- a/packages/eas-cli/src/utils/__tests__/relay-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/relay-test.ts
@@ -627,11 +627,15 @@ describe(selectPaginatedAsync, () => {
     expect(queryAsync).toHaveBeenCalledWith({ first: pageSize });
   });
 
-  test('returns the only item when there is only one', async () => {
+  test('still prompts if there is only one item avaiable', async () => {
     const node = { id: '1', name: 'Node 1' };
     queryAsync.mockResolvedValueOnce({
       edges: [{ node }],
+      pageInfo: { hasNextPage: false },
     });
+    jest.mocked(promptAsync).mockImplementation(async () => ({
+      item: node,
+    }));
 
     const result = await selectPaginatedAsync({
       queryAsync,
@@ -644,6 +648,7 @@ describe(selectPaginatedAsync, () => {
     expect(queryAsync).toHaveBeenCalledWith({
       first: pageSize,
     });
+    expect(promptAsync).toBeCalledTimes(1);
   });
 
   test('prompts for selection when there are multiple items', async () => {
@@ -676,15 +681,6 @@ describe(selectPaginatedAsync, () => {
     const node1 = { id: '1', name: 'Node 1' };
     const node2 = { id: '2', name: 'Node 2' };
     const node3 = { id: '3', name: 'Node 3' };
-
-    // for preflight
-    queryAsync.mockResolvedValueOnce({
-      edges: [{ node: node1 }, { node: node2 }],
-      pageInfo: {
-        endCursor: 'endCursor',
-        hasNextPage: true,
-      },
-    });
 
     queryAsync.mockResolvedValueOnce({
       edges: [{ node: node1 }, { node: node2 }],
@@ -738,15 +734,6 @@ describe(selectPaginatedAsync, () => {
     const node1 = { id: '1', name: 'Node 1' };
     const node2 = { id: '2', name: 'Node 2' };
     const node3 = { id: '3', name: 'Node 3' };
-
-    // for preflight
-    queryAsync.mockResolvedValueOnce({
-      edges: [{ node: node1 }, { node: node2 }],
-      pageInfo: {
-        endCursor: 'endCursor',
-        hasNextPage: true,
-      },
-    });
 
     queryAsync.mockResolvedValueOnce({
       edges: [{ node: node1 }, { node: node2 }],

--- a/packages/eas-cli/src/utils/relay.ts
+++ b/packages/eas-cli/src/utils/relay.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 
 import { PageInfo } from '../graphql/generated';
-import Log from '../log';
 import { promptAsync } from '../prompts';
 
 export type Connection<T> = {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

UX improvements from dogfooding feedback:
- Better runtime selection: remove the option to manually input a runtime in the case where there is no shared runtime on the two rollout branches. Instead, let the user choose a runtime from an existing branch or use the runtime specified in their project config.
- Remove automatic selection if only 1 is available: Automatic selection in this case is the most 'efficient' but causes confusion without human prompting. For example, when determining a channel or branch for a rollout, the selectors used to return the only eligible item without prompting, but this ended up causing confusion. This PR changes the selectors to always require human interaction to select an option (even if there is only 1 available). 
- Print better logs if no eligible item: In cases where there isn't a branch available for a rollout, instead of saying the user has no branches, say tell the user they need to make another branch.


# Test Plan

- [ ] manually tested
