### PR TITLE
[eas-cli] bump `@expo/apple-utils` to switch between `developer.apple.com` and `developer-mdn.apple.com` domains when one of them doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2277](https://github.com/expo/eas-cli/pull/2277) by [@expo-bot](https://github.com/expo-bot))
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2283](https://github.com/expo/eas-cli/pull/2283) by [@expo-bot](https://github.com/expo-bot))
+- Bump the `@expo/apple-utils` version to switch between the `developer.apple.com` and `developer-mdn.apple.com` domains when one of them doesn't work. ([#2290](https://github.com/expo/eas-cli/pull/2290) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [7.5.0](https://github.com/expo/eas-cli/releases/tag/v7.5.0) - 2024-03-11
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "1.5.0",
+    "@expo/apple-utils": "1.6.0",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "8.5.4",
     "@expo/config-plugins": "7.8.4",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "1.6.0",
+    "@expo/apple-utils": "1.7.0",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "8.5.4",
     "@expo/config-plugins": "7.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1354,10 +1354,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.6.0.tgz#728f2d502c39f98b7d6a1fd9f681c3d5d429f23a"
-  integrity sha512-oospYiXOIzeHKsgPWaNhJULDx7nHGiPNs+9cEUWv7cC8CDncewemS2VcD2zSc56zNMgXSnejIMOExiyvWFTaJw==
+"@expo/apple-utils@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.7.0.tgz#b8ac565f37b077c3a1bb562b8db5c5864bd6aba7"
+  integrity sha512-RVzZTiOeuNT04fE5V4f536XmIyxbRFOJ3m/rE6kImbIZ65upOS7xdIQpihEdYOiHB5uZAcD3JClUEsMfFhTv4w==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1354,10 +1354,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.5.0.tgz#1ba5ffb946f5d4a5109efaaa2a5e1548e6e74420"
-  integrity sha512-4IxSx4KlS9AughFvUOVC6d22y0fXtLpzDvlqxoPX+wf3ZCxtpg/dbVbitxU7Pcpj+hLIBm6xg2gAmK8asOMqjg==
+"@expo/apple-utils@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.6.0.tgz#728f2d502c39f98b7d6a1fd9f681c3d5d429f23a"
+  integrity sha512-oospYiXOIzeHKsgPWaNhJULDx7nHGiPNs+9cEUWv7cC8CDncewemS2VcD2zSc56zNMgXSnejIMOExiyvWFTaJw==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Bump `@expo/apple-utils` to include changes from https://github.com/expo/third-party/pull/99

# How

Bump `@expo/apple-utils`

# Test Plan

Tests, test authentication manually
