### PR TITLE
[ENG-11076][eas-cli] prompt user to map channel on update if unmapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Remove "bare"-specific **eas.json** template. ([#2179](https://github.com/expo/eas-cli/pull/2179) by [@sjchmiela](https://github.com/sjchmiela))
 - Prompt users if they want to continue if EAS CLI fails to provision the devices. ([#2181](https://github.com/expo/eas-cli/pull/2181) by [@szdziedzic](https://github.com/szdziedzic))
 - Update `eas-cli` and `@expo/eas-json` dependencies. ([#2176](https://github.com/expo/eas-cli/pull/2176) by [@szdziedzic](https://github.com/szdziedzic))
+- Prompt user to map channel on update if unmapped. ([#2185](https://github.com/expo/eas-cli/pull/2185) by [@quinlanj](https://github.com/quinlanj))
 
 ## [6.0.0](https://github.com/expo/eas-cli/releases/tag/v6.0.0) - 2024-01-12
 

--- a/packages/eas-cli/src/commands/update/republish.ts
+++ b/packages/eas-cli/src/commands/update/republish.ts
@@ -293,7 +293,12 @@ async function askUpdatesFromChannelNameAsync(
     nonInteractive,
   }: { projectId: string; channelName: string; json: boolean; nonInteractive: boolean }
 ): Promise<UpdateToRepublish[]> {
-  const branchName = await getBranchNameFromChannelNameAsync(graphqlClient, projectId, channelName);
+  const branchName = await getBranchNameFromChannelNameAsync(
+    graphqlClient,
+    projectId,
+    channelName,
+    { json, nonInteractive, offset: 0 }
+  );
 
   return await askUpdatesFromBranchNameAsync(graphqlClient, {
     projectId,

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -575,7 +575,12 @@ export async function getBranchNameForCommandAsync({
   }
 
   if (channelNameArg) {
-    return await getBranchNameFromChannelNameAsync(graphqlClient, projectId, channelNameArg);
+    return await getBranchNameFromChannelNameAsync(
+      graphqlClient,
+      projectId,
+      channelNameArg,
+      paginatedQueryOptions
+    );
   }
 
   if (branchNameArg) {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
When an update is created with the `channel` flag, it will error if the channel is not mapped to a branch. 

```
> eas update --channel main
Channel has no branches associated with it. Run 'eas channel:edit' to map a branch
```

This PR allows the user to select the branch to map in this case:
```
>  eas-dev update --channel blah
Channel has no branches associated with it.
✔ Which branch would you like blah to point at? › gh/quinlanj/3/orig
```

# Test Plan

- [ ] amended test to expect new behaviour
