### PR TITLE
[eas-cli] Add `turtleJobRunId` to `UpdatePublishMutation` input

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -11924,6 +11924,22 @@
             "deprecationReason": null
           },
           {
+            "name": "keyP8",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "name",
             "description": null,
             "args": [],
@@ -22730,6 +22746,49 @@
       },
       {
         "kind": "OBJECT",
+        "name": "DeploymentSignedUrlResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "deploymentId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "DeploymentsConnection",
         "description": "Represents the connection over the deployments edge of an App",
         "fields": [
@@ -22767,6 +22826,62 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeploymentsMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "createSignedDeploymentUrl",
+            "description": "Create a signed deployment URL",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "deploymentId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeploymentSignedUrlResult",
                 "ofType": null
               }
             },
@@ -29850,6 +29965,38 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "updateGroups",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "Update",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -32899,6 +33046,18 @@
             "deprecationReason": null
           },
           {
+            "name": "turtleJobRunId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updateInfoGroup",
             "description": null,
             "type": {
@@ -33781,6 +33940,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "BuildAnnotationMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deployments",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeploymentsMutation",
                 "ofType": null
               }
             },
@@ -38892,6 +39067,18 @@
                 "name": "Boolean",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "jobRun",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "JobRun",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1815,6 +1815,7 @@ export type AppStoreConnectApiKey = {
   id: Scalars['ID']['output'];
   issuerIdentifier: Scalars['String']['output'];
   keyIdentifier: Scalars['String']['output'];
+  keyP8: Scalars['String']['output'];
   name?: Maybe<Scalars['String']['output']>;
   roles?: Maybe<Array<AppStoreConnectUserRole>>;
   updatedAt: Scalars['DateTime']['output'];
@@ -3334,11 +3335,29 @@ export type DeploymentInsightsUniqueUsersOverTimeArgs = {
   timespan: InsightsTimespan;
 };
 
+export type DeploymentSignedUrlResult = {
+  __typename?: 'DeploymentSignedUrlResult';
+  deploymentId: Scalars['ID']['output'];
+  url: Scalars['String']['output'];
+};
+
 /** Represents the connection over the deployments edge of an App */
 export type DeploymentsConnection = {
   __typename?: 'DeploymentsConnection';
   edges: Array<DeploymentEdge>;
   pageInfo: PageInfo;
+};
+
+export type DeploymentsMutation = {
+  __typename?: 'DeploymentsMutation';
+  /** Create a signed deployment URL */
+  createSignedDeploymentUrl: DeploymentSignedUrlResult;
+};
+
+
+export type DeploymentsMutationCreateSignedDeploymentUrlArgs = {
+  appId: Scalars['ID']['input'];
+  deploymentId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type DiscordUser = {
@@ -4289,6 +4308,7 @@ export type JobRun = {
   priority: JobRunPriority;
   startedAt?: Maybe<Scalars['DateTime']['output']>;
   status: JobRunStatus;
+  updateGroups: Array<Array<Update>>;
 };
 
 export enum JobRunPriority {
@@ -4751,6 +4771,7 @@ export type PublishUpdateGroupInput = {
   message?: InputMaybe<Scalars['String']['input']>;
   rollBackToEmbeddedInfoGroup?: InputMaybe<UpdateRollBackToEmbeddedGroup>;
   runtimeVersion: Scalars['String']['input'];
+  turtleJobRunId?: InputMaybe<Scalars['String']['input']>;
   updateInfoGroup?: InputMaybe<UpdateInfoGroup>;
 };
 
@@ -4880,6 +4901,7 @@ export type RootMutation = {
   build: BuildMutation;
   /** Mutations that create, update, and delete Build Annotations */
   buildAnnotation: BuildAnnotationMutation;
+  deployments: DeploymentsMutation;
   /** Mutations that assign or modify DevDomainNames for apps */
   devDomainName: AppDevDomainNameMutation;
   /** Mutations for Discord users */
@@ -5636,6 +5658,7 @@ export type Update = ActivityTimelineProjectActivity & {
   insights: UpdateInsights;
   isGitWorkingTreeDirty: Scalars['Boolean']['output'];
   isRollBackToEmbedded: Scalars['Boolean']['output'];
+  jobRun?: Maybe<JobRun>;
   manifestFragment: Scalars['String']['output'];
   manifestPermalink: Scalars['String']['output'];
   message?: Maybe<Scalars['String']['output']>;

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -14,6 +14,8 @@ import {
 } from '../generated';
 import { UpdateFragmentNode } from '../types/Update';
 
+const turtleJobRunId = process.env.EAS_BUILD_ID;
+
 export const PublishMutation = {
   async getUploadURLsAsync(
     graphqlClient: ExpoGraphqlClient,
@@ -57,7 +59,12 @@ export const PublishMutation = {
             }
             ${print(UpdateFragmentNode)}
           `,
-          { publishUpdateGroupsInput }
+          {
+            publishUpdateGroupsInput: publishUpdateGroupsInput.map(input => ({
+              ...input,
+              turtleJobRunId,
+            })),
+          }
         )
         .toPromise()
     );


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We want to save the relationship between a job run and an update.

# How

See https://github.com/expo/universe/pull/15329.

# Test Plan

Tested with staging.