### PR TITLE
[eas-cli] Add flag to emit build meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+- Added flag `--emit-build-meta` to emit `eas-update-metadata.json` in the bundle folder with detailed informations about the generated bundle(s)
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-- Added flag `--emit-build-meta` to emit `eas-update-metadata.json` in the bundle folder with detailed informations about the generated bundle(s)
+
+- Added flag `--emit-metadata` to emit `eas-update-metadata.json` in the bundle folder with detailed information about the generated updates ([#2451](https://github.com/expo/eas-cli/pull/2451) by [@rainst](https://github.com/rainst))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -1294,6 +1294,7 @@ FLAGS
   --channel=<value>                 Channel that the published update should affect
   --clear-cache                     Clear the bundler cache before publishing
   --group=<value>                   Update group to republish (deprecated, see republish command)
+  --emit-build-meta                 Emit "eas-update-metadata.json" in the bundle folder with detailed informations about the generated bundle(s)
   --input-dir=<value>               [default: dist] Location of the bundle
   --json                            Enable JSON output, non-JSON messages will be printed to stderr.
   --non-interactive                 Run the command in non-interactive mode.

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -1294,7 +1294,7 @@ FLAGS
   --channel=<value>                 Channel that the published update should affect
   --clear-cache                     Clear the bundler cache before publishing
   --group=<value>                   Update group to republish (deprecated, see republish command)
-  --emit-build-meta                 Emit "eas-update-metadata.json" in the bundle folder with detailed informations about the generated bundle(s)
+  --emit-metadata                   Emit "eas-update-metadata.json" in the bundle folder with detailed information about the generated updates
   --input-dir=<value>               [default: dist] Location of the bundle
   --json                            Enable JSON output, non-JSON messages will be printed to stderr.
   --non-interactive                 Run the command in non-interactive mode.

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -470,7 +470,7 @@ export default class UpdatePublish extends EasCommand {
       throw e;
     }
 
-    if (!skipBundler && emitBuildMeta) {
+    if (!skipBundler && emitMetadata) {
       Log.log('Generating eas-update-metadata.json');
       await generateEasMetadataAsync(distRoot, getUpdateJsonInfosForUpdates(newUpdates));
     }
@@ -575,10 +575,10 @@ export default class UpdatePublish extends EasCommand {
     }
 
     const skipBundler = flags['skip-bundler'] ?? false;
-    let emitBuildMeta = flags['emit-metadata'] ?? false;
+    let emitMetadata = flags['emit-metadata'] ?? false;
 
-    if (skipBundler && emitBuildMeta) {
-      emitBuildMeta = false;
+    if (skipBundler && emitMetadata) {
+      emitMetadata = false;
       Log.warn(
         'ignoring flag --emit-metadata as metadata cannot be generated when skipping bundle generation'
       );
@@ -595,7 +595,7 @@ export default class UpdatePublish extends EasCommand {
       platform: flags.platform as RequestedPlatform,
       privateKeyPath: flags['private-key-path'],
       nonInteractive,
-      emitBuildMeta,
+      emitMetadata,
       json: flags.json ?? false,
     };
   }

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -30,6 +30,7 @@ import {
   collectAssetsAsync,
   defaultPublishPlatforms,
   filterExportedPlatformsByFlag,
+  generateEasMetadataAsync,
   getBranchNameForCommandAsync,
   getRequestedPlatform,
   getRuntimeToPlatformMappingFromRuntimeVersions,
@@ -462,6 +463,9 @@ export default class UpdatePublish extends EasCommand {
       throw e;
     }
 
+    if (!skipBundler) {
+      await generateEasMetadataAsync(distRoot, getUpdateJsonInfosForUpdates(newUpdates));
+    }
     if (jsonFlag) {
       printJsonOnlyOutput(getUpdateJsonInfosForUpdates(newUpdates));
     } else {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -87,7 +87,7 @@ type UpdateFlags = {
   privateKeyPath?: string;
   json: boolean;
   nonInteractive: boolean;
-  emitBuildMeta: boolean;
+  emitMetadata: boolean;
 };
 
 export default class UpdatePublish extends EasCommand {
@@ -175,7 +175,7 @@ export default class UpdatePublish extends EasCommand {
       json: jsonFlag,
       nonInteractive,
       branchName: branchNameArg,
-      emitBuildMeta,
+      emitMetadata,
     } = this.sanitizeFlags(rawFlags);
 
     const {

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -67,7 +67,7 @@ type RawUpdateFlags = {
   'clear-cache': boolean;
   'private-key-path'?: string;
   'non-interactive': boolean;
-  'emit-build-meta': boolean;
+  'emit-metadata': boolean;
   json: boolean;
   /** @deprecated see UpdateRepublish command */
   group?: string;
@@ -128,8 +128,8 @@ export default class UpdatePublish extends EasCommand {
       description: `Clear the bundler cache before publishing`,
       default: false,
     }),
-    'emit-build-meta': Flags.boolean({
-      description: `Emit "eas-update-metadata.json" in the bundle folder with detailed informations about the generated bundle(s)`,
+    'emit-metadata': Flags.boolean({
+      description: `Emit "eas-update-metadata.json" in the bundle folder with detailed information about the generated updates`,
       default: false,
     }),
     platform: Flags.enum({
@@ -575,12 +575,12 @@ export default class UpdatePublish extends EasCommand {
     }
 
     const skipBundler = flags['skip-bundler'] ?? false;
-    let emitBuildMeta = flags['emit-build-meta'] ?? false;
+    let emitBuildMeta = flags['emit-metadata'] ?? false;
 
     if (skipBundler && emitBuildMeta) {
       emitBuildMeta = false;
       Log.warn(
-        'ignoring flag --emit-build-meta as metadata cannot be generated when skipping bundle generation'
+        'ignoring flag --emit-metadata as metadata cannot be generated when skipping bundle generation'
       );
     }
 

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -24,7 +24,11 @@ import Log, { learnMore } from '../log';
 import { RequestedPlatform, requestedPlatformDisplayNames } from '../platform';
 import { promptAsync } from '../prompts';
 import { getBranchNameFromChannelNameAsync } from '../update/getBranchNameFromChannelNameAsync';
-import { formatUpdateMessage, truncateString as truncateUpdateMessage } from '../update/utils';
+import {
+  UpdateJsonInfo,
+  formatUpdateMessage,
+  truncateString as truncateUpdateMessage,
+} from '../update/utils';
 import { PresignedPost, uploadWithPresignedPostWithRetryAsync } from '../uploads';
 import {
   expoCommandAsync,
@@ -291,6 +295,14 @@ export function loadMetadata(distRoot: string): Metadata {
   }
   Log.debug(`Loaded ${platforms.length} platform(s): ${platforms.join(', ')}`);
   return metadata;
+}
+
+export async function generateEasMetadataAsync(
+  distRoot: string,
+  metadata: UpdateJsonInfo[]
+): Promise<void> {
+  const easMetadataPath = path.join(distRoot, 'eas-update-metadata.json');
+  await JsonFile.writeAsync(easMetadataPath, { updates: metadata });
 }
 
 export function filterExportedPlatformsByFlag<T extends Partial<Record<Platform, any>>>(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Currently Bugsnag [doesn't support](https://docs.bugsnag.com/platforms/react-native/expo/#eas-update) automatic source map upload after running eas update so I made a script that makes a manual submission after bundling and submitting an update. The script is relying on `eas-update-metadata.json` to obtain the bundle ids.

I am currently using eas-cli@6.1 and the update script is working well, but I have realised that this feature was removed [with the v7 release](https://github.com/expo/eas-cli/releases/tag/v7.0.0) thus preventing me from updating to a newer version of `eas-cli`.

# How

This feature was introduced in #2158 and removed in #2187, so I have reverted the changes and put the feature behind  the `--emit-build-meta` flag rather than having it aways on so nothing will change for people that don't really need it.

# Test Plan

I have tested with my update pipeline script and it works as expected.

- Run `eas update --emit-build-meta` and in the dist folder there should be `eas-update-metadata.json` with the following shape:

```
{
  "updates": [
    {
      "id": "f3021b72-f530-4ce6-94eb-4441b0bb237f",
      "createdAt": "2024-07-08T06:07:00.573Z",
      "group": "f889ce3d-3a8e-4415-98f5-23232",
      "branch": "main",
      "message": "test",
      "runtimeVersion": "1.23.1",
      "platform": "android",
      "manifestPermalink": "https://u.expo.dev/update/f3021b72-f530-4ce6-94eb-4441b0bb237f",
      "isRollBackToEmbedded": false,
      "gitCommitHash": "00e36199b3c15ad2df049f9f5d9a03bc32dfeb03"
    },
    {
      "id": "a1f730fa-cac2-4a08-b157-b44415af3c724",
      "createdAt": "2024-07-08T06:07:00.573Z",
      "group": "f889ce3d-3a8e-4415-98f5-f3232395fc725",
      "branch": "main",
      "message": "test",
      "runtimeVersion": "1.23.1",
      "platform": "ios",
      "manifestPermalink": "https://u.expo.dev/update/a1f730fa-cac2-4a08-b157-b44415af3c724",
      "isRollBackToEmbedded": false,
      "gitCommitHash": "00e36199b3c15ad2df049f9f5d9a03bc32dfeb03"
    }
  ]
}
```
- The file should not be emitted when running `eas update` without the `--emit-build-meta` flag
- When the `--skip-bundler` flag is set a warning will notify the user that `--emit-build-meta` will be ignored because not applicable