### PR TITLE
Add eas `env:push` and `env:pull` commands

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -10260,7 +10260,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "String",
+                    "name": "WorkerDeploymentIdentifier",
                     "ofType": null
                   }
                 },
@@ -10286,7 +10286,7 @@
                 "description": null,
                 "type": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "WorkerDeploymentIdentifier",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -10501,6 +10501,51 @@
             "type": {
               "kind": "OBJECT",
               "name": "WorkerDeploymentMetrics",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerDeploymentsRequests",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "RequestsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentRequests",
               "ofType": null
             },
             "isDeprecated": false,
@@ -21391,6 +21436,65 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "ContinentCode",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "AF",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "AN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "AS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EU",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "T1",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "CrashesTimespan",
         "description": null,
@@ -22689,7 +22793,7 @@
                 "description": null,
                 "type": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "WorkerDeploymentIdentifier",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -22932,7 +23036,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "String",
+              "name": "WorkerDeploymentIdentifier",
               "ofType": null
             },
             "isDeprecated": false,
@@ -24219,7 +24323,7 @@
                 "description": null,
                 "type": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "WorkerDeploymentIdentifier",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -24325,7 +24429,7 @@
                 "description": null,
                 "type": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "WorkerDeploymentIdentifier",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -33247,13 +33351,9 @@
                 "name": "otp",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -33412,13 +33512,9 @@
                 "name": "otp",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -33494,13 +33590,9 @@
                 "name": "otp",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -33629,13 +33721,9 @@
                 "name": "otp",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -35898,6 +35986,45 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "UpdateInfoGroup",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestsTimespan",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "end",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "defaultValue": null,
@@ -40743,6 +40870,18 @@
             "deprecationReason": null
           },
           {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "SubmissionPriority",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "status",
             "description": null,
             "args": [],
@@ -41182,6 +41321,29 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SubmissionPriority",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "HIGH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NORMAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -47980,7 +48142,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "WorkerDeploymentIdentifier",
                 "ofType": null
               }
             },
@@ -48138,7 +48300,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "String",
+              "name": "WorkerDeploymentIdentifier",
               "ofType": null
             },
             "isDeprecated": false,
