### PR TITLE
[eas-json][eas-cli] add global `withoutCredentials` property to `eas.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Pass credentials to custom iOS builds. ([#1989](https://github.com/expo/eas-cli/pull/1989) by [@szdziedzic](https://github.com/szdziedzic))
+- Add the `withoutCredentials` option as a common build profile field in `eas.json`. ([#1994](https://github.com/expo/eas-cli/pull/1994) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -55,5 +55,5 @@ export async function ensureIosCredentialsForBuildResignAsync(
 }
 
 function shouldProvideCredentials(buildCtx: BuildContext<Platform.IOS>): boolean {
-  return !buildCtx.buildProfile.simulator;
+  return !buildCtx.buildProfile.simulator && !buildCtx.buildProfile.withoutCredentials;
 }

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -91,6 +91,12 @@
       "type": "object",
       "description": "The build profile configuration.",
       "properties": {
+        "withoutCredentials": {
+          "type": "boolean",
+          "description": "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when working with custom builds.",
+          "markdownDescription": "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when working with custom builds.",
+          "default": false
+        },
         "extends": {
           "type": "string",
           "description": "The name of the build profile that the current one should inherit values from. This value can't be specified per platform."
@@ -208,8 +214,8 @@
       "properties": {
         "withoutCredentials": {
           "type": "boolean",
-          "description": "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository.",
-          "markdownDescription": "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository.",
+          "description": "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository or working with custom builds.",
+          "markdownDescription": "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository or working with custom builds.",
           "default": false
         },
         "image": {
@@ -301,6 +307,12 @@
       "type": "object",
       "description": "The iOS-specific build profile configuration.",
       "properties": {
+        "withoutCredentials": {
+          "type": "boolean",
+          "description": "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when working with custom builds.",
+          "markdownDescription": "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when working with custom builds.",
+          "default": false
+        },
         "simulator": {
           "type": "boolean",
           "description": "If set to true, creates build for simulator.",

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -188,6 +188,7 @@ test('valid eas.json with top level and platform-sepcific withoutCredentials pro
     credentialsSource: 'remote',
     distribution: 'store',
     developmentClient: true,
+    withoutCredentials: true,
   });
 
   expect(iosProfile).toEqual({

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -100,6 +100,104 @@ test('valid eas.json for development client builds', async () => {
   });
 });
 
+test('valid eas.json with top level withoutCredentials property', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      production: {},
+      debug: {
+        developmentClient: true,
+        withoutCredentials: true,
+      },
+    },
+  });
+
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
+  const iosProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'debug');
+  const androidProfile = await EasJsonUtils.getBuildProfileAsync(
+    accessor,
+    Platform.ANDROID,
+    'debug'
+  );
+  expect(androidProfile).toEqual({
+    credentialsSource: 'remote',
+    distribution: 'store',
+    developmentClient: true,
+    withoutCredentials: true,
+  });
+
+  expect(iosProfile).toEqual({
+    credentialsSource: 'remote',
+    distribution: 'store',
+    developmentClient: true,
+    withoutCredentials: true,
+  });
+});
+
+test('valid eas.json with iOS withoutCredentials property', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      production: {},
+      debug: {
+        developmentClient: true,
+        ios: { withoutCredentials: true },
+      },
+    },
+  });
+
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
+  const iosProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'debug');
+  const androidProfile = await EasJsonUtils.getBuildProfileAsync(
+    accessor,
+    Platform.ANDROID,
+    'debug'
+  );
+  expect(androidProfile).toEqual({
+    credentialsSource: 'remote',
+    distribution: 'store',
+    developmentClient: true,
+  });
+
+  expect(iosProfile).toEqual({
+    credentialsSource: 'remote',
+    distribution: 'store',
+    developmentClient: true,
+    withoutCredentials: true,
+  });
+});
+
+test('valid eas.json with top level and platform-sepcific withoutCredentials property', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      production: {},
+      debug: {
+        developmentClient: true,
+        withoutCredentials: true,
+        ios: { withoutCredentials: false },
+      },
+    },
+  });
+
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
+  const iosProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'debug');
+  const androidProfile = await EasJsonUtils.getBuildProfileAsync(
+    accessor,
+    Platform.ANDROID,
+    'debug'
+  );
+  expect(androidProfile).toEqual({
+    credentialsSource: 'remote',
+    distribution: 'store',
+    developmentClient: true,
+  });
+
+  expect(iosProfile).toEqual({
+    credentialsSource: 'remote',
+    distribution: 'store',
+    developmentClient: true,
+    withoutCredentials: false,
+  });
+});
+
 test(`valid eas.json with autoIncrement flag at build profile root`, async () => {
   await fs.writeJson('/project/eas.json', {
     build: {

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -25,9 +25,11 @@ const CacheSchema = Joi.object({
   cacheDefaultPaths: Joi.boolean(),
   customPaths: Joi.array().items(Joi.string()),
   paths: Joi.array().items(Joi.string()),
-}).rename('customPaths', 'paths')
+})
+  .rename('customPaths', 'paths')
   .messages({
-    'object.rename.override': 'Cannot provide both "cache.customPaths" and "cache.paths" - use "cache.paths"'
+    'object.rename.override':
+      'Cannot provide both "cache.customPaths" and "cache.paths" - use "cache.paths"',
   });
 
 const CommonBuildProfileSchema = Joi.object({
@@ -63,6 +65,9 @@ const CommonBuildProfileSchema = Joi.object({
 
   // custom build configuration
   config: Joi.string(),
+
+  // credentials
+  withoutCredentials: Joi.boolean(),
 });
 
 const PlatformBuildProfileSchema = CommonBuildProfileSchema.concat(
@@ -83,9 +88,6 @@ const AndroidBuildProfileSchema = PlatformBuildProfileSchema.concat(
 
     // build environment
     ndk: Joi.string().empty(null).custom(semverCheck),
-
-    // credentials
-    withoutCredentials: Joi.boolean(),
 
     // build configuration
     gradleCommand: Joi.string(),

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -70,6 +70,9 @@ export interface CommonBuildProfile {
 
   // custom build configuration
   config?: string;
+
+  // credentials
+  withoutCredentials?: boolean;
 }
 
 interface PlatformBuildProfile extends Omit<CommonBuildProfile, 'autoIncrement'> {
@@ -85,9 +88,6 @@ export interface AndroidBuildProfile extends PlatformBuildProfile {
   // build environment
   image?: Android.BuilderEnvironment['image'];
   ndk?: string;
-
-  // credentials
-  withoutCredentials?: boolean;
 
   // build configuration
   gradleCommand?: string;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Add global `withoutCredentials` property to `eas.json` (it currently only exists for Android). We discussed it with Brent and decided that it would be handy for custom builds.

# How

Add global `withoutCredentials` property to `eas.json`

# Test Plan

Add automated tests
