### PR TITLE
[eas-ci] rollouts: fix fp precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix rollout-preview ending with republish with code signing. ([#1978](https://github.com/expo/eas-cli/pull/1978) by [@wschurman](https://github.com/wschurman))
+- Rollouts: fix fp precision. ([#1985](https://github.com/expo/eas-cli/pull/1985) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/rollout/branch-mapping.ts
+++ b/packages/eas-cli/src/rollout/branch-mapping.ts
@@ -126,7 +126,7 @@ export function getRolloutInfoFromBranchMapping(branchMapping: RolloutBranchMapp
     assertNumber(operand);
     return {
       rolledOutBranchId,
-      percentRolledOut: operand * 100,
+      percentRolledOut: Math.round(operand * 100),
       runtimeVersion,
       defaultBranchId,
     };
@@ -137,7 +137,7 @@ export function getRolloutInfoFromBranchMapping(branchMapping: RolloutBranchMapp
     assertNumber(operand);
     return {
       rolledOutBranchId,
-      percentRolledOut: operand * 100,
+      percentRolledOut: Math.round(operand * 100),
       defaultBranchId,
     };
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

If someone has a rollout of 7%, we store it as 0.07. However, in javascript, when you perform 0.07 * 100 it yields 7.000000000000001 due to floating point precision issues. This is problematic when we display the rollout to users. To fix this, when converting a decimal to a whole number, we can run `Math.round` to round it to the nearest integer

# Test Plan

- [ ] manually tested
