### PR TITLE
[eas-cli] fix expo-updates fingerprinting during update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Fix expo-updates fingerprinting during update. ([#2231](https://github.com/expo/eas-cli/pull/2231) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -359,12 +359,12 @@ export default class UpdatePublish extends EasCommand {
       throw e;
     }
 
-    const runtimeVersions = await getRuntimeVersionObjectAsync(
+    const runtimeVersions = await getRuntimeVersionObjectAsync({
       exp,
-      realizedPlatforms,
+      platforms: realizedPlatforms,
       projectDir,
-      vcsClient
-    );
+      vcsClient,
+    });
     const runtimeToPlatformMapping =
       getRuntimeToPlatformMappingFromRuntimeVersions(runtimeVersions);
 

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -201,12 +201,12 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
     const gitCommitHash = await vcsClient.getCommitHashAsync();
     const isGitWorkingTreeDirty = await vcsClient.hasUncommittedChangesAsync();
 
-    const runtimeVersions = await getRuntimeVersionObjectAsync(
+    const runtimeVersions = await getRuntimeVersionObjectAsync({
       exp,
-      realizedPlatforms,
+      platforms: realizedPlatforms,
       projectDir,
-      vcsClient
-    );
+      vcsClient,
+    });
 
     let newUpdates: UpdatePublishMutation['updateBranch']['publishUpdateGroups'];
     const publishSpinner = ora('Publishing...').start();

--- a/packages/eas-cli/src/utils/expoUpdatesCli.ts
+++ b/packages/eas-cli/src/utils/expoUpdatesCli.ts
@@ -1,0 +1,40 @@
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
+
+import Log, { link } from '../log';
+
+export async function expoUpdatesCommandAsync(projectDir: string, args: string[]): Promise<string> {
+  let expoUpdatesCli;
+  try {
+    expoUpdatesCli =
+      silentResolveFrom(projectDir, 'expo-updates/bin/cli') ??
+      resolveFrom(projectDir, 'expo-updates/bin/cli.js');
+  } catch (e: any) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        `The \`expo-updates\` package was not found. Follow the installation directions at ${link(
+          'https://docs.expo.dev/bare/installing-expo-modules/'
+        )}`
+      );
+    }
+    throw e;
+  }
+
+  const spawnPromise = spawnAsync(expoUpdatesCli, args, {
+    stdio: ['inherit', 'pipe', 'pipe'], // inherit stdin so user can install a missing expo-cli from inside this command
+  });
+  const {
+    child: { stderr },
+  } = spawnPromise;
+  if (!stderr) {
+    throw new Error('Failed to spawn expo-updates cli');
+  }
+  stderr.on('data', data => {
+    for (const line of data.toString().trim().split('\n')) {
+      Log.warn(`${chalk.gray('[expo-cli]')} ${line}`);
+    }
+  });
+  const result = await spawnPromise;
+  return result.stdout;
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Successor to https://github.com/expo/eas-cli/pull/2225 (previous attempt at this).

This PR calls in to the new `expo-updates` CLI command to generate the fingerprint: https://github.com/expo/expo/pull/27119. This ensures that the version of the fingerprint package being used is consistent between builds and this `eas update` command when calculating the runtime version.

# How

In test bare app in expo/expo repo with all the modules installed locally (checked out to https://github.com/expo/expo/pull/27119), run `neas update -p ios` and ensure the fingerprint matches.

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
