### PR TITLE
[ENG-11658][eas-cli] Add --no-channel flag for update and rollback to embedded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add --no-channel flag for update and rollback to embedded. ([#2339](https://github.com/expo/eas-cli/pull/2339) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
@@ -82,6 +82,16 @@ describe(UpdateRollBackToEmbedded.name, () => {
     );
   });
 
+  it('errors with both --channel and --no-channel', async () => {
+    const flags = ['--channel=channel123', '--no-channel'];
+
+    mockTestProject();
+
+    await expect(new UpdateRollBackToEmbedded(flags, commandOptions).run()).rejects.toThrow(
+      'Cannot use --channel with --no-channel'
+    );
+  });
+
   it('creates a roll back to embedded with --non-interactive, --branch, and --message', async () => {
     const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When users create an update, we make sure that the branch they publish to is linked to a channel of the same name. However, this behaviour is not always desirable. For example, in the development usecase where someone is trying to load their update in the dev-client, a channel is not necesary. Users will either navigate to the update they want in the dev client menu or via a preview QR code. 

When we've interviewed users who use the dev client/qr code flow, they are always running `eas delete:channel` after the `eas update` command. 

# How

This PR adds a flag, `--no-channel` for the development usecase. This prevents a channel from being automatically created. 

# Test Plan

- [ ] new tests pass
