### PR TITLE
[eas-cli] Remove support for classic updates release channel in 50+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Remove support for classic updates release channel in 50+. ([#2189](https://github.com/expo/eas-cli/pull/2189) by [@wschurman](https://github.com/wschurman))
+
 ## [7.0.0](https://github.com/expo/eas-cli/releases/tag/v7.0.0) - 2024-01-19
 
 ### 🛠 Breaking changes

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -9,7 +9,11 @@ import { BuildContext } from './context';
 import { maybeResolveVersionsAsync as maybeResolveIosVersionsAsync } from './ios/version';
 import { LocalBuildMode } from './local';
 import Log from '../log';
-import { getUsername, isExpoUpdatesInstalled } from '../project/projectUtils';
+import {
+  getUsername,
+  isClassicUpdatesSupportedAsync,
+  isExpoUpdatesInstalled,
+} from '../project/projectUtils';
 import {
   readChannelSafelyAsync as readAndroidChannelSafelyAsync,
   readReleaseChannelSafelyAsync as readAndroidReleaseChannelSafelyAsync,
@@ -125,13 +129,19 @@ async function resolveChannelOrReleaseChannelAsync<T extends Platform>(
   if (ctx.buildProfile.channel) {
     return { channel: ctx.buildProfile.channel };
   }
-  if (ctx.buildProfile.releaseChannel) {
-    return { releaseChannel: ctx.buildProfile.releaseChannel };
-  }
   const channel = await getNativeChannelAsync(ctx);
   if (channel) {
     return { channel };
   }
+
+  if (!(await isClassicUpdatesSupportedAsync(ctx.projectDir))) {
+    return null;
+  }
+
+  if (ctx.buildProfile.releaseChannel) {
+    return { releaseChannel: ctx.buildProfile.releaseChannel };
+  }
+
   const releaseChannel = await getNativeReleaseChannelAsync(ctx);
   return { releaseChannel };
 }

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -138,7 +138,7 @@ export async function isClassicUpdatesSupportedAsync(projectDir: string): Promis
     return false;
   }
 
-  return !semver.gte(expoUpdatesPackageVersion, '0.19.0');
+  return semver.lt(expoUpdatesPackageVersion, '0.19.0');
 }
 
 export async function installExpoUpdatesAsync(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

As of SDK 50, classic updates is no longer supported. So builds should no longer configure a classic release channel and should instead configure nothing even when "releaseChannel" is set in eas.json for expo-updates.

Related: https://github.com/expo/eas-build/pull/319
Closes ENG-11121.

# How

Check expo-updates version and prevent setting releaseChannel in build job metadata if expo-updates package version >= 0.19.0.

# Test Plan

`neas build`, click URL, no longer see releaseChannel set in metadata in resulting build
