### PR TITLE
[ci] auto update EAS CLI version used on production for builds triggered using GitHub trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,13 @@ jobs:
           VERSION=$(cat lerna.json | jq -r .version)
           echo //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN > ~/.npmrc
           npm dist-tag add eas-cli@$VERSION latest-eas-build-staging
-          echo "Run \"npm dist-tag add eas-cli@$VERSION latest-eas-build\" to promote it to production."
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+      - name: Add latest-eas-build tag
+        run: |
+          VERSION=$(cat lerna.json | jq -r .version)
+          echo //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN > ~/.npmrc
+          npm dist-tag add eas-cli@$VERSION latest-eas-build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
   release-changelog:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,3 @@ The algorithm works as follows:
 - If there are any entries in the "🛠 Breaking changes" section, bump the MAJOR version.
 - Otherwise, if there are any entries in the "🎉 New features", bump the MINOR version.
 - Otherwise, bump the PATCH version.
-
-## Updating EAS CLI version on EAS Build
-
-The release process promotes the new version to staging. After verifying it works there, you can promote it to production with `npm dist-tag add eas-cli@{version} latest-eas-build`.


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/CRM0Y8JLU/p1706823546329859?thread_ts=1706822844.405259&cid=CRM0Y8JLU

It's super easy to forget about it and prod version is getting out of sync

# How

Bump the `latest-eas-build` tag (the tag determining which EAS CLI version used for GH builds on prod) automatically after publishing the release

