### PR TITLE
[eas-cli] Add link to SDK upgrade page for SDK-gated command error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add link to SDK upgrade page for SDK-gated command error. ([#2106](https://github.com/expo/eas-cli/pull/2106) by [@wschurman](https://github.com/wschurman))
+
 ## [5.6.0](https://github.com/expo/eas-cli/releases/tag/v5.6.0) - 2023-10-27
 
 ### 🎉 New features

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -9,7 +9,7 @@ import { getEASUpdateURL } from '../api';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { AccountFragment, AppPrivacy } from '../graphql/generated';
 import { AppQuery } from '../graphql/queries/AppQuery';
-import Log from '../log';
+import Log, { learnMore } from '../log';
 import { Actor } from '../user/User';
 import { expoCommandAsync } from '../utils/expoCli';
 
@@ -122,7 +122,9 @@ export async function enforceRollBackToEmbeddedUpdateSupportAsync(
   }
 
   throw new Error(
-    'The expo-updates package must have a version >= 0.19.0 to use roll back to embedded, which corresponds to Expo SDK 50 or greater.'
+    `The expo-updates package must have a version >= 0.19.0 to use roll back to embedded, which corresponds to Expo SDK 50 or greater. ${learnMore(
+      'https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/'
+    )}`
   );
 }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

See https://github.com/expo/expo/pull/25146 for context. We want to link to that page to instruct people how to upgrade in order to get this feature. Note that it is still in alpha.

# How

Add link.

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
