### PR TITLE
Fix expiration date check for build list source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Use the correct app config for no GitHub flow in `init:onboarding`. ([#2397](https://github.com/expo/eas-cli/pull/2397) by [@szdziedzic](https://github.com/szdziedzic))
+- Disallow picking expired builds as submit archive source. ([#2406](https://github.com/expo/eas-cli/pull/2406) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/submit/ArchiveSource.ts
+++ b/packages/eas-cli/src/submit/ArchiveSource.ts
@@ -270,8 +270,6 @@ async function handleBuildListSourceAsync(
 ): Promise<ResolvedArchiveSource> {
   try {
     const appPlatform = toAppPlatform(ctx.platform);
-    const expiryDate = new Date(); // artifacts expire after 30 days
-    expiryDate.setDate(expiryDate.getDate() - 30);
 
     const recentBuilds = await getRecentBuildsForSubmissionAsync(
       ctx.graphqlClient,
@@ -294,7 +292,7 @@ async function handleBuildListSourceAsync(
       });
     }
 
-    if (recentBuilds.every(it => new Date(it.updatedAt) < expiryDate)) {
+    if (recentBuilds.every(it => new Date(it.expirationDate) <= new Date())) {
       Log.error(
         chalk.bold(
           'It looks like all of your build artifacts have expired. ' +
@@ -306,7 +304,7 @@ async function handleBuildListSourceAsync(
       });
     }
 
-    const choices = recentBuilds.map(build => formatBuildChoice(build, expiryDate));
+    const choices = recentBuilds.map(build => formatBuildChoice(build));
     choices.push({
       title: 'None of the above (select another option)',
       value: null,
@@ -336,7 +334,7 @@ async function handleBuildListSourceAsync(
   }
 }
 
-function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choice {
+function formatBuildChoice(build: BuildFragment): prompts.Choice {
   const {
     id,
     updatedAt,
@@ -380,7 +378,7 @@ function formatBuildChoice(build: BuildFragment, expiryDate: Date): prompts.Choi
     title,
     description: filteredDescriptionArray.length > 0 ? filteredDescriptionArray.join('\n') : '',
     value: build,
-    disabled: buildDate < expiryDate,
+    disabled: new Date(build.expirationDate) < new Date(),
   };
 }
 

--- a/packages/eas-cli/src/submit/__tests__/ArchiveSource-test.ts
+++ b/packages/eas-cli/src/submit/__tests__/ArchiveSource-test.ts
@@ -273,7 +273,9 @@ describe(getArchiveAsync, () => {
     jest.mocked(getRecentBuildsForSubmissionAsync).mockResolvedValueOnce([
       {
         ...MOCK_BUILD_FRAGMENT,
-        updatedAt: new Date(Date.now() - 31 * 24 * 3600 * 1000),
+        // We're setting expirationDate to be in the past,
+        // because we want to build to appear expired.
+        expirationDate: new Date(Date.now() - 31 * 24 * 3600 * 1000),
       } as BuildFragment,
     ]);
     jest


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The check for build expiration was wrong.

# How

Instead of relying on an old hardcoded value, use `expirationDate` fetched from GraphQL.

# Test Plan

Adjusted tests. Also tested manually:
<img width="449" alt="Zrzut ekranu 2024-06-4 o 11 33 06" src="https://github.com/expo/eas-cli/assets/1151041/c7706ae2-8201-464f-ae3b-817b553faa1b">

```
43f278b2-3257-49c6-9c01-615a3f958f27	2023-07-20 14:36:18.021724+00
5167ab23-3913-4741-8e08-db75c9c420ab	2024-07-26 19:54:01.386308+00
f73eec2a-3936-40e3-9504-1cb4ebb29e12	2024-04-27 15:25:24.338+00
```

