### PR TITLE
refactor(eas-cli): use built-in Node fetch instead of undici

### DIFF
--- a/packages/eas-cli/__mocks__/undici.ts
+++ b/packages/eas-cli/__mocks__/undici.ts
@@ -1,7 +1,0 @@
-const undici = require('undici');
-
-// This workaround swaps `undici.fetch` for `global.fetch` to connect Nock with Undici.
-// See: https://github.com/nock/nock/issues/2183
-require('nock');
-
-module.exports = { ...undici, fetch: global.fetch };

--- a/packages/eas-cli/src/fetch.ts
+++ b/packages/eas-cli/src/fetch.ts
@@ -1,15 +1,11 @@
 import { env } from 'node:process';
-import {
-  ProxyAgent,
-  type RequestInfo,
-  type RequestInit,
-  type Response,
-  fetch,
-  getGlobalDispatcher,
-  setGlobalDispatcher,
-} from 'undici';
+import { ProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
 
-export { Agent, Headers, type RequestInfo, type RequestInit, Response } from 'undici';
+// Re-export the fetch-related Node globals
+export type RequestInfo = globalThis.RequestInfo;
+export type RequestInit = globalThis.RequestInit;
+export type Response = globalThis.Response;
+export const Headers = globalThis.Headers;
 
 export class RequestError extends Error {
   constructor(


### PR DESCRIPTION
# Why

This is a follow-up PR of #2414, to try and fall-back to the built-in Node `fetch` support as much as possible. This is an attempt, as likely more things will pop up that require refactoring.

# How

- Re-exported Node `fetch` globals instead from `undici`
- TBD

# Test Plan

See GitHub Actions, and manual testing (everything)