### PR TITLE
[eas-cli] make `init:onboarding` command public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Make `eas init:onboarding` command public. ([#2399](https://github.com/expo/eas-cli/pull/2399) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -38,11 +38,10 @@ import { easCliVersion } from '../../utils/easCli';
 import GitClient from '../../vcs/clients/git';
 
 export default class Onboarding extends EasCommand {
-  static override hidden = true;
-
   static override aliases = ['init:onboarding', 'onboarding'];
 
-  static override description = 'continue onboarding process started on the expo.dev website';
+  static override description =
+    'continue onboarding process started on the https://expo.new website.';
 
   static override flags = {};
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://expo.new is released 🎉 

let's make the `eas init:onboarding` command public ✅ 

# How

remove `hidden` property

