### PR TITLE
Revert "feat(eas-cli): expose expo export dev flag as an option in eas update (#2050)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Revert expose expo export dev flag as an option in eas update. ([#2214](https://github.com/expo/eas-cli/pull/2214) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 - Remove duplicated log message when creating ASC API key. ([#2208](https://github.com/expo/eas-cli/pull/2208) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -56,7 +56,6 @@ import { maybeWarnAboutEasOutagesAsync } from '../../utils/statuspageService';
 
 type RawUpdateFlags = {
   auto: boolean;
-  dev: boolean;
   branch?: string;
   channel?: string;
   message?: string;
@@ -75,7 +74,6 @@ type RawUpdateFlags = {
 
 type UpdateFlags = {
   auto: boolean;
-  dev: boolean;
   platform: ExpoCLIExportPlatformFlag;
   branchName?: string;
   channelName?: string;
@@ -136,10 +134,6 @@ export default class UpdatePublish extends EasCommand {
       default: 'all',
       required: false,
     }),
-    dev: Flags.boolean({
-      description: 'Publish a development bundle',
-      default: false,
-    }),
     auto: Flags.boolean({
       description:
         'Use the current git branch and commit message for the EAS branch and update message',
@@ -165,7 +159,6 @@ export default class UpdatePublish extends EasCommand {
       auto: autoFlag,
       platform: platformFlag,
       channelName: channelNameArg,
-      dev,
       updateMessage: updateMessageArg,
       inputDir,
       skipBundler,
@@ -234,7 +227,7 @@ export default class UpdatePublish extends EasCommand {
     if (!skipBundler) {
       const bundleSpinner = ora().start('Exporting...');
       try {
-        await buildBundlesAsync({ projectDir, inputDir, dev, exp, platformFlag, clearCache });
+        await buildBundlesAsync({ projectDir, inputDir, exp, platformFlag, clearCache });
         bundleSpinner.succeed('Exported bundle(s)');
       } catch (e) {
         bundleSpinner.fail('Export failed');
@@ -547,7 +540,7 @@ export default class UpdatePublish extends EasCommand {
   private sanitizeFlags(flags: RawUpdateFlags): UpdateFlags {
     const nonInteractive = flags['non-interactive'] ?? false;
 
-    const { auto, branch: branchName, channel: channelName, dev, message: updateMessage } = flags;
+    const { auto, branch: branchName, channel: channelName, message: updateMessage } = flags;
     if (nonInteractive && !auto && !(updateMessage && (branchName || channelName))) {
       Errors.error(
         '--branch and --message, or --channel and --message are required when updating in non-interactive mode unless --auto is specified',
@@ -576,7 +569,6 @@ export default class UpdatePublish extends EasCommand {
       auto,
       branchName,
       channelName,
-      dev,
       updateMessage,
       inputDir: flags['input-dir'],
       skipBundler: flags['skip-bundler'],

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -185,14 +185,12 @@ export async function buildBundlesAsync({
   exp,
   platformFlag,
   clearCache,
-  dev = false,
 }: {
   projectDir: string;
   inputDir: string;
   exp: Pick<ExpoConfig, 'sdkVersion' | 'web'>;
   platformFlag: ExpoCLIExportPlatformFlag;
   clearCache?: boolean;
-  dev?: boolean;
 }): Promise<void> {
   const packageJSON = JsonFile.read(path.resolve(projectDir, 'package.json'));
   if (!packageJSON) {
@@ -210,7 +208,6 @@ export async function buildBundlesAsync({
       '--dump-sourcemap',
       '--dump-assetmap',
       `--platform=${platformFlag}`,
-      ...(dev ? ['--dev'] : []),
       ...(clearCache ? ['--clear'] : []),
     ]);
   }
@@ -230,7 +227,6 @@ export async function buildBundlesAsync({
       '--dump-sourcemap',
       '--dump-assetmap',
       ...platformArgs,
-      ...(dev ? ['--dev'] : []),
       ...(clearCache ? ['--clear'] : []),
     ]);
   }
@@ -252,7 +248,6 @@ export async function buildBundlesAsync({
     '--dump-sourcemap',
     '--dump-assetmap',
     `--platform=${platformFlag}`,
-    ...(dev ? ['--dev'] : []),
     ...(clearCache ? ['--clear'] : []),
   ]);
 }


### PR DESCRIPTION
# Why

This reverts commit 8751a2835f38e4be5079c7f2ffe7129f9a060301.

The reason we're reverting this is that it is causing some confusion around whether dev bundles work with EAS update. The answer is that they probably shouldn't, or at least aren't officially supported.

> "Dev" bundles are quite different from production bundles (no minification, possibly different Babel presets running, different NODE_ENV is set, and `__DEV__` value is different). The value of `__DEV__` is used in many places to change behavior to fit a development environment, for example in [expo-asset](https://github.com/expo/expo/blob/dd5f37fc1a8df22b7ae1da98b085b9c5ad06dcd1/packages/expo-asset/src/AssetSourceResolver.ts#L13-L23). If we want to support loading updates that are published in dev mode, we should ensure we have adequate test coverage and that this is something we are consciously supporting.

Instead, to address the original concern in https://github.com/expo/eas-cli/pull/2050 (accessing the dev menu), we'll address that issue in a more targeted manner: by making accessing the dev menu even in places when `__DEV__` isn't set.

Alternatively, one could theoretically do the export step manually during an `eas update` by running the `npx expo export` command manually and then running `eas update --skip-bundler`.

Closes ENG-11290.

# How

Revert.

# Test Plan

CI
