### PR TITLE
[eas-cli] Prevent `ora` flooding logs

### DIFF
--- a/packages/eas-cli/src/ora.ts
+++ b/packages/eas-cli/src/ora.ts
@@ -67,7 +67,24 @@ export function ora(options?: Options | string): Ora {
   };
 
   spinner.start = (text): Ora => {
-    wrapNativeLogs();
+    // wrapNativeLogs wraps calls to console so they always:
+    // 1. stop the spinner
+    // 2. log the message
+    // 3. start the spinner again
+    // Every restart of the spinner causes the spinner message to be logged again
+    // which makes logs look like
+    //
+    // - Exporting...
+    // [expo-cli] Starting Metro Bundler
+    // - Exporting...
+    // [expo-cli] Android Bundling complete 3492ms
+    // - Exporting...
+    //
+    // Skipping wrapping native logs removes the repeated interleaved "Exporting..." messages.
+    if (!disabled) {
+      wrapNativeLogs();
+    }
+
     return oraStart(text);
   };
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I noticed logs look off in CI when running `eas update --auto`.

<img width="1000" alt="Zrzut ekranu 2024-05-10 o 17 50 10" src="https://github.com/expo/eas-cli/assets/1151041/ed50d014-62f1-4342-bde2-0673f49d52b4">

# How

I pinpointed it to Ora being restarted on every log.

# Test Plan

Ran `CI=1 easd update --auto` and got ⬇️ which I think is much more readable.

```
CI=1 easd update --auto
- Exporting...
[expo-cli] Starting Metro Bundler
[expo-cli] Android Bundling complete 3492ms
[expo-cli] iOS Bundling complete 3493ms
[expo-cli] iOS Building Hermes bytecode for the bundle
[expo-cli] Android Building Hermes bytecode for the bundle
[expo-cli] 
[expo-cli] Bundle                      Size
[expo-cli] ┌ index.ios.hbc           858 kB
[expo-cli] ├ index.android.hbc       864 kB
[expo-cli] ├ index.ios.hbc.map      3.45 MB
[expo-cli] └ index.android.hbc.map  3.48 MB
[expo-cli] 
[expo-cli] 💡 JavaScript bundle sizes affect startup time. Learn more: https://expo.fyi/javascript-bundle-sizes
[expo-cli] Finished saving JS Bundles
[expo-cli] Dumping asset map
[expo-cli] Dumping source maps
[expo-cli] Preparing additional debugging files
[expo-cli] Export was successful. Your exported files can be found in dist
✔ Exported bundle(s)
- Uploading...
✔ Uploaded 2 app bundles
✔ Uploading assets skipped - no new assets found
ℹ 1 iOS asset, 1 Android asset (maximum: 20000 total per update). Learn more about asset limits: https://expo.fyi/eas-update-asset-limits
- Publishing...
✔ Published!
```