### PR TITLE
[eas-cli] revert update platform web exclusion

### DIFF
--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -86,11 +86,7 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
     }),
     platform: Flags.enum({
       char: 'p',
-      options: [
-        // TODO: Add web when it's fully supported
-        ...defaultPublishPlatforms,
-        'all',
-      ],
+      options: [...defaultPublishPlatforms, 'all'],
       default: 'all',
       required: false,
     }),

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -194,9 +194,7 @@ export async function buildBundlesAsync({
   }
 
   const platformArgs =
-    platformFlag === 'all'
-      ? ['--platform', 'ios', '--platform', 'android']
-      : ['--platform', platformFlag];
+    platformFlag === 'all' ? ['--platform', 'ios', '--platform', 'android'] : [platformFlag];
 
   if (shouldUseVersionedExpoCLI(projectDir, exp)) {
     await expoCommandAsync(projectDir, [

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -193,9 +193,6 @@ export async function buildBundlesAsync({
     throw new Error('Could not locate package.json');
   }
 
-  const platformArgs =
-    platformFlag === 'all' ? ['--platform', 'ios', '--platform', 'android'] : [platformFlag];
-
   if (shouldUseVersionedExpoCLI(projectDir, exp)) {
     await expoCommandAsync(projectDir, [
       'export',
@@ -203,7 +200,8 @@ export async function buildBundlesAsync({
       inputDir,
       '--dump-sourcemap',
       '--dump-assetmap',
-      ...platformArgs,
+      '--platform',
+      platformFlag,
       ...(clearCache ? ['--clear'] : []),
     ]);
   } else {
@@ -216,7 +214,8 @@ export async function buildBundlesAsync({
       '--non-interactive',
       '--dump-sourcemap',
       '--dump-assetmap',
-      ...platformArgs,
+      '--platform',
+      platformFlag,
       ...(clearCache ? ['--clear'] : []),
     ]);
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This broke updating for old expo CLI combinations.

# How

Revert.

# Test Plan

Inspect.
