### PR TITLE
[eas-cli] make sure that spinner is not used for interactive `git clone` command in `inint:onboarding`

### DIFF
--- a/packages/eas-cli/src/onboarding/git.ts
+++ b/packages/eas-cli/src/onboarding/git.ts
@@ -24,6 +24,7 @@ export async function runGitCloneAsync({
       shouldPrintStderrLineAsStdout: line => {
         return line.includes('Cloning into');
       },
+      showSpinner: false,
     });
     return { targetProjectDir };
   } catch (error: any) {

--- a/packages/eas-cli/src/onboarding/runCommand.ts
+++ b/packages/eas-cli/src/onboarding/runCommand.ts
@@ -2,7 +2,7 @@ import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 
 import Log from '../log';
-import { ora } from '../ora';
+import { Ora, ora } from '../ora';
 
 export async function runCommandAsync({
   cwd,
@@ -10,15 +10,20 @@ export async function runCommandAsync({
   command,
   shouldShowStderrLine,
   shouldPrintStderrLineAsStdout,
+  showSpinner = true,
 }: {
   cwd?: string;
   args: string[];
   command: string;
   shouldShowStderrLine?: (line: string) => boolean;
   shouldPrintStderrLineAsStdout?: (line: string) => boolean;
+  showSpinner?: boolean;
 }): Promise<void> {
   Log.log(`🏗️  Running ${chalk.bold(`${command} ${args.join(' ')}`)}...`);
-  const spinner = ora(`${chalk.bold(`${command} ${args.join(' ')}`)}`).start();
+  let spinner: Ora | undefined;
+  if (showSpinner) {
+    spinner = ora(`${chalk.bold(`${command} ${args.join(' ')}`)}`).start();
+  }
   const spawnPromise = spawnAsync(command, args, {
     stdio: ['inherit', 'pipe', 'pipe'],
     cwd,
@@ -53,9 +58,18 @@ export async function runCommandAsync({
   try {
     await spawnPromise;
   } catch (error) {
-    spinner.fail(`${chalk.bold(`${command} ${args.join(' ')}`)} failed`);
+    if (showSpinner) {
+      spinner?.fail(`${chalk.bold(`${command} ${args.join(' ')}`)} failed`);
+    } else {
+      Log.error(`❌ ${chalk.bold(`${command} ${args.join(' ')}`)} failed`);
+    }
     throw error;
   }
-  spinner.succeed(`✅ ${chalk.bold(`${command} ${args.join(' ')}`)} succeeded`);
+
+  if (showSpinner) {
+    spinner?.succeed(`✅ ${chalk.bold(`${command} ${args.join(' ')}`)} succeeded`);
+  } else {
+    Log.log(`✅ ${chalk.bold(`${command} ${args.join(' ')}`)} succeeded`);
+  }
   Log.log('');
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Before:
![screenshot_2024-05-09_at_18 56 01_720](https://github.com/expo/eas-cli/assets/55145344/b54f4e80-0318-49f7-9ed8-0cebbccfe9c1)

spinner was printed on top of the logs which contained a prompt to accept something

# How

make sure that it's not used for `git clone`

# Test Plan

After:
![screenshot_2024-05-09_at_19 04 12_720](https://github.com/expo/eas-cli/assets/55145344/de551bbd-2e36-4f12-9315-60629e7a0c4d)
