### PR TITLE
fix parsing EXPO_APPLE_PROVIER_ID env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Add explicit workflow arg to expo-update CLI calls. ([#2340](https://github.com/expo/eas-cli/pull/2340) by [@wschurman](https://github.com/wschurman))
+- Correctly parse the EXPO_APPLE_PROVIER_ID environment variable. ([#2349](https://github.com/expo/eas-cli/pull/2349) by [@louix](https://github.com/louix))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
@@ -8,7 +8,7 @@ import {
 } from '@expo/apple-utils';
 import assert from 'assert';
 import chalk from 'chalk';
-import { int } from 'getenv';
+import * as getenv from 'getenv';
 
 import {
   ApiKeyAuthCtx,
@@ -191,7 +191,7 @@ async function authenticateAsUserAsync(options: Options = {}): Promise<AuthCtx> 
         cookies: options.cookies,
         teamId: options.teamId ?? process.env.EXPO_APPLE_TEAM_ID,
         providerId: process.env.EXPO_APPLE_PROVIDER_ID
-          ? int(process.env.EXPO_APPLE_PROVIDER_ID)
+          ? getenv.int('EXPO_APPLE_PROVIDER_ID')
           : undefined,
       },
       {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->
# Why

`getenv.int(process.env.EXPO_APPLE_PROVIER_ID)` will lookup the value of the `process.env.EXPO_APPLE_PROVIER_ID` in `process.env` (i.e. `process.env[process.env.EXPO_APPLE_PROVIER_ID]`) and try to parse that (undefined value) as an int.

If at runtime `process.env.EXPO_APPLE_PROVIER_ID` is `12345`, the code will fail with:

```
Authentication with Apple Developer Portal failed!
GetEnv.Nonexistent: 12345 does not exist and no fallback value provided.
```

Where process.env["12345"] does not exist.

# Test Plan

Simply try to set EXPO_APPLE_PROVIER_ID to anything on the current eas-cli build.