### PR TITLE
[eas-cli] create keystore for Android emulator builds in `init:onboarding`

### DIFF
--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -161,7 +161,9 @@ export default class Onboarding extends EasCommand {
           actor,
         }),
         platform,
-        'development',
+        actor.preferences.onboarding.deviceType === OnboardingDeviceType.Simulator
+          ? 'development-simulator'
+          : 'development',
         finalTargetProjectDirectory
       ).runAsync();
     }

--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -139,7 +139,9 @@ export default class Onboarding extends EasCommand {
     await vcsClient.trackFileAsync('package-lock.json');
 
     const shouldSetupCredentials =
-      actor.preferences.onboarding.deviceType === OnboardingDeviceType.Device &&
+      ((platform === Platform.IOS &&
+        actor.preferences.onboarding.deviceType === OnboardingDeviceType.Device) ||
+        platform === Platform.ANDROID) &&
       actor.preferences.onboarding.environment === OnboardingEnvironment.DevBuild;
     if (shouldSetupCredentials) {
       Log.log('🔑 Now we need to set up build credentials for your project:');


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C06EBFAVCEA/p1715397103308639

create keystore for Android emulator builds in `init:onboarding`

# How

create keystore for Android emulator builds in `init:onboarding`

# Test Plan

test manually
