### PR TITLE
[eas-cli] rollouts: more robust printing function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Rollouts: more robust printing function. ([#2047](https://github.com/expo/eas-cli/pull/2047) by [@quinlanj](https://github.com/quinlanj))
+
 ## [5.2.0](https://github.com/expo/eas-cli/releases/tag/v5.2.0) - 2023-09-05
 
 ### 🎉 New features

--- a/packages/eas-cli/src/rollout/utils.ts
+++ b/packages/eas-cli/src/rollout/utils.ts
@@ -10,9 +10,13 @@ import Log from '../log';
 import { promptAsync } from '../prompts';
 import { FormattedUpdateGroupDescription, getUpdateGroupDescriptions } from '../update/utils';
 import formatFields from '../utils/formatFields';
-import { Rollout, getRollout, isConstrainedRollout } from './branch-mapping';
+import { Rollout, getRollout, isConstrainedRollout, isRollout } from './branch-mapping';
 
 export function printRollout(channel: UpdateChannelObject): void {
+  if (!isRollout(channel)) {
+    Log.log(`Channel ${chalk.bold(channel.name)} doesn't have a rollout.`);
+    return;
+  }
   const rollout = getRollout(channel);
   displayRolloutDetails(channel.name, rollout);
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

More robust printing function for rollouts

# Test Plan

- [ ] manually tested
