### PR TITLE
[eas-cli] reword the update configure instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2229](https://github.com/expo/eas-cli/pull/2229) by [@expo-bot](https://github.com/expo-bot))
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2230](https://github.com/expo/eas-cli/pull/2230) by [@expo-bot](https://github.com/expo-bot))
+- Reword update configuration warning. ([#2234](https://github.com/expo/eas-cli/pull/2234) by [@quinlanj](https://github.com/quinlanj))
 
 ## [7.2.0](https://github.com/expo/eas-cli/releases/tag/v7.2.0) - 2024-02-11
 

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -231,7 +231,7 @@ function warnEASUpdatesManualConfig({
     )}`
   );
   Log.warn(
-    `Finish configuring EAS Update by adding the following to the project app.config.js:\n${learnMore(
+    `Manually configure EAS Update by adding the following to the project app.config.js:\n${learnMore(
       'https://expo.fyi/eas-update-config'
     )}\n`
   );

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -231,7 +231,7 @@ function warnEASUpdatesManualConfig({
     )}`
   );
   Log.warn(
-    `Manually configure EAS Update by adding the following to the project app.config.js:\n${learnMore(
+    `Add the following EAS Update key-values to the project app.config.js:\n${learnMore(
       'https://expo.fyi/eas-update-config'
     )}\n`
   );


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We run `ensureEASUpdateIsConfiguredAsync` in most of our eas update commands, and if you have a dynamic app.config.js configuration, we tell you to `finish configuring EAS Update` by adding some key values to the config. While this is the final step to configure for `app.json`, if the user is running `eas update:configure`, we still need to configure `eas.json`.

# How

Reword the error message so the user isn't led to believe they are completely done with the configuration process (in the case of `eas update:configure`)

# Test Plan

- [ ] manually tested
