### PR TITLE
[ENG-8801][eas-cli] allow modification of provisioning profile in CI, add `--freeze-credentials` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Allow modification of provisioning profile in CI, add --freeze-credentials flag. ([#2347](https://github.com/expo/eas-cli/pull/2347) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -41,6 +41,7 @@ export async function createBuildContextAsync<T extends Platform>({
   getDynamicPrivateProjectConfigAsync,
   customBuildConfigMetadata,
   buildLoggerLevel,
+  freezeCredentials,
 }: {
   buildProfileName: string;
   buildProfile: BuildProfile<T>;
@@ -60,6 +61,7 @@ export async function createBuildContextAsync<T extends Platform>({
   getDynamicPrivateProjectConfigAsync: DynamicConfigContextFn;
   customBuildConfigMetadata?: CustomBuildConfigMetadata;
   buildLoggerLevel?: LoggerLevel;
+  freezeCredentials: boolean;
 }): Promise<BuildContext<T>> {
   const { exp, projectId } = await getDynamicPrivateProjectConfigAsync({ env: buildProfile.env });
   const projectName = exp.slug;
@@ -86,6 +88,7 @@ export async function createBuildContextAsync<T extends Platform>({
     env: buildProfile.env,
     easJsonCliConfig,
     vcsClient,
+    freezeCredentials,
   });
 
   const devClientProperties = getDevClientEventProperties({

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -95,6 +95,7 @@ export interface BuildFlags {
   resourceClass?: ResourceClass;
   message?: string;
   buildLoggerLevel?: LoggerLevel;
+  freezeCredentials: boolean;
 }
 
 export async function runBuildAndSubmitAsync(
@@ -363,6 +364,7 @@ async function prepareAndStartBuildAsync({
     getDynamicPrivateProjectConfigAsync,
     customBuildConfigMetadata,
     buildLoggerLevel: flags.buildLoggerLevel,
+    freezeCredentials: flags.freezeCredentials,
   });
 
   if (moreBuilds) {

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -35,6 +35,7 @@ interface RawBuildFlags {
   'resource-class'?: ResourceClass;
   message?: string;
   'build-logger-level'?: LoggerLevel;
+  'freeze-credentials': boolean;
 }
 
 export default class Build extends EasCommand {
@@ -103,6 +104,10 @@ export default class Build extends EasCommand {
     'build-logger-level': Flags.enum({
       description: 'The level of logs to output during the build process. Defaults to "info".',
       options: Object.values(LoggerLevel),
+    }),
+    'freeze-credentials': Flags.boolean({
+      default: false,
+      description: 'Prevent the build from updating credentials',
     }),
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -217,6 +222,7 @@ export default class Build extends EasCommand {
       resourceClass: flags['resource-class'],
       message,
       buildLoggerLevel: flags['build-logger-level'],
+      freezeCredentials: flags['freeze-credentials'],
     };
   }
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -107,7 +107,7 @@ export default class Build extends EasCommand {
     }),
     'freeze-credentials': Flags.boolean({
       default: false,
-      description: 'Prevent the build from updating credentials',
+      description: 'Prevent the build from updating credentials in non-interactive mode',
     }),
     ...EasNonInteractiveAndJsonFlags,
   };

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -105,6 +105,7 @@ export default class BuildInspect extends EasCommand {
           projectDir,
           {
             nonInteractive: false,
+            freezeCredentials: false,
             wait: true,
             clearCache: false,
             json: false,

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -77,6 +77,7 @@ export default class BuildInternal extends EasCommand {
         requestedPlatform: flags.platform as RequestedPlatform,
         profile: flags.profile,
         nonInteractive: true,
+        freezeCredentials: false,
         wait: false,
         clearCache: false,
         json: true,

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
@@ -1,5 +1,5 @@
 import AppStoreApi from '../ios/appstore/AppStoreApi';
-import { AuthCtx } from '../ios/appstore/authenticateTypes';
+import { AuthCtx, AuthenticationMode } from '../ios/appstore/authenticateTypes';
 
 export const testAuthCtx: AuthCtx = {
   appleId: 'test-apple-id',
@@ -9,6 +9,7 @@ export const testAuthCtx: AuthCtx = {
 
 export function getAppstoreMock(): AppStoreApi {
   return {
+    defaultAuthenticationMode: AuthenticationMode.USER,
     ensureAuthenticatedAsync: jest.fn(),
     ensureBundleIdExistsAsync: jest.fn(),
     listDistributionCertificatesAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -25,6 +25,7 @@ export class CredentialsContext {
   public readonly appStore = new AppStoreApi();
   public readonly ios = IosGraphqlClient;
   public readonly nonInteractive: boolean;
+  public readonly freezeCredentials: boolean = false;
   public readonly projectDir: string;
   public readonly user: Actor;
   public readonly graphqlClient: ExpoGraphqlClient;
@@ -47,6 +48,7 @@ export class CredentialsContext {
       graphqlClient: ExpoGraphqlClient;
       analytics: Analytics;
       vcsClient: Client;
+      freezeCredentials?: boolean;
       env?: Env;
     }
   ) {
@@ -58,6 +60,7 @@ export class CredentialsContext {
     this.vcsClient = options.vcsClient;
     this.nonInteractive = options.nonInteractive ?? false;
     this.projectInfo = options.projectInfo;
+    this.freezeCredentials = options.freezeCredentials ?? false;
   }
 
   get hasProjectContext(): boolean {

--- a/packages/eas-cli/src/credentials/errors.ts
+++ b/packages/eas-cli/src/credentials/errors.ts
@@ -4,6 +4,15 @@ export class MissingCredentialsNonInteractiveError extends Error {
   }
 }
 
+export class InsufficientAuthenticationNonInteractiveError extends Error {
+  constructor(message?: string) {
+    super(
+      message ??
+        'Authentication with an ASC API key is required in non-interactive mode, see <TODO:ADD LINK HERE> for more information.'
+    );
+  }
+}
+
 export class ForbidCredentialModificationError extends Error {
   constructor(message?: string) {
     super(

--- a/packages/eas-cli/src/credentials/errors.ts
+++ b/packages/eas-cli/src/credentials/errors.ts
@@ -4,6 +4,15 @@ export class MissingCredentialsNonInteractiveError extends Error {
   }
 }
 
+export class ForbidCredentialModificationError extends Error {
+  constructor(message?: string) {
+    super(
+      message ??
+        'Credentials cannot be modified. Run this command again without the --freeze-credentials flag.'
+    );
+  }
+}
+
 export class MissingCredentialsError extends Error {
   constructor(message?: string) {
     super(message ?? 'Credentials are not set up.');

--- a/packages/eas-cli/src/credentials/errors.ts
+++ b/packages/eas-cli/src/credentials/errors.ts
@@ -1,3 +1,5 @@
+import { learnMore } from '../log';
+
 export class MissingCredentialsNonInteractiveError extends Error {
   constructor(message?: string) {
     super(message ?? 'Credentials are not set up. Run this command again in interactive mode.');
@@ -8,7 +10,9 @@ export class InsufficientAuthenticationNonInteractiveError extends Error {
   constructor(message?: string) {
     super(
       message ??
-        'Authentication with an ASC API key is required in non-interactive mode, see <TODO:ADD LINK HERE> for more information.'
+        `Authentication with an ASC API key is required in non-interactive mode. ${learnMore(
+          'https://docs.expo.dev/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team'
+        )}`
     );
   }
 }

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -5,7 +5,7 @@ import {
   AppleDistributionCertificateFragment,
   AppleProvisioningProfileFragment,
 } from '../../../graphql/generated';
-import Log from '../../../log';
+import Log, { learnMore } from '../../../log';
 import { ora } from '../../../ora';
 import { getApplePlatformFromTarget } from '../../../project/ios/target';
 import { CredentialsContext } from '../../context';
@@ -39,7 +39,9 @@ export class ConfigureProvisioningProfile {
       ctx.appStore.defaultAuthenticationMode !== AuthenticationMode.API_KEY
     ) {
       throw new InsufficientAuthenticationNonInteractiveError(
-        'In order to configure your Provisioning Profile, authentication with an ASC API key is required in non-interactive mode. See <TODO:ADD LINK HERE> for more information.'
+        `In order to configure your Provisioning Profile, authentication with an ASC API key is required in non-interactive mode. ${learnMore(
+          'https://docs.expo.dev/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team'
+        )}`
       );
     }
     const { developerPortalIdentifier, provisioningProfile } = this.originalProvisioningProfile;

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -9,11 +9,14 @@ import Log from '../../../log';
 import { ora } from '../../../ora';
 import { getApplePlatformFromTarget } from '../../../project/ios/target';
 import { CredentialsContext } from '../../context';
-import { ForbidCredentialModificationError } from '../../errors';
+import {
+  ForbidCredentialModificationError,
+  InsufficientAuthenticationNonInteractiveError,
+} from '../../errors';
 import { AppleProvisioningProfileMutationResult } from '../api/graphql/mutations/AppleProvisioningProfileMutation';
 import { AppLookupParams } from '../api/graphql/types/AppLookupParams';
 import { ProvisioningProfileStoreInfo } from '../appstore/Credentials.types';
-import { AuthCtx } from '../appstore/authenticateTypes';
+import { AuthCtx, AuthenticationMode } from '../appstore/authenticateTypes';
 import { Target } from '../types';
 
 export class ConfigureProvisioningProfile {
@@ -30,6 +33,13 @@ export class ConfigureProvisioningProfile {
     if (ctx.freezeCredentials) {
       throw new ForbidCredentialModificationError(
         'Remove the --freeze-credentials flag to configure a Provisioning Profile.'
+      );
+    } else if (
+      ctx.nonInteractive &&
+      ctx.appStore.defaultAuthenticationMode !== AuthenticationMode.API_KEY
+    ) {
+      throw new InsufficientAuthenticationNonInteractiveError(
+        'In order to configure your Provisioning Profile, authentication with an ASC API key is required in non-interactive mode. See <TODO:ADD LINK HERE> for more information.'
       );
     }
     const { developerPortalIdentifier, provisioningProfile } = this.originalProvisioningProfile;

--- a/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ConfigureProvisioningProfile.ts
@@ -9,7 +9,7 @@ import Log from '../../../log';
 import { ora } from '../../../ora';
 import { getApplePlatformFromTarget } from '../../../project/ios/target';
 import { CredentialsContext } from '../../context';
-import { MissingCredentialsNonInteractiveError } from '../../errors';
+import { ForbidCredentialModificationError } from '../../errors';
 import { AppleProvisioningProfileMutationResult } from '../api/graphql/mutations/AppleProvisioningProfileMutation';
 import { AppLookupParams } from '../api/graphql/types/AppLookupParams';
 import { ProvisioningProfileStoreInfo } from '../appstore/Credentials.types';
@@ -27,9 +27,9 @@ export class ConfigureProvisioningProfile {
   public async runAsync(
     ctx: CredentialsContext
   ): Promise<AppleProvisioningProfileMutationResult | null> {
-    if (ctx.nonInteractive) {
-      throw new MissingCredentialsNonInteractiveError(
-        'Configuring Provisioning Profiles is only supported in interactive mode.'
+    if (ctx.freezeCredentials) {
+      throw new ForbidCredentialModificationError(
+        'Remove the --freeze-credentials flag to configure a Provisioning Profile.'
       );
     }
     const { developerPortalIdentifier, provisioningProfile } = this.originalProvisioningProfile;
@@ -46,7 +46,7 @@ export class ConfigureProvisioningProfile {
       return null;
     }
 
-    const applePlatform = await getApplePlatformFromTarget(this.target);
+    const applePlatform = getApplePlatformFromTarget(this.target);
     const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
       this.app.bundleIdentifier,
       applePlatform

--- a/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
@@ -4,7 +4,7 @@ import nullthrows from 'nullthrows';
 import { resolveAppleTeamIfAuthenticatedAsync } from './AppleTeamUtils';
 import { generateProvisioningProfileAsync } from './ProvisioningProfileUtils';
 import { AppleDistributionCertificateFragment } from '../../../graphql/generated';
-import Log from '../../../log';
+import Log, { learnMore } from '../../../log';
 import { CredentialsContext } from '../../context';
 import {
   ForbidCredentialModificationError,
@@ -35,7 +35,9 @@ export class CreateProvisioningProfile {
       ctx.appStore.defaultAuthenticationMode !== AuthenticationMode.API_KEY
     ) {
       throw new InsufficientAuthenticationNonInteractiveError(
-        'In order to generate a new Provisioning Profile, authentication with an ASC API key is required in non-interactive mode. See <TODO:ADD LINK HERE> for more information.'
+        `In order to generate a new Provisioning Profile, authentication with an ASC API key is required in non-interactive mode. ${learnMore(
+          'https://docs.expo.dev/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team'
+        )}`
       );
     }
     const appleAuthCtx = await ctx.appStore.ensureAuthenticatedAsync();

--- a/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
@@ -25,7 +25,7 @@ export class CreateProvisioningProfile {
   async runAsync(ctx: CredentialsContext): Promise<AppleProvisioningProfileMutationResult> {
     if (ctx.freezeCredentials) {
       throw new ForbidCredentialModificationError(
-        'Provisioning profile is not configured correctly. Run this command again without the --freeze-credentials flag.'
+        'Run this command again without the --freeze-credentials flag in order to generate a new Provisioning Profile.'
       );
     }
     const appleAuthCtx = await ctx.appStore.ensureAuthenticatedAsync();

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
@@ -15,6 +15,7 @@ import {
   IosAppBuildCredentialsFragment,
   IosDistributionType,
 } from '../../../graphql/generated';
+import { learnMore } from '../../../log';
 import { getApplePlatformFromTarget } from '../../../project/ios/target';
 import { confirmAsync } from '../../../prompts';
 import { CredentialsContext } from '../../context';
@@ -115,7 +116,9 @@ export class SetUpProvisioningProfile {
       ctx.appStore.defaultAuthenticationMode !== AuthenticationMode.API_KEY
     ) {
       throw new InsufficientAuthenticationNonInteractiveError(
-        'In order to configure your Provisioning Profile, authentication with an ASC API key is required in non-interactive mode. See <TODO:ADD LINK HERE> for more information.'
+        `In order to configure your Provisioning Profile, authentication with an ASC API key is required in non-interactive mode. ${learnMore(
+          'https://docs.expo.dev/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team'
+        )}`
       );
     }
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
@@ -18,9 +18,13 @@ import {
 import { getApplePlatformFromTarget } from '../../../project/ios/target';
 import { confirmAsync } from '../../../prompts';
 import { CredentialsContext } from '../../context';
-import { ForbidCredentialModificationError } from '../../errors';
+import {
+  ForbidCredentialModificationError,
+  InsufficientAuthenticationNonInteractiveError,
+} from '../../errors';
 import { AppLookupParams } from '../api/graphql/types/AppLookupParams';
 import { ProvisioningProfileStoreInfo } from '../appstore/Credentials.types';
+import { AuthenticationMode } from '../appstore/authenticateTypes';
 import { Target } from '../types';
 import { validateProvisioningProfileAsync } from '../validators/validateProvisioningProfile';
 
@@ -105,6 +109,13 @@ export class SetUpProvisioningProfile {
     if (ctx.freezeCredentials) {
       throw new ForbidCredentialModificationError(
         'Provisioning profile is not configured correctly. Remove the --freeze-credentials flag to configure it.'
+      );
+    } else if (
+      ctx.nonInteractive &&
+      ctx.appStore.defaultAuthenticationMode !== AuthenticationMode.API_KEY
+    ) {
+      throw new InsufficientAuthenticationNonInteractiveError(
+        'In order to configure your Provisioning Profile, authentication with an ASC API key is required in non-interactive mode. See <TODO:ADD LINK HERE> for more information.'
       );
     }
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
@@ -104,7 +104,7 @@ export class SetUpProvisioningProfile {
     }
     if (ctx.freezeCredentials) {
       throw new ForbidCredentialModificationError(
-        'Provisioning profile is not configured correctly. Run this command again without the --freeze-credentials flag.'
+        'Provisioning profile is not configured correctly. Remove the --freeze-credentials flag to configure it.'
       );
     }
 

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/ConfigureProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/ConfigureProvisioningProfile-test.ts
@@ -11,7 +11,11 @@ import {
   testTarget,
   testTargets,
 } from '../../../__tests__/fixtures-ios';
-import { ForbidCredentialModificationError } from '../../../errors';
+import {
+  ForbidCredentialModificationError,
+  InsufficientAuthenticationNonInteractiveError,
+} from '../../../errors';
+import { AuthenticationMode } from '../../appstore/authenticateTypes';
 import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { ConfigureProvisioningProfile } from '../ConfigureProvisioningProfile';
 
@@ -34,6 +38,8 @@ describe('ConfigureProvisioningProfile', () => {
       nonInteractive: mode === 'NON_INTERACTIVE',
       appStore: {
         ...getAppstoreMock(),
+        defaultAuthenticationMode:
+          mode === 'NON_INTERACTIVE' ? AuthenticationMode.API_KEY : AuthenticationMode.USER,
         ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
         authCtx: testAuthCtx,
         createProvisioningProfileAsync: jest.fn(() => testProvisioningProfile),
@@ -74,6 +80,29 @@ describe('ConfigureProvisioningProfile', () => {
     );
     await expect(provProfConfigurator.runAsync(ctx)).rejects.toThrowError(
       ForbidCredentialModificationError
+    );
+
+    // expect provisioning profile not to be updated on expo servers
+    expect(jest.mocked(ctx.ios.updateProvisioningProfileAsync).mock.calls.length).toBe(0);
+    // expect provisioning profile not to be updated on apple portal
+    expect(jest.mocked(ctx.appStore.useExistingProvisioningProfileAsync).mock.calls.length).toBe(0);
+  });
+  it('errors with wrong authentication type in nonInteractive mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = await getAppLookupParamsFromContextAsync(
+      ctx,
+      findApplicationTarget(testTargets)
+    );
+    const provProfConfigurator = new ConfigureProvisioningProfile(
+      appLookupParams,
+      testTarget,
+      testDistCertFragmentNoDependencies,
+      testProvisioningProfileFragment
+    );
+    await expect(provProfConfigurator.runAsync(ctx)).rejects.toThrowError(
+      InsufficientAuthenticationNonInteractiveError
     );
 
     // expect provisioning profile not to be updated on expo servers

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/CreateProvisioningProfile-test.ts
@@ -10,7 +10,11 @@ import {
   testTarget,
   testTargets,
 } from '../../../__tests__/fixtures-ios';
-import { ForbidCredentialModificationError } from '../../../errors';
+import {
+  ForbidCredentialModificationError,
+  InsufficientAuthenticationNonInteractiveError,
+} from '../../../errors';
+import { AuthenticationMode } from '../../appstore/authenticateTypes';
 import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { CreateProvisioningProfile } from '../CreateProvisioningProfile';
 
@@ -29,6 +33,8 @@ describe('CreateProvisioningProfile', () => {
       nonInteractive: mode === 'NON_INTERACTIVE',
       appStore: {
         ...getAppstoreMock(),
+        defaultAuthenticationMode:
+          mode === 'NON_INTERACTIVE' ? AuthenticationMode.API_KEY : AuthenticationMode.USER,
         ensureAuthenticatedAsync: jest.fn(() => testAuthCtx),
         authCtx: testAuthCtx,
         createProvisioningProfileAsync: jest.fn(() => testProvisioningProfile),
@@ -65,6 +71,28 @@ describe('CreateProvisioningProfile', () => {
     );
     await expect(createProvProfAction.runAsync(ctx)).rejects.toThrowError(
       ForbidCredentialModificationError
+    );
+
+    // expect provisioning profile not to be created on expo servers
+    expect(jest.mocked(ctx.ios.createProvisioningProfileAsync).mock.calls.length).toBe(0);
+    // expect provisioning profile not to be created on apple portal
+    expect(jest.mocked(ctx.appStore.createProvisioningProfileAsync).mock.calls.length).toBe(0);
+  });
+  it('errors with wrong authentication type in nonInteractive mode', async () => {
+    const ctx = createCtxMock({
+      nonInteractive: true,
+    });
+    const appLookupParams = await getAppLookupParamsFromContextAsync(
+      ctx,
+      findApplicationTarget(testTargets)
+    );
+    const createProvProfAction = new CreateProvisioningProfile(
+      appLookupParams,
+      testTarget,
+      testDistCertFragmentNoDependencies
+    );
+    await expect(createProvProfAction.runAsync(ctx)).rejects.toThrowError(
+      InsufficientAuthenticationNonInteractiveError
     );
 
     // expect provisioning profile not to be created on expo servers


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We currently support passing in an ASC Api Key to eas build through environment variables. However, we've barred modifying iOS credentials automatically in CI. For many credentials like a Push Key, revoking/generating them in CI is a bad idea since an account has a very low limit on how many keys they are allowed to generate and revoking a push key can have a large impact on production. However, modifying provisioning profiles are relatively safe and needed on a semi-regular basis (ie) annual profile expiration

# How

This PR allows for the creation and modification of app store and enterprise Provisioning Profiles in CI. Apple resigns app store provisioning profiles when it is distributed, so this should be relatively safe. For users that want to ensure their credentials don't get modified in CI, I've added a `--freeze-credentials` flag. 

# Test Plan

- [ ] added + amended a bunch of tests

### Manual sanity tests
- [ ] `--non-interactive`, wrong authentication method, expect to fail with helpful error message
- [ ] ASC api key auth, `--freeze-credentials`, expect to fail with helpful error message
- [ ] `--non-interactive`, ASC api key auth, succeed
