### PR TITLE
[vscode] Include src/**/build directories in search and replace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "eslint.enable": true,
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "**/*.code-search": true,
+    "**/src/**/build/**": false,
+    "**/src/build/**": false,
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2237](https://github.com/expo/eas-cli/pull/2237) by [@expo-bot](https://github.com/expo-bot))
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2240](https://github.com/expo/eas-cli/pull/2240) by [@expo-bot](https://github.com/expo-bot))
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2253](https://github.com/expo/eas-cli/pull/2253) by [@expo-bot](https://github.com/expo-bot))
+- Include src/**/build directories in vscode search and replace. ([#2250](https://github.com/expo/eas-cli/pull/2250) by [@wschurman](https://github.com/wschurman))
 
 ## [7.3.0](https://github.com/expo/eas-cli/releases/tag/v7.3.0) - 2024-02-19
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Directories named `build` are a special case in the default vscode search excludes since most projects don't want to search the build folder since it is compiled code (including us in this repo, we build to the `build` folder as destination and don't want the compiled js files to be included in search results).

But, we also have some folders named `build` that need to be named build to appease oclif that we do want to appear in search results and be respected in find/replace.

# How

Add vscode setting to re-include certain `build` folders.

Note that usually I don't recommend checking in this .vscode folder or any editor settings folder (they're excluded by default and even this file is still excluded in this repo, it was force added to the commit), but in this instance I think it's warranted.

# Test Plan

Search for "getRuntimeVersion" and now see the file in the build folder show up.
