### PR TITLE
[eas-cli] remove unreachable codesigning option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Remove unreachable codesigning option. ([#2041](https://github.com/expo/eas-cli/pull/2041) by [@quinlanj](https://github.com/quinlanj))
+
 ## [5.1.0](https://github.com/expo/eas-cli/releases/tag/v5.1.0) - 2023-09-01
 
 ### 🎉 New features

--- a/packages/eas-cli/src/rollout/actions/NonInteractiveRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/NonInteractiveRollout.ts
@@ -1,7 +1,6 @@
 import { EASUpdateAction, EASUpdateContext } from '../../eas-update/utils';
 import { UpdateChannelBasicInfoFragment } from '../../graphql/generated';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
-import { CodeSigningInfo } from '../../utils/code-signing';
 import {
   CreateRollout,
   NonInteractiveOptions as CreateRolloutNonInteractiveOptions,
@@ -25,7 +24,6 @@ export class NonInteractiveRollout implements EASUpdateAction<void> {
   constructor(
     private options: {
       channelName?: string;
-      codeSigningInfo?: CodeSigningInfo;
       action?: RolloutActions;
     } & Partial<EditRolloutNonInteractiveOptions> &
       Partial<EndRolloutNonInteractiveOptions> &


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The `codeSigningInfo` option doesn't appear to be reachable. Code signing info looks like it's populated with the `privateKeyPath` option [here](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/commands/channel/rollout.ts#L184) instead

# Test Plan

- [ ] typechecking still passes
