### PR TITLE
[eas-cli] Support requireCommit for EAS Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Support requireCommit for EAS Update. ([#2196](https://github.com/expo/eas-cli/pull/2196) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
 import { ensureBranchExistsAsync } from '../../branch/queries';
+import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
 import { getUpdateGroupUrl } from '../../build/utils/url';
 import { ensureChannelExistsAsync } from '../../channel/queries';
 import EasCommand from '../../commandUtils/EasCommand';
@@ -187,6 +188,9 @@ export default class UpdatePublish extends EasCommand {
     if (jsonFlag) {
       enableJsonOutput();
     }
+
+    await vcsClient.ensureRepoExistsAsync();
+    await ensureRepoIsCleanAsync(vcsClient, nonInteractive);
 
     const {
       exp: expPossiblyWithoutEasUpdateConfigured,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When the `requireCommit` preference has been set in eas.json (`cli` section), the `eas update` command should read and respect that preference.

Closes ENG-11110.

# How

Apply same function calls as build/submit.

# Test Plan

1. Add `requireCommit: true` to eas.json cli section
2. 
```
$ neas update

Warning! Your repository working tree is dirty.
This operation needs to be run on a clean working tree. Commit all your changes before proceeding.
✖ Commit changes to git? … yes
```
