### PR TITLE
[eas-cli][eas-update] Add rollback disambiguation command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add rollback disambiguation command. ([#2004](https://github.com/expo/eas-cli/pull/2004) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
@@ -57,12 +57,6 @@ jest.mock('../../../fetch');
 describe(UpdateRepublish.name, () => {
   afterEach(() => vol.reset());
 
-  it('errors without --channel, --branch, or --group', async () => {
-    await expect(new UpdateRepublish([], commandOptions).run()).rejects.toThrow(
-      '--channel, --branch, or --group must be specified'
-    );
-  });
-
   it('errors when providing both --group and --branch', async () => {
     const flags = ['--group=1234', '--branch=main'];
 

--- a/packages/eas-cli/src/commands/update/rollback.ts
+++ b/packages/eas-cli/src/commands/update/rollback.ts
@@ -8,6 +8,8 @@ import UpdateRollBackToEmbedded from './roll-back-to-embedded';
 export default class UpdateRollback extends EasCommand {
   static override description = 'roll back to an embedded update or an existing update';
 
+  static override hidden = true;
+
   static override flags = {
     'private-key-path': Flags.string({
       description: `File containing the PEM-encoded private key corresponding to the certificate in expo-updates' configuration. Defaults to a file named "private-key.pem" in the certificate's directory.`,

--- a/packages/eas-cli/src/commands/update/rollback.ts
+++ b/packages/eas-cli/src/commands/update/rollback.ts
@@ -1,0 +1,40 @@
+import { Flags } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { promptAsync } from '../../prompts';
+import UpdateRepublish from './republish';
+import UpdateRollBackToEmbedded from './roll-back-to-embedded';
+
+export default class UpdateRollback extends EasCommand {
+  static override description = 'roll back to an embedded update or an existing update';
+
+  static override flags = {
+    'private-key-path': Flags.string({
+      description: `File containing the PEM-encoded private key corresponding to the certificate in expo-updates' configuration. Defaults to a file named "private-key.pem" in the certificate's directory.`,
+      required: false,
+    }),
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(UpdateRollback);
+
+    const { choice } = await promptAsync({
+      type: 'select',
+      message: 'Which type of update would you like to roll back to?',
+      name: 'choice',
+      choices: [
+        { title: 'Published Update', value: 'published' },
+        { title: 'Embedded Update', value: 'embedded' },
+      ],
+    });
+
+    const privateKeyPathArg = flags['private-key-path']
+      ? ['--private-key-path', flags['private-key-path']]
+      : [];
+    if (choice === 'published') {
+      await UpdateRepublish.run(privateKeyPathArg);
+    } else {
+      await UpdateRollBackToEmbedded.run(privateKeyPathArg);
+    }
+  }
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

As requested by @jonsamp:

> i would love (love!) if this command were the same command as rollback/revert/republish, such that you could “go back” to any state that your app has been in.
the naming is hard because taking the embedded update and making it active again is not the same as re publishing an actual update.
> 
> but thinking as a developer (introspecting), i don’t think id care that much. i think id care a lot more that i knew a command that worked in all situations rather than using republish all the time then having it not work when trying to re-publish an embedded update, only to then be confused and thinking “what, why can’t I??”
> 
> TLDR:
>  - i would love one command to rule them all
>  - if we need two commands, then we need a message when trying the wrong commands with the wrong updates, saying to use the correct command (but even typing this out it seems needlessly unpleasant)

And after consulting with people in the CLI sync meeting, we decided that it didn't make sense to try to combine the commands since they contain different sets of flags. But, we decided that there could be the best of both worlds:
- Keep `eas update:republish` and `eas update:roll-back-to-embedded` commands for power users and for non-interactive/json output.
- Add `eas update:rollback` command for an interactive disambiguation command that routes to one of the other two based on a prompt.

Closes ENG-9420.

# How

Add disambiguation command, ability for `republish` command to be fully interactive (not need to provide any flags).

# Test Plan

```
$ neas update:rollback --private-key-path keys/private-key.pem
✔ Which type of update would you like to roll back to? › Embedded Update
✔ Which branch would you like to use? › main - current update: "Republish "Initial commit

Generated by create-expo-app 2.0.3." - group: bd8a520c-7299-4e57-9268-350294064474" (1 week ago by wschurman)
✔ Provide an update message: … rb
✔ Channel: main pointed at branch: main
🔒 Signing roll back
✔ Published!

Branch             main
Runtime version    1.0.0
Platform           android, ios
Update group ID    c59d7422-0064-4fee-b14e-259517a223f0
Android update ID  123e05e7-9e84-4c85-ae96-cfff5c7aeb48
iOS update ID      2f4b5d7e-23e4-4692-8d8c-57f4aab26709
Message            rb
Commit             dc02dab7a9b0f31788b7298fd1fdb6f50176276e*
Website link       https://expo.dev/accounts/wschurman/projects/watwathuh/updates/c59d7422-0064-4fee-b14e-259517a223f0

$ neas update:rollback --private-key-path keys/private-key.pem
✔ Which type of update would you like to roll back to? › Published Update
✔ Find update by branch or channel? › Branch
✔ Select branch from which to choose update › main
✔ Load more update groups? › [Aug 03 15:49 by wschurman, runtimeVersion: 1.0.0] Republish "Initial commit

Generated by create-expo-app 2.0.3." - group: bd8a520c-7299-4e57-9268-350294064474
✔ The republished update group will appear only on: all
✔ Provide an update message. … Republish "Republish "Initial commit

Generated by create-expo-app 2.0.3." - group: bd8a520c-7299-4e57-9268-350294064474" - group: f9dd2abc-edf8-49c3-b770-a1fdcd0aacc4
✔ The republished update group will be signed
🔒 Signing republished update group
✔ Republished update group

Branch             main
Runtime version    1.0.0
Platform           android, ios
Update group ID    2b32e277-8f00-4c4a-92b9-80dcbd721eaf
Android update ID  64c8a3d0-1ada-4403-9002-28cf552060a7
iOS update ID      34e9f064-5498-41cc-a7c7-04413311faa2
Message            Republish "Republish "Initial commit

Generated by create-expo-app 2.0.3." - group: bd8a520c-7299-4e57-9268-350294064474" - group: f9dd2abc-edf8-49c3-b770-a1fdcd0aacc4
Website link       https://expo.dev/accounts/wschurman/projects/watwathuh/updates/2b32e277-8f00-4c4a-92b9-80dcbd721eaf
```
