### PR TITLE
[eas-cli] [ENG-11247] Remove duplicate log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Remove duplicated log message when creating ASC API key. ([#2208](https://github.com/expo/eas-cli/pull/2208) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+
 ## [7.1.2](https://github.com/expo/eas-cli/releases/tag/v7.1.2) - 2024-01-30
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/credentials/ios/actions/CreateAscApiKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateAscApiKey.ts
@@ -1,6 +1,5 @@
 import { AppStoreApiKeyPurpose, provideOrGenerateAscApiKeyAsync } from './AscApiKeyUtils';
 import { AccountFragment, AppStoreConnectApiKeyFragment } from '../../../graphql/generated';
-import Log from '../../../log';
 import { CredentialsContext } from '../../context';
 
 export class CreateAscApiKey {
@@ -15,8 +14,6 @@ export class CreateAscApiKey {
     }
 
     const ascApiKey = await provideOrGenerateAscApiKeyAsync(ctx, purpose);
-    const result = await ctx.ios.createAscApiKeyAsync(ctx.graphqlClient, this.account, ascApiKey);
-    Log.succeed('Created App Store Connect API Key');
-    return result;
+    return await ctx.ios.createAscApiKeyAsync(ctx.graphqlClient, this.account, ascApiKey);
   }
 }


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-11247/fix-console-output-when-creating-asc-key

# How

Information about App Store Connect API key being created was displayed twice to the user. This removes the duplicate

# Test Plan

Tested manually

# Screens
## Before
![Screenshot 2024-02-01 at 11 37 59](https://github.com/expo/eas-cli/assets/2974455/63cd0564-9602-4912-b3e4-444d389ad5ab)
## After
![Screenshot 2024-02-01 at 11 38 23](https://github.com/expo/eas-cli/assets/2974455/cf84378e-4bd7-4414-bd59-222358baa9d0)
