### PR TITLE
[eas-cli] Pass env from process.env and build profile to expo-updates CLI calls where applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Pass env from process.env and build profile to expo-updates CLI calls where applicable. ([#2359](https://github.com/expo/eas-cli/pull/2359) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 - Remove more classic updates code. ([#2357](https://github.com/expo/eas-cli/pull/2357) by [@wschurman](https://github.com/wschurman))

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -107,6 +107,7 @@ export async function prepareAndroidBuildAsync(
             ? false
             : ctx.buildProfile.autoIncrement,
         vcsClient: ctx.vcsClient,
+        env: ctx.buildProfile.env,
       });
     },
     prepareJobAsync: async (

--- a/packages/eas-cli/src/build/android/syncProjectConfiguration.ts
+++ b/packages/eas-cli/src/build/android/syncProjectConfiguration.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { AndroidConfig } from '@expo/config-plugins';
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Env, Platform, Workflow } from '@expo/eas-build-job';
 import { AndroidVersionAutoIncrement } from '@expo/eas-json';
 import chalk from 'chalk';
 import fs from 'fs-extra';
@@ -18,11 +18,13 @@ export async function syncProjectConfigurationAsync({
   exp,
   localAutoIncrement,
   vcsClient,
+  env,
 }: {
   projectDir: string;
   exp: ExpoConfig;
   localAutoIncrement?: AndroidVersionAutoIncrement;
   vcsClient: Client;
+  env: Env | undefined;
 }): Promise<void> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
   const versionBumpStrategy = resolveVersionBumpStrategy(localAutoIncrement ?? false);
