### PR TITLE
[ENG-10464][eas-cli] throw error if custom build config is gitignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Throw error if custom build config is gitignored. ([#2123](https://github.com/expo/eas-cli/pull/2123) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [5.9.1](https://github.com/expo/eas-cli/releases/tag/v5.9.1) - 2023-11-20
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -143,7 +143,11 @@ export async function runBuildAndSubmitAsync(
     {};
   for (const buildProfile of buildProfiles) {
     validateBuildProfileVersionSettings(buildProfile, easJsonCliConfig);
-    const maybeMetadata = await validateCustomBuildConfigAsync(projectDir, buildProfile.profile);
+    const maybeMetadata = await validateCustomBuildConfigAsync({
+      projectDir,
+      profile: buildProfile.profile,
+      vcsClient,
+    });
     if (maybeMetadata) {
       customBuildConfigMetadataByPlatform[toAppPlatform(buildProfile.platform)] = maybeMetadata;
     }

--- a/packages/eas-cli/src/project/customBuildConfig.ts
+++ b/packages/eas-cli/src/project/customBuildConfig.ts
@@ -5,14 +5,21 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
+import { Client } from '../vcs/vcs';
+
 export interface CustomBuildConfigMetadata {
   workflowName?: string;
 }
 
-export async function validateCustomBuildConfigAsync(
-  projectDir: string,
-  profile: BuildProfile<Platform>
-): Promise<CustomBuildConfigMetadata | undefined> {
+export async function validateCustomBuildConfigAsync({
+  profile,
+  projectDir,
+  vcsClient,
+}: {
+  projectDir: string;
+  profile: BuildProfile<Platform>;
+  vcsClient: Client;
+}): Promise<CustomBuildConfigMetadata | undefined> {
   if (!profile.config) {
     return undefined;
   }
@@ -22,6 +29,13 @@ export async function validateCustomBuildConfigAsync(
   if (!(await fs.pathExists(configPath))) {
     throw new Error(
       `Custom build configuration file ${chalk.bold(relativeConfigPath)} does not exist.`
+    );
+  }
+  if (await vcsClient.isFileIgnoredAsync(relativeConfigPath)) {
+    throw new Error(
+      `Custom build configuration file ${chalk.bold(
+        relativeConfigPath
+      )} is ignored by your version control system. Remove it from the ignore list to successfully create custom build.`
     );
   }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

If you create a custom build with git ignored config file build on a server will fail even though local validation passed. 

# How

Use the VCS client to check if the file is ignored. Throw an error if it is.

# Test Plan

Test locally. Git ignore the config. Make sure the build runs fine without git ignored config.

<img width="978" alt="Screenshot 2023-11-16 at 17 07 44" src="https://github.com/expo/eas-cli/assets/55145344/03675914-691a-4bd4-9563-171596927888">

