### PR TITLE
[eas-cli] improvements to eas onboarding after dogfooding

### DIFF
--- a/packages/eas-cli/src/onboarding/runCommand.ts
+++ b/packages/eas-cli/src/onboarding/runCommand.ts
@@ -2,6 +2,7 @@ import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 
 import Log from '../log';
+import { ora } from '../ora';
 
 export async function runCommandAsync({
   cwd,
@@ -17,6 +18,7 @@ export async function runCommandAsync({
   shouldPrintStderrLineAsStdout?: (line: string) => boolean;
 }): Promise<void> {
   Log.log(`🏗️  Running ${chalk.bold(`${command} ${args.join(' ')}`)}...`);
+  const spinner = ora(`${chalk.bold(`${command} ${args.join(' ')}`)}`).start();
   const spawnPromise = spawnAsync(command, args, {
     stdio: ['inherit', 'pipe', 'pipe'],
     cwd,
@@ -48,7 +50,12 @@ export async function runCommandAsync({
     }
   });
 
-  await spawnPromise;
-  Log.succeed(`✅ ${chalk.bold(`${command} ${args.join(' ')}`)} succeeded`);
+  try {
+    await spawnPromise;
+  } catch (error) {
+    spinner.fail(`${chalk.bold(`${command} ${args.join(' ')}`)} failed`);
+    throw error;
+  }
+  spinner.succeed(`✅ ${chalk.bold(`${command} ${args.join(' ')}`)} succeeded`);
   Log.log('');
 }

--- a/packages/eas-cli/src/vcs/git.ts
+++ b/packages/eas-cli/src/vcs/git.ts
@@ -50,8 +50,17 @@ export async function gitDiffAsync({
   cwd: string | undefined;
 }): Promise<void> {
   const options = withPager ? [] : ['--no-pager'];
-  await spawnAsync('git', [...options, 'diff'], {
-    stdio: ['ignore', 'inherit', 'inherit'],
-    cwd,
-  });
+  try {
+    await spawnAsync('git', [...options, 'diff'], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+      cwd,
+    });
+  } catch (error: any) {
+    if (typeof error.message === 'string' && error.message.includes('SIGPIPE')) {
+      // This error is thrown when the user exits the pager with `q`.
+      // do nothing
+      return;
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

improvements to eas onboarding after dogfooding

- add spinner
- don't let EAS CLI crash after git diff with pager is closed with `q`
- remove the redundant white checkmark from logs
- ask the user to which directory we should clone the repo instead of if they want to continue

# How

improvements to eas onboarding after dogfooding

# Test Plan

test manually
