### PR TITLE
[eas-cli][updates] configure updates as well when somebody tries to run a build with channel set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Support republishing roll back to embedded updates. ([#2006](https://github.com/expo/eas-cli/pull/2006) by [@wschurman](https://github.com/wschurman))
+- Configure updates as well when somebody tries to run a build with channel set. ([#2016](https://github.com/expo/eas-cli/pull/2016) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -1,3 +1,4 @@
+import { ExpoConfig } from '@expo/config-types';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import {
   AppVersionSource,
@@ -38,7 +39,6 @@ import {
 import { checkExpoSdkIsSupportedAsync } from '../project/expoSdk';
 import { validateMetroConfigForManagedWorkflowAsync } from '../project/metroConfig';
 import {
-  installExpoUpdatesAsync,
   isExpoUpdatesInstalledAsDevDependency,
   isExpoUpdatesInstalledOrAvailable,
   validateAppVersionRuntimePolicySupportAsync,
@@ -57,6 +57,7 @@ import {
   waitToCompleteAsync as waitForSubmissionsToCompleteAsync,
 } from '../submit/submit';
 import { printSubmissionDetailsUrls } from '../submit/utils/urls';
+import { ensureEASUpdateIsConfiguredAsync } from '../update/configure';
 import { validateBuildProfileConfigMatchesProjectConfigAsync } from '../update/utils';
 import { Actor } from '../user/User';
 import { downloadAndMaybeExtractAppAsync } from '../utils/download';
@@ -320,6 +321,9 @@ async function prepareAndStartBuildAsync({
   );
   if (buildProfile.profile.channel) {
     await validateExpoUpdatesInstalledAsProjectDependencyAsync({
+      graphqlClient,
+      exp: buildCtx.exp,
+      projectId: buildCtx.projectId,
       projectDir,
       sdkVersion: buildCtx.exp.sdkVersion,
       nonInteractive: flags.nonInteractive,
@@ -447,11 +451,17 @@ async function maybeDownloadAndRunSimulatorBuildsAsync(
 }
 
 async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
+  exp,
+  graphqlClient,
+  projectId,
   projectDir,
   buildProfile,
   nonInteractive,
   sdkVersion,
 }: {
+  graphqlClient: ExpoGraphqlClient;
+  exp: ExpoConfig;
+  projectId: string;
   projectDir: string;
   buildProfile: ProfileData<'build'>;
   nonInteractive: boolean;
@@ -467,18 +477,24 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
     );
   } else if (nonInteractive) {
     Log.warn(
-      `The build profile "${buildProfile.profileName}" has specified the channel "${buildProfile.profile.channel}", but the "expo-updates" package hasn't been installed. To use channels for your builds, install the "expo-updates" package by running "npx expo install expo-updates".`
+      `The build profile "${buildProfile.profileName}" has specified the channel "${buildProfile.profile.channel}", but the "expo-updates" package hasn't been installed. To use channels for your builds, install the "expo-updates" package by running "npx expo install expo-updates" followed by "eas update:configure".`
     );
   } else {
     Log.warn(
-      `The build profile "${buildProfile.profileName}" specifies the channel "${buildProfile.profile.channel}", but the "expo-updates" package is missing. To use channels in your builds, install the "expo-updates" package.`
+      `The build profile "${buildProfile.profileName}" specifies the channel "${buildProfile.profile.channel}", but the "expo-updates" package is missing. To use channels in your builds, install the "expo-updates" package and run "eas update:configure".`
     );
     const installExpoUpdates = await confirmAsync({
-      message: `Would you like to install the "expo-updates" package?`,
+      message: `Would you like to install the "expo-updates" package and configure EAS Update now?`,
     });
     if (installExpoUpdates) {
-      await installExpoUpdatesAsync(projectDir, { silent: false });
-      Log.withTick('Installed expo-updates');
+      await ensureEASUpdateIsConfiguredAsync(graphqlClient, {
+        exp,
+        projectId,
+        projectDir,
+        platform: RequestedPlatform.All,
+      });
+      Log.withTick('Installed expo-updates and configured EAS Update.');
+      throw new Error('Command must be re-run to pick up new updates configuration.');
     }
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://github.com/expo/eas-cli/pull/1885 added code to auto-install expo-updates when channel was set in eas.json. But just installing expo-updates isn't sufficient, and actually when it is installed but not configured it crashes upon startup (separate issue, maybe).

# How

Also make it configure EAS update.

The problem here is that when EAS update is configured, it mutates the ExpoConfig on dis, making the ExpoConfig in the build context in memory stale. The only way to resolve this is to either: a) reload the config (which is prone to bugs), or b) ask the user to run the command again. I went with B.

# Test Plan

```
yarn create expo-app testjadskjhadshjkads
export EXPO_STAGING=1
eas init
eas build:configure
```

Add channel to `eas.json`:

```
...
  "build": {
    "development": {
      "developmentClient": true,
      "distribution": "internal",
      "channel": "development"
    },
    "preview": {
      "distribution": "internal",
      "channel": "preview"
    },
    "production": {"channel": "production"}
  },
...
```
```
$ neas build -p android
Loaded "env" configuration for the "production" profile: no environment variables specified. Learn more

📝  Android application id Learn more
✔ What would you like your Android application id to be? … com.willtestssouser1.testjadskjhadshjkads
The build profile "production" specifies the channel "production", but the "expo-updates" package is missing. To use channels in your builds, install the "expo-updates" package and run "eas update:configure".
✔ Would you like to install the "expo-updates" package and configure EAS Update now? … yes
> npx expo install expo-updates
[expo-cli] › Installing 1 SDK 49.0.0 compatible native module using yarn
[expo-cli] > yarn add expo-updates@~0.18.12
[expo-cli] yarn add v1.22.19
[expo-cli] [1/4] Resolving packages...
[expo-cli] [2/4] Fetching packages...
[expo-cli] [3/4] Linking dependencies...
[expo-cli] warning "react-native > @react-native/codegen@0.72.6" has unmet peer dependency "@babel/preset-env@^7.1.6".
[expo-cli] warning "react-native > @react-native/codegen > jscodeshift@0.14.0" has unmet peer dependency "@babel/preset-env@^7.1.6".
[expo-cli] [4/4] Building fresh packages...
[expo-cli] success Saved lockfile.
[expo-cli] success Saved 6 new dependencies.
[expo-cli] info Direct dependencies
[expo-cli] └─ expo-updates@0.18.12
[expo-cli] info All dependencies
[expo-cli] ├─ expo-eas-client@0.6.0
[expo-cli] ├─ expo-json-utils@0.7.1
[expo-cli] ├─ expo-manifests@0.7.2
[expo-cli] ├─ expo-structured-headers@3.3.0
[expo-cli] ├─ expo-updates-interface@0.10.1
[expo-cli] └─ expo-updates@0.18.12
[expo-cli] Done in 2.35s.
✔ Installed expo-updates
✔ Configured updates.url to "https://staging-u.expo.dev/4d0262eb-6b4f-45e2-adc3-e642ba892e8c"
✔ Configured runtimeVersion for Android and iOS with "{"policy":"appVersion"}"

All builds of your app going forward will be eligible to receive updates published with EAS Update.

✔ Installed expo-updates and configured EAS Update.
Command must be re-run to pick up new updates configuration.
    Error: build command failed.
```
