### PR TITLE
[eas-cli] amend credential removal wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Amend credential removal wording. ([#2334](https://github.com/expo/eas-cli/pull/2334) by [@quinlanj](https://github.com/quinlanj))
+
 ## [7.8.2](https://github.com/expo/eas-cli/releases/tag/v7.8.2) - 2024-04-15
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -48,8 +48,13 @@ export function formatDistributionCertificate(
     buildCredentials => buildCredentials.iosAppCredentials.app
   );
   if (apps.length) {
-    const appFullNames = apps.map(app => app.fullName).join(',');
-    line += chalk.gray(`\n    📲 Used by: ${appFullNames}`);
+    // iosAppBuildCredentialsList is capped at 20 on www
+    const appFullNames = apps
+      .map(app => app.fullName)
+      .slice(0, 19)
+      .join(',');
+    const andMaybeMore = apps.length > 19 ? ' (and more)' : '';
+    line += chalk.gray(`\n    📲 Used by: ${appFullNames}${andMaybeMore}`);
   }
 
   if (validSerialNumbers?.includes(serialNumber)) {

--- a/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
@@ -185,8 +185,13 @@ export function formatPushKey(
 
   const apps = pushKey.iosAppCredentialsList.map(appCredentials => appCredentials.app);
   if (apps.length) {
-    const appFullNames = apps.map(app => app.fullName).join(',');
-    line += chalk.gray(`\n    📲 Used by: ${appFullNames}`);
+    // iosAppCredentialsList is capped at 20 on www
+    const appFullNames = apps
+      .map(app => app.fullName)
+      .slice(0, 19)
+      .join(',');
+    const andMaybeMore = apps.length > 19 ? ' (and more)' : '';
+    line += chalk.gray(`\n    📲 Used by: ${appFullNames}${andMaybeMore}`);
   }
 
   if (validPushKeyIdentifiers?.includes(keyIdentifier)) {

--- a/packages/eas-cli/src/credentials/ios/actions/RemoveDistributionCertificate.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemoveDistributionCertificate.ts
@@ -34,14 +34,20 @@ export class RemoveDistributionCertificate {
       buildCredentials => buildCredentials.iosAppCredentials.app
     );
     if (apps.length !== 0) {
-      const appFullNames = apps.map(app => app.fullName).join(',');
+      // iosAppBuildCredentialsList is capped at 20 on www
+      const appFullNames = apps
+        .map(app => app.fullName)
+        .slice(0, 19)
+        .join(',');
+      const andMaybeMore = apps.length > 19 ? ' (and more)' : '';
+
       if (ctx.nonInteractive) {
         throw new Error(
-          `Certificate is currently used by ${appFullNames} and cannot be deleted in non-interactive mode.`
+          `Certificate is currently used by ${appFullNames}${andMaybeMore} and cannot be deleted in non-interactive mode.`
         );
       }
       const confirm = await confirmAsync({
-        message: `You are removing certificate used by ${appFullNames}. Do you want to continue?`,
+        message: `You are removing certificate used by ${appFullNames}${andMaybeMore}. Do you want to continue?`,
       });
       if (!confirm) {
         Log.log('Aborting');

--- a/packages/eas-cli/src/credentials/ios/actions/RemovePushKey.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/RemovePushKey.ts
@@ -27,9 +27,14 @@ export class RemovePushKey {
 
     const apps = this.pushKey.iosAppCredentialsList.map(appCredentials => appCredentials.app);
     if (apps.length !== 0) {
-      const appFullNames = apps.map(app => app.fullName).join(',');
+      // iosAppCredentialsList is capped at 20 on www
+      const appFullNames = apps
+        .map(app => app.fullName)
+        .slice(0, 19)
+        .join(',');
+      const andMaybeMore = apps.length > 19 ? ' (and more)' : '';
       const confirm = await confirmAsync({
-        message: `Removing this push key will disable push notifications for ${appFullNames}. Do you want to continue?`,
+        message: `Removing this push key will disable push notifications for ${appFullNames}${andMaybeMore}. Do you want to continue?`,
       });
       if (!confirm) {
         Log.log('Aborting');


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I recently capped the number of Entities we load from www on the ApplePushKey `iosAppCredentialsList` edge and the AppleDistributionCertificate `iosAppBuildCredentialsList` edge because we had some outlier users that had thousands of entities on those edges. We use the edges to tell the user which apps still use the credential when users try to delete it. 

# How

Amend the wording to tell the user that they may have more apps relying on the credential if the `www` limit has been hit. 

<img width="1278" alt="Screenshot 2024-04-18 at 8 49 19 PM" src="https://github.com/expo/eas-cli/assets/6380927/64746bcf-43b5-4066-921f-df4ef3d6af8e">


# Test Plan

- [x] manually tested apple push key removal on <20 apps and 20+ apps
- [x] manually tested apple dist cert removal on <20 apps and 20+ apps
