### PR TITLE
[eas-cli] Add explicit workflow arg to expo-update CLI calls

### DIFF
--- a/packages/eas-cli/src/build/android/syncProjectConfiguration.ts
+++ b/packages/eas-cli/src/build/android/syncProjectConfiguration.ts
@@ -30,7 +30,7 @@ export async function syncProjectConfigurationAsync({
   if (workflow === Workflow.GENERIC) {
     await cleanUpOldEasBuildGradleScriptAsync(projectDir);
     if (isExpoUpdatesInstalled(projectDir)) {
-      await syncUpdatesConfigurationAsync(projectDir, exp);
+      await syncUpdatesConfigurationAsync(projectDir, exp, workflow);
     }
     await bumpVersionAsync({ projectDir, exp, bumpStrategy: versionBumpStrategy });
   } else {

--- a/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts
+++ b/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts
@@ -27,7 +27,7 @@ export async function syncProjectConfigurationAsync({
 
   if (workflow === Workflow.GENERIC) {
     if (isExpoUpdatesInstalled(projectDir)) {
-      await syncUpdatesConfigurationAsync(vcsClient, projectDir, exp);
+      await syncUpdatesConfigurationAsync(vcsClient, projectDir, exp, workflow);
     }
     await bumpVersionAsync({ projectDir, exp, bumpStrategy: versionBumpStrategy, targets });
   } else {

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -74,14 +74,14 @@ export default class BuildConfigure extends EasCommand {
       if ([RequestedPlatform.Android, RequestedPlatform.All].includes(platform)) {
         const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
         if (workflow === Workflow.GENERIC) {
-          await syncAndroidUpdatesConfigurationAsync(projectDir, exp);
+          await syncAndroidUpdatesConfigurationAsync(projectDir, exp, workflow);
         }
       }
 
       if ([RequestedPlatform.Ios, RequestedPlatform.All].includes(platform)) {
         const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
         if (workflow === Workflow.GENERIC) {
-          await syncIosUpdatesConfigurationAsync(vcsClient, projectDir, exp);
+          await syncIosUpdatesConfigurationAsync(vcsClient, projectDir, exp, workflow);
         }
       }
     }

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -125,6 +125,7 @@ export default class ChannelRollout extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.Vcs,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -133,6 +134,7 @@ export default class ChannelRollout extends EasCommand {
     const argsAndFlags = this.sanitizeArgsAndFlags({ ...flags, ...args });
     const {
       privateProjectConfig: { exp, projectId, projectDir },
+      vcsClient,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelRollout, {
       nonInteractive: argsAndFlags.nonInteractive,
@@ -146,6 +148,7 @@ export default class ChannelRollout extends EasCommand {
       nonInteractive: argsAndFlags.nonInteractive,
       graphqlClient,
       app,
+      vcsClient,
     };
     if (argsAndFlags.nonInteractive) {
       await new NonInteractiveRollout(argsAndFlags).runAsync(ctx);

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -1,4 +1,5 @@
 import { Platform as PublishPlatform } from '@expo/config';
+import { Workflow } from '@expo/eas-build-job';
 import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
@@ -40,6 +41,7 @@ import {
   resolveInputDirectoryAsync,
   uploadAssetsAsync,
 } from '../../project/publish';
+import { resolveWorkflowPerPlatformAsync } from '../../project/workflow';
 import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
 import { getUpdateJsonInfosForUpdates } from '../../update/utils';
 import {
@@ -359,11 +361,15 @@ export default class UpdatePublish extends EasCommand {
       throw e;
     }
 
+    const workflows = await resolveWorkflowPerPlatformAsync(projectDir, vcsClient);
     const runtimeVersions = await getRuntimeVersionObjectAsync({
       exp,
       platforms: realizedPlatforms,
       projectDir,
-      vcsClient,
+      workflows: {
+        ...workflows,
+        web: Workflow.UNKNOWN,
+      },
     });
     const runtimeToPlatformMapping =
       getRuntimeToPlatformMappingFromRuntimeVersions(runtimeVersions);

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -1,4 +1,5 @@
 import { Platform as PublishPlatform } from '@expo/config';
+import { Workflow } from '@expo/eas-build-job';
 import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
@@ -33,6 +34,7 @@ import {
   getRuntimeVersionObjectAsync,
   getUpdateMessageForCommandAsync,
 } from '../../project/publish';
+import { resolveWorkflowPerPlatformAsync } from '../../project/workflow';
 import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
 import { getUpdateJsonInfosForUpdates } from '../../update/utils';
 import {
@@ -201,11 +203,15 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
     const gitCommitHash = await vcsClient.getCommitHashAsync();
     const isGitWorkingTreeDirty = await vcsClient.hasUncommittedChangesAsync();
 
+    const workflows = await resolveWorkflowPerPlatformAsync(projectDir, vcsClient);
     const runtimeVersions = await getRuntimeVersionObjectAsync({
       exp,
       platforms: realizedPlatforms,
       projectDir,
-      vcsClient,
+      workflows: {
+        ...workflows,
+        web: Workflow.UNKNOWN,
+      },
     });
 
     let newUpdates: UpdatePublishMutation['updateBranch']['publishUpdateGroups'];

--- a/packages/eas-cli/src/eas-update/utils.ts
+++ b/packages/eas-cli/src/eas-update/utils.ts
@@ -1,11 +1,13 @@
 import { ExpoConfig } from '@expo/config-types';
 
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { Client } from '../vcs/vcs';
 
 export type EASUpdateContext = {
   graphqlClient: ExpoGraphqlClient;
   nonInteractive: boolean;
   app: { exp: ExpoConfig; projectId: string; projectDir: string };
+  vcsClient: Client;
 };
 
 export interface EASUpdateAction<T = any> {

--- a/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
+++ b/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
+import { Workflow } from '@expo/eas-build-job';
 
 import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from './projectUtils';
 import Log from '../log';
@@ -11,10 +12,12 @@ import {
 export async function resolveRuntimeVersionAsync({
   exp,
   platform,
+  workflow,
   projectDir,
 }: {
   exp: ExpoConfig;
   platform: 'ios' | 'android';
+  workflow: Workflow;
   projectDir: string;
 }): Promise<string | null> {
   if (!(await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir))) {
@@ -32,6 +35,8 @@ export async function resolveRuntimeVersionAsync({
       'runtimeversion:resolve',
       '--platform',
       platform,
+      '--workflow',
+      workflow,
       ...extraArgs,
     ]);
     const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);

--- a/packages/eas-cli/src/rollout/actions/CreateRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/CreateRollout.ts
@@ -24,6 +24,7 @@ import {
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import Log from '../../log';
 import { resolveRuntimeVersionAsync } from '../../project/resolveRuntimeVersionAsync';
+import { resolveWorkflowPerPlatformAsync } from '../../project/workflow';
 import { confirmAsync, promptAsync } from '../../prompts';
 import { truthy } from '../../utils/expodash/filter';
 import {
@@ -272,10 +273,16 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
 
   async selectRuntimeVersionFromProjectConfigAsync(ctx: EASUpdateContext): Promise<string> {
     const platforms: ('ios' | 'android')[] = ['ios', 'android'];
+    const workflows = await resolveWorkflowPerPlatformAsync(ctx.app.projectDir, ctx.vcsClient);
     const runtimes = (
       await Promise.all(
         platforms.map(platform =>
-          resolveRuntimeVersionAsync({ projectDir: ctx.app.projectDir, exp: ctx.app.exp, platform })
+          resolveRuntimeVersionAsync({
+            projectDir: ctx.app.projectDir,
+            exp: ctx.app.exp,
+            platform,
+            workflow: workflows[platform],
+          })
         )
       )
     ).filter(truthy);

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { AndroidConfig, AndroidManifest, XML } from '@expo/config-plugins';
+import { Workflow } from '@expo/eas-build-job';
 
 import { RequestedPlatform } from '../../platform';
 import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '../../project/projectUtils';
@@ -11,7 +12,8 @@ import { ensureValidVersions } from '../utils';
  */
 export async function syncUpdatesConfigurationAsync(
   projectDir: string,
-  exp: ExpoConfig
+  exp: ExpoConfig,
+  workflow: Workflow
 ): Promise<void> {
   ensureValidVersions(exp, RequestedPlatform.Android);
 
@@ -20,6 +22,8 @@ export async function syncUpdatesConfigurationAsync(
       'configuration:syncnative',
       '--platform',
       'android',
+      '--workflow',
+      workflow,
     ]);
     return;
   }

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -272,12 +272,12 @@ async function ensureEASUpdateIsConfiguredNativelyAsync(
   }
 ): Promise<void> {
   if (['all', 'android'].includes(platform) && workflows.android === Workflow.GENERIC) {
-    await syncAndroidUpdatesConfigurationAsync(projectDir, exp);
+    await syncAndroidUpdatesConfigurationAsync(projectDir, exp, workflows.android);
     Log.withTick(`Configured ${chalk.bold('AndroidManifest.xml')} for EAS Update`);
   }
 
   if (['all', 'ios'].includes(platform) && workflows.ios === Workflow.GENERIC) {
-    await syncIosUpdatesConfigurationAsync(vcsClient, projectDir, exp);
+    await syncIosUpdatesConfigurationAsync(vcsClient, projectDir, exp, workflows.ios);
     Log.withTick(`Configured ${chalk.bold('Expo.plist')} for EAS Update`);
   }
 }

--- a/packages/eas-cli/src/update/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/ios/UpdatesModule.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
+import { Workflow } from '@expo/eas-build-job';
 
 import { RequestedPlatform } from '../../platform';
 import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '../../project/projectUtils';
@@ -11,12 +12,19 @@ import { ensureValidVersions } from '../utils';
 export async function syncUpdatesConfigurationAsync(
   vcsClient: Client,
   projectDir: string,
-  exp: ExpoConfig
+  exp: ExpoConfig,
+  workflow: Workflow
 ): Promise<void> {
   ensureValidVersions(exp, RequestedPlatform.Ios);
 
   if (await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir)) {
-    await expoUpdatesCommandAsync(projectDir, ['configuration:syncnative', '--platform', 'ios']);
+    await expoUpdatesCommandAsync(projectDir, [
+      'configuration:syncnative',
+      '--platform',
+      'ios',
+      '--workflow',
+      workflow,
+    ]);
     return;
   }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

eas-cli part of https://github.com/expo/expo/pull/28403 and https://github.com/expo/eas-build/pull/384.

Closes ENG-12107.

# How

Pass workflow through so that the workflow inference within expo-updates isn't necessary.

# Test Plan

Follow test plan of https://github.com/expo/eas-build/pull/384 for project setup, then:

`neas update`