### PR TITLE
[eas-cli] fix printing bug: branch with no update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add rollback disambiguation command. ([#2004](https://github.com/expo/eas-cli/pull/2004) by [@wschurman](https://github.com/wschurman))
 - Detect devices that fail to be provisioned, list them to the user and show the explanation message with the link to the devices page to check actual status. ([#2011](https://github.com/expo/eas-cli/pull/2011) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 - Add info to EAS Update asset upload process about asset counts and limits. ([#2013](https://github.com/expo/eas-cli/pull/2013) by [@wschurman](https://github.com/wschurman))
-
 - .nvmrc support for setting node version. ([#1954](https://github.com/expo/eas-cli/pull/1954) by [@khamilowicz](https://github.com/khamilowicz))
 
 ### 🐛 Bug fixes
 
 - Support republishing roll back to embedded updates. ([#2006](https://github.com/expo/eas-cli/pull/2006) by [@wschurman](https://github.com/wschurman))
 - Configure updates as well when somebody tries to run a build with channel set. ([#2016](https://github.com/expo/eas-cli/pull/2016) by [@wschurman](https://github.com/wschurman))
+- Fix printing bug: branch with no update. ([#2023](https://github.com/expo/eas-cli/pull/2023) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/channel/__tests__/print-utils-test.ts
+++ b/packages/eas-cli/src/channel/__tests__/print-utils-test.ts
@@ -1,0 +1,54 @@
+import { getAlwaysTrueBranchMapping, getEmptyBranchMapping } from '../branch-mapping';
+import { getDescriptionByBranchId } from '../print-utils';
+import { testChannelObject, testUpdateBranch1, testUpdateBranch2 } from './fixtures';
+
+describe(getDescriptionByBranchId, () => {
+  it('should get descriptions for multiple branches with multiple update groups', () => {
+    const descriptionByBranchId = getDescriptionByBranchId(testChannelObject);
+    expect(Object.values(descriptionByBranchId)).toHaveLength(2);
+    expect(descriptionByBranchId[testUpdateBranch1.id]).toEqual({
+      branch: 'wrong-channel',
+      branchRolloutPercentage: 15,
+      update: {
+        codeSigningKey: undefined,
+        group: '16ca6dba-e63b-48b0-baa3-15a894ee9434',
+        isRollBackToEmbedded: false,
+        message: '"fix bug" (1 month ago by quintest113)',
+        platforms: 'android, ios',
+        runtimeVersion: 'exposdk:48.0.0',
+      },
+    });
+    expect(descriptionByBranchId[testUpdateBranch2.id]).toEqual({
+      branch: 'production',
+      branchRolloutPercentage: 85,
+      update: {
+        codeSigningKey: undefined,
+        group: 'e40ad156-e9af-4cc2-8e9d-c7b5c328db48',
+        isRollBackToEmbedded: false,
+        message: '"fix bug" (2 months ago by quintest113)',
+        platforms: 'android, ios',
+        runtimeVersion: 'exposdk:48.0.0',
+      },
+    });
+  });
+  it('should get descriptions for branches with no updates', () => {
+    const noUpdatesBranch = { ...testUpdateBranch1, updateGroups: [] };
+    const oneBranchChannel = {
+      ...testChannelObject,
+      updateBranches: [noUpdatesBranch],
+      branchMapping: JSON.stringify(getAlwaysTrueBranchMapping(noUpdatesBranch.id)),
+    };
+    const descriptionByBranchId = getDescriptionByBranchId(oneBranchChannel);
+    expect(Object.values(descriptionByBranchId)).toHaveLength(1);
+    expect(descriptionByBranchId[testUpdateBranch1.id]).toEqual({ branch: 'wrong-channel' });
+  });
+  it('should get descriptions for no branches', () => {
+    const noBranchChannel = {
+      ...testChannelObject,
+      updateBranches: [],
+      branchMapping: JSON.stringify(getEmptyBranchMapping()),
+    };
+    const descriptionByBranchId = getDescriptionByBranchId(noBranchChannel);
+    expect(Object.values(descriptionByBranchId)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
Our `channel:list` and `channel:view` commands have a bug, where if a channel has a branch, but the branch has no updates, we print `There are no branches`. This is not true, so I have refactored and fixed the printing function to do the following:
- print the branch, but dont display updates if there are none
- dont throw on unsupported mappings, just print 'custom mapping detected'
- the print function assumes that the Channel object passed to it has at most one Update group (the function still works if there are multiple, but the log output isn't coherent). Refactor the function to only print the latest Update group if it exists, and make a docblock describing the behaviour.


# How
```
MacBook-Pro:test101-staging quin$ EXPO_STAGING=1 eas-dev channel:list

Channel:
Name  custom-mapping-channel
ID    1ee72531-8b16-4073-8b6a-7c67a3efb788

Branches pointed at this channel and their most recent update group:

Custom branch mapping detected.

———

Channel:
Name  staging
ID    e6cd7106-3b40-4345-8d43-394d63417e42

Branches pointed at this channel and their most recent update group:

Branch           staging
Platforms        android, ios
Runtime Version  2.0.0
Message          "Initial commit

Generated by create-expo-app 2.0.3." (1 week ago by quintest110)
Group ID         a9404fac-b4f3-443f-8216-9d5f3a156f12

———

Channel:
Name  production
ID    eebb1f97-8ef0-40ef-a0b3-ba674d0e5d45

Branches pointed at this channel and their most recent update group:

Branch           main2
Rollout          7%
Platforms        N/A
Runtime Version  N/A
Message          N/A
Group ID         N/A

———

Branch           main
Rollout          93%
Platforms        android, ios
Runtime Version  2.0.0
Message          "blah" (1 week ago by quintest110)
Group ID         18a96b43-a1a0-4003-9ea6-fce6980c2d93

———

Channel:
Name  main
ID    245eaf7c-84d0-4b54-9531-ffe592eef4e1

Branches pointed at this channel and their most recent update group:

Branch           main
Platforms        android, ios
Runtime Version  2.0.0
Message          "blah" (1 week ago by quintest110)
Group ID         18a96b43-a1a0-4003-9ea6-fce6980c2d93
```

# Test Plan
Printing functions are getting to the point where it's hard to manually test, so added unit tests for the different cases.

- [x] new tests pass
