### PR TITLE
[ci] fix `release-changelog` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
         working-directory: ./scripts
         run: yarn --silent release-changelog $EAS_CLI_VERSION > /tmp/current-changelog
       - name: Publish release
-        run: hub release edit v$EAS_CLI_VERSION --draft=false -F /tmp/current-changelog
+        run: gh release edit v$EAS_CLI_VERSION --draft=false -F /tmp/current-changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Commit and push


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://github.com/expo/eas-cli/actions/runs/6638762355/job/18036077524

Similar to https://github.com/expo/eas-cli/pull/2095

# How

Use `gh` instead of `hub`
