### PR TITLE
[eas-cli] install dependencies before resolving expo config in `init:onboarding`

### DIFF
--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -164,6 +164,10 @@ export default class Onboarding extends EasCommand {
         targetDir: finalTargetProjectDirectory,
       });
     }
+
+    await installDependenciesAsync({
+      projectDir: finalTargetProjectDirectory,
+    });
     const exp = await getPrivateExpoConfigWithProjectIdAsync({
       projectDir: finalTargetProjectDirectory,
       graphqlClient,
@@ -175,9 +179,6 @@ export default class Onboarding extends EasCommand {
       actor,
     });
 
-    await installDependenciesAsync({
-      projectDir: finalTargetProjectDirectory,
-    });
     if (!app.githubRepository) {
       await runCommandAsync({
         cwd: finalTargetProjectDirectory,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

install dependencies before resolving the expo config

# How

install dependencies before resolving the expo config

