### PR TITLE
[eas-cli] Use expo-updates runtime version CLI to generate runtime versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Fix expo-updates package version detection for canaries. ([#2243](https://github.com/expo/eas-cli/pull/2243) by [@wschurman](https://github.com/wschurman))
 - Add missing `config` property to `eas.json` schema. ([#2248](https://github.com/expo/eas-cli/pull/2248) by [@sjchmiela](https://github.com/sjchmiela))
+- Use expo-updates runtime version CLI to generate runtime versions. ([#2251](https://github.com/expo/eas-cli/pull/2251) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,4 +1,3 @@
-import { Updates } from '@expo/config-plugins';
 import { Metadata, Platform, sanitizeMetadata } from '@expo/eas-build-job';
 import { IosEnterpriseProvisioning } from '@expo/eas-json';
 import fs from 'fs-extra';
@@ -15,6 +14,7 @@ import {
   isClassicUpdatesSupportedAsync,
   isExpoUpdatesInstalled,
 } from '../project/projectUtils';
+import { resolveRuntimeVersionAsync } from '../project/resolveRuntimeVersionAsync';
 import {
   readChannelSafelyAsync as readAndroidChannelSafelyAsync,
   readReleaseChannelSafelyAsync as readAndroidReleaseChannelSafelyAsync,
@@ -37,9 +37,7 @@ export async function collectMetadataAsync<T extends Platform>(
     workflow: ctx.workflow,
     credentialsSource: ctx.buildProfile.credentialsSource,
     sdkVersion: ctx.exp.sdkVersion,
-    runtimeVersion:
-      (await Updates.getRuntimeVersionNullableAsync(ctx.projectDir, ctx.exp, ctx.platform)) ??
-      undefined,
+    runtimeVersion: (await resolveRuntimeVersionAsync(ctx)) ?? undefined,
     reactNativeVersion: await getReactNativeVersionAsync(ctx.projectDir),
     ...channelOrReleaseChannel,
     distribution,

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -31,7 +31,11 @@ import {
   shouldUseVersionedExpoCLI,
   shouldUseVersionedExpoCLIWithExplicitPlatforms,
 } from '../utils/expoCli';
-import { expoUpdatesCommandAsync } from '../utils/expoUpdatesCli';
+import {
+  ExpoUpdatesCLIInvalidCommandError,
+  ExpoUpdatesCLIModuleNotFoundError,
+  expoUpdatesCommandAsync,
+} from '../utils/expoUpdatesCli';
 import chunk from '../utils/expodash/chunk';
 import { truthy } from '../utils/expodash/filter';
 import uniqBy from '../utils/expodash/uniqBy';
@@ -717,31 +721,31 @@ async function getRuntimeVersionForPlatformAsync({
     return 'UNVERSIONED';
   }
 
+  try {
+    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
+      'runtimeversion:resolve',
+      '--platform',
+      platform,
+    ]);
+    const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
+    if (runtimeVersionResult.fingerprintSources) {
+      Log.debug(`Resolved fingeprint runtime version for platform "${platform}". Sources:`);
+      Log.debug(runtimeVersionResult.fingerprintSources);
+    }
+    return nullthrows(runtimeVersionResult.runtimeVersion);
+  } catch (e: any) {
+    // if it's a known set of errors thrown by the CLI it means that we need to default back to the
+    // previous behavior, otherwise we throw the error since something is wrong
+    if (
+      !(e instanceof ExpoUpdatesCLIModuleNotFoundError) &&
+      !(e instanceof ExpoUpdatesCLIInvalidCommandError)
+    ) {
+      throw e;
+    }
+  }
+
   const runtimeVersion = exp[platform]?.runtimeVersion ?? exp.runtimeVersion;
   if (typeof runtimeVersion === 'object') {
-    const policy = runtimeVersion.policy;
-
-    if (policy === 'fingerprintExperimental') {
-      // log to inform the user that the fingerprint has been calculated
-      Log.warn(
-        `Calculating native fingerprint for platform ${platform} using current state of the "${platform}" directory. ` +
-          `If the fingerprint differs from the build's fingerint, ensure the state of your project is consistent ` +
-          `(repository is clean, ios and android native directories are in the same state as the build if applicable).`
-      );
-
-      const fingerprintRawString = await expoUpdatesCommandAsync(projectDir, [
-        'fingerprint:generate',
-        '--platform',
-        platform,
-      ]);
-      const fingerprintObject = JSON.parse(fingerprintRawString);
-      const hash = nullthrows(
-        fingerprintObject.hash,
-        'invalid response from expo-update CLI for fingerprint generation'
-      );
-      return hash;
-    }
-
     const workflow = await resolveWorkflowAsync(
       projectDir,
       platform as EASBuildJobPlatform,

--- a/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
+++ b/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
@@ -1,0 +1,44 @@
+import { ExpoConfig } from '@expo/config';
+import { Updates } from '@expo/config-plugins';
+
+import Log from '../log';
+import {
+  ExpoUpdatesCLIInvalidCommandError,
+  ExpoUpdatesCLIModuleNotFoundError,
+  expoUpdatesCommandAsync,
+} from '../utils/expoUpdatesCli';
+
+export async function resolveRuntimeVersionAsync({
+  exp,
+  platform,
+  projectDir,
+}: {
+  exp: ExpoConfig;
+  platform: 'ios' | 'android';
+  projectDir: string;
+}): Promise<string | null> {
+  try {
+    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
+      'runtimeversion:resolve',
+      '--platform',
+      platform,
+    ]);
+    const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
+    if (runtimeVersionResult.fingerprintSources) {
+      Log.debug(`Resolved fingeprint runtime version for platform "${platform}". Sources:`);
+      Log.debug(runtimeVersionResult.fingerprintSources);
+    }
+    return runtimeVersionResult.runtimeVersion ?? null;
+  } catch (e: any) {
+    // if expo-updates is not installed, there's no need for a runtime version in the build
+    if (e instanceof ExpoUpdatesCLIModuleNotFoundError) {
+      return null;
+    } else if (e instanceof ExpoUpdatesCLIInvalidCommandError) {
+      // fall back to the previous behavior (using the @expo/config-plugins eas-cli dependency rather
+      // than the versioned @expo/config-plugins dependency in the project)
+      return await Updates.getRuntimeVersionNullableAsync(projectDir, exp, platform);
+    }
+
+    throw e;
+  }
+}

--- a/packages/eas-cli/src/rollout/actions/CreateRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/CreateRollout.ts
@@ -1,4 +1,3 @@
-import { Updates } from '@expo/config-plugins';
 import assert from 'assert';
 
 import { SelectRuntime } from './SelectRuntime';
@@ -24,6 +23,7 @@ import {
 } from '../../graphql/queries/ChannelQuery';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import Log from '../../log';
+import { resolveRuntimeVersionAsync } from '../../project/resolveRuntimeVersionAsync';
 import { confirmAsync, promptAsync } from '../../prompts';
 import { truthy } from '../../utils/expodash/filter';
 import {
@@ -275,7 +275,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     const runtimes = (
       await Promise.all(
         platforms.map(platform =>
-          Updates.getRuntimeVersionAsync(ctx.app.projectDir, ctx.app.exp, platform)
+          resolveRuntimeVersionAsync({ projectDir: ctx.app.projectDir, exp: ctx.app.exp, platform })
         )
       )
     ).filter(truthy);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This makes use of https://github.com/expo/expo/pull/27263 to generate the correct runtime version for build metadata and updates.

# How

Call the command in the package to use the versioned config-plugins for the app. This way the runtime version is consistent no matter what version of eas-cli is used (and for canary versions so we don't have to update eas-cli to use canaries).

# Test Plan

Run tests.

Manual test:
1. `neas build` with a bare-app in expo/expo
2. `neas update` with same app, including with `EXPO_DEBUG=1` to see fingerprint sources.
