### PR TITLE
[eas-cli] fix asset limit punctuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2291](https://github.com/expo/eas-cli/pull/2291) by [@expo-bot](https://github.com/expo-bot))
+- Fix asset limit punctuation. ([#2296](https://github.com/expo/eas-cli/pull/2296) by [@quinlanj](https://github.com/quinlanj))
 
 ## [7.6.0](https://github.com/expo/eas-cli/releases/tag/v7.6.0) - 2024-03-18
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -351,7 +351,7 @@ export default class UpdatePublish extends EasCommand {
       Log.withInfo(
         `${platformString} (maximum: ${assetLimitPerUpdateGroup} total per update). ${learnMore(
           'https://expo.fyi/eas-update-asset-limits',
-          { learnMoreMessage: 'Learn more about asset limits.' }
+          { learnMoreMessage: 'Learn more about asset limits' }
         )}`
       );
     } catch (e) {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
nit: there is a `.` before the `:` when printing out the line about asset limits

# before
![image (5)](https://github.com/expo/eas-cli/assets/6380927/707f1b30-14cf-4a6c-acfc-fd7170cc99ef)

# after
![Screenshot 2024-03-21 at 12 09 31 PM](https://github.com/expo/eas-cli/assets/6380927/c7a58501-8c5e-4b43-a8e1-f30c7e7c7ae4)

# Test Plan

- [x] manually inspected
