### PR TITLE
[expo-updates] Gate roll back to embedded to expo-updates >= 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add account type to the items in the prompt to select project owner. ([#2083](https://github.com/expo/eas-cli/pull/2083) by [@alanjhughes](https://github.com/alanjhughes))
+- Gate roll back to embedded to expo-updates >= 0.19.0. ([#2094](https://github.com/expo/eas-cli/pull/2094) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
@@ -43,6 +43,10 @@ jest.mock('@expo/config');
 jest.mock('@expo/config-plugins');
 jest.mock('../../../branch/queries');
 jest.mock('../../../commandUtils/context/contextUtils/getProjectIdAsync');
+jest.mock('../../../project/projectUtils', () => ({
+  ...jest.requireActual('../../../project/projectUtils'),
+  enforceRollBackToEmbeddedUpdateSupportAsync: jest.fn(),
+}));
 jest.mock('../../../update/configure');
 jest.mock('../../../update/getBranchNameFromChannelNameAsync');
 jest.mock('../../../graphql/mutations/PublishMutation');

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -20,7 +20,10 @@ import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import Log, { link } from '../../log';
 import { ora } from '../../ora';
 import { RequestedPlatform } from '../../platform';
-import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
+import {
+  enforceRollBackToEmbeddedUpdateSupportAsync,
+  getOwnerAccountForProjectIdAsync,
+} from '../../project/projectUtils';
 import {
   ExpoCLIExportPlatformFlag,
   defaultPublishPlatforms,
@@ -68,7 +71,6 @@ type UpdateFlags = {
 };
 
 export default class UpdateRollBackToEmbedded extends EasCommand {
-  static override hidden = true; // until we launch
   static override description = 'roll back to the embedded update';
 
   static override flags = {
@@ -151,6 +153,9 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
       projectDir,
       projectId,
     });
+
+    // check that the expo-updates package version supports roll back to embedded
+    await enforceRollBackToEmbeddedUpdateSupportAsync(projectDir);
 
     const { exp } = await getDynamicPublicProjectConfigAsync();
     const { exp: expPrivate } = await getDynamicPrivateProjectConfigAsync();

--- a/packages/eas-cli/src/commands/update/rollback.ts
+++ b/packages/eas-cli/src/commands/update/rollback.ts
@@ -8,8 +8,6 @@ import UpdateRollBackToEmbedded from './roll-back-to-embedded';
 export default class UpdateRollback extends EasCommand {
   static override description = 'roll back to an embedded update or an existing update';
 
-  static override hidden = true;
-
   static override flags = {
     'private-key-path': Flags.string({
       description: `File containing the PEM-encoded private key corresponding to the certificate in expo-updates' configuration. Defaults to a file named "private-key.pem" in the certificate's directory.`,

--- a/packages/eas-cli/src/project/__tests__/projectUtils.test.ts
+++ b/packages/eas-cli/src/project/__tests__/projectUtils.test.ts
@@ -1,0 +1,68 @@
+import { AppJSONConfig, PackageJSONConfig } from '@expo/config';
+import { vol } from 'memfs';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+import { enforceRollBackToEmbeddedUpdateSupportAsync } from '../projectUtils';
+
+jest.mock('fs');
+jest.mock('resolve-from');
+
+const projectRoot = '/test-project';
+
+describe(enforceRollBackToEmbeddedUpdateSupportAsync, () => {
+  it('does not throw when an appropriate version is installed', async () => {
+    mockTestProject('0.19.1');
+
+    await enforceRollBackToEmbeddedUpdateSupportAsync(projectRoot);
+  });
+
+  it('throws when an unappropriate version is installed', async () => {
+    mockTestProject('0.18.0');
+
+    await expect(enforceRollBackToEmbeddedUpdateSupportAsync(projectRoot)).rejects.toThrowError(
+      'The expo-updates package must have a version >= 0.19.0 to use roll back to embedded, which corresponds to Expo SDK 50 or greater.'
+    );
+  });
+});
+
+function mockTestProject(expoUpdatesPackageVersion: string): { appJson: AppJSONConfig } {
+  const packageJSON: PackageJSONConfig = {
+    name: 'testing123',
+    version: '0.1.0',
+    description: 'fake description',
+    main: 'index.js',
+    dependencies: {
+      'expo-updates': expoUpdatesPackageVersion,
+    },
+  };
+
+  const expoUpdatesPackageJSON: PackageJSONConfig = {
+    name: 'expo-updates',
+    version: expoUpdatesPackageVersion,
+  };
+
+  const appJSON: AppJSONConfig = {
+    expo: {
+      name: 'testing 123',
+      version: '0.1.0',
+      slug: 'testing-123',
+      sdkVersion: '33.0.0',
+    },
+  };
+
+  jest
+    .mocked(resolveFrom.silent)
+    .mockReturnValue(path.join(projectRoot, 'node_modules/expo-updates/package.json'));
+
+  vol.fromJSON(
+    {
+      'package.json': JSON.stringify(packageJSON),
+      'app.json': JSON.stringify(appJSON),
+      'node_modules/expo-updates/package.json': JSON.stringify(expoUpdatesPackageJSON),
+    },
+    projectRoot
+  );
+
+  return { appJson: appJSON };
+}

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -109,6 +109,23 @@ export async function validateAppVersionRuntimePolicySupportAsync(
   );
 }
 
+export async function enforceRollBackToEmbeddedUpdateSupportAsync(
+  projectDir: string
+): Promise<void> {
+  const maybePackageJson = resolveFrom.silent(projectDir, 'expo-updates/package.json');
+
+  if (maybePackageJson) {
+    const { version } = await fs.readJson(maybePackageJson);
+    if (semver.gte(version, '0.19.0')) {
+      return;
+    }
+  }
+
+  throw new Error(
+    'The expo-updates package must have a version >= 0.19.0 to use roll back to embedded, which corresponds to Expo SDK 50 or greater.'
+  );
+}
+
 export async function installExpoUpdatesAsync(
   projectDir: string,
   options?: { silent: boolean }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This feature wasn't officially added and tested until 0.19.0. It still hasn't been fully dogfooded or documented, but should theoretically be ready to release as of 0.19.0.

We can always change this in the future to something higher if we find bugs.

# How

Add condition to running the command and also release commands publicly.

# Test Plan

Run new tests.