@@ -30,7 +32,7 @@ export async function syncProjectConfigurationAsync({
   if (workflow === Workflow.GENERIC) {
     await cleanUpOldEasBuildGradleScriptAsync(projectDir);
     if (isExpoUpdatesInstalled(projectDir)) {
-      await syncUpdatesConfigurationAsync(projectDir, exp, workflow);
+      await syncUpdatesConfigurationAsync({ projectDir, exp, workflow, env });
     }
     await bumpVersionAsync({ projectDir, exp, bumpStrategy: versionBumpStrategy });
   } else {

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -89,6 +89,7 @@ export async function prepareIosBuildAsync(
             ? false
             : ctx.buildProfile.autoIncrement,
         vcsClient: ctx.vcsClient,
+        env: ctx.buildProfile.env,
       });
     },
     prepareJobAsync: async (

--- a/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts
+++ b/packages/eas-cli/src/build/ios/syncProjectConfiguration.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config';
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Env, Platform, Workflow } from '@expo/eas-build-job';
 import { IosVersionAutoIncrement } from '@expo/eas-json';
 
 import { BumpStrategy, bumpVersionAsync, bumpVersionInAppJsonAsync } from './version';
@@ -15,19 +15,21 @@ export async function syncProjectConfigurationAsync({
   targets,
   localAutoIncrement,
   vcsClient,
+  env,
 }: {
   projectDir: string;
   exp: ExpoConfig;
   targets: Target[];
   localAutoIncrement?: IosVersionAutoIncrement;
   vcsClient: Client;
+  env: Env | undefined;
 }): Promise<void> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
   const versionBumpStrategy = resolveVersionBumpStrategy(localAutoIncrement ?? false);
 
   if (workflow === Workflow.GENERIC) {
     if (isExpoUpdatesInstalled(projectDir)) {
-      await syncUpdatesConfigurationAsync(vcsClient, projectDir, exp, workflow);
+      await syncUpdatesConfigurationAsync({ vcsClient, projectDir, exp, workflow, env });
     }
     await bumpVersionAsync({ projectDir, exp, bumpStrategy: versionBumpStrategy, targets });
   } else {

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -27,7 +27,14 @@ export async function collectMetadataAsync<T extends Platform>(
     workflow: ctx.workflow,
     credentialsSource: ctx.buildProfile.credentialsSource,
     sdkVersion: ctx.exp.sdkVersion,
-    runtimeVersion: (await resolveRuntimeVersionAsync(ctx)) ?? undefined,
+    runtimeVersion:
+      (await resolveRuntimeVersionAsync({
+        exp: ctx.exp,
+        platform: ctx.platform,
+        workflow: ctx.workflow,
+        projectDir: ctx.projectDir,
+        env: ctx.buildProfile.env,
+      })) ?? undefined,
     reactNativeVersion: await getReactNativeVersionAsync(ctx.projectDir),
     ...channelObject,
     distribution,

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config-types';
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Env, Platform, Workflow } from '@expo/eas-build-job';
 import {
   AppVersionSource,
   BuildProfile,
@@ -385,6 +385,7 @@ async function prepareAndStartBuildAsync({
       sdkVersion: buildCtx.exp.sdkVersion,
       nonInteractive: flags.nonInteractive,
       buildProfile,
+      env: buildProfile.profile.env,
     });
     if (isUsingEASUpdate(buildCtx.exp, buildCtx.projectId)) {
       const doesChannelExist = await doesChannelExistAsync(graphqlClient, {
@@ -529,6 +530,7 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
   buildProfile,
   nonInteractive,
   sdkVersion,
+  env,
 }: {
   exp: ExpoConfig;
   projectId: string;
@@ -537,6 +539,7 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
   buildProfile: ProfileData<'build'>;
   nonInteractive: boolean;
   sdkVersion?: string;
+  env: Env | undefined
 }): Promise<void> {
   if (isExpoUpdatesInstalledOrAvailable(projectDir, sdkVersion)) {
     return;
@@ -564,6 +567,7 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
         projectDir,
         platform: RequestedPlatform.All,
         vcsClient,
+        env,
       });
       Log.withTick('Installed expo-updates and configured EAS Update.');
       throw new Error('Command must be re-run to pick up new updates configuration.');

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -539,7 +539,7 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
   buildProfile: ProfileData<'build'>;
   nonInteractive: boolean;
   sdkVersion?: string;
-  env: Env | undefined
+  env: Env | undefined;
 }): Promise<void> {
   if (isExpoUpdatesInstalledOrAvailable(projectDir, sdkVersion)) {
     return;

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -74,14 +74,20 @@ export default class BuildConfigure extends EasCommand {
       if ([RequestedPlatform.Android, RequestedPlatform.All].includes(platform)) {
         const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
         if (workflow === Workflow.GENERIC) {
-          await syncAndroidUpdatesConfigurationAsync(projectDir, exp, workflow);
+          await syncAndroidUpdatesConfigurationAsync({ projectDir, exp, workflow, env: undefined });
         }
       }
 
       if ([RequestedPlatform.Ios, RequestedPlatform.All].includes(platform)) {
         const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
         if (workflow === Workflow.GENERIC) {
-          await syncIosUpdatesConfigurationAsync(vcsClient, projectDir, exp, workflow);
+          await syncIosUpdatesConfigurationAsync({
+            vcsClient,
+            projectDir,
+            exp,
+            workflow,
+            env: undefined,
+          });
         }
       }
     }

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -52,6 +52,7 @@ export default class UpdateConfigure extends EasCommand {
       projectDir,
       platform,
       vcsClient,
+      env: undefined,
     });
 
     await ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir);

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -200,6 +200,7 @@ export default class UpdatePublish extends EasCommand {
       projectDir,
       projectId,
       vcsClient,
+      env: undefined,
     });
 
     const { exp } = await getDynamicPublicProjectConfigAsync();
@@ -369,6 +370,7 @@ export default class UpdatePublish extends EasCommand {
         ...workflows,
         web: Workflow.UNKNOWN,
       },
+      env: undefined,
     });
     const runtimeToPlatformMapping =
       getRuntimeToPlatformMappingFromRuntimeVersions(runtimeVersions);

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -154,6 +154,7 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
       projectDir,
       projectId,
       vcsClient,
+      env: undefined,
     });
 
     // check that the expo-updates package version supports roll back to embedded
@@ -201,6 +202,7 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
         ...workflows,
         web: Workflow.UNKNOWN,
       },
+      env: undefined,
     });
 
     let newUpdates: UpdatePublishMutation['updateBranch']['publishUpdateGroups'];

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig, Platform } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
-import { Workflow } from '@expo/eas-build-job';
+import { Env, Workflow } from '@expo/eas-build-job';
 import JsonFile from '@expo/json-file';
 import assert from 'assert';
 import chalk from 'chalk';
