### PR TITLE
[eas-cli] fix `eas update` passing `platform` argument incorrectly to `expo-cli`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Pass `platform` argument to expo-cli correctly when using the `eas update` command. ([#2028](https://github.com/expo/eas-cli/pull/2028) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [5.0.0](https://github.com/expo/eas-cli/releases/tag/v5.0.0) - 2023-08-28

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -194,7 +194,9 @@ export async function buildBundlesAsync({
   }
 
   const platformArgs =
-    platformFlag === 'all' ? ['--platform', 'ios', '--platform', 'android'] : [platformFlag];
+    platformFlag === 'all'
+      ? ['--platform', 'ios', '--platform', 'android']
+      : ['--platform', platformFlag];
 
   if (shouldUseVersionedExpoCLI(projectDir, exp)) {
     await expoCommandAsync(projectDir, [


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

<img width="813" alt="Screenshot 2023-08-28 at 19 42 48" src="https://github.com/expo/eas-cli/assets/55145344/fa98aa67-45bc-40a0-b733-df5170c6ec65">

I believe that https://github.com/expo/eas-cli/pull/2002/files introduced this regression. If the `platform` argument for the `eas update` command is specified it currently calls expo cli like
```
expo-cli ... platform
```
instead of
```
expo-cli ... --platform platform
```
what seems to cause this error.

# How

If the `platform` argument is specified for the `eas update` command, pass it to `expo-cli` like `--platform platform`.

# Test Plan

Test manually
<img width="1080" alt="Screenshot 2023-08-28 at 19 43 10" src="https://github.com/expo/eas-cli/assets/55145344/ba1ff4f1-f34f-44a9-abce-7a7484862e2d">

