### PR TITLE
chore: bump minimum required Node version to `18.13.0`

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -121,7 +121,7 @@
     "typescript": "5.3.3"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.13.0"
   },
   "files": [
     "/bin",

--- a/packages/eas-json/package.json
+++ b/packages/eas-json/package.json
@@ -25,7 +25,7 @@
     "typescript": "5.3.3"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.13.0"
   },
   "homepage": "https://github.com/expo/eas-cli",
   "license": "MIT",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,7 +15,7 @@
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.13.0"
   },
   "dependencies": {
     "chalk": "5.2.0",


### PR DESCRIPTION
# Why

This version includes the `File` primitive that might be required for FormData and large file uploads.

See: https://nodejs.org/en/blog/release/v18.13.0#introduce-file
See: https://github.com/expo/eas-cli/pull/2414#discussion_r1634640527

# How

Bumped all `engines: node: >=18.0.0` to `engines: node: >=18.13.0`

# Test Plan

Only a package change.
