### PR TITLE
[eas-cli][eas-update] Allow undefined update message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Allow undefined update message for EAS Update publishing when no VCS. ([#2148](https://github.com/expo/eas-cli/pull/2148) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -515,7 +515,7 @@ export default class UpdatePublish extends EasCommand {
               ? [{ label: 'Android update ID', value: newAndroidUpdate.id }]
               : []),
             ...(newIosUpdate ? [{ label: 'iOS update ID', value: newIosUpdate.id }] : []),
-            { label: 'Message', value: updateMessage },
+            { label: 'Message', value: updateMessage ?? '' },
             ...(gitCommitHash
               ? [
                   {

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -270,7 +270,7 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
               ? [{ label: 'Android update ID', value: newAndroidUpdate.id }]
               : []),
             ...(newIosUpdate ? [{ label: 'iOS update ID', value: newIosUpdate.id }] : []),
-            { label: 'Message', value: updateMessage },
+            { label: 'Message', value: updateMessage ?? '' },
             ...(gitCommitHash
               ? [
                   {
@@ -300,7 +300,7 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
     graphqlClient: ExpoGraphqlClient;
     isGitWorkingTreeDirty: boolean | undefined;
     gitCommitHash: string | undefined;
-    updateMessage: string;
+    updateMessage: string | undefined;
     branchId: string;
     codeSigningInfo: CodeSigningInfo | undefined;
     runtimeVersions: { platform: string; runtimeVersion: string }[];

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -217,6 +217,10 @@ export default class GitClient extends Client {
       return false;
     }
   }
+
+  public override canGetLastCommitMessage(): boolean {
+    return true;
+  }
 }
 
 async function ensureGitConfiguredAsync({

--- a/packages/eas-cli/src/vcs/clients/noVcs.ts
+++ b/packages/eas-cli/src/vcs/clients/noVcs.ts
@@ -16,4 +16,8 @@ export default class NoVcsClient extends Client {
     await ignore.initIgnoreAsync();
     return ignore.ignores(filePath);
   }
+
+  public override canGetLastCommitMessage(): boolean {
+    return true;
+  }
 }

--- a/packages/eas-cli/src/vcs/vcs.ts
+++ b/packages/eas-cli/src/vcs/vcs.ts
@@ -78,4 +78,10 @@ export abstract class Client {
   public async isFileIgnoredAsync(_filePath: string): Promise<boolean> {
     return false;
   }
+
+  /**
+   * Whether this VCS client can get the last commit message.
+   * Used for EAS Update - implementation can be false for noVcs client.
+   */
+  public abstract canGetLastCommitMessage(): boolean;
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This was requested for cases where there isn't a VCS and also no update message is manually supplied.

Closes ENG-9633.

# How

It is already optional in the GraphQL mutation, so this is just a product decision that we need to deliberately make.

# For Reviewers

I think it's worth having a discussion on the UX benefits/costs of this product decision. This PR is meant to just start the discussion, not convey a strong intent to make the change as I'm probably oblivious to potential downsides.

# Test Plan

Create an update and don't specify message.
