### PR TITLE
[ENG-11416][eas-cli] add `--auto-submit` flag to `eas build:internal` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Fix expo-updates package version detection for canaries. ([#2243](https://github.com/expo/eas-cli/pull/2243) by [@wschurman](https://github.com/wschurman))
 - Add missing `config` property to `eas.json` schema. ([#2248](https://github.com/expo/eas-cli/pull/2248) by [@sjchmiela](https://github.com/sjchmiela))
 - Use expo-updates runtime version CLI to generate runtime versions. ([#2251](https://github.com/expo/eas-cli/pull/2251) by [@wschurman](https://github.com/wschurman))
-- Update @expo/apple-utils to handle changes in API. ([#notspecified]() by [@brentvatne](https://github.com/brentvatne))
+- Update @expo/apple-utils to handle changes in API. ([73ba19de6662763cc6bff9fac6b7700ffbd0e88a](https://github.com/expo/eas-cli/commit/73ba19de6662763cc6bff9fac6b7700ffbd0e88a) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Fix expo-updates package version detection for canaries. ([#2243](https://github.com/expo/eas-cli/pull/2243) by [@wschurman](https://github.com/wschurman))
 - Add missing `config` property to `eas.json` schema. ([#2248](https://github.com/expo/eas-cli/pull/2248) by [@sjchmiela](https://github.com/sjchmiela))
 - Use expo-updates runtime version CLI to generate runtime versions. ([#2251](https://github.com/expo/eas-cli/pull/2251) by [@wschurman](https://github.com/wschurman))
-- Update @expo/apple-utils to handle changes in API
+- Update @expo/apple-utils to handle changes in API. (by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `--auto-submit` option to `eas build:internal` command. ([#2271](https://github.com/expo/eas-cli/pull/2271) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Fix expo-updates package version detection for canaries. ([#2243](https://github.com/expo/eas-cli/pull/2243) by [@wschurman](https://github.com/wschurman))
 - Add missing `config` property to `eas.json` schema. ([#2248](https://github.com/expo/eas-cli/pull/2248) by [@sjchmiela](https://github.com/sjchmiela))
 - Use expo-updates runtime version CLI to generate runtime versions. ([#2251](https://github.com/expo/eas-cli/pull/2251) by [@wschurman](https://github.com/wschurman))
-- Update @expo/apple-utils to handle changes in API. (by [@brentvatne](https://github.com/brentvatne))
+- Update @expo/apple-utils to handle changes in API. ([#notspecified]() by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -30,6 +30,17 @@ export default class BuildInternal extends EasCommand {
         'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
       helpValue: 'PROFILE_NAME',
     }),
+    'auto-submit': Flags.boolean({
+      default: false,
+      description:
+        'Submit on build complete using the submit profile with the same name as the build profile',
+      exclusive: ['auto-submit-with-profile'],
+    }),
+    'auto-submit-with-profile': Flags.string({
+      description: 'Submit on build complete using the submit profile with provided name',
+      helpValue: 'PROFILE_NAME',
+      exclusive: ['auto-submit'],
+    }),
   };
 
   static override contextDefinition = {
@@ -71,10 +82,11 @@ export default class BuildInternal extends EasCommand {
         wait: false,
         clearCache: false,
         json: true,
-        autoSubmit: false,
+        autoSubmit: flags['auto-submit'] || flags['auto-submit-with-profile'] !== undefined,
         localBuildOptions: {
           localBuildMode: LocalBuildMode.INTERNAL,
         },
+        submitProfile: flags['auto-submit-with-profile'] ?? flags.profile,
       },
       actor,
       getDynamicPrivateProjectConfigAsync


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We want to add support for `--auto-submit` for our GitHub integration. Yet the only place where we can automagically resolve the credentials for GH builds is EAS CLI if don't want to ask the user for any input like bundle identifier and so on and I believe that this is what we decided to do. We already run `eas build:internal` during the build process to resolve build credentials for the same reasons as mentioned above, so we can just add the auto-submit flag to trigger the submission from the build worker.

It's hacky but at the same time, it's not very different from running `eas build:internal` which we already do.

# How

Add `--auto-submit` flags to the `eas build:internal` command.

# Test Plan

Tested manually. Checked if a submission was created.
