### PR TITLE
[eas-cli] ask user for prefered `git clone` method when running `eas init:onboarding`

### DIFF
--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -143,10 +143,22 @@ export default class Onboarding extends EasCommand {
     }
     Log.log();
 
+    const { cloneMethod } = await promptAsync({
+      type: 'select',
+      message: 'Select git clone method',
+      name: 'cloneMethod',
+      choices: [
+        { title: 'SSH', value: 'ssh' },
+        { title: 'HTTPS', value: 'https' },
+      ],
+    });
+    Log.log();
+
     const { targetProjectDir: finalTargetProjectDirectory } = await runGitCloneAsync({
       githubUsername,
       githubRepositoryName,
       targetProjectDir: initialTargetProjectDirectory,
+      cloneMethod,
     });
 
     const vcsClient = new GitClient(finalTargetProjectDirectory);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Prompt user to get a preferred `git clone` method (either `https` or `ssh`)

# How

Prompt user to get a preferred `git clone` method (either `https` or `ssh`)


# Test Plan

Test manually

<img width="682" alt="Screenshot 2024-05-22 at 17 57 34" src="https://github.com/expo/eas-cli/assets/55145344/9f62e07d-93ad-4559-ac83-b8f3b7b0e4dd">

<img width="682" alt="Screenshot 2024-05-22 at 17 57 48" src="https://github.com/expo/eas-cli/assets/55145344/62e02191-bf73-4aed-812b-ca454834a51b">

<img width="682" alt="Screenshot 2024-05-22 at 17 58 07" src="https://github.com/expo/eas-cli/assets/55145344/39ef0159-8ac0-4767-b615-415eeee4fa06">

