### PR TITLE
[eas-cli] resolve correct submit profile configuration for `eas build --auto-submit-with-profile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Resolve correct submit profile configuration for `eas build` command with `--auto-submit-with-profile` flag. ([#2425](https://github.com/expo/eas-cli/pull/2425) by [@szdziedzic](https://github.com/szdziedzic))
 - Correctly parse the EXPO_APPLE_PROVIER_ID environment variable. ([#2349](https://github.com/expo/eas-cli/pull/2349) by [@louix](https://github.com/louix))
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -258,6 +258,7 @@ export async function runBuildAndSubmitAsync(
         buildProfile: startedBuild.buildProfile.profile,
         submitProfile,
         nonInteractive: flags.nonInteractive,
+        selectedSubmitProfileName: flags.submitProfile,
       });
       startedBuild.build = await BuildQuery.withSubmissionsByIdAsync(
         graphqlClient,
@@ -453,6 +454,7 @@ async function prepareAndStartSubmissionAsync({
   projectDir,
   buildProfile,
   submitProfile,
+  selectedSubmitProfileName,
   nonInteractive,
 }: {
   build: BuildFragment;
@@ -461,6 +463,7 @@ async function prepareAndStartSubmissionAsync({
   projectDir: string;
   buildProfile: BuildProfile;
   submitProfile: SubmitProfile;
+  selectedSubmitProfileName?: string;
   nonInteractive: boolean;
 }): Promise<SubmissionFragment> {
   const platform = toPlatform(build.platform);
@@ -480,6 +483,7 @@ async function prepareAndStartSubmissionAsync({
     exp: buildCtx.exp,
     vcsClient: buildCtx.vcsClient,
     isVerboseFastlaneEnabled: false,
+    specifiedProfile: selectedSubmitProfileName,
   });
 
   if (moreBuilds) {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

In https://github.com/expo/eas-cli/pull/2101 we added a logic to refresh the submit profile with the new submit profile with `submit profile name === build profile name` (if it exists) unless the `submissionCtx.specifiedProfile` value is set.

However, we didn't set the `submissionCtx.specifiedProfile` for submissions triggered via `eas build --auto-submit` and this caused us to always refresh the submit profile with the submit profile with the name of the build profile.

https://github.com/expo/eas-cli/blob/daf3ed83f8471e75bbce968cf7c40f89086d856d/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts#L45-L47

It's also the root cause of https://exponent-internal.slack.com/archives/C02123T524U/p1718015524335999 issue

# How

Set `submissionCtx.specifiedProfile` for submission triggered by the `eas build --auto-submit-with-profile` command.

# Test Plan

test manually
