### PR TITLE
Use credentials types from eas-build-job where possible

### DIFF
--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -6,7 +6,6 @@ import { transformJob } from './graphql';
 import { prepareJobAsync } from './prepareJob';
 import { syncProjectConfigurationAsync } from './syncProjectConfiguration';
 import { resolveRemoteBuildNumberAsync } from './version';
-import { IosCredentials } from '../../credentials/ios/types';
 import { BuildParamsInput } from '../../graphql/generated';
 import { BuildMutation, BuildResult } from '../../graphql/mutations/BuildMutation';
 import { ensureBundleIdentifierIsDefinedForManagedProjectAsync } from '../../project/ios/bundleIdentifier';
@@ -94,7 +93,7 @@ export async function prepareIosBuildAsync(
     },
     prepareJobAsync: async (
       ctx: BuildContext<Platform.IOS>,
-      jobData: JobData<IosCredentials>
+      jobData: JobData<Ios.BuildCredentials>
     ): Promise<Job> => {
       return await prepareJobAsync(ctx, {
         ...jobData,

--- a/packages/eas-cli/src/build/ios/credentials.ts
+++ b/packages/eas-cli/src/build/ios/credentials.ts
@@ -1,10 +1,10 @@
-import { Platform } from '@expo/eas-build-job';
+import { Ios, Platform } from '@expo/eas-build-job';
 import { BuildProfile } from '@expo/eas-json';
 
 import { CredentialsContext } from '../../credentials/context';
 import IosCredentialsProvider from '../../credentials/ios/IosCredentialsProvider';
 import { getAppFromContextAsync } from '../../credentials/ios/actions/BuildCredentialsUtils';
-import { IosCredentials, Target } from '../../credentials/ios/types';
+import { Target } from '../../credentials/ios/types';
 import { CredentialsResult } from '../build';
 import { BuildContext } from '../context';
 import { logCredentialsSource } from '../utils/credentials';
@@ -12,7 +12,7 @@ import { logCredentialsSource } from '../utils/credentials';
 export async function ensureIosCredentialsAsync(
   buildCtx: BuildContext<Platform.IOS>,
   targets: Target[]
-): Promise<CredentialsResult<IosCredentials> | undefined> {
+): Promise<CredentialsResult<Ios.BuildCredentials> | undefined> {
   if (!shouldProvideCredentials(buildCtx)) {
     return;
   }
@@ -37,7 +37,7 @@ export async function ensureIosCredentialsForBuildResignAsync(
   credentialsCtx: CredentialsContext,
   targets: Target[],
   buildProfile: BuildProfile<Platform.IOS>
-): Promise<CredentialsResult<IosCredentials>> {
+): Promise<CredentialsResult<Ios.BuildCredentials>> {
   const provider = new IosCredentialsProvider(credentialsCtx, {
     app: await getAppFromContextAsync(credentialsCtx),
     targets,

--- a/packages/eas-cli/src/credentials/credentialsJson/types.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/types.ts
@@ -2,20 +2,6 @@ import Joi from 'joi';
 
 import { Keystore } from '../android/credentials';
 
-export interface CredentialsJson {
-  android?: CredentialsJsonAndroidCredentials;
-  ios?: CredentialsJsonIosTargetCredentials | CredentialsJsonIosCredentials;
-}
-
-export interface CredentialsJsonAndroidCredentials {
-  keystore: {
-    keystorePath: string;
-    keystorePassword: string;
-    keyAlias: string;
-    keyPassword?: string;
-  };
-}
-
 export interface CredentialsJsonIosTargetCredentials {
   provisioningProfilePath: string;
   distributionCertificate: {
@@ -23,22 +9,12 @@ export interface CredentialsJsonIosTargetCredentials {
     password: string;
   };
 }
-export type CredentialsJsonIosCredentials = Record<string, CredentialsJsonIosTargetCredentials>;
 
 export interface AndroidCredentials {
   keystore: Keystore;
 }
 
-export interface IosTargetCredentials {
-  provisioningProfile: string;
-  distributionCertificate: {
-    certificateP12: string;
-    certificatePassword: string;
-  };
-}
-export type IosCredentials = Record<string, IosTargetCredentials>;
-
-const CredentialsJsonIosTargetCredentialsSchema = Joi.object({
+const CredentialsJsonIosTargetCredentialsSchema = Joi.object<CredentialsJsonIosTargetCredentials>({
   provisioningProfilePath: Joi.string().required(),
   distributionCertificate: Joi.object({
     path: Joi.string().required(),
@@ -46,7 +22,19 @@ const CredentialsJsonIosTargetCredentialsSchema = Joi.object({
   }).required(),
 });
 
-export const CredentialsJsonSchema = Joi.object({
+export type CredentialsJson = {
+  android?: {
+    keystore: {
+      keystorePath: string;
+      keystorePassword: string;
+      keyAlias: string;
+      keyPassword?: string;
+    };
+  };
+  ios?: CredentialsJsonIosTargetCredentials | Record<string, CredentialsJsonIosTargetCredentials>;
+};
+
+export const CredentialsJsonSchema = Joi.object<CredentialsJson>({
   android: Joi.object({
     keystore: Joi.object({
       keystorePath: Joi.string().required(),

--- a/packages/eas-cli/src/credentials/credentialsJson/utils.ts
+++ b/packages/eas-cli/src/credentials/credentialsJson/utils.ts
@@ -1,6 +1,6 @@
+import { Ios } from '@expo/eas-build-job';
 import path from 'path';
 
-import { IosCredentials } from './types';
 import { Target } from '../ios/types';
 
 export function getCredentialsJsonPath(projectDir: string): string {
@@ -9,7 +9,7 @@ export function getCredentialsJsonPath(projectDir: string): string {
 
 export function ensureAllTargetsAreConfigured(
   targets: Target[],
-  credentialsJson: IosCredentials
+  credentialsJson: Ios.BuildCredentials
 ): void {
   const notConfiguredTargets: string[] = [];
   for (const target of targets) {

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -1,4 +1,4 @@
-import { Platform } from '@expo/eas-build-job';
+import { Ios, Platform } from '@expo/eas-build-job';
 import {
   CredentialsSource,
   DistributionType,
@@ -9,7 +9,7 @@ import {
 import { getAppFromContextAsync } from './actions/BuildCredentialsUtils';
 import { SetUpBuildCredentials } from './actions/SetUpBuildCredentials';
 import { SetUpPushKey } from './actions/SetUpPushKey';
-import { App, IosCredentials, Target } from './types';
+import { App, Target } from './types';
 import { isAdHocProfile, isEnterpriseUniversalProfile } from './utils/provisioningProfile';
 import { CommonIosAppCredentialsFragment } from '../../graphql/generated';
 import Log from '../../log';
@@ -35,14 +35,11 @@ enum PushNotificationSetupOption {
 export default class IosCredentialsProvider {
   public readonly platform = Platform.IOS;
 
-  constructor(
-    private ctx: CredentialsContext,
-    private options: Options
-  ) {}
+  constructor(private ctx: CredentialsContext, private options: Options) {}
 
   public async getCredentialsAsync(
     src: CredentialsSource.LOCAL | CredentialsSource.REMOTE
-  ): Promise<IosCredentials> {
+  ): Promise<Ios.BuildCredentials> {
     let buildCredentials;
     if (src === CredentialsSource.LOCAL) {
       buildCredentials = await this.getLocalAsync();
@@ -53,7 +50,7 @@ export default class IosCredentialsProvider {
     return buildCredentials;
   }
 
-  private async getLocalAsync(): Promise<IosCredentials> {
+  private async getLocalAsync(): Promise<Ios.BuildCredentials> {
     const applicationTarget = findApplicationTarget(this.options.targets);
     const iosCredentials = await credentialsJsonReader.readIosCredentialsAsync(
       this.ctx.projectDir,
@@ -62,14 +59,14 @@ export default class IosCredentialsProvider {
     ensureAllTargetsAreConfigured(this.options.targets, iosCredentials);
     for (const target of this.options.targets) {
       this.assertProvisioningProfileType(
-        iosCredentials[target.targetName].provisioningProfile,
+        iosCredentials[target.targetName].provisioningProfileBase64,
         target.targetName
       );
     }
     return iosCredentials;
   }
 
-  private async getRemoteAsync(): Promise<IosCredentials> {
+  private async getRemoteAsync(): Promise<Ios.BuildCredentials> {
     return await new SetUpBuildCredentials({
       app: this.options.app,
       targets: this.options.targets,

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpBuildCredentials.ts
@@ -1,3 +1,4 @@
+import { Ios } from '@expo/eas-build-job';
 import { DistributionType, IosEnterpriseProvisioning } from '@expo/eas-json';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
@@ -5,7 +6,7 @@ import nullthrows from 'nullthrows';
 import { SetUpTargetBuildCredentials } from './SetUpTargetBuildCredentials';
 import Log from '../../../log';
 import { CredentialsContext } from '../../context';
-import { App, IosAppBuildCredentialsMap, IosCredentials, Target } from '../types';
+import { App, IosAppBuildCredentialsMap, Target } from '../types';
 import { displayProjectCredentials } from '../utils/printCredentials';
 
 interface Options {
@@ -18,7 +19,7 @@ interface Options {
 export class SetUpBuildCredentials {
   constructor(private options: Options) {}
 
-  async runAsync(ctx: CredentialsContext): Promise<IosCredentials> {
+  async runAsync(ctx: CredentialsContext): Promise<Ios.BuildCredentials> {
     const hasManyTargets = this.options.targets.length > 1;
     const iosAppBuildCredentialsMap: IosAppBuildCredentialsMap = {};
     if (hasManyTargets) {
@@ -71,19 +72,19 @@ export class SetUpBuildCredentials {
   }
 }
 
-function toIosCredentials(appBuildCredentialsMap: IosAppBuildCredentialsMap): IosCredentials {
+function toIosCredentials(appBuildCredentialsMap: IosAppBuildCredentialsMap): Ios.BuildCredentials {
   return Object.entries(appBuildCredentialsMap).reduce((acc, [targetName, appBuildCredentials]) => {
     acc[targetName] = {
       distributionCertificate: {
-        certificateP12: nullthrows(appBuildCredentials.distributionCertificate?.certificateP12),
-        certificatePassword: nullthrows(
-          appBuildCredentials.distributionCertificate?.certificatePassword
-        ),
+        dataBase64: nullthrows(appBuildCredentials.distributionCertificate?.certificateP12),
+        password: nullthrows(appBuildCredentials.distributionCertificate?.certificatePassword),
       },
-      provisioningProfile: nullthrows(appBuildCredentials.provisioningProfile?.provisioningProfile),
+      provisioningProfileBase64: nullthrows(
+        appBuildCredentials.provisioningProfile?.provisioningProfile
+      ),
     };
     return acc;
-  }, {} as IosCredentials);
+  }, {} as Ios.BuildCredentials);
 }
 
 function formatAppInfo({ account, projectName }: App, targets: Target[]): string {

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpBuildCredentialsFromCredentialsJson.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpBuildCredentialsFromCredentialsJson.ts
@@ -1,3 +1,4 @@
+import { Ios } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
 import { SetUpTargetBuildCredentialsFromCredentialsJson } from './SetUpTargetBuildCredentialsFromCredentialsJson';
@@ -6,7 +7,6 @@ import Log from '../../../log';
 import { findApplicationTarget } from '../../../project/ios/target';
 import { CredentialsContext } from '../../context';
 import { readIosCredentialsAsync } from '../../credentialsJson/read';
-import { IosCredentials } from '../../credentialsJson/types';
 import { ensureAllTargetsAreConfigured } from '../../credentialsJson/utils';
 import { App, Target } from '../types';
 
@@ -45,7 +45,7 @@ export class SetUpBuildCredentialsFromCredentialsJson {
     }
   }
 
-  private async readCredentialsJsonAsync(ctx: CredentialsContext): Promise<IosCredentials> {
+  private async readCredentialsJsonAsync(ctx: CredentialsContext): Promise<Ios.BuildCredentials> {
     const applicationTarget = findApplicationTarget(this.targets);
     try {
       return await readIosCredentialsAsync(ctx.projectDir, applicationTarget);

--- a/packages/eas-cli/src/credentials/ios/types.ts
+++ b/packages/eas-cli/src/credentials/ios/types.ts
@@ -21,15 +21,5 @@ export interface Target {
   buildSettings?: XCBuildConfiguration['buildSettings'];
 }
 
-export interface TargetCredentials {
-  distributionCertificate: {
-    certificateP12: string;
-    certificatePassword: string;
-  };
-  provisioningProfile: string;
-}
-
-export type IosCredentials = Record<string, TargetCredentials>;
-
 export type IosAppBuildCredentialsMap = Record<string, IosAppBuildCredentialsFragment>;
 export type IosAppCredentialsMap = Record<string, CommonIosAppCredentialsFragment | null>;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I've noticed we have two very similar types in `eas-build` and `eas-cli`. The types in `eas-cli` are just intermediate — in the end, when we hand off the build request to `www` we change them into the `eas-build` ones.

Wouldn't it be nice if we used the target types from the beginning?

# How

Removed `TargetCredentials` in favor of `Ios.TargetCredentials`. `IosCredentials` in favor of `Ios.BuildCredentials`. Basically, that's it!

Also made some minor change to `credentialsJson/types` so that less types are exported so we are forced to try to use the `eas-build-job` ones.

# Test Plan

_TODO_