### PR TITLE
[eas-cli] fix onboarding mutation

### DIFF
--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -174,8 +174,9 @@ export default class Onboarding extends EasCommand {
       });
     }
 
+    const { __typename, ...previousPreferences } = actor.preferences.onboarding;
     await UserPreferencesMutation.markCliDoneInOnboardingUserPreferencesAsync(graphqlClient, {
-      ...actor.preferences.onboarding,
+      ...previousPreferences,
       appId: app.id,
     });
 

--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -175,6 +175,7 @@ export default class Onboarding extends EasCommand {
     }
 
     await UserPreferencesMutation.markCliDoneInOnboardingUserPreferencesAsync(graphqlClient, {
+      ...actor.preferences.onboarding,
       appId: app.id,
     });
 

--- a/packages/eas-cli/src/graphql/mutations/UserPreferencesMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/UserPreferencesMutation.ts
@@ -6,14 +6,13 @@ import { withErrorHandlingAsync } from '../client';
 import {
   MarkCliDoneInOnboardingUserPreferencesMutation,
   MarkCliDoneInOnboardingUserPreferencesMutationVariables,
+  UserPreferencesOnboardingInput,
 } from '../generated';
 
 export const UserPreferencesMutation = {
   async markCliDoneInOnboardingUserPreferencesAsync(
     graphqlClient: ExpoGraphqlClient,
-    userPreferencesData: {
-      appId: string;
-    }
+    userPreferencesData: Partial<UserPreferencesOnboardingInput> & { appId: string }
   ): Promise<{
     isCLIDone: boolean;
     appId: string;


### PR DESCRIPTION
# Why

There's a bug in how we update onboarding data. UserPreferences is a key-value store with shallow comparison so we also need to pass the other info that was stored there for it to work.

# How

By spreading previous preferences.

# Test Plan

Not sure how to test it. @szdziedzic can you help me?