### PR TITLE
[ENG-11090][eas-cli] prompt users if they want to continue if provisioning the devices fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Remove "bare"-specific **eas.json** template. ([#2179](https://github.com/expo/eas-cli/pull/2179) by [@sjchmiela](https://github.com/sjchmiela))
+- Prompt users if they want to continue if EAS CLI fails to provision the devices. ([#2181](https://github.com/expo/eas-cli/pull/2181) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [6.0.0](https://github.com/expo/eas-cli/releases/tag/v6.0.0) - 2024-01-12
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
@@ -4,10 +4,6 @@ import assert from 'assert';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
-import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
-import { assignBuildCredentialsAsync, getBuildCredentialsAsync } from './BuildCredentialsUtils';
-import { chooseDevicesAsync, formatDeviceLabel } from './DeviceUtils';
-import { SetUpDistributionCertificate } from './SetUpDistributionCertificate';
 import DeviceCreateAction, { RegistrationMethod } from '../../../devices/actions/create/action';
 import {
   AppleAppIdentifierFragment,
@@ -34,6 +30,10 @@ import { ProvisioningProfile } from '../appstore/Credentials.types';
 import { ApplePlatform } from '../appstore/constants';
 import { Target } from '../types';
 import { validateProvisioningProfileAsync } from '../validators/validateProvisioningProfile';
+import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
+import { assignBuildCredentialsAsync, getBuildCredentialsAsync } from './BuildCredentialsUtils';
+import { chooseDevicesAsync, formatDeviceLabel } from './DeviceUtils';
+import { SetUpDistributionCertificate } from './SetUpDistributionCertificate';
 
 enum ReuseAction {
   Yes,

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../../graphql/generated';
 import Log from '../../../../log';
 import { getApplePlatformFromTarget } from '../../../../project/ios/target';
+import { selectAsync } from '../../../../prompts';
 import { Actor } from '../../../../user/User';
 import { Client } from '../../../../vcs/vcs';
 import { CredentialsContext, CredentialsContextProjectInfo } from '../../../context';
@@ -34,6 +35,7 @@ jest.mock('../DeviceUtils', () => {
   };
 });
 jest.mock('../../../../project/ios/target');
+jest.mock('../../../../prompts');
 
 describe(doUDIDsMatch, () => {
   it('return false if UDIDs do not match', () => {
@@ -67,6 +69,7 @@ describe('runWithDistributionCertificateAsync', () => {
               developerPortalIdentifier: 'provisioningProfileId',
             },
           } as IosAppBuildCredentialsFragment);
+          jest.mocked(selectAsync).mockImplementation(async () => true);
           ctx.ios.updateProvisioningProfileAsync = jest.fn().mockResolvedValue({
             appleTeam: {},
             appleDevices: [{ identifier: 'id1' }],


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-11090/prompt-user-whether-they-want-to-continue-if-we-fail-to-provision

# How

Prompt users if they want to continue if we fail to provision the devices

# Test Plan

(Yeah I know it says 0, I commented out the if statement to test it)
<img width="1180" alt="Screenshot 2024-01-16 at 10 57 13" src="https://github.com/expo/eas-cli/assets/55145344/d8afd0af-2bb0-4db6-bd53-591a464b2674">
<img width="1190" alt="Screenshot 2024-01-16 at 10 54 42" src="https://github.com/expo/eas-cli/assets/55145344/137c7844-c2e8-4c1e-9b4e-96c58814709c">

