### PR TITLE
[ENG-12118][eas-cli] improve error message if server returns `UNAUTHORIZED_ERROR`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Improve error message if the server returns `UNAUTHORIZED_ERROR`. ([#2345](https://github.com/expo/eas-cli/pull/2345) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [7.8.4](https://github.com/expo/eas-cli/releases/tag/v7.8.4) - 2024-04-24
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -1,5 +1,6 @@
 import { Command } from '@oclif/core';
 import { CombinedError } from '@urql/core';
+import chalk from 'chalk';
 import { GraphQLError } from 'graphql/error';
 import nullthrows from 'nullthrows';
 
@@ -210,7 +211,13 @@ export default abstract class EasCommand extends Command {
           const defaultMsg = `${messageLine}${requestIdLine}`;
 
           if (graphQLError.extensions?.errorCode === 'UNAUTHORIZED_ERROR') {
-            return `You don't have the required permissions to perform this operation.\n\n${defaultMsg}`;
+            return `${chalk.bold(
+              `You don't have the required permissions to perform this operation.`
+            )}\n\nThis can sometimes happen if you are logged in as incorrect user.\nRun ${chalk.bold(
+              'eas whoami'
+            )} to check the username you are logged in as.\nRun ${chalk.bold(
+              'eas login'
+            )} to change the account.\n\nOriginal error message: ${defaultMsg}`;
           }
 
           return defaultMsg;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-12118/improve-error-message-displayed-in-eas-cli-when-somebody-is-logged-in

# How

improve error message

# Test Plan


Test manually

