### PR TITLE
[eas-cli] Improve login info message for other login options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Improve login info message for other login options. ([#2352](https://github.com/expo/eas-cli/pull/2352) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 - Upgrade [`eas-build`](https://github.com/expo/eas-build) dependencies. ([#2351](https://github.com/expo/eas-cli/pull/2351) by [@expo-bot](https://github.com/expo-bot))

--- a/packages/eas-cli/src/user/SessionManager.ts
+++ b/packages/eas-cli/src/user/SessionManager.ts
@@ -171,8 +171,8 @@ export default class SessionManager {
 
     Log.log(
       `Log in to EAS with email or username (exit and run ${chalk.bold(
-        'eas login'
-      )} for other options)`
+        'eas login --help'
+      )} to see other login options)`
     );
 
     const { username, password } = await promptAsync([


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

As noted by @jonsamp, this message could be a bit clearer.

# How

Add more info to what the user can do to list other login options.

# Test Plan

Inspect.
