### PR TITLE
[ENG-12122][eas-cli] don't prompt users to set push notifications by default if they don't have the `expo-notifications` installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Don't prompt users to set push notifications by default if they don't have the `expo-notifications` installed. ([#2343](https://github.com/expo/eas-cli/pull/2343) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [7.8.4](https://github.com/expo/eas-cli/releases/tag/v7.8.4) - 2024-04-24
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -14,6 +14,7 @@ import { isAdHocProfile, isEnterpriseUniversalProfile } from './utils/provisioni
 import { CommonIosAppCredentialsFragment } from '../../graphql/generated';
 import Log from '../../log';
 import { findApplicationTarget } from '../../project/ios/target';
+import { isExpoNotificationsInstalled } from '../../project/projectUtils';
 import { selectAsync } from '../../prompts';
 import { CredentialsContext } from '../context';
 import * as credentialsJsonReader from '../credentialsJson/read';
@@ -104,6 +105,11 @@ export default class IosCredentialsProvider {
     }
 
     if (ctx.easJsonCliConfig?.promptToConfigurePushNotifications === false) {
+      return null;
+    } else if (
+      ctx.easJsonCliConfig?.promptToConfigurePushNotifications === undefined &&
+      !(await isExpoNotificationsInstalled(ctx.projectDir))
+    ) {
       return null;
     }
 

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -67,6 +67,11 @@ export function isExpoUpdatesInstalled(projectDir: string): boolean {
   return !!(packageJson.dependencies && 'expo-updates' in packageJson.dependencies);
 }
 
+export function isExpoNotificationsInstalled(projectDir: string): boolean {
+  const packageJson = getPackageJson(projectDir);
+  return !!(packageJson.dependencies && 'expo-notifications' in packageJson.dependencies);
+}
+
 export function isExpoUpdatesInstalledAsDevDependency(projectDir: string): boolean {
   const packageJson = getPackageJson(projectDir);
   return !!(packageJson.devDependencies && 'expo-updates' in packageJson.devDependencies);

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -40,7 +40,7 @@
         },
         "promptToConfigurePushNotifications": {
           "type": "boolean",
-          "description": "Specifies where EAS CLI should prompt to configure Push Notifications credentials. Defaults to true.",
+          "description": "Specifies where EAS CLI should prompt to configure Push Notifications credentials. It defaults to true if expo-notifications is in your project dependencies, otherwise it defaults to false.",
           "default": true
         }
       }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-12122/dont-prompt-people-to-set-push-notifications-by-default-if-they-dont

It was noticed that these prompts not always make sense and may be annoying

# How

don't prompt users to set push notifications by default if they don't have the `expo-notifications` installed

# Test Plan

test manually

with `promptToConfigurePushNotifications` not set and `expo-notifications` not installed:
<img width="1235" alt="Screenshot 2024-04-24 at 18 26 25" src="https://github.com/expo/eas-cli/assets/55145344/89ba4219-bfce-4a4f-a222-be3c6abe0595">

with `promptToConfigurePushNotifications` not set and `expo-notifications` installed:
<img width="1214" alt="Screenshot 2024-04-24 at 18 27 38" src="https://github.com/expo/eas-cli/assets/55145344/734b44d6-291e-4dd0-9ba5-356781854297">
