### PR TITLE
[eas-cli] use `GitNoCommitClient` for `eas build:internal` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Use a custom build config path with POSIX separator when sending data to the EAS Build server. ([#2285](https://github.com/expo/eas-cli/pull/2285) by [@szdziedzic](https://github.com/szdziedzic))
+- Improve resolving vcsClient as a part of the project context. ([#2295](https://github.com/expo/eas-cli/pull/2295) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/android/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/android/__tests__/version-test.ts
@@ -8,7 +8,7 @@ import os from 'os';
 import path from 'path';
 
 import { getAppBuildGradleAsync, resolveConfigValue } from '../../../project/android/gradleUtils';
-import { getVcsClient } from '../../../vcs';
+import { resolveVcsClient } from '../../../vcs';
 import {
   BumpStrategy,
   bumpVersionAsync,
@@ -19,7 +19,7 @@ import {
 const fsReal = jest.requireActual('fs').promises as typeof fs;
 jest.mock('fs');
 
-const vcsClient = getVcsClient();
+const vcsClient = resolveVcsClient();
 
 afterAll(async () => {
   // do not remove the following line

--- a/packages/eas-cli/src/build/ios/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/ios/__tests__/version-test.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import type { XCBuildConfiguration } from 'xcode';
 
 import { readPlistAsync } from '../../../utils/plist';
-import { getVcsClient } from '../../../vcs';
+import { resolveVcsClient } from '../../../vcs';
 import {
   BumpStrategy,
   bumpVersionAsync,
@@ -19,7 +19,7 @@ import {
 
 jest.mock('fs');
 
-const vcsClient = getVcsClient();
+const vcsClient = resolveVcsClient();
 
 const getXCBuildConfigurationFromPbxproj = jest.spyOn(
   IOSConfig.Target,

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -24,6 +24,7 @@ import {
 } from '../analytics/AnalyticsManager';
 import Log from '../log';
 import SessionManager from '../user/SessionManager';
+import { Client } from '../vcs/vcs';
 
 export type ContextInput<
   T extends {
@@ -139,7 +140,7 @@ export default abstract class EasCommand extends Command {
     } = object,
   >(
     commandClass: { contextDefinition: ContextInput<C> },
-    { nonInteractive }: { nonInteractive: boolean }
+    { nonInteractive, vcsClientOverride }: { nonInteractive: boolean; vcsClientOverride?: Client }
   ): Promise<ContextOutput<C>> {
     const contextDefinition = commandClass.contextDefinition;
 
@@ -152,6 +153,7 @@ export default abstract class EasCommand extends Command {
           nonInteractive,
           sessionManager: this.sessionManager,
           analytics: this.analytics,
+          vcsClientOverride,
         }),
       ]);
     }

--- a/packages/eas-cli/src/commandUtils/context/ContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/ContextField.ts
@@ -1,10 +1,12 @@
 import { Analytics } from '../../analytics/AnalyticsManager';
 import SessionManager from '../../user/SessionManager';
+import { Client } from '../../vcs/vcs';
 
 export interface ContextOptions {
   sessionManager: SessionManager;
   analytics: Analytics;
   nonInteractive: boolean;
+  vcsClientOverride?: Client;
 }
 
 export default abstract class ContextField<T> {

--- a/packages/eas-cli/src/commandUtils/context/VcsClientContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/VcsClientContextField.ts
@@ -1,9 +1,18 @@
+import { EasJsonAccessor, EasJsonUtils } from '@expo/eas-json';
+
 import ContextField from './ContextField';
-import { getVcsClient } from '../../vcs';
+import { findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
+import { resolveVcsClient } from '../../vcs';
 import { Client } from '../../vcs/vcs';
 
 export default class VcsClientContextField extends ContextField<Client> {
-  async getValueAsync(): Promise<Client> {
-    return getVcsClient();
+  async getValueAsync({ vcsClientOverride }: { vcsClientOverride?: Client }): Promise<Client> {
+    if (vcsClientOverride) {
+      return vcsClientOverride;
+    }
+    const projectDir = await findProjectDirAndVerifyProjectSetupAsync();
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
+    const config = await EasJsonUtils.getCliConfigAsync(easJsonAccessor);
+    return resolveVcsClient(config?.requireCommit);
   }
 }

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
@@ -8,8 +8,7 @@ import semver from 'semver';
 
 import { learnMore } from '../../../log';
 import { easCliVersion } from '../../../utils/easCli';
-import { getVcsClient, setVcsClient } from '../../../vcs';
-import GitClient from '../../../vcs/clients/git';
+import { resolveVcsClient } from '../../../vcs';
 
 async function applyCliConfigAsync(projectDir: string): Promise<void> {
   const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
@@ -18,9 +17,6 @@ async function applyCliConfigAsync(projectDir: string): Promise<void> {
     throw new Error(
       `You are on eas-cli@${easCliVersion} which does not satisfy the CLI version constraint in eas.json (${config.version})`
     );
-  }
-  if (config?.requireCommit) {
-    setVcsClient(new GitClient());
   }
 }
 
@@ -92,7 +88,7 @@ export async function findProjectRootAsync({
   } else {
     let vcsRoot;
     try {
-      vcsRoot = path.normalize(await getVcsClient().getRootPathAsync());
+      vcsRoot = path.normalize(await resolveVcsClient().getRootPathAsync());
     } catch {}
     if (vcsRoot && vcsRoot.startsWith(projectRootDir) && vcsRoot !== projectRootDir) {
       throw new Error(

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -6,7 +6,7 @@ import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import EasCommand from '../../commandUtils/EasCommand';
 import { RequestedPlatform } from '../../platform';
 import { enableJsonOutput } from '../../utils/json';
-import { getVcsClient, setVcsClient } from '../../vcs';
+import { setVcsClient } from '../../vcs';
 import GitNoCommitClient from '../../vcs/clients/gitNoCommit';
 
 /**
@@ -61,6 +61,7 @@ export default class BuildInternal extends EasCommand {
       getDynamicPrivateProjectConfigAsync,
       projectDir,
       analytics,
+      vcsClient,
     } = await this.getContextAsync(BuildInternal, {
       nonInteractive: true,
     });
@@ -72,7 +73,7 @@ export default class BuildInternal extends EasCommand {
     await runBuildAndSubmitAsync(
       graphqlClient,
       analytics,
-      getVcsClient(),
+      vcsClient,
       projectDir,
       {
         requestedPlatform: flags.platform as RequestedPlatform,

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -6,7 +6,7 @@ import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import EasCommand from '../../commandUtils/EasCommand';
 import { RequestedPlatform } from '../../platform';
 import { enableJsonOutput } from '../../utils/json';
-import { setVcsClient } from '../../vcs';
+import { getVcsClient, setVcsClient } from '../../vcs';
 import GitNoCommitClient from '../../vcs/clients/gitNoCommit';
 
 /**
@@ -61,7 +61,6 @@ export default class BuildInternal extends EasCommand {
       getDynamicPrivateProjectConfigAsync,
       projectDir,
       analytics,
-      vcsClient,
     } = await this.getContextAsync(BuildInternal, {
       nonInteractive: true,
     });
@@ -73,7 +72,7 @@ export default class BuildInternal extends EasCommand {
     await runBuildAndSubmitAsync(
       graphqlClient,
       analytics,
-      vcsClient,
+      getVcsClient(),
       projectDir,
       {
         requestedPlatform: flags.platform as RequestedPlatform,

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -6,7 +6,6 @@ import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import EasCommand from '../../commandUtils/EasCommand';
 import { RequestedPlatform } from '../../platform';
 import { enableJsonOutput } from '../../utils/json';
-import { setVcsClient } from '../../vcs';
 import GitNoCommitClient from '../../vcs/clients/gitNoCommit';
 
 /**
@@ -64,9 +63,8 @@ export default class BuildInternal extends EasCommand {
       vcsClient,
     } = await this.getContextAsync(BuildInternal, {
       nonInteractive: true,
+      vcsClientOverride: new GitNoCommitClient(),
     });
-
-    setVcsClient(new GitNoCommitClient());
 
     await handleDeprecatedEasJsonAsync(projectDir, flags.nonInteractive);
 

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -12,6 +12,7 @@ import {
   DynamicPublicProjectConfigContextField,
 } from '../../../commandUtils/context/DynamicProjectConfigContextField';
 import LoggedInContextField from '../../../commandUtils/context/LoggedInContextField';
+import VcsClientContextField from '../../../commandUtils/context/VcsClientContextField';
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import FeatureGateEnvOverrides from '../../../commandUtils/gating/FeatureGateEnvOverrides';
 import FeatureGating from '../../../commandUtils/gating/FeatureGating';
@@ -21,6 +22,7 @@ import { PublishMutation } from '../../../graphql/mutations/PublishMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { collectAssetsAsync, uploadAssetsAsync } from '../../../project/publish';
 import { getBranchNameFromChannelNameAsync } from '../../../update/getBranchNameFromChannelNameAsync';
+import { resolveVcsClient } from '../../../vcs';
 
 const projectRoot = '/test-project';
 const commandOptions = { root: projectRoot } as any;
@@ -265,6 +267,9 @@ function mockTestProject({
     featureGating: new FeatureGating({}, new FeatureGateEnvOverrides()),
     graphqlClient,
   });
+  jest
+    .spyOn(VcsClientContextField.prototype, 'getValueAsync')
+    .mockResolvedValue(resolveVcsClient());
 
   jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
     id: '1234',

--- a/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
@@ -11,6 +11,7 @@ import {
   DynamicPublicProjectConfigContextField,
 } from '../../../commandUtils/context/DynamicProjectConfigContextField';
 import LoggedInContextField from '../../../commandUtils/context/LoggedInContextField';
+import VcsClientContextField from '../../../commandUtils/context/VcsClientContextField';
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import FeatureGateEnvOverrides from '../../../commandUtils/gating/FeatureGateEnvOverrides';
 import FeatureGating from '../../../commandUtils/gating/FeatureGating';
@@ -19,6 +20,7 @@ import { UpdateFragment } from '../../../graphql/generated';
 import { PublishMutation } from '../../../graphql/mutations/PublishMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { getBranchNameFromChannelNameAsync } from '../../../update/getBranchNameFromChannelNameAsync';
+import { resolveVcsClient } from '../../../vcs';
 import UpdateRollBackToEmbedded from '../roll-back-to-embedded';
 
 const projectRoot = '/test-project';
@@ -250,6 +252,9 @@ function mockTestProject({
     featureGating: new FeatureGating({}, new FeatureGateEnvOverrides()),
     graphqlClient,
   });
+  jest
+    .spyOn(VcsClientContextField.prototype, 'getValueAsync')
+    .mockResolvedValue(resolveVcsClient());
 
   jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
     id: '1234',

--- a/packages/eas-cli/src/project/__tests__/workflow-test.ts
+++ b/packages/eas-cli/src/project/__tests__/workflow-test.ts
@@ -1,13 +1,13 @@
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { vol } from 'memfs';
 
-import { getVcsClient } from '../../vcs';
+import { resolveVcsClient } from '../../vcs';
 import { resolveWorkflowAsync, resolveWorkflowPerPlatformAsync } from '../workflow';
 
 jest.mock('fs');
 
 const projectDir = '/app';
-const vcsClient = getVcsClient();
+const vcsClient = resolveVcsClient();
 
 describe(resolveWorkflowAsync, () => {
   beforeEach(() => {

--- a/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
@@ -7,7 +7,7 @@ import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/cr
 import { jester, jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { promptAsync } from '../../../prompts';
-import { getVcsClient } from '../../../vcs';
+import { resolveVcsClient } from '../../../vcs';
 import {
   ensureApplicationIdIsDefinedForManagedProjectAsync,
   getApplicationIdAsync,
@@ -18,7 +18,7 @@ jest.mock('../../../prompts');
 jest.mock('../../../graphql/queries/AppQuery');
 jest.mock('../../../user/actions', () => ({ ensureLoggedInAsync: jest.fn(() => mockJester) }));
 
-const vcsClient = getVcsClient();
+const vcsClient = resolveVcsClient();
 
 beforeEach(async () => {
   vol.reset();

--- a/packages/eas-cli/src/project/android/__tests__/gradle-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/gradle-test.ts
@@ -4,14 +4,14 @@ import os from 'os';
 
 import { jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { promptAsync } from '../../../prompts';
-import { getVcsClient } from '../../../vcs';
+import { resolveVcsClient } from '../../../vcs';
 import { resolveGradleBuildContextAsync } from '../gradle';
 
 jest.mock('fs');
 jest.mock('../../../prompts');
 jest.mock('../../../user/actions', () => ({ ensureLoggedInAsync: jest.fn(() => mockJester) }));
 
-const vcsClient = getVcsClient();
+const vcsClient = resolveVcsClient();
 
 beforeEach(async () => {
   vol.reset();

--- a/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
@@ -8,7 +8,7 @@ import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/cr
 import { jester, jester as mockJester } from '../../../credentials/__tests__/fixtures-constants';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { promptAsync } from '../../../prompts';
-import { getVcsClient } from '../../../vcs';
+import { resolveVcsClient } from '../../../vcs';
 import {
   ensureBundleIdentifierIsDefinedForManagedProjectAsync,
   getBundleIdentifierAsync,
@@ -20,7 +20,7 @@ jest.mock('../../../prompts');
 jest.mock('../../../graphql/queries/AppQuery');
 jest.mock('../../../user/actions', () => ({ ensureLoggedInAsync: jest.fn(() => mockJester) }));
 
-const vcsClient = getVcsClient();
+const vcsClient = resolveVcsClient();
 
 beforeEach(async () => {
   vol.reset();

--- a/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/AndroidSubmitCommand-test.ts
@@ -20,7 +20,7 @@ import {
 import { SubmissionMutation } from '../../../graphql/mutations/SubmissionMutation';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
-import { getVcsClient } from '../../../vcs';
+import { resolveVcsClient } from '../../../vcs';
 import {
   ArchiveResolverContext,
   ArchiveSource,
@@ -57,7 +57,7 @@ jest.mock('../../commons', () => {
   };
 });
 
-const vcsClient = getVcsClient();
+const vcsClient = resolveVcsClient();
 
 describe(AndroidSubmitCommand, () => {
   const testProject = createTestProject(testProjectId, mockJester.accounts[0].name, {

--- a/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/eas-cli/src/submit/android/__tests__/ServiceAccountSource-test.ts
@@ -15,7 +15,7 @@ import { SetUpGoogleServiceAccountKeyForSubmissions } from '../../../credentials
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
 import { promptAsync } from '../../../prompts';
-import { getVcsClient } from '../../../vcs';
+import { resolveVcsClient } from '../../../vcs';
 import { createSubmissionContextAsync } from '../../context';
 import {
   ServiceAccountSource,
@@ -45,7 +45,7 @@ const mockDetectableServiceAccountJson = JSON.stringify({
   client_email: 'beep-boop@iam.gserviceaccount.com',
 });
 
-const vcsClient = getVcsClient();
+const vcsClient = resolveVcsClient();
 
 beforeAll(() => {
   vol.fromJSON({

--- a/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/AscApiKeySource-test.ts
@@ -17,7 +17,7 @@ import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { getBundleIdentifierAsync } from '../../../project/ios/bundleIdentifier';
 import { promptAsync } from '../../../prompts';
-import { getVcsClient } from '../../../vcs';
+import { resolveVcsClient } from '../../../vcs';
 import { SubmissionContext, createSubmissionContextAsync } from '../../context';
 import {
   AscApiKeySource,
@@ -42,7 +42,7 @@ const testProject = createTestProject(testProjectId, mockJester.accounts[0].name
 });
 const projectId = uuidv4();
 
-const vcsClient = getVcsClient();
+const vcsClient = resolveVcsClient();
 
 async function getIosSubmissionContextAsync(): Promise<SubmissionContext<Platform.IOS>> {
   const graphqlClient = instance(mock<ExpoGraphqlClient>());

--- a/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
@@ -13,7 +13,7 @@ import { BuildFragment, SubmissionArchiveSourceType } from '../../../graphql/gen
 import { SubmissionMutation } from '../../../graphql/mutations/SubmissionMutation';
 import { createTestProject } from '../../../project/__tests__/project-utils';
 import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
-import { getVcsClient } from '../../../vcs';
+import { resolveVcsClient } from '../../../vcs';
 import {
   ArchiveResolverContext,
   ArchiveSource,
@@ -53,7 +53,7 @@ jest.mock('../../commons', () => {
   };
 });
 
-const vcsClient = getVcsClient();
+const vcsClient = resolveVcsClient();
 
 describe(IosSubmitCommand, () => {
   const testProject = createTestProject(testProjectId, mockJester.accounts[0].name, {});

--- a/packages/eas-cli/src/vcs/index.ts
+++ b/packages/eas-cli/src/vcs/index.ts
@@ -1,14 +1,13 @@
 import chalk from 'chalk';
 
+import GitClient from './clients/git';
 import GitNoCommitClient from './clients/gitNoCommit';
 import NoVcsClient from './clients/noVcs';
 import { Client } from './vcs';
 
 const NO_VCS_WARNING = `Using EAS CLI without version control system is not recommended, use this mode only if you know what you are doing.`;
 
-let vcsClient = resolveDefaultVcsClient();
-
-function resolveDefaultVcsClient(): Client {
+export function resolveVcsClient(requireCommit: boolean = false): Client {
   if (process.env.EAS_NO_VCS) {
     if (process.env.NODE_ENV !== 'test') {
       // This log might be printed before cli arguments are evaluated,
@@ -19,13 +18,8 @@ function resolveDefaultVcsClient(): Client {
     }
     return new NoVcsClient();
   }
+  if (requireCommit) {
+    return new GitClient();
+  }
   return new GitNoCommitClient();
-}
-
-export function setVcsClient(client: Client): void {
-  vcsClient = client;
-}
-
-export function getVcsClient(): Client {
-  return vcsClient;
 }


### PR DESCRIPTION
# Why

We don't want to fail builds when running `eas build:internal` for people who have `requiredCommit: true` and have modified their project files before the `CONFIGURE_PROJECT` build phase is run. We want to always override the `vcsClient` for the `build:internal` command to `GitNoCommitClient`.

# How

While working on it I noticed that resolving the `vcsClient` works correctly when running `getContextAsync` only because it is always specified as a last field in the command `contextDefinition`. If the order was different `getVcsClient` (used in the `vcsClient` field resolver) might have returned an incorrect value because `setVcsClient` is run separately in other places and it might not be well synchronized.

I deleted the `getVcsClient` and `setVcsClient` functions so `getContextAsync` is the only source of `vcsClient`.

I added the `vcsClientOverride` option to the `getContextAsync` function so we can manually override it if needed like in the `build:internal` command case.

# Test Plan

Use a project with uncommitted changes with `requireCommit: true` and run the `build:internal` command.

Before:
<img width="961" alt="Screenshot 2024-03-21 at 08 56 58" src="https://github.com/expo/eas-cli/assets/55145344/66e68c99-7923-4abc-99e1-581f77184e2d">


After:
<img width="1090" alt="Screenshot 2024-03-21 at 08 57 31" src="https://github.com/expo/eas-cli/assets/55145344/11848d91-ecfe-4801-94e8-dc706b6f465a">

Tests

Run the `eas build` command and check that `vcsClient` behaves correctly depending on whether there are any uncommitted changes and `requireCommit` option value.


