### PR TITLE
add username and password flags to `eas login`

### DIFF
--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -14,6 +14,14 @@ export default class AccountLogin extends EasCommand {
       char: 's',
       default: false,
     }),
+    username: Flags.string({
+      description: 'Username',
+      char: 'u',
+    }),
+    password: Flags.string({
+      description: 'Password',
+      char: 'p',
+    }),
   };
 
   static override contextDefinition = {
@@ -22,11 +30,11 @@ export default class AccountLogin extends EasCommand {
 
   async runAsync(): Promise<void> {
     const {
-      flags: { sso },
+      flags: { sso, username, password },
     } = await this.parse(AccountLogin);
 
     const { sessionManager } = await this.getContextAsync(AccountLogin, { nonInteractive: false });
-    await sessionManager.showLoginPromptAsync({ sso });
+    await sessionManager.showLoginPromptAsync({ sso, username, password });
     Log.log('Logged in');
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Context:
https://discord.com/channels/695411232856997968/1253063539598295141

Basically, as a freelancer, I need to login to multiple expo accounts in a day, and doing the whole logout/login dance is taking time.

My ideal scenario is that when i enter a directory/repo, eas will be on the right account, but to get there, we need a few steps. The first step is to allow `eas login` to take username and password flags, so that I can have these in a `.env` and with a simple npm script like `eas logout; eas login -u $EXPO_USERNAME -p $EXPO_PASSWORD`, I can at least run that when I enter the directory. That alone will make a huge difference.

# How

I added the flags. If they exist, the prompt will not ask for whatever was given.

# Test Plan

I used the `easd` alias that you suggest in the contributing file, and then I tried to login and out. I also tried like I described above, with direnv and `.envrc`, and it worked.
