### PR TITLE
[ENG-9772][eas-cli] don't ask user to install dev client if running in non-interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Don't ask a user to install the dev client if running in non-interactive mode. ([#2124](https://github.com/expo/eas-cli/pull/2124) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [5.9.0](https://github.com/expo/eas-cli/releases/tag/v5.9.0) - 2023-11-15

--- a/packages/eas-cli/src/build/utils/devClient.ts
+++ b/packages/eas-cli/src/build/utils/devClient.ts
@@ -57,6 +57,19 @@ export async function ensureExpoDevClientInstalledForDevClientBuildsAsync({
       'expo-dev-client'
     )} installed for your project.`
   );
+  if (nonInteractive) {
+    Log.error(`You'll need to install ${chalk.bold('expo-dev-client')} manually.`);
+    Log.error(
+      learnMore('https://docs.expo.dev/clients/installation/', {
+        learnMoreMessage: 'See installation instructions on how to do it.',
+        dim: false,
+      })
+    );
+    Errors.error(`Install ${chalk.bold('expo-dev-client')} manually and try again later.`, {
+      exit: 1,
+    });
+  }
+
   const areAllManaged = workflowPerPlatformList.every(i => i === Workflow.MANAGED);
   if (areAllManaged) {
     const install = await confirmAsync({


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-9772/prevent-interactive-cli-commands-in-build-configuration-step

We don't want to prompt users to install the dev client in non-interactive mode.

# How

Instead of displaying the confirm prompt in non-interactive mode fail with a helpful error message.

# Test Plan

Test locally 
<img width="641" alt="Screenshot 2023-11-16 at 17 38 56" src="https://github.com/expo/eas-cli/assets/55145344/b768a9b8-e5b2-4849-bbc3-59cec098919c">
