### PR TITLE
[eas-cli] rollouts websupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Logger to say website support is coming soon for rollouts. ([#1997](https://github.com/expo/eas-cli/pull/1997) by [@quinlanj](https://github.com/quinlanj))
+
 ## [4.0.0](https://github.com/expo/eas-cli/releases/tag/v4.0.0) - 2023-08-07
 
 ### 🛠 Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Logger to say website support is coming soon for rollouts. ([#1997](https://github.com/expo/eas-cli/pull/1997) by [@quinlanj](https://github.com/quinlanj))
+
 ## [4.1.0](https://github.com/expo/eas-cli/releases/tag/v4.1.0) - 2023-08-08
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -153,7 +153,7 @@ export default class ChannelRollout extends EasCommand {
     } else {
       Log.addNewLineIfNone();
       Log.warn(
-        `✨ This command is in Developer Preview and has not been released to production yet`
+        `✨ This command is in Developer Preview and has not been released to production yet. Website support is coming soon.`
       );
       Log.addNewLineIfNone();
       await new RolloutMainMenu(argsAndFlags).runAsync(ctx);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

small nit in developer preview logger to say website support is coming soon for rollouts


