### PR TITLE
chore!: drop support for Node 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['16', '18', '20']
+        node: ['18', '20', '22']
         include:
           - node: '20'
             coverage: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Drop support for Node 16. ([#2413](https://github.com/expo/eas-cli/pull/2413) by [@byCedric](https://github.com/byCedric))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Update test workflow Node versions to 18, 20, and 22. ([#2413](https://github.com/expo/eas-cli/pull/2413) by [@byCedric](https://github.com/byCedric))
+
 ## [9.2.0](https://github.com/expo/eas-cli/releases/tag/v9.2.0) - 2024-06-06
 
 ### 🎉 New features

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -121,7 +121,7 @@
     "typescript": "5.3.3"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "/bin",

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -25,7 +25,7 @@
     "typescript": "5.3.3"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "homepage": "https://github.com/expo/eas-cli",
   "license": "MIT",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,7 +15,7 @@
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "chalk": "5.2.0",


### PR DESCRIPTION
# Why

- Node 16 is End Of Life (EOL)
- Node 18 is currently in maintenance LTS
- Node 20 is currently in active LTS
- Node 22 is scheduled to take active LTS status on **2024-10-29**

> Source: https://nodejs.org/en/about/previous-releases

To support Node 22, we'd need to remove `node-fetch`. Starting from Node 18, we can use the built-in fetch which is based on `undici`. Unfortunately, we still need the `undici` package to maintain support for `https_proxy` functionality through `ProxyAgent`.

Dropping support for Node 16 helps in this transition, and matches our other tooling support (which is LTS+ - both maintenance and active LTS versions).

# How

- Removed Node 16 from workflow
- Added Node 22 to workflow

# Test Plan

See GitHub Actions.
