### PR TITLE
[eas-cli] use correct app config for no gh `init:onboarding` flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Use the correct app config for no GitHub flow in `init:onboarding`. ([#2397](https://github.com/expo/eas-cli/pull/2397) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [9.1.0](https://github.com/expo/eas-cli/releases/tag/v9.1.0) - 2024-05-23

--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -449,7 +449,11 @@ async function configureProjectFromBareDefaultExpoTemplateAsync({
   );
   Log.log();
 
+  const baseExpoConfig = JSON.parse(await fs.readFile(path.join(targetDir, 'app.json'), 'utf8'))
+    .expo as ExpoConfig;
+
   const expoConfig: ExpoConfig = {
+    ...baseExpoConfig,
     name: app.name ?? app.slug,
     slug: app.slug,
     extra: {
@@ -465,9 +469,11 @@ async function configureProjectFromBareDefaultExpoTemplateAsync({
       policy: 'appVersion',
     },
     ios: {
+      ...baseExpoConfig.ios,
       bundleIdentifier,
     },
     android: {
+      ...baseExpoConfig.android,
       package: bundleIdentifier,
     },
   };


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Instead of extending and overriding some parts of the base config we just created a new, incomplete one

# How

extend and override base config from `expo-template-default` instead of creating a new incomplete one

# Test Plan

test manually
