### PR TITLE
[ENG-12793][eas-cli] make `eas login` and `eas whoami` behave more clearly when one is authenticated using `EXPO_TOKEN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Indicate if a user is logged in using `EXPO_TOKEN` when running `eas whoami` command. [#2461](https://github.com/expo/eas-cli/pull/2461) by [@szdziedzic](https://github.com/szdziedzic)
-- Throw error when `eas login` command is run with `EXPO_TOKEN` environment variable set. [#2461](https://github.com/expo/eas-cli/pull/2461) by [@szdziedzic](https://github.com/szdziedzic)
-- Check if user is already logged in when running `eas login` command. [#2461](https://github.com/expo/eas-cli/pull/2461) by [@szdziedzic](https://github.com/szdziedzic)
+- Indicate if a user is logged in using `EXPO_TOKEN` when running `eas whoami` command. ([#2461](https://github.com/expo/eas-cli/pull/2461) by [@szdziedzic](https://github.com/szdziedzic))
+- Throw error when `eas login` command is run with `EXPO_TOKEN` environment variable set. ([#2461](https://github.com/expo/eas-cli/pull/2461) by [@szdziedzic](https://github.com/szdziedzic))
+- Check if user is already logged in when running `eas login` command. ([#2461](https://github.com/expo/eas-cli/pull/2461) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [10.2.0](https://github.com/expo/eas-cli/releases/tag/v10.2.0) - 2024-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Indicate if a user is logged in using `EXPO_TOKEN` when running `eas whoami` command. [#2461](https://github.com/expo/eas-cli/pull/2461) by [@szdziedzic](https://github.com/szdziedzic)
+- Throw error when `eas login` command is run with `EXPO_TOKEN` environment variable set. [#2461](https://github.com/expo/eas-cli/pull/2461) by [@szdziedzic](https://github.com/szdziedzic)
+- Check if user is already logged in when running `eas login` command. [#2461](https://github.com/expo/eas-cli/pull/2461) by [@szdziedzic](https://github.com/szdziedzic)
+
 ## [10.2.0](https://github.com/expo/eas-cli/releases/tag/v10.2.0) - 2024-07-15
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -35,31 +35,13 @@ export default class AccountLogin extends EasCommand {
     } = await this.getContextAsync(AccountLogin, { nonInteractive: false });
 
     if (sessionManager.getAccessToken()) {
-      Log.warn(
-        'We detected that you have set EXPO_TOKEN in your environment. If EXPO_TOKEN is set, it takes precedence over the current session as an authentication method.'
+      throw new Error(
+        'EXPO_TOKEN is set in your environment, and is being used for all EAS authentication. To use username/password authentication, unset EXPO_TOKEN in your environment and re-run the command.'
       );
-      Log.warn(
-        'Even if you log in with a different account, EXPO_TOKEN will still be used if set.'
-      );
-      Log.warn(
-        `You don't need to use ${chalk.bold(
-          'eas login'
-        )} command if you are planning to use EXPO_TOKEN.`
-      );
-
-      const shouldContinue = await confirmAsync({
-        message: 'Do you want to continue?',
-      });
-      if (!shouldContinue) {
-        Errors.error('Aborted', { exit: 1 });
-      }
     }
 
     if (actor) {
-      const loggedInAs = sessionManager.getAccessToken()
-        ? `${getActorDisplayName(actor)} (by using EXPO_TOKEN)`
-        : getActorDisplayName(actor);
-      Log.warn(`You are already logged in as ${chalk.bold(loggedInAs)}.`);
+      Log.warn(`You are already logged in as ${chalk.bold(getActorDisplayName(actor))}.`);
 
       const shouldContinue = await confirmAsync({
         message: 'Do you want to continue?',

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -1,7 +1,10 @@
-import { Flags } from '@oclif/core';
+import { Errors, Flags } from '@oclif/core';
+import chalk from 'chalk';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import Log from '../../log';
+import { confirmAsync } from '../../prompts';
+import { getActorDisplayName } from '../../user/User';
 
 export default class AccountLogin extends EasCommand {
   static override description = 'log in with your Expo account';
@@ -17,6 +20,7 @@ export default class AccountLogin extends EasCommand {
   };
 
   static override contextDefinition = {
+    ...this.ContextOptions.MaybeLoggedIn,
     ...this.ContextOptions.SessionManagment,
   };
 
@@ -25,7 +29,46 @@ export default class AccountLogin extends EasCommand {
       flags: { sso },
     } = await this.parse(AccountLogin);
 
-    const { sessionManager } = await this.getContextAsync(AccountLogin, { nonInteractive: false });
+    const {
+      sessionManager,
+      maybeLoggedIn: { actor },
+    } = await this.getContextAsync(AccountLogin, { nonInteractive: false });
+
+    if (sessionManager.getAccessToken()) {
+      Log.warn(
+        'We detected that you have set EXPO_TOKEN in your environment. If EXPO_TOKEN is set, it takes precedence over the current session as an authentication method.'
+      );
+      Log.warn(
+        'Even if you log in with a different account, EXPO_TOKEN will still be used if set.'
+      );
+      Log.warn(
+        `You don't need to use ${chalk.bold(
+          'eas login'
+        )} command if you are planning to use EXPO_TOKEN.`
+      );
+
+      const shouldContinue = await confirmAsync({
+        message: 'Do you want to continue?',
+      });
+      if (!shouldContinue) {
+        Errors.error('Aborted', { exit: 1 });
+      }
+    }
+
+    if (actor) {
+      const loggedInAs = sessionManager.getAccessToken()
+        ? `${getActorDisplayName(actor)} (by using EXPO_TOKEN)`
+        : getActorDisplayName(actor);
+      Log.warn(`You are already logged in as ${chalk.bold(loggedInAs)}.`);
+
+      const shouldContinue = await confirmAsync({
+        message: 'Do you want to continue?',
+      });
+      if (!shouldContinue) {
+        Errors.error('Aborted', { exit: 1 });
+      }
+    }
+
     await sessionManager.showLoginPromptAsync({ sso });
     Log.log('Logged in');
   }

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -22,7 +22,7 @@ export default class AccountView extends EasCommand {
     } = await this.getContextAsync(AccountView, { nonInteractive: true });
     if (actor) {
       const loggedInAs = sessionManager.getAccessToken()
-        ? `${getActorDisplayName(actor)} (by using EXPO_TOKEN)`
+        ? `${getActorDisplayName(actor)} (authenticated using EXPO_TOKEN)`
         : getActorDisplayName(actor);
       Log.log(chalk.green(loggedInAs));
 

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -12,14 +12,19 @@ export default class AccountView extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.MaybeLoggedIn,
+    ...this.ContextOptions.SessionManagment,
   };
 
   async runAsync(): Promise<void> {
     const {
       maybeLoggedIn: { actor },
+      sessionManager,
     } = await this.getContextAsync(AccountView, { nonInteractive: true });
     if (actor) {
-      Log.log(chalk.green(getActorDisplayName(actor)));
+      const loggedInAs = sessionManager.getAccessToken()
+        ? `${getActorDisplayName(actor)} (by using EXPO_TOKEN)`
+        : getActorDisplayName(actor);
+      Log.log(chalk.green(loggedInAs));
 
       // personal account is included, only show if more accounts that personal account
       // but do show personal account in list if there are more


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Using `EXPO_TOKEN` seems confusing to people.

https://github.com/expo/eas-cli/pull/2460

# How

When using the `eas whoami` command signal that a user is authenticated by using `EXPO_TOKEN`. It seems like people sometimes tend to forget that they have `EXPO_TOKEN` set, then they log in as a different account but `eas whoami` still returns the same value because they are authed using `EXPO_TOKEN` and it seems to be confusing.

Warn people when running `eas login` with the `EXPO_TOKEN` set that this is not necessary. 

# Test Plan

Test manually

`eas whoami` after and before
<img width="887" alt="Screenshot 2024-07-16 at 16 39 28" src="https://github.com/user-attachments/assets/6f4fa1af-76c6-4233-9fe3-8f22d232e20d">


`eas login` 
<img width="688" alt="Screenshot 2024-07-16 at 16 52 52" src="https://github.com/user-attachments/assets/6299c657-5293-4aad-9550-099f9ee34955">
<img width="519" alt="Screenshot 2024-07-16 at 16 53 06" src="https://github.com/user-attachments/assets/3a8bfdda-a6fd-4ce2-b6fa-84a6c410056e">
<img width="1134" alt="Screenshot 2024-07-16 at 16 53 39" src="https://github.com/user-attachments/assets/bea6b9ca-10b5-4bac-8ec6-7ecb04509c07">
