### PR TITLE
Remove logging of metadata file upload

### DIFF
--- a/packages/eas-cli/src/uploads.ts
+++ b/packages/eas-cli/src/uploads.ts
@@ -18,7 +18,7 @@ export async function uploadFileAtPathToGCSAsync(
   graphqlClient: ExpoGraphqlClient,
   type: UploadSessionType,
   path: string,
-  handleProgressEvent: ProgressHandler
+  handleProgressEvent: ProgressHandler = () => {}
 ): Promise<string> {
   const signedUrl = await UploadSessionMutation.createUploadSessionAsync(graphqlClient, type);
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

User doesn't need to know about metadata file, fewer log lines is better.

<img width="596" alt="image" src="https://github.com/expo/eas-cli/assets/1774298/2c7efd3b-c56b-4772-bb27-42e22a8a2b28">

# How

Removed logging of metadata operations, parallelised uploading project archive and metadata file.

# Test Plan

Tested manually.