### PR TITLE
[eas-cli] [ENG-11602] Update eas.schema.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Update the list of available Android images. ([#2337](https://github.com/expo/eas-cli/pull/2337) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+
 ## [7.8.3](https://github.com/expo/eas-cli/releases/tag/v7.8.3) - 2024-04-23
 
 ### 🐛 Bug fixes

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -241,7 +241,6 @@
               "enum": [
                 "auto",
                 "latest",
-                "stable",
                 "sdk-51",
                 "sdk-50",
                 "sdk-49",
@@ -259,7 +258,6 @@
               "markdownEnumDescriptions": [
                 "When using this option the build image is selected automatically based on the project configuration, detected Expo SDK and React Native versions.",
                 "The latest Android image currently available. It is resolved to `ubuntu-22.04-jdk-17-ndk-r25b`. The `latest` to image mapping will be updated as new images are released.",
-                "The latest Android image available that is considered stable. It is resolved to `ubuntu-22.04-jdk-17-ndk-r21e`. The `stable` to image mapping will be updated as new images are released.",
                 "The recommended image for SDK 51 builds: `ubuntu-22.04-jdk-17-ndk-r25b`",
                 "The recommended image for SDK 50 builds: `ubuntu-22.04-jdk-17-ndk-r25b`",
                 "The recommended image for SDK 49 builds: `ubuntu-22.04-jdk-11-ndk-r23b`"

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -239,7 +239,7 @@
           "anyOf": [
             {
               "enum": [
-                "default",
+                "auto",
                 "latest",
                 "stable",
                 "sdk-51",

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -259,6 +259,8 @@
               "markdownEnumDescriptions": [
                 "When using this option the build image is selected automatically based on the project configuration, detected Expo SDK and React Native versions.",
                 "The latest Android image currently available. It is resolved to `ubuntu-22.04-jdk-17-ndk-r25b`. The `latest` to image mapping will be updated as new images are released.",
+                "The latest Android image available that is considered stable. It is resolved to `ubuntu-22.04-jdk-17-ndk-r21e`. The `stable` to image mapping will be updated as new images are released.",
+                "The recommended image for SDK 51 builds: `ubuntu-22.04-jdk-17-ndk-r25b`",
                 "The recommended image for SDK 50 builds: `ubuntu-22.04-jdk-17-ndk-r25b`",
                 "The recommended image for SDK 49 builds: `ubuntu-22.04-jdk-11-ndk-r23b`"
               ]

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -258,9 +258,9 @@
               ],
               "markdownEnumDescriptions": [
                 "When using this option the build image is selected automatically based on the project configuration, detected Expo SDK and React Native versions.",
-                "The latest Android image currently available. It is resolved to `ubuntu-22.04-jdk-17-ndk-r21e`. The `latest` to image mapping will be updated as new images are released.",
-                "The recommended image for SDK 50 builds: `ubuntu-22.04-jdk-17-ndk-r21e`",
-                "The recommended image for SDK 49 builds: `ubuntu-22.04-jdk-11-ndk-r21e`"
+                "The latest Android image currently available. It is resolved to `ubuntu-22.04-jdk-17-ndk-r25b`. The `latest` to image mapping will be updated as new images are released.",
+                "The recommended image for SDK 50 builds: `ubuntu-22.04-jdk-17-ndk-r25b`",
+                "The recommended image for SDK 49 builds: `ubuntu-22.04-jdk-11-ndk-r23b`"
               ]
             },
             {

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -239,10 +239,15 @@
           "anyOf": [
             {
               "enum": [
-                "auto",
+                "default",
                 "latest",
+                "stable",
+                "sdk-51",
                 "sdk-50",
                 "sdk-49",
+                "ubuntu-22.04-jdk-17-ndk-r25b",
+                "ubuntu-22.04-jdk-11-ndk-r23b",
+                "ubuntu-20.04-jdk-11-ndk-r23b",
                 "ubuntu-22.04-jdk-17-ndk-r21e",
                 "ubuntu-22.04-jdk-11-ndk-r21e",
                 "ubuntu-20.04-jdk-11-ndk-r21e",


### PR DESCRIPTION
# Why

Companion to: https://github.com/expo/turtle-v2/pull/1744
https://linear.app/expo/issue/ENG-11602/preinstall-gradle-and-ndks-used-in-the-3-latests-sdks-on-android
New options for Android images have been added and eas.schema.json needs to reflect that

# How

Updated the eas.schema.json with the current image values for Android images

# Test Plan

Automated tests pass
