### PR TITLE
[eas-cli] Show the -s, --sso option in the login command help.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Improve login info message for other login options. ([#2352](https://github.com/expo/eas-cli/pull/2352) by [@wschurman](https://github.com/wschurman))
+- Show the -s, --sso option in the login command help. ([#2353](https://github.com/expo/eas-cli/pull/2353) by [@lzkb](https://github.com/lzkb))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -970,7 +970,10 @@ log in with your Expo account
 
 ```
 USAGE
-  $ eas login
+  $ eas login [--sso]
+
+FLAGS
+  -s, --sso Log in with SSO
 
 DESCRIPTION
   log in with your Expo account

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -13,7 +13,6 @@ export default class AccountLogin extends EasCommand {
       description: 'Login with SSO',
       char: 's',
       default: false,
-      hidden: true,
     }),
   };
 


### PR DESCRIPTION
# Why
As noted by @jonsamp, the login info message was not clear. It was changed to  show use of 'login --help' to see more login options. On checking, the sso login option was missing/hidden in the help and README.

Related PR: https://github.com/expo/eas-cli/pull/2352

# How

Added back the login help option. 

# Test Plan

##  Checked login help locally before making any changes:

`eas-cli % ./bin/run login --help
log in with your Expo account

USAGE
  $ eas login [-s]

FLAGS
  -s, --sso  Login with SSO

DESCRIPTION
  log in with your Expo account

ALIASES
  $ eas login
`
## Login help after adding back the sso help:

`eas-cli % ./bin/run login --help                  
log in with your Expo account

USAGE
  $ eas login [-s]

FLAGS
  -s, --sso  Login with SSO

DESCRIPTION
  log in with your Expo account

ALIASES
  $ eas login

`
