### PR TITLE
[eas-cli] only print channel-branch pairing if we created a channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Make app config error not repeat indefinitely. ([#2020](https://github.com/expo/eas-cli/pull/2020) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+- Update: only print channel-branch pairing if we created a channel. ([#2036](https://github.com/expo/eas-cli/pull/2036) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -360,9 +360,10 @@ export default class UpdatePublish extends EasCommand {
         branchId,
         channelName: branchName,
       });
+      Log.withTick(
+        `Channel: ${chalk.bold(branchName)} pointed at branch: ${chalk.bold(branchName)}`
+      );
     }
-
-    Log.withTick(`Channel: ${chalk.bold(branchName)} pointed at branch: ${chalk.bold(branchName)}`);
 
     const vcsClient = getVcsClient();
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When someone runs `eas update` to publish an update to a branch (let's call it Branch X for our example), we always print `Channel X points to Branch X`. However, this is not always true. 

# How
I suspect the statement was meant to be put in the adjacent `if` clause, so I've moved it there.

In the event where Branch X does not exist, we create it. Then, we also create a channel with the same name (X). If Channel X can be created, we link it to Branch X. In the case we can create Channel X, then the statement `Channel X points to Branch X` will always be true.

# Test Plan

- [ ] manually tested