@@ -684,11 +684,13 @@ export async function getRuntimeVersionObjectAsync({
   platforms,
   workflows,
   projectDir,
+  env,
 }: {
   exp: ExpoConfig;
   platforms: Platform[];
   workflows: Record<Platform, Workflow>;
   projectDir: string;
+  env: Env | undefined;
 }): Promise<{ platform: string; runtimeVersion: string }[]> {
   return await Promise.all(
     platforms.map(async platform => {
@@ -699,6 +701,7 @@ export async function getRuntimeVersionObjectAsync({
           platform,
           workflow: workflows[platform],
           projectDir,
+          env,
         }),
       };
     })
@@ -710,11 +713,13 @@ async function getRuntimeVersionForPlatformAsync({
   platform,
   workflow,
   projectDir,
+  env,
 }: {
   exp: ExpoConfig;
   platform: Platform;
   workflow: Workflow;
   projectDir: string;
+  env: Env | undefined;
 }): Promise<string> {
   if (platform === 'web') {
     return 'UNVERSIONED';
@@ -726,14 +731,11 @@ async function getRuntimeVersionForPlatformAsync({
 
       const extraArgs = Log.isDebug ? ['--debug'] : [];
 
-      const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
-        'runtimeversion:resolve',
-        '--platform',
-        platform,
-        '--workflow',
-        workflow,
-        ...extraArgs,
-      ]);
+      const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(
+        projectDir,
+        ['runtimeversion:resolve', '--platform', platform, '--workflow', workflow, ...extraArgs],
+        { env }
+      );
       const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
 
       Log.debug('runtimeversion:resolve output:');

--- a/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
+++ b/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
-import { Workflow } from '@expo/eas-build-job';
+import { Env, Workflow } from '@expo/eas-build-job';
 
 import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from './projectUtils';
 import Log from '../log';
@@ -14,11 +14,13 @@ export async function resolveRuntimeVersionAsync({
   platform,
   workflow,
   projectDir,
+  env,
 }: {
   exp: ExpoConfig;
   platform: 'ios' | 'android';
   workflow: Workflow;
   projectDir: string;
+  env: Env | undefined;
 }): Promise<string | null> {
   if (!(await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir))) {
     // fall back to the previous behavior (using the @expo/config-plugins eas-cli dependency rather
@@ -31,14 +33,11 @@ export async function resolveRuntimeVersionAsync({
 
     const extraArgs = Log.isDebug ? ['--debug'] : [];
 
-    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectDir, [
-      'runtimeversion:resolve',
-      '--platform',
-      platform,
-      '--workflow',
-      workflow,
-      ...extraArgs,
-    ]);
+    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(
+      projectDir,
+      ['runtimeversion:resolve', '--platform', platform, '--workflow', workflow, ...extraArgs],
+      { env }
+    );
     const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
 
     Log.debug('runtimeversion:resolve output:');

--- a/packages/eas-cli/src/rollout/actions/CreateRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/CreateRollout.ts
@@ -282,6 +282,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
             exp: ctx.app.exp,
             platform,
             workflow: workflows[platform],
+            env: undefined,
           })
         )
       )

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { AndroidConfig, AndroidManifest, XML } from '@expo/config-plugins';
-import { Workflow } from '@expo/eas-build-job';
+import { Env, Workflow } from '@expo/eas-build-job';
 
 import { RequestedPlatform } from '../../platform';
 import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '../../project/projectUtils';
@@ -10,21 +10,25 @@ import { ensureValidVersions } from '../utils';
 /**
  * Synchronize updates configuration to native files. This needs to do essentially the same thing as `withUpdates`
  */
-export async function syncUpdatesConfigurationAsync(
-  projectDir: string,
-  exp: ExpoConfig,
-  workflow: Workflow
-): Promise<void> {
+export async function syncUpdatesConfigurationAsync({
+  projectDir,
+  exp,
+  workflow,
+  env,
+}: {
+  projectDir: string;
+  exp: ExpoConfig;
+  workflow: Workflow;
+  env: Env | undefined;
+}): Promise<void> {
   ensureValidVersions(exp, RequestedPlatform.Android);
 
   if (await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir)) {
-    await expoUpdatesCommandAsync(projectDir, [
-      'configuration:syncnative',
-      '--platform',
-      'android',
-      '--workflow',
-      workflow,
-    ]);
+    await expoUpdatesCommandAsync(
+      projectDir,
+      ['configuration:syncnative', '--platform', 'android', '--workflow', workflow],
+      { env }
+    );
     return;
   }
 

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config-types';
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Env, Platform, Workflow } from '@expo/eas-build-job';
 import { EasJsonAccessor } from '@expo/eas-json';
 import chalk from 'chalk';
 import fs from 'fs-extra';
@@ -264,20 +264,33 @@ async function ensureEASUpdateIsConfiguredNativelyAsync(
     projectDir,
     platform,
     workflows,
+    env,
   }: {
     exp: ExpoConfig;
     projectDir: string;
     platform: RequestedPlatform;
     workflows: Record<Platform, Workflow>;
+    env: Env | undefined;
   }
 ): Promise<void> {
   if (['all', 'android'].includes(platform) && workflows.android === Workflow.GENERIC) {
-    await syncAndroidUpdatesConfigurationAsync(projectDir, exp, workflows.android);
+    await syncAndroidUpdatesConfigurationAsync({
+      projectDir,
+      exp,
+      workflow: workflows.android,
+      env,
+    });
     Log.withTick(`Configured ${chalk.bold('AndroidManifest.xml')} for EAS Update`);
   }
 
   if (['all', 'ios'].includes(platform) && workflows.ios === Workflow.GENERIC) {
-    await syncIosUpdatesConfigurationAsync(vcsClient, projectDir, exp, workflows.ios);
+    await syncIosUpdatesConfigurationAsync({
+      vcsClient,
+      projectDir,
+      exp,
+      workflow: workflows.ios,
+      env,
+    });
     Log.withTick(`Configured ${chalk.bold('Expo.plist')} for EAS Update`);
   }
 }
