### PR TITLE
`s/Website link/EAS Dashboard` when displaying update info

### DIFF
--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -514,7 +514,7 @@ export default class UpdatePublish extends EasCommand {
                   },
                 ]
               : []),
-            { label: 'Website link', value: updateGroupLink },
+            { label: 'EAS Dashboard', value: updateGroupLink },
           ])
         );
         Log.addNewLineIfNone();

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -276,7 +276,7 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
                   },
                 ]
               : []),
-            { label: 'Website link', value: updateGroupLink },
+            { label: 'EAS Dashboard', value: updateGroupLink },
           ])
         );
         Log.addNewLineIfNone();

--- a/packages/eas-cli/src/update/republish.ts
+++ b/packages/eas-cli/src/update/republish.ts
@@ -195,7 +195,7 @@ export async function republishAsync({
         ? [{ label: 'iOS update ID', value: updatesRepublishedByPlatform.ios.id }]
         : []),
       { label: 'Message', value: updateMessage },
-      { label: 'Website link', value: link(updateGroupUrl, { dim: false }) },
+      { label: 'EAS Dashboard', value: link(updateGroupUrl, { dim: false }) },
     ])
   );
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Implementing @tchayen's suggestion.

# How

Changed wording

# Test Plan

None.