### PR TITLE
[eas-cli] Fill in min expo-updates version for expo-updates CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Fill in min expo-updates version for expo-updates CLI. ([#2344](https://github.com/expo/eas-cli/pull/2344) by [@wschurman](https://github.com/wschurman))
+
 ## [7.8.4](https://github.com/expo/eas-cli/releases/tag/v7.8.4) - 2024-04-24
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -165,8 +165,8 @@ export async function isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAs
     return true;
   }
 
-  // TODO(wschurman): add semver check once we know the SDK51 version of expo-updates that supports this
-  return false;
+  // Anything SDK 51 or greater uses the expo-updates CLI
+  return semver.gte(expoUpdatesPackageVersion, '0.25.4');
 }
 
 export async function installExpoUpdatesAsync(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Same as https://github.com/expo/eas-build/pull/385 but for eas-cli.

Closes ENG-12103.

# How

Hardcode

# Test Plan

Inspect.
