### PR TITLE
[ENG-12057][eas-cli] don't prompt user to set `android.package` and `ios.bundleIdentifier` value when runing in non-interactive mode

### DIFF
--- a/packages/eas-cli/src/commands/build/version/get.ts
+++ b/packages/eas-cli/src/commands/build/version/get.ts
@@ -88,6 +88,7 @@ export default class BuildVersionGetView extends EasCommand {
         buildProfile: profile,
         platform,
         vcsClient,
+        nonInteractive: flags['non-interactive'],
       });
       const remoteVersions = await AppVersionQuery.latestVersionAsync(
         graphqlClient,

--- a/packages/eas-cli/src/commands/build/version/set.ts
+++ b/packages/eas-cli/src/commands/build/version/set.ts
@@ -77,6 +77,7 @@ export default class BuildVersionSetView extends EasCommand {
       buildProfile: profile,
       platform,
       vcsClient,
+      nonInteractive: false,
     });
     const remoteVersions = await AppVersionQuery.latestVersionAsync(
       graphqlClient,

--- a/packages/eas-cli/src/commands/build/version/sync.ts
+++ b/packages/eas-cli/src/commands/build/version/sync.ts
@@ -102,6 +102,7 @@ export default class BuildVersionSyncView extends EasCommand {
         buildProfile: profileInfo.profile,
         platform: profileInfo.platform,
         vcsClient,
+        nonInteractive: false,
       });
       const remoteVersions = await AppVersionQuery.latestVersionAsync(
         graphqlClient,

--- a/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/applicationId-test.ts
@@ -133,8 +133,29 @@ describe(ensureApplicationIdIsDefinedForManagedProjectAsync, () => {
           projectId: '',
           exp: {} as any,
           vcsClient,
+          nonInteractive: false,
         })
       ).rejects.toThrowError(/we can't update this file programmatically/);
+    });
+    it('throws an error in non-interactive mode', async () => {
+      const graphqlClient = instance(mock<ExpoGraphqlClient>());
+
+      vol.fromJSON(
+        {
+          'app.json': '{ "blah": {} }',
+        },
+        '/app'
+      );
+      await expect(
+        ensureApplicationIdIsDefinedForManagedProjectAsync({
+          graphqlClient,
+          projectDir: '/app',
+          projectId: '',
+          exp: {} as any,
+          vcsClient,
+          nonInteractive: true,
+        })
+      ).rejects.toThrowError(/non-interactive/);
     });
     it('prompts for the Android package if using app.json', async () => {
       const graphqlClient = instance(mock<ExpoGraphqlClient>());
@@ -163,6 +184,7 @@ describe(ensureApplicationIdIsDefinedForManagedProjectAsync, () => {
           projectId: '',
           exp: {} as any,
           vcsClient,
+          nonInteractive: false,
         })
       ).resolves.toBe('com.expo.notdominik');
       expect(promptAsync).toHaveBeenCalled();
@@ -196,6 +218,7 @@ describe(ensureApplicationIdIsDefinedForManagedProjectAsync, () => {
           projectId: '',
           exp: {} as any,
           vcsClient,
+          nonInteractive: false,
         })
       ).resolves.toBe('com.expo.notdominik');
       const appJson = JSON.parse(await fs.readFile('/app/app.json', 'utf-8'));

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -28,12 +28,14 @@ export async function ensureApplicationIdIsDefinedForManagedProjectAsync({
   projectId,
   exp,
   vcsClient,
+  nonInteractive,
 }: {
   graphqlClient: ExpoGraphqlClient;
   projectDir: string;
   projectId: string;
   exp: ExpoConfig;
   vcsClient: Client;
+  nonInteractive: boolean;
 }): Promise<string> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
   assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
@@ -43,7 +45,13 @@ export async function ensureApplicationIdIsDefinedForManagedProjectAsync({
       moduleName: gradleUtils.DEFAULT_MODULE_NAME,
     });
   } catch {
-    return await configureApplicationIdAsync({ graphqlClient, projectDir, projectId, exp });
+    return await configureApplicationIdAsync({
+      graphqlClient,
+      projectDir,
+      projectId,
+      exp,
+      nonInteractive,
+    });
   }
 }
 
