### PR TITLE
fix: update lockfile to only include `@types/node@20.11.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Update lockfile to only include `@types/node@20.11.0`. ([#2412](https://github.com/expo/eas-cli/pull/2412) by [@byCedric](https://github.com/byCedric))
+
 ## [9.2.0](https://github.com/expo/eas-cli/releases/tag/v9.2.0) - 2024-06-06
 
 ### 🎉 New features

--- a/yarn.lock
+++ b/yarn.lock
@@ -3853,12 +3853,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>= 8":
-  version "14.0.27"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
-  integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
-
-"@types/node@20.11.0":
+"@types/node@*", "@types/node@20.11.0", "@types/node@>= 8":
   version "20.11.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.0.tgz#8e0b99e70c0c1ade1a86c4a282f7b7ef87c9552f"
   integrity sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==


### PR DESCRIPTION
# Why

Running `yarn typecheck` in **packages/eas-cli** fails due to outdated `@types/node` being used. 

This is caused because our lockfile resolves to the outdated node types.
- Some libraries are using `dependencies: @types/node: *`, which is ok
- Our lockfile resolves `@types/node@*` to `14.0.27`, which is not ok

# How

- Update `@types/node` in our lockfile to only contain `20.11.0`

# Test Plan

Run this before changing anything:
- `$ node --print "require('@types/node/package.json').version"`
- Should print `14.0.27`, which is not correct

After pulling this PR:
- `$ yarn install --frozen-lockfile`
- `$ cd packages/eas-cli`
- `$ yarn typecheck` (should pass)
- `$ node --print "require('@types/node/package.json').version"` (should print `20.11.0`)
