### PR TITLE
[eas-cli][eas-update] Support republishing roll back to embedded updates

### DIFF
--- a/packages/eas-cli/src/update/republish.ts
+++ b/packages/eas-cli/src/update/republish.ts
@@ -5,14 +5,16 @@ import nullthrows from 'nullthrows';
 import { getUpdateGroupUrl } from '../build/utils/url';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import fetch from '../fetch';
-import { Update, UpdateInfoGroup } from '../graphql/generated';
+import { UpdateFragment, UpdateInfoGroup } from '../graphql/generated';
 import { PublishMutation } from '../graphql/mutations/PublishMutation';
 import Log, { link } from '../log';
 import { ora } from '../ora';
 import { getOwnerAccountForProjectIdAsync } from '../project/projectUtils';
 import {
   CodeSigningInfo,
+  checkDirectiveBodyAgainstUpdateInfoGroup,
   checkManifestBodyAgainstUpdateInfoGroup,
+  getDirectiveBodyAsync,
   getManifestBodyAsync,
   signBody,
 } from '../utils/code-signing';
@@ -23,15 +25,7 @@ export type UpdateToRepublish = {
   groupId: string;
   branchId: string;
   branchName: string;
-} & Pick<
-  Update,
-  | 'message'
-  | 'runtimeVersion'
-  | 'manifestFragment'
-  | 'platform'
-  | 'gitCommitHash'
-  | 'codeSigningInfo'
->;
+} & UpdateFragment;
 
 /**
  * @param updatesToPublish The update group to republish
@@ -65,6 +59,13 @@ export async function republishAsync({
     update.branchName === arbitraryUpdate.branchName &&
     update.runtimeVersion === arbitraryUpdate.runtimeVersion;
   assert(updatesToPublish.every(isSameGroup), 'All updates must belong to the same update group');
+
+  assert(
+    updatesToPublish.every(u => u.isRollBackToEmbedded) ||
+      updatesToPublish.every(u => !u.isRollBackToEmbedded),
+    'All updates must either be roll back to embedded updates or not'
+  );
+
   const { runtimeVersion } = arbitraryUpdate;
 
   // If codesigning was created for the original update, we need to add it to the republish.
@@ -96,16 +97,25 @@ export async function republishAsync({
   let updatesRepublished: Awaited<ReturnType<typeof PublishMutation.publishUpdateGroupAsync>>;
 
   try {
-    const updateInfoGroup = Object.fromEntries(
-      updatesToPublish.map(update => [update.platform, JSON.parse(update.manifestFragment)])
-    );
+    const arbitraryUpdate = updatesToPublish[0];
+    const objectToMergeIn = arbitraryUpdate.isRollBackToEmbedded
+      ? {
+          rollBackToEmbeddedInfoGroup: Object.fromEntries(
+            updatesToPublish.map(update => [update.platform, true])
+          ),
+        }
+      : {
+          updateInfoGroup: Object.fromEntries(
+            updatesToPublish.map(update => [update.platform, JSON.parse(update.manifestFragment)])
+          ),
+        };
 
     updatesRepublished = await PublishMutation.publishUpdateGroupAsync(graphqlClient, [
       {
         branchId: targetBranchId,
         runtimeVersion,
         message: updateMessage,
-        updateInfoGroup,
+        ...objectToMergeIn,
         gitCommitHash: updatesToPublish[0].gitCommitHash,
         awaitingCodeSigningInfo: !!codeSigningInfo,
       },
@@ -120,19 +130,31 @@ export async function republishAsync({
             method: 'GET',
             headers: { accept: 'multipart/mixed' },
           });
-          const manifestBody = nullthrows(await getManifestBodyAsync(response));
 
-          checkManifestBodyAgainstUpdateInfoGroup(
-            manifestBody,
-            nullthrows(nullthrows(updateInfoGroup)[newUpdate.platform as keyof UpdateInfoGroup])
-          );
+          let signature;
+          if (newUpdate.isRollBackToEmbedded) {
+            const directiveBody = nullthrows(await getDirectiveBodyAsync(response));
 
-          const manifestSignature = signBody(manifestBody, codeSigningInfo);
+            checkDirectiveBodyAgainstUpdateInfoGroup(directiveBody);
+            signature = signBody(directiveBody, codeSigningInfo);
+          } else {
+            const manifestBody = nullthrows(await getManifestBodyAsync(response));
+
+            checkManifestBodyAgainstUpdateInfoGroup(
+              manifestBody,
+              nullthrows(
+                nullthrows(objectToMergeIn.updateInfoGroup)[
+                  newUpdate.platform as keyof UpdateInfoGroup
+                ]
+              )
+            );
+            signature = signBody(manifestBody, codeSigningInfo);
+          }
 
           await PublishMutation.setCodeSigningInfoAsync(graphqlClient, newUpdate.id, {
             alg: codeSigningInfo.codeSigningMetadata.alg,
             keyid: codeSigningInfo.codeSigningMetadata.keyid,
-            sig: manifestSignature,
+            sig: signature,
           });
         })
       );


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://github.com/expo/eas-cli/pull/2004#issuecomment-1677356680

When a roll back to embedded type update was republished, the code failed. This fixes it.

# How

Support republishing signed roll-back-to-embedded updates.

# Test Plan

$ neas update:rollback --private-key-path keys/private-key.pem
✔ Which type of update would you like to roll back to? › Published Update
✔ Find update by branch or channel? › Channel
✔ Select a channel to view › main
✔ Load more update groups? › [Aug 14 09:38 by wschurman, runtimeVersion: 1.0.0] rb
✔ The republished update group will appear only on: all
✔ Provide an update message. … Republish "rb" - group: c59d7422-0064-4fee-b14e-259517a223f0
✔ The republished update group will be signed
- Republishing...
🔒 Signing republished update group
- Republishing...
✔ Republished update group

Branch             main
Runtime version    1.0.0
Platform           android, ios
Update group ID    0849f86f-5808-4c4d-8c08-f257998e235d
Android update ID  e6266b29-07ff-4470-91e9-b8352b10dd3c
iOS update ID      894ba423-53a0-4564-afa7-d6362ebda3fb
Message            Republish "rb" - group: c59d7422-0064-4fee-b14e-259517a223f0
Website link       https://expo.dev/accounts/wschurman/projects/watwathuh/updates/0849f86f-5808-4c4d-8c08-f257998e235d
