### PR TITLE
feat(eas-cli): expose expo export dev flag as an option in eas update

### DIFF
--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -185,12 +185,14 @@ export async function buildBundlesAsync({
   exp,
   platformFlag,
   clearCache,
+  dev = false,
 }: {
   projectDir: string;
   inputDir: string;
   exp: Pick<ExpoConfig, 'sdkVersion' | 'web'>;
   platformFlag: ExpoCLIExportPlatformFlag;
   clearCache?: boolean;
+  dev?: boolean;
 }): Promise<void> {
   const packageJSON = JsonFile.read(path.resolve(projectDir, 'package.json'));
   if (!packageJSON) {
@@ -208,6 +210,7 @@ export async function buildBundlesAsync({
       '--dump-sourcemap',
       '--dump-assetmap',
       `--platform=${platformFlag}`,
+      ...(dev ? ['--dev'] : []),
       ...(clearCache ? ['--clear'] : []),
     ]);
   }
@@ -227,6 +230,7 @@ export async function buildBundlesAsync({
       '--dump-sourcemap',
       '--dump-assetmap',
       ...platformArgs,
+      ...(dev ? ['--dev'] : []),
       ...(clearCache ? ['--clear'] : []),
     ]);
   }
@@ -248,6 +252,7 @@ export async function buildBundlesAsync({
     '--dump-sourcemap',
     '--dump-assetmap',
     `--platform=${platformFlag}`,
+    ...(dev ? ['--dev'] : []),
     ...(clearCache ? ['--clear'] : []),
   ]);
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When `__DEV__` is unset or `false`, [expo-dev-menu's `registerDevMenuItems` option is a no-op](https://github.com/expo/expo/blob/main/packages/expo-dev-menu/src/DevMenu.ts#L38-L40). 

In order to be able to use custom expo-dev-menu menu items in updates/previews for a debug build, it is necessary for the `__DEV__` global variable to be set to `true` in the generated updates and preview bundles.

EAS does not currently expose the `--dev` option from Expo CLI's `export` command, which is what determines whether or not `__DEV__` gets stripped during bundling.

# How

Adds a new CLI flag (`--dev`) to the `eas update` command.

When set, an additional CLI argument `--dev` is passed to `expo update`.

# Test Plan

I tested this in my own project and it successfully deployed an update where `__DEV__` is set to true and my custom dev menu items are being registered correctly.
