### PR TITLE
[eas-cli] [ENG-8973] Use selected builds profile name if not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Use corresponding submit profile when selecting build from EAS. ([#2101](https://github.com/expo/eas-cli/pull/2101) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -138,6 +138,7 @@ export default class Submit extends EasCommand {
         exp,
         projectId,
         vcsClient,
+        specifiedProfile: flagsWithPlatform.profile,
       });
 
       if (submissionProfiles.length > 1) {

--- a/packages/eas-cli/src/submit/__tests__/commons-test.ts
+++ b/packages/eas-cli/src/submit/__tests__/commons-test.ts
@@ -1,0 +1,134 @@
+import { Platform } from '@expo/eas-build-job';
+import {
+  AndroidReleaseStatus,
+  AndroidReleaseTrack,
+  EasJsonAccessor,
+  EasJsonUtils,
+} from '@expo/eas-json';
+import { MissingProfileError } from '@expo/eas-json/build/errors';
+
+import { refreshContextSubmitProfileAsync } from '../commons';
+import { SubmissionContext } from '../context';
+
+jest.mock('@expo/eas-json');
+
+describe(refreshContextSubmitProfileAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('iOS', () => {
+    it('returns updated context if profile exists', async () => {
+      const submitContext = {
+        profile: { language: 'pl-PL' },
+      } as any as SubmissionContext<Platform.IOS>;
+      jest
+        .mocked(EasJsonUtils.getSubmitProfileAsync)
+        .mockImplementation(
+          async (
+            _accessor: EasJsonAccessor,
+            _platform: Platform,
+            _profileName: string | undefined
+          ) => {
+            return { language: 'en-US' };
+          }
+        );
+
+      const result = await refreshContextSubmitProfileAsync(submitContext, 'existingProfile');
+
+      expect(result).toEqual({ profile: { language: 'en-US' } });
+    });
+    it('returns unmodified context if profile does not exist', async () => {
+      const submitContext = {
+        profile: { language: 'pl-PL' },
+      } as any as SubmissionContext<Platform.IOS>;
+      jest
+        .mocked(EasJsonUtils.getSubmitProfileAsync)
+        .mockImplementation(
+          async (
+            _accessor: EasJsonAccessor,
+            _platform: Platform,
+            profileName: string | undefined
+          ) => {
+            throw new MissingProfileError(`Missing submit profile in eas.json: ${profileName}`);
+          }
+        );
+
+      const result = await refreshContextSubmitProfileAsync(submitContext, 'nonExistingProfile');
+
+      expect(result).toEqual({ profile: { language: 'pl-PL' } });
+    });
+  });
+
+  describe('Android', () => {
+    it('returns updated context if profile exists', async () => {
+      const submitContext = {
+        profile: {
+          track: AndroidReleaseTrack.internal,
+          releaseStatus: AndroidReleaseStatus.draft,
+          changesNotSentForReview: false,
+          applicationId: 'appId1',
+        },
+      } as any as SubmissionContext<Platform.ANDROID>;
+      jest
+        .mocked(EasJsonUtils.getSubmitProfileAsync)
+        .mockImplementation(
+          async (
+            _accessor: EasJsonAccessor,
+            _platform: Platform,
+            _profileName: string | undefined
+          ) => {
+            return {
+              track: AndroidReleaseTrack.beta,
+              releaseStatus: AndroidReleaseStatus.inProgress,
+              changesNotSentForReview: true,
+              applicationId: 'appId2',
+            };
+          }
+        );
+
+      const result = await refreshContextSubmitProfileAsync(submitContext, 'existingProfile');
+
+      expect(result).toEqual({
+        profile: {
+          track: AndroidReleaseTrack.beta,
+          releaseStatus: AndroidReleaseStatus.inProgress,
+          changesNotSentForReview: true,
+          applicationId: 'appId2',
+        },
+      });
+    });
+    it('returns unmodified context if profile does not exist', async () => {
+      const submitContext = {
+        profile: {
+          track: AndroidReleaseTrack.internal,
+          releaseStatus: AndroidReleaseStatus.draft,
+          changesNotSentForReview: false,
+          applicationId: 'appId1',
+        },
+      } as any as SubmissionContext<Platform.ANDROID>;
+      jest
+        .mocked(EasJsonUtils.getSubmitProfileAsync)
+        .mockImplementation(
+          async (
+            _accessor: EasJsonAccessor,
+            _platform: Platform,
+            profileName: string | undefined
+          ) => {
+            throw new MissingProfileError(`Missing submit profile in eas.json: ${profileName}`);
+          }
+        );
+
+      const result = await refreshContextSubmitProfileAsync(submitContext, 'nonExistingProfile');
+
+      expect(result).toEqual({
+        profile: {
+          track: AndroidReleaseTrack.internal,
+          releaseStatus: AndroidReleaseStatus.draft,
+          changesNotSentForReview: false,
+          applicationId: 'appId1',
+        },
+      });
+    });
+  });
+});

