### PR TITLE
[eas-cli] Add support for updated fingerprint policy to eas update

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -15,6 +15,7 @@
     "@expo/config-types": "50.0.0",
     "@expo/eas-build-job": "1.0.70",
     "@expo/eas-json": "7.1.3",
+    "@expo/fingerprint": "0.6.0",
     "@expo/json-file": "8.2.37",
     "@expo/multipart-body-parser": "1.1.0",
     "@expo/osascript": "2.0.33",

--- a/packages/eas-cli/src/build/android/syncProjectConfiguration.ts
+++ b/packages/eas-cli/src/build/android/syncProjectConfiguration.ts
@@ -24,7 +24,9 @@ export async function syncProjectConfigurationAsync({
   localAutoIncrement?: AndroidVersionAutoIncrement;
   vcsClient: Client;
 }): Promise<void> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   const versionBumpStrategy = resolveVersionBumpStrategy(localAutoIncrement ?? false);
 
   if (workflow === Workflow.GENERIC) {

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -100,7 +100,9 @@ export async function maybeResolveVersionsAsync(
   buildProfile: BuildProfile<Platform.ANDROID>,
   vcsClient: Client
 ): Promise<{ appVersion?: string; appBuildVersion?: string }> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   if (workflow === Workflow.GENERIC) {
     const buildGradle = await getAppBuildGradleAsync(projectDir);
     try {

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -61,7 +61,9 @@ export async function createBuildContextAsync<T extends Platform>({
   const { exp, projectId } = await getDynamicPrivateProjectConfigAsync({ env: buildProfile.env });
   const projectName = exp.slug;
   const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
-  const workflow = await resolveWorkflowAsync(projectDir, platform, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, platform, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   const accountId = account.id;
   const runFromCI = getenv.boolish('CI', false);
   const developmentClient =

--- a/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts
+++ b/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts
@@ -22,7 +22,9 @@ export async function syncProjectConfigurationAsync({
   localAutoIncrement?: IosVersionAutoIncrement;
   vcsClient: Client;
 }): Promise<void> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   const versionBumpStrategy = resolveVersionBumpStrategy(localAutoIncrement ?? false);
 
   if (workflow === Workflow.GENERIC) {

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -114,7 +114,9 @@ export async function readShortVersionAsync(
   buildSettings: XCBuildConfiguration['buildSettings'],
   vcsClient: Client
 ): Promise<string | undefined> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   if (workflow === Workflow.GENERIC) {
     const infoPlist = await readInfoPlistAsync(projectDir, buildSettings);
 
@@ -136,7 +138,9 @@ export async function readBuildNumberAsync(
   buildSettings: XCBuildConfiguration['buildSettings'],
   vcsClient: Client
 ): Promise<string | undefined> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   if (workflow === Workflow.GENERIC) {
     const infoPlist = await readInfoPlistAsync(projectDir, buildSettings);
     return (

--- a/packages/eas-cli/src/build/utils/devClient.ts
+++ b/packages/eas-cli/src/build/utils/devClient.ts
@@ -43,7 +43,11 @@ export async function ensureExpoDevClientInstalledForDevClientBuildsAsync({
   );
 
   const workflowPerPlatformList = await Promise.all(
-    platformsToCheck.map(platform => resolveWorkflowAsync(projectDir, platform, vcsClient))
+    platformsToCheck.map(platform =>
+      resolveWorkflowAsync(projectDir, platform, vcsClient, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      })
+    )
   );
 
   Log.newLine();

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -107,7 +107,9 @@ export async function makeProjectTarballAsync(
   startTimer(compressTimerLabel);
 
   try {
-    await vcsClient.makeShallowCopyAsync(shallowClonePath);
+    await vcsClient.makeShallowCopyAsync(shallowClonePath, {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+    });
     await tar.create({ cwd: shallowClonePath, file: tarPath, prefix: 'project', gzip: true }, [
       '.',
     ]);

--- a/packages/eas-cli/src/build/validate.ts
+++ b/packages/eas-cli/src/build/validate.ts
@@ -32,7 +32,9 @@ export async function checkGoogleServicesFileAsync<T extends Platform>(
   if (
     (await fs.pathExists(absGoogleServicesFilePath)) &&
     (!isInsideDirectory(absGoogleServicesFilePath, rootDir) ||
-      (await ctx.vcsClient.isFileIgnoredAsync(path.relative(rootDir, absGoogleServicesFilePath))))
+      (await ctx.vcsClient.isFileIgnoredAsync(path.relative(rootDir, absGoogleServicesFilePath), {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      })))
   ) {
     Log.warn(
       `File specified via "${ctx.platform}.googleServicesFile" field in your app.json is not checked in to your repository and won't be uploaded to the builder.`

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -72,14 +72,18 @@ export default class BuildConfigure extends EasCommand {
     // configure expo-updates
     if (expoUpdatesIsInstalled) {
       if ([RequestedPlatform.Android, RequestedPlatform.All].includes(platform)) {
-        const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
+        const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+          useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+        });
         if (workflow === Workflow.GENERIC) {
           await syncAndroidUpdatesConfigurationAsync(projectDir, exp);
         }
       }
 
       if ([RequestedPlatform.Ios, RequestedPlatform.All].includes(platform)) {
-        const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+        const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+          useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+        });
         if (workflow === Workflow.GENERIC) {
           await syncIosUpdatesConfigurationAsync(vcsClient, projectDir, exp);
         }

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -94,7 +94,9 @@ export default class BuildInspect extends EasCommand {
 
     if (flags.stage === InspectStage.ARCHIVE) {
       await vcsClient.ensureRepoExistsAsync();
-      await vcsClient.makeShallowCopyAsync(tmpWorkingdir);
+      await vcsClient.makeShallowCopyAsync(tmpWorkingdir, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      });
       await this.copyToOutputDirAsync(tmpWorkingdir, outputDirectory);
     } else {
       try {

--- a/packages/eas-cli/src/commands/build/version/sync.ts
+++ b/packages/eas-cli/src/commands/build/version/sync.ts
@@ -109,7 +109,9 @@ export default class BuildVersionSyncView extends EasCommand {
         toAppPlatform(profileInfo.platform),
         applicationIdentifier
       );
-      const workflow = await resolveWorkflowAsync(projectDir, profileInfo.platform, vcsClient);
+      const workflow = await resolveWorkflowAsync(projectDir, profileInfo.platform, vcsClient, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      });
       if (!remoteVersions?.buildVersion) {
         Log.warn(
           `Skipping versions sync for ${platformDisplayName}. There are no versions configured on Expo servers, use "eas build:version:set" or run a build to initialize it.`

--- a/packages/eas-cli/src/commands/diagnostics.ts
+++ b/packages/eas-cli/src/commands/diagnostics.ts
@@ -50,8 +50,12 @@ export default class Diagnostics extends EasCommand {
   }
 
   private async printWorkflowAsync(projectDir: string, vcsClient: Client): Promise<void> {
-    const androidWorkflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
-    const iosWorkflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+    const androidWorkflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+    });
+    const iosWorkflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+    });
 
     if (androidWorkflow === iosWorkflow) {
       Log.log(`    Project workflow: ${androidWorkflow}`);

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -359,12 +359,13 @@ export default class UpdatePublish extends EasCommand {
       throw e;
     }
 
-    const runtimeVersions = await getRuntimeVersionObjectAsync(
+    const runtimeVersions = await getRuntimeVersionObjectAsync({
       exp,
-      realizedPlatforms,
+      platforms: realizedPlatforms,
       projectDir,
-      vcsClient
-    );
+      vcsClient,
+      nonInteractive,
+    });
     const runtimeToPlatformMapping =
       getRuntimeToPlatformMappingFromRuntimeVersions(runtimeVersions);
 

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -201,12 +201,13 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
     const gitCommitHash = await vcsClient.getCommitHashAsync();
     const isGitWorkingTreeDirty = await vcsClient.hasUncommittedChangesAsync();
 
-    const runtimeVersions = await getRuntimeVersionObjectAsync(
+    const runtimeVersions = await getRuntimeVersionObjectAsync({
       exp,
-      realizedPlatforms,
+      platforms: realizedPlatforms,
       projectDir,
-      vcsClient
-    );
+      vcsClient,
+      nonInteractive,
+    });
 
     let newUpdates: UpdatePublishMutation['updateBranch']['publishUpdateGroups'];
     const publishSpinner = ora('Publishing...').start();

--- a/packages/eas-cli/src/project/__tests__/workflow-test.ts
+++ b/packages/eas-cli/src/project/__tests__/workflow-test.ts
@@ -23,12 +23,16 @@ describe(resolveWorkflowAsync, () => {
       projectDir
     );
 
-    await expect(resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient)).resolves.toBe(
-      Workflow.GENERIC
-    );
-    await expect(resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient)).resolves.toBe(
-      Workflow.GENERIC
-    );
+    await expect(
+      resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      })
+    ).resolves.toBe(Workflow.GENERIC);
+    await expect(
+      resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      })
+    ).resolves.toBe(Workflow.GENERIC);
   });
 
   test('bare workflow for single platform', async () => {
@@ -39,12 +43,16 @@ describe(resolveWorkflowAsync, () => {
       projectDir
     );
 
-    await expect(resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient)).resolves.toBe(
-      Workflow.MANAGED
-    );
-    await expect(resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient)).resolves.toBe(
-      Workflow.GENERIC
-    );
+    await expect(
+      resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      })
+    ).resolves.toBe(Workflow.MANAGED);
+    await expect(
+      resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      })
+    ).resolves.toBe(Workflow.GENERIC);
   });
 
   test('android/ios directories are ignored', async () => {
@@ -57,12 +65,16 @@ describe(resolveWorkflowAsync, () => {
       projectDir
     );
 
-    await expect(resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient)).resolves.toBe(
-      Workflow.MANAGED
-    );
-    await expect(resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient)).resolves.toBe(
-      Workflow.MANAGED
-    );
+    await expect(
+      resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      })
+    ).resolves.toBe(Workflow.MANAGED);
+    await expect(
+      resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      })
+    ).resolves.toBe(Workflow.MANAGED);
   });
 });
 
