### PR TITLE
[ENG-9685][eas-cli] create a linked channel on build if not exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - More branch map utility functions. ([#2001](https://github.com/expo/eas-cli/pull/2001) by [@quinlanj](https://github.com/quinlanj))
 - More branch mapping utils. ([#2003](https://github.com/expo/eas-cli/pull/2003) by [@quinlanj](https://github.com/quinlanj))
+- Create a linked channel on build if not exists. ([#2017](https://github.com/expo/eas-cli/pull/2017) by [@quinlanj](https://github.com/quinlanj))
 
 ## [4.1.2](https://github.com/expo/eas-cli/releases/tag/v4.1.2) - 2023-08-10
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -13,10 +13,9 @@ import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
 import { Analytics } from '../analytics/AnalyticsManager';
-import { doesChannelExistAsync } from '../channel/queries';
+import { createAndLinkChannelAsync, doesChannelExistAsync } from '../channel/queries';
 import { DynamicConfigContextFn } from '../commandUtils/context/DynamicProjectConfigContextField';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
-import { createAndLinkChannelAsync } from '../commands/channel/create';
 import {
   AppPlatform,
   BuildFragment,

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -294,7 +294,7 @@ export async function doesChannelExistAsync(
  *
  * @param appId the app ID, also known as the project ID
  * @param channelName the name of the channel to create
- * @param shouldPrintJson set to true to print only the JSON output
+ * @param shouldPrintJson print only the JSON output
  */
 export async function createAndLinkChannelAsync(
   graphqlClient: ExpoGraphqlClient,

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -21,6 +21,7 @@ import {
   paginatedQueryWithConfirmPromptAsync,
   paginatedQueryWithSelectPromptAsync,
 } from '../utils/queries';
+import { ChannelNotFoundError } from './errors';
 import { logChannelDetails } from './print-utils';
 
 export const CHANNELS_LIMIT = 25;
@@ -263,4 +264,22 @@ export async function ensureChannelExistsAsync(
       throw e;
     }
   }
+}
+
+export async function doesChannelExistAsync(
+  graphqlClient: ExpoGraphqlClient,
+  { appId, channelName }: { appId: string; channelName: string }
+): Promise<boolean> {
+  try {
+    await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      appId,
+      channelName,
+    });
+  } catch (err) {
+    if (err instanceof ChannelNotFoundError) {
+      return false;
+    }
+    throw err;
+  }
+  return true;
 }

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -2,6 +2,8 @@ import chalk from 'chalk';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
+import { createUpdateBranchOnAppAsync } from '../branch/queries';
+import { BranchNotFoundError } from '../branch/utils';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { PaginatedQueryOptions } from '../commandUtils/pagination';
 import { withErrorHandlingAsync } from '../graphql/client';
@@ -15,6 +17,7 @@ import { BranchQuery, UpdateBranchOnChannelObject } from '../graphql/queries/Bra
 import { ChannelQuery, UpdateChannelObject } from '../graphql/queries/ChannelQuery';
 import { UpdateChannelBasicInfoFragmentNode } from '../graphql/types/UpdateChannelBasicInfo';
 import Log from '../log';
+import { getDisplayNameForProjectIdAsync } from '../project/projectUtils';
 import formatFields from '../utils/formatFields';
 import { printJsonOnlyOutput } from '../utils/json';
 import {
@@ -23,6 +26,7 @@ import {
 } from '../utils/queries';
 import { ChannelNotFoundError } from './errors';
 import { logChannelDetails } from './print-utils';
+import { ChannelBasicInfo } from './utils';
 
 export const CHANNELS_LIMIT = 25;
 
@@ -282,4 +286,84 @@ export async function doesChannelExistAsync(
     throw err;
   }
   return true;
+}
+
+/**
+ *
+ * Creates a channel and links it to a branch with the same name.
+ *
+ * @param appId the app ID, also known as the project ID
+ * @param channelName the name of the channel to create
+ * @param shouldPrintJson set to true to print only the JSON output
+ */
+export async function createAndLinkChannelAsync(
+  graphqlClient: ExpoGraphqlClient,
+  {
+    appId,
+    channelName,
+    shouldPrintJson,
+  }: { appId: string; channelName: string; shouldPrintJson?: boolean }
+): Promise<ChannelBasicInfo> {
+  let branchId: string;
+  let branchMessage: string;
+
+  try {
+    const branch = await BranchQuery.getBranchByNameAsync(graphqlClient, {
+      appId,
+      name: channelName,
+    });
+    branchId = branch.id;
+    branchMessage = `We found a branch with the same name`;
+  } catch (error) {
+    if (error instanceof BranchNotFoundError) {
+      const newBranch = await createUpdateBranchOnAppAsync(graphqlClient, {
+        appId,
+        name: channelName,
+      });
+      branchId = newBranch.id;
+      branchMessage = `We also went ahead and made a branch with the same name`;
+    } else {
+      throw error;
+    }
+  }
+
+  const {
+    updateChannel: { createUpdateChannelForApp: newChannel },
+  } = await createChannelOnAppAsync(graphqlClient, {
+    appId,
+    channelName,
+    branchId,
+  });
+
+  if (!newChannel) {
+    throw new Error(
+      `Could not create channel with name ${channelName} on project with id ${appId}`
+    );
+  }
+
+  if (shouldPrintJson) {
+    printJsonOnlyOutput(newChannel);
+  } else {
+    Log.addNewLineIfNone();
+    Log.withTick(
+      `Created a new channel on project ${chalk.bold(
+        await getDisplayNameForProjectIdAsync(graphqlClient, appId)
+      )}`
+    );
+    Log.log(
+      formatFields([
+        { label: 'Name', value: newChannel.name },
+        { label: 'ID', value: newChannel.id },
+      ])
+    );
+    Log.addNewLineIfNone();
+    Log.withTick(`${branchMessage} and have pointed the channel at it.`);
+    Log.log(
+      formatFields([
+        { label: 'Name', value: newChannel.name },
+        { label: 'ID', value: branchId },
+      ])
+    );
+  }
+  return newChannel;
 }

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -1,18 +1,11 @@
 import chalk from 'chalk';
 
-import { createUpdateBranchOnAppAsync } from '../../branch/queries';
-import { BranchNotFoundError } from '../../branch/utils';
-import { createChannelOnAppAsync } from '../../channel/queries';
-import { ChannelBasicInfo } from '../../channel/utils';
+import { createAndLinkChannelAsync } from '../../channel/queries';
 import EasCommand from '../../commandUtils/EasCommand';
-import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import { BranchQuery } from '../../graphql/queries/BranchQuery';
 import Log from '../../log';
-import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import formatFields from '../../utils/formatFields';
-import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+import { enableJsonOutput } from '../../utils/json';
 
 export default class ChannelCreate extends EasCommand {
   static override description = 'create a channel';
@@ -71,76 +64,4 @@ export default class ChannelCreate extends EasCommand {
     Log.addNewLineIfNone();
     Log.log(chalk.bold('You can now update your app by publishing!'));
   }
-}
-
-export async function createAndLinkChannelAsync(
-  graphqlClient: ExpoGraphqlClient,
-  {
-    appId,
-    channelName,
-    shouldPrintJson,
-  }: { appId: string; channelName: string; shouldPrintJson?: boolean }
-): Promise<ChannelBasicInfo> {
-  let branchId: string;
-  let branchMessage: string;
-
-  try {
-    const branch = await BranchQuery.getBranchByNameAsync(graphqlClient, {
-      appId,
-      name: channelName,
-    });
-    branchId = branch.id;
-    branchMessage = `We found a branch with the same name`;
-  } catch (error) {
-    if (error instanceof BranchNotFoundError) {
-      const newBranch = await createUpdateBranchOnAppAsync(graphqlClient, {
-        appId,
-        name: channelName,
-      });
-      branchId = newBranch.id;
-      branchMessage = `We also went ahead and made a branch with the same name`;
-    } else {
-      throw error;
-    }
-  }
-
-  const {
-    updateChannel: { createUpdateChannelForApp: newChannel },
-  } = await createChannelOnAppAsync(graphqlClient, {
-    appId,
-    channelName,
-    branchId,
-  });
-
-  if (!newChannel) {
-    throw new Error(
-      `Could not create channel with name ${channelName} on project with id ${appId}`
-    );
-  }
-
-  if (shouldPrintJson) {
-    printJsonOnlyOutput(newChannel);
-  } else {
-    Log.addNewLineIfNone();
-    Log.withTick(
-      `Created a new channel on project ${chalk.bold(
-        await getDisplayNameForProjectIdAsync(graphqlClient, appId)
-      )}`
-    );
-    Log.log(
-      formatFields([
-        { label: 'Name', value: newChannel.name },
-        { label: 'ID', value: newChannel.id },
-      ])
-    );
-    Log.addNewLineIfNone();
-    Log.withTick(`${branchMessage} and have pointed the channel at it.`);
-    Log.log(
-      formatFields([
-        { label: 'Name', value: newChannel.name },
-        { label: 'ID', value: branchId },
-      ])
-    );
-  }
-  return newChannel;
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

If someone performs a build, uses `expo-updates`, EAS Update, and they declare a channel in their build profile, check if the channel exists. If it doesnt, create one and link it to a branch of the same name. This flow is shared with `eas channel:create`.

# How
Creating new channel
```
MacBook-Pro:build-test quin$ eas-dev build
✔ Select platform › All
Loaded "env" configuration for the "production" profile: no environment variables specified. Learn more: https://docs.expo.dev/build-reference/variables/

🤖 Android build

✔ Created a new channel on project @quintest113/build-test
Name  production
ID    d6562f1a-7fcd-4928-8ddc-0d506469ca40

✔ We also went ahead and made a branch with the same name and have pointed the channel at it.
Name  production
ID    4bb470a3-d54a-4932-982e-ddb33535bb7a
✔ Using remote Android credentials (Expo server)
✔ Using Keystore from configuration: Build Credentials 1_qm87913m (default)

Compressing project files and uploading to EAS Build. Learn more: https://expo.fyi/eas-build-archive
✔ Uploaded to EAS 
```

Already created channel:
```
MacBook-Pro:build-test quin$ eas-dev build
✔ Select platform › All
Loaded "env" configuration for the "production" profile: no environment variables specified. Learn more: https://docs.expo.dev/build-reference/variables/

🤖 Android build
✔ Using remote Android credentials (Expo server)
✔ Using Keystore from configuration: Build Credentials 1_qm87913m (default)

Compressing project files and uploading to EAS Build. Learn more: https://expo.fyi/eas-build-archive
✔ Uploaded to EAS 
```

# Test Plan

- [x] TODO: manually test 