@@ -356,12 +369,14 @@ export async function ensureEASUpdateIsConfiguredAsync({
   projectDir,
   vcsClient,
   platform,
+  env,
 }: {
   exp: ExpoConfig;
   projectId: string;
   projectDir: string;
   vcsClient: Client;
   platform: RequestedPlatform | null;
+  env: Env | undefined;
 }): Promise<void> {
   const hasExpoUpdates = isExpoUpdatesInstalledOrAvailable(
     projectDir,
@@ -399,6 +414,7 @@ export async function ensureEASUpdateIsConfiguredAsync({
       projectDir,
       platform,
       workflows,
+      env,
     });
   }
 

--- a/packages/eas-cli/src/update/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/ios/UpdatesModule.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
-import { Workflow } from '@expo/eas-build-job';
+import { Env, Workflow } from '@expo/eas-build-job';
 
 import { RequestedPlatform } from '../../platform';
 import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '../../project/projectUtils';
@@ -9,22 +9,27 @@ import { readPlistAsync, writePlistAsync } from '../../utils/plist';
 import { Client } from '../../vcs/vcs';
 import { ensureValidVersions } from '../utils';
 
-export async function syncUpdatesConfigurationAsync(
-  vcsClient: Client,
-  projectDir: string,
-  exp: ExpoConfig,
-  workflow: Workflow
-): Promise<void> {
+export async function syncUpdatesConfigurationAsync({
+  vcsClient,
+  projectDir,
+  exp,
+  workflow,
+  env,
+}: {
+  vcsClient: Client;
+  projectDir: string;
+  exp: ExpoConfig;
+  workflow: Workflow;
+  env: Env | undefined;
+}): Promise<void> {
   ensureValidVersions(exp, RequestedPlatform.Ios);
 
   if (await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir)) {
-    await expoUpdatesCommandAsync(projectDir, [
-      'configuration:syncnative',
-      '--platform',
-      'ios',
-      '--workflow',
-      workflow,
-    ]);
+    await expoUpdatesCommandAsync(
+      projectDir,
+      ['configuration:syncnative', '--platform', 'ios', '--workflow', workflow],
+      { env }
+    );
     return;
   }
 

--- a/packages/eas-cli/src/utils/expoUpdatesCli.ts
+++ b/packages/eas-cli/src/utils/expoUpdatesCli.ts
@@ -1,3 +1,4 @@
+import { Env } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
 import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
 
@@ -7,7 +8,11 @@ export class ExpoUpdatesCLIModuleNotFoundError extends Error {}
 export class ExpoUpdatesCLIInvalidCommandError extends Error {}
 export class ExpoUpdatesCLICommandFailedError extends Error {}
 
-export async function expoUpdatesCommandAsync(projectDir: string, args: string[]): Promise<string> {
+export async function expoUpdatesCommandAsync(
+  projectDir: string,
+  args: string[],
+  options: { env: Env | undefined }
+): Promise<string> {
   let expoUpdatesCli;
   try {
     expoUpdatesCli =
@@ -25,7 +30,12 @@ export async function expoUpdatesCommandAsync(projectDir: string, args: string[]
   }
 
   try {
-    return (await spawnAsync(expoUpdatesCli, args, { stdio: 'pipe' })).stdout;
+    return (
+      await spawnAsync(expoUpdatesCli, args, {
+        stdio: 'pipe',
+        env: { ...process.env, ...options.env },
+      })
+    ).stdout;
   } catch (e: any) {
     if (e.stderr && typeof e.stderr === 'string') {
       if (e.stderr.includes('Invalid command')) {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This is the eas-cli equivalent of https://github.com/expo/eas-build/pull/388.

Essentially, when getting the project config in expo-updates CLI, the env must be supplied.

# How

Pass the env to the `spawnAsync`. Note that this passes the build profile env when possible as well (only in build command).

# Test Plan

Still need to come up with a test plan here. I think it will be:
1. Create a test app with an app.config.ts similar to https://github.com/expo/expo/blob/main/apps/eas-expo-go/app.config.ts and expo-updates installed (beta). (`yarn create expo-app --template default@beta`)
2. `eas init`, `eas update:configure`, `eas build:configure`
3. Add environment variable to eas.json env key in each profile.
4. Run `eas build -p android`, see it fails (current prod version of eas-cli)
5. Run `neas build -p android`, see it succeeds.