### PR TITLE
[ENG-12120][eas-cli] make multi-select for revoking distribution certificates more readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Update the list of available Android images. ([#2337](https://github.com/expo/eas-cli/pull/2337) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+- Make multi-select for revoking distribution certificates more readable. ([#2342](https://github.com/expo/eas-cli/pull/2342) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [7.8.3](https://github.com/expo/eas-cli/releases/tag/v7.8.3) - 2024-04-23
 

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -259,6 +259,10 @@ function formatDistributionCertificateFromApple(
   const { name, status, id, expires, created, ownerName, serialNumber } = appleInfo;
   const expiresDate = new Date(expires * 1000).toDateString();
   const createdDate = new Date(created * 1000).toDateString();
-  return `${name} (${status}) - Cert ID: ${id}, Serial number: ${serialNumber}, Team ID: ${appleInfo.ownerId}, Team name: ${ownerName}
-    expires: ${expiresDate}, created: ${createdDate}`;
+  return [
+    `🍏 ${chalk.bold(name)} (${status})`,
+    `${chalk.bold('ID:')} ${id} ${chalk.bold('Serial Number:')} ${serialNumber}`,
+    `${chalk.bold('Apple Team:')} ${appleInfo.ownerId} (${ownerName})`,
+    `${chalk.bold('Expires:')} ${expiresDate} ${chalk.bold('Created:')} ${createdDate}`,
+  ].join('\n\t');
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-12120/make-multi-select-for-revoking-distribution-certificates-more-readable

# How

Make it look better

# Test Plan

test manually