@@ -48573,6 +48735,16 @@
         "possibleTypes": null
       },
       {
+        "kind": "SCALAR",
+        "name": "WorkerDeploymentIdentifier",
+        "description": "A alias name for a serverless deployment",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "WorkerDeploymentLogLevel",
         "description": null,
@@ -48943,6 +49115,199 @@
                 "kind": "OBJECT",
                 "name": "WorkerDeployment",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestLocation",
+        "description": null,
+        "fields": [
+          {
+            "name": "continent",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "ContinentCode",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "regionCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestNode",
+        "description": null,
+        "fields": [
+          {
+            "name": "location",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentRequestLocation",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "method",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pathname",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "search",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequests",
+        "description": null,
+        "fields": [
+          {
+            "name": "minRowsWithoutLimit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestNode",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,

--- a/packages/eas-cli/src/authUtils.ts
+++ b/packages/eas-cli/src/authUtils.ts
@@ -1,0 +1,21 @@
+import SessionManager from './user/SessionManager';
+
+// Handle the case where a user needs to be in sudo mode to perform an action.
+export async function handleSudoCallAsync<T>(
+  sessionManager: SessionManager,
+  fn: () => Promise<T>
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error: any) {
+    const isSudoError = error.graphQLErrors?.some(
+      (err: { extensions: { errorCode: string } }) =>
+        err?.extensions?.errorCode === 'SUDO_MODE_REQUIRED'
+    );
+    if (!isSudoError) {
+      throw error;
+    }
+    await sessionManager.showSudoPromptAsync({ sso: false });
+    return await fn();
+  }
+}

--- a/packages/eas-cli/src/authUtils.ts
+++ b/packages/eas-cli/src/authUtils.ts
@@ -1,12 +1,12 @@
 import SessionManager from './user/SessionManager';
 
 // Handle the case where a user needs to be in sudo mode to perform an action.
-export async function handleSudoCallAsync<T>(
+export async function withSudoModeAsync<T>(
   sessionManager: SessionManager,
-  fn: () => Promise<T>
+  graphqlQuery: () => Promise<T>
 ): Promise<T> {
   try {
-    return await fn();
+    return await graphqlQuery();
   } catch (error: any) {
     const isSudoError = error.graphQLErrors?.some(
       (err: { extensions: { errorCode: string } }) =>
@@ -16,6 +16,6 @@ export async function handleSudoCallAsync<T>(
       throw error;
     }
     await sessionManager.showSudoPromptAsync({ sso: false });
-    return await fn();
+    return await graphqlQuery();
   }
 }

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -116,8 +116,7 @@ export default class EnvironmentVariableCreate extends EasCommand {
       }
       const { appVariables: existingVariables } = await EnvironmentVariablesQuery.byAppIdAsync(
         graphqlClient,
-        projectId,
-        environment
+        { appId: projectId, environment }
       );
       const existingVariable = existingVariables.find(variable => variable.name === name);
 
@@ -189,7 +188,9 @@ export default class EnvironmentVariableCreate extends EasCommand {
         `Created a new variable ${chalk.bold(name)} on project ${chalk.bold(projectDisplayName)}.`
       );
     } else if (scope === EnvironmentVariableScope.Shared) {
-      const sharedVariables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, projectId);
+      const sharedVariables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, {
+        appId: projectId,
+      });
       const existingVariable = sharedVariables.find(variable => variable.name === name);
       if (existingVariable) {
         throw new Error(

--- a/packages/eas-cli/src/commands/env/delete.ts
+++ b/packages/eas-cli/src/commands/env/delete.ts
@@ -58,9 +58,13 @@ export default class EnvironmentVariableDelete extends EasCommand {
 
     const variables =
       scope === EnvironmentVariableScope.Project && environment
-        ? (await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, projectId, environment))
-            .appVariables
-        : await EnvironmentVariablesQuery.sharedAsync(graphqlClient, projectId);
+        ? (
+            await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
+              appId: projectId,
+              environment,
+            })
+          ).appVariables
+        : await EnvironmentVariablesQuery.sharedAsync(graphqlClient, { appId: projectId });
 
     if (!name) {
       ({ name } = await promptAsync({

--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -130,19 +130,19 @@ async function getVariableAsync(
     throw new Error('Environment is required.');
   }
   if (environment && scope === EnvironmentVariableScope.Project) {
-    const { appVariables } = await EnvironmentVariablesQuery.byAppIdAsync(
-      graphqlClient,
-      projectId,
+    const { appVariables } = await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
+      appId: projectId,
       environment,
-      [name]
-    );
+      filterNames: [name],
+    });
     return appVariables[0];
   }
 
   if (scope === EnvironmentVariableScope.Shared) {
-    const sharedVariables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, projectId, [
-      name,
-    ]);
+    const sharedVariables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, {
+      appId: projectId,
+      filterNames: [name],
+    });
     return sharedVariables[0];
   }
 

--- a/packages/eas-cli/src/commands/env/link.ts
+++ b/packages/eas-cli/src/commands/env/link.ts
@@ -40,7 +40,9 @@ export default class EnvironmentVariableLink extends EasCommand {
     });
 
     const projectDisplayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
-    const variables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, projectId);
+    const variables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, {
+      appId: projectId,
+    });
 
     if (!name) {
       name = await selectAsync(

--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -45,9 +45,13 @@ export default class EnvironmentValueList extends EasCommand {
 
     const variables =
       scope === EnvironmentVariableScope.Project && environment
-        ? (await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, projectId, environment))
-            .appVariables
-        : await EnvironmentVariablesQuery.sharedAsync(graphqlClient, projectId);
+        ? (
+            await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
+              appId: projectId,
+              environment,
+            })
+          ).appVariables
+        : await EnvironmentVariablesQuery.sharedAsync(graphqlClient, { appId: projectId });
 
     if (format === 'short') {
       for (const variable of variables) {

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core';
-import assert from 'assert';
 import fs from 'fs-extra';
 
 import { withSudoModeAsync } from '../../authUtils';
@@ -47,8 +46,6 @@ export default class EnvironmentValuePull extends EasCommand {
       'non-interactive': nonInteractive,
     } = this.validateFlags(flags);
 
-    assert(environment);
-
     const {
       privateProjectConfig: { projectId },
       loggedIn: { graphqlClient },
@@ -79,8 +76,10 @@ export default class EnvironmentValuePull extends EasCommand {
     const filePrefix = `# Environment: ${environment}\n\n`;
 
     const envFileContent = environmentVariables
-      .filter((variable: EnvironmentVariableFragment) => !!variable.value)
       .map((variable: EnvironmentVariableFragment) => {
+        if (variable.value === null) {
+          return `# ${variable.name}=***** (secret variables are not available for reading)`;
+        }
         return `${variable.name}=${variable.value}`;
       })
       .join('\n');
@@ -90,10 +89,10 @@ export default class EnvironmentValuePull extends EasCommand {
     Log.log(`Pulled environment variables from ${environment} environment to ${targetPath}.`);
   }
 
-  private validateFlags(flags: PullFlags): PullFlags {
+  private validateFlags(flags: PullFlags): Required<PullFlags> {
     if (!flags.environment) {
       throw new Error('Please provide an environment to pull the env file from.');
     }
-    return flags;
+    return { ...flags, environment: flags.environment };
   }
 }

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -1,0 +1,74 @@
+import { Flags } from '@oclif/core';
+import fs from 'fs-extra';
+
+import { handleSudoCallAsync } from '../../authUtils';
+import EasCommand from '../../commandUtils/EasCommand';
+import { EASEnvironmentFlag } from '../../commandUtils/flags';
+import { EnvironmentVariableFragment } from '../../graphql/generated';
+import { EnvironmentVariablesQuery } from '../../graphql/queries/EnvironmentVariablesQuery';
+import Log from '../../log';
+import { confirmAsync } from '../../prompts';
+
+export default class EnvironmentValuePull extends EasCommand {
+  static override description = 'pull env file';
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+    ...this.ContextOptions.SessionManagment,
+  };
+
+  static override flags = {
+    ...EASEnvironmentFlag,
+    path: Flags.string({
+      description: 'Path to save the env file',
+      default: '.env.local',
+    }),
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      flags: { environment, path: targetPath },
+    } = await this.parse(EnvironmentValuePull);
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+      sessionManager,
+    } = await this.getContextAsync(EnvironmentValuePull, {
+      nonInteractive: true,
+    });
+
+    if (!environment) {
+      throw new Error('Please provide an environment to pull the env file from.');
+    }
+
+    const { appVariables: environmentVariables } = await handleSudoCallAsync(sessionManager, () =>
+      EnvironmentVariablesQuery.byAppIdWithSensitiveAsync(graphqlClient, {
+        appId: projectId,
+        environment,
+      })
+    );
+
+    if (await fs.exists(targetPath)) {
+      const result = await confirmAsync({
+        message: `File ${targetPath} already exists. Do you want to overwrite it?`,
+      });
+      if (!result) {
+        Log.log('Aborting...');
+        return;
+      }
+    }
+
+    const filePrefix = `# Environment: ${environment}\n\n`;
+
+    const envFileContent = environmentVariables
+      .map((variable: EnvironmentVariableFragment) => {
+        return `${variable.name}=${variable.value}`;
+      })
+      .join('\n');
+
+    await fs.writeFile(targetPath, filePrefix + envFileContent);
+
+    Log.log(`Pull env file from ${environment} environment to ${targetPath}.`);
+  }
+}

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -1,0 +1,176 @@
+import { Flags } from '@oclif/core';
+import fs from 'fs-extra';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { EASEnvironmentFlag } from '../../commandUtils/flags';
+import {
+  EnvironmentVariableFragment,
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+} from '../../graphql/generated';
+import {
+  EnvironmentVariableMutation,
+  EnvironmentVariablePushInput,
+} from '../../graphql/mutations/EnvironmentVariableMutation';
+import { EnvironmentVariablesQuery } from '../../graphql/queries/EnvironmentVariablesQuery';
+import Log from '../../log';
+import { promptAsync } from '../../prompts';
+
+export default class EnvironmentValuePush extends EasCommand {
+  static override description = 'push env file';
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  static override flags = {
+    ...EASEnvironmentFlag,
+    path: Flags.string({
+      description: 'Path to the env file',
+      default: '.env.local',
+    }),
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      flags: { environment, path: envPath },
+    } = await this.parse(EnvironmentValuePush);
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(EnvironmentValuePush, {
+      nonInteractive: true,
+    });
+
+    if (!environment) {
+      throw new Error('Please provide an environment to push the env file to.');
+    }
+
+    const updateVariables: Record<string, EnvironmentVariablePushInput> =
+      await this.parseEnvFileAsync(envPath, environment);
+
+    const variableNames = Object.keys(updateVariables);
+
+    const { appVariables: existingVariables } = await EnvironmentVariablesQuery.byAppIdAsync(
+      graphqlClient,
+      { appId: projectId, environment, filterNames: variableNames }
+    );
+
+    // Check if any of the variables already exist in the environment. Prompt the user to overwrite them.
+    const existingSensitiveVariables = existingVariables.filter(
+      variable => variable.value === null
+    );
+
+    if (existingSensitiveVariables.length > 0) {
+      const existingSensitiveVariablesNames = existingSensitiveVariables.map(
+        variable => variable.name
+      );
+      Log.log(
+        'Sensitive variables cannot be overwritten with `push` command.\nUse `eas env:update` to change them:'
+      );
+      existingSensitiveVariablesNames.forEach(name => Log.log(`- ${name}`));
+    }
+
+    const existingDifferentVariables: EnvironmentVariableFragment[] = [];
+    // Remove variables that are the same as the ones in the environment or sensitive.
+    existingVariables.forEach(variable => {
+      const existingVariableUpdate = updateVariables[variable.name];
+      if (
+        existingVariableUpdate &&
+        existingVariableUpdate.value !== variable.value &&
+        variable.value !== null
+      ) {
+        existingDifferentVariables.push(variable);
+      } else {
+        delete updateVariables[variable.name];
+      }
+    });
+
+    const existingDifferentSharedVariables = existingDifferentVariables.filter(
+      variable => variable.scope === EnvironmentVariableScope.Shared
+    );
+
+    if (existingDifferentSharedVariables.length > 0) {
+      const existingDifferentSharedVariablesNames = existingDifferentSharedVariables.map(
+        variable => variable.name
+      );
+      Log.error(
+        'Shared variables cannot be overwritten.\nPlease remove them from the env file or unlink them from the project:'
+      );
+      existingDifferentSharedVariablesNames.forEach(name => Log.error(`- ${name}`));
+      return;
+    }
+
+    if (existingDifferentVariables.length > 0) {
+      Log.warn('Some variables already exist in the environment.');
+
+      const { variablesToOverwrite } = await promptAsync({
+        type: 'multiselect',
+        name: 'variablesToOverwrite',
+        message: 'Select variables to overwrite:',
+        // @ts-expect-error property missing from `@types/prompts`
+        optionsPerPage: 20,
+        choices: existingDifferentVariables.map(variable => ({
+          title: `${variable.name}: ${updateVariables[variable.name].value}`,
+          value: variable.name,
+        })),
+      });
+
+      for (const existingVariable of existingVariables) {
+        const name = existingVariable.name;
+        if (variablesToOverwrite.includes(name)) {
+          updateVariables[name]['overwrite'] = true;
+        } else {
+          delete updateVariables[name];
+        }
+      }
+    }
+
+    const variablesToPush = Object.values(updateVariables);
+
+    if (variablesToPush.length === 0) {
+      Log.log('No new variables to push.');
+      return;
+    }
+
+    await EnvironmentVariableMutation.createBulkEnvironmentVariablesForAppAsync(
+      graphqlClient,
+      variablesToPush,
+      projectId
+    );
+
+    Log.log(`Uploaded env file to ${environment} environment.`);
+  }
+
+  private async parseEnvFileAsync(
+    envPath: string,
+    environment: string
+  ): Promise<Record<string, EnvironmentVariablePushInput>> {
+    if (!(await fs.exists(envPath))) {
+      throw new Error(`File ${envPath} does not exist.`);
+    }
+    const variables: Record<string, EnvironmentVariablePushInput> = {};
+    const content = await fs.readFile(envPath, 'utf8');
+
+    content
+      .trim()
+      .split('\n')
+      .filter(line => !line.startsWith('#') && line.includes('='))
+      .forEach(line => {
+        const [name, value] = line.split('=');
+        if (name && value && name.match(/^\w+$/)) {
+          const visibility = name.startsWith('EXPO_SECRET')
+            ? EnvironmentVariableVisibility.Sensitive
+            : EnvironmentVariableVisibility.Public;
+          variables[name] = {
+            name,
+            value,
+            environment,
+            visibility,
+          };
+        }
+      });
+    return variables;
+  }
+}

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core';
-import assert from 'assert';
 import dotenv from 'dotenv';
 import fs from 'fs-extra';
 
@@ -50,10 +49,8 @@ export default class EnvironmentValuePush extends EasCommand {
       privateProjectConfig: { projectId },
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentValuePush, {
-      nonInteractive: true,
+      nonInteractive: false,
     });
-
-    assert(environment);
 
     const updateVariables: Record<string, EnvironmentVariablePushInput> =
       await this.parseEnvFileAsync(envPath, environment);
@@ -84,7 +81,7 @@ export default class EnvironmentValuePush extends EasCommand {
       const existingDifferentSharedVariablesNames = existingDifferentSharedVariables.map(
         variable => variable.name
       );
-      Log.error('Shared variables cannot be overwritten.');
+      Log.error('Shared variables cannot be overwritten by eas env:push command.');
       Log.error('Remove them from the env file or unlink them from the project to continue:');
       existingDifferentSharedVariablesNames.forEach(name => Log.error(`- ${name}`));
       throw new Error('Shared variables cannot be overwritten by eas env:push command');
@@ -122,7 +119,7 @@ export default class EnvironmentValuePush extends EasCommand {
           optionsPerPage: 20,
           choices: existingDifferentVariables.map(variable => ({
             title: `${variable.name}: ${updateVariables[variable.name].value} (was ${
-              variable.value
+              variable.value ?? '(secret)'
             })`,
             value: variable.name,
           })),
@@ -200,11 +197,11 @@ export default class EnvironmentValuePush extends EasCommand {
     return pushInput;
   }
 
-  private validateFlags(flags: PushFlags): PushFlags {
+  private validateFlags(flags: PushFlags): Required<PushFlags> {
     if (!flags.environment) {
       throw new Error('Please provide an environment to push the env file to.');
     }
 
-    return flags;
+    return { ...flags, environment: flags.environment };
   }
 }

--- a/packages/eas-cli/src/commands/env/unlink.ts
+++ b/packages/eas-cli/src/commands/env/unlink.ts
@@ -46,10 +46,10 @@ export default class EnvironmentVariableUnlink extends EasCommand {
 
     const projectDisplayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
 
-    const { appVariables } = await EnvironmentVariablesQuery.byAppIdAsync(
-      graphqlClient,
-      { appId: projectId, environment }
-    );
+    const { appVariables } = await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
+      appId: projectId,
+      environment,
+    });
     const linkedVariables = appVariables.filter(
       ({ scope }) => scope === EnvironmentVariableScope.Shared
     );

--- a/packages/eas-cli/src/commands/env/unlink.ts
+++ b/packages/eas-cli/src/commands/env/unlink.ts
@@ -48,8 +48,7 @@ export default class EnvironmentVariableUnlink extends EasCommand {
 
     const { appVariables } = await EnvironmentVariablesQuery.byAppIdAsync(
       graphqlClient,
-      projectId,
-      environment
+      { appId: projectId, environment }
     );
     const linkedVariables = appVariables.filter(
       ({ scope }) => scope === EnvironmentVariableScope.Shared

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -77,8 +77,7 @@ export default class EnvironmentVariableUpdate extends EasCommand {
       }
       const { appVariables: existingVariables } = await EnvironmentVariablesQuery.byAppIdAsync(
         graphqlClient,
-        projectId,
-        environment
+        { appId: projectId, environment }
       );
       if (!name) {
         name = await selectAsync(
@@ -131,7 +130,9 @@ export default class EnvironmentVariableUpdate extends EasCommand {
         )}.`
       );
     } else if (scope === EnvironmentVariableScope.Shared) {
-      const sharedVariables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, projectId);
+      const sharedVariables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, {
+        appId: projectId,
+      });
 
       if (!name) {
         name = await selectAsync(

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -23,6 +23,7 @@ export type Scalars = {
   DevDomainName: { input: any; output: any; }
   JSON: { input: any; output: any; }
   JSONObject: { input: any; output: any; }
+  WorkerDeploymentIdentifier: { input: any; output: any; }
 };
 
 export type AcceptUserInvitationResult = {
@@ -1352,6 +1353,7 @@ export type App = Project & {
   workerDeployments: WorkerDeploymentsConnection;
   workerDeploymentsCrashes?: Maybe<WorkerDeploymentCrashes>;
   workerDeploymentsMetrics?: Maybe<WorkerDeploymentMetrics>;
+  workerDeploymentsRequests?: Maybe<WorkerDeploymentRequests>;
 };
 
 
@@ -1570,13 +1572,13 @@ export type AppWebhooksArgs = {
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentArgs = {
-  deploymentIdentifier: Scalars['String']['input'];
+  deploymentIdentifier: Scalars['WorkerDeploymentIdentifier']['input'];
 };
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentAliasArgs = {
-  aliasName?: InputMaybe<Scalars['String']['input']>;
+  aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
 };
 
 
@@ -1608,6 +1610,13 @@ export type AppWorkerDeploymentsCrashesArgs = {
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentsMetricsArgs = {
   timespan: MetricsTimespan;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkerDeploymentsRequestsArgs = {
+  limit?: Scalars['Int']['input'];
+  timespan: RequestsTimespan;
 };
 
 export type AppBranchEdge = {
@@ -3146,6 +3155,17 @@ export type Concurrencies = {
   total: Scalars['Int']['output'];
 };
 
+export enum ContinentCode {
+  Af = 'AF',
+  An = 'AN',
+  As = 'AS',
+  Eu = 'EU',
+  Na = 'NA',
+  Oc = 'OC',
+  Sa = 'SA',
+  T1 = 'T1'
+}
+
 export type CrashesTimespan = {
   end: Scalars['DateTime']['input'];
   start?: InputMaybe<Scalars['DateTime']['input']>;
@@ -3308,7 +3328,7 @@ export type CustomDomainMutationRefreshCustomDomainArgs = {
 
 
 export type CustomDomainMutationRegisterCustomDomainArgs = {
-  aliasName?: InputMaybe<Scalars['String']['input']>;
+  aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
   appId: Scalars['ID']['input'];
   hostname: Scalars['String']['input'];
 };
@@ -3345,7 +3365,7 @@ export type DeleteAccountSsoConfigurationResult = {
 
 export type DeleteAliasResult = {
   __typename?: 'DeleteAliasResult';
-  aliasName?: Maybe<Scalars['String']['output']>;
+  aliasName?: Maybe<Scalars['WorkerDeploymentIdentifier']['output']>;
   id: Scalars['ID']['output'];
 };
 
@@ -3562,7 +3582,7 @@ export type DeploymentsMutation = {
 
 
 export type DeploymentsMutationAssignAliasArgs = {
-  aliasName?: InputMaybe<Scalars['String']['input']>;
+  aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
   appId: Scalars['ID']['input'];
   deploymentIdentifier: Scalars['ID']['input'];
 };
@@ -3575,7 +3595,7 @@ export type DeploymentsMutationCreateSignedDeploymentUrlArgs = {
 
 
 export type DeploymentsMutationDeleteAliasArgs = {
-  aliasName?: InputMaybe<Scalars['String']['input']>;
+  aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
   appId: Scalars['ID']['input'];
 };
 
@@ -4851,7 +4871,7 @@ export type MeMutation = {
 
 export type MeMutationAddSecondFactorDeviceArgs = {
   deviceConfiguration: SecondFactorDeviceConfiguration;
-  otp: Scalars['String']['input'];
+  otp?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -4876,7 +4896,7 @@ export type MeMutationDeleteSsoUserArgs = {
 
 
 export type MeMutationDeleteSecondFactorDeviceArgs = {
-  otp: Scalars['String']['input'];
+  otp?: InputMaybe<Scalars['String']['input']>;
   userSecondFactorDeviceId: Scalars['ID']['input'];
 };
 
@@ -4887,7 +4907,7 @@ export type MeMutationDeleteSnackArgs = {
 
 
 export type MeMutationDisableSecondFactorAuthenticationArgs = {
-  otp: Scalars['String']['input'];
+  otp?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -4903,7 +4923,7 @@ export type MeMutationLeaveAccountArgs = {
 
 
 export type MeMutationRegenerateSecondFactorBackupCodesArgs = {
-  otp: Scalars['String']['input'];
+  otp?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -5193,6 +5213,11 @@ export type PublishUpdateGroupInput = {
   runtimeVersion: Scalars['String']['input'];
   turtleJobRunId?: InputMaybe<Scalars['String']['input']>;
   updateInfoGroup?: InputMaybe<UpdateInfoGroup>;
+};
+
+export type RequestsTimespan = {
+  end: Scalars['DateTime']['input'];
+  start?: InputMaybe<Scalars['DateTime']['input']>;
 };
 
 export type RescindUserInvitationResult = {
@@ -5911,6 +5936,7 @@ export type Submission = ActivityTimelineProjectActivity & {
   maxRetryTimeMinutes: Scalars['Int']['output'];
   parentSubmission?: Maybe<Submission>;
   platform: AppPlatform;
+  priority?: Maybe<SubmissionPriority>;
   status: SubmissionStatus;
   submittedBuild?: Maybe<Build>;
   updatedAt: Scalars['DateTime']['output'];
@@ -5991,6 +6017,11 @@ export type SubmissionMutationCreateIosSubmissionArgs = {
 export type SubmissionMutationRetrySubmissionArgs = {
   parentSubmissionId: Scalars['ID']['input'];
 };
+
+export enum SubmissionPriority {
+  High = 'HIGH',
+  Normal = 'NORMAL'
+}
 
 export type SubmissionQuery = {
   __typename?: 'SubmissionQuery';
@@ -6966,7 +6997,7 @@ export type WorkerDeployment = {
   aliases?: Maybe<Array<WorkerDeploymentAlias>>;
   createdAt: Scalars['DateTime']['output'];
   deploymentDomain: Scalars['String']['output'];
-  deploymentIdentifier: Scalars['String']['output'];
+  deploymentIdentifier: Scalars['WorkerDeploymentIdentifier']['output'];
   devDomainName: Scalars['DevDomainName']['output'];
   id: Scalars['ID']['output'];
   logs?: Maybe<WorkerDeploymentLogs>;
@@ -6988,7 +7019,7 @@ export type WorkerDeploymentMetricsArgs = {
 
 export type WorkerDeploymentAlias = {
   __typename?: 'WorkerDeploymentAlias';
-  aliasName?: Maybe<Scalars['String']['output']>;
+  aliasName?: Maybe<Scalars['WorkerDeploymentIdentifier']['output']>;
   createdAt: Scalars['DateTime']['output'];
   deploymentDomain: Scalars['String']['output'];
   devDomainName: Scalars['DevDomainName']['output'];
@@ -7089,6 +7120,29 @@ export type WorkerDeploymentQuery = {
 
 export type WorkerDeploymentQueryByIdArgs = {
   id: Scalars['ID']['input'];
+};
+
+export type WorkerDeploymentRequestLocation = {
+  __typename?: 'WorkerDeploymentRequestLocation';
+  continent?: Maybe<ContinentCode>;
+  countryCode?: Maybe<Scalars['String']['output']>;
+  regionCode?: Maybe<Scalars['String']['output']>;
+};
+
+export type WorkerDeploymentRequestNode = {
+  __typename?: 'WorkerDeploymentRequestNode';
+  location?: Maybe<WorkerDeploymentRequestLocation>;
+  method: Scalars['String']['output'];
+  pathname: Scalars['String']['output'];
+  search?: Maybe<Scalars['String']['output']>;
+  status: Scalars['Int']['output'];
+  timestamp: Scalars['DateTime']['output'];
+};
+
+export type WorkerDeploymentRequests = {
+  __typename?: 'WorkerDeploymentRequests';
+  minRowsWithoutLimit?: Maybe<Scalars['Int']['output']>;
+  nodes: Array<WorkerDeploymentRequestNode>;
 };
 
 export type WorkerDeploymentsConnection = {
@@ -7733,6 +7787,14 @@ export type DeleteEnvironmentVariableMutationVariables = Exact<{
 
 export type DeleteEnvironmentVariableMutation = { __typename?: 'RootMutation', environmentVariable: { __typename?: 'EnvironmentVariableMutation', deleteEnvironmentVariable: { __typename?: 'DeleteEnvironmentVariableResult', id: string } } };
 
+export type CreateBulkEnvironmentVariablesForAppMutationVariables = Exact<{
+  input: Array<CreateEnvironmentVariableInput> | CreateEnvironmentVariableInput;
+  appId: Scalars['ID']['input'];
+}>;
+
+
+export type CreateBulkEnvironmentVariablesForAppMutation = { __typename?: 'RootMutation', environmentVariable: { __typename?: 'EnvironmentVariableMutation', createBulkEnvironmentVariablesForApp: Array<{ __typename?: 'EnvironmentVariable', id: string }> } };
+
 export type CreateKeystoreGenerationUrlMutationVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -7938,6 +8000,15 @@ export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
 
 
 export type EnvironmentSecretsByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, ownerAccount: { __typename?: 'Account', id: string, environmentSecrets: Array<{ __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any }> }, environmentSecrets: Array<{ __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any }> } } };
+
+export type EnvironmentVariablesIncludingSensitiveByAppIdQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  filterNames?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
+  environment: EnvironmentVariableEnvironment;
+}>;
+
+
+export type EnvironmentVariablesIncludingSensitiveByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, environmentVariablesIncludingSensitive: Array<{ __typename?: 'EnvironmentVariableWithSecret', id: string, name: string, value?: string | null }> } } };
 
 export type EnvironmentVariablesByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/mutations/EnvironmentVariableMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/EnvironmentVariableMutation.ts
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../client';
 import {
+  CreateBulkEnvironmentVariablesForAppMutation,
   CreateEnvironmentVariableForAccountMutation,
   CreateEnvironmentVariableForAppMutation,
   DeleteEnvironmentVariableMutation,
@@ -195,5 +196,35 @@ export const EnvironmentVariableMutation = {
     );
 
     return data.environmentVariable.deleteEnvironmentVariable;
+  },
+  async createBulkEnvironmentVariablesForAppAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: EnvironmentVariablePushInput[],
+    appId: string
+  ): Promise<boolean> {
+    await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateBulkEnvironmentVariablesForAppMutation>(
+          gql`
+            mutation CreateBulkEnvironmentVariablesForApp(
+              $input: [CreateEnvironmentVariableInput!]!
+              $appId: ID!
+            ) {
+              environmentVariable {
+                createBulkEnvironmentVariablesForApp(
+                  environmentVariablesData: $input
+                  appId: $appId
+                ) {
+                  id
+                }
+              }
+            }
+          `,
+          { input, appId }
+        )
+        .toPromise()
+    );
+
+    return true;
   },
 };

--- a/packages/eas-cli/src/graphql/queries/EnvironmentVariablesQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EnvironmentVariablesQuery.ts
@@ -19,7 +19,7 @@ export const EnvironmentVariablesQuery = {
       filterNames,
     }: {
       appId: string;
-      environment: EnvironmentVariableEnvironment;
+      environment: string;
       filterNames?: string[];
     }
   ): Promise<{
@@ -61,9 +61,15 @@ export const EnvironmentVariablesQuery = {
   },
   async byAppIdAsync(
     graphqlClient: ExpoGraphqlClient,
-    appId: string,
-    environment: string,
-    filterNames?: string[]
+    {
+      appId,
+      environment,
+      filterNames,
+    }: {
+      appId: string;
+      environment: string;
+      filterNames?: string[];
+    }
   ): Promise<{
     sharedVariables: EnvironmentVariableFragment[];
     appVariables: EnvironmentVariableFragment[];
@@ -109,8 +115,7 @@ export const EnvironmentVariablesQuery = {
   },
   async sharedAsync(
     graphqlClient: ExpoGraphqlClient,
-    appId: string,
-    filterNames?: string[]
+    { appId, filterNames }: { appId: string; filterNames?: string[] }
   ): Promise<EnvironmentVariableFragment[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient

--- a/packages/eas-cli/src/graphql/queries/EnvironmentVariablesQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EnvironmentVariablesQuery.ts
@@ -3,11 +3,7 @@ import gql from 'graphql-tag';
 
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../client';
-import {
-  EnvironmentVariableEnvironment,
-  EnvironmentVariableFragment,
-  EnvironmentVariablesByAppIdQuery,
-} from '../generated';
+import { EnvironmentVariableFragment, EnvironmentVariablesByAppIdQuery } from '../generated';
 import { EnvironmentVariableFragmentNode } from '../types/EnvironmentVariable';
 
 export const EnvironmentVariablesQuery = {

--- a/packages/eas-cli/src/user/fetchSessionSecretAndUser.ts
+++ b/packages/eas-cli/src/user/fetchSessionSecretAndUser.ts
@@ -27,7 +27,7 @@ export async function fetchSessionSecretAndUserAsync({
   };
 }
 
-export async function upgradeSudoSessionAndAsync(
+export async function upgradeToSudoSessionAsync(
   apiV2Client: ApiV2Client,
   {
     password,

--- a/packages/eas-cli/src/user/fetchSessionSecretAndUser.ts
+++ b/packages/eas-cli/src/user/fetchSessionSecretAndUser.ts
@@ -26,3 +26,18 @@ export async function fetchSessionSecretAndUserAsync({
     username: userData.username,
   };
 }
+
+export async function upgradeSudoSessionAndAsync(
+  apiV2Client: ApiV2Client,
+  {
+    password,
+    otp,
+  }: {
+    password: string;
+    otp?: string;
+  }
+): Promise<void> {
+  await apiV2Client.postAsync('auth/upgradeSudo', {
+    body: { password, otp },
+  });
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

User should be able to synchronise local environment variables with upstream.

- https://linear.app/expo/issue/ENG-11920/add-eas-envpush-command
- https://linear.app/expo/issue/ENG-11919/add-eas-envpull-command

# How

- added `eas env:pull` and `eas env:push` commands
- `eas env:pull` handles sudo access to request values of sensitive variables

# Test Plan

Tested manually