### PR TITLE
[1/1][eas-cli] generate eas-update-metadata.json  on publish

### DIFF
--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -29,13 +29,13 @@ import {
   collectAssetsAsync,
   defaultPublishPlatforms,
   filterExportedPlatformsByFlag,
+  generateEasMetadataAsync,
   getBranchNameForCommandAsync,
   getRequestedPlatform,
   getRuntimeToPlatformMappingFromRuntimeVersions,
   getRuntimeVersionObjectAsync,
   getUpdateMessageForCommandAsync,
   isUploadedAssetCountAboveWarningThreshold,
-  patchEasMetadataAsync,
   platformDisplayNames,
   resolveInputDirectoryAsync,
   uploadAssetsAsync,
@@ -470,7 +470,7 @@ export default class UpdatePublish extends EasCommand {
     }
 
     if (!skipBundler) {
-      await patchEasMetadataAsync(distRoot, getUpdatesJsonInfo(newUpdates));
+      await generateEasMetadataAsync(distRoot, getUpdateJsonInfosForUpdates(newUpdates));
     }
     if (jsonFlag) {
       printJsonOnlyOutput(getUpdateJsonInfosForUpdates(newUpdates));

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -35,6 +35,7 @@ import {
   getRuntimeVersionObjectAsync,
   getUpdateMessageForCommandAsync,
   isUploadedAssetCountAboveWarningThreshold,
+  patchEasMetadataAsync,
   platformDisplayNames,
   resolveInputDirectoryAsync,
   uploadAssetsAsync,
@@ -468,6 +469,9 @@ export default class UpdatePublish extends EasCommand {
       throw e;
     }
 
+    if (!skipBundler) {
+      await patchEasMetadataAsync(distRoot, getUpdatesJsonInfo(newUpdates));
+    }
     if (jsonFlag) {
       printJsonOnlyOutput(getUpdateJsonInfosForUpdates(newUpdates));
     } else {

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -48,7 +48,6 @@ type Metadata = {
   fileMetadata: {
     [key in Platform]: { assets: { path: string; ext: string }[]; bundle: string };
   };
-  easMetadata: UpdateJsonInfo[];
 };
 export type RawAsset = {
   fileExtension?: string;
@@ -102,7 +101,6 @@ export const MetadataJoi = Joi.object({
     ios: fileMetadataJoi,
     web: fileMetadataJoi,
   }).required(),
-  easMetadata: Joi.array().optional(),
 }).required();
 
 export function guessContentTypeFromExtension(ext?: string): string {
@@ -300,12 +298,12 @@ export function loadMetadata(distRoot: string): Metadata {
   return metadata;
 }
 
-export async function patchEasMetadataAsync(
+export async function generateEasMetadataAsync(
   distRoot: string,
   metadata: UpdateJsonInfo[]
 ): Promise<void> {
-  const metadataPath = path.join(distRoot, 'metadata.json');
-  await JsonFile.setAsync(metadataPath, 'easMetadata', metadata);
+  const easMetadataPath = path.join(distRoot, 'eas-update-metadata.json');
+  await JsonFile.writeAsync(easMetadataPath, { updates: metadata });
 }
 
 export function filterExportedPlatformsByFlag<T extends Partial<Record<Platform, any>>>(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When we publish an update, a `metadata.json` file gets generated in the `dist` folder. This PR patches the `metadata.json` with some `eas` metadata. 

# motivation
It would be nice to have this for sentry-expo integration. While it is possible for users to specify the `json` flag for the update command to output the same information, it will be nicer if we can tell people to just run `eas update` and then run another script that will read from the `metadata.json` file

# Test Plan

manually tested
