### PR TITLE
[eas-cli] Fix display of errors when expo-updates CLI command fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix display of errors when expo-updates CLI command fails. ([#2324](https://github.com/expo/eas-cli/pull/2324) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 ## [7.8.1](https://github.com/expo/eas-cli/releases/tag/v7.8.1) - 2024-04-11

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -723,16 +723,21 @@ async function getRuntimeVersionForPlatformAsync({
 
   if (await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir)) {
     try {
+      Log.debug('Using expo-updates runtimeversion:resolve CLI for runtime version resolution');
+
+      const extraArgs = Log.isDebug ? ['--debug'] : [];
+
       const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
         'runtimeversion:resolve',
         '--platform',
         platform,
+        ...extraArgs,
       ]);
       const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
-      if (runtimeVersionResult.fingerprintSources) {
-        Log.debug(`Resolved fingeprint runtime version for platform "${platform}". Sources:`);
-        Log.debug(runtimeVersionResult.fingerprintSources);
-      }
+
+      Log.debug('runtimeversion:resolve output:');
+      Log.debug(resolvedRuntimeVersionJSONResult);
+
       return nullthrows(
         runtimeVersionResult.runtimeVersion,
         `Unable to determine runtime version for ${

--- a/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
+++ b/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
@@ -24,16 +24,21 @@ export async function resolveRuntimeVersionAsync({
   }
 
   try {
+    Log.debug('Using expo-updates runtimeversion:resolve CLI for runtime version resolution');
+
+    const extraArgs = Log.isDebug ? ['--debug'] : [];
+
     const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
       'runtimeversion:resolve',
       '--platform',
       platform,
+      ...extraArgs,
     ]);
     const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
-    if (runtimeVersionResult.fingerprintSources) {
-      Log.debug(`Resolved fingeprint runtime version for platform "${platform}". Sources:`);
-      Log.debug(runtimeVersionResult.fingerprintSources);
-    }
+
+    Log.debug('runtimeversion:resolve output:');
+    Log.debug(resolvedRuntimeVersionJSONResult);
+
     return runtimeVersionResult.runtimeVersion ?? null;
   } catch (e: any) {
     // if expo-updates is not installed, there's no need for a runtime version in the build


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

It seems that the error thrown by the expo-updates CLI is a normal JS Error, and due to the way the CLI is called, the JS error doesn't print super well when it is thrown.

# How

This PR wraps all stderr output in a new error type that at least shows the full error to the user. Still room for improvement on the expo-updates CLI end to make the stderr cleaner.

# Test Plan

```
neas update
...
/Users/wschurman/temp/my-app/node_modules/expo-updates/utils/build/resolveRuntimeVersionAsync.js:24
        throw new Error(`You're currently using the bare workflow, where runtime version policies are not supported. You must set your runtime version manually. For example, define your runtime version as "1.0.0", not {"policy": "appVersion"} in your app config. https://docs.expo.dev/eas-update/runtime-versions`);
              ^

Error: You're currently using the bare workflow, where runtime version policies are not supported. You must set your runtime version manually. For example, define your runtime version as "1.0.0", not {"policy": "appVersion"} in your app config. https://docs.expo.dev/eas-update/runtime-versions
    at resolveRuntimeVersionAsync (/Users/wschurman/temp/my-app/node_modules/expo-updates/utils/build/resolveRuntimeVersionAsync.js:24:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async resolveRuntimeVersion (/Users/wschurman/temp/my-app/node_modules/expo-updates/cli/build/resolveRuntimeVersion.js:63:32)

Node.js v18.18.2

    Error: update command failed.
```