### PR TITLE
Fix project metadata spinner persisting after upload

### DIFF
--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -133,6 +133,7 @@ export async function makeProjectMetadataFileAsync(archivePath: string): Promise
     }
     throw e;
   }
+  clearTimeout(timer);
 
   const duration = endTimer(timerLabel);
   const prettyTime = formatMilliseconds(duration);


### PR DESCRIPTION
# Why

Fixes bug where `eas build` would not exit after build is finished

# How

Clear spinner timer