### PR TITLE
[ENG-12371][eas-cli] allow user to select package manager when doing onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Allow selecting package manager when doing onboarding. ([#2402](https://github.com/expo/eas-cli/pull/2402) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 - Use the correct app config for no GitHub flow in `init:onboarding`. ([#2397](https://github.com/expo/eas-cli/pull/2397) by [@szdziedzic](https://github.com/szdziedzic))

--- a/packages/eas-cli/src/onboarding/installDependencies.ts
+++ b/packages/eas-cli/src/onboarding/installDependencies.ts
@@ -1,13 +1,16 @@
+import { PackageManager } from './packageManagers';
 import { runCommandAsync } from './runCommand';
 
 export async function installDependenciesAsync({
   projectDir,
+  packageManager,
 }: {
   projectDir: string;
+  packageManager: PackageManager;
 }): Promise<void> {
   // TODO: add support for other package managers
   await runCommandAsync({
-    command: 'npm',
+    command: packageManager,
     args: ['install'],
     cwd: projectDir,
     shouldShowStderrLine: line => {

--- a/packages/eas-cli/src/onboarding/packageManagers.ts
+++ b/packages/eas-cli/src/onboarding/packageManagers.ts
@@ -1,0 +1,58 @@
+import spawnAsync from '@expo/spawn-async';
+
+export type PackageManager = 'bun' | 'yarn' | 'pnpm' | 'npm';
+
+export function getLockfileForPackageManager(packageManager: PackageManager): string {
+  switch (packageManager) {
+    case 'bun':
+      return 'bun.lockb';
+    case 'yarn':
+      return 'yarn.lock';
+    case 'pnpm':
+      return 'pnpm-lock.yaml';
+    case 'npm':
+      return 'package-lock.json';
+  }
+}
+
+export async function getAvailablePackageManagersAsync(): Promise<PackageManager[]> {
+  const availablePackageManagers: PackageManager[] = [];
+  if (await isBunAvailableAsync()) {
+    availablePackageManagers.push('bun');
+  }
+  if (await isYarnAvailableAsync()) {
+    availablePackageManagers.push('yarn');
+  }
+  if (await isPnpmAvailableAsync()) {
+    availablePackageManagers.push('pnpm');
+  }
+  availablePackageManagers.push('npm');
+  return availablePackageManagers;
+}
+
+async function isBunAvailableAsync(): Promise<boolean> {
+  try {
+    await spawnAsync('bun', ['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isYarnAvailableAsync(): Promise<boolean> {
+  try {
+    await spawnAsync('yarn', ['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isPnpmAvailableAsync(): Promise<boolean> {
+  try {
+    await spawnAsync('pnpm', ['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

allow the user to select package manager when doing onboarding

# How

allow the user to select package manager when doing onboarding

# Test Plan

<img width="571" alt="Screenshot 2024-05-29 at 10 35 02" src="https://github.com/expo/eas-cli/assets/55145344/d54ee50c-96e5-4d12-bde2-e3a5a79c3313">
<img width="573" alt="Screenshot 2024-05-29 at 10 32 04" src="https://github.com/expo/eas-cli/assets/55145344/9414e3a2-d7b4-4ef5-83fe-a072d8b7622d">

