### PR TITLE
[ENG-5266] Suggest correct bundleId when account name not available

### DIFF
--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -201,8 +201,14 @@ async function getSuggestedBundleIdentifierAsync(
   } else {
     // the only callsite is heavily interactive
     const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
+    let possibleId: string;
     // It's common to use dashes in your node project name, strip them from the suggested package name.
-    const possibleId = `com.${account.name}.${exp.slug}`.split('-').join('');
+    if (account.name) {
+      possibleId = `com.${account.name}.${exp.slug}`.split('-').join('');
+    } else {
+      possibleId = `com.${exp.slug}`.split('-').join('');
+    }
+
     if (isBundleIdentifierValid(possibleId)) {
       return possibleId;
     }


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-5266/eas-build-doesnt-use-the-bot-name-to-suggest-bundle-identifier

# How

Added special case in `getSuggestedBundleIdentifierAsync`