### PR TITLE
[eas-cli][update] Only export at most ios and android dist

### DIFF
--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -86,7 +86,11 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
     }),
     platform: Flags.enum({
       char: 'p',
-      options: [...defaultPublishPlatforms, 'all'],
+      options: [
+        // TODO: Add web when it's fully supported
+        ...defaultPublishPlatforms,
+        'all',
+      ],
       default: 'all',
       required: false,
     }),

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -193,6 +193,9 @@ export async function buildBundlesAsync({
     throw new Error('Could not locate package.json');
   }
 
+  const platformArgs =
+    platformFlag === 'all' ? ['--platform', 'ios', '--platform', 'android'] : [platformFlag];
+
   if (shouldUseVersionedExpoCLI(projectDir, exp)) {
     await expoCommandAsync(projectDir, [
       'export',
@@ -200,8 +203,7 @@ export async function buildBundlesAsync({
       inputDir,
       '--dump-sourcemap',
       '--dump-assetmap',
-      '--platform',
-      platformFlag,
+      ...platformArgs,
       ...(clearCache ? ['--clear'] : []),
     ]);
   } else {
@@ -214,8 +216,7 @@ export async function buildBundlesAsync({
       '--non-interactive',
       '--dump-sourcemap',
       '--dump-assetmap',
-      '--platform',
-      platformFlag,
+      ...platformArgs,
       ...(clearCache ? ['--clear'] : []),
     ]);
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Sometime in SDK 49 web was added as a default exported platform when calling `npx expo export -p all`. EAS CLI is unversioned, so it was always just passing in `all` as the flag when `all` was requested. But EAS update doesn't really support web yet so exporting and uploading the web update doesn't make sense yet. 

So only export at most ios and android.

Closes ENG-9300.
Closes ENG-9723.

# Test Plan

`neas update` on a project configured for metro web, see it no longer publishes web by default.
