### PR TITLE
[eas-cli] Use new expo-updates configuration:syncnative for versioned native sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Use new expo-updates configuration:syncnative for versioned native sync. ([#2269](https://github.com/expo/eas-cli/pull/2269) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 - Fix expo-updates package version detection for canaries. ([#2243](https://github.com/expo/eas-cli/pull/2243) by [@wschurman](https://github.com/wschurman))

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -2,6 +2,8 @@ import { ExpoConfig } from '@expo/config';
 import { AndroidConfig, AndroidManifest, XML } from '@expo/config-plugins';
 
 import { RequestedPlatform } from '../../platform';
+import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '../../project/projectUtils';
+import { expoUpdatesCommandAsync } from '../../utils/expoUpdatesCli';
 import { ensureValidVersions } from '../utils';
 
 /**
@@ -12,6 +14,15 @@ export async function syncUpdatesConfigurationAsync(
   exp: ExpoConfig
 ): Promise<void> {
   ensureValidVersions(exp, RequestedPlatform.Android);
+
+  if (await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir)) {
+    await expoUpdatesCommandAsync(projectDir, [
+      'configuration:syncnative',
+      '--platform',
+      'android',
+    ]);
+    return;
+  }
 
   // sync AndroidManifest.xml
   const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
@@ -32,6 +43,7 @@ export async function syncUpdatesConfigurationAsync(
     path: stringsJSONPath,
   });
 
+  // TODO(wschurman): this dependency needs to be updated for fingerprint
   const updatedStringsResourceXML =
     await AndroidConfig.Updates.applyRuntimeVersionFromConfigForProjectRootAsync(
       projectDir,

--- a/packages/eas-cli/src/update/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/ios/UpdatesModule.ts
@@ -2,6 +2,8 @@ import { ExpoConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
 
 import { RequestedPlatform } from '../../platform';
+import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '../../project/projectUtils';
+import { expoUpdatesCommandAsync } from '../../utils/expoUpdatesCli';
 import { readPlistAsync, writePlistAsync } from '../../utils/plist';
 import { Client } from '../../vcs/vcs';
 import { ensureValidVersions } from '../utils';
@@ -12,7 +14,14 @@ export async function syncUpdatesConfigurationAsync(
   exp: ExpoConfig
 ): Promise<void> {
   ensureValidVersions(exp, RequestedPlatform.Ios);
+
+  if (await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir)) {
+    await expoUpdatesCommandAsync(projectDir, ['configuration:syncnative', '--platform', 'ios']);
+    return;
+  }
+
   const expoPlist = await readExpoPlistAsync(projectDir);
+  // TODO(wschurman): this dependency needs to be updated for fingerprint
   const updatedExpoPlist = await IOSConfig.Updates.setUpdatesConfigAsync(
     projectDir,
     exp,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This makes use of the new command added in https://github.com/expo/expo/pull/27511 to ensure that the runtime version resolution and synchronization are both versioned.

# How

Call the CLI instead of using the version of config plugins depended on by eas-cli when possible.

# Test Plan

In a generic project using fingerprint and `requireCommit: true`:
```
yarn link expo-updates
neas build -p android
```

and ensure the native sync is no longer the old version (meaning it called the CLI to do the native sync).