### PR TITLE
[eas-cli] [ENG-10555] Fix device provsioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fixed provisioning of new devices into an existing profile. ([#2119](https://github.com/expo/eas-cli/pull/2119) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+
 ### 🧹 Chores
 
 ## [5.7.0](https://github.com/expo/eas-cli/releases/tag/v5.7.0) - 2023-11-08

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -2,7 +2,6 @@ import { Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import Log from '../../log';
 import { NonInteractiveOptions as CreateRolloutNonInteractiveOptions } from '../../rollout/actions/CreateRollout';
 import { NonInteractiveOptions as EditRolloutNonInteractiveOptions } from '../../rollout/actions/EditRollout';
 import {

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
@@ -57,30 +57,63 @@ describe('runWithDistributionCertificateAsync', () => {
   });
   describe('compare chosen and provisioned devices', () => {
     describe('not all devices provisioned', () => {
-      it('displays warning to the user and lists the missing devices', async () => {
-        const { ctx, distCert } = setUpTest();
-        jest.mocked(getBuildCredentialsAsync).mockResolvedValue({
-          provisioningProfile: {
+      describe('still not provisioned after an update', () => {
+        it('displays warning to the user and lists the missing devices', async () => {
+          const { ctx, distCert } = setUpTest();
+          jest.mocked(getBuildCredentialsAsync).mockResolvedValue({
+            provisioningProfile: {
+              appleTeam: {},
+              appleDevices: [{ identifier: 'id1' }],
+              developerPortalIdentifier: 'provisioningProfileId',
+            },
+          } as IosAppBuildCredentialsFragment);
+          ctx.ios.updateProvisioningProfileAsync = jest.fn().mockResolvedValue({
             appleTeam: {},
             appleDevices: [{ identifier: 'id1' }],
             developerPortalIdentifier: 'provisioningProfileId',
-          },
-        } as IosAppBuildCredentialsFragment);
-        const LogWarnSpy = jest.spyOn(Log, 'warn');
-        const LogLogSpy = jest.spyOn(Log, 'log');
-        const result = await setUpAdhocProvisioningProfile.runWithDistributionCertificateAsync(
-          ctx,
-          distCert
-        );
-        expect(result).toEqual({} as IosAppBuildCredentialsFragment);
-        expect(LogWarnSpy).toHaveBeenCalledTimes(3);
-        expect(LogWarnSpy).toHaveBeenCalledWith('Failed to provision 2 of the selected devices:');
-        expect(LogWarnSpy).toHaveBeenCalledWith('- id2 (iPhone) (Device 2)');
-        expect(LogWarnSpy).toHaveBeenCalledWith('- id3 (Mac) (Device 3)');
-        expect(LogLogSpy).toHaveBeenCalledTimes(1);
-        expect(LogLogSpy).toHaveBeenCalledWith(
-          'Most commonly devices fail to to be provisioned while they are still being processed by Apple, which can take up to 24-72 hours. Check your Apple Developer Portal page at https://developer.apple.com/account/resources/devices/list, the devices in "Processing" status cannot be provisioned yet'
-        );
+          });
+          const LogWarnSpy = jest.spyOn(Log, 'warn');
+          const LogLogSpy = jest.spyOn(Log, 'log');
+          const result = await setUpAdhocProvisioningProfile.runWithDistributionCertificateAsync(
+            ctx,
+            distCert
+          );
+          expect(result).toEqual({} as IosAppBuildCredentialsFragment);
+          expect(LogWarnSpy).toHaveBeenCalledTimes(3);
+          expect(LogWarnSpy).toHaveBeenCalledWith('Failed to provision 2 of the selected devices:');
+          expect(LogWarnSpy).toHaveBeenCalledWith('- id2 (iPhone) (Device 2)');
+          expect(LogWarnSpy).toHaveBeenCalledWith('- id3 (Mac) (Device 3)');
+          expect(LogLogSpy).toHaveBeenCalledTimes(1);
+          expect(LogLogSpy).toHaveBeenCalledWith(
+            'Most commonly devices fail to to be provisioned while they are still being processed by Apple, which can take up to 24-72 hours. Check your Apple Developer Portal page at https://developer.apple.com/account/resources/devices/list, the devices in "Processing" status cannot be provisioned yet'
+          );
+        });
+      });
+      describe('all devices provisioned after an update', () => {
+        it('does not display warning', async () => {
+          const { ctx, distCert } = setUpTest();
+          jest.mocked(getBuildCredentialsAsync).mockResolvedValue({
+            provisioningProfile: {
+              appleTeam: {},
+              appleDevices: [{ identifier: 'id1' }],
+              developerPortalIdentifier: 'provisioningProfileId',
+            },
+          } as IosAppBuildCredentialsFragment);
+          ctx.ios.updateProvisioningProfileAsync = jest.fn().mockResolvedValue({
+            appleTeam: {},
+            appleDevices: [{ identifier: 'id1' }, { identifier: 'id2' }, { identifier: 'id3' }],
+            developerPortalIdentifier: 'provisioningProfileId',
+          });
+          const LogWarnSpy = jest.spyOn(Log, 'warn');
+          const LogLogSpy = jest.spyOn(Log, 'log');
+          const result = await setUpAdhocProvisioningProfile.runWithDistributionCertificateAsync(
+            ctx,
+            distCert
+          );
+          expect(result).toEqual({} as IosAppBuildCredentialsFragment);
+          expect(LogWarnSpy).not.toHaveBeenCalled();
+          expect(LogLogSpy).not.toHaveBeenCalled();
+        });
       });
     });
     describe('all devices provisioned', () => {


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-10555/ios-devices-get-stuck-in-failed-to-provision-state-until-the-developer
https://www.reddit.com/r/expo/comments/17kr7rr/failed_to_provision/?sort=new

# How

The problem happened when the provisioning profile already existed and the user wanted to add new devices to it. In such a case, a missing device was added to the Apple Developer Portal if needed, but the provisioning profile from EAS was used unchanged. This meant that no matter what the devices list in the provisioning profile used was the same as before and thus resulted in a warning message and a failure.
Now another check has been added, if the id of the profile from EAS matches the one from Apple the list of devices is compared. If it's the same then the profile is reused as before. If the list is different then the profile in EAS gets updated first with the current devices data from Apple

# Test Plan

Tested manually by reproducing the issue mentioned by the users, applying fix and confirming that the issue went away.
Also added an automated test to cover the new case and adjusted existing tests
