### PR TITLE
[ci] Only lint changelog in Node 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         node: ['14', '16', '18']
         include:
+          - node: '16'
+            lint-changelog: true
           - node: '18'
             coverage: true
     name: Test with Node ${{ matrix.node }}
@@ -42,6 +44,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - run: yarn lint-changelog
+        if: ${{ matrix.lint-changelog }}
 
   notify-slack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`lint-changelog` tends to sometimes fail on Node 18 (see [this](https://github.com/expo/eas-cli/actions/runs/7184124974/job/19571620519)). I don't want to debug why.

# How

After noticing `scripts/tsconfig.json` mentions "node16", I figured maybe scripts are supposed to only run on Node 16. Adjusted matrix and job spec.

https://github.com/expo/eas-cli/blob/04a8b08f5981615373bca680530e5c1a0bb904e4/scripts/tsconfig.json#L4-L5

# Test Plan

I mean, it's linting changelog…