### PR TITLE
[ci] Cancel in progress jobs when new are run

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,10 @@ on:
       - labeled
       - unlabeled
 
+concurrency:
+  group: changelog-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-changelog-entry:
     name: Check CHANGELOG.md updated

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -2,6 +2,9 @@ name: Size
 on:
   pull_request:
     types: [synchronize, opened]
+concurrency:
+  group: size-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   compare:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -13,6 +13,10 @@ on:
     paths:
       - 'scripts/**'
 
+concurrency:
+  group: test-scripts-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I've noticed tests ran for an old commit even though I pushed a new one.

# How

Added `concurrency` where I thought it was applicable.

# Test Plan

None.