### PR TITLE
[ci] Try to fix changelog-bot usage of hub CLI

### DIFF
--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 18
       - name: Checkout Pull Request
-        run: hub pr checkout ${{ github.event.issue.number }}
+        run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`hub` was removed: https://github.com/mislav/hub/issues/3338

our action is failing: https://github.com/expo/eas-cli/actions/runs/6565215869

# How

Use `gh` CLI instead.

# Test Plan

It is preinstalled so it should be good to go.
