### PR TITLE
[eas-cli] make branch mapping utility files have no dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Make branch mapping utility files have no dependencies. ([#1993](https://github.com/expo/eas-cli/pull/1993) by [@quinlanj](https://github.com/quinlanj))
+
 ## [4.0.0](https://github.com/expo/eas-cli/releases/tag/v4.0.0) - 2023-08-07
 
 ### 🛠 Breaking changes

--- a/packages/eas-cli/src/channel/__tests__/branch-mapping-fixtures.ts
+++ b/packages/eas-cli/src/channel/__tests__/branch-mapping-fixtures.ts
@@ -1,0 +1,22 @@
+import { BranchBasicInfo, ChannelBasicInfo, UpdateChannelInfoWithBranches } from '../utils';
+
+export const testChannelBasicInfo: ChannelBasicInfo = {
+  id: '9309afc2-9752-40db-8ef7-4abc10744c61',
+  name: 'production',
+  branchMapping:
+    '{"data":[{"branchId":"754bf17f-efc0-46ab-8a59-a03f20e53e9b","branchMappingLogic":{"operand":0.15,"clientKey":"rolloutToken","branchMappingOperator":"hash_lt"}},{"branchId":"6941a8dd-5c0a-48bc-8876-f49c88ed419f","branchMappingLogic":"true"}],"version":0}',
+};
+
+export const testBasicBranchInfo1: BranchBasicInfo = {
+  id: '754bf17f-efc0-46ab-8a59-a03f20e53e9b',
+  name: 'wrong-channel',
+};
+
+export const testBasicBranchInfo2: BranchBasicInfo = {
+  id: '6941a8dd-5c0a-48bc-8876-f49c88ed419f',
+  name: 'production',
+};
+export const channelInfoWithBranches: UpdateChannelInfoWithBranches<BranchBasicInfo> = {
+  ...testChannelBasicInfo,
+  updateBranches: [testBasicBranchInfo1, testBasicBranchInfo2],
+};

--- a/packages/eas-cli/src/channel/__tests__/branch-mapping-test.ts
+++ b/packages/eas-cli/src/channel/__tests__/branch-mapping-test.ts
@@ -12,15 +12,15 @@ import {
   isAlwaysTrueBranchMapping,
   isEmptyBranchMapping,
 } from '../branch-mapping';
-import { testChannelObject } from './fixtures';
+import { testChannelBasicInfo } from './branch-mapping-fixtures';
 
 describe(assertVersion, () => {
   it('throws if the branch mapping is not the correct version', () => {
-    expect(() => assertVersion(testChannelObject, 5)).toThrowError(BranchMappingValidationError);
+    expect(() => assertVersion(testChannelBasicInfo, 5)).toThrowError(BranchMappingValidationError);
   });
   it('asserts the correct version', () => {
-    assertVersion(testChannelObject, 0);
-    expect(getBranchMapping(testChannelObject.branchMapping).version).toBe(0);
+    assertVersion(testChannelBasicInfo, 0);
+    expect(getBranchMapping(testChannelBasicInfo.branchMapping).version).toBe(0);
   });
 });
 
@@ -49,10 +49,12 @@ describe(getAlwaysTrueBranchMapping, () => {
 
 describe(getStandardBranchId, () => {
   it('throws if the branch mapping is not a standard mapping', () => {
-    expect(() => getStandardBranchId(testChannelObject)).toThrowError(BranchMappingValidationError);
+    expect(() => getStandardBranchId(testChannelBasicInfo)).toThrowError(
+      BranchMappingValidationError
+    );
   });
   it('gets a standard branch id', () => {
-    const channelObjectWithStandardMapping = { ...testChannelObject };
+    const channelObjectWithStandardMapping = { ...testChannelBasicInfo };
     channelObjectWithStandardMapping.branchMapping = JSON.stringify(standardBranchMapping);
     expect(getStandardBranchId(channelObjectWithStandardMapping)).toBe(
       standardBranchMapping.data[0].branchId

--- a/packages/eas-cli/src/channel/__tests__/utils-test.ts
+++ b/packages/eas-cli/src/channel/__tests__/utils-test.ts
@@ -1,11 +1,11 @@
 import { getUpdateBranch } from '../utils';
-import { testChannelObject, testUpdateBranch1 } from './fixtures';
+import { channelInfoWithBranches, testBasicBranchInfo1 } from './branch-mapping-fixtures';
 
 describe(getUpdateBranch, () => {
   it('gets the update branch', () => {
-    expect(getUpdateBranch(testChannelObject, '754bf17f-efc0-46ab-8a59-a03f20e53e9b')).toBe(
-      testUpdateBranch1
+    expect(getUpdateBranch(channelInfoWithBranches, '754bf17f-efc0-46ab-8a59-a03f20e53e9b')).toBe(
+      testBasicBranchInfo1
     );
-    expect(() => getUpdateBranch(testChannelObject, 'not-a-branch-ID')).toThrow();
+    expect(() => getUpdateBranch(channelInfoWithBranches, 'not-a-branch-ID')).toThrow();
   });
 });

--- a/packages/eas-cli/src/channel/branch-mapping.ts
+++ b/packages/eas-cli/src/channel/branch-mapping.ts
@@ -1,4 +1,4 @@
-import { UpdateChannelBasicInfoFragment } from '../graphql/generated';
+import { ChannelBasicInfo } from './utils';
 
 // TODO(quin): move this into a common package with www
 export type BranchMappingOperator =
@@ -62,17 +62,17 @@ export function getAlwaysTrueBranchMapping(branchId: string): AlwaysTrueBranchMa
   };
 }
 
-export function hasEmptyBranchMap(channelInfo: UpdateChannelBasicInfoFragment): boolean {
+export function hasEmptyBranchMap(channelInfo: ChannelBasicInfo): boolean {
   const branchMapping = getBranchMapping(channelInfo.branchMapping);
   return isEmptyBranchMapping(branchMapping);
 }
 
-export function hasStandardBranchMap(channelInfo: UpdateChannelBasicInfoFragment): boolean {
+export function hasStandardBranchMap(channelInfo: ChannelBasicInfo): boolean {
   const branchMapping = getBranchMapping(channelInfo.branchMapping);
   return isAlwaysTrueBranchMapping(branchMapping);
 }
 
-export function getStandardBranchId(channelInfo: UpdateChannelBasicInfoFragment): string {
+export function getStandardBranchId(channelInfo: ChannelBasicInfo): string {
   const branchMapping = getBranchMapping(channelInfo.branchMapping);
   assertAlwaysTrueBranchMapping(branchMapping);
   return getBranchIdFromStandardMapping(branchMapping);
@@ -153,7 +153,7 @@ function isVersion(branchMapping: BranchMapping, version: number): boolean {
   return branchMapping.version === version;
 }
 
-export function assertVersion(channelInfo: UpdateChannelBasicInfoFragment, version: number): void {
+export function assertVersion(channelInfo: ChannelBasicInfo, version: number): void {
   const branchMapping = getBranchMapping(channelInfo.branchMapping);
   if (!isVersion(branchMapping, version)) {
     throw new BranchMappingValidationError(

--- a/packages/eas-cli/src/channel/utils.ts
+++ b/packages/eas-cli/src/channel/utils.ts
@@ -1,18 +1,26 @@
-import { UpdateBranchObject, UpdateChannelObject } from '../graphql/queries/ChannelQuery';
+import {
+  UpdateBranchBasicInfoFragment,
+  UpdateChannelBasicInfoFragment,
+} from '../graphql/generated';
 
-function getUpdateBranchNullable(
-  channel: UpdateChannelObject,
+export type UpdateChannelInfoWithBranches<Branch extends UpdateBranchBasicInfoFragment> =
+  UpdateChannelBasicInfoFragment & {
+    updateBranches: Branch[];
+  };
+
+function getUpdateBranchNullable<Branch extends UpdateBranchBasicInfoFragment>(
+  channel: UpdateChannelInfoWithBranches<Branch>,
   branchId: string
-): UpdateBranchObject | null {
+): Branch | null {
   const updateBranches = channel.updateBranches;
   const updateBranch = updateBranches.find(branch => branch.id === branchId);
   return updateBranch ?? null;
 }
 
-export function getUpdateBranch(
-  channel: UpdateChannelObject,
+export function getUpdateBranch<Branch extends UpdateBranchBasicInfoFragment>(
+  channel: UpdateChannelInfoWithBranches<Branch>,
   branchId: string
-): UpdateBranchObject {
+): Branch {
   const updateBranch = getUpdateBranchNullable(channel, branchId);
   if (!updateBranch) {
     throw new Error(

--- a/packages/eas-cli/src/channel/utils.ts
+++ b/packages/eas-cli/src/channel/utils.ts
@@ -1,14 +1,18 @@
-import {
-  UpdateBranchBasicInfoFragment,
-  UpdateChannelBasicInfoFragment,
-} from '../graphql/generated';
+export type ChannelBasicInfo = {
+  id: string;
+  name: string;
+  branchMapping: string;
+};
+export type BranchBasicInfo = {
+  id: string;
+  name: string;
+};
 
-export type UpdateChannelInfoWithBranches<Branch extends UpdateBranchBasicInfoFragment> =
-  UpdateChannelBasicInfoFragment & {
-    updateBranches: Branch[];
-  };
+export type UpdateChannelInfoWithBranches<Branch extends BranchBasicInfo> = ChannelBasicInfo & {
+  updateBranches: Branch[];
+};
 
-function getUpdateBranchNullable<Branch extends UpdateBranchBasicInfoFragment>(
+function getUpdateBranchNullable<Branch extends BranchBasicInfo>(
   channel: UpdateChannelInfoWithBranches<Branch>,
   branchId: string
 ): Branch | null {
@@ -17,7 +21,7 @@ function getUpdateBranchNullable<Branch extends UpdateBranchBasicInfoFragment>(
   return updateBranch ?? null;
 }
 
-export function getUpdateBranch<Branch extends UpdateBranchBasicInfoFragment>(
+export function getUpdateBranch<Branch extends BranchBasicInfo>(
   channel: UpdateChannelInfoWithBranches<Branch>,
   branchId: string
 ): Branch {

--- a/packages/eas-cli/src/rollout/__tests__/branch-mapping-test.ts
+++ b/packages/eas-cli/src/rollout/__tests__/branch-mapping-test.ts
@@ -1,10 +1,11 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import {
-  testChannelObject,
-  testUpdateBranch1,
-  testUpdateBranch2,
-} from '../../channel/__tests__/fixtures';
+  channelInfoWithBranches,
+  testBasicBranchInfo1,
+  testBasicBranchInfo2,
+  testChannelBasicInfo,
+} from '../../channel/__tests__/branch-mapping-fixtures';
 import {
   BranchMappingOperator,
   BranchMappingValidationError,
@@ -34,16 +35,16 @@ import {
 
 describe(composeRollout, () => {
   it('composes a rollout', () => {
-    const rollout = getRollout(testChannelObject);
-    const rolloutInfo = getRolloutInfo(testChannelObject);
-    const composedRollout = composeRollout(rolloutInfo, testUpdateBranch2, testUpdateBranch1);
+    const rollout = getRollout(channelInfoWithBranches);
+    const rolloutInfo = getRolloutInfo(testChannelBasicInfo);
+    const composedRollout = composeRollout(rolloutInfo, testBasicBranchInfo2, testBasicBranchInfo1);
     expect(composedRollout).toEqual(rollout);
   });
   it('throws if the branches to not match the rollout info', () => {
-    const rolloutInfo = getRolloutInfo(testChannelObject);
-    expect(() => composeRollout(rolloutInfo, testUpdateBranch1, testUpdateBranch2)).toThrowError(
-      BranchMappingValidationError
-    );
+    const rolloutInfo = getRolloutInfo(testChannelBasicInfo);
+    expect(() =>
+      composeRollout(rolloutInfo, testBasicBranchInfo1, testBasicBranchInfo2)
+    ).toThrowError(BranchMappingValidationError);
   });
 });
 
@@ -119,33 +120,33 @@ describe(isConstrainedRollout, () => {
 
 describe(getRollout, () => {
   it('doesnt get the mapping if it isnt a rollout', () => {
-    const notRollout = { ...testChannelObject };
+    const notRollout = { ...channelInfoWithBranches };
     notRollout.branchMapping = JSON.stringify(standardBranchMapping);
     expect(() => getRollout(notRollout)).toThrowError();
   });
   it('gets a constrained rollout', () => {
-    const constrainedRollout = { ...testChannelObject };
+    const constrainedRollout = { ...channelInfoWithBranches };
     const rolloutBranchMappingWithCorrectBranch = { ...rolloutBranchMapping };
-    rolloutBranchMappingWithCorrectBranch.data[0].branchId = testUpdateBranch1.id;
-    rolloutBranchMappingWithCorrectBranch.data[1].branchId = testUpdateBranch2.id;
+    rolloutBranchMappingWithCorrectBranch.data[0].branchId = testBasicBranchInfo1.id;
+    rolloutBranchMappingWithCorrectBranch.data[1].branchId = testBasicBranchInfo2.id;
     constrainedRollout.branchMapping = JSON.stringify(rolloutBranchMapping);
 
     const rollout = getRollout(constrainedRollout);
     expect(rollout.percentRolledOut).toEqual(10);
     expect(isConstrainedRolloutInfo(rollout)).toBe(true);
-    expect(rollout.defaultBranch).toEqual(testUpdateBranch2);
-    expect(rollout.rolledOutBranch).toEqual(testUpdateBranch1);
-    expect(rollout.defaultBranchId).toEqual(testUpdateBranch2.id);
-    expect(rollout.rolledOutBranchId).toEqual(testUpdateBranch1.id);
+    expect(rollout.defaultBranch).toEqual(testBasicBranchInfo2);
+    expect(rollout.rolledOutBranch).toEqual(testBasicBranchInfo1);
+    expect(rollout.defaultBranchId).toEqual(testBasicBranchInfo2.id);
+    expect(rollout.rolledOutBranchId).toEqual(testBasicBranchInfo1.id);
   });
   it('gets a legacy rollout', () => {
-    const rollout = getRollout(testChannelObject);
+    const rollout = getRollout(channelInfoWithBranches);
     expect(rollout.percentRolledOut).toEqual(15);
     expect(isLegacyRolloutInfo(rollout)).toBe(true);
-    expect(rollout.defaultBranch).toEqual(testUpdateBranch2);
-    expect(rollout.rolledOutBranch).toEqual(testUpdateBranch1);
-    expect(rollout.defaultBranchId).toEqual(testUpdateBranch2.id);
-    expect(rollout.rolledOutBranchId).toEqual(testUpdateBranch1.id);
+    expect(rollout.defaultBranch).toEqual(testBasicBranchInfo2);
+    expect(rollout.rolledOutBranch).toEqual(testBasicBranchInfo1);
+    expect(rollout.defaultBranchId).toEqual(testBasicBranchInfo2.id);
+    expect(rollout.rolledOutBranchId).toEqual(testBasicBranchInfo1.id);
   });
 });
 

--- a/packages/eas-cli/src/rollout/actions/EndRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/EndRollout.ts
@@ -5,7 +5,11 @@ import { getAlwaysTrueBranchMapping } from '../../channel/branch-mapping';
 import { updateChannelBranchMappingAsync } from '../../commands/channel/edit';
 import { EASUpdateAction, EASUpdateContext } from '../../eas-update/utils';
 import { UpdateChannelBasicInfoFragment } from '../../graphql/generated';
-import { ChannelQuery, UpdateChannelObject } from '../../graphql/queries/ChannelQuery';
+import {
+  ChannelQuery,
+  UpdateBranchObject,
+  UpdateChannelObject,
+} from '../../graphql/queries/ChannelQuery';
 import Log from '../../log';
 import { confirmAsync, promptAsync } from '../../prompts';
 import { republishAsync } from '../../update/republish';
@@ -103,7 +107,7 @@ export class EndRollout implements EASUpdateAction<UpdateChannelBasicInfoFragmen
     });
   }
 
-  async selectOutcomeAsync(rollout: Rollout): Promise<EndOutcome> {
+  async selectOutcomeAsync(rollout: Rollout<UpdateBranchObject>): Promise<EndOutcome> {
     const { rolledOutBranch, percentRolledOut, defaultBranch } = rollout;
     const rolledOutUpdateGroup = rolledOutBranch.updateGroups[0];
     const defaultUpdateGroup = defaultBranch.updateGroups[0];
@@ -142,7 +146,7 @@ export class EndRollout implements EASUpdateAction<UpdateChannelBasicInfoFragmen
 
   async performOutcomeAsync(
     ctx: EASUpdateContext,
-    rollout: Rollout,
+    rollout: Rollout<UpdateBranchObject>,
     outcome: EndOutcome
   ): Promise<UpdateChannelBasicInfoFragment> {
     const { graphqlClient, app } = ctx;
@@ -184,7 +188,7 @@ export class EndRollout implements EASUpdateAction<UpdateChannelBasicInfoFragmen
   async confirmOutcomeAsync(
     ctx: EASUpdateContext,
     selectedOutcome: EndOutcome,
-    rollout: Rollout
+    rollout: Rollout<UpdateBranchObject>
   ): Promise<boolean> {
     const { nonInteractive } = ctx;
     if (nonInteractive) {

--- a/packages/eas-cli/src/rollout/utils.ts
+++ b/packages/eas-cli/src/rollout/utils.ts
@@ -1,6 +1,10 @@
 import chalk from 'chalk';
 
-import { RuntimeFragment, UpdateFragment } from '../graphql/generated';
+import {
+  RuntimeFragment,
+  UpdateBranchBasicInfoFragment,
+  UpdateFragment,
+} from '../graphql/generated';
 import { UpdateBranchObject, UpdateChannelObject } from '../graphql/queries/ChannelQuery';
 import Log from '../log';
 import { promptAsync } from '../prompts';
@@ -13,7 +17,10 @@ export function printRollout(channel: UpdateChannelObject): void {
   displayRolloutDetails(channel.name, rollout);
 }
 
-export function displayRolloutDetails(channelName: string, rollout: Rollout): void {
+export function displayRolloutDetails(
+  channelName: string,
+  rollout: Rollout<UpdateBranchBasicInfoFragment>
+): void {
   const rolledOutPercent = rollout.percentRolledOut;
   Log.newLine();
   Log.log(chalk.bold('🚀 Rollout:'));


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Eventually we will want to move the branch mapping utility functions into their own library. This PR does the following:
- removes dependencies on graphql types so it can be used in other repo's
- replaces the test fixtures used so it doesnt use graphql types, and can be used in other repo's

# Test Plan

- [ ] tests still pass
