### PR TITLE
[eas-json] move ubuntu 18 images to ubuntu 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Throw error if custom build config is gitignored. ([#2123](https://github.com/expo/eas-cli/pull/2123) by [@szdziedzic](https://github.com/szdziedzic))
 - Update `@expo/steps` library to `1.0.51`. ([#2130](https://github.com/expo/eas-cli/pull/2130) by [@szdziedzic](https://github.com/szdziedzic))
+- Update `eas.schema.json` to include changes after some of our images were migrated to Ubuntu 20 from Ubuntu 18. ([#2137](https://github.com/expo/eas-cli/pull/2137) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [5.9.1](https://github.com/expo/eas-cli/releases/tag/v5.9.1) - 2023-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Throw error if custom build config is gitignored. ([#2123](https://github.com/expo/eas-cli/pull/2123) by [@szdziedzic](https://github.com/szdziedzic))
 - Update `@expo/steps` library to `1.0.51`. ([#2130](https://github.com/expo/eas-cli/pull/2130) by [@szdziedzic](https://github.com/szdziedzic))
-- Update `eas.schema.json` to include changes after some of our images were migrated to Ubuntu 20 from Ubuntu 18. ([#2137](https://github.com/expo/eas-cli/pull/2137) by [@szdziedzic](https://github.com/szdziedzic))
+- Update `eas.schema.json` to include changes after some of our images were migrated from Ubuntu 18.04 to Ubuntu 20.04. ([#2137](https://github.com/expo/eas-cli/pull/2137) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [5.9.1](https://github.com/expo/eas-cli/releases/tag/v5.9.1) - 2023-11-20
 

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -243,11 +243,11 @@
                 "ubuntu-22.04-jdk-8-ndk-r21e",
                 "ubuntu-20.04-jdk-11-ndk-r21e",
                 "ubuntu-20.04-jdk-8-ndk-r21e",
-                "ubuntu-18.04-jdk-11-ndk-r19c",
-                "ubuntu-18.04-jdk-8-ndk-r19c"
+                "ubuntu-20.04-jdk-11-ndk-r19c",
+                "ubuntu-20.04-jdk-8-ndk-r19c"
               ],
               "markdownEnumDescriptions": [
-                "- React Native `>=0.68.0` - `ubuntu-22.04-jdk-11-ndk-r21e`\n- React Native `<0.68.0` - `ubuntu-18.04-jdk-8-ndk-r19c`",
+                "- React Native `>=0.68.0` - `ubuntu-22.04-jdk-11-ndk-r21e`\n- React Native `<0.68.0` - `ubuntu-20.04-jdk-8-ndk-r19c`",
                 "`ubuntu-22.04-jdk-17-ndk-r21e`",
                 "`ubuntu-22.04-jdk-11-ndk-r21e`"
               ]


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We migrated our ubuntu 18 images to ubuntu 20

# How

Update `eas.schema.json`