@@ -128,12 +136,22 @@ async function configureApplicationIdAsync({
   projectDir,
   projectId,
   exp,
+  nonInteractive,
 }: {
   graphqlClient: ExpoGraphqlClient;
   projectDir: string;
   projectId: string;
   exp: ExpoConfig;
+  nonInteractive: boolean;
 }): Promise<string> {
+  if (nonInteractive) {
+    throw new Error(
+      `The "android.package" is required to be set in app config when running in non-interactive mode. ${learnMore(
+        'https://docs.expo.dev/versions/latest/config/app/#package'
+      )}`
+    );
+  }
+
   const paths = getConfigFilePaths(projectDir);
   // we can't automatically update app.config.js
   if (paths.dynamicConfigPath) {

--- a/packages/eas-cli/src/project/applicationIdentifier.ts
+++ b/packages/eas-cli/src/project/applicationIdentifier.ts
@@ -25,6 +25,7 @@ export async function getApplicationIdentifierAsync({
   buildProfile,
   platform,
   vcsClient,
+  nonInteractive,
 }: {
   graphqlClient: ExpoGraphqlClient;
   projectDir: string;
@@ -33,6 +34,7 @@ export async function getApplicationIdentifierAsync({
   buildProfile: BuildProfile;
   platform: Platform;
   vcsClient: Client;
+  nonInteractive: boolean;
 }): Promise<string> {
   if (platform === Platform.ANDROID) {
     const profile = buildProfile as BuildProfile<Platform.ANDROID>;
@@ -45,6 +47,7 @@ export async function getApplicationIdentifierAsync({
         projectId,
         exp,
         vcsClient,
+        nonInteractive,
       });
     }
 
@@ -60,6 +63,7 @@ export async function getApplicationIdentifierAsync({
         projectId,
         exp,
         vcsClient,
+        nonInteractive,
       });
     }
 

--- a/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/bundleIdentifier-test.ts
@@ -111,8 +111,28 @@ describe(ensureBundleIdentifierIsDefinedForManagedProjectAsync, () => {
           projectId: '1234',
           exp: {} as any,
           vcsClient,
+          nonInteractive: false,
         })
       ).rejects.toThrowError(/we can't update this file programmatically/);
+    });
+    it('throws an error if using app.config.js', async () => {
+      const graphqlClient = instance(mock<ExpoGraphqlClient>());
+      vol.fromJSON(
+        {
+          'app.json': '{ "blah": {} }',
+        },
+        '/app'
+      );
+      await expect(
+        ensureBundleIdentifierIsDefinedForManagedProjectAsync({
+          graphqlClient,
+          projectDir: '/app',
+          projectId: '1234',
+          exp: {} as any,
+          vcsClient,
+          nonInteractive: true,
+        })
+      ).rejects.toThrowError(/non-interactive/);
     });
     it('prompts for the bundle identifier if using app.json', async () => {
       const graphqlClient = instance(mock<ExpoGraphqlClient>());
@@ -141,6 +161,7 @@ describe(ensureBundleIdentifierIsDefinedForManagedProjectAsync, () => {
           projectId: '1234',
           exp: {} as any,
           vcsClient,
+          nonInteractive: false,
         })
       ).resolves.toBe('com.expo.notdominik');
       expect(promptAsync).toHaveBeenCalled();
@@ -172,6 +193,7 @@ describe(ensureBundleIdentifierIsDefinedForManagedProjectAsync, () => {
           projectId: '1234',
           exp: {} as any,
           vcsClient,
+          nonInteractive: false,
         })
       ).resolves.toBe('com.expo.notdominik');
       const appJson = JSON.parse(await fs.readFile('/app/app.json', 'utf-8'));

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -21,12 +21,14 @@ export async function ensureBundleIdentifierIsDefinedForManagedProjectAsync({
   projectId,
   exp,
   vcsClient,
+  nonInteractive,
 }: {
   graphqlClient: ExpoGraphqlClient;
   projectDir: string;
   projectId: string;
   exp: ExpoConfig;
   vcsClient: Client;
+  nonInteractive: boolean;
 }): Promise<string> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
   assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
@@ -39,6 +41,7 @@ export async function ensureBundleIdentifierIsDefinedForManagedProjectAsync({
       projectDir,
       exp,
       projectId,
+      nonInteractive,
     });
   }
 }
@@ -120,12 +123,22 @@ async function configureBundleIdentifierAsync({
   projectDir,
   projectId,
   exp,
+  nonInteractive,
 }: {
   graphqlClient: ExpoGraphqlClient;
   projectDir: string;
   projectId: string;
   exp: ExpoConfig;
+  nonInteractive: boolean;
 }): Promise<string> {
+  if (nonInteractive) {
+    throw new Error(
+      `The "ios.bundleIdentifier" is required to be set in app config when running in non-interactive mode. ${learnMore(
+        'https://docs.expo.dev/versions/latest/config/app/#bundleidentifier'
+      )}`
+    );
+  }
+
   const paths = getConfigFilePaths(projectDir);
   // we can't automatically update app.config.js
   if (paths.dynamicConfigPath) {
@@ -148,6 +161,7 @@ async function configureBundleIdentifierAsync({
     exp,
     projectId
   );
+
   const { bundleIdentifier } = await promptAsync({
     name: 'bundleIdentifier',
     type: 'text',


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-12057/fail-with-a-nice-and-meaningful-error-message-if-iosbundleidentifier

# How

Throw meaningful error instead

# Test Plan

Tests
