### PR TITLE
[eas-cli] [ENG-10225] add requiredPackageManager to build metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add `requiredPackageManager` to metadata. ([#2015](https://github.com/expo/eas-cli/pull/2056) by [@kadikraman](https://github.com/kadikraman))
+
 ## [5.3.0](https://github.com/expo/eas-cli/releases/tag/v5.3.0) - 2023-09-25
 
 ### 🎉 New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Add `requiredPackageManager` to metadata. ([#2015](https://github.com/expo/eas-cli/pull/2056) by [@kadikraman](https://github.com/kadikraman))
+- Add `requiredPackageManager` to metadata. ([#2015](https://github.com/expo/eas-cli/pull/2067) by [@kadikraman](https://github.com/kadikraman))
 
 ## [5.3.0](https://github.com/expo/eas-cli/releases/tag/v5.3.0) - 2023-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Add `requiredPackageManager` to metadata. ([#2015](https://github.com/expo/eas-cli/pull/2067) by [@kadikraman](https://github.com/kadikraman))
+- Add `requiredPackageManager` to metadata. ([#2067](https://github.com/expo/eas-cli/pull/2067) by [@kadikraman](https://github.com/kadikraman))
 
 ## [5.3.0](https://github.com/expo/eas-cli/releases/tag/v5.3.0) - 2023-09-25
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -14731,6 +14731,18 @@
             "deprecationReason": null
           },
           {
+            "name": "requiredPackageManager",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "resourceClass",
             "description": "The builder resource class requested by the developer",
             "args": [],
@@ -16197,6 +16209,18 @@
           },
           {
             "name": "releaseChannel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requiredPackageManager",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -9437,18 +9437,6 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
-              },
-              {
-                "name": "useDeprecatedBackend",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
               }
             ],
             "type": {
@@ -9474,18 +9462,6 @@
                     "name": "InsightsTimespan",
                     "ofType": null
                   }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "useDeprecatedBackend",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -9519,18 +9495,6 @@
                     "name": "InsightsTimespan",
                     "ofType": null
                   }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "useDeprecatedBackend",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -18,7 +18,7 @@
     "@expo/json-file": "8.2.37",
     "@expo/multipart-body-parser": "1.1.0",
     "@expo/osascript": "2.0.33",
-    "@expo/package-manager": "0.0.57",
+    "@expo/package-manager": "1.1.1",
     "@expo/pkcs12": "0.0.8",
     "@expo/plist": "0.0.20",
     "@expo/plugin-help": "5.1.22",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/config": "8.1.2",
     "@expo/config-plugins": "7.2.4",
     "@expo/config-types": "49.0.0",
-    "@expo/eas-build-job": "1.0.43",
+    "@expo/eas-build-job": "1.0.45",
     "@expo/eas-json": "5.3.0",
     "@expo/json-file": "8.2.37",
     "@expo/multipart-body-parser": "1.1.0",

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -1,6 +1,7 @@
 import { ExpoConfig } from '@expo/config';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { BuildProfile, EasJson } from '@expo/eas-json';
+import { NodePackageManager } from '@expo/package-manager';
 
 import { Analytics, AnalyticsEventProperties } from '../analytics/AnalyticsManager';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
@@ -56,4 +57,5 @@ export interface BuildContext<T extends Platform> {
   android: T extends Platform.ANDROID ? AndroidBuildContext : undefined;
   ios: T extends Platform.IOS ? IosBuildContext : undefined;
   developmentClient: boolean;
+  requiredPackageManager: NodePackageManager['name'] | null;
 }

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -1,6 +1,7 @@
 import { Platform } from '@expo/eas-build-job';
 import { BuildProfile, EasJson, ResourceClass } from '@expo/eas-json';
 import JsonFile from '@expo/json-file';
+import { resolvePackageManager } from '@expo/package-manager';
 import getenv from 'getenv';
 import resolveFrom from 'resolve-from';
 import { v4 as uuidv4 } from 'uuid';
@@ -67,6 +68,8 @@ export async function createBuildContextAsync<T extends Platform>({
       : (buildProfile as BuildProfile<Platform.IOS>)?.buildConfiguration === 'Debug') ??
     false;
 
+  const requiredPackageManager = resolvePackageManager(projectDir);
+
   const credentialsCtx = new CredentialsContext({
     projectInfo: { exp, projectId },
     nonInteractive,
@@ -127,6 +130,7 @@ export async function createBuildContextAsync<T extends Platform>({
     runFromCI,
     customBuildConfigMetadata,
     developmentClient,
+    requiredPackageManager,
   };
   if (platform === Platform.ANDROID) {
     const common = commonContext as CommonContext<Platform.ANDROID>;

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -64,6 +64,8 @@ export async function collectMetadataAsync<T extends Platform>(
     buildMode: ctx.buildProfile.config ? BuildMode.CUSTOM : BuildMode.BUILD,
     customWorkflowName: ctx.customBuildConfigMetadata?.workflowName,
     developmentClient: ctx.developmentClient,
+    // @ts-expect-error TODO needs @expo/eas-build-job to be relesed
+    requiredPackageManager: ctx.requiredPackageManager,
   };
   return sanitizeMetadata(metadata);
 }

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -64,8 +64,7 @@ export async function collectMetadataAsync<T extends Platform>(
     buildMode: ctx.buildProfile.config ? BuildMode.CUSTOM : BuildMode.BUILD,
     customWorkflowName: ctx.customBuildConfigMetadata?.workflowName,
     developmentClient: ctx.developmentClient,
-    // @ts-expect-error TODO needs @expo/eas-build-job to be relesed
-    requiredPackageManager: ctx.requiredPackageManager,
+    requiredPackageManager: ctx.requiredPackageManager ?? undefined,
   };
   return sanitizeMetadata(metadata);
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2123,6 +2123,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   queuePosition?: Maybe<Scalars['Int']>;
   reactNativeVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
+  requiredPackageManager?: Maybe<Scalars['String']>;
   /**
    * The builder resource class requested by the developer
    * @deprecated Use resourceClassDisplayName instead
@@ -2315,6 +2316,7 @@ export type BuildMetadataInput = {
   message?: InputMaybe<Scalars['String']>;
   reactNativeVersion?: InputMaybe<Scalars['String']>;
   releaseChannel?: InputMaybe<Scalars['String']>;
+  requiredPackageManager?: InputMaybe<Scalars['String']>;
   runFromCI?: InputMaybe<Scalars['Boolean']>;
   runWithNoWaitFlag?: InputMaybe<Scalars['Boolean']>;
   runtimeVersion?: InputMaybe<Scalars['String']>;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1401,19 +1401,16 @@ export type AppInsights = {
 
 export type AppInsightsTotalUniqueUsersArgs = {
   timespan: InsightsTimespan;
-  useDeprecatedBackend?: InputMaybe<Scalars['Boolean']>;
 };
 
 
 export type AppInsightsUniqueUsersByAppVersionOverTimeArgs = {
   timespan: InsightsTimespan;
-  useDeprecatedBackend?: InputMaybe<Scalars['Boolean']>;
 };
 
 
 export type AppInsightsUniqueUsersByPlatformOverTimeArgs = {
   timespan: InsightsTimespan;
-  useDeprecatedBackend?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type AppMutation = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,10 +1403,10 @@
     joi "^17.9.2"
     semver "^7.5.4"
 
-"@expo/eas-build-job@1.0.43":
-  version "1.0.43"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-1.0.43.tgz#e331b5039372c31b15aedbadc229efee3dcaefba"
-  integrity sha512-LMOoDIEax31uGBGux6/ocbCjUbWK3cUHuCxrsYlU+bvba4pGifegYWt2YQ/HC2477paq+K69IGjOUCHvNWG6Yg==
+"@expo/eas-build-job@1.0.45":
+  version "1.0.45"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-1.0.45.tgz#8a49cf6afb5abe46e3b2fb0476e4f8a7acb285a6"
+  integrity sha512-cPs4U6ROaiwW9ppWg4iy50fKBZ9pN6nLT2KdoEuui9jYFsVFxM8W8akIFDnmawJBuHY7OA7JhVsCbs+1TrLu7w==
   dependencies:
     joi "^17.9.2"
     semver "^7.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,15 +1428,6 @@
     semver "7.3.2"
     tempy "0.3.0"
 
-"@expo/json-file@8.2.36":
-  version "8.2.36"
-  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.36.tgz#62a505cb7f30a34d097386476794680a3f7385ff"
-  integrity sha512-tOZfTiIFA5KmMpdW9KF7bc6CFiGjb0xnbieJhTGlHrLL+ps2G0OkqmuZ3pFEXBOMnJYUVpnSy++52LFxvpa5ZQ==
-  dependencies:
-    "@babel/code-frame" "~7.10.4"
-    json5 "^1.0.1"
-    write-file-atomic "^2.3.0"
-
 "@expo/json-file@8.2.37", "@expo/json-file@^8.2.37", "@expo/json-file@~8.2.37":
   version "8.2.37"
   resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.37.tgz#9c02d3b42134907c69cc0a027b18671b69344049"
@@ -1471,19 +1462,20 @@
     "@expo/spawn-async" "^1.5.0"
     exec-async "^2.2.0"
 
-"@expo/package-manager@0.0.57":
-  version "0.0.57"
-  resolved "https://registry.yarnpkg.com/@expo/package-manager/-/package-manager-0.0.57.tgz#1cd71da0632c52a9a001b45e5d0d7e1e16de97d3"
-  integrity sha512-Y4RpSL9EqaPF+Vd2GrK6r7Xx7Dv0Xdq3AGAD9C0KwV21WqP/scj/dpjxFY+ABwmdhNsFzYXb8fmDyh4tiKenPQ==
+"@expo/package-manager@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@expo/package-manager/-/package-manager-1.1.1.tgz#065326c5684c2acfbfdc290d93eabb7a36225507"
+  integrity sha512-NxtfIA25iEiNwMT+s8PEmdKzjyfWd2qkCLJkf6jKZGaH9c06YXyOAi2jvCyM8XuSzJz4pcEH8kz1HkJAInjB7Q==
   dependencies:
-    "@expo/json-file" "8.2.36"
+    "@expo/json-file" "^8.2.37"
     "@expo/spawn-async" "^1.5.0"
     ansi-regex "^5.0.0"
     chalk "^4.0.0"
     find-up "^5.0.0"
     find-yarn-workspace-root "~2.0.0"
+    js-yaml "^3.13.1"
+    micromatch "^4.0.2"
     npm-package-arg "^7.0.0"
-    rimraf "^3.0.2"
     split "^1.0.1"
     sudo-prompt "9.1.1"
 


### PR DESCRIPTION
# Why

We want to know what the user's package manager is going to be at the "install custom tools" step of the build process, so we're determining it based on the user's lockfiles and adding it to build metadata.

1. `eas-build-job` https://github.com/expo/eas-build/pull/281
2. `www` https://github.com/expo/universe/pull/13522
3. 👉 `eas-cli` https://github.com/expo/eas-cli/pull/2067
4. `turtle-v2` https://github.com/expo/turtle-v2/pull/1460

# How

Added the field.

# Test Plan

Unit tests and building locally.
