### PR TITLE
Log dirty files in non-interactive when bailing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Print uncommitted files in non-interactive mode if they fail the execution. ([#2288](https://github.com/expo/eas-cli/pull/2288) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🐛 Bug fixes
 
 - Fix expo-updates package version detection for canaries. ([#2243](https://github.com/expo/eas-cli/pull/2243) by [@wschurman](https://github.com/wschurman))

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -40,7 +40,7 @@ async function configureAsync({
   nonInteractive,
   vcsClient,
 }: ConfigureParams): Promise<void> {
-  await maybeBailOnRepoStatusAsync(vcsClient);
+  await maybeBailOnRepoStatusAsync(vcsClient, nonInteractive);
 
   await createEasJsonAsync(projectDir, vcsClient);
 

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -12,7 +12,10 @@ import { getTmpDirectory } from '../../utils/paths';
 import { endTimer, formatMilliseconds, startTimer } from '../../utils/timer';
 import { Client } from '../../vcs/vcs';
 
-export async function maybeBailOnRepoStatusAsync(vcsClient: Client): Promise<void> {
+export async function maybeBailOnRepoStatusAsync(
+  vcsClient: Client,
+  nonInteractive: boolean
+): Promise<void> {
   if (!(await vcsClient.isCommitRequiredAsync())) {
     return;
   }
@@ -28,6 +31,11 @@ export async function maybeBailOnRepoStatusAsync(vcsClient: Client): Promise<voi
   });
 
   if (!answer) {
+    if (nonInteractive) {
+      Log.log('The following files need to be committed:');
+      await vcsClient.showChangedFilesAsync();
+    }
+
     throw new Error('Commit all changes. Aborting...');
   }
 }
@@ -47,6 +55,9 @@ export async function ensureRepoIsCleanAsync(
     )}.`
   );
   if (nonInteractive) {
+    Log.log('The following files need to be committed:');
+    await vcsClient.showChangedFilesAsync();
+
     throw new Error('Commit all changes. Aborting...');
   }
   const answer = await confirmAsync({

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -111,6 +111,11 @@ export default class GitClient extends Client {
     return await this.hasUncommittedChangesAsync();
   }
 
+  public override async showChangedFilesAsync(): Promise<void> {
+    const gitStatusOutput = await gitStatusAsync({ showUntracked: true });
+    Log.log(gitStatusOutput);
+  }
+
   public override async hasUncommittedChangesAsync(): Promise<boolean> {
     const changes = await gitStatusAsync({ showUntracked: true });
     return changes.length > 0;

--- a/packages/eas-cli/src/vcs/vcs.ts
+++ b/packages/eas-cli/src/vcs/vcs.ts
@@ -51,6 +51,9 @@ export abstract class Client {
   // `commitAsync({ commitAllFiles: false })`
   public async showDiffAsync(): Promise<void> {}
 
+  /** (optional) print list of changed files */
+  public async showChangedFilesAsync(): Promise<void> {}
+
   // (optional) returns hash of the last commit
   // used for metadata - implementation can be safely skipped
   public async getCommitHashAsync(): Promise<string | undefined> {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-11730/dump-git-status-when-ci=1-and-we-abort-eas-build-due-to-dirty-working#comment-2c875628

# How

Added `git status` logging when bailing on dirty repo in non-interactive mode.

# Test Plan

<img width="611" alt="Zrzut ekranu 2024-03-15 o 21 42 04" src="https://github.com/expo/eas-cli/assets/1151041/a2efc4f0-b59a-4d03-baf0-c1d5dd9c4f12">
