### PR TITLE
[eas-cli] Remove more classic updates code

### DIFF
--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -145,19 +145,6 @@ export async function enforceRollBackToEmbeddedUpdateSupportAsync(
   );
 }
 
-export async function isClassicUpdatesSupportedAsync(projectDir: string): Promise<boolean> {
-  const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(projectDir);
-  if (expoUpdatesPackageVersion === null) {
-    return false;
-  }
-
-  if (expoUpdatesPackageVersion.includes('canary')) {
-    return false;
-  }
-
-  return semver.lt(expoUpdatesPackageVersion, '0.19.0');
-}
-
 export async function isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(
   projectDir: string
 ): Promise<boolean> {

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -57,18 +57,6 @@ export async function syncUpdatesConfigurationAsync(
   await XML.writeXMLAsync({ path: stringsJSONPath, xml: updatedStringsResourceXML });
 }
 
-export async function readReleaseChannelSafelyAsync(projectDir: string): Promise<string | null> {
-  try {
-    const androidManifest = await getAndroidManifestAsync(projectDir);
-    return AndroidConfig.Manifest.getMainApplicationMetaDataValue(
-      androidManifest,
-      AndroidConfig.Updates.Config.RELEASE_CHANNEL
-    );
-  } catch {
-    return null;
-  }
-}
-
 export async function readChannelSafelyAsync(projectDir: string): Promise<string | null> {
   try {
     const androidManifest = await getAndroidManifestAsync(projectDir);

--- a/packages/eas-cli/src/update/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/ios/UpdatesModule.ts
@@ -53,15 +53,6 @@ async function writeExpoPlistAsync(
   await vcsClient.trackFileAsync(expoPlistPath);
 }
 
-export async function readReleaseChannelSafelyAsync(projectDir: string): Promise<string | null> {
-  try {
-    const expoPlist = await readExpoPlistAsync(projectDir);
-    return expoPlist[IOSConfig.Updates.Config.RELEASE_CHANNEL] ?? null;
-  } catch {
-    return null;
-  }
-}
-
 export async function readChannelSafelyAsync(projectDir: string): Promise<string | null> {
   try {
     const expoPlist = await readExpoPlistAsync(projectDir);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Classic updates are no longer supported in any SDK, so we can remove `isClassicUpdatesSupportedAsync` and all code underneath it.

# How

Remove.

# Test Plan

`yarn tsc`
