### PR TITLE
[eas-cli] add `--repack` flag to `eas build` command

### DIFF
--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -93,11 +93,16 @@ export async function prepareJobAsync(
     experimental: {
       prebuildCommand: buildProfile.prebuildCommand,
     },
-    mode: buildProfile.config ? BuildMode.CUSTOM : BuildMode.BUILD,
+    mode: buildProfile.config || ctx.repack ? BuildMode.CUSTOM : BuildMode.BUILD,
     triggeredBy: BuildTrigger.EAS_CLI,
     ...(maybeCustomBuildConfigPath && {
       customBuildConfig: {
         path: maybeCustomBuildConfigPath,
+      },
+    }),
+    ...(ctx.repack && {
+      customBuildConfig: {
+        path: '__eas/repack.yml',
       },
     }),
     loggerLevel: ctx.loggerLevel,

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -62,4 +62,5 @@ export interface BuildContext<T extends Platform> {
   requiredPackageManager: NodePackageManager['name'] | null;
   vcsClient: Client;
   loggerLevel?: LoggerLevel;
+  repack: boolean;
 }

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -42,6 +42,7 @@ export async function createBuildContextAsync<T extends Platform>({
   customBuildConfigMetadata,
   buildLoggerLevel,
   freezeCredentials,
+  repack,
 }: {
   buildProfileName: string;
   buildProfile: BuildProfile<T>;
@@ -62,6 +63,7 @@ export async function createBuildContextAsync<T extends Platform>({
   customBuildConfigMetadata?: CustomBuildConfigMetadata;
   buildLoggerLevel?: LoggerLevel;
   freezeCredentials: boolean;
+  repack: boolean;
 }): Promise<BuildContext<T>> {
   const { exp, projectId } = await getDynamicPrivateProjectConfigAsync({ env: buildProfile.env });
   const projectName = exp.slug;
@@ -143,6 +145,7 @@ export async function createBuildContextAsync<T extends Platform>({
     developmentClient,
     requiredPackageManager,
     loggerLevel: buildLoggerLevel,
+    repack,
   };
   if (platform === Platform.ANDROID) {
     const common = commonContext as CommonContext<Platform.ANDROID>;

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -88,11 +88,16 @@ export async function prepareJobAsync(
     experimental: {
       prebuildCommand: buildProfile.prebuildCommand,
     },
-    mode: buildProfile.config ? BuildMode.CUSTOM : BuildMode.BUILD,
+    mode: buildProfile.config || ctx.repack ? BuildMode.CUSTOM : BuildMode.BUILD,
     triggeredBy: BuildTrigger.EAS_CLI,
     ...(maybeCustomBuildConfigPath && {
       customBuildConfig: {
         path: maybeCustomBuildConfigPath,
+      },
+    }),
+    ...(ctx.repack && {
+      customBuildConfig: {
+        path: '__eas/repack.yml',
       },
     }),
     loggerLevel: ctx.loggerLevel,

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -95,6 +95,7 @@ export interface BuildFlags {
   message?: string;
   buildLoggerLevel?: LoggerLevel;
   freezeCredentials: boolean;
+  repack: boolean;
 }
 
 export async function runBuildAndSubmitAsync(
@@ -375,6 +376,7 @@ async function prepareAndStartBuildAsync({
     customBuildConfigMetadata,
     buildLoggerLevel: flags.buildLoggerLevel,
     freezeCredentials: flags.freezeCredentials,
+    repack: flags.repack,
   });
 
   if (moreBuilds) {

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -36,6 +36,7 @@ interface RawBuildFlags {
   message?: string;
   'build-logger-level'?: LoggerLevel;
   'freeze-credentials': boolean;
+  repack: boolean;
 }
 
 export default class Build extends EasCommand {
@@ -108,6 +109,11 @@ export default class Build extends EasCommand {
     'freeze-credentials': Flags.boolean({
       default: false,
       description: 'Prevent the build from updating credentials in non-interactive mode',
+    }),
+    repack: Flags.boolean({
+      default: false,
+      hidden: true,
+      description: 'Use the golden dev client build repack flow as it works for onboarding',
     }),
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -223,6 +229,7 @@ export default class Build extends EasCommand {
       message,
       buildLoggerLevel: flags['build-logger-level'],
       freezeCredentials: flags['freeze-credentials'],
+      repack: flags.repack,
     };
   }
 

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -120,6 +120,7 @@ export default class BuildInspect extends EasCommand {
               workingdir: tmpWorkingdir,
               artifactsDir: path.join(tmpWorkingdir, 'artifacts'),
             },
+            repack: false,
           },
           actor,
           getDynamicPrivateProjectConfigAsync

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -86,6 +86,7 @@ export default class BuildInternal extends EasCommand {
           localBuildMode: LocalBuildMode.INTERNAL,
         },
         submitProfile: flags['auto-submit-with-profile'] ?? flags.profile,
+        repack: false,
       },
       actor,
       getDynamicPrivateProjectConfigAsync

--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -291,6 +291,7 @@ export default class Onboarding extends EasCommand {
           autoSubmit: false,
           localBuildOptions: {},
           freezeCredentials: false,
+          repack: true,
         },
         actor,
         getDynamicProjectConfigFn


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Add the `--repack` flag to the `eas build` command. This flag is not intended to be user-facing, it's just for us to test the onboarding repack flow

# How

Add hidden `--repack` flag to `eas build` command. If the flag is used run build as custom with `__eas/repack.yml` config

# Test Plan

test manually