### PR TITLE
[ENG-10176][eas-json] update images info in `eas.schema.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Update EAS Build images description in our VSCode plugin. Add new `macos-ventura-13.6-xcode-15.0` image. ([#2068](https://github.com/expo/eas-cli/pull/2068) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [5.3.0](https://github.com/expo/eas-cli/releases/tag/v5.3.0) - 2023-09-25
 
 ### 🎉 New features

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -24,19 +24,14 @@
         "version": {
           "type": "string",
           "description": "The compatible versions of EAS CLI with this config",
-          "examples": [
-            ">=0.54.1"
-          ]
+          "examples": [">=0.54.1"]
         },
         "requireCommit": {
           "type": "boolean",
           "description": "If all changes required to be committed before building or submitting"
         },
         "appVersionSource": {
-          "enum": [
-            "local",
-            "remote"
-          ],
+          "enum": ["local", "remote"],
           "markdownDescription": "Version policy defines whether version of your app should be based on your local project or values stored on EAS servers (remote).\n\nThis is the configuration required for `eas build:version:set` and works with the `autoIncrement` options per platform.",
           "markdownEnumDescriptions": [
             "When using local, the `autoIncrement` is based on your local project values.",
@@ -107,10 +102,7 @@
           "description": "The name of the build profile that the current one should inherit values from. This value can't be specified per platform."
         },
         "credentialsSource": {
-          "enum": [
-            "remote",
-            "local"
-          ],
+          "enum": ["remote", "local"],
           "description": "The source of credentials used to sign build artifacts. Learn more: https://docs.expo.dev/app-signing/local-credentials/",
           "markdownDescription": "The source of credentials used to sign build artifacts.\n\n- `remote` - if you want to use the credentials managed by EAS.\n- `local` - if you want to provide your own `credentials.json` file. [learn more](https://docs.expo.dev/app-signing/local-credentials/)",
           "default": "remote",
@@ -132,10 +124,7 @@
           "markdownDescription": "The channel is a name we can give to multiple builds to identify them easily. [Learn more](https://docs.expo.dev/eas-update/how-eas-update-works/)\n\n**This field only applies to the EAS Update service**, if your project still uses Classic Updates then use the [releaseChannel](https://docs.expo.dev/build-reference/eas-json/#releasechannel) field instead."
         },
         "distribution": {
-          "enum": [
-            "internal",
-            "store"
-          ],
+          "enum": ["internal", "store"],
           "description": "The method of distributing your app. Learn more: https://docs.expo.dev/build/internal-distribution/",
           "markdownDescription": "The method of distributing your app.\n\n- `internal` - with this option you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK or IPA file. Otherwise, the shareable URL will be useless. [Learn more](https://docs.expo.dev/build/internal-distribution/)\n- `store` - produces builds for store uploads, your build URLs won't be shareable.",
           "markdownEnumDescriptions": [
@@ -214,11 +203,7 @@
           "default": "default",
           "anyOf": [
             {
-              "enum": [
-                "default",
-                "medium",
-                "large"
-              ]
+              "enum": ["default", "medium", "large"]
             },
             {
               "type": "string"
@@ -277,11 +262,7 @@
           "default": "default",
           "anyOf": [
             {
-              "enum": [
-                "default",
-                "medium",
-                "large"
-              ]
+              "enum": ["default", "medium", "large"]
             },
             {
               "type": "string"
@@ -293,12 +274,7 @@
           "description": "The version of Android NDK."
         },
         "autoIncrement": {
-          "enum": [
-            false,
-            true,
-            "versionCode",
-            "version"
-          ],
+          "enum": [false, true, "versionCode", "version"],
           "description": "Controls how EAS CLI bumps your application build version.",
           "markdownDescription": "Controls how EAS CLI bumps your application build version.\n\nAllowed values:\n- `\"version\"` - bumps the patch of `expo.version` (e.g. `1.2.3` -> `1.2.4`).\n- `\"versionCode\"` (or `true`) - bumps `expo.android.versionCode` (e.g. `3` -> `4`).\n- `false` - versions won't be bumped automatically (default)\n\nIn the case of a bare project, it also updates versions in native code. `expo.version` corresponds to `versionName` and `expo.android.versionCode` to `versionCode` in the `build.gradle`. Google Play uses these values to identify the app build, `versionName` is the version visible to users, whereas `versionCode` defines the version number. The combination of those needs to be unique, so you can bump either of them.\n\nThis feature is not intended for use with dynamic configuration (app.config.js). EAS CLI will throw an error if you don't use app.json.",
           "default": false,
