### PR TITLE
[eas-cli] track how much is `local` build mode used in analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Track usage of `--local` build mode in analytics. ([#2445](https://github.com/expo/eas-cli/pull/2445) by [@szdziedzic](https://github.com/szdziedzic))
 - Remove any mentions of deleted Xcode < 15 images. ([#2438](https://github.com/expo/eas-cli/pull/2438) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [10.0.2](https://github.com/expo/eas-cli/releases/tag/v10.0.2) - 2024-06-17

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -10,7 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { createAndroidContextAsync } from './android/build';
 import { BuildContext, CommonContext } from './context';
 import { createIosContextAsync } from './ios/build';
-import { LocalBuildOptions } from './local';
+import { LocalBuildMode, LocalBuildOptions } from './local';
 import { resolveBuildResourceClassAsync } from './utils/resourceClass';
 import { Analytics, AnalyticsEventProperties, BuildEvent } from '../analytics/AnalyticsManager';
 import { DynamicConfigContextFn } from '../commandUtils/context/DynamicProjectConfigContextField';
@@ -108,6 +108,7 @@ export async function createBuildContextAsync<T extends Platform>({
     ...devClientProperties,
     no_wait: noWait,
     run_from_ci: runFromCI,
+    local: localBuildOptions.localBuildMode === LocalBuildMode.LOCAL_BUILD_PLUGIN,
   };
   analytics.logEvent(BuildEvent.BUILD_COMMAND, analyticsEventProperties);
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Track how much is `local` build mode used in analytics

# How

Add `local` to the analytics context

# Test Plan

tests, run the command locally