### PR TITLE
[eas-cli] [ENG-7591] Detect not provisioned devices

### DIFF
--- a/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
@@ -177,7 +177,23 @@ export class SetUpAdhocProvisioningProfile {
       );
     }
 
-    // 6. Create (or update) app build credentials
+    // 6. Compare selected devices with the ones actually provisioned
+    const diffList = differenceBy(
+      chosenDevices,
+      appleProvisioningProfile.appleDevices,
+      'identifier'
+    );
+    if (diffList && diffList.length > 0) {
+      Log.warn(`Failed to provision ${diffList.length} of the selected devices:`);
+      for (const missingDevice of diffList) {
+        Log.warn(`- ${formatDeviceLabel(missingDevice)}`);
+      }
+      Log.log(
+        'Most commonly devices fail to to be provisioned while they are still being processed by Apple, which can take up to 24-72 hours. Check your Apple Developer Portal > Certificates, Identifiers & Profiles > Devices page, the devices in "Processing" status cannot be provisioned yet'
+      );
+    }
+
+    // 7. Create (or update) app build credentials
     assert(appleProvisioningProfile);
     return await assignBuildCredentialsAsync(
       ctx,

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
@@ -1,4 +1,38 @@
-import { doUDIDsMatch } from '../SetUpAdhocProvisioningProfile';
+import { Env } from '@expo/eas-build-job';
+import { EasJson } from '@expo/eas-json';
+
+import { Analytics } from '../../../../analytics/AnalyticsManager';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import {
+  Account,
+  AppleAppIdentifierFragment,
+  AppleDevice,
+  AppleDeviceClass,
+  AppleDeviceFragment,
+  AppleDistributionCertificateFragment,
+  IosAppBuildCredentialsFragment,
+} from '../../../../graphql/generated';
+import Log from '../../../../log';
+import { getApplePlatformFromTarget } from '../../../../project/ios/target';
+import { Actor } from '../../../../user/User';
+import { CredentialsContext, CredentialsContextProjectInfo } from '../../../context';
+import { ProvisioningProfile } from '../../appstore/Credentials.types';
+import { ApplePlatform } from '../../appstore/constants';
+import { assignBuildCredentialsAsync, getBuildCredentialsAsync } from '../BuildCredentialsUtils';
+import { chooseDevicesAsync } from '../DeviceUtils';
+import { SetUpAdhocProvisioningProfile, doUDIDsMatch } from '../SetUpAdhocProvisioningProfile';
+
+jest.mock('../BuildCredentialsUtils');
+jest.mock('../../../context');
+jest.mock('../../../ios/api/GraphqlClient');
+jest.mock('../DeviceUtils', () => {
+  return {
+    __esModule: true,
+    chooseDevicesAsync: jest.fn(),
+    formatDeviceLabel: jest.requireActual('../DeviceUtils').formatDeviceLabel,
+  };
+});
+jest.mock('../../../../project/ios/target');
 
 describe(doUDIDsMatch, () => {
   it('return false if UDIDs do not match', () => {
@@ -12,3 +46,104 @@ describe(doUDIDsMatch, () => {
     expect(doUDIDsMatch(udidsA, udidsB)).toBe(true);
   });
 });
+describe('runWithDistributionCertificateAsync', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+  const setUpAdhocProvisioningProfile = new SetUpAdhocProvisioningProfile({
+    app: { account: {} as Account, projectName: 'projName', bundleIdentifier: 'bundleId' },
+    target: { targetName: 'targetName', bundleIdentifier: 'bundleId', entitlements: {} },
+  });
+  describe('compare chosen and provisioned devices', () => {
+    describe('not all devices provisioned', () => {
+      it('displays warning to the user and lists the missing devices', async () => {
+        const { ctx, distCert } = setUpTest();
+        jest.mocked(getBuildCredentialsAsync).mockResolvedValue({
+          provisioningProfile: {
+            appleTeam: {},
+            appleDevices: [{ identifier: 'id1' }],
+            developerPortalIdentifier: 'provisioningProfileId',
+          },
+        } as IosAppBuildCredentialsFragment);
+        const LogWarnSpy = jest.spyOn(Log, 'warn');
+        const LogLogSpy = jest.spyOn(Log, 'log');
+        const result = await setUpAdhocProvisioningProfile.runWithDistributionCertificateAsync(
+          ctx,
+          distCert
+        );
+        expect(result).toEqual({} as IosAppBuildCredentialsFragment);
+        expect(LogWarnSpy).toHaveBeenCalledTimes(3);
+        expect(LogWarnSpy).toHaveBeenCalledWith('Failed to provision 2 of the selected devices:');
+        expect(LogWarnSpy).toHaveBeenCalledWith('- id2 (iPhone) (Device 2)');
+        expect(LogWarnSpy).toHaveBeenCalledWith('- id3 (Mac) (Device 3)');
+        expect(LogLogSpy).toHaveBeenCalledTimes(1);
+        expect(LogLogSpy).toHaveBeenCalledWith(
+          'Most commonly devices fail to to be provisioned while they are still being processed by Apple, which can take up to 24-72 hours. Check your Apple Developer Portal > Certificates, Identifiers & Profiles > Devices page, the devices in "Processing" status cannot be provisioned yet'
+        );
+      });
+    });
+    describe('all devices provisioned', () => {
+      it('does not display warning', async () => {
+        const { ctx, distCert } = setUpTest();
+        jest.mocked(getBuildCredentialsAsync).mockResolvedValue({
+          provisioningProfile: {
+            appleTeam: {},
+            appleDevices: [{ identifier: 'id1' }, { identifier: 'id2' }, { identifier: 'id3' }],
+            developerPortalIdentifier: 'provisioningProfileId',
+          },
+        } as IosAppBuildCredentialsFragment);
+        const LogWarnSpy = jest.spyOn(Log, 'warn');
+        const LogLogSpy = jest.spyOn(Log, 'log');
+        const result = await setUpAdhocProvisioningProfile.runWithDistributionCertificateAsync(
+          ctx,
+          distCert
+        );
+        expect(result).toEqual({} as IosAppBuildCredentialsFragment);
+        expect(LogWarnSpy).not.toHaveBeenCalled();
+        expect(LogLogSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+});
+
+function setUpTest(): { ctx: CredentialsContext; distCert: AppleDistributionCertificateFragment } {
+  const ctx = jest.mocked(
+    new CredentialsContext(
+      {} as {
+        projectInfo: CredentialsContextProjectInfo | null;
+        easJsonCliConfig?: EasJson['cli'];
+        nonInteractive: boolean;
+        projectDir: string;
+        user: Actor;
+        graphqlClient: ExpoGraphqlClient;
+        analytics: Analytics;
+        env?: Env;
+      }
+    )
+  );
+  Object.defineProperty(ctx, 'ios', { value: jest.mock('../../../ios/api/GraphqlClient') });
+  ctx.ios.getDevicesForAppleTeamAsync = jest
+    .fn()
+    .mockResolvedValue([
+      { identifier: 'id1' },
+      { identifier: 'id2' },
+      { identifier: 'id3' },
+    ] as AppleDeviceFragment[]);
+  jest.mocked(chooseDevicesAsync).mockResolvedValue([
+    { identifier: 'id1', name: 'Device 1', deviceClass: AppleDeviceClass.Ipad },
+    { identifier: 'id2', name: 'Device 2', deviceClass: AppleDeviceClass.Iphone },
+    { identifier: 'id3', name: 'Device 3', deviceClass: AppleDeviceClass.Mac },
+  ] as AppleDevice[]);
+  // @ts-ignore
+  jest.mocked(getApplePlatformFromTarget).mockResolvedValue(ApplePlatform.IOS);
+  Object.defineProperty(ctx, 'appStore', { value: jest.mock('../../appstore/AppStoreApi') });
+  ctx.appStore.createOrReuseAdhocProvisioningProfileAsync = jest.fn().mockResolvedValue({
+    provisioningProfileId: 'provisioningProfileId',
+  } as ProvisioningProfile);
+  ctx.ios.createOrGetExistingAppleAppIdentifierAsync = jest
+    .fn()
+    .mockResolvedValue({} as AppleAppIdentifierFragment);
+  jest.mocked(assignBuildCredentialsAsync).mockResolvedValue({} as IosAppBuildCredentialsFragment);
+  const distCert = {} as AppleDistributionCertificateFragment;
+  return { ctx, distCert };
+}


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-7591/detect-processing-devices-on-apple-developer-portal-and-dont-allow-the

# How

After selecting devices to be provisioned and making a call to App Store Connect API the result is compared with the list of chosen devices. If any are missing, a message is displayed to the user

# Test Plan

Added automated tests
TODO: manual testing
