### PR TITLE
[eas-cli] Add info to EAS Update asset upload process about asset counts and limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Add rollback disambiguation command. ([#2004](https://github.com/expo/eas-cli/pull/2004) by [@wschurman](https://github.com/wschurman))
 - Detect devices that fail to be provisioned, list them to the user and show the explanation message with the link to the devices page to check actual status. ([#2011](https://github.com/expo/eas-cli/pull/2011) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+- Add info to EAS Update asset upload process about asset counts and limits. ([#2013](https://github.com/expo/eas-cli/pull/2013) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -35,6 +35,7 @@ import {
   getRuntimeVersionObjectAsync,
   getUpdateMessageForCommandAsync,
   isUploadedAssetCountAboveWarningThreshold,
+  platformDisplayNames,
   resolveInputDirectoryAsync,
   uploadAssetsAsync,
 } from '../../project/publish';
@@ -325,6 +326,21 @@ export default class UpdatePublish extends EasCommand {
       for (const uploadedAssetPath of uploadResults.uniqueUploadedAssetPaths) {
         Log.debug(chalk.dim(`- ${uploadedAssetPath}`));
       }
+
+      const platformString = (Object.keys(assets) as PublishPlatform[])
+        .map(platform => {
+          const collectedAssetForPlatform = nullthrows(assets[platform]);
+          const totalAssetsForPlatform = collectedAssetForPlatform.assets.length + 1; // launch asset
+          const assetString = totalAssetsForPlatform === 1 ? 'asset' : 'assets';
+          return `${totalAssetsForPlatform} ${platformDisplayNames[platform]} ${assetString}`;
+        })
+        .join(', ');
+      Log.withInfo(
+        `${platformString} (maximum: ${assetLimitPerUpdateGroup} total per update). ${learnMore(
+          'https://expo.fyi/eas-update-asset-limits',
+          { learnMoreMessage: 'Learn more about asset limits.' }
+        )}`
+      );
     } catch (e) {
       assetSpinner.fail('Failed to upload');
       throw e;

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -57,6 +57,10 @@ export default class Log {
     Log.consoleLog(chalk.green(figures.tick), ...args);
   }
 
+  public static withInfo(...args: any[]): void {
+    Log.consoleLog(chalk.green(figures.info), ...args);
+  }
+
   private static consoleLog(...args: any[]): void {
     Log.updateIsLastLineNewLine(args);
     // eslint-disable-next-line no-console

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -683,3 +683,9 @@ export function getRuntimeToPlatformMappingFromRuntimeVersions(
   }
   return runtimeToPlatformMapping;
 }
+
+export const platformDisplayNames: Record<Platform, string> = {
+  android: 'Android',
+  ios: 'iOS',
+  web: 'Web',
+};


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This shows the number of assets in a published update along with info about the limit to help developers be aware of the limits.

Depends on https://github.com/expo/fyi/pull/128.

Closes ENG-9806.

# How

Add message.

# Test Plan

```
$ neas update
✔ Which branch would you like to use? › main - current update: "Initial commit

Generated by create-expo-app 2.0.3." (1 minute ago by willtestssouser1)
✔ Provide an update message: … Initial commit

Generated by create-expo-app 2.0.3.
[expo-cli] Starting Metro Bundler
[expo-cli]
[expo-cli] iOS Bundling complete 4213ms
[expo-cli]
[expo-cli] Android Bundling complete 4217ms
[expo-cli] iOS Building Hermes bytecode for the bundle
[expo-cli] Android Building Hermes bytecode for the bundle
[expo-cli]
[expo-cli]
[expo-cli] Bundle                      Size
[expo-cli] ┌ index.ios.hbc           857 kB
[expo-cli] ├ index.android.hbc       863 kB
[expo-cli] ├ index.ios.hbc.map      3.47 MB
[expo-cli] └ index.android.hbc.map  3.49 MB
[expo-cli] 💡 JavaScript bundle sizes affect startup time. Learn more: https://expo.fyi/javascript-bundle-sizes
[expo-cli] Finished saving JS Bundles
[expo-cli] Dumping asset map
[expo-cli] Dumping source maps
[expo-cli] Preparing additional debugging files
[expo-cli] Export was successful. Your exported files can be found in dist
✔ Exported bundle(s)
✔ Uploaded 2 app bundles
✔ Uploading assets skipped - no new assets found
ℹ 1 iOS asset, 1 Android asset (maximum: 20000 total per update). Learn more about asset limits.
✔ Channel: main pointed at branch: main
✔ Published!
```