@@ -80,7 +92,11 @@ describe(resolveWorkflowPerPlatformAsync, () => {
       projectDir
     );
 
-    await expect(resolveWorkflowPerPlatformAsync(projectDir, vcsClient)).resolves.toEqual({
+    await expect(
+      resolveWorkflowPerPlatformAsync(projectDir, vcsClient, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      })
+    ).resolves.toEqual({
       android: Workflow.GENERIC,
       ios: Workflow.GENERIC,
     });

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -35,7 +35,9 @@ export async function ensureApplicationIdIsDefinedForManagedProjectAsync({
   exp: ExpoConfig;
   vcsClient: Client;
 }): Promise<string> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
 
   try {
@@ -101,7 +103,9 @@ export async function getApplicationIdAsync(
   vcsClient: Client,
   gradleContext?: GradleBuildContext
 ): Promise<string> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   if (workflow === Workflow.GENERIC) {
     warnIfAndroidPackageDefinedInAppConfigForBareWorkflowProject(projectDir, exp);
 

--- a/packages/eas-cli/src/project/android/gradle.ts
+++ b/packages/eas-cli/src/project/android/gradle.ts
@@ -16,7 +16,9 @@ export async function resolveGradleBuildContextAsync(
   buildProfile: BuildProfile<Platform.ANDROID>,
   vcsClient: Client
 ): Promise<GradleBuildContext | undefined> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   if (workflow === Workflow.GENERIC) {
     try {
       if (buildProfile.gradleCommand) {

--- a/packages/eas-cli/src/project/applicationIdentifier.ts
+++ b/packages/eas-cli/src/project/applicationIdentifier.ts
@@ -36,7 +36,9 @@ export async function getApplicationIdentifierAsync({
 }): Promise<string> {
   if (platform === Platform.ANDROID) {
     const profile = buildProfile as BuildProfile<Platform.ANDROID>;
-    const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
+    const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient, {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+    });
 
     if (workflow === Workflow.MANAGED) {
       return await ensureApplicationIdIsDefinedForManagedProjectAsync({
@@ -51,7 +53,9 @@ export async function getApplicationIdentifierAsync({
     const gradleContext = await resolveGradleBuildContextAsync(projectDir, profile, vcsClient);
     return await getApplicationIdAsync(projectDir, exp, vcsClient, gradleContext);
   } else {
-    const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+    const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+    });
     const profile = buildProfile as BuildProfile<Platform.IOS>;
     if (workflow === Workflow.MANAGED) {
       return await ensureBundleIdentifierIsDefinedForManagedProjectAsync({

--- a/packages/eas-cli/src/project/customBuildConfig.ts
+++ b/packages/eas-cli/src/project/customBuildConfig.ts
@@ -31,7 +31,11 @@ export async function validateCustomBuildConfigAsync({
       `Custom build configuration file ${chalk.bold(relativeConfigPath)} does not exist.`
     );
   }
-  if (await vcsClient.isFileIgnoredAsync(relativeConfigPath)) {
+  if (
+    await vcsClient.isFileIgnoredAsync(relativeConfigPath, {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+    })
+  ) {
     throw new Error(
       `Custom build configuration file ${chalk.bold(
         relativeConfigPath

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -28,7 +28,9 @@ export async function ensureBundleIdentifierIsDefinedForManagedProjectAsync({
   exp: ExpoConfig;
   vcsClient: Client;
 }): Promise<string> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
 
   try {
@@ -55,7 +57,9 @@ export async function getBundleIdentifierAsync(
   vcsClient: Client,
   xcodeContext?: { targetName?: string; buildConfiguration?: string }
 ): Promise<string> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   if (workflow === Workflow.GENERIC) {
     warnIfBundleIdentifierDefinedInAppConfigForBareWorkflowProject(projectDir, exp);
 

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -28,7 +28,9 @@ export async function getManagedApplicationTargetEntitlementsAsync(
       projectRoot: projectDir,
       platforms: ['ios'],
       introspect: true,
-      ignoreExistingNativeFiles: await hasIgnoredIosProjectAsync(projectDir, vcsClient),
+      ignoreExistingNativeFiles: await hasIgnoredIosProjectAsync(projectDir, vcsClient, {
+        useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+      }),
     });
     return expWithMods.ios?.entitlements || {};
   } finally {

--- a/packages/eas-cli/src/project/ios/scheme.ts
+++ b/packages/eas-cli/src/project/ios/scheme.ts
@@ -24,7 +24,9 @@ export async function resolveXcodeBuildContextAsync(
   }: { exp: ExpoConfig; projectDir: string; nonInteractive: boolean; vcsClient: Client },
   buildProfile: BuildProfile<Platform.IOS>
 ): Promise<XcodeBuildContext> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   if (workflow === Workflow.GENERIC) {
     const buildScheme =
       buildProfile.scheme ??

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -145,7 +145,9 @@ export async function resolveBareProjectTargetsAsync({
 }
 
 export async function resolveTargetsAsync(opts: ResolveTargetOptions): Promise<Target[]> {
-  const workflow = await resolveWorkflowAsync(opts.projectDir, Platform.IOS, opts.vcsClient);
+  const workflow = await resolveWorkflowAsync(opts.projectDir, Platform.IOS, opts.vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   if (workflow === Workflow.GENERIC) {
     return await resolveBareProjectTargetsAsync(opts);
   } else if (workflow === Workflow.MANAGED) {

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -384,7 +384,9 @@ export async function ensureEASUpdateIsConfiguredAsync({
     return;
   }
 
-  const workflows = await resolveWorkflowPerPlatformAsync(projectDir, vcsClient);
+  const workflows = await resolveWorkflowPerPlatformAsync(projectDir, vcsClient, {
+    useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true,
+  });
   const { projectChanged, exp: expWithUpdates } =
     await ensureEASUpdatesIsConfiguredInExpoConfigAsync({
       exp: expMaybeWithoutUpdates,

--- a/packages/eas-cli/src/vcs/__tests__/local-test.ts
+++ b/packages/eas-cli/src/vcs/__tests__/local-test.ts
@@ -18,7 +18,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = new Ignore('/root');
+    const ignore = new Ignore('/root', { useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true });
     await ignore.initIgnoreAsync();
     expect(ignore.ignores('aaa')).toBe(true);
     expect(ignore.ignores('bbb')).toBe(false);
@@ -36,12 +36,31 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = new Ignore('/root');
+    const ignore = new Ignore('/root', { useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true });
     await ignore.initIgnoreAsync();
     expect(ignore.ignores('aaa')).toBe(false);
     expect(ignore.ignores('bbb')).toBe(false);
     expect(ignore.ignores('ccc')).toBe(true);
     expect((ignore as any).ignoreMapping.map((i: any) => i[0])).toEqual(['', '']);
+  });
+
+  it('uses .gitignore files if .easignore is present but useEASIgnoreIfAvailableWhenEvaluatingFileIgnores is false', async () => {
+    vol.fromJSON(
+      {
+        '.gitignore': 'aaa',
+        '.easignore': 'ccc',
+        'dir/.gitignore': 'bbb',
+      },
+      '/root'
+    );
+
+    const ignore = new Ignore('/root', { useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: false });
+    await ignore.initIgnoreAsync();
+    expect(ignore.ignores('aaa')).toBe(true);
+    expect(ignore.ignores('bbb')).toBe(false);
+    expect(ignore.ignores('ccc')).toBe(false);
+    expect(ignore.ignores('dir/aaa')).toBe(true);
+    expect(ignore.ignores('dir/bbb')).toBe(true);
   });
 
   it('ignores .gitignore files in node_modules content', async () => {
@@ -54,7 +73,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = new Ignore('/root');
+    const ignore = new Ignore('/root', { useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true });
     await ignore.initIgnoreAsync();
     expect(ignore.ignores('aaa')).toBe(true);
     expect(ignore.ignores('bbb')).toBe(false);
@@ -72,7 +91,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = new Ignore('/root');
+    const ignore = new Ignore('/root', { useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true });
     await ignore.initIgnoreAsync();
     expect(ignore.ignores('dir/ccc')).toBe(true);
   });
@@ -80,7 +99,7 @@ describe(Ignore, () => {
   it('ignores .git', async () => {
     vol.fromJSON({}, '/root');
 
-    const ignore = new Ignore('/root');
+    const ignore = new Ignore('/root', { useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true });
     await ignore.initIgnoreAsync();
     expect(ignore.ignores('.git')).toBe(true);
   });
@@ -93,7 +112,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = new Ignore('/root');
+    const ignore = new Ignore('/root', { useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: true });
     await ignore.initIgnoreAsync();
     expect(() => ignore.ignores('dir/test')).not.toThrowError();
   });

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -120,7 +120,12 @@ export default class GitClient extends Client {
     return (await spawnAsync('git', ['rev-parse', '--show-toplevel'])).stdout.trim();
   }
 
-  public async makeShallowCopyAsync(destinationPath: string): Promise<void> {
+  public async makeShallowCopyAsync(
+    destinationPath: string,
+    _options: {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: boolean;
+    }
+  ): Promise<void> {
     if (await this.hasUncommittedChangesAsync()) {
       // it should already be checked before this function is called, but in case it wasn't
       // we want to ensure that any changes were introduced by call to `setGitCaseSensitivityAsync`
@@ -207,7 +212,12 @@ export default class GitClient extends Client {
     );
   }
 
-  public override async isFileIgnoredAsync(filePath: string): Promise<boolean> {
+  public override async isFileIgnoredAsync(
+    filePath: string,
+    _options: {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: boolean;
+    }
+  ): Promise<boolean> {
     try {
       await spawnAsync('git', ['check-ignore', '-q', filePath], {
         cwd: path.normalize(await this.getRootPathAsync()),

--- a/packages/eas-cli/src/vcs/clients/gitNoCommit.ts
+++ b/packages/eas-cli/src/vcs/clients/gitNoCommit.ts
@@ -15,16 +15,26 @@ export default class GitNoCommitClient extends GitClient {
     return (await spawnAsync('git', ['rev-parse', '--show-toplevel'])).stdout.trim();
   }
 
-  public override async makeShallowCopyAsync(destinationPath: string): Promise<void> {
+  public override async makeShallowCopyAsync(
+    destinationPath: string,
+    options: {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: boolean;
+    }
+  ): Promise<void> {
     // normalize converts C:/some/path to C:\some\path on windows
     const srcPath = path.normalize(await this.getRootPathAsync());
-    await makeShallowCopyAsync(srcPath, destinationPath);
+    await makeShallowCopyAsync(srcPath, destinationPath, options);
   }
 
-  public override async isFileIgnoredAsync(filePath: string): Promise<boolean> {
+  public override async isFileIgnoredAsync(
+    filePath: string,
+    options: {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: boolean;
+    }
+  ): Promise<boolean> {
     // normalize converts C:/some/path to C:\some\path on windows
     const rootPath = path.normalize(await this.getRootPathAsync());
-    const ignore = new Ignore(rootPath);
+    const ignore = new Ignore(rootPath, options);
     await ignore.initIgnoreAsync();
     return ignore.ignores(filePath);
   }

--- a/packages/eas-cli/src/vcs/clients/noVcs.ts
+++ b/packages/eas-cli/src/vcs/clients/noVcs.ts
@@ -6,13 +6,23 @@ export default class NoVcsClient extends Client {
     return getRootPath();
   }
 
-  public async makeShallowCopyAsync(destinationPath: string): Promise<void> {
+  public async makeShallowCopyAsync(
+    destinationPath: string,
+    options: {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: boolean;
+    }
+  ): Promise<void> {
     const srcPath = getRootPath();
-    await makeShallowCopyAsync(srcPath, destinationPath);
+    await makeShallowCopyAsync(srcPath, destinationPath, options);
   }
 
-  public override async isFileIgnoredAsync(filePath: string): Promise<boolean> {
-    const ignore = new Ignore(getRootPath());
+  public override async isFileIgnoredAsync(
+    filePath: string,
+    options: {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: boolean;
+    }
+  ): Promise<boolean> {
+    const ignore = new Ignore(getRootPath(), options);
     await ignore.initIgnoreAsync();
     return ignore.ignores(filePath);
   }

--- a/packages/eas-cli/src/vcs/vcs.ts
+++ b/packages/eas-cli/src/vcs/vcs.ts
@@ -3,7 +3,12 @@ export abstract class Client {
   // destination, folder created this way will be uploaded "as is", so implementation should skip
   // anything that is not committed to the repository. Most optimal solution is to create shallow clone
   // using tooling provided by specific VCS, that respects all ignore rules
-  public abstract makeShallowCopyAsync(destinationPath: string): Promise<void>;
+  public abstract makeShallowCopyAsync(
+    destinationPath: string,
+    options: {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: boolean;
+    }
+  ): Promise<void>;
 
   // Find root of the repository.
   //
@@ -75,7 +80,12 @@ export abstract class Client {
   //
   // @param filePath has to be a relative normalized path pointing to a file
   // located under the root of the repository
-  public async isFileIgnoredAsync(_filePath: string): Promise<boolean> {
+  public async isFileIgnoredAsync(
+    _filePath: string,
+    _options: {
+      useEASIgnoreIfAvailableWhenEvaluatingFileIgnores: boolean;
+    }
+  ): Promise<boolean> {
     return false;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,7 +1470,7 @@
     joi "^17.11.0"
     semver "^7.5.4"
 
-"@expo/fingerprint@^0.6.0":
+"@expo/fingerprint@0.6.0", "@expo/fingerprint@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@expo/fingerprint/-/fingerprint-0.6.0.tgz#77366934673d4ecea37284109b4dd67f9e6a7487"
   integrity sha512-KfpoVRTMwMNJ/Cf5o+Ou8M/Y0EGSTqK+rbi70M2Y0K2qgWNfMJ1gm6sYO9uc8lcTr7YSYM1Rme3dk7QXhpScNA==


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Corresponding eas-cli change to https://github.com/expo/expo/pull/26901 for the updates part.

This does fingerprint runtime version policy evaluation during `eas update`.

# How

Intercept the calls to get the runtime version and, if fingerprint, run the fingerprint.

I still need to figure out how to enforce that the native directories are in a good state (have been prebuilt if necessary). TBH I'm not sure how we'll do this since we can't tell whether the project uses prebuild here. I guess we could just check for the platform native directory (`ios/` or `android/` respectively) and if it isn't there throw?

# Test Plan

This is just an RFC for now to go along with https://github.com/expo/expo/pull/26901, so it hasn't been tested fully end-to-end yet.
