### PR TITLE
[eas-update] Increase asset upload timeout to 90s and reset on upload retry for slow connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- EAS Update: Increase asset upload timeout to 90s and reset on upload retry for slow connections. ([#2085](https://github.com/expo/eas-cli/pull/2085) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 - Add `requiredPackageManager` to metadata. ([#2067](https://github.com/expo/eas-cli/pull/2067) by [@kadikraman](https://github.com/kadikraman))

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -250,20 +250,22 @@ export default class UpdatePublish extends EasCommand {
       realizedPlatforms = Object.keys(assets) as PublishPlatform[];
 
       // Timeout mechanism:
-      // - Start with 60 second timeout. 60 seconds is chosen because the cloud function that processes
-      //   uploaded assets has a timeout of 60 seconds.
-      // - Each time one or more assets reports as ready, reset the timeout to 60 seconds.
-      // - Start upload. Internally, uploadAssetsAsync uploads them all and then checks for successful
+      // - Start with NO_ACTIVITY_TIMEOUT. 90 seconds is chosen because the cloud function that processes
+      //   uploaded assets has a timeout of 60 seconds and uploading can take some time on a slow connection.
+      // - Each time one or more assets reports as ready, reset the timeout.
+      // - Each time an asset upload begins, reset the timeout. This includes retries.
+      // - Start upload. Internally, uploadAssetsAsync uploads them all first and then checks for successful
       //   processing every (5 + n) seconds with a linear backoff of n + 1 second.
       // - At the same time as upload is started, start timeout checker which checks every 1 second to see
       //   if timeout has been reached. When timeout expires, send a cancellation signal to currently running
       //   upload function call to instruct it to stop uploading or checking for successful processing.
+      const NO_ACTIVITY_TIMEOUT = 90 * 1000; // 90 seconds
       let lastUploadedStorageKeys = new Set<string>();
       let lastAssetUploadResults: {
         asset: RawAsset & { storageKey: string };
         finished: boolean;
       }[] = [];
-      let timeAtWhichToTimeout = Date.now() + 60 * 1000; // sixty seconds from now
+      let timeAtWhichToTimeout = Date.now() + NO_ACTIVITY_TIMEOUT;
       const cancelationToken = { isCanceledOrFinished: false };
 
       const uploadResults = await Promise.race([
@@ -277,7 +279,7 @@ export default class UpdatePublish extends EasCommand {
               assetUploadResults.filter(r => r.finished).map(r => r.asset.storageKey)
             );
             if (!areSetsEqual(currentUploadedStorageKeys, lastUploadedStorageKeys)) {
-              timeAtWhichToTimeout = Date.now() + 60 * 1000; // reset timeout to sixty seconds from now
+              timeAtWhichToTimeout = Date.now() + NO_ACTIVITY_TIMEOUT; // reset timeout to NO_ACTIVITY_TIMEOUT
               lastUploadedStorageKeys = currentUploadedStorageKeys;
               lastAssetUploadResults = assetUploadResults;
             }
@@ -285,6 +287,10 @@ export default class UpdatePublish extends EasCommand {
             const totalAssets = assetUploadResults.length;
             const missingAssetCount = assetUploadResults.filter(a => !a.finished).length;
             assetSpinner.text = `Uploading (${totalAssets - missingAssetCount}/${totalAssets})`;
+          },
+          () => {
+            // when an upload is retried, reset the timeout as we know this will now need more time
+            timeAtWhichToTimeout = Date.now() + NO_ACTIVITY_TIMEOUT; // reset timeout to NO_ACTIVITY_TIMEOUT
           }
         ),
         (async () => {

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -576,6 +576,7 @@ describe(uploadAssetsAsync, () => {
         assetsForUpdateInfoGroup,
         testProjectId,
         { isCanceledOrFinished: false },
+        () => {},
         () => {}
       )
     ).resolves.toEqual({
@@ -622,6 +623,7 @@ describe(uploadAssetsAsync, () => {
         {
           isCanceledOrFinished: false,
         },
+        () => {},
         () => {}
       )
     ).resolves.toEqual({
@@ -667,7 +669,8 @@ describe(uploadAssetsAsync, () => {
       assetsForUpdateInfoGroup,
       testProjectId,
       { isCanceledOrFinished: false },
-      onAssetUploadResultsChangedFn
+      onAssetUploadResultsChangedFn,
+      () => {}
     );
     expect(onAssetUploadResultsChangedFn).toHaveBeenCalledTimes(3);
   });

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -424,7 +424,8 @@ export async function uploadAssetsAsync(
   cancelationToken: { isCanceledOrFinished: boolean },
   onAssetUploadResultsChanged: (
     assetUploadResults: { asset: RawAsset & { storageKey: string }; finished: boolean }[]
-  ) => void
+  ) => void,
+  onAssetUploadBegin: () => void
 ): Promise<AssetUploadResult> {
   let assets: RawAsset[] = [];
   let platform: keyof CollectedAssets;
@@ -486,7 +487,11 @@ export async function uploadAssetsAsync(
           throw Error('Canceled upload');
         }
         const presignedPost: PresignedPost = JSON.parse(specifications[i]);
-        await uploadWithPresignedPostWithRetryAsync(missingAsset.path, presignedPost);
+        await uploadWithPresignedPostWithRetryAsync(
+          missingAsset.path,
+          presignedPost,
+          onAssetUploadBegin
+        );
       });
     }),
   ]);

--- a/packages/eas-cli/src/uploads.ts
+++ b/packages/eas-cli/src/uploads.ts
@@ -28,13 +28,15 @@ export async function uploadFileAtPathToGCSAsync(
 
 export async function uploadWithPresignedPostWithRetryAsync(
   file: string,
-  presignedPost: PresignedPost
+  presignedPost: PresignedPost,
+  onAssetUploadBegin: () => void
 ): Promise<Response> {
   return await promiseRetry(
     async retry => {
       // retry fetch errors (usually connection or DNS errors)
       let response: Response;
       try {
+        onAssetUploadBegin();
         response = await uploadWithPresignedPostAsync(file, presignedPost);
       } catch (e: any) {
         return retry(e);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

For slow connections that take a while to upload, 60s is not enough of a timeout. For example, lets say there's only one asset to upload, and it takes even 1 second to upload and 60s to process (the max of the cloud function), it'll time out. The p99 of the processing cloud function is 29s, so changing this timeout to 90s gives a upload timeout of 60s.

We also change the semantics of when to reset the timeout, and now reset it when the upload is retried. So, in the example above, let's say the asset takes 59 seconds to upload, but fails at the 58th second, it will be retried and the timeout will reset to give it an additional 60 seconds to upload.

# Test Plan

This is tough to test. Would need to simulate a super slow connection and some failures.

Tested manually by uploading 5k assets (1 failed randomly, not sure why, but lucky that it did and timeout still worked) and seeing that the timeout still worked.