### PR TITLE
[eas-cli] [ENG-7536] Stop app config error repeating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add rollback disambiguation command. ([#2004](https://github.com/expo/eas-cli/pull/2004) by [@wschurman](https://github.com/wschurman))
 - Detect devices that fail to be provisioned, list them to the user and show the explanation message with the link to the devices page to check actual status. ([#2011](https://github.com/expo/eas-cli/pull/2011) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 - Add info to EAS Update asset upload process about asset counts and limits. ([#2013](https://github.com/expo/eas-cli/pull/2013) by [@wschurman](https://github.com/wschurman))
-
 - .nvmrc support for setting node version. ([#1954](https://github.com/expo/eas-cli/pull/1954) by [@khamilowicz](https://github.com/khamilowicz))
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add rollback disambiguation command. ([#2004](https://github.com/expo/eas-cli/pull/2004) by [@wschurman](https://github.com/wschurman))
 - Detect devices that fail to be provisioned, list them to the user and show the explanation message with the link to the devices page to check actual status. ([#2011](https://github.com/expo/eas-cli/pull/2011) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 - Add info to EAS Update asset upload process about asset counts and limits. ([#2013](https://github.com/expo/eas-cli/pull/2013) by [@wschurman](https://github.com/wschurman))
-
 - .nvmrc support for setting node version. ([#1954](https://github.com/expo/eas-cli/pull/1954) by [@khamilowicz](https://github.com/khamilowicz))
 
 ### 🐛 Bug fixes
 
 - Support republishing roll back to embedded updates. ([#2006](https://github.com/expo/eas-cli/pull/2006) by [@wschurman](https://github.com/wschurman))
+- Make app config error not repeat indefinitely. ([#2020](https://github.com/expo/eas-cli/pull/2020) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../project/projectUtils';
 import { promptAsync } from '../../../prompts';
 import { CredentialsContext } from '../../context';
+import { AndroidPackageNotDefinedError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
 
 /**
@@ -111,7 +112,7 @@ export async function getAppLookupParamsFromContextAsync(
     gradleContext
   );
   if (!androidApplicationIdentifier) {
-    throw new Error(
+    throw new AndroidPackageNotDefinedError(
       `android.package needs to be defined in your ${getProjectConfigDescription(
         ctx.projectDir
       )} file`

--- a/packages/eas-cli/src/credentials/errors.ts
+++ b/packages/eas-cli/src/credentials/errors.ts
@@ -15,3 +15,9 @@ export class UnsupportedCredentialsChoiceError extends Error {
     super(message);
   }
 }
+
+export class AndroidPackageNotDefinedError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'android.package needs to be defined in your app.json/app.config.js file');
+  }
+}

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -4,6 +4,7 @@ import assert from 'assert';
 
 import Log, { learnMore } from '../../log';
 import { GradleBuildContext, resolveGradleBuildContextAsync } from '../../project/android/gradle';
+import { getProjectConfigDescription } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { AssignFcm } from '../android/actions/AssignFcm';
 import { AssignGoogleServiceAccountKey } from '../android/actions/AssignGoogleServiceAccountKey';
@@ -131,6 +132,18 @@ export class ManageAndroid {
 
         await this.runProjectSpecificActionAsync(ctx, chosenAction, gradleContext);
       } catch (err) {
+        if (
+          err instanceof Error &&
+          err.message ===
+            `Specify "android.package" in ${getProjectConfigDescription(
+              ctx.projectDir
+            )} and run this command again.`
+        ) {
+          err.message += `\n${learnMore(
+            'https://docs.expo.dev/workflow/configuration/'
+          )} about configuration with app.json/app.config.js`;
+          throw err; // breaks out of the loop to avoid failing again after continuation
+        }
         Log.error(err);
         if (process.env.DEBUG) {
           throw err; // breaks out of the loop so we can get stack trace

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -4,7 +4,6 @@ import assert from 'assert';
 
 import Log, { learnMore } from '../../log';
 import { GradleBuildContext, resolveGradleBuildContextAsync } from '../../project/android/gradle';
-import { getProjectConfigDescription } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { AssignFcm } from '../android/actions/AssignFcm';
 import { AssignGoogleServiceAccountKey } from '../android/actions/AssignGoogleServiceAccountKey';
@@ -28,6 +27,7 @@ import {
   displayEmptyAndroidCredentials,
 } from '../android/utils/printCredentials';
 import { CredentialsContext, CredentialsContextProjectInfo } from '../context';
+import { AndroidPackageNotDefinedError } from '../errors';
 import { ActionInfo, AndroidActionType, Scope } from './Actions';
 import {
   buildCredentialsActions,
@@ -132,13 +132,7 @@ export class ManageAndroid {
 
         await this.runProjectSpecificActionAsync(ctx, chosenAction, gradleContext);
       } catch (err) {
-        if (
-          err instanceof Error &&
-          err.message ===
-            `Specify "android.package" in ${getProjectConfigDescription(
-              ctx.projectDir
-            )} and run this command again.`
-        ) {
+        if (err instanceof AndroidPackageNotDefinedError) {
           err.message += `\n${learnMore(
             'https://docs.expo.dev/workflow/configuration/'
           )} about configuration with app.json/app.config.js`;

--- a/packages/eas-cli/src/credentials/manager/__tests__/ManageAndroid-test.ts
+++ b/packages/eas-cli/src/credentials/manager/__tests__/ManageAndroid-test.ts
@@ -9,6 +9,7 @@ import { pressAnyKeyToContinueAsync } from '../../../prompts';
 import { Actor } from '../../../user/User';
 import { getAppLookupParamsFromContextAsync } from '../../android/actions/BuildCredentialsUtils';
 import { CredentialsContextProjectInfo } from '../../context';
+import { AndroidPackageNotDefinedError } from '../../errors';
 import { Action } from '../HelperActions';
 import { ManageAndroid } from '../ManageAndroid';
 
@@ -43,7 +44,9 @@ describe('runAsync', () => {
         .mockResolvedValue({} as BuildProfile<Platform.ANDROID>);
       jest.mocked(getProjectConfigDescription).mockReturnValue('app.json');
       jest.mocked(getAppLookupParamsFromContextAsync).mockImplementation(() => {
-        throw new Error('Specify "android.package" in app.json and run this command again.');
+        throw new AndroidPackageNotDefinedError(
+          'Specify "android.package" in app.json and run this command again.'
+        );
       });
       const pressAnyKeyToContinueAsyncMock = jest.mocked(pressAnyKeyToContinueAsync);
       Array.from(Array(100)).map((_, i) => {
@@ -54,7 +57,7 @@ describe('runAsync', () => {
         // fail after 102nd time
         fail('test should not reach this place - if it does, the error repeats indefinitely');
       });
-      const reThrownError = new Error(
+      const reThrownError = new AndroidPackageNotDefinedError(
         'Specify "android.package" in app.json and run this command again.\n' +
           `${learnMore(
             'https://docs.expo.dev/workflow/configuration/'

--- a/packages/eas-cli/src/credentials/manager/__tests__/ManageAndroid-test.ts
+++ b/packages/eas-cli/src/credentials/manager/__tests__/ManageAndroid-test.ts
@@ -1,0 +1,66 @@
+import { Platform } from '@expo/eas-build-job';
+import { BuildProfile, EasJsonUtils } from '@expo/eas-json';
+
+import { Analytics } from '../../../analytics/AnalyticsManager';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { learnMore } from '../../../log';
+import { getProjectConfigDescription } from '../../../project/projectUtils';
+import { pressAnyKeyToContinueAsync } from '../../../prompts';
+import { Actor } from '../../../user/User';
+import { getAppLookupParamsFromContextAsync } from '../../android/actions/BuildCredentialsUtils';
+import { CredentialsContextProjectInfo } from '../../context';
+import { Action } from '../HelperActions';
+import { ManageAndroid } from '../ManageAndroid';
+
+jest.mock('../../android/actions/BuildCredentialsUtils');
+jest.mock('../../../prompts', () => {
+  return {
+    ...jest.requireActual('../../../prompts'),
+    pressAnyKeyToContinueAsync: jest.fn(),
+  };
+});
+jest.mock('../../../project/projectUtils');
+
+describe('runAsync', () => {
+  describe('"android.package" missing in app.json', () => {
+    const manageAndroid = new ManageAndroid(
+      {
+        projectInfo: {} as CredentialsContextProjectInfo,
+        actor: {} as Actor,
+        graphqlClient: {} as ExpoGraphqlClient,
+        analytics: {} as Analytics,
+        getDynamicPrivateProjectConfigAsync: jest
+          .fn()
+          .mockResolvedValue({ exp: {}, projectId: '' }),
+        runAsync: jest.fn(),
+      } as Action,
+      ''
+    );
+    it('does not repeat the error indefinitely and prints useful error', async () => {
+      jest.spyOn(EasJsonUtils, 'getBuildProfileNamesAsync').mockResolvedValue(['testProfile']);
+      jest
+        .spyOn(EasJsonUtils, 'getBuildProfileAsync')
+        .mockResolvedValue({} as BuildProfile<Platform.ANDROID>);
+      jest.mocked(getProjectConfigDescription).mockReturnValue('app.json');
+      jest.mocked(getAppLookupParamsFromContextAsync).mockImplementation(() => {
+        throw new Error('Specify "android.package" in app.json and run this command again.');
+      });
+      const pressAnyKeyToContinueAsyncMock = jest.mocked(pressAnyKeyToContinueAsync);
+      Array.from(Array(100)).map((_, i) => {
+        // continue 101 times if error is rethrown indefinitely
+        pressAnyKeyToContinueAsyncMock.mockResolvedValueOnce();
+      });
+      pressAnyKeyToContinueAsyncMock.mockImplementationOnce(async () => {
+        // fail after 102nd time
+        fail('test should not reach this place - if it does, the error repeats indefinitely');
+      });
+      const reThrownError = new Error(
+        'Specify "android.package" in app.json and run this command again.\n' +
+          `${learnMore(
+            'https://docs.expo.dev/workflow/configuration/'
+          )} about configuration with app.json/app.config.js`
+      );
+      await expect(manageAndroid.runAsync()).rejects.toThrow(reThrownError);
+    });
+  });
+});


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-7536/make-app-config-error-on-credentials-command-not-repeat-indefinitely

# How

If app config error is thrown it is re-thrown with modified message instead of printing it to the as a "cryptic error" and repeating with 0% chances of success (since the config is incorrect)

# Test Plan

Added automated test

Tested manually:
<img width="1504" alt="Screenshot 2023-08-25 at 16 54 36" src="https://github.com/expo/eas-cli/assets/2974455/1085e1a8-1d8e-4290-ad8c-7ceb74a293a2">

The link from the message leads to the docs:
<img width="1504" alt="Screenshot 2023-08-25 at 16 54 57" src="https://github.com/expo/eas-cli/assets/2974455/1458b37e-eeba-48f4-a059-cb13023af242">
