### PR TITLE
[FIX] Remove semver validation from node version read from .nvmrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Support node aliases in .nvmrc. ([#2052](https://github.com/expo/eas-cli/pull/2052) by [@khamilowicz](https://github.com/khamilowicz))
+
 ### 🧹 Chores
 
 - Rollouts: more robust printing function. ([#2047](https://github.com/expo/eas-cli/pull/2047) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/utils/profiles.ts
+++ b/packages/eas-cli/src/utils/profiles.ts
@@ -8,7 +8,6 @@ import {
 } from '@expo/eas-json';
 import fs from 'fs-extra';
 import path from 'path';
-import semver from 'semver';
 
 import Log, { learnMore } from '../log';
 

--- a/packages/eas-cli/src/utils/profiles.ts
+++ b/packages/eas-cli/src/utils/profiles.ts
@@ -83,9 +83,6 @@ async function getNodeVersionFromFileAsync(projectDir: string): Promise<string |
   } catch {
     return undefined;
   }
-  if (!semver.valid(semver.coerce(nodeVersion))) {
-    throw new Error(`Invalid node version in .nvmrc: ${nodeVersion}`);
-  }
   return nodeVersion;
 }
 


### PR DESCRIPTION

# Why

https://github.com/expo/eas-cli/issues/1975#issuecomment-1702986526
Node version can be specified as an alias (such as `iojs`, `lts/hydrogen` etc), so validating it as semver may cause errors for some users.

# How

Remove validation

# Test Plan

Specify node version in `.nvmrc` as something like `lts/gallium` and run build.