### PR TITLE
[ENG-12116][eas-cli] improve error message displayed when EAS CLI version doesn't satisfy minimal version required specified in `eas.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Update the list of available Android images. ([#2337](https://github.com/expo/eas-cli/pull/2337) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+- Improve error message displayed when EAS CLI version doesn't satisfy minimal version required specified in eas.json. ([#2341](https://github.com/expo/eas-cli/pull/2341) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [7.8.3](https://github.com/expo/eas-cli/releases/tag/v7.8.3) - 2024-04-23
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
@@ -17,7 +17,7 @@ async function applyCliConfigAsync(projectDir: string): Promise<void> {
     throw new Error(
       `You are on eas-cli@${easCliVersion} which does not satisfy the CLI version constraint defined in eas.json (${
         config.version
-      }).\n\nThi error probably means that you need update your eas-cli to a newer version.\nRun ${chalk.bold(
+      }).\n\nThis error probably means that you need update your eas-cli to a newer version.\nRun ${chalk.bold(
         'npm install -g eas-cli'
       )} to update the eas-cli to the latest version.`
     );

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
@@ -15,7 +15,11 @@ async function applyCliConfigAsync(projectDir: string): Promise<void> {
   const config = await EasJsonUtils.getCliConfigAsync(easJsonAccessor);
   if (config?.version && !semver.satisfies(easCliVersion, config.version)) {
     throw new Error(
-      `You are on eas-cli@${easCliVersion} which does not satisfy the CLI version constraint in eas.json (${config.version})`
+      `You are on eas-cli@${easCliVersion} which does not satisfy the CLI version constraint defined in eas.json (${
+        config.version
+      }).\n\nThi error probably means that you need update your eas-cli to a newer version.\nRun ${chalk.bold(
+        'npm install -g eas-cli'
+      )} to update the eas-cli to the latest version.`
     );
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-12116/improve-error-message-displayed-when-eas-cli-version-doesnt-satisfy

# How

Improve error message

# Test Plan

<img width="569" alt="Screenshot 2024-04-24 at 15 59 42" src="https://github.com/expo/eas-cli/assets/55145344/f90fa4bf-c8cb-4e1c-8ece-57ea8fdeda30">
