### PR TITLE
[eas-cli] fix typo in onboarding commit message

### DIFF
--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -174,7 +174,7 @@ export default class Onboarding extends EasCommand {
       await reviewAndCommitChangesAsync(
         vcsClient,
         `[eas-onboarding] Install dependencies${
-          shouldSetupCredentials ? 'and set up build credentials' : ''
+          shouldSetupCredentials ? ' and set up build credentials' : ''
         }`,
         { nonInteractive: false }
       );


### PR DESCRIPTION
# Why

Fix typo in EAS CLI onboarding commit message, when we also include credential changes.

# How

Add missing space.

# Test Plan

N/A
