### PR TITLE
[ENG-11658][eas-cli] dont generate channel on `eas update` without flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Stop creating a channel on `eas update` and `eas update:roll-back-to-embedded` unless the `--channel` flag is specified. ([#2346](https://github.com/expo/eas-cli/pull/2346) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -6,7 +6,6 @@ import nullthrows from 'nullthrows';
 import { ensureBranchExistsAsync } from '../../branch/queries';
 import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
 import { getUpdateGroupUrl } from '../../build/utils/url';
-import { ensureChannelExistsAsync } from '../../channel/queries';
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { getPaginatedQueryOptions } from '../../commandUtils/pagination';
@@ -368,20 +367,10 @@ export default class UpdatePublish extends EasCommand {
     const runtimeToPlatformMapping =
       getRuntimeToPlatformMappingFromRuntimeVersions(runtimeVersions);
 
-    const { branchId, createdBranch } = await ensureBranchExistsAsync(graphqlClient, {
+    const { branchId } = await ensureBranchExistsAsync(graphqlClient, {
       appId: projectId,
       branchName,
     });
-    if (createdBranch) {
-      await ensureChannelExistsAsync(graphqlClient, {
-        appId: projectId,
-        branchId,
-        channelName: branchName,
-      });
-      Log.withTick(
-        `Channel: ${chalk.bold(branchName)} pointed at branch: ${chalk.bold(branchName)}`
-      );
-    }
 
     const gitCommitHash = await vcsClient.getCommitHashAsync();
     const isGitWorkingTreeDirty = await vcsClient.hasUncommittedChangesAsync();

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -1,11 +1,9 @@
 import { Platform as PublishPlatform } from '@expo/config';
 import { Errors, Flags } from '@oclif/core';
-import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
 import { ensureBranchExistsAsync } from '../../branch/queries';
 import { getUpdateGroupUrl } from '../../build/utils/url';
-import { ensureChannelExistsAsync } from '../../channel/queries';
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
@@ -184,19 +182,10 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
     const realizedPlatforms: PublishPlatform[] =
       platformFlag === 'all' ? defaultPublishPlatforms : [platformFlag];
 
-    const { branchId, createdBranch } = await ensureBranchExistsAsync(graphqlClient, {
+    const { branchId } = await ensureBranchExistsAsync(graphqlClient, {
       appId: projectId,
       branchName,
     });
-    if (createdBranch) {
-      await ensureChannelExistsAsync(graphqlClient, {
-        appId: projectId,
-        branchId,
-        channelName: branchName,
-      });
-    }
-
-    Log.withTick(`Channel: ${chalk.bold(branchName)} pointed at branch: ${chalk.bold(branchName)}`);
 
     const gitCommitHash = await vcsClient.getCommitHashAsync();
     const isGitWorkingTreeDirty = await vcsClient.hasUncommittedChangesAsync();


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
An alternative solution to https://github.com/expo/eas-cli/pull/2339 , after talking to @jonsamp and @wschurman 

When users create an update, we make sure that the branch they publish to is linked to a channel of the same name. However, this behaviour is not always desirable. For example, in the development usecase where someone is trying to load their update in the dev-client, a channel is not necesary. Users will either navigate to the update they want in the dev client menu or via a preview QR code.

# How

- Only create a channel and link it to a branch when the `--channel` flag is passed

# Test Plan

- [x] ensure `eas update --channel bar` creates channel `bar`, links it to branch `bar`, then publishes an update to the branch
- [x] ensure `eas update:roll-back-to-embedded --channel bar` creates channel `bar`, links it to branch `bar`, then publishes an update to the branch
- [x] ensure `eas update --branch bar` and `eas update --auto` no longer create a channel
- [x] - [ ] ensure `eas update:roll-back-to-embedded --branch bar` and `eas update:roll-back-to-embedded --auto` no longer create a channel