### PR TITLE
[eas-cli] Pass build mode only in `job`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Update `@expo/steps` library to `1.0.51`. ([#2130](https://github.com/expo/eas-cli/pull/2130) by [@szdziedzic](https://github.com/szdziedzic))
 - Update `eas.schema.json` to include changes after some of our images were migrated from Ubuntu 18.04 to Ubuntu 20.04. ([#2137](https://github.com/expo/eas-cli/pull/2137) by [@szdziedzic](https://github.com/szdziedzic))
 - Update oclif dependencies. ([#2008](https://github.com/expo/eas-cli/pull/2008) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+- Upgrade `eas-build-job` and unify how we're handling `buildMode`. ([#2138](https://github.com/expo/eas-cli/pull/2138) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## [5.9.1](https://github.com/expo/eas-cli/releases/tag/v5.9.1) - 2023-11-20
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/config": "8.1.2",
     "@expo/config-plugins": "7.2.4",
     "@expo/config-types": "49.0.0",
-    "@expo/eas-build-job": "1.0.48",
+    "@expo/eas-build-job": "1.0.50",
     "@expo/eas-json": "5.7.0",
     "@expo/json-file": "8.2.37",
     "@expo/multipart-body-parser": "1.1.0",

--- a/packages/eas-cli/src/build/graphql.ts
+++ b/packages/eas-cli/src/build/graphql.ts
@@ -1,6 +1,7 @@
 import {
   ArchiveSource,
   ArchiveSourceType,
+  BuildMode,
   BuildTrigger,
   Metadata,
   Workflow,
@@ -10,9 +11,9 @@ import {
   BuildCredentialsSource,
   BuildIosEnterpriseProvisioning,
   BuildMetadataInput,
-  BuildMode,
   BuildWorkflow,
   DistributionType,
+  BuildMode as GraphQLBuildMode,
   BuildTrigger as GraphQLBuildTrigger,
   ProjectArchiveSourceInput,
   ProjectArchiveSourceType,
@@ -42,7 +43,6 @@ export function transformProjectArchive(archiveSource: ArchiveSource): ProjectAr
 export function transformMetadata(metadata: Metadata): BuildMetadataInput {
   return {
     ...metadata,
-    buildMode: metadata.buildMode && transformBuildMode(metadata.buildMode),
     credentialsSource:
       metadata.credentialsSource && transformCredentialsSource(metadata.credentialsSource),
     distribution: metadata.distribution && transformDistribution(metadata.distribution),
@@ -91,14 +91,13 @@ export function transformIosEnterpriseProvisioning(
   }
 }
 
-// TODO: check what in metadata
-export function transformBuildMode(buildMode: string): BuildMode {
+export function transformBuildMode(buildMode: BuildMode): GraphQLBuildMode {
   if (buildMode === 'build') {
-    return BuildMode.Build;
+    return GraphQLBuildMode.Build;
   } else if (buildMode === 'resign') {
-    return BuildMode.Resign;
+    return GraphQLBuildMode.Resign;
   } else if (buildMode === 'custom') {
-    return BuildMode.Custom;
+    return GraphQLBuildMode.Custom;
   } else {
     throw new Error(`Unsupported build mode: ${buildMode}`);
   }

--- a/packages/eas-cli/src/build/graphql.ts
+++ b/packages/eas-cli/src/build/graphql.ts
@@ -6,6 +6,7 @@ import {
   Metadata,
   Workflow,
 } from '@expo/eas-build-job';
+import assert from 'assert';
 
 import {
   BuildCredentialsSource,
@@ -91,16 +92,16 @@ export function transformIosEnterpriseProvisioning(
   }
 }
 
+const buildModeToGraphQLBuildMode: Record<BuildMode, GraphQLBuildMode> = {
+  [BuildMode.BUILD]: GraphQLBuildMode.Build,
+  [BuildMode.CUSTOM]: GraphQLBuildMode.Custom,
+  [BuildMode.RESIGN]: GraphQLBuildMode.Resign,
+};
+
 export function transformBuildMode(buildMode: BuildMode): GraphQLBuildMode {
-  if (buildMode === 'build') {
-    return GraphQLBuildMode.Build;
-  } else if (buildMode === 'resign') {
-    return GraphQLBuildMode.Resign;
-  } else if (buildMode === 'custom') {
-    return GraphQLBuildMode.Custom;
-  } else {
-    throw new Error(`Unsupported build mode: ${buildMode}`);
-  }
+  const graphQLBuildMode = buildModeToGraphQLBuildMode[buildMode];
+  assert(graphQLBuildMode, `Unsupported build mode: ${buildMode}`);
+  return graphQLBuildMode;
 }
 
 export function transformBuildTrigger(buildTrigger: BuildTrigger): GraphQLBuildTrigger {

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,5 +1,5 @@
 import { Updates } from '@expo/config-plugins';
-import { BuildMode, Metadata, Platform, sanitizeMetadata } from '@expo/eas-build-job';
+import { Metadata, Platform, sanitizeMetadata } from '@expo/eas-build-job';
 import { IosEnterpriseProvisioning } from '@expo/eas-json';
 import fs from 'fs-extra';
 import resolveFrom from 'resolve-from';
@@ -59,7 +59,6 @@ export async function collectMetadataAsync<T extends Platform>(
     }),
     runWithNoWaitFlag: ctx.noWait,
     runFromCI: ctx.runFromCI,
-    buildMode: ctx.buildProfile.config ? BuildMode.CUSTOM : BuildMode.BUILD,
     customWorkflowName: ctx.customBuildConfigMetadata?.workflowName,
     developmentClient: ctx.developmentClient,
     requiredPackageManager: ctx.requiredPackageManager ?? undefined,

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
     "@babel/code-frame": "7.18.6",
-    "@expo/eas-build-job": "1.0.48",
+    "@expo/eas-build-job": "1.0.50",
     "chalk": "4.1.2",
     "env-string": "1.0.1",
     "fs-extra": "10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,14 +1252,6 @@
     slugify "^1.3.4"
     sucrase "^3.20.0"
 
-"@expo/eas-build-job@1.0.48":
-  version "1.0.48"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-1.0.48.tgz#fca70a6f15171ff1bd6f28021a4473b924f3c11e"
-  integrity sha512-44N9fKrur7xOtY8DnHcFEzJTPenOBUkfpNous4xziG8u58oXvlraiNaTSi++4EpFfsBS3U+jQAW9UMlJqfu8WA==
-  dependencies:
-    joi "^17.9.2"
-    semver "^7.5.4"
-
 "@expo/eas-build-job@1.0.50":
   version "1.0.50"
   resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-1.0.50.tgz#fed1a7f73a7436ed3179f1d957beb641a2832d33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,6 +1260,14 @@
     joi "^17.9.2"
     semver "^7.5.4"
 
+"@expo/eas-build-job@1.0.50":
+  version "1.0.50"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-1.0.50.tgz#fed1a7f73a7436ed3179f1d957beb641a2832d33"
+  integrity sha512-mG+U5hag4OLVI51Crbc1lxIeWgMBv9ZUm1eL/AkoA04NJFtVpwTCVqdpMsRWsXLFM8Poy/ktN9UOma06eXHWHQ==
+  dependencies:
+    joi "^17.9.2"
+    semver "^7.5.4"
+
 "@expo/image-utils@0.3.22":
   version "0.3.22"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.22.tgz#3a45fb2e268d20fcc761c87bca3aca7fd8e24260"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We use two build modes meaning the same thing. In https://github.com/expo/universe/pull/14035 I'm merging them into the single `job.mode`.

# How

Updated `eas-build-job` which already removed `buildMode` from metadata. Then adjusted code so it:
- does not send `buildMode` in metadata
- transforms internal `buildMode` to the GraphQL `BuildMode`.

# Test Plan

In a test project, triggered:
- [a custom build](https://staging.expo.dev/accounts/sjchmiela/projects/staging-app/builds/3abbbe06-7e64-449c-9fa3-05a4b14652f5) with `EXPO_STAGING=1 easd build -p ios -e demo`
- [a regular build](https://staging.expo.dev/accounts/sjchmiela/projects/staging-app/builds/15dc26e2-3e89-486d-be32-8ee12d81693d) with `EXPO_STAGING=1 easd build -p ios -e simulator`

they both ran as expected.