--- a/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts
@@ -43,7 +43,7 @@ export default class AndroidSubmitCommand {
     const archiveProfile =
       archive.sourceType === ArchiveSourceType.build ? archive.build.buildProfile : undefined;
 
-    if (archiveProfile) {
+    if (archiveProfile && !this.ctx.specifiedProfile) {
       this.ctx = await refreshContextSubmitProfileAsync(this.ctx, archiveProfile);
     }
     const submissionOptions = await this.getAndroidSubmissionOptionsAsync(archiveSourceValue);

--- a/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitCommand.ts
@@ -13,8 +13,8 @@ import {
   getApplicationIdAsync,
 } from '../../project/android/applicationId';
 import capitalizeFirstLetter from '../../utils/expodash/capitalize';
-import { ArchiveSource } from '../ArchiveSource';
-import { resolveArchiveSource } from '../commons';
+import { ArchiveSource, ArchiveSourceType, getArchiveAsync } from '../ArchiveSource';
+import { refreshContextSubmitProfileAsync, resolveArchiveSource } from '../commons';
 import { SubmissionContext } from '../context';
 import AndroidSubmitter, { AndroidSubmissionOptions } from './AndroidSubmitter';
 import { ServiceAccountSource, ServiceAccountSourceType } from './ServiceAccountSource';
@@ -24,21 +24,42 @@ export default class AndroidSubmitCommand {
 
   async runAsync(): Promise<SubmissionFragment> {
     Log.addNewLineIfNone();
-    const submissionOptions = await this.getAndroidSubmissionOptionsAsync();
-    const submitter = new AndroidSubmitter(this.ctx, submissionOptions);
+    const archiveSource = this.resolveArchiveSource();
+    if (!archiveSource.ok) {
+      Log.error(archiveSource.reason?.message);
+      throw new Error('Submission failed');
+    }
+
+    const archiveSourceValue = archiveSource.enforceValue();
+    const archive = await getArchiveAsync(
+      {
+        graphqlClient: this.ctx.graphqlClient,
+        platform: Platform.ANDROID,
+        projectId: this.ctx.projectId,
+        nonInteractive: this.ctx.nonInteractive,
+      },
+      archiveSourceValue
+    );
+    const archiveProfile =
+      archive.sourceType === ArchiveSourceType.build ? archive.build.buildProfile : undefined;
+
+    if (archiveProfile) {
+      this.ctx = await refreshContextSubmitProfileAsync(this.ctx, archiveProfile);
+    }
+    const submissionOptions = await this.getAndroidSubmissionOptionsAsync(archiveSourceValue);
+    const submitter = new AndroidSubmitter(this.ctx, submissionOptions, archive);
     return await submitter.submitAsync();
   }
 
-  private async getAndroidSubmissionOptionsAsync(): Promise<AndroidSubmissionOptions> {
+  private async getAndroidSubmissionOptionsAsync(
+    archiveSource: ArchiveSource
+  ): Promise<AndroidSubmissionOptions> {
     const track = this.resolveTrack();
     const releaseStatus = this.resolveReleaseStatus();
-    const archiveSource = this.resolveArchiveSource();
     const rollout = this.resolveRollout();
     const serviceAccountSource = await this.resolveServiceAccountSourceAsync();
 
-    const errored = [track, releaseStatus, archiveSource, serviceAccountSource, rollout].filter(
-      r => !r.ok
-    );
+    const errored = [track, releaseStatus, serviceAccountSource, rollout].filter(r => !r.ok);
     if (errored.length > 0) {
       const message = errored.map(err => err.reason?.message).join('\n');
       Log.error(message);
@@ -50,7 +71,7 @@ export default class AndroidSubmitCommand {
       track: track.enforceValue(),
       releaseStatus: releaseStatus.enforceValue(),
       rollout: rollout.enforceValue(),
-      archiveSource: archiveSource.enforceValue(),
+      archiveSource,
       serviceAccountSource: serviceAccountSource.enforceValue(),
       changesNotSentForReview: this.ctx.profile.changesNotSentForReview,
     };

--- a/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
@@ -10,7 +10,7 @@ import {
 } from '../../graphql/generated';
 import { SubmissionMutation } from '../../graphql/mutations/SubmissionMutation';
 import formatFields from '../../utils/formatFields';
-import { ArchiveSource, ResolvedArchiveSource, getArchiveAsync } from '../ArchiveSource';
+import { ArchiveSource, ResolvedArchiveSource } from '../ArchiveSource';
 import BaseSubmitter, { SubmissionInput } from '../BaseSubmitter';
 import { SubmissionContext } from '../context';
 import {

--- a/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
+++ b/packages/eas-cli/src/submit/android/AndroidSubmitter.ts
@@ -44,19 +44,14 @@ export default class AndroidSubmitter extends BaseSubmitter<
   ResolvedSourceOptions,
   AndroidSubmissionOptions
 > {
-  constructor(ctx: SubmissionContext<Platform.ANDROID>, options: AndroidSubmissionOptions) {
+  constructor(
+    ctx: SubmissionContext<Platform.ANDROID>,
+    options: AndroidSubmissionOptions,
+    archive: ResolvedArchiveSource
+  ) {
     const sourceOptionsResolver = {
       // eslint-disable-next-line async-protect/async-suffix
-      archive: async () =>
-        await getArchiveAsync(
-          {
-            graphqlClient: ctx.graphqlClient,
-            platform: Platform.ANDROID,
-            projectId: ctx.projectId,
-            nonInteractive: ctx.nonInteractive,
-          },
-          this.options.archiveSource
-        ),
+      archive: async () => archive,
       // eslint-disable-next-line async-protect/async-suffix
       serviceAccountKeyResult: async () => {
         return await getServiceAccountKeyResultAsync(this.ctx, this.options.serviceAccountSource);

--- a/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
@@ -21,7 +21,14 @@ import { SubmissionMutation } from '../../../graphql/mutations/SubmissionMutatio
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
 import { getVcsClient } from '../../../vcs';
-import { createSubmissionContextAsync } from '../../context';
+import {
+  ArchiveResolverContext,
+  ArchiveSource,
+  ArchiveSourceType,
+  getArchiveAsync,
+} from '../../ArchiveSource';
+import { refreshContextSubmitProfileAsync } from '../../commons';
+import { SubmissionContext, createSubmissionContextAsync } from '../../context';
 import { getRecentBuildsForSubmissionAsync } from '../../utils/builds';
 import AndroidSubmitCommand from '../AndroidSubmitCommand';
 
@@ -35,6 +42,20 @@ jest.mock('../../../credentials/android/api/graphql/queries/AndroidAppCredential
 }));
 jest.mock('../../utils/builds');
 jest.mock('../../../project/projectUtils');
+jest.mock('../../ArchiveSource', () => {
+  return {
+    __esModule__: true,
+    ...jest.requireActual('../../ArchiveSource'),
+    getArchiveAsync: jest.fn(),
+  };
+});
+jest.mock('../../commons', () => {
+  return {
+    __esModule__: true,
+    ...jest.requireActual('../../commons'),
+    refreshContextSubmitProfileAsync: jest.fn(),
+  };
+});
 
 const vcsClient = getVcsClient();
 
@@ -51,6 +72,11 @@ describe(AndroidSubmitCommand, () => {
       type: 'service_account',
       private_key: 'super secret',
       client_email: 'beep-boop@iam.gserviceaccount.com',
+    }),
+    '/google-other-service-account.json': JSON.stringify({
+      type: 'service_account',
+      private_key: 'other super secret',
+      client_email: 'beep-boop-blep@iam.gserviceaccount.com',
     }),
   };
 
@@ -81,6 +107,9 @@ describe(AndroidSubmitCommand, () => {
       const projectId = uuidv4();
       const graphqlClient = {} as any as ExpoGraphqlClient;
       const analytics = instance(mock<Analytics>());
+      jest
+        .mocked(getArchiveAsync)
+        .mockImplementation(jest.requireActual('../../ArchiveSource').getArchiveAsync);
 
       const ctx = await createSubmissionContextAsync({
         platform: Platform.ANDROID,
@@ -113,6 +142,9 @@ describe(AndroidSubmitCommand, () => {
       const projectId = uuidv4();
       const graphqlClient = {} as any as ExpoGraphqlClient;
       const analytics = instance(mock<Analytics>());
+      jest
+        .mocked(getArchiveAsync)
+        .mockImplementation(jest.requireActual('../../ArchiveSource').getArchiveAsync);
 
       const ctx = await createSubmissionContextAsync({
         platform: Platform.ANDROID,
@@ -154,6 +186,9 @@ describe(AndroidSubmitCommand, () => {
       const projectId = uuidv4();
       const graphqlClient = {} as any as ExpoGraphqlClient;
       const analytics = instance(mock<Analytics>());
+      jest
+        .mocked(getArchiveAsync)
+        .mockImplementation(jest.requireActual('../../ArchiveSource').getArchiveAsync);
 
       const ctx = await createSubmissionContextAsync({
         platform: Platform.ANDROID,
@@ -198,6 +233,9 @@ describe(AndroidSubmitCommand, () => {
       jest
         .mocked(getRecentBuildsForSubmissionAsync)
         .mockResolvedValueOnce([fakeBuildFragment as BuildFragment]);
+      jest
+        .mocked(getArchiveAsync)
+        .mockImplementation(jest.requireActual('../../ArchiveSource').getArchiveAsync);
 
       const ctx = await createSubmissionContextAsync({
         platform: Platform.ANDROID,
@@ -231,6 +269,135 @@ describe(AndroidSubmitCommand, () => {
           changesNotSentForReview: false,
         },
         submittedBuildId: fakeBuildFragment.id,
+      });
+    });
+    describe('build selected from EAS', () => {
+      it('sends a request to EAS Submit', async () => {
+        const projectId = uuidv4();
+        const graphqlClient = {} as any as ExpoGraphqlClient;
+        const analytics = instance(mock<Analytics>());
+        const selectedBuild = {
+          id: uuidv4(),
+          buildProfile: 'otherProfile',
+        } as any as BuildFragment;
+        jest
+          .mocked(getArchiveAsync)
+          .mockImplementation(async (_ctx: ArchiveResolverContext, _source: ArchiveSource) => {
+            return {
+              sourceType: ArchiveSourceType.build,
+              build: selectedBuild,
+            };
+          });
+        jest
+          .mocked(refreshContextSubmitProfileAsync)
+          .mockImplementation(async (ctx: SubmissionContext<Platform>, _archiveProfile: string) => {
+            ctx.profile = {
+              serviceAccountKeyPath: '/google-other-service-account.json',
+              track: AndroidReleaseTrack.beta,
+              releaseStatus: AndroidReleaseStatus.draft,
+              changesNotSentForReview: false,
+              applicationId: 'otherAppId',
+            };
+            return ctx;
+          });
+
+        const ctx = await createSubmissionContextAsync({
+          platform: Platform.ANDROID,
+          projectDir: testProject.projectRoot,
+          archiveFlags: {},
+          profile: {
+            serviceAccountKeyPath: '/google-service-account.json',
+            track: AndroidReleaseTrack.internal,
+            releaseStatus: AndroidReleaseStatus.draft,
+            changesNotSentForReview: false,
+          },
+          nonInteractive: false,
+          actor: mockJester,
+          graphqlClient,
+          analytics,
+          exp: testProject.appJSON.expo,
+          projectId,
+          vcsClient,
+        });
+
+        const command = new AndroidSubmitCommand(ctx);
+        await command.runAsync();
+
+        expect(SubmissionMutation.createAndroidSubmissionAsync).toHaveBeenCalledWith(
+          graphqlClient,
+          {
+            appId: projectId,
+            archiveSource: undefined,
+            config: {
+              googleServiceAccountKeyJson: fakeFiles['/google-other-service-account.json'],
+              releaseStatus: SubmissionAndroidReleaseStatus.Draft,
+              track: SubmissionAndroidTrack.Beta,
+              changesNotSentForReview: false,
+              rollout: undefined,
+            },
+            submittedBuildId: selectedBuild.id,
+          }
+        );
+      });
+      it('sends a request to EAS Submit with default profile data when submit profile matching selected build profile does not exist', async () => {
+        const projectId = uuidv4();
+        const graphqlClient = {} as any as ExpoGraphqlClient;
+        const analytics = instance(mock<Analytics>());
+        const selectedBuild = {
+          id: uuidv4(),
+          buildProfile: 'otherProfile',
+        } as any as BuildFragment;
+        jest
+          .mocked(getArchiveAsync)
+          .mockImplementation(async (_ctx: ArchiveResolverContext, _source: ArchiveSource) => {
+            return {
+              sourceType: ArchiveSourceType.build,
+              build: selectedBuild,
+            };
+          });
+        jest
+          .mocked(refreshContextSubmitProfileAsync)
+          .mockImplementation(async (ctx: SubmissionContext<Platform>, _archiveProfile: string) => {
+            return ctx;
+          });
+
+        const ctx = await createSubmissionContextAsync({
+          platform: Platform.ANDROID,
+          projectDir: testProject.projectRoot,
+          archiveFlags: {},
+          profile: {
+            serviceAccountKeyPath: '/google-service-account.json',
+            track: AndroidReleaseTrack.internal,
+            releaseStatus: AndroidReleaseStatus.draft,
+            changesNotSentForReview: false,
+          },
+          nonInteractive: false,
+          actor: mockJester,
+          graphqlClient,
+          analytics,
+          exp: testProject.appJSON.expo,
+          projectId,
+          vcsClient,
+        });
+
+        const command = new AndroidSubmitCommand(ctx);
+        await command.runAsync();
+
+        expect(SubmissionMutation.createAndroidSubmissionAsync).toHaveBeenCalledWith(
+          graphqlClient,
+          {
+            appId: projectId,
+            archiveSource: undefined,
+            config: {
+              googleServiceAccountKeyJson: fakeFiles['/google-service-account.json'],
+              releaseStatus: SubmissionAndroidReleaseStatus.Draft,
+              track: SubmissionAndroidTrack.Internal,
+              changesNotSentForReview: false,
+              rollout: undefined,
+            },
+            submittedBuildId: selectedBuild.id,
+          }
+        );
       });
     });
   });

--- a/packages/eas-cli/src/submit/commons.ts
+++ b/packages/eas-cli/src/submit/commons.ts
@@ -1,5 +1,8 @@
 import { Platform } from '@expo/eas-build-job';
+import { EasJsonAccessor, EasJsonUtils, SubmitProfile } from '@expo/eas-json';
+import { MissingProfileError } from '@expo/eas-json/build/errors';
 
+import Log from '../log';
 import { ArchiveSource, ArchiveSourceType, isUuidV4 } from './ArchiveSource';
 import { SubmissionContext } from './context';
 
@@ -39,4 +42,26 @@ export function resolveArchiveSource<T extends Platform>(ctx: SubmissionContext<
       sourceType: ArchiveSourceType.prompt,
     };
   }
+}
+
+export async function refreshContextSubmitProfileAsync<T extends Platform>(
+  ctx: SubmissionContext<T>,
+  archiveProfile: string
+): Promise<SubmissionContext<T>> {
+  try {
+    ctx.profile = (await EasJsonUtils.getSubmitProfileAsync(
+      EasJsonAccessor.fromProjectPath(ctx.projectDir),
+      ctx.platform,
+      archiveProfile ? archiveProfile : 'production'
+    )) as SubmitProfile<T>;
+  } catch (err) {
+    if (err instanceof MissingProfileError) {
+      Log.log(
+        `Selected build uses "${archiveProfile}" build profile but a submit profile with the same name is missing in eas.json. Using provided or default ("production") profile`
+      );
+    } else {
+      throw err;
+    }
+  }
+  return ctx;
 }

--- a/packages/eas-cli/src/submit/commons.ts
+++ b/packages/eas-cli/src/submit/commons.ts
@@ -57,7 +57,7 @@ export async function refreshContextSubmitProfileAsync<T extends Platform>(
   } catch (err) {
     if (err instanceof MissingProfileError) {
       Log.log(
-        `Selected build uses "${archiveProfile}" build profile but a submit profile with the same name is missing in eas.json. Using provided or default ("production") profile`
+        `Selected build uses "${archiveProfile}" build profile but a submit profile with the same name is missing in eas.json. Using default ("production") profile`
       );
     } else {
       throw err;

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -31,6 +31,7 @@ export interface SubmissionContext<T extends Platform> {
   analytics: Analytics;
   vcsClient: Client;
   applicationIdentifierOverride?: string;
+  specifiedProfile?: string;
 }
 
 export interface SubmitArchiveFlags {
@@ -55,6 +56,7 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
   exp: ExpoConfig;
   projectId: string;
   vcsClient: Client;
+  specifiedProfile?: string;
 }): Promise<SubmissionContext<T>> {
   const {
     applicationIdentifier,

--- a/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
@@ -42,7 +42,7 @@ export default class IosSubmitCommand {
     const archiveProfile =
       archive.sourceType === ArchiveSourceType.build ? archive.build.buildProfile : undefined;
 
-    if (archiveProfile) {
+    if (archiveProfile && !this.ctx.specifiedProfile) {
       this.ctx = await refreshContextSubmitProfileAsync(this.ctx, archiveProfile);
     }
     const options = await this.resolveSubmissionOptionsAsync(archiveSourceValue);

--- a/packages/eas-cli/src/submit/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitter.ts
@@ -6,7 +6,7 @@ import { MinimalAscApiKey } from '../../credentials/ios/credentials';
 import { IosSubmissionConfigInput, SubmissionFragment } from '../../graphql/generated';
 import { SubmissionMutation } from '../../graphql/mutations/SubmissionMutation';
 import formatFields from '../../utils/formatFields';
-import { ArchiveSource, ResolvedArchiveSource, getArchiveAsync } from '../ArchiveSource';
+import { ArchiveSource, ResolvedArchiveSource } from '../ArchiveSource';
 import BaseSubmitter, { SubmissionInput } from '../BaseSubmitter';
 import { SubmissionContext } from '../context';
 import {

--- a/packages/eas-cli/src/submit/ios/IosSubmitter.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitter.ts
@@ -47,19 +47,14 @@ export default class IosSubmitter extends BaseSubmitter<
   ResolvedSourceOptions,
   IosSubmissionOptions
 > {
-  constructor(ctx: SubmissionContext<Platform.IOS>, options: IosSubmissionOptions) {
+  constructor(
+    ctx: SubmissionContext<Platform.IOS>,
+    options: IosSubmissionOptions,
+    archive: ResolvedArchiveSource
+  ) {
     const sourceOptionsResolver = {
       // eslint-disable-next-line async-protect/async-suffix
-      archive: async () =>
-        await getArchiveAsync(
-          {
-            graphqlClient: ctx.graphqlClient,
-            platform: Platform.IOS,
-            projectId: ctx.projectId,
-            nonInteractive: ctx.nonInteractive,
-          },
-          this.options.archiveSource
-        ),
+      archive: async () => archive,
       // eslint-disable-next-line async-protect/async-suffix
       credentials: async () => {
         const maybeAppSpecificPassword = this.options.appSpecificPasswordSource

--- a/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
@@ -274,6 +274,69 @@ describe(IosSubmitCommand, () => {
 
         delete process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD;
       });
+      it('sends a request to EAS Submit with specified profile data even when submit profile matching selected build profile exists', async () => {
+        const projectId = uuidv4();
+        const graphqlClient = {} as any as ExpoGraphqlClient;
+        const analytics = instance(mock<Analytics>());
+        const selectedBuild = {
+          id: uuidv4(),
+          buildProfile: 'otherProfile',
+        } as any as BuildFragment;
+        jest
+          .mocked(getArchiveAsync)
+          .mockImplementation(async (_ctx: ArchiveResolverContext, _source: ArchiveSource) => {
+            return {
+              sourceType: ArchiveSourceType.build,
+              build: selectedBuild,
+            };
+          });
+        jest
+          .mocked(refreshContextSubmitProfileAsync)
+          .mockImplementation(async (ctx: SubmissionContext<Platform>, _archiveProfile: string) => {
+            ctx.profile = {
+              language: 'en-US',
+              appleId: 'other-test@example.com',
+              ascAppId: '87654321',
+            };
+            return ctx;
+          });
+
+        process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD = 'supersecret';
+
+        const ctx = await createSubmissionContextAsync({
+          platform: Platform.IOS,
+          projectDir: testProject.projectRoot,
+          archiveFlags: {},
+          profile: {
+            language: 'en-US',
+            appleId: 'test@example.com',
+            ascAppId: '12345678',
+          },
+          nonInteractive: false,
+          actor: mockJester,
+          graphqlClient,
+          analytics,
+          exp: testProject.appJSON.expo,
+          projectId,
+          vcsClient,
+          specifiedProfile: 'specificProfile',
+        });
+        const command = new IosSubmitCommand(ctx);
+        await command.runAsync();
+
+        expect(SubmissionMutation.createIosSubmissionAsync).toHaveBeenCalledWith(graphqlClient, {
+          appId: projectId,
+          submittedBuildId: selectedBuild.id,
+          config: {
+            appleIdUsername: 'test@example.com',
+            appleAppSpecificPassword: 'supersecret',
+            ascAppIdentifier: '12345678',
+          },
+          archiveSource: undefined,
+        });
+
+        delete process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD;
+      });
     });
   });
 });

--- a/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
@@ -9,12 +9,19 @@ import {
   jester as mockJester,
   testProjectId,
 } from '../../../credentials/__tests__/fixtures-constants';
-import { SubmissionArchiveSourceType } from '../../../graphql/generated';
+import { BuildFragment, SubmissionArchiveSourceType } from '../../../graphql/generated';
 import { SubmissionMutation } from '../../../graphql/mutations/SubmissionMutation';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
 import { getVcsClient } from '../../../vcs';
-import { createSubmissionContextAsync } from '../../context';
+import {
+  ArchiveResolverContext,
+  ArchiveSource,
+  ArchiveSourceType,
+  getArchiveAsync,
+} from '../../ArchiveSource';
+import { refreshContextSubmitProfileAsync } from '../../commons';
+import { SubmissionContext, createSubmissionContextAsync } from '../../context';
 import IosSubmitCommand from '../IosSubmitCommand';
 
 jest.mock('fs');
@@ -31,6 +38,20 @@ jest.mock('../../../user/actions', () => ({
   ensureLoggedInAsync: jest.fn(() => mockJester),
 }));
 jest.mock('../../../project/projectUtils');
+jest.mock('../../ArchiveSource', () => {
+  return {
+    __esModule__: true,
+    ...jest.requireActual('../../ArchiveSource'),
+    getArchiveAsync: jest.fn(),
+  };
+});
+jest.mock('../../commons', () => {
+  return {
+    __esModule__: true,
+    ...jest.requireActual('../../commons'),
+    refreshContextSubmitProfileAsync: jest.fn(),
+  };
+});
 
 const vcsClient = getVcsClient();
 
@@ -53,6 +74,7 @@ describe(IosSubmitCommand, () => {
   });
 
   beforeEach(() => {
+    jest.clearAllMocks();
     jest.mocked(getOwnerAccountForProjectIdAsync).mockResolvedValue(mockJester.accounts[0]);
   });
 
@@ -61,6 +83,9 @@ describe(IosSubmitCommand, () => {
       const projectId = uuidv4();
       const graphqlClient = {} as any as ExpoGraphqlClient;
       const analytics = instance(mock<Analytics>());
+      jest
+        .mocked(getArchiveAsync)
+        .mockImplementation(jest.requireActual('../../ArchiveSource').getArchiveAsync);
 
       const ctx = await createSubmissionContextAsync({
         platform: Platform.IOS,
@@ -89,6 +114,9 @@ describe(IosSubmitCommand, () => {
       const projectId = uuidv4();
       const graphqlClient = {} as any as ExpoGraphqlClient;
       const analytics = instance(mock<Analytics>());
+      jest
+        .mocked(getArchiveAsync)
+        .mockImplementation(jest.requireActual('../../ArchiveSource').getArchiveAsync);
 
       process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD = 'supersecret';
 
@@ -125,6 +153,127 @@ describe(IosSubmitCommand, () => {
       });
 
       delete process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD;
+    });
+    describe('build selected from EAS', () => {
+      it('sends a request to EAS Submit with profile data matching selected build profile', async () => {
+        const projectId = uuidv4();
+        const graphqlClient = {} as any as ExpoGraphqlClient;
+        const analytics = instance(mock<Analytics>());
+        const selectedBuild = {
+          id: uuidv4(),
+          buildProfile: 'otherProfile',
+        } as any as BuildFragment;
+        jest
+          .mocked(getArchiveAsync)
+          .mockImplementation(async (_ctx: ArchiveResolverContext, _source: ArchiveSource) => {
+            return {
+              sourceType: ArchiveSourceType.build,
+              build: selectedBuild,
+            };
+          });
+        jest
+          .mocked(refreshContextSubmitProfileAsync)
+          .mockImplementation(async (ctx: SubmissionContext<Platform>, _archiveProfile: string) => {
+            ctx.profile = {
+              language: 'en-US',
+              appleId: 'other-test@example.com',
+              ascAppId: '87654321',
+            };
+            return ctx;
+          });
+
+        process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD = 'supersecret';
+
+        const ctx = await createSubmissionContextAsync({
+          platform: Platform.IOS,
+          projectDir: testProject.projectRoot,
+          archiveFlags: {},
+          profile: {
+            language: 'en-US',
+            appleId: 'test@example.com',
+            ascAppId: '12345678',
+          },
+          nonInteractive: false,
+          actor: mockJester,
+          graphqlClient,
+          analytics,
+          exp: testProject.appJSON.expo,
+          projectId,
+          vcsClient,
+        });
+        const command = new IosSubmitCommand(ctx);
+        await command.runAsync();
+
+        expect(SubmissionMutation.createIosSubmissionAsync).toHaveBeenCalledWith(graphqlClient, {
+          appId: projectId,
+          submittedBuildId: selectedBuild.id,
+          config: {
+            appleIdUsername: 'other-test@example.com',
+            appleAppSpecificPassword: 'supersecret',
+            ascAppIdentifier: '87654321',
+          },
+          archiveSource: undefined,
+        });
+
+        delete process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD;
+      });
+      it('sends a request to EAS Submit with default profile data when submit profile matching selected build profile does not exist', async () => {
+        const projectId = uuidv4();
+        const graphqlClient = {} as any as ExpoGraphqlClient;
+        const analytics = instance(mock<Analytics>());
+        const selectedBuild = {
+          id: uuidv4(),
+          buildProfile: 'otherProfile',
+        } as any as BuildFragment;
+        jest
+          .mocked(getArchiveAsync)
+          .mockImplementation(async (_ctx: ArchiveResolverContext, _source: ArchiveSource) => {
+            return {
+              sourceType: ArchiveSourceType.build,
+              build: selectedBuild,
+            };
+          });
+        jest
+          .mocked(refreshContextSubmitProfileAsync)
+          .mockImplementation(async (ctx: SubmissionContext<Platform>, _archiveProfile: string) => {
+            return ctx;
+          });
+
+        process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD = 'supersecret';
+
+        const ctx = await createSubmissionContextAsync({
+          platform: Platform.IOS,
+          projectDir: testProject.projectRoot,
+          archiveFlags: {},
+          profile: {
+            language: 'en-US',
+            appleId: 'test@example.com',
+            ascAppId: '12345678',
+          },
+          nonInteractive: false,
+          actor: mockJester,
+          graphqlClient,
+          analytics,
+          exp: testProject.appJSON.expo,
+          projectId,
+          vcsClient,
+        });
+        const command = new IosSubmitCommand(ctx);
+        await command.runAsync();
+
+        expect(SubmissionMutation.createIosSubmissionAsync).toHaveBeenCalledWith(graphqlClient, {
+          appId: projectId,
+          submittedBuildId: selectedBuild.id,
+          config: {
+            appleIdUsername: 'test@example.com',
+            appleAppSpecificPassword: 'supersecret',
+            ascAppIdentifier: '12345678',
+          },
+          archiveSource: undefined,
+        });
+
+        delete process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD;
+      });
     });
   });
 });


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-8973/eas-submit-doesnt-use-asc-configuration-from-selected-build-profile

# How

Moved the archive selection before any submit options are determined, and if the archive is selected from EAS then the profile in the submission context is refreshed to use the submit profile with same name as the name of the build profile in the archive (if exists)

# Test Plan

Added automated tests and checked parts of the process manually

When corresponding build profile does not exist
<img width="612" alt="Screenshot 2023-10-25 at 19 11 06" src="https://github.com/expo/eas-cli/assets/2974455/b61f489d-9b7e-4ce8-828e-6a4077d48bb2">
<img width="547" alt="Screenshot 2023-10-25 at 19 10 07" src="https://github.com/expo/eas-cli/assets/2974455/d41fe4e0-6e54-45e5-a01c-db801c7ebb0b">
<img width="1021" alt="Screenshot 2023-10-25 at 19 10 23" src="https://github.com/expo/eas-cli/assets/2974455/aeb9e405-086c-46fd-85a1-e26acb26012a">
