### PR TITLE
[eas-cli] pass iOS credentials to custom builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Pass credentials to custom iOS builds. ([#1989](https://github.com/expo/eas-cli/pull/1989) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 - Fix `eas channel:*` to work with empty branch mappings. ([#1992](https://github.com/expo/eas-cli/pull/1992) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -55,6 +55,5 @@ export async function ensureIosCredentialsForBuildResignAsync(
 }
 
 function shouldProvideCredentials(buildCtx: BuildContext<Platform.IOS>): boolean {
-  const isCustomBuild = buildCtx.buildProfile.config !== undefined;
-  return !buildCtx.buildProfile.simulator && !isCustomBuild;
+  return !buildCtx.buildProfile.simulator;
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Pass iOS credentials to custom builds

# How

Pass iOS credentials to custom builds

# Test Plan

Tested manually
