### PR TITLE
Revert "Revert "[eas-cli] Use expo-updates runtime version CLI to generate runtime ve…" (#2264)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Fix expo-updates package version detection for canaries. ([#2243](https://github.com/expo/eas-cli/pull/2243) by [@wschurman](https://github.com/wschurman))
 - Add missing `config` property to `eas.json` schema. ([#2248](https://github.com/expo/eas-cli/pull/2248) by [@sjchmiela](https://github.com/sjchmiela))
+- Use expo-updates runtime version CLI to generate runtime versions. ([#2251](https://github.com/expo/eas-cli/pull/2251) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -1,4 +1,3 @@
-import { Updates } from '@expo/config-plugins';
 import { Metadata, Platform, sanitizeMetadata } from '@expo/eas-build-job';
 import { IosEnterpriseProvisioning } from '@expo/eas-json';
 import fs from 'fs-extra';
@@ -15,6 +14,7 @@ import {
   isClassicUpdatesSupportedAsync,
   isExpoUpdatesInstalled,
 } from '../project/projectUtils';
+import { resolveRuntimeVersionAsync } from '../project/resolveRuntimeVersionAsync';
 import {
   readChannelSafelyAsync as readAndroidChannelSafelyAsync,
   readReleaseChannelSafelyAsync as readAndroidReleaseChannelSafelyAsync,
@@ -37,9 +37,7 @@ export async function collectMetadataAsync<T extends Platform>(
     workflow: ctx.workflow,
     credentialsSource: ctx.buildProfile.credentialsSource,
     sdkVersion: ctx.exp.sdkVersion,
-    runtimeVersion:
-      (await Updates.getRuntimeVersionNullableAsync(ctx.projectDir, ctx.exp, ctx.platform)) ??
-      undefined,
+    runtimeVersion: (await resolveRuntimeVersionAsync(ctx)) ?? undefined,
     reactNativeVersion: await getReactNativeVersionAsync(ctx.projectDir),
     ...channelOrReleaseChannel,
     distribution,

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -153,6 +153,22 @@ export async function isClassicUpdatesSupportedAsync(projectDir: string): Promis
   return semver.lt(expoUpdatesPackageVersion, '0.19.0');
 }
 
+export async function isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(
+  projectDir: string
+): Promise<boolean> {
+  const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(projectDir);
+  if (expoUpdatesPackageVersion === null) {
+    return false;
+  }
+
+  if (expoUpdatesPackageVersion.includes('canary')) {
+    return true;
+  }
+
+  // TODO(wschurman): add semver check once we know the SDK51 version of expo-updates that supports this
+  return false;
+}
+
 export async function installExpoUpdatesAsync(
   projectDir: string,
   options?: { silent: boolean }

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -31,7 +31,11 @@ import {
   shouldUseVersionedExpoCLI,
   shouldUseVersionedExpoCLIWithExplicitPlatforms,
 } from '../utils/expoCli';
-import { expoUpdatesCommandAsync } from '../utils/expoUpdatesCli';
+import {
+  ExpoUpdatesCLIInvalidCommandError,
+  ExpoUpdatesCLIModuleNotFoundError,
+  expoUpdatesCommandAsync,
+} from '../utils/expoUpdatesCli';
 import chunk from '../utils/expodash/chunk';
 import { truthy } from '../utils/expodash/filter';
 import uniqBy from '../utils/expodash/uniqBy';
@@ -717,31 +721,31 @@ async function getRuntimeVersionForPlatformAsync({
     return 'UNVERSIONED';
   }
 
+  try {
+    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
+      'runtimeversion:resolve',
+      '--platform',
+      platform,
+    ]);
+    const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
+    if (runtimeVersionResult.fingerprintSources) {
+      Log.debug(`Resolved fingeprint runtime version for platform "${platform}". Sources:`);
+      Log.debug(runtimeVersionResult.fingerprintSources);
+    }
+    return nullthrows(runtimeVersionResult.runtimeVersion);
+  } catch (e: any) {
+    // if it's a known set of errors thrown by the CLI it means that we need to default back to the
+    // previous behavior, otherwise we throw the error since something is wrong
+    if (
+      !(e instanceof ExpoUpdatesCLIModuleNotFoundError) &&
+      !(e instanceof ExpoUpdatesCLIInvalidCommandError)
+    ) {
+      throw e;
+    }
+  }
+
   const runtimeVersion = exp[platform]?.runtimeVersion ?? exp.runtimeVersion;
   if (typeof runtimeVersion === 'object') {
-    const policy = runtimeVersion.policy;
-
-    if (policy === 'fingerprintExperimental') {
-      // log to inform the user that the fingerprint has been calculated
-      Log.warn(
-        `Calculating native fingerprint for platform ${platform} using current state of the "${platform}" directory. ` +
-          `If the fingerprint differs from the build's fingerint, ensure the state of your project is consistent ` +
-          `(repository is clean, ios and android native directories are in the same state as the build if applicable).`
-      );
-
-      const fingerprintRawString = await expoUpdatesCommandAsync(projectDir, [
-        'fingerprint:generate',
-        '--platform',
-        platform,
-      ]);
-      const fingerprintObject = JSON.parse(fingerprintRawString);
-      const hash = nullthrows(
-        fingerprintObject.hash,
-        'invalid response from expo-update CLI for fingerprint generation'
-      );
-      return hash;
-    }
-
     const workflow = await resolveWorkflowAsync(
       projectDir,
       platform as EASBuildJobPlatform,

--- a/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
+++ b/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
@@ -1,0 +1,44 @@
+import { ExpoConfig } from '@expo/config';
+import { Updates } from '@expo/config-plugins';
+
+import Log from '../log';
+import {
+  ExpoUpdatesCLIInvalidCommandError,
+  ExpoUpdatesCLIModuleNotFoundError,
+  expoUpdatesCommandAsync,
+} from '../utils/expoUpdatesCli';
+
+export async function resolveRuntimeVersionAsync({
+  exp,
+  platform,
+  projectDir,
+}: {
+  exp: ExpoConfig;
+  platform: 'ios' | 'android';
+  projectDir: string;
+}): Promise<string | null> {
+  try {
+    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
+      'runtimeversion:resolve',
+      '--platform',
+      platform,
+    ]);
+    const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
+    if (runtimeVersionResult.fingerprintSources) {
+      Log.debug(`Resolved fingeprint runtime version for platform "${platform}". Sources:`);
+      Log.debug(runtimeVersionResult.fingerprintSources);
+    }
+    return runtimeVersionResult.runtimeVersion ?? null;
+  } catch (e: any) {
+    // if expo-updates is not installed, there's no need for a runtime version in the build
+    if (e instanceof ExpoUpdatesCLIModuleNotFoundError) {
+      return null;
+    } else if (e instanceof ExpoUpdatesCLIInvalidCommandError) {
+      // fall back to the previous behavior (using the @expo/config-plugins eas-cli dependency rather
+      // than the versioned @expo/config-plugins dependency in the project)
+      return await Updates.getRuntimeVersionNullableAsync(projectDir, exp, platform);
+    }
+
+    throw e;
+  }
+}

--- a/packages/eas-cli/src/rollout/actions/CreateRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/CreateRollout.ts
@@ -1,4 +1,3 @@
-import { Updates } from '@expo/config-plugins';
 import assert from 'assert';
 
 import { SelectRuntime } from './SelectRuntime';
@@ -24,6 +23,7 @@ import {
 } from '../../graphql/queries/ChannelQuery';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import Log from '../../log';
+import { resolveRuntimeVersionAsync } from '../../project/resolveRuntimeVersionAsync';
 import { confirmAsync, promptAsync } from '../../prompts';
 import { truthy } from '../../utils/expodash/filter';
 import {
@@ -275,7 +275,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     const runtimes = (
       await Promise.all(
         platforms.map(platform =>
-          Updates.getRuntimeVersionAsync(ctx.app.projectDir, ctx.app.exp, platform)
+          resolveRuntimeVersionAsync({ projectDir: ctx.app.projectDir, exp: ctx.app.exp, platform })
         )
       )
     ).filter(truthy);

--- a/packages/eas-cli/src/utils/expoUpdatesCli.ts
+++ b/packages/eas-cli/src/utils/expoUpdatesCli.ts
@@ -26,15 +26,10 @@ export async function expoUpdatesCommandAsync(projectDir: string, args: string[]
   try {
     return (await spawnAsync(expoUpdatesCli, args)).stdout;
   } catch (e: any) {
-    if (e.stderr && typeof e.stderr === 'string') {
-      if (
-        e.stderr.includes('Invalid command') || // SDK 51+
-        e.stderr.includes('commands[command] is not a function') // SDK <= 50
-      ) {
-        throw new ExpoUpdatesCLIInvalidCommandError(
-          `The command specified by ${args} was not valid in the \`expo-updates\` CLI.`
-        );
-      }
+    if (e.stderr && typeof e.stderr === 'string' && e.stderr.includes('Invalid command')) {
+      throw new ExpoUpdatesCLIInvalidCommandError(
+        `The command specified by ${args} was not valid in the \`expo-updates\` CLI.`
+      );
     }
     throw e;
   }

--- a/packages/eas-cli/src/utils/expoUpdatesCli.ts
+++ b/packages/eas-cli/src/utils/expoUpdatesCli.ts
@@ -26,8 +26,11 @@ export async function expoUpdatesCommandAsync(projectDir: string, args: string[]
   try {
     return (await spawnAsync(expoUpdatesCli, args)).stdout;
   } catch (e: any) {
-    if (e.stderr) {
-      if ((e.stderr as string).includes('Invalid command')) {
+    if (e.stderr && typeof e.stderr === 'string') {
+      if (
+        e.stderr.includes('Invalid command') || // SDK 51+
+        e.stderr.includes('commands[command] is not a function') // SDK <= 50
+      ) {
         throw new ExpoUpdatesCLIInvalidCommandError(
           `The command specified by ${args} was not valid in the \`expo-updates\` CLI.`
         );


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This reverts commit https://github.com/expo/eas-cli/commit/2b59a5e2ee2ad1a7fcf405380f62f29ce4ba9baf.

Then, this applies a fix on top of it to support older SDKs.

# How

Revert, re-test with SDK 45-50.

# Test Plan

```
yarn create expo-app kjdasjkds555hjkdashjk50 --template blank@50
eas init
eas update:configure
~/expo/run-with-local-eas-build.sh build --local
```

(the last step uses a local eas-build to patch the revert in that repo: https://github.com/expo/eas-build/pull/356)