### PR TITLE
[eas-cli] pass `cwd` to `findProjectRootAsync` in onboarding

### DIFF
--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -96,11 +96,13 @@ export async function validateOrSetProjectIdAsync({
   graphqlClient,
   actor,
   options,
+  cwd,
 }: {
   exp: ExpoConfig;
   graphqlClient: ExpoGraphqlClient;
   actor: Actor;
   options: { env?: Env; nonInteractive: boolean };
+  cwd?: string;
 }): Promise<string> {
   const localProjectId = exp.extra?.eas?.projectId;
   if (localProjectId) {
@@ -161,7 +163,9 @@ export async function validateOrSetProjectIdAsync({
     return localProjectId;
   }
 
-  const projectDir = await findProjectRootAsync();
+  const projectDir = await findProjectRootAsync({
+    cwd,
+  });
   if (!projectDir) {
     throw new Error('This command must be run inside a project directory.');
   }

--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -348,6 +348,7 @@ async function getPrivateExpoConfigWithProjectIdAsync({
     options: {
       nonInteractive: false,
     },
+    cwd: projectDir,
   });
   const exp = getPrivateExpoConfig(projectDir, options);
   return {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C06EBFAVCEA/p1716401295496209


The error Charlie got was thrown here https://github.com/expo/eas-cli/blob/c76d3dca237945e05f243c4722febae16f1f1b74/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts#L78-L91

I believe that the `cwd` was set to the wrong dir in the context of what we are doing in onboarding  and it should be the project target dir (the place where we clone the repo to)

# How

pass correct `cwd`

# Test Plan

test manually
