### PR TITLE
[eas-cli] Always refresh provisioning profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Don't ask a user to install the dev client if running in non-interactive mode. ([#2124](https://github.com/expo/eas-cli/pull/2124) by [@szdziedzic](https://github.com/szdziedzic))
+- Always refresh existing provisioning profile before use. ([#2125](https://github.com/expo/eas-cli/pull/2125) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
@@ -6,7 +6,6 @@ import nullthrows from 'nullthrows';
 import DeviceCreateAction, { RegistrationMethod } from '../../../devices/actions/create/action';
 import {
   AppleAppIdentifierFragment,
-  AppleDevice,
   AppleDeviceFragment,
   AppleDistributionCertificateFragment,
   AppleProvisioningProfileFragment,
@@ -147,15 +146,14 @@ export class SetUpAdhocProvisioningProfile {
       app,
       appleTeam
     );
-    let appleProvisioningProfile: AppleProvisioningProfileFragment | null = null;
+    let appleProvisioningProfile: AppleProvisioningProfileFragment | null;
     if (currentBuildCredentials?.provisioningProfile) {
       appleProvisioningProfile = await this.reuseCurrentProvisioningProfileAsync(
         currentBuildCredentials.provisioningProfile,
         provisioningProfileStoreInfo,
         ctx,
         app,
-        appleAppIdentifier,
-        chosenDevices
+        appleAppIdentifier
       );
     } else {
       appleProvisioningProfile = await ctx.ios.createProvisioningProfileAsync(
@@ -202,8 +200,7 @@ export class SetUpAdhocProvisioningProfile {
     provisioningProfileStoreInfo: ProvisioningProfile,
     ctx: CredentialsContext,
     app: AppLookupParams,
-    appleAppIdentifier: AppleAppIdentifierFragment,
-    chosenDevices: AppleDevice[]
+    appleAppIdentifier: AppleAppIdentifierFragment
   ): Promise<AppleProvisioningProfileFragment> {
     if (
       currentProvisioningProfile.developerPortalIdentifier !==
@@ -222,10 +219,8 @@ export class SetUpAdhocProvisioningProfile {
           developerPortalIdentifier: provisioningProfileStoreInfo.provisioningProfileId,
         }
       );
-    } else if (
-      differenceBy(chosenDevices, currentProvisioningProfile.appleDevices, 'identifier').length > 0
-    ) {
-      // If IDs match, but the devices lists don't, the profile needs to be updated first
+    } else {
+      // If not, the profile needs to be updated first
       return await ctx.ios.updateProvisioningProfileAsync(
         ctx.graphqlClient,
         currentProvisioningProfile.id,
@@ -234,9 +229,6 @@ export class SetUpAdhocProvisioningProfile {
           developerPortalIdentifier: provisioningProfileStoreInfo.provisioningProfileId,
         }
       );
-    } else {
-      // Otherwise the current profile can be reused
-      return currentProvisioningProfile;
     }
   }
 

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
@@ -126,6 +126,11 @@ describe('runWithDistributionCertificateAsync', () => {
             developerPortalIdentifier: 'provisioningProfileId',
           },
         } as IosAppBuildCredentialsFragment);
+        ctx.ios.updateProvisioningProfileAsync = jest.fn().mockResolvedValue({
+          appleTeam: {},
+          appleDevices: [{ identifier: 'id1' }, { identifier: 'id2' }, { identifier: 'id3' }],
+          developerPortalIdentifier: 'provisioningProfileId',
+        });
         const LogWarnSpy = jest.spyOn(Log, 'warn');
         const LogLogSpy = jest.spyOn(Log, 'log');
         const result = await setUpAdhocProvisioningProfile.runWithDistributionCertificateAsync(


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C9PRD479V/p1700236895524379
https://exponent-internal.slack.com/archives/C9PRD479V/p1700229660146479

# How

There are other cases when the provisioning profile needs to be refreshed before use and which cannot be easily validated at runtime without bigger changes in the code. It is simpler (at least for the time being) to just refresh existing profile each time

# Test Plan

Run automated tests
