### PR TITLE
[ENG-11823][2/2] move credentials endpoints to paginated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix display of errors when expo-updates CLI command fails. ([#2324](https://github.com/expo/eas-cli/pull/2324) by [@wschurman](https://github.com/wschurman))
+- Move credentials endpoints to paginated counterparts. ([#2327](https://github.com/expo/eas-cli/pull/2327) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -9471,6 +9471,22 @@
             "deprecationReason": "Classic updates have been deprecated."
           },
           {
+            "name": "pushNotifications",
+            "description": "App query field for querying details about an app's push notifications",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppPushNotifications",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "pushSecurityEnabled",
             "description": null,
             "args": [],
@@ -11318,6 +11334,109 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppPushNotifications",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insights",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppPushNotificationsInsights",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppPushNotificationsInsights",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notificationsSentOverTime",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NotificationsSentOverTimeData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -30960,6 +31079,33 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NotificationsSentOverTimeData",
+        "description": null,
+        "fields": [
+          {
+            "name": "data",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "LineChartData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
+++ b/packages/eas-cli/src/credentials/ios/api/GraphqlClient.ts
@@ -326,7 +326,7 @@ export async function getDevicesForAppleTeamAsync(
 ): Promise<AppleDeviceFragment[]> {
   return await AppleDeviceQuery.getAllByAppleTeamIdentifierAsync(
     graphqlClient,
-    account.id,
+    account.name,
     appleTeamIdentifier,
     {
       useCache,

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/AppleDeviceQuery.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 
@@ -7,15 +6,16 @@ import { DeviceNotFoundError } from '../../../../../devices/utils/errors';
 import { withErrorHandlingAsync } from '../../../../../graphql/client';
 import {
   AppleDevice,
+  AppleDeviceFilterInput,
   AppleDeviceFragment,
-  AppleDevicesByAppleTeamQuery,
-  AppleDevicesByIdentifierQuery,
   AppleDevicesByTeamIdentifierQuery,
   AppleDevicesByTeamIdentifierQueryVariables,
+  AppleDevicesPaginatedByAccountQuery,
   AppleTeamFragment,
 } from '../../../../../graphql/generated';
 import { AppleDeviceFragmentNode } from '../../../../../graphql/types/credentials/AppleDevice';
 import { AppleTeamFragmentNode } from '../../../../../graphql/types/credentials/AppleTeam';
+import { Connection, QueryParams, fetchEntireDatasetAsync } from '../../../../../utils/relay';
 import { formatAppleTeam } from '../../../actions/AppleTeamFormatting';
 
 export type AppleDeviceFragmentWithAppleTeam = AppleDeviceFragment & {
@@ -38,51 +38,25 @@ export type AppleDevicesByIdentifierQueryResult = AppleDeviceQueryResult & {
 export const AppleDeviceQuery = {
   async getAllByAppleTeamIdentifierAsync(
     graphqlClient: ExpoGraphqlClient,
-    accountId: string,
+    accountName: string,
     appleTeamIdentifier: string,
     { useCache = true }: { useCache?: boolean } = {}
   ): Promise<AppleDeviceFragmentWithAppleTeam[]> {
-    const data = await withErrorHandlingAsync(
-      graphqlClient
-        .query<AppleDevicesByAppleTeamQuery>(
-          gql`
-            query AppleDevicesByAppleTeamQuery($accountId: ID!, $appleTeamIdentifier: String!) {
-              appleTeam {
-                byAppleTeamIdentifier(accountId: $accountId, identifier: $appleTeamIdentifier) {
-                  id
-                  ...AppleTeamFragment
-                  appleDevices {
-                    id
-                    ...AppleDeviceFragment
-                    appleTeam {
-                      id
-                      ...AppleTeamFragment
-                    }
-                  }
-                }
-              }
-            }
-            ${print(AppleTeamFragmentNode)}
-            ${print(AppleDeviceFragmentNode)}
-          `,
-          {
-            accountId,
-            appleTeamIdentifier,
-          },
-          {
-            additionalTypenames: ['AppleDevice'],
-            requestPolicy: useCache ? 'cache-first' : 'network-only',
-          }
-        )
-        .toPromise()
-    );
-    assert(
-      data.appleTeam.byAppleTeamIdentifier,
-      'byAppleTeamIdentifier should be defined in this context - enforced by GraphQL'
-    );
-    const { appleDevices } = data.appleTeam.byAppleTeamIdentifier;
-    assert(appleDevices, 'Apple Devices should be defined in this context - enforced by GraphQL');
-    return appleDevices;
+    const paginatedGetterAsync = async (
+      relayArgs: QueryParams
+    ): Promise<Connection<AppleDeviceFragmentWithAppleTeam>> => {
+      return await AppleDeviceQuery.getAllForAccountPaginatedAsync(graphqlClient, accountName, {
+        ...relayArgs,
+        filter: {
+          appleTeamIdentifier,
+        },
+        useCache,
+      });
+    };
+    return await fetchEntireDatasetAsync({
+      paginatedGetterAsync,
+      progressBarLabel: 'Fetching Apple devices...',
+    });
   },
 
   async getAllForAppleTeamAsync(
@@ -139,46 +113,108 @@ export const AppleDeviceQuery = {
     graphqlClient: ExpoGraphqlClient,
     accountName: string,
     identifier: string
-  ): Promise<AppleDevicesByIdentifierQueryResult> {
-    const data = await withErrorHandlingAsync(
-      graphqlClient
-        .query<AppleDevicesByIdentifierQuery>(
-          gql`
-            query AppleDevicesByIdentifier($accountName: String!, $identifier: String!) {
-              account {
-                byName(accountName: $accountName) {
-                  id
-                  appleDevices(identifier: $identifier) {
-                    id
-                    model
-                    identifier
-                    name
-                    deviceClass
-                    enabled
-                    appleTeam {
-                      id
-                      appleTeamIdentifier
-                      appleTeamName
-                    }
-                  }
-                }
-              }
-            }
-          `,
-          { accountName, identifier },
-          {
-            additionalTypenames: ['AppleDevice', 'AppleTeam'],
-          }
-        )
-        .toPromise()
-    );
-
-    const device = data.account.byName.appleDevices[0];
+  ): Promise<AppleDeviceFragmentWithAppleTeam> {
+    const paginatedGetterAsync = async (
+      relayArgs: QueryParams
+    ): Promise<Connection<AppleDeviceFragmentWithAppleTeam>> => {
+      return await AppleDeviceQuery.getAllForAccountPaginatedAsync(graphqlClient, accountName, {
+        ...relayArgs,
+        filter: {
+          identifier,
+        },
+      });
+    };
+    const devices = await fetchEntireDatasetAsync({
+      paginatedGetterAsync,
+    });
+    const device = devices[0];
     if (!device) {
       throw new DeviceNotFoundError(
         `Device with id ${identifier} was not found on account ${accountName}.`
       );
     }
     return device;
+  },
+  async getAllForAccountPaginatedAsync(
+    graphqlClient: ExpoGraphqlClient,
+    accountName: string,
+    {
+      after,
+      first,
+      before,
+      last,
+      filter,
+      useCache = true,
+    }: {
+      after?: string;
+      first?: number;
+      before?: string;
+      last?: number;
+      filter?: AppleDeviceFilterInput;
+      useCache?: boolean;
+    }
+  ): Promise<AppleDevicesPaginatedByAccountQuery['account']['byName']['appleDevicesPaginated']> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<AppleDevicesPaginatedByAccountQuery>(
+          gql`
+            query AppleDevicesPaginatedByAccountQuery(
+              $accountName: String!
+              $after: String
+              $first: Int
+              $before: String
+              $last: Int
+              $filter: AppleDeviceFilterInput
+            ) {
+              account {
+                byName(accountName: $accountName) {
+                  id
+                  appleDevicesPaginated(
+                    after: $after
+                    first: $first
+                    before: $before
+                    last: $last
+                    filter: $filter
+                  ) {
+                    edges {
+                      cursor
+                      node {
+                        id
+                        ...AppleDeviceFragment
+                        appleTeam {
+                          id
+                          ...AppleTeamFragment
+                        }
+                      }
+                    }
+                    pageInfo {
+                      hasNextPage
+                      hasPreviousPage
+                      startCursor
+                      endCursor
+                    }
+                  }
+                }
+              }
+            }
+            ${print(AppleTeamFragmentNode)}
+            ${print(AppleDeviceFragmentNode)}
+          `,
+          {
+            accountName,
+            after,
+            first,
+            before,
+            last,
+            filter,
+          },
+          {
+            additionalTypenames: ['AppleDevice'],
+            requestPolicy: useCache ? 'cache-first' : 'network-only',
+          }
+        )
+        .toPromise()
+    );
+    return data.account.byName.appleDevicesPaginated;
   },
 };

--- a/packages/eas-cli/src/credentials/ios/api/graphql/queries/ApplePushKeyQuery.ts
+++ b/packages/eas-cli/src/credentials/ios/api/graphql/queries/ApplePushKeyQuery.ts
@@ -3,25 +3,75 @@ import gql from 'graphql-tag';
 
 import { ExpoGraphqlClient } from '../../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../../../../../graphql/client';
-import { ApplePushKeyByAccountQuery, ApplePushKeyFragment } from '../../../../../graphql/generated';
+import {
+  ApplePushKeyFragment,
+  ApplePushKeysPaginatedByAccountQuery,
+} from '../../../../../graphql/generated';
 import { ApplePushKeyFragmentNode } from '../../../../../graphql/types/credentials/ApplePushKey';
+import { Connection, QueryParams, fetchEntireDatasetAsync } from '../../../../../utils/relay';
 
 export const ApplePushKeyQuery = {
   async getAllForAccountAsync(
     graphqlClient: ExpoGraphqlClient,
     accountName: string
   ): Promise<ApplePushKeyFragment[]> {
+    const paginatedGetterAsync = async (
+      relayArgs: QueryParams
+    ): Promise<Connection<ApplePushKeyFragment>> => {
+      return await ApplePushKeyQuery.getAllForAccountPaginatedAsync(
+        graphqlClient,
+        accountName,
+        relayArgs
+      );
+    };
+    return await fetchEntireDatasetAsync({
+      paginatedGetterAsync,
+      progressBarLabel: 'fetching Apple Push Keys...',
+    });
+  },
+  async getAllForAccountPaginatedAsync(
+    graphqlClient: ExpoGraphqlClient,
+    accountName: string,
+    {
+      after,
+      first,
+      before,
+      last,
+    }: { after?: string; first?: number; before?: string; last?: number }
+  ): Promise<ApplePushKeysPaginatedByAccountQuery['account']['byName']['applePushKeysPaginated']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<ApplePushKeyByAccountQuery>(
+        .query<ApplePushKeysPaginatedByAccountQuery>(
           gql`
-            query ApplePushKeyByAccountQuery($accountName: String!) {
+            query ApplePushKeysPaginatedByAccountQuery(
+              $accountName: String!
+              $after: String
+              $first: Int
+              $before: String
+              $last: Int
+            ) {
               account {
                 byName(accountName: $accountName) {
                   id
-                  applePushKeys {
-                    id
-                    ...ApplePushKeyFragment
+                  applePushKeysPaginated(
+                    after: $after
+                    first: $first
+                    before: $before
+                    last: $last
+                  ) {
+                    edges {
+                      cursor
+                      node {
+                        id
+                        ...ApplePushKeyFragment
+                      }
+                    }
+                    pageInfo {
+                      hasNextPage
+                      hasPreviousPage
+                      startCursor
+                      endCursor
+                    }
                   }
                 }
               }
@@ -30,6 +80,10 @@ export const ApplePushKeyQuery = {
           `,
           {
             accountName,
+            after,
+            first,
+            before,
+            last,
           },
           {
             additionalTypenames: ['ApplePushKey'],
@@ -37,6 +91,6 @@ export const ApplePushKeyQuery = {
         )
         .toPromise()
     );
-    return data.account.byName.applePushKeys;
+    return data.account.byName.applePushKeysPaginated;
   },
 };

--- a/packages/eas-cli/src/devices/actions/create/action.ts
+++ b/packages/eas-cli/src/devices/actions/create/action.ts
@@ -34,7 +34,7 @@ export default class DeviceCreateAction {
       await runDeveloperPortalMethodAsync(
         this.graphqlClient,
         this.appStoreApi,
-        this.account.id,
+        this.account,
         this.appleTeam
       );
     } else if (method === RegistrationMethod.INPUT) {

--- a/packages/eas-cli/src/devices/actions/create/developerPortalMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/developerPortalMethod.ts
@@ -9,7 +9,7 @@ import {
 import AppStoreApi from '../../../credentials/ios/appstore/AppStoreApi';
 import { getRequestContext } from '../../../credentials/ios/appstore/authenticate';
 import { AuthCtx } from '../../../credentials/ios/appstore/authenticateTypes';
-import { AppleDeviceClass, AppleTeam } from '../../../graphql/generated';
+import { AccountFragment, AppleDeviceClass, AppleTeam } from '../../../graphql/generated';
 import Log from '../../../log';
 import { ora } from '../../../ora';
 import { promptAsync } from '../../../prompts';
@@ -25,14 +25,14 @@ const DEVICE_CLASS_TO_GRAPHQL_TYPE: Partial<Record<DeviceClass, AppleDeviceClass
 export async function runDeveloperPortalMethodAsync(
   graphqlClient: ExpoGraphqlClient,
   appStoreApi: AppStoreApi,
-  accountId: string,
+  account: AccountFragment,
   appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName' | 'id'>
 ): Promise<void> {
   const appleAuthCtx = await appStoreApi.ensureAuthenticatedAsync();
   const unregisteredPortalDevices = await findUnregisteredPortalDevicesAsync(
     graphqlClient,
     appleAuthCtx,
-    accountId,
+    account.name,
     appleTeam
   );
   if (unregisteredPortalDevices.length === 0) {
@@ -40,7 +40,7 @@ export async function runDeveloperPortalMethodAsync(
     return;
   }
   const devicesToImport = await chooseDevicesToImportAsync(unregisteredPortalDevices);
-  await importDevicesAsync(graphqlClient, accountId, appleTeam, devicesToImport);
+  await importDevicesAsync(graphqlClient, account.id, appleTeam, devicesToImport);
 }
 
 async function importDevicesAsync(
@@ -88,12 +88,12 @@ async function importDeviceChunkAsync(
 async function findUnregisteredPortalDevicesAsync(
   graphqlClient: ExpoGraphqlClient,
   appleAuthCtx: AuthCtx,
-  accountId: string,
+  accountName: string,
   appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName' | 'id'>
 ): Promise<Device[]> {
   const expoRegisteredDevices = await AppleDeviceQuery.getAllByAppleTeamIdentifierAsync(
     graphqlClient,
-    accountId,
+    accountName,
     appleTeam.appleTeamIdentifier,
     { useCache: false }
   );

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1326,6 +1326,8 @@ export type App = Project & {
    * @deprecated Classic updates have been deprecated.
    */
   published: Scalars['Boolean']['output'];
+  /** App query field for querying details about an app's push notifications */
+  pushNotifications: AppPushNotifications;
   pushSecurityEnabled: Scalars['Boolean']['output'];
   /**
    * Classic update release channel names (to be removed)
@@ -1739,6 +1741,23 @@ export enum AppPrivacy {
   Public = 'PUBLIC',
   Unlisted = 'UNLISTED'
 }
+
+export type AppPushNotifications = {
+  __typename?: 'AppPushNotifications';
+  id: Scalars['ID']['output'];
+  insights: AppPushNotificationsInsights;
+};
+
+export type AppPushNotificationsInsights = {
+  __typename?: 'AppPushNotificationsInsights';
+  id: Scalars['ID']['output'];
+  notificationsSentOverTime: NotificationsSentOverTimeData;
+};
+
+
+export type AppPushNotificationsInsightsNotificationsSentOverTimeArgs = {
+  timespan: InsightsTimespan;
+};
 
 export type AppQuery = {
   __typename?: 'AppQuery';
@@ -4503,6 +4522,11 @@ export enum NotificationType {
   Web = 'WEB'
 }
 
+export type NotificationsSentOverTimeData = {
+  __typename?: 'NotificationsSentOverTimeData';
+  data: LineChartData;
+};
+
 export type Offer = {
   __typename?: 'Offer';
   features?: Maybe<Array<Maybe<Feature>>>;
@@ -6736,12 +6760,16 @@ export type SetAppStoreConnectApiKeyForSubmissionsMutationVariables = Exact<{
 
 export type SetAppStoreConnectApiKeyForSubmissionsMutation = { __typename?: 'RootMutation', iosAppCredentials: { __typename?: 'IosAppCredentialsMutation', setAppStoreConnectApiKeyForSubmissions: { __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null }>, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
 
-export type AppStoreConnectApiKeyByAccountQueryVariables = Exact<{
+export type AppStoreConnectApiKeysPaginatedByAccountQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
-export type AppStoreConnectApiKeyByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appStoreConnectApiKeys: Array<{ __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null }> } } };
+export type AppStoreConnectApiKeysPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appStoreConnectApiKeysPaginated: { __typename?: 'AccountAppStoreConnectApiKeysConnection', edges: Array<{ __typename?: 'AccountAppStoreConnectApiKeysEdge', cursor: string, node: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type AppleAppIdentifierByBundleIdQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
@@ -6777,6 +6805,17 @@ export type AppleDevicesByIdentifierQueryVariables = Exact<{
 
 export type AppleDevicesByIdentifierQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, model?: string | null, identifier: string, name?: string | null, deviceClass?: AppleDeviceClass | null, enabled?: boolean | null, appleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } }> } } };
 
+export type AppleDevicesPaginatedByAccountQueryVariables = Exact<{
+  accountName: Scalars['String']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+
+export type AppleDevicesPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDevicesPaginated: { __typename?: 'AccountAppleDevicesConnection', edges: Array<{ __typename?: 'AccountAppleDevicesEdge', cursor: string, node: { __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any, appleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
+
 export type AppleDistributionCertificateByAppQueryVariables = Exact<{
   projectFullName: Scalars['String']['input'];
   appleAppIdentifierId: Scalars['String']['input'];
@@ -6786,12 +6825,16 @@ export type AppleDistributionCertificateByAppQueryVariables = Exact<{
 
 export type AppleDistributionCertificateByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null }> }> } } };
 
-export type AppleDistributionCertificateByAccountQueryVariables = Exact<{
+export type AppleDistributionCertificatesPaginatedByAccountQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
-export type AppleDistributionCertificateByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDistributionCertificates: Array<{ __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> }> } } };
+export type AppleDistributionCertificatesPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDistributionCertificatesPaginated: { __typename?: 'AccountAppleDistributionCertificatesConnection', edges: Array<{ __typename?: 'AccountAppleDistributionCertificatesEdge', cursor: string, node: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type AppleProvisioningProfilesByAppQueryVariables = Exact<{
   projectFullName: Scalars['String']['input'];
@@ -6802,12 +6845,16 @@ export type AppleProvisioningProfilesByAppQueryVariables = Exact<{
 
 export type AppleProvisioningProfilesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }>, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } } | null }> }> } } };
 
-export type ApplePushKeyByAccountQueryVariables = Exact<{
+export type ApplePushKeysPaginatedByAccountQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
-export type ApplePushKeyByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, applePushKeys: Array<{ __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> }> } } };
+export type ApplePushKeysPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, applePushKeysPaginated: { __typename?: 'AccountApplePushKeysConnection', edges: Array<{ __typename?: 'AccountApplePushKeysEdge', cursor: string, node: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type AppleTeamsByAccountNameQueryVariables = Exact<{
   accountName: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -6595,6 +6595,17 @@ export type GoogleServiceAccountKeyByAccountQueryVariables = Exact<{
 
 export type GoogleServiceAccountKeyByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, googleServiceAccountKeys: Array<{ __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any }> } } };
 
+export type GoogleServiceAccountKeysPaginatedByAccountQueryVariables = Exact<{
+  accountName: Scalars['String']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+
+export type GoogleServiceAccountKeysPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, googleServiceAccountKeysPaginated: { __typename?: 'AccountGoogleServiceAccountKeysConnection', edges: Array<{ __typename?: 'AccountGoogleServiceAccountKeysEdge', cursor: string, node: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
+
 export type CreateAppStoreConnectApiKeyMutationVariables = Exact<{
   appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput;
   accountId: Scalars['ID']['input'];
@@ -6779,14 +6790,6 @@ export type AppleAppIdentifierByBundleIdQueryVariables = Exact<{
 
 export type AppleAppIdentifierByBundleIdQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleAppIdentifiers: Array<{ __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }> } } };
 
-export type AppleDevicesByAppleTeamQueryVariables = Exact<{
-  accountId: Scalars['ID']['input'];
-  appleTeamIdentifier: Scalars['String']['input'];
-}>;
-
-
-export type AppleDevicesByAppleTeamQuery = { __typename?: 'RootQuery', appleTeam: { __typename?: 'AppleTeamQuery', byAppleTeamIdentifier?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any, appleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } }> } | null } };
-
 export type AppleDevicesByTeamIdentifierQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
   appleTeamIdentifier: Scalars['String']['input'];
@@ -6797,20 +6800,13 @@ export type AppleDevicesByTeamIdentifierQueryVariables = Exact<{
 
 export type AppleDevicesByTeamIdentifierQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleTeams: Array<{ __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, deviceClass?: AppleDeviceClass | null, enabled?: boolean | null, model?: string | null, createdAt: any }> }> } } };
 
-export type AppleDevicesByIdentifierQueryVariables = Exact<{
-  accountName: Scalars['String']['input'];
-  identifier: Scalars['String']['input'];
-}>;
-
-
-export type AppleDevicesByIdentifierQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, model?: string | null, identifier: string, name?: string | null, deviceClass?: AppleDeviceClass | null, enabled?: boolean | null, appleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } }> } } };
-
 export type AppleDevicesPaginatedByAccountQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
   after?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  filter?: InputMaybe<AppleDeviceFilterInput>;
 }>;
 
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Move credentials endpoints to their better paginated counterparts.

# How

Affects dist cert, asc api keys, apple devices and push key fetching

# Test Plan
Tested userflows which rely on
- [x] fetching asc api keys ( < 1 page and multiple pages)
- [x] fetching dist certs ( < 1 page and multiple pages)
- [x] apple devices ( < 1 page and multiple pages)
- [x] push key fetching ( < 1 page and multiple pages)
- [x] google service account key fetching ( < 1 page and multiple pages)
