### PR TITLE
[eas-cli] send a path to custom build config to EAS Build server with posix separator for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Use a custom build config path with POSIX separator when sending data to the EAS Build server. ([#2285](https://github.com/expo/eas-cli/pull/2285) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2277](https://github.com/expo/eas-cli/pull/2277) by [@expo-bot](https://github.com/expo-bot))

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -12,10 +12,9 @@ import path from 'path';
 import slash from 'slash';
 
 import { AndroidCredentials } from '../../credentials/android/AndroidCredentialsProvider';
-import { getCustomBuildConfigPath } from '../../project/customBuildConfig';
+import { getCustomBuildConfigPathForJob } from '../../project/customBuildConfig';
 import { getUsername } from '../../project/projectUtils';
 import { BuildContext } from '../context';
-import { LocalBuildMode } from '../local';
 
 interface JobData {
   projectArchive: ArchiveSource;
@@ -54,16 +53,12 @@ export async function prepareJobAsync(
     buildType = Android.BuildType.APK;
   }
 
-  let maybeCustomBuildConfigPath = buildProfile.config
-    ? getCustomBuildConfigPath(buildProfile.config)
+  const maybeCustomBuildConfigPath = buildProfile.config
+    ? getCustomBuildConfigPathForJob({
+        configFilename: buildProfile.config,
+        localBuildMode: ctx.localBuildOptions.localBuildMode,
+      })
     : undefined;
-  if (
-    maybeCustomBuildConfigPath &&
-    ctx.localBuildOptions.localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN &&
-    process.platform === 'win32'
-  ) {
-    maybeCustomBuildConfigPath = path.posix.join(...maybeCustomBuildConfigPath.split(path.sep));
-  }
 
   const job: Android.Job = {
     type: ctx.workflow,

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -54,10 +54,7 @@ export async function prepareJobAsync(
   }
 
   const maybeCustomBuildConfigPath = buildProfile.config
-    ? getCustomBuildConfigPathForJob({
-        configFilename: buildProfile.config,
-        localBuildMode: ctx.localBuildOptions.localBuildMode,
-      })
+    ? getCustomBuildConfigPathForJob(buildProfile.config)
     : undefined;
 
   const job: Android.Job = {

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -59,7 +59,8 @@ export async function prepareJobAsync(
     : undefined;
   if (
     maybeCustomBuildConfigPath &&
-    ctx.localBuildOptions.localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN
+    ctx.localBuildOptions.localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN &&
+    process.platform === 'win32'
   ) {
     maybeCustomBuildConfigPath = path.posix.join(...maybeCustomBuildConfigPath.split(path.sep));
   }

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -15,6 +15,7 @@ import { AndroidCredentials } from '../../credentials/android/AndroidCredentials
 import { getCustomBuildConfigPath } from '../../project/customBuildConfig';
 import { getUsername } from '../../project/projectUtils';
 import { BuildContext } from '../context';
+import { LocalBuildMode } from '../local';
 
 interface JobData {
   projectArchive: ArchiveSource;
@@ -53,9 +54,15 @@ export async function prepareJobAsync(
     buildType = Android.BuildType.APK;
   }
 
-  const maybeCustomBuildConfigPath = buildProfile.config
+  let maybeCustomBuildConfigPath = buildProfile.config
     ? getCustomBuildConfigPath(buildProfile.config)
     : undefined;
+  if (
+    maybeCustomBuildConfigPath &&
+    ctx.localBuildOptions.localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN
+  ) {
+    maybeCustomBuildConfigPath = path.posix.join(...maybeCustomBuildConfigPath.split(path.sep));
+  }
 
   const job: Android.Job = {
     type: ctx.workflow,

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -51,7 +51,8 @@ export async function prepareJobAsync(
     : undefined;
   if (
     maybeCustomBuildConfigPath &&
-    ctx.localBuildOptions.localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN
+    ctx.localBuildOptions.localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN &&
+    process.platform === 'win32'
   ) {
     maybeCustomBuildConfigPath = path.posix.join(...maybeCustomBuildConfigPath.split(path.sep));
   }

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -46,10 +46,7 @@ export async function prepareJobAsync(
   }
 
   const maybeCustomBuildConfigPath = buildProfile.config
-    ? getCustomBuildConfigPathForJob({
-        configFilename: buildProfile.config,
-        localBuildMode: ctx.localBuildOptions.localBuildMode,
-      })
+    ? getCustomBuildConfigPathForJob(buildProfile.config)
     : undefined;
 
   const job: Ios.Job = {

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -14,10 +14,9 @@ import slash from 'slash';
 
 import { IosCredentials, TargetCredentials } from '../../credentials/ios/types';
 import { IosJobSecretsInput } from '../../graphql/generated';
-import { getCustomBuildConfigPath } from '../../project/customBuildConfig';
+import { getCustomBuildConfigPathForJob } from '../../project/customBuildConfig';
 import { getUsername } from '../../project/projectUtils';
 import { BuildContext } from '../context';
-import { LocalBuildMode } from '../local';
 
 interface JobData {
   projectArchive: ArchiveSource;
@@ -46,16 +45,12 @@ export async function prepareJobAsync(
     }
   }
 
-  let maybeCustomBuildConfigPath = buildProfile.config
-    ? getCustomBuildConfigPath(buildProfile.config)
+  const maybeCustomBuildConfigPath = buildProfile.config
+    ? getCustomBuildConfigPathForJob({
+        configFilename: buildProfile.config,
+        localBuildMode: ctx.localBuildOptions.localBuildMode,
+      })
     : undefined;
-  if (
-    maybeCustomBuildConfigPath &&
-    ctx.localBuildOptions.localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN &&
-    process.platform === 'win32'
-  ) {
-    maybeCustomBuildConfigPath = path.posix.join(...maybeCustomBuildConfigPath.split(path.sep));
-  }
 
   const job: Ios.Job = {
     type: ctx.workflow,

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -17,6 +17,7 @@ import { IosJobSecretsInput } from '../../graphql/generated';
 import { getCustomBuildConfigPath } from '../../project/customBuildConfig';
 import { getUsername } from '../../project/projectUtils';
 import { BuildContext } from '../context';
+import { LocalBuildMode } from '../local';
 
 interface JobData {
   projectArchive: ArchiveSource;
@@ -45,9 +46,15 @@ export async function prepareJobAsync(
     }
   }
 
-  const maybeCustomBuildConfigPath = buildProfile.config
+  let maybeCustomBuildConfigPath = buildProfile.config
     ? getCustomBuildConfigPath(buildProfile.config)
     : undefined;
+  if (
+    maybeCustomBuildConfigPath &&
+    ctx.localBuildOptions.localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN
+  ) {
+    maybeCustomBuildConfigPath = path.posix.join(...maybeCustomBuildConfigPath.split(path.sep));
+  }
 
   const job: Ios.Job = {
     type: ctx.workflow,

--- a/packages/eas-cli/src/project/customBuildConfig.ts
+++ b/packages/eas-cli/src/project/customBuildConfig.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
+import { LocalBuildMode } from '../build/local';
 import { Client } from '../vcs/vcs';
 
 export interface CustomBuildConfigMetadata {
@@ -67,4 +68,22 @@ export async function validateCustomBuildConfigAsync({
 
 export function getCustomBuildConfigPath(configFilename: string): string {
   return path.join('.eas/build', configFilename);
+}
+
+export function getCustomBuildConfigPathForJob({
+  configFilename,
+  localBuildMode,
+}: {
+  configFilename: string;
+  localBuildMode?: LocalBuildMode;
+}): string {
+  let customBuildConfigPath = getCustomBuildConfigPath(configFilename);
+  if (
+    customBuildConfigPath &&
+    localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN &&
+    process.platform === 'win32'
+  ) {
+    customBuildConfigPath = path.posix.join(...customBuildConfigPath.split(path.sep));
+  }
+  return customBuildConfigPath;
 }

--- a/packages/eas-cli/src/project/customBuildConfig.ts
+++ b/packages/eas-cli/src/project/customBuildConfig.ts
@@ -5,7 +5,6 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { LocalBuildMode } from '../build/local';
 import { Client } from '../vcs/vcs';
 
 export interface CustomBuildConfigMetadata {
@@ -70,16 +69,6 @@ export function getCustomBuildConfigPath(configFilename: string): string {
   return path.join('.eas/build', configFilename);
 }
 
-export function getCustomBuildConfigPathForJob({
-  configFilename,
-  localBuildMode,
-}: {
-  configFilename: string;
-  localBuildMode?: LocalBuildMode;
-}): string {
-  let customBuildConfigPath = getCustomBuildConfigPath(configFilename);
-  if (localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN && process.platform === 'win32') {
-    customBuildConfigPath = path.posix.join(...customBuildConfigPath.split(path.sep));
-  }
-  return customBuildConfigPath;
+export function getCustomBuildConfigPathForJob(configFilename: string): string {
+  return path.posix.join('.eas/build', configFilename);
 }

--- a/packages/eas-cli/src/project/customBuildConfig.ts
+++ b/packages/eas-cli/src/project/customBuildConfig.ts
@@ -78,11 +78,7 @@ export function getCustomBuildConfigPathForJob({
   localBuildMode?: LocalBuildMode;
 }): string {
   let customBuildConfigPath = getCustomBuildConfigPath(configFilename);
-  if (
-    customBuildConfigPath &&
-    localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN &&
-    process.platform === 'win32'
-  ) {
+  if (localBuildMode !== LocalBuildMode.LOCAL_BUILD_PLUGIN && process.platform === 'win32') {
     customBuildConfigPath = path.posix.join(...customBuildConfigPath.split(path.sep));
   }
   return customBuildConfigPath;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Our server expects to get this path with a POSIX separator

Closes https://github.com/expo/eas-cli/issues/2160

# How

If a build is not local use the posix separator for Windows.

# Test Plan

Tests

Comment out `process.platform === 'win32'` and see if it works on my Mac machine

I don't have a Windows machine to test it
