### PR TITLE
[eas-cli] [ENG-11310] Don't require expo on fresh react-native project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Don't require expo on fresh react-native project. ([#2235](https://github.com/expo/eas-cli/pull/2235) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+
 ### 🧹 Chores
 
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2229](https://github.com/expo/eas-cli/pull/2229) by [@expo-bot](https://github.com/expo-bot))

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -68,8 +68,10 @@ export default class ProjectInit extends EasCommand {
         Log.warn(
           'Cannot determine which native SDK version your project uses because the module `expo` is not installed.'
         );
+        return;
+      } else {
+        throw error;
       }
-      return;
     }
     switch (result.type) {
       case 'success':

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -1,4 +1,4 @@
-import { getProjectConfigDescription } from '@expo/config';
+import { ConfigError, getProjectConfigDescription } from '@expo/config';
 import { ExpoConfig } from '@expo/config-types';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -60,7 +60,17 @@ export default class ProjectInit extends EasCommand {
     projectDir: string,
     modifications: Partial<ExpoConfig>
   ): Promise<void> {
-    const result = await createOrModifyExpoConfigAsync(projectDir, modifications);
+    let result;
+    try {
+      result = await createOrModifyExpoConfigAsync(projectDir, modifications);
+    } catch (error) {
+      if (error instanceof ConfigError && error.code === 'MODULE_NOT_FOUND') {
+        Log.warn(
+          'Cannot determine which native SDK version your project uses because the module `expo` is not installed.'
+        );
+      }
+      return;
+    }
     switch (result.type) {
       case 'success':
         break;


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-11310/fix-warnings-errors-that-come-up-when-adding-eas-to-a-react-native-cli

# How

When Expo config error is thrown while initiating a project only a warning message is printed instead of throwing an error and failing the command

# Test Plan
## Automatic tests
All tests pass
## Manual tests
### Before
`eas init`
![Screenshot 2024-02-19 at 14 36 36](https://github.com/expo/eas-cli/assets/2974455/fa2184bd-096b-42b0-a72b-3c02d9ed4131)
### After
`eas init`
![Screenshot 2024-02-19 at 14 37 45](https://github.com/expo/eas-cli/assets/2974455/88c01001-cff5-48c3-8c76-22290d06b5f4)
`eas build -p ios --auto-submit`
![Screenshot 2024-02-19 at 14 40 39](https://github.com/expo/eas-cli/assets/2974455/6195d355-1d16-4e83-9ee1-5e4156b038e6)
