### PR TITLE
[0/1][eas-cli] rename getUpdateGroupJsonInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Rename getUpdateGroupJsonInfo. ([#2157](https://github.com/expo/eas-cli/pull/2157) by [@quinlanj](https://github.com/quinlanj))
+
 ## [5.9.2](https://github.com/expo/eas-cli/releases/tag/v5.9.2) - 2023-12-15
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -40,7 +40,7 @@ import {
   uploadAssetsAsync,
 } from '../../project/publish';
 import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
-import { getUpdateGroupJsonInfo } from '../../update/utils';
+import { getUpdatesJsonInfo } from '../../update/utils';
 import {
   checkManifestBodyAgainstUpdateInfoGroup,
   getCodeSigningInfoAsync,
@@ -469,7 +469,7 @@ export default class UpdatePublish extends EasCommand {
     }
 
     if (jsonFlag) {
-      printJsonOnlyOutput(getUpdateGroupJsonInfo(newUpdates));
+      printJsonOnlyOutput(getUpdatesJsonInfo(newUpdates));
     } else {
       if (new Set(newUpdates.map(update => update.group)).size > 1) {
         Log.addNewLineIfNone();

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -40,7 +40,7 @@ import {
   uploadAssetsAsync,
 } from '../../project/publish';
 import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
-import { getUpdatesJsonInfo } from '../../update/utils';
+import { getUpdateJsonInfosForUpdates } from '../../update/utils';
 import {
   checkManifestBodyAgainstUpdateInfoGroup,
   getCodeSigningInfoAsync,
@@ -469,7 +469,7 @@ export default class UpdatePublish extends EasCommand {
     }
 
     if (jsonFlag) {
-      printJsonOnlyOutput(getUpdatesJsonInfo(newUpdates));
+      printJsonOnlyOutput(getUpdateJsonInfosForUpdates(newUpdates));
     } else {
       if (new Set(newUpdates.map(update => update.group)).size > 1) {
         Log.addNewLineIfNone();

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -34,7 +34,7 @@ import {
   getUpdateMessageForCommandAsync,
 } from '../../project/publish';
 import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
-import { getUpdatesJsonInfo } from '../../update/utils';
+import { getUpdateJsonInfosForUpdates } from '../../update/utils';
 import {
   CodeSigningInfo,
   checkDirectiveBodyAgainstUpdateInfoGroup,
@@ -228,7 +228,7 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
     }
 
     if (jsonFlag) {
-      printJsonOnlyOutput(getUpdatesJsonInfo(newUpdates));
+      printJsonOnlyOutput(getUpdateJsonInfosForUpdates(newUpdates));
     } else {
       if (new Set(newUpdates.map(update => update.group)).size > 1) {
         Log.addNewLineIfNone();

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -34,7 +34,7 @@ import {
   getUpdateMessageForCommandAsync,
 } from '../../project/publish';
 import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
-import { getUpdateGroupJsonInfo } from '../../update/utils';
+import { getUpdatesJsonInfo } from '../../update/utils';
 import {
   CodeSigningInfo,
   checkDirectiveBodyAgainstUpdateInfoGroup,
@@ -228,7 +228,7 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
     }
 
     if (jsonFlag) {
-      printJsonOnlyOutput(getUpdateGroupJsonInfo(newUpdates));
+      printJsonOnlyOutput(getUpdatesJsonInfo(newUpdates));
     } else {
       if (new Set(newUpdates.map(update => update.group)).size > 1) {
         Log.addNewLineIfNone();

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -7,7 +7,7 @@ import Log from '../../log';
 import {
   formatUpdateGroup,
   getUpdateGroupDescriptions,
-  getUpdateGroupJsonInfo,
+  getUpdatesJsonInfo,
 } from '../../update/utils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
@@ -47,7 +47,7 @@ export default class UpdateView extends EasCommand {
     const updatesByGroup = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, { groupId });
 
     if (jsonFlag) {
-      printJsonOnlyOutput(getUpdateGroupJsonInfo(updatesByGroup));
+      printJsonOnlyOutput(getUpdatesJsonInfo(updatesByGroup));
     } else {
       const [updateGroupDescription] = getUpdateGroupDescriptions([updatesByGroup]);
 

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -7,7 +7,7 @@ import Log from '../../log';
 import {
   formatUpdateGroup,
   getUpdateGroupDescriptions,
-  getUpdatesJsonInfo,
+  getUpdateJsonInfosForUpdates,
 } from '../../update/utils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
@@ -47,7 +47,7 @@ export default class UpdateView extends EasCommand {
     const updatesByGroup = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, { groupId });
 
     if (jsonFlag) {
-      printJsonOnlyOutput(getUpdatesJsonInfo(updatesByGroup));
+      printJsonOnlyOutput(getUpdateJsonInfosForUpdates(updatesByGroup));
     } else {
       const [updateGroupDescription] = getUpdateGroupDescriptions([updatesByGroup]);
 

--- a/packages/eas-cli/src/update/utils.ts
+++ b/packages/eas-cli/src/update/utils.ts
@@ -201,8 +201,8 @@ export function formatUpdateTitle(update: UpdateFragment): string {
   )} by ${actorName}, runtimeVersion: ${runtimeVersion}] ${message}`;
 }
 
-export function getUpdateGroupJsonInfo(updateGroups: UpdateFragment[]): UpdateJsonInfo[] {
-  return updateGroups.map(update => ({
+export function getUpdatesJsonInfo(updates: UpdateFragment[]): UpdateJsonInfo[] {
+  return updates.map(update => ({
     id: update.id,
     createdAt: update.createdAt,
     group: update.group,

--- a/packages/eas-cli/src/update/utils.ts
+++ b/packages/eas-cli/src/update/utils.ts
@@ -201,7 +201,7 @@ export function formatUpdateTitle(update: UpdateFragment): string {
   )} by ${actorName}, runtimeVersion: ${runtimeVersion}] ${message}`;
 }
 
-export function getUpdatesJsonInfo(updates: UpdateFragment[]): UpdateJsonInfo[] {
+export function getUpdateJsonInfosForUpdates(updates: UpdateFragment[]): UpdateJsonInfo[] {
   return updates.map(update => ({
     id: update.id,
     createdAt: update.createdAt,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Rename `getUpdateGroupJsonInfo` because it is not correct. 

The output of the our `publishUpdateGroups` mutation (which can publish multiple update groups) is an array of updates, belonging to 1 or more groups. With the outputted `Update[]`, we generate some json info with `getUpdateGroupJsonInfo`

# Test Plan

- [ ] typecheck passes
