### PR TITLE
[eas-cli] move rollouts out of dev preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Move channel:rollout out of developer preview. ([#2114](https://github.com/expo/eas-cli/pull/2114) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -152,11 +152,6 @@ export default class ChannelRollout extends EasCommand {
     if (argsAndFlags.nonInteractive) {
       await new NonInteractiveRollout(argsAndFlags).runAsync(ctx);
     } else {
-      Log.addNewLineIfNone();
-      Log.warn(
-        `✨ This command is in Developer Preview and has not been released to production yet. Website support is coming soon.`
-      );
-      Log.addNewLineIfNone();
       await new RolloutMainMenu(argsAndFlags).runAsync(ctx);
     }
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Move the rollout out of developer preview, cleanup warning logs

# Test Plan

- [ ] manually tested
