### PR TITLE
feat: add tap to pay on iphone entitlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add support for the Tap to Pay on iPhone iOS entitlement. ([#2069](https://github.com/expo/eas-cli/pull/2069) by [@fobos531](https://github.com/fobos531))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "1.3.1",
+    "@expo/apple-utils": "1.3.2",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "8.1.2",
     "@expo/config-plugins": "7.2.4",

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -734,6 +734,13 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     getOptions: getBooleanOptions,
   },
   {
+    entitlement: 'com.apple.developer.proximity-reader.payment.acceptance',
+    name: 'Tap to Pay on iPhone',
+    capability: CapabilityType.TAP_TO_DISPLAY_ID,
+    validateOptions: validateBooleanOptions,
+    getOptions: getBooleanOptions,
+  },
+  {
     entitlement: 'com.apple.developer.matter.allow-setup-payload',
     name: 'Matter Allow Setup Payload',
     capability: CapabilityType.MATTER_ALLOW_SETUP_PAYLOAD,

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -736,7 +736,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
   {
     entitlement: 'com.apple.developer.proximity-reader.payment.acceptance',
     name: 'Tap to Pay on iPhone',
-    capability: CapabilityType.TAP_TO_DISPLAY_ID,
+    capability: 'TAP_TO_PAY_ON_IPHONE' as CapabilityType,
     validateOptions: validateBooleanOptions,
     getOptions: getBooleanOptions,
   },

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -736,7 +736,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
   {
     entitlement: 'com.apple.developer.proximity-reader.payment.acceptance',
     name: 'Tap to Pay on iPhone',
-    capability: 'TAP_TO_PAY_ON_IPHONE' as CapabilityType,
+    capability: CapabilityType.TAP_TO_PAY_ON_IPHONE,
     validateOptions: validateBooleanOptions,
     getOptions: getBooleanOptions,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,10 +1329,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@expo/apple-utils@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.3.1.tgz#99a2627c167af138722af9806a09a35f87115a39"
-  integrity sha512-ADPHXIpTWlt9tIg9yhwyuxQ6UMICWMfHgoCE1v8zzyYsa3BcKvawgkAGApYNxp2IYUKiNMqRYzViEKgq+Svk3w==
+"@expo/apple-utils@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.3.2.tgz#c2c80e03bb4c310e183b109ea37bbc88cef59313"
+  integrity sha512-8utf2r+ka9uI1qhazBEbLzjPX0CIBvvpBHy0o4XFoLUiZDvBqGBEctduvJc49hvu/16hxVtNqGXs1U97OVKe4g==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Seems like it's missing - but not sure if that was intentional or there's any other hindrance to it? 

# How

Add the entitlement object exactly like the others. It doesn't seem like there's anything else to do? 

# Test Plan

@EvanBacon It seems `@expo/apple-utils` is a private package, so I cannot contribute a change to add a `TAP_TO_PAY_ON_IPHONE` constant for the `CapabilityType` - for now I just force casted this to keep TS happy. 

Thoughts?