@@ -310,10 +286,7 @@
           ]
         },
         "buildType": {
-          "enum": [
-            "app-bundle",
-            "apk"
-          ],
+          "enum": ["app-bundle", "apk"],
           "description": "Type of the artifact you want to build.",
           "markdownDescription": "Type of the artifact you want to build. It controls what Gradle task will be used, can be overridden by `gradleCommand` or `developmentClient: true` option.\n- `app-bundle` - `:app:bundleRelease`\n- `apk` - `:app:assembleRelease`",
           "markdownEnumDescriptions": [
@@ -356,22 +329,14 @@
           "default": false
         },
         "enterpriseProvisioning": {
-          "enum": [
-            "universal",
-            "adhoc"
-          ],
+          "enum": ["universal", "adhoc"],
           "markdownDescription": "Provisioning method used for `\"distribution\": \"internal\"` when you have an Apple account with Apple Developer Enterprise Program membership.\n\nYou can choose if you want to use `adhoc` or `universal` provisioning. The latter is recommended as it does not require you to register each individual device. If you don't provide this option and you still authenticate with an enterprise team, you'll be prompted which provisioning method to use.",
           "markdownEnumDescriptions": [
             "Recommended as it does not require you to register each individual device"
           ]
         },
         "autoIncrement": {
-          "enum": [
-            false,
-            true,
-            "buildNumber",
-            "version"
-          ],
+          "enum": [false, true, "buildNumber", "version"],
           "description": "Controls how EAS CLI bumps your application build version.",
           "markdownDescription": "Controls how EAS CLI bumps your application build version.\n\nAllowed values:\n\n- `\"version\"` - bumps the patch of `expo.version` (e.g. `1.2.3` -> `1.2.4`).\n- `\"buildNumber\"` (or `true`) - bumps the last component of `expo.ios.buildNumber` (e.g. `1.2.3.39` -> `1.2.3.40`).\n- `false` - versions won't be bumped automatically (default)\n\nIn the case of a bare project, it also updates versions in native code. `expo.version` corresponds to `CFBundleShortVersionString` and `expo.ios.buildNumber` to `CFBundleVersion` in the `Info.plist`. The App Store is using those values to identify the app build, `CFBundleShortVersionString` is the version visible to users, whereas `CFBundleVersion` defines the build number. The combination of those needs to be unique, so you can bump either of them.\n\nThis feature is not intended for use with dynamic configuration (app.config.js). EAS CLI will throw an error if you don't use app.json.",
           "default": false,
@@ -391,26 +356,32 @@
               "enum": [
                 "default",
                 "latest",
+                "macos-ventura-13.6-xcode-15.0",
                 "macos-ventura-13.4-xcode-14.3.1",
                 "macos-ventura-13.3-xcode-14.3",
                 "macos-monterey-12.6-xcode-14.2",
                 "macos-monterey-12.6-xcode-14.1",
-                "macos-monterey-12.6-xcode-14.0",
-                "macos-monterey-12.4-xcode-13.4",
-                "macos-monterey-12.3-xcode-13.3",
-                "macos-monterey-12.1-xcode-13.2",
-                "macos-big-sur-11.4-xcode-13.0",
-                "macos-big-sur-11.4-xcode-12.5"
+                "macos-monterey-12.6-xcode-14.0"
               ],
               "markdownEnumDescriptions": [
-                "`macos-ventura-13.3-xcode-14.3` for Apple silicon builders, `macos-monterey-12.6-xcode-14.1` for Intel builders",
-                "`macos-ventura-13.4-xcode-14.3.1` for Apple silicon builders, `macos-monterey-12.6-xcode-14.2` for Intel builders",
+                "`macos-ventura-13.4-xcode-14.3.1`",
+                "`macos-ventura-13.6-xcode-15.0`",
                 "only available for Apple silicon builders",
                 "only available for Apple silicon builders"
               ]
             },
             {
-              "type": "string"
+              "deprecated": true,
+              "enum": [
+                "macos-monterey-12.4-xcode-13.4",
+                "macos-monterey-12.3-xcode-13.3",
+                "macos-monterey-12.1-xcode-13.2"
+              ],
+              "markdownEnumDescriptions": [
+                "This image is deprecated, please use one of the more recent images instead.",
+                "This image is deprecated, please use one of the more recent images instead.",
+                "This image is deprecated, please use one of the more recent images instead."
+              ]
             }
           ]
         },
@@ -420,12 +391,7 @@
           "default": "default",
           "anyOf": [
             {
-              "enum": [
-                "default",
-                "medium",
-                "large",
-                "m-medium"
-              ]
+              "enum": ["default", "medium", "large", "m-medium"]
             },
             {
               "type": "string"
@@ -505,12 +471,7 @@
           "markdownDescription": "Path to the JSON file with service account key used to authenticate with Google Play. [Learn more](https://expo.fyi/creating-google-service-account)"
         },
         "track": {
-          "enum": [
-            "beta",
-            "alpha",
-            "internal",
-            "production"
-          ],
+          "enum": ["beta", "alpha", "internal", "production"],
           "description": "The track of the application to use. Learn more: https://support.google.com/googleplay/android-developer/answer/9859348?hl=en",
           "markdownDescription": "The [track of the application](https://support.google.com/googleplay/android-developer/answer/9859348?hl=en) to use.",
           "markdownEnumDescriptions": [
@@ -521,12 +482,7 @@
           ]
         },
         "releaseStatus": {
-          "enum": [
-            "draft",
-            "inProgress",
-            "halted",
-            "completed"
-          ],
+          "enum": ["draft", "inProgress", "halted", "completed"],
           "description": "The status of a release. Learn more: https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks",
           "markdownDescription": "The status of a release. [Learn more](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks)",
           "enumDescriptions": [


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We've added a new `macos-ventura-13.6-xcode-15.0` image. It's also a good opportunity to clean up a bit by deprecating some images and deleting images only available for Intel workers which we will delete soon (29th September).

# How

Updated `eas.schema.json`. Use @byCedric suggestion to mark some images as deprecated by using the new syntax.
