### PR TITLE
[eas-cli] add a `credentials:configure-build` subcommand that prepares a project for EAS Build without executing the build from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `eas credentials:configure-build` subcommand.
+  ([#2282](https://github.com/expo/eas-cli/pull/2282) by [@fiberjw](https://github.com/fiberjw))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores
@@ -61,7 +64,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2237](https://github.com/expo/eas-cli/pull/2237) by [@expo-bot](https://github.com/expo-bot))
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2240](https://github.com/expo/eas-cli/pull/2240) by [@expo-bot](https://github.com/expo-bot))
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2253](https://github.com/expo/eas-cli/pull/2253) by [@expo-bot](https://github.com/expo-bot))
-- Include src/**/build directories in vscode search and replace. ([#2250](https://github.com/expo/eas-cli/pull/2250) by [@wschurman](https://github.com/wschurman))
+- Include src/\*\*/build directories in vscode search and replace. ([#2250](https://github.com/expo/eas-cli/pull/2250) by [@wschurman](https://github.com/wschurman))
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2259](https://github.com/expo/eas-cli/pull/2259) by [@expo-bot](https://github.com/expo-bot))
 
 ## [7.3.0](https://github.com/expo/eas-cli/releases/tag/v7.3.0) - 2024-02-19

--- a/packages/eas-cli/src/commands/credentials/configure-build.ts
+++ b/packages/eas-cli/src/commands/credentials/configure-build.ts
@@ -1,13 +1,14 @@
+import { Platform } from '@expo/eas-build-job';
 import { Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
-import { SelectPlatform } from '../../credentials/manager/SelectPlatform';
+import { SetUpBuildCredentialsCommandAction } from '../../credentials/manager/SetUpBuildCredentialsCommandAction';
 
 export default class InitializeBuildCredentials extends EasCommand {
   static override description = 'Set up credentials for building your project.';
 
   static override flags = {
-    platform: Flags.enum({ char: 'p', options: ['android', 'ios'], required: true }),
+    platform: Flags.enum({ char: 'p', options: [Platform.ANDROID, Platform.IOS], required: true }),
     profile: Flags.string({
       char: 'e',
       description:
@@ -38,14 +39,15 @@ export default class InitializeBuildCredentials extends EasCommand {
       nonInteractive: false,
     });
 
-    await new SelectPlatform(
+    await new SetUpBuildCredentialsCommandAction(
       actor,
       graphqlClient,
       vcsClient,
       analytics,
       privateProjectConfig ?? null,
       getDynamicPrivateProjectConfigAsync,
-      flags.platform
+      flags.platform,
+      flags.profile
     ).runAsync();
   }
 }

--- a/packages/eas-cli/src/commands/credentials/configure-build.ts
+++ b/packages/eas-cli/src/commands/credentials/configure-build.ts
@@ -10,7 +10,7 @@ export default class InitializeBuildCredentials extends EasCommand {
   static override flags = {
     platform: Flags.enum({
       char: 'p',
-      options: [Platform.ANDROID, Platform.IOS, 'all'],
+      options: [Platform.ANDROID, Platform.IOS],
       required: true,
     }),
     profile: Flags.string({
@@ -50,7 +50,7 @@ export default class InitializeBuildCredentials extends EasCommand {
       analytics,
       privateProjectConfig ?? null,
       getDynamicPrivateProjectConfigAsync,
-      flags.platform as Platform | 'all',
+      flags.platform,
       flags.profile
     ).runAsync();
   }

--- a/packages/eas-cli/src/commands/credentials/configure-build.ts
+++ b/packages/eas-cli/src/commands/credentials/configure-build.ts
@@ -8,7 +8,11 @@ export default class InitializeBuildCredentials extends EasCommand {
   static override description = 'Set up credentials for building your project.';
 
   static override flags = {
-    platform: Flags.enum({ char: 'p', options: [Platform.ANDROID, Platform.IOS], required: true }),
+    platform: Flags.enum({
+      char: 'p',
+      options: [Platform.ANDROID, Platform.IOS, 'all'],
+      required: true,
+    }),
     profile: Flags.string({
       char: 'e',
       description:
@@ -46,7 +50,7 @@ export default class InitializeBuildCredentials extends EasCommand {
       analytics,
       privateProjectConfig ?? null,
       getDynamicPrivateProjectConfigAsync,
-      flags.platform,
+      flags.platform as Platform | 'all',
       flags.profile
     ).runAsync();
   }

--- a/packages/eas-cli/src/commands/credentials/configure-build.ts
+++ b/packages/eas-cli/src/commands/credentials/configure-build.ts
@@ -3,6 +3,7 @@ import { Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { SetUpBuildCredentialsCommandAction } from '../../credentials/manager/SetUpBuildCredentialsCommandAction';
+import { selectPlatformAsync } from '../../platform';
 
 export default class InitializeBuildCredentials extends EasCommand {
   static override description = 'Set up credentials for building your project.';
@@ -11,14 +12,11 @@ export default class InitializeBuildCredentials extends EasCommand {
     platform: Flags.enum({
       char: 'p',
       options: [Platform.ANDROID, Platform.IOS],
-      required: true,
     }),
     profile: Flags.string({
       char: 'e',
-      description:
-        'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
+      description: 'The name of the build profile in eas.json.',
       helpValue: 'PROFILE_NAME',
-      default: 'production',
       required: true,
     }),
   };
@@ -43,6 +41,8 @@ export default class InitializeBuildCredentials extends EasCommand {
       nonInteractive: false,
     });
 
+    const platform = await selectPlatformAsync(flags.platform);
+
     await new SetUpBuildCredentialsCommandAction(
       actor,
       graphqlClient,
@@ -50,7 +50,7 @@ export default class InitializeBuildCredentials extends EasCommand {
       analytics,
       privateProjectConfig ?? null,
       getDynamicPrivateProjectConfigAsync,
-      flags.platform,
+      platform,
       flags.profile
     ).runAsync();
   }

--- a/packages/eas-cli/src/commands/credentials/index.ts
+++ b/packages/eas-cli/src/commands/credentials/index.ts
@@ -1,7 +1,7 @@
 import { Flags } from '@oclif/core';
 
-import EasCommand from '../commandUtils/EasCommand';
-import { SelectPlatform } from '../credentials/manager/SelectPlatform';
+import EasCommand from '../../commandUtils/EasCommand';
+import { SelectPlatform } from '../../credentials/manager/SelectPlatform';
 
 export default class Credentials extends EasCommand {
   static override description = 'manage credentials';

--- a/packages/eas-cli/src/commands/credentials/init-build.ts
+++ b/packages/eas-cli/src/commands/credentials/init-build.ts
@@ -1,0 +1,51 @@
+import { Flags } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { SelectPlatform } from '../../credentials/manager/SelectPlatform';
+
+export default class InitializeBuildCredentials extends EasCommand {
+  static override description = 'Set up credentials for building your project.';
+
+  static override flags = {
+    platform: Flags.enum({ char: 'p', options: ['android', 'ios'], required: true }),
+    profile: Flags.string({
+      char: 'e',
+      description:
+        'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
+      helpValue: 'PROFILE_NAME',
+      default: 'production',
+      required: true,
+    }),
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+    ...this.ContextOptions.OptionalProjectConfig,
+    ...this.ContextOptions.DynamicProjectConfig,
+    ...this.ContextOptions.Analytics,
+    ...this.ContextOptions.Vcs,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(InitializeBuildCredentials);
+    const {
+      loggedIn: { actor, graphqlClient },
+      privateProjectConfig,
+      getDynamicPrivateProjectConfigAsync,
+      analytics,
+      vcsClient,
+    } = await this.getContextAsync(InitializeBuildCredentials, {
+      nonInteractive: false,
+    });
+
+    await new SelectPlatform(
+      actor,
+      graphqlClient,
+      vcsClient,
+      analytics,
+      privateProjectConfig ?? null,
+      getDynamicPrivateProjectConfigAsync,
+      flags.platform
+    ).runAsync();
+  }
+}

--- a/packages/eas-cli/src/credentials/manager/Actions.ts
+++ b/packages/eas-cli/src/credentials/manager/Actions.ts
@@ -35,6 +35,7 @@ export enum AndroidActionType {
   SetUpGsaKeyForFcmV1,
   UpdateCredentialsJson,
   SetUpBuildCredentialsFromCredentialsJson,
+  SetUpBuildCredentials,
 }
 
 export enum IosActionType {

--- a/packages/eas-cli/src/credentials/manager/CheckBuildProfileFlagAgainstEasJson.ts
+++ b/packages/eas-cli/src/credentials/manager/CheckBuildProfileFlagAgainstEasJson.ts
@@ -1,0 +1,46 @@
+import { Platform } from '@expo/eas-build-job';
+import { BuildProfile, EasJsonAccessor, EasJsonUtils } from '@expo/eas-json';
+
+import Log from '../../log';
+
+export class CheckBuildProfileFlagAgainstEasJson<T extends Platform> {
+  private easJsonAccessor: EasJsonAccessor;
+
+  constructor(
+    projectDir: string,
+    private platform: T,
+    private profileNameFromFlag: string
+  ) {
+    this.easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
+  }
+
+  async runAsync(): Promise<BuildProfile<T>> {
+    const profileName = await this.getProfileNameFromEasConfigAsync();
+    const easConfig = await EasJsonUtils.getBuildProfileAsync<T>(
+      this.easJsonAccessor,
+      this.platform,
+      profileName
+    );
+    Log.succeed(`Using build profile: ${profileName}`);
+    return easConfig;
+  }
+
+  async getProfileNameFromEasConfigAsync(): Promise<string> {
+    const buildProfileNames = await EasJsonUtils.getBuildProfileNamesAsync(this.easJsonAccessor);
+    if (buildProfileNames.length === 0) {
+      throw new Error(
+        'You need at least one iOS build profile declared in eas.json. Go to https://docs.expo.dev/build/eas-json/ for more details'
+      );
+    } else if (buildProfileNames.length === 1) {
+      return buildProfileNames[0];
+    }
+
+    if (buildProfileNames.includes(this.profileNameFromFlag)) {
+      return this.profileNameFromFlag;
+    } else {
+      throw new Error(
+        `Build profile ${this.profileNameFromFlag} does not exist in eas.json. Go to https://docs.expo.dev/build/eas-json/ for more details`
+      );
+    }
+  }
+}

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -48,8 +48,8 @@ import { AndroidPackageNotDefinedError } from '../errors';
 
 export class ManageAndroid {
   constructor(
-    private callingAction: Action,
-    private projectDir: string
+    protected callingAction: Action,
+    protected projectDir: string
   ) {}
 
   async runAsync(currentActions: ActionInfo[] = highLevelActions): Promise<void> {
@@ -164,7 +164,7 @@ export class ManageAndroid {
     }
   }
 
-  private async createProjectContextAsync(
+  protected async createProjectContextAsync(
     ctx: CredentialsContext,
     buildProfile: BuildProfile<Platform.ANDROID>
   ): Promise<GradleBuildContext | undefined> {
@@ -172,7 +172,7 @@ export class ManageAndroid {
     return await resolveGradleBuildContextAsync(ctx.projectDir, buildProfile, ctx.vcsClient);
   }
 
-  private async runProjectSpecificActionAsync(
+  protected async runProjectSpecificActionAsync(
     ctx: CredentialsContext,
     action: AndroidActionType,
     gradleContext?: GradleBuildContext

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -34,6 +34,7 @@ import { DownloadKeystore } from '../android/actions/DownloadKeystore';
 import { RemoveFcm } from '../android/actions/RemoveFcm';
 import { SelectAndRemoveGoogleServiceAccountKey } from '../android/actions/RemoveGoogleServiceAccountKey';
 import { RemoveKeystore } from '../android/actions/RemoveKeystore';
+import { SetUpBuildCredentials } from '../android/actions/SetUpBuildCredentials';
 import { SetUpBuildCredentialsFromCredentialsJson } from '../android/actions/SetUpBuildCredentialsFromCredentialsJson';
 import { SetUpGoogleServiceAccountKeyForFcmV1 } from '../android/actions/SetUpGoogleServiceAccountKeyForFcmV1';
 import { SetUpGoogleServiceAccountKeyForSubmissions } from '../android/actions/SetUpGoogleServiceAccountKeyForSubmissions';
@@ -239,6 +240,8 @@ export class ManageAndroid {
       }
     } else if (action === AndroidActionType.SetUpBuildCredentialsFromCredentialsJson) {
       await new SetUpBuildCredentialsFromCredentialsJson(appLookupParams).runAsync(ctx);
+    } else if (action === AndroidActionType.SetUpBuildCredentials) {
+      await new SetUpBuildCredentials({ app: appLookupParams }).runAsync(ctx);
     }
   }
 }

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -56,8 +56,8 @@ import { displayIosCredentials } from '../ios/utils/printCredentials';
 
 export class ManageIos {
   constructor(
-    private callingAction: Action,
-    private projectDir: string
+    protected callingAction: Action,
+    protected projectDir: string
   ) {}
 
   async runAsync(currentActions: ActionInfo[] = highLevelActions): Promise<void> {
@@ -182,7 +182,7 @@ export class ManageIos {
     }
   }
 
-  private async createProjectContextAsync(
+  protected async createProjectContextAsync(
     ctx: CredentialsContext,
     account: AccountFragment,
     buildProfile: BuildProfile<Platform.IOS>
@@ -215,7 +215,7 @@ export class ManageIos {
     };
   }
 
-  private async runAccountSpecificActionAsync(
+  protected async runAccountSpecificActionAsync(
     ctx: CredentialsContext,
     account: AccountFragment,
     action: IosActionType
@@ -235,7 +235,7 @@ export class ManageIos {
     }
   }
 
-  private async runProjectSpecificActionAsync(
+  protected async runProjectSpecificActionAsync(
     ctx: CredentialsContext,
     app: App,
     targets: Target[],
@@ -396,7 +396,7 @@ export class ManageIos {
     }
   }
 
-  private async setupProvisioningProfileWithSpecificDistCertAsync(
+  protected async setupProvisioningProfileWithSpecificDistCertAsync(
     ctx: CredentialsContext,
     target: Target,
     appLookupParams: AppLookupParams,
@@ -419,7 +419,7 @@ export class ManageIos {
     }
   }
 
-  private async selectTargetAsync(targets: Target[]): Promise<Target> {
+  protected async selectTargetAsync(targets: Target[]): Promise<Target> {
     if (targets.length === 1) {
       return targets[0];
     }

--- a/packages/eas-cli/src/credentials/manager/SetUpAndroidBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/SetUpAndroidBuildCredentials.ts
@@ -1,0 +1,155 @@
+import { Platform } from '@expo/eas-build-job';
+import { BuildProfile } from '@expo/eas-json';
+import assert from 'assert';
+
+import { AndroidActionType } from './Actions';
+import { CheckBuildProfileFlagAgainstEasJson } from './CheckBuildProfileFlagAgainstEasJson';
+import { CreateAndroidBuildCredentials } from './CreateAndroidBuildCredentials';
+import { Action } from './HelperActions';
+import { SelectExistingAndroidBuildCredentials } from './SelectAndroidBuildCredentials';
+import { SetDefaultAndroidKeystore } from './SetDefaultAndroidKeystore';
+import { GradleBuildContext, resolveGradleBuildContextAsync } from '../../project/android/gradle';
+import { AssignFcm } from '../android/actions/AssignFcm';
+import { AssignGoogleServiceAccountKeyForFcmV1 } from '../android/actions/AssignGoogleServiceAccountKeyForFcmV1';
+import { AssignGoogleServiceAccountKeyForSubmissions } from '../android/actions/AssignGoogleServiceAccountKeyForSubmissions';
+import { getAppLookupParamsFromContextAsync } from '../android/actions/BuildCredentialsUtils';
+import { CreateFcm } from '../android/actions/CreateFcm';
+import { CreateGoogleServiceAccountKey } from '../android/actions/CreateGoogleServiceAccountKey';
+import { DownloadKeystore } from '../android/actions/DownloadKeystore';
+import { RemoveFcm } from '../android/actions/RemoveFcm';
+import { SelectAndRemoveGoogleServiceAccountKey } from '../android/actions/RemoveGoogleServiceAccountKey';
+import { RemoveKeystore } from '../android/actions/RemoveKeystore';
+import { SetUpBuildCredentialsFromCredentialsJson } from '../android/actions/SetUpBuildCredentialsFromCredentialsJson';
+import { SetUpGoogleServiceAccountKeyForFcmV1 } from '../android/actions/SetUpGoogleServiceAccountKeyForFcmV1';
+import { SetUpGoogleServiceAccountKeyForSubmissions } from '../android/actions/SetUpGoogleServiceAccountKeyForSubmissions';
+import { UpdateCredentialsJson } from '../android/actions/UpdateCredentialsJson';
+import { UseExistingGoogleServiceAccountKey } from '../android/actions/UseExistingGoogleServiceAccountKey';
+import { CredentialsContext, CredentialsContextProjectInfo } from '../context';
+
+export class SetUpAndroidBuildCredentials {
+  constructor(
+    private callingAction: Action,
+    private projectDir: string,
+    private setUpBuildCredentialsWithProfileNameFromFlag: string
+  ) {}
+
+  async runAsync(): Promise<void> {
+    const hasProjectContext = !!this.callingAction.projectInfo;
+    const buildProfile = hasProjectContext
+      ? await new CheckBuildProfileFlagAgainstEasJson(
+          this.projectDir,
+          Platform.ANDROID,
+          this.setUpBuildCredentialsWithProfileNameFromFlag
+        ).runAsync()
+      : null;
+    let projectInfo: CredentialsContextProjectInfo | null = null;
+    if (hasProjectContext) {
+      const { exp, projectId } = await this.callingAction.getDynamicPrivateProjectConfigAsync({
+        env: buildProfile?.env,
+      });
+      projectInfo = { exp, projectId };
+    }
+    const ctx = new CredentialsContext({
+      projectDir: process.cwd(),
+      projectInfo,
+      user: this.callingAction.actor,
+      graphqlClient: this.callingAction.graphqlClient,
+      analytics: this.callingAction.analytics,
+      env: buildProfile?.env,
+      nonInteractive: false,
+      vcsClient: this.callingAction.vcsClient,
+    });
+
+    let gradleContext;
+    if (ctx.hasProjectContext) {
+      assert(buildProfile, 'buildProfile must be defined in a project context');
+      gradleContext = await this.createProjectContextAsync(ctx, buildProfile);
+    }
+
+    if (this.setUpBuildCredentialsWithProfileNameFromFlag) {
+      await this.runProjectSpecificActionAsync(
+        ctx,
+        AndroidActionType.CreateKeystore, // Directly proceed to CreateKeystore
+        gradleContext
+      );
+    }
+  }
+
+  private async createProjectContextAsync(
+    ctx: CredentialsContext,
+    buildProfile: BuildProfile<Platform.ANDROID>
+  ): Promise<GradleBuildContext | undefined> {
+    assert(ctx.hasProjectContext, 'createProjectContextAsync: must have project context.');
+    return await resolveGradleBuildContextAsync(ctx.projectDir, buildProfile, ctx.vcsClient);
+  }
+
+  private async runProjectSpecificActionAsync(
+    ctx: CredentialsContext,
+    action: AndroidActionType,
+    gradleContext?: GradleBuildContext
+  ): Promise<void> {
+    assert(
+      ctx.hasProjectContext,
+      'You must be in your project directory in order to perform this action'
+    );
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx, gradleContext);
+    if (action === AndroidActionType.CreateKeystore) {
+      await new CreateAndroidBuildCredentials(appLookupParams).runAsync(ctx);
+    } else if (action === AndroidActionType.SetDefaultKeystore) {
+      await new SetDefaultAndroidKeystore(appLookupParams).runAsync(ctx);
+    } else if (action === AndroidActionType.DownloadKeystore) {
+      const buildCredentials = await new SelectExistingAndroidBuildCredentials(
+        appLookupParams
+      ).runAsync(ctx);
+      if (buildCredentials) {
+        await new DownloadKeystore({ app: appLookupParams }).runAsync(ctx, buildCredentials);
+      }
+    } else if (action === AndroidActionType.RemoveKeystore) {
+      const buildCredentials = await new SelectExistingAndroidBuildCredentials(
+        appLookupParams
+      ).runAsync(ctx);
+      if (buildCredentials) {
+        await new RemoveKeystore(appLookupParams).runAsync(ctx, buildCredentials);
+      }
+    } else if (action === AndroidActionType.CreateFcm) {
+      const fcm = await new CreateFcm(appLookupParams.account).runAsync(ctx);
+      await new AssignFcm(appLookupParams).runAsync(ctx, fcm);
+    } else if (action === AndroidActionType.RemoveFcm) {
+      await new RemoveFcm(appLookupParams).runAsync(ctx);
+    } else if (action === AndroidActionType.SetUpGsaKeyForSubmissions) {
+      await new SetUpGoogleServiceAccountKeyForSubmissions(appLookupParams).runAsync(ctx);
+    } else if (action === AndroidActionType.UseExistingGsaKeyForSubmissions) {
+      const gsaKey = await new UseExistingGoogleServiceAccountKey(appLookupParams.account).runAsync(
+        ctx
+      );
+      if (gsaKey) {
+        await new AssignGoogleServiceAccountKeyForSubmissions(appLookupParams).runAsync(
+          ctx,
+          gsaKey
+        );
+      }
+    } else if (action === AndroidActionType.SetUpGsaKeyForFcmV1) {
+      await new SetUpGoogleServiceAccountKeyForFcmV1(appLookupParams).runAsync(ctx);
+    } else if (action === AndroidActionType.UseExistingGsaKeyForFcmV1) {
+      const gsaKey = await new UseExistingGoogleServiceAccountKey(appLookupParams.account).runAsync(
+        ctx
+      );
+      if (gsaKey) {
+        await new AssignGoogleServiceAccountKeyForFcmV1(appLookupParams).runAsync(ctx, gsaKey);
+      }
+    } else if (action === AndroidActionType.CreateGsaKey) {
+      await new CreateGoogleServiceAccountKey(appLookupParams.account).runAsync(ctx);
+    } else if (action === AndroidActionType.RemoveGsaKey) {
+      await new SelectAndRemoveGoogleServiceAccountKey(appLookupParams.account).runAsync(ctx);
+    } else if (action === AndroidActionType.UpdateCredentialsJson) {
+      const buildCredentials = await new SelectExistingAndroidBuildCredentials(
+        appLookupParams
+      ).runAsync(ctx);
+      if (buildCredentials) {
+        await new UpdateCredentialsJson().runAsync(ctx, buildCredentials);
+      }
+    } else if (action === AndroidActionType.SetUpBuildCredentialsFromCredentialsJson) {
+      await new SetUpBuildCredentialsFromCredentialsJson(appLookupParams).runAsync(ctx);
+    }
+  }
+}

--- a/packages/eas-cli/src/credentials/manager/SetUpAndroidBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/SetUpAndroidBuildCredentials.ts
@@ -1,39 +1,22 @@
 import { Platform } from '@expo/eas-build-job';
-import { BuildProfile } from '@expo/eas-json';
 import assert from 'assert';
 
 import { AndroidActionType } from './Actions';
 import { CheckBuildProfileFlagAgainstEasJson } from './CheckBuildProfileFlagAgainstEasJson';
-import { CreateAndroidBuildCredentials } from './CreateAndroidBuildCredentials';
 import { Action } from './HelperActions';
-import { SelectExistingAndroidBuildCredentials } from './SelectAndroidBuildCredentials';
-import { SetDefaultAndroidKeystore } from './SetDefaultAndroidKeystore';
-import { GradleBuildContext, resolveGradleBuildContextAsync } from '../../project/android/gradle';
-import { AssignFcm } from '../android/actions/AssignFcm';
-import { AssignGoogleServiceAccountKeyForFcmV1 } from '../android/actions/AssignGoogleServiceAccountKeyForFcmV1';
-import { AssignGoogleServiceAccountKeyForSubmissions } from '../android/actions/AssignGoogleServiceAccountKeyForSubmissions';
-import { getAppLookupParamsFromContextAsync } from '../android/actions/BuildCredentialsUtils';
-import { CreateFcm } from '../android/actions/CreateFcm';
-import { CreateGoogleServiceAccountKey } from '../android/actions/CreateGoogleServiceAccountKey';
-import { DownloadKeystore } from '../android/actions/DownloadKeystore';
-import { RemoveFcm } from '../android/actions/RemoveFcm';
-import { SelectAndRemoveGoogleServiceAccountKey } from '../android/actions/RemoveGoogleServiceAccountKey';
-import { RemoveKeystore } from '../android/actions/RemoveKeystore';
-import { SetUpBuildCredentialsFromCredentialsJson } from '../android/actions/SetUpBuildCredentialsFromCredentialsJson';
-import { SetUpGoogleServiceAccountKeyForFcmV1 } from '../android/actions/SetUpGoogleServiceAccountKeyForFcmV1';
-import { SetUpGoogleServiceAccountKeyForSubmissions } from '../android/actions/SetUpGoogleServiceAccountKeyForSubmissions';
-import { UpdateCredentialsJson } from '../android/actions/UpdateCredentialsJson';
-import { UseExistingGoogleServiceAccountKey } from '../android/actions/UseExistingGoogleServiceAccountKey';
+import { ManageAndroid } from './ManageAndroid';
 import { CredentialsContext, CredentialsContextProjectInfo } from '../context';
 
-export class SetUpAndroidBuildCredentials {
+export class SetUpAndroidBuildCredentials extends ManageAndroid {
   constructor(
-    private callingAction: Action,
-    private projectDir: string,
+    callingAction: Action,
+    projectDir: string,
     private setUpBuildCredentialsWithProfileNameFromFlag: string
-  ) {}
+  ) {
+    super(callingAction, projectDir);
+  }
 
-  async runAsync(): Promise<void> {
+  override async runAsync(): Promise<void> {
     const hasProjectContext = !!this.callingAction.projectInfo;
     const buildProfile = hasProjectContext
       ? await new CheckBuildProfileFlagAgainstEasJson(
@@ -72,84 +55,6 @@ export class SetUpAndroidBuildCredentials {
         AndroidActionType.CreateKeystore, // Directly proceed to CreateKeystore
         gradleContext
       );
-    }
-  }
-
-  private async createProjectContextAsync(
-    ctx: CredentialsContext,
-    buildProfile: BuildProfile<Platform.ANDROID>
-  ): Promise<GradleBuildContext | undefined> {
-    assert(ctx.hasProjectContext, 'createProjectContextAsync: must have project context.');
-    return await resolveGradleBuildContextAsync(ctx.projectDir, buildProfile, ctx.vcsClient);
-  }
-
-  private async runProjectSpecificActionAsync(
-    ctx: CredentialsContext,
-    action: AndroidActionType,
-    gradleContext?: GradleBuildContext
-  ): Promise<void> {
-    assert(
-      ctx.hasProjectContext,
-      'You must be in your project directory in order to perform this action'
-    );
-    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx, gradleContext);
-    if (action === AndroidActionType.CreateKeystore) {
-      await new CreateAndroidBuildCredentials(appLookupParams).runAsync(ctx);
-    } else if (action === AndroidActionType.SetDefaultKeystore) {
-      await new SetDefaultAndroidKeystore(appLookupParams).runAsync(ctx);
-    } else if (action === AndroidActionType.DownloadKeystore) {
-      const buildCredentials = await new SelectExistingAndroidBuildCredentials(
-        appLookupParams
-      ).runAsync(ctx);
-      if (buildCredentials) {
-        await new DownloadKeystore({ app: appLookupParams }).runAsync(ctx, buildCredentials);
-      }
-    } else if (action === AndroidActionType.RemoveKeystore) {
-      const buildCredentials = await new SelectExistingAndroidBuildCredentials(
-        appLookupParams
-      ).runAsync(ctx);
-      if (buildCredentials) {
-        await new RemoveKeystore(appLookupParams).runAsync(ctx, buildCredentials);
-      }
-    } else if (action === AndroidActionType.CreateFcm) {
-      const fcm = await new CreateFcm(appLookupParams.account).runAsync(ctx);
-      await new AssignFcm(appLookupParams).runAsync(ctx, fcm);
-    } else if (action === AndroidActionType.RemoveFcm) {
-      await new RemoveFcm(appLookupParams).runAsync(ctx);
-    } else if (action === AndroidActionType.SetUpGsaKeyForSubmissions) {
-      await new SetUpGoogleServiceAccountKeyForSubmissions(appLookupParams).runAsync(ctx);
-    } else if (action === AndroidActionType.UseExistingGsaKeyForSubmissions) {
-      const gsaKey = await new UseExistingGoogleServiceAccountKey(appLookupParams.account).runAsync(
-        ctx
-      );
-      if (gsaKey) {
-        await new AssignGoogleServiceAccountKeyForSubmissions(appLookupParams).runAsync(
-          ctx,
-          gsaKey
-        );
-      }
-    } else if (action === AndroidActionType.SetUpGsaKeyForFcmV1) {
-      await new SetUpGoogleServiceAccountKeyForFcmV1(appLookupParams).runAsync(ctx);
-    } else if (action === AndroidActionType.UseExistingGsaKeyForFcmV1) {
-      const gsaKey = await new UseExistingGoogleServiceAccountKey(appLookupParams.account).runAsync(
-        ctx
-      );
-      if (gsaKey) {
-        await new AssignGoogleServiceAccountKeyForFcmV1(appLookupParams).runAsync(ctx, gsaKey);
-      }
-    } else if (action === AndroidActionType.CreateGsaKey) {
-      await new CreateGoogleServiceAccountKey(appLookupParams.account).runAsync(ctx);
-    } else if (action === AndroidActionType.RemoveGsaKey) {
-      await new SelectAndRemoveGoogleServiceAccountKey(appLookupParams.account).runAsync(ctx);
-    } else if (action === AndroidActionType.UpdateCredentialsJson) {
-      const buildCredentials = await new SelectExistingAndroidBuildCredentials(
-        appLookupParams
-      ).runAsync(ctx);
-      if (buildCredentials) {
-        await new UpdateCredentialsJson().runAsync(ctx, buildCredentials);
-      }
-    } else if (action === AndroidActionType.SetUpBuildCredentialsFromCredentialsJson) {
-      await new SetUpBuildCredentialsFromCredentialsJson(appLookupParams).runAsync(ctx);
     }
   }
 }

--- a/packages/eas-cli/src/credentials/manager/SetUpAndroidBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/SetUpAndroidBuildCredentials.ts
@@ -52,7 +52,7 @@ export class SetUpAndroidBuildCredentials extends ManageAndroid {
     if (this.setUpBuildCredentialsWithProfileNameFromFlag) {
       await this.runProjectSpecificActionAsync(
         ctx,
-        AndroidActionType.CreateKeystore, // Directly proceed to CreateKeystore
+        AndroidActionType.SetUpBuildCredentials,
         gradleContext
       );
     }

--- a/packages/eas-cli/src/credentials/manager/SetUpBuildCredentialsCommandAction.ts
+++ b/packages/eas-cli/src/credentials/manager/SetUpBuildCredentialsCommandAction.ts
@@ -1,0 +1,32 @@
+import { Platform } from '@expo/eas-build-job';
+
+import { Analytics } from '../../analytics/AnalyticsManager';
+import { DynamicConfigContextFn } from '../../commandUtils/context/DynamicProjectConfigContextField';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { Actor } from '../../user/User';
+import { Client } from '../../vcs/vcs';
+import { CredentialsContextProjectInfo } from '../context';
+import { SetUpAndroidBuildCredentials } from '../manager/SetUpAndroidBuildCredentials';
+import { SetUpIosBuildCredentials } from '../manager/SetUpIosBuildCredentials';
+
+export class SetUpBuildCredentialsCommandAction {
+  constructor(
+    public readonly actor: Actor,
+    public readonly graphqlClient: ExpoGraphqlClient,
+    public readonly vcsClient: Client,
+    public readonly analytics: Analytics,
+    public readonly projectInfo: CredentialsContextProjectInfo | null,
+    public readonly getDynamicPrivateProjectConfigAsync: DynamicConfigContextFn,
+    private readonly platform: Platform,
+    private readonly profileName: string
+  ) {}
+
+  async runAsync(): Promise<void> {
+    // TODO: add an option for "all" which logs before running each platform action
+
+    if (this.platform === Platform.IOS) {
+      return await new SetUpIosBuildCredentials(this, process.cwd(), this.profileName).runAsync();
+    }
+    return await new SetUpAndroidBuildCredentials(this, process.cwd(), this.profileName).runAsync();
+  }
+}

--- a/packages/eas-cli/src/credentials/manager/SetUpBuildCredentialsCommandAction.ts
+++ b/packages/eas-cli/src/credentials/manager/SetUpBuildCredentialsCommandAction.ts
@@ -17,12 +17,12 @@ export class SetUpBuildCredentialsCommandAction {
     public readonly analytics: Analytics,
     public readonly projectInfo: CredentialsContextProjectInfo | null,
     public readonly getDynamicPrivateProjectConfigAsync: DynamicConfigContextFn,
-    private readonly platform: Platform,
+    private readonly platform: Platform | 'all',
     private readonly profileName: string
   ) {}
 
   async runAsync(): Promise<void> {
-    // TODO: add an option for "all" which logs before running each platform action
+    // TODO: support the for "all" option which logs before running each platform action
 
     if (this.platform === Platform.IOS) {
       return await new SetUpIosBuildCredentials(this, process.cwd(), this.profileName).runAsync();

--- a/packages/eas-cli/src/credentials/manager/SetUpBuildCredentialsCommandAction.ts
+++ b/packages/eas-cli/src/credentials/manager/SetUpBuildCredentialsCommandAction.ts
@@ -17,13 +17,11 @@ export class SetUpBuildCredentialsCommandAction {
     public readonly analytics: Analytics,
     public readonly projectInfo: CredentialsContextProjectInfo | null,
     public readonly getDynamicPrivateProjectConfigAsync: DynamicConfigContextFn,
-    private readonly platform: Platform | 'all',
+    private readonly platform: Platform,
     private readonly profileName: string
   ) {}
 
   async runAsync(): Promise<void> {
-    // TODO: support the for "all" option which logs before running each platform action
-
     if (this.platform === Platform.IOS) {
       return await new SetUpIosBuildCredentials(this, process.cwd(), this.profileName).runAsync();
     }

--- a/packages/eas-cli/src/credentials/manager/SetUpIosBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/SetUpIosBuildCredentials.ts
@@ -1,0 +1,338 @@
+import { Platform } from '@expo/eas-build-job';
+import { BuildProfile } from '@expo/eas-json';
+import assert from 'assert';
+import nullthrows from 'nullthrows';
+
+import { IosActionType } from './Actions';
+import { CheckBuildProfileFlagAgainstEasJson } from './CheckBuildProfileFlagAgainstEasJson';
+import { Action } from './HelperActions';
+import { SelectIosDistributionTypeGraphqlFromBuildProfile } from './SelectIosDistributionTypeGraphqlFromBuildProfile';
+import {
+  AccountFragment,
+  AppleDistributionCertificateFragment,
+  IosAppBuildCredentialsFragment,
+  IosDistributionType as IosDistributionTypeGraphql,
+} from '../../graphql/generated';
+import Log from '../../log';
+import { resolveXcodeBuildContextAsync } from '../../project/ios/scheme';
+import { resolveTargetsAsync } from '../../project/ios/target';
+import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
+import { confirmAsync, selectAsync } from '../../prompts';
+import { ensureActorHasPrimaryAccount } from '../../user/actions';
+import { CredentialsContext, CredentialsContextProjectInfo } from '../context';
+import {
+  AppStoreApiKeyPurpose,
+  selectAscApiKeysFromAccountAsync,
+} from '../ios/actions/AscApiKeyUtils';
+import { AssignAscApiKey } from '../ios/actions/AssignAscApiKey';
+import { AssignPushKey } from '../ios/actions/AssignPushKey';
+import { getAppLookupParamsFromContextAsync } from '../ios/actions/BuildCredentialsUtils';
+import { CreateAscApiKey } from '../ios/actions/CreateAscApiKey';
+import { CreateDistributionCertificate } from '../ios/actions/CreateDistributionCertificate';
+import { CreatePushKey } from '../ios/actions/CreatePushKey';
+import { selectValidDistributionCertificateAsync } from '../ios/actions/DistributionCertificateUtils';
+import { selectPushKeyAsync } from '../ios/actions/PushKeyUtils';
+import { RemoveProvisioningProfiles } from '../ios/actions/RemoveProvisioningProfile';
+import { SetUpAdhocProvisioningProfile } from '../ios/actions/SetUpAdhocProvisioningProfile';
+import { SetUpAscApiKey } from '../ios/actions/SetUpAscApiKey';
+import { SetUpBuildCredentials } from '../ios/actions/SetUpBuildCredentials';
+import { SetUpBuildCredentialsFromCredentialsJson } from '../ios/actions/SetUpBuildCredentialsFromCredentialsJson';
+import { SetUpProvisioningProfile } from '../ios/actions/SetUpProvisioningProfile';
+import { SetUpPushKey } from '../ios/actions/SetUpPushKey';
+import { UpdateCredentialsJson } from '../ios/actions/UpdateCredentialsJson';
+import { AppLookupParams } from '../ios/api/graphql/types/AppLookupParams';
+import { App, Target } from '../ios/types';
+
+export class SetUpIosBuildCredentials {
+  constructor(
+    private callingAction: Action,
+    private projectDir: string,
+    private setUpBuildCredentialsWithProfileNameFromFlag: string
+  ) {}
+
+  async runAsync(): Promise<void> {
+    const buildProfile = this.callingAction.projectInfo
+      ? await new CheckBuildProfileFlagAgainstEasJson(
+          this.projectDir,
+          Platform.IOS,
+          this.setUpBuildCredentialsWithProfileNameFromFlag
+        ).runAsync()
+      : null;
+
+    let projectInfo: CredentialsContextProjectInfo | null = null;
+    if (this.callingAction.projectInfo) {
+      const { exp, projectId } = await this.callingAction.getDynamicPrivateProjectConfigAsync({
+        env: buildProfile?.env,
+      });
+      projectInfo = { exp, projectId };
+    }
+
+    const ctx = new CredentialsContext({
+      projectDir: process.cwd(),
+      projectInfo,
+      user: this.callingAction.actor,
+      graphqlClient: this.callingAction.graphqlClient,
+      analytics: this.callingAction.analytics,
+      env: buildProfile?.env,
+      nonInteractive: false,
+      vcsClient: this.callingAction.vcsClient,
+    });
+
+    await ctx.bestEffortAppStoreAuthenticateAsync();
+
+    const getAccountForProjectAsync = async (projectId: string): Promise<AccountFragment> => {
+      return await getOwnerAccountForProjectIdAsync(ctx.graphqlClient, projectId);
+    };
+
+    const account = ctx.hasProjectContext
+      ? await getAccountForProjectAsync(ctx.projectId)
+      : ensureActorHasPrimaryAccount(ctx.user);
+
+    let app = null;
+    let targets = null;
+    if (ctx.hasProjectContext) {
+      assert(buildProfile, 'buildProfile must be defined in project context');
+      const projectContext = await this.createProjectContextAsync(ctx, account, buildProfile);
+      app = projectContext.app;
+      targets = projectContext.targets;
+    }
+
+    await this.runProjectSpecificActionAsync(
+      ctx,
+      nullthrows(app, 'app must be defined in project context'),
+      nullthrows(targets, 'targets must be defined in project context'),
+      nullthrows(buildProfile, 'buildProfile must be defined in project context'),
+      IosActionType.SetUpBuildCredentials // Directly proceed to SetUpBuildCredentials
+    );
+  }
+
+  private async createProjectContextAsync(
+    ctx: CredentialsContext,
+    account: AccountFragment,
+    buildProfile: BuildProfile<Platform.IOS>
+  ): Promise<{
+    app: App;
+    targets: Target[];
+  }> {
+    assert(ctx.hasProjectContext, 'createProjectContextAsync: must have project context.');
+
+    const app = { account, projectName: ctx.exp.slug };
+    const xcodeBuildContext = await resolveXcodeBuildContextAsync(
+      {
+        projectDir: ctx.projectDir,
+        nonInteractive: ctx.nonInteractive,
+        exp: ctx.exp,
+        vcsClient: ctx.vcsClient,
+      },
+      buildProfile
+    );
+    const targets = await resolveTargetsAsync({
+      exp: ctx.exp,
+      projectDir: ctx.projectDir,
+      xcodeBuildContext,
+      env: buildProfile.env,
+      vcsClient: ctx.vcsClient,
+    });
+    return {
+      app,
+      targets,
+    };
+  }
+
+  private async runProjectSpecificActionAsync(
+    ctx: CredentialsContext,
+    app: App,
+    targets: Target[],
+    buildProfile: BuildProfile<Platform.IOS>,
+    action: IosActionType
+  ): Promise<void> {
+    if (action === IosActionType.SetUpBuildCredentials) {
+      await new SetUpBuildCredentials({
+        app,
+        targets,
+        distribution: buildProfile.distribution,
+        enterpriseProvisioning: buildProfile.enterpriseProvisioning,
+      }).runAsync(ctx);
+      return;
+    }
+
+    const distributionType = await new SelectIosDistributionTypeGraphqlFromBuildProfile(
+      buildProfile
+    ).runAsync(ctx);
+
+    if (action === IosActionType.SetUpBuildCredentialsFromCredentialsJson) {
+      await new SetUpBuildCredentialsFromCredentialsJson(app, targets, distributionType).runAsync(
+        ctx
+      );
+      return;
+    } else if (action === IosActionType.UpdateCredentialsJson) {
+      await new UpdateCredentialsJson(app, targets, distributionType).runAsync(ctx);
+      return;
+    }
+
+    const target = await this.selectTargetAsync(targets);
+    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx, target);
+    switch (action) {
+      case IosActionType.UseExistingDistributionCertificate: {
+        const distCert = await selectValidDistributionCertificateAsync(ctx, appLookupParams);
+        if (!distCert) {
+          return;
+        }
+        await this.setupProvisioningProfileWithSpecificDistCertAsync(
+          ctx,
+          target,
+          appLookupParams,
+          distCert,
+          distributionType
+        );
+        return;
+      }
+      case IosActionType.CreateDistributionCertificate: {
+        const distCert = await new CreateDistributionCertificate(appLookupParams.account).runAsync(
+          ctx
+        );
+        const confirm = await confirmAsync({
+          message: `Do you want ${appLookupParams.projectName} to use the new Distribution Certificate?`,
+        });
+        if (confirm) {
+          await this.setupProvisioningProfileWithSpecificDistCertAsync(
+            ctx,
+            target,
+            appLookupParams,
+            distCert,
+            distributionType
+          );
+        }
+        return;
+      }
+      case IosActionType.RemoveProvisioningProfile: {
+        const iosAppCredentials = await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(
+          ctx.graphqlClient,
+          appLookupParams
+        );
+        const provisioningProfile = iosAppCredentials?.iosAppBuildCredentialsList.find(
+          buildCredentials => buildCredentials.iosDistributionType === distributionType
+        )?.provisioningProfile;
+        if (!provisioningProfile) {
+          Log.log(
+            `No provisioning profile associated with the ${distributionType} configuration of ${appLookupParams.projectName}`
+          );
+          return;
+        }
+        const confirm = await confirmAsync({
+          message: `Delete the provisioning profile associated with the ${distributionType} configuration of ${appLookupParams.projectName}?`,
+        });
+        if (confirm) {
+          await new RemoveProvisioningProfiles([appLookupParams], [provisioningProfile]).runAsync(
+            ctx
+          );
+        }
+        return;
+      }
+      case IosActionType.SetUpPushKey: {
+        const setupPushKeyAction = await new SetUpPushKey(appLookupParams);
+        const isPushKeySetup = await setupPushKeyAction.isPushKeySetupAsync(ctx);
+        if (isPushKeySetup) {
+          Log.log(
+            `Push Key is already set up for ${appLookupParams.projectName} ${appLookupParams.bundleIdentifier}`
+          );
+        } else {
+          await new SetUpPushKey(appLookupParams).runAsync(ctx);
+        }
+        return;
+      }
+      case IosActionType.CreatePushKey: {
+        const pushKey = await new CreatePushKey(appLookupParams.account).runAsync(ctx);
+        const confirm = await confirmAsync({
+          message: `Do you want ${appLookupParams.projectName} to use the new Push Key?`,
+        });
+        if (confirm) {
+          await new AssignPushKey(appLookupParams).runAsync(ctx, pushKey);
+        }
+        return;
+      }
+      case IosActionType.UseExistingPushKey: {
+        const selectedPushKey = await selectPushKeyAsync(ctx, appLookupParams.account);
+        if (selectedPushKey) {
+          await new AssignPushKey(appLookupParams).runAsync(ctx, selectedPushKey);
+        }
+        return;
+      }
+      case IosActionType.SetUpAscApiKeyForSubmissions: {
+        await new SetUpAscApiKey(
+          appLookupParams,
+          AppStoreApiKeyPurpose.SUBMISSION_SERVICE
+        ).runAsync(ctx);
+        return;
+      }
+      case IosActionType.UseExistingAscApiKeyForSubmissions: {
+        const ascApiKey = await selectAscApiKeysFromAccountAsync(ctx, appLookupParams.account, {
+          filterDifferentAppleTeam: true,
+        });
+        if (ascApiKey) {
+          await new AssignAscApiKey(appLookupParams).runAsync(
+            ctx,
+            ascApiKey,
+            AppStoreApiKeyPurpose.SUBMISSION_SERVICE
+          );
+        }
+        return;
+      }
+      case IosActionType.CreateAscApiKeyForSubmissions: {
+        const ascApiKey = await new CreateAscApiKey(appLookupParams.account).runAsync(
+          ctx,
+          AppStoreApiKeyPurpose.SUBMISSION_SERVICE
+        );
+        const confirm = await confirmAsync({
+          message: `Do you want ${appLookupParams.projectName} to use the new API Key?`,
+        });
+        if (confirm) {
+          await new AssignAscApiKey(appLookupParams).runAsync(
+            ctx,
+            ascApiKey,
+            AppStoreApiKeyPurpose.SUBMISSION_SERVICE
+          );
+        }
+        return;
+      }
+      default:
+        throw new Error('Unknown action selected');
+    }
+  }
+
+  private async setupProvisioningProfileWithSpecificDistCertAsync(
+    ctx: CredentialsContext,
+    target: Target,
+    appLookupParams: AppLookupParams,
+    distCert: AppleDistributionCertificateFragment,
+    distributionType: IosDistributionTypeGraphql
+  ): Promise<IosAppBuildCredentialsFragment> {
+    Log.log(`Setting up ${appLookupParams.projectName} to use Distribution Certificate`);
+    Log.log(`Creating provisioning profile...`);
+    if (distributionType === IosDistributionTypeGraphql.AdHoc) {
+      return await new SetUpAdhocProvisioningProfile({
+        app: appLookupParams,
+        target,
+      }).runWithDistributionCertificateAsync(ctx, distCert);
+    } else {
+      return await new SetUpProvisioningProfile(
+        appLookupParams,
+        target,
+        distributionType
+      ).createAndAssignProfileAsync(ctx, distCert);
+    }
+  }
+
+  private async selectTargetAsync(targets: Target[]): Promise<Target> {
+    if (targets.length === 1) {
+      return targets[0];
+    }
+    return await selectAsync<Target>(
+      'Which target do you want to use?',
+      targets.map(target => ({
+        title: `${target.targetName} (Bundle Identifier: ${target.bundleIdentifier})`,
+        value: target,
+      }))
+    );
+  }
+}

--- a/packages/eas-cli/src/credentials/manager/SetUpIosBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/SetUpIosBuildCredentials.ts
@@ -72,7 +72,7 @@ export class SetUpIosBuildCredentials extends ManageIos {
       nullthrows(app, 'app must be defined in project context'),
       nullthrows(targets, 'targets must be defined in project context'),
       nullthrows(buildProfile, 'buildProfile must be defined in project context'),
-      IosActionType.SetUpBuildCredentials // Directly proceed to SetUpBuildCredentials
+      IosActionType.SetUpBuildCredentials
     );
   }
 }

--- a/packages/eas-cli/src/credentials/manager/SetUpIosBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/SetUpIosBuildCredentials.ts
@@ -1,56 +1,26 @@
 import { Platform } from '@expo/eas-build-job';
-import { BuildProfile } from '@expo/eas-json';
 import assert from 'assert';
 import nullthrows from 'nullthrows';
 
 import { IosActionType } from './Actions';
 import { CheckBuildProfileFlagAgainstEasJson } from './CheckBuildProfileFlagAgainstEasJson';
 import { Action } from './HelperActions';
-import { SelectIosDistributionTypeGraphqlFromBuildProfile } from './SelectIosDistributionTypeGraphqlFromBuildProfile';
-import {
-  AccountFragment,
-  AppleDistributionCertificateFragment,
-  IosAppBuildCredentialsFragment,
-  IosDistributionType as IosDistributionTypeGraphql,
-} from '../../graphql/generated';
-import Log from '../../log';
-import { resolveXcodeBuildContextAsync } from '../../project/ios/scheme';
-import { resolveTargetsAsync } from '../../project/ios/target';
+import { ManageIos } from './ManageIos';
+import { AccountFragment } from '../../graphql/generated';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
-import { confirmAsync, selectAsync } from '../../prompts';
 import { ensureActorHasPrimaryAccount } from '../../user/actions';
 import { CredentialsContext, CredentialsContextProjectInfo } from '../context';
-import {
-  AppStoreApiKeyPurpose,
-  selectAscApiKeysFromAccountAsync,
-} from '../ios/actions/AscApiKeyUtils';
-import { AssignAscApiKey } from '../ios/actions/AssignAscApiKey';
-import { AssignPushKey } from '../ios/actions/AssignPushKey';
-import { getAppLookupParamsFromContextAsync } from '../ios/actions/BuildCredentialsUtils';
-import { CreateAscApiKey } from '../ios/actions/CreateAscApiKey';
-import { CreateDistributionCertificate } from '../ios/actions/CreateDistributionCertificate';
-import { CreatePushKey } from '../ios/actions/CreatePushKey';
-import { selectValidDistributionCertificateAsync } from '../ios/actions/DistributionCertificateUtils';
-import { selectPushKeyAsync } from '../ios/actions/PushKeyUtils';
-import { RemoveProvisioningProfiles } from '../ios/actions/RemoveProvisioningProfile';
-import { SetUpAdhocProvisioningProfile } from '../ios/actions/SetUpAdhocProvisioningProfile';
-import { SetUpAscApiKey } from '../ios/actions/SetUpAscApiKey';
-import { SetUpBuildCredentials } from '../ios/actions/SetUpBuildCredentials';
-import { SetUpBuildCredentialsFromCredentialsJson } from '../ios/actions/SetUpBuildCredentialsFromCredentialsJson';
-import { SetUpProvisioningProfile } from '../ios/actions/SetUpProvisioningProfile';
-import { SetUpPushKey } from '../ios/actions/SetUpPushKey';
-import { UpdateCredentialsJson } from '../ios/actions/UpdateCredentialsJson';
-import { AppLookupParams } from '../ios/api/graphql/types/AppLookupParams';
-import { App, Target } from '../ios/types';
 
-export class SetUpIosBuildCredentials {
+export class SetUpIosBuildCredentials extends ManageIos {
   constructor(
-    private callingAction: Action,
-    private projectDir: string,
+    callingAction: Action,
+    projectDir: string,
     private setUpBuildCredentialsWithProfileNameFromFlag: string
-  ) {}
+  ) {
+    super(callingAction, projectDir);
+  }
 
-  async runAsync(): Promise<void> {
+  override async runAsync(): Promise<void> {
     const buildProfile = this.callingAction.projectInfo
       ? await new CheckBuildProfileFlagAgainstEasJson(
           this.projectDir,
@@ -103,236 +73,6 @@ export class SetUpIosBuildCredentials {
       nullthrows(targets, 'targets must be defined in project context'),
       nullthrows(buildProfile, 'buildProfile must be defined in project context'),
       IosActionType.SetUpBuildCredentials // Directly proceed to SetUpBuildCredentials
-    );
-  }
-
-  private async createProjectContextAsync(
-    ctx: CredentialsContext,
-    account: AccountFragment,
-    buildProfile: BuildProfile<Platform.IOS>
-  ): Promise<{
-    app: App;
-    targets: Target[];
-  }> {
-    assert(ctx.hasProjectContext, 'createProjectContextAsync: must have project context.');
-
-    const app = { account, projectName: ctx.exp.slug };
-    const xcodeBuildContext = await resolveXcodeBuildContextAsync(
-      {
-        projectDir: ctx.projectDir,
-        nonInteractive: ctx.nonInteractive,
-        exp: ctx.exp,
-        vcsClient: ctx.vcsClient,
-      },
-      buildProfile
-    );
-    const targets = await resolveTargetsAsync({
-      exp: ctx.exp,
-      projectDir: ctx.projectDir,
-      xcodeBuildContext,
-      env: buildProfile.env,
-      vcsClient: ctx.vcsClient,
-    });
-    return {
-      app,
-      targets,
-    };
-  }
-
-  private async runProjectSpecificActionAsync(
-    ctx: CredentialsContext,
-    app: App,
-    targets: Target[],
-    buildProfile: BuildProfile<Platform.IOS>,
-    action: IosActionType
-  ): Promise<void> {
-    if (action === IosActionType.SetUpBuildCredentials) {
-      await new SetUpBuildCredentials({
-        app,
-        targets,
-        distribution: buildProfile.distribution,
-        enterpriseProvisioning: buildProfile.enterpriseProvisioning,
-      }).runAsync(ctx);
-      return;
-    }
-
-    const distributionType = await new SelectIosDistributionTypeGraphqlFromBuildProfile(
-      buildProfile
-    ).runAsync(ctx);
-
-    if (action === IosActionType.SetUpBuildCredentialsFromCredentialsJson) {
-      await new SetUpBuildCredentialsFromCredentialsJson(app, targets, distributionType).runAsync(
-        ctx
-      );
-      return;
-    } else if (action === IosActionType.UpdateCredentialsJson) {
-      await new UpdateCredentialsJson(app, targets, distributionType).runAsync(ctx);
-      return;
-    }
-
-    const target = await this.selectTargetAsync(targets);
-    const appLookupParams = await getAppLookupParamsFromContextAsync(ctx, target);
-    switch (action) {
-      case IosActionType.UseExistingDistributionCertificate: {
-        const distCert = await selectValidDistributionCertificateAsync(ctx, appLookupParams);
-        if (!distCert) {
-          return;
-        }
-        await this.setupProvisioningProfileWithSpecificDistCertAsync(
-          ctx,
-          target,
-          appLookupParams,
-          distCert,
-          distributionType
-        );
-        return;
-      }
-      case IosActionType.CreateDistributionCertificate: {
-        const distCert = await new CreateDistributionCertificate(appLookupParams.account).runAsync(
-          ctx
-        );
-        const confirm = await confirmAsync({
-          message: `Do you want ${appLookupParams.projectName} to use the new Distribution Certificate?`,
-        });
-        if (confirm) {
-          await this.setupProvisioningProfileWithSpecificDistCertAsync(
-            ctx,
-            target,
-            appLookupParams,
-            distCert,
-            distributionType
-          );
-        }
-        return;
-      }
-      case IosActionType.RemoveProvisioningProfile: {
-        const iosAppCredentials = await ctx.ios.getIosAppCredentialsWithCommonFieldsAsync(
-          ctx.graphqlClient,
-          appLookupParams
-        );
-        const provisioningProfile = iosAppCredentials?.iosAppBuildCredentialsList.find(
-          buildCredentials => buildCredentials.iosDistributionType === distributionType
-        )?.provisioningProfile;
-        if (!provisioningProfile) {
-          Log.log(
-            `No provisioning profile associated with the ${distributionType} configuration of ${appLookupParams.projectName}`
-          );
-          return;
-        }
-        const confirm = await confirmAsync({
-          message: `Delete the provisioning profile associated with the ${distributionType} configuration of ${appLookupParams.projectName}?`,
-        });
-        if (confirm) {
-          await new RemoveProvisioningProfiles([appLookupParams], [provisioningProfile]).runAsync(
-            ctx
-          );
-        }
-        return;
-      }
-      case IosActionType.SetUpPushKey: {
-        const setupPushKeyAction = await new SetUpPushKey(appLookupParams);
-        const isPushKeySetup = await setupPushKeyAction.isPushKeySetupAsync(ctx);
-        if (isPushKeySetup) {
-          Log.log(
-            `Push Key is already set up for ${appLookupParams.projectName} ${appLookupParams.bundleIdentifier}`
-          );
-        } else {
-          await new SetUpPushKey(appLookupParams).runAsync(ctx);
-        }
-        return;
-      }
-      case IosActionType.CreatePushKey: {
-        const pushKey = await new CreatePushKey(appLookupParams.account).runAsync(ctx);
-        const confirm = await confirmAsync({
-          message: `Do you want ${appLookupParams.projectName} to use the new Push Key?`,
-        });
-        if (confirm) {
-          await new AssignPushKey(appLookupParams).runAsync(ctx, pushKey);
-        }
-        return;
-      }
-      case IosActionType.UseExistingPushKey: {
-        const selectedPushKey = await selectPushKeyAsync(ctx, appLookupParams.account);
-        if (selectedPushKey) {
-          await new AssignPushKey(appLookupParams).runAsync(ctx, selectedPushKey);
-        }
-        return;
-      }
-      case IosActionType.SetUpAscApiKeyForSubmissions: {
-        await new SetUpAscApiKey(
-          appLookupParams,
-          AppStoreApiKeyPurpose.SUBMISSION_SERVICE
-        ).runAsync(ctx);
-        return;
-      }
-      case IosActionType.UseExistingAscApiKeyForSubmissions: {
-        const ascApiKey = await selectAscApiKeysFromAccountAsync(ctx, appLookupParams.account, {
-          filterDifferentAppleTeam: true,
-        });
-        if (ascApiKey) {
-          await new AssignAscApiKey(appLookupParams).runAsync(
-            ctx,
-            ascApiKey,
-            AppStoreApiKeyPurpose.SUBMISSION_SERVICE
-          );
-        }
-        return;
-      }
-      case IosActionType.CreateAscApiKeyForSubmissions: {
-        const ascApiKey = await new CreateAscApiKey(appLookupParams.account).runAsync(
-          ctx,
-          AppStoreApiKeyPurpose.SUBMISSION_SERVICE
-        );
-        const confirm = await confirmAsync({
-          message: `Do you want ${appLookupParams.projectName} to use the new API Key?`,
-        });
-        if (confirm) {
-          await new AssignAscApiKey(appLookupParams).runAsync(
-            ctx,
-            ascApiKey,
-            AppStoreApiKeyPurpose.SUBMISSION_SERVICE
-          );
-        }
-        return;
-      }
-      default:
-        throw new Error('Unknown action selected');
-    }
-  }
-
-  private async setupProvisioningProfileWithSpecificDistCertAsync(
-    ctx: CredentialsContext,
-    target: Target,
-    appLookupParams: AppLookupParams,
-    distCert: AppleDistributionCertificateFragment,
-    distributionType: IosDistributionTypeGraphql
-  ): Promise<IosAppBuildCredentialsFragment> {
-    Log.log(`Setting up ${appLookupParams.projectName} to use Distribution Certificate`);
-    Log.log(`Creating provisioning profile...`);
-    if (distributionType === IosDistributionTypeGraphql.AdHoc) {
-      return await new SetUpAdhocProvisioningProfile({
-        app: appLookupParams,
-        target,
-      }).runWithDistributionCertificateAsync(ctx, distCert);
-    } else {
-      return await new SetUpProvisioningProfile(
-        appLookupParams,
-        target,
-        distributionType
-      ).createAndAssignProfileAsync(ctx, distCert);
-    }
-  }
-
-  private async selectTargetAsync(targets: Target[]): Promise<Target> {
-    if (targets.length === 1) {
-      return targets[0];
-    }
-    return await selectAsync<Target>(
-      'Which target do you want to use?',
-      targets.map(target => ({
-        title: `${target.targetName} (Bundle Identifier: ${target.bundleIdentifier})`,
-        value: target,
-      }))
     );
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

To help a developer get configured for GitHub builds, it would be nice to let them use an EAS CLI command locally that sets up credentials for a build without actually executing it. In theory it would be awesome to be able to do this work from the browser/server, but as we know, some constraints prevent us from that.

# How

I added a new command that largely inherits most of its behavior from `ManageIos/ManageAndroid`, but goes right to the `SetUpBuildCredentials` step for each platform, skipping printing out existing credentials and the 4+ step prompt flow that takes you to this action.

# Test Plan

With `neas` as an alias pointed to my local build of EAS CLI,

`neas credentials:configure-build` should prompt you for both parameters and execute the build credentials setup for the selected platform.

`neas credentials:configure-build --platform <android/ios>` should prompt you for a build profile listed inside your **eas.json** and execute the build credentials setup for the selected platform.

`neas credentials:configure-build --platform <android/ios> --profile PROFILE_NAME` should immediately execute the build credentials setup for the selected platform.