### PR TITLE
[eas-cli] Fix expo-updates package version detection for canaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix expo-updates package version detection for canaries. ([#2243](https://github.com/expo/eas-cli/pull/2243) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2237](https://github.com/expo/eas-cli/pull/2237) by [@expo-bot](https://github.com/expo-bot))

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -108,7 +108,11 @@ export async function validateAppVersionRuntimePolicySupportAsync(
   }
 
   const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(projectDir);
-  if (expoUpdatesPackageVersion !== null && semver.gte(expoUpdatesPackageVersion, '0.14.4')) {
+  if (
+    expoUpdatesPackageVersion !== null &&
+    (semver.gte(expoUpdatesPackageVersion, '0.14.4') ||
+      expoUpdatesPackageVersion.includes('canary'))
+  ) {
     return;
   }
 
@@ -121,7 +125,11 @@ export async function enforceRollBackToEmbeddedUpdateSupportAsync(
   projectDir: string
 ): Promise<void> {
   const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(projectDir);
-  if (expoUpdatesPackageVersion !== null && semver.gte(expoUpdatesPackageVersion, '0.19.0')) {
+  if (
+    expoUpdatesPackageVersion !== null &&
+    (semver.gte(expoUpdatesPackageVersion, '0.19.0') ||
+      expoUpdatesPackageVersion.includes('canary'))
+  ) {
     return;
   }
 
@@ -135,6 +143,10 @@ export async function enforceRollBackToEmbeddedUpdateSupportAsync(
 export async function isClassicUpdatesSupportedAsync(projectDir: string): Promise<boolean> {
   const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(projectDir);
   if (expoUpdatesPackageVersion === null) {
+    return false;
+  }
+
+  if (expoUpdatesPackageVersion.includes('canary')) {
     return false;
   }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Currently canaries fail these version checks since their versions are of the form `0.0.1-canary-20240109-93608d8` (semver 0.0.1). We've been investigating changing the canary versioning scheme, but it's a bit more complex than anticipated. Instead, just handle the current canary versioning scheme.

# How

If canary is in the version, assume that it has features (for now).

# Test Plan

Inspect.
