### PR TITLE
[eas-cli] print network error message if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Print network error message if present. ([#2407](https://github.com/expo/eas-cli/pull/2407) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [9.1.0](https://github.com/expo/eas-cli/releases/tag/v9.1.0) - 2024-05-23
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -201,7 +201,7 @@ export default abstract class EasCommand extends Command {
     if (err instanceof EasCommandError) {
       Log.error(err.message);
     } else if (err instanceof CombinedError && err?.graphQLErrors) {
-      const cleanMessage = err?.graphQLErrors
+      const cleanGQLErrorsMessage = err?.graphQLErrors
         .map((graphQLError: GraphQLError) => {
           const messageLine = graphQLError.message.replace('[GraphQL] ', '');
           const requestIdLine = graphQLError.extensions?.requestId
@@ -223,6 +223,9 @@ export default abstract class EasCommand extends Command {
           return defaultMsg;
         })
         .join('\n');
+      const cleanMessage = err.networkError
+        ? `${cleanGQLErrorsMessage}\n${err.networkError.message}`
+        : cleanGQLErrorsMessage;
       Log.error(cleanMessage);
       baseMessage = BASE_GRAPHQL_ERROR_MESSAGE;
     } else {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I noticed that we don't print any error logs if `CombinedError` has an empty `graphQLErrors` array and contains only `networkError`

https://exponent-internal.slack.com/archives/C017N0N99RA/p1717071253573369

# How

Print network error message if present

