### PR TITLE
[eas-cli] display build profile in `eas build:list` command details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Display build profile in the output of `eas build:list`. ([#2408](https://github.com/expo/eas-cli/pull/2408) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 - Use the correct app config for no GitHub flow in `init:onboarding`. ([#2397](https://github.com/expo/eas-cli/pull/2397) by [@szdziedzic](https://github.com/szdziedzic))

--- a/packages/eas-cli/src/build/utils/formatBuild.ts
+++ b/packages/eas-cli/src/build/utils/formatBuild.ts
@@ -40,6 +40,10 @@ export function formatGraphQLBuild(build: BuildFragment): string {
       },
     },
     {
+      label: 'Profile',
+      value: build.buildProfile,
+    },
+    {
       label: 'Message',
       value: build.message,
     },


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When looking at https://github.com/expo/eas-cli/issues/2404 I noticed that we don't display build profile info in this list, yet we allow people to filter by it which makes it confusing

# How

Display build profile info as well

# Test Plan

test manually
