### PR TITLE
[eas-cli] account for empty branch mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix `eas channel:*` to work with empty branch mappings. ([#1992](https://github.com/expo/eas-cli/pull/1992) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🧹 Chores
 
 ## [4.0.0](https://github.com/expo/eas-cli/releases/tag/v4.0.0) - 2023-08-07

--- a/packages/eas-cli/src/channel/__tests__/branch-mapping-test.ts
+++ b/packages/eas-cli/src/channel/__tests__/branch-mapping-test.ts
@@ -1,4 +1,8 @@
-import { rolloutBranchMapping, standardBranchMapping } from '../../rollout/__tests__/fixtures';
+import {
+  emptyBranchMapping,
+  rolloutBranchMapping,
+  standardBranchMapping,
+} from '../../rollout/__tests__/fixtures';
 import {
   BranchMappingValidationError,
   assertVersion,
@@ -6,6 +10,7 @@ import {
   getBranchMapping,
   getStandardBranchId,
   isAlwaysTrueBranchMapping,
+  isEmptyBranchMapping,
 } from '../branch-mapping';
 import { testChannelObject } from './fixtures';
 
@@ -19,10 +24,19 @@ describe(assertVersion, () => {
   });
 });
 
+describe(isEmptyBranchMapping, () => {
+  it('detects empty branch mappings', () => {
+    expect(isEmptyBranchMapping(emptyBranchMapping)).toBe(true);
+    expect(isEmptyBranchMapping(standardBranchMapping)).toBe(false);
+    expect(isEmptyBranchMapping(rolloutBranchMapping)).toBe(false);
+  });
+});
+
 describe(isAlwaysTrueBranchMapping, () => {
   it('detects always true branch mappings', () => {
     expect(isAlwaysTrueBranchMapping(standardBranchMapping)).toBe(true);
     expect(isAlwaysTrueBranchMapping(rolloutBranchMapping)).toBe(false);
+    expect(isAlwaysTrueBranchMapping(emptyBranchMapping)).toBe(false);
   });
 });
 

--- a/packages/eas-cli/src/channel/branch-mapping.ts
+++ b/packages/eas-cli/src/channel/branch-mapping.ts
@@ -45,6 +45,11 @@ export type AlwaysTrueBranchMapping = {
   ];
 };
 
+export type EmptyBranchMapping = {
+  version: number;
+  data: [];
+};
+
 export function getAlwaysTrueBranchMapping(branchId: string): AlwaysTrueBranchMapping {
   return {
     version: 0,
@@ -57,6 +62,11 @@ export function getAlwaysTrueBranchMapping(branchId: string): AlwaysTrueBranchMa
   };
 }
 
+export function hasEmptyBranchMap(channelInfo: UpdateChannelBasicInfoFragment): boolean {
+  const branchMapping = getBranchMapping(channelInfo.branchMapping);
+  return isEmptyBranchMapping(branchMapping);
+}
+
 export function hasStandardBranchMap(channelInfo: UpdateChannelBasicInfoFragment): boolean {
   const branchMapping = getBranchMapping(channelInfo.branchMapping);
   return isAlwaysTrueBranchMapping(branchMapping);
@@ -66,6 +76,12 @@ export function getStandardBranchId(channelInfo: UpdateChannelBasicInfoFragment)
   const branchMapping = getBranchMapping(channelInfo.branchMapping);
   assertAlwaysTrueBranchMapping(branchMapping);
   return getBranchIdFromStandardMapping(branchMapping);
+}
+
+export function isEmptyBranchMapping(
+  branchMapping: BranchMapping
+): branchMapping is EmptyBranchMapping {
+  return branchMapping.data.length === 0;
 }
 
 export function isAlwaysTrueBranchMapping(

--- a/packages/eas-cli/src/channel/print-utils.ts
+++ b/packages/eas-cli/src/channel/print-utils.ts
@@ -9,12 +9,12 @@ import {
   formatBranch,
   getUpdateGroupDescriptionsWithBranch,
 } from '../update/utils';
-import { assertVersion, hasStandardBranchMap } from './branch-mapping';
+import { assertVersion, hasEmptyBranchMap, hasStandardBranchMap } from './branch-mapping';
 
 export function logChannelDetails(channel: UpdateChannelObject): void {
   assertVersion(channel, 0);
   assert(
-    hasStandardBranchMap(channel) || isRollout(channel),
+    hasEmptyBranchMap(channel) || hasStandardBranchMap(channel) || isRollout(channel),
     'Only standard branch mappings and rollouts are supported.'
   );
 

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -4,7 +4,7 @@ import { print } from 'graphql';
 import gql from 'graphql-tag';
 
 import { selectBranchOnAppAsync } from '../../branch/queries';
-import { hasStandardBranchMap } from '../../channel/branch-mapping';
+import { hasEmptyBranchMap, hasStandardBranchMap } from '../../channel/branch-mapping';
 import { selectChannelOnAppAsync } from '../../channel/queries';
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
@@ -102,7 +102,7 @@ export default class ChannelEdit extends EasCommand {
 
     if (isRollout(existingChannel)) {
       throw new Error('There is a rollout in progress. Manage it with "channel:rollout" instead.');
-    } else if (!hasStandardBranchMap(existingChannel)) {
+    } else if (!hasStandardBranchMap(existingChannel) && !hasEmptyBranchMap(existingChannel)) {
       throw new Error('Only standard branch mappings can be edited with this command.');
     }
 

--- a/packages/eas-cli/src/rollout/__tests__/fixtures.ts
+++ b/packages/eas-cli/src/rollout/__tests__/fixtures.ts
@@ -68,3 +68,8 @@ export const standardBranchMapping: BranchMapping = {
   version: 0,
   data: [{ branchId: uuidv4(), branchMappingLogic: alwaysTrue() }],
 };
+
+export const emptyBranchMapping: BranchMapping = {
+  version: 0,
+  data: [],
+};

--- a/packages/eas-cli/src/rollout/actions/CreateRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/CreateRollout.ts
@@ -2,7 +2,11 @@ import { Updates } from '@expo/config-plugins';
 import assert from 'assert';
 
 import { SelectBranch } from '../../branch/actions/SelectBranch';
-import { getStandardBranchId, hasStandardBranchMap } from '../../channel/branch-mapping';
+import {
+  getStandardBranchId,
+  hasEmptyBranchMap,
+  hasStandardBranchMap,
+} from '../../channel/branch-mapping';
 import { getUpdateBranch } from '../../channel/utils';
 import { updateChannelBranchMappingAsync } from '../../commands/channel/edit';
 import { EASUpdateAction, EASUpdateContext } from '../../eas-update/utils';
@@ -70,6 +74,11 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     }
     if (isRollout(this.channelInfo)) {
       throw new Error(`A rollout is already in progress for channel ${this.channelInfo.name}`);
+    }
+    if (hasEmptyBranchMap(this.channelInfo)) {
+      throw new Error(
+        `Your channel needs to be linked to a branch before a rollout can be created. Do this by running 'eas channel:edit'`
+      );
     }
     if (!hasStandardBranchMap(this.channelInfo)) {
       throw new Error(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Account for empty branch mappings in `eas channel:*` workflows. Users should be able to view and edit channels linked to no branches. 

# Test Plan

- [ ] new tests pass
