### PR TITLE
[eas-cli] bump asset upload timeout from 90 to 180 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Bump asset upload timeout from 90 to 180 seconds. ([#2466](https://github.com/expo/eas-cli/pull/2466) by [@quinlanj](https://github.com/quinlanj))
+
 ## [10.2.1](https://github.com/expo/eas-cli/releases/tag/v10.2.1) - 2024-07-18
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -260,7 +260,7 @@ export default class UpdatePublish extends EasCommand {
       realizedPlatforms = Object.keys(assets) as PublishPlatform[];
 
       // Timeout mechanism:
-      // - Start with NO_ACTIVITY_TIMEOUT. 90 seconds is chosen because the cloud function that processes
+      // - Start with NO_ACTIVITY_TIMEOUT. 180 seconds is chosen because the cloud function that processes
       //   uploaded assets has a timeout of 60 seconds and uploading can take some time on a slow connection.
       // - Each time one or more assets reports as ready, reset the timeout.
       // - Each time an asset upload begins, reset the timeout. This includes retries.
@@ -269,7 +269,7 @@ export default class UpdatePublish extends EasCommand {
       // - At the same time as upload is started, start timeout checker which checks every 1 second to see
       //   if timeout has been reached. When timeout expires, send a cancellation signal to currently running
       //   upload function call to instruct it to stop uploading or checking for successful processing.
-      const NO_ACTIVITY_TIMEOUT = 90 * 1000; // 90 seconds
+      const NO_ACTIVITY_TIMEOUT = 180 * 1000; // 180 seconds
       let lastUploadedStorageKeys = new Set<string>();
       let lastAssetUploadResults: {
         asset: RawAsset & { storageKey: string };


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Extend the timeout from 90 seconds to 180 seconds, because some people have really slow internet connections. Using a p99 of the cloud function time of 29s, we essentially change the upload timeout from 60s to 150s

# background
Why we chose 90 seconds in the first place, from https://github.com/expo/eas-cli/pull/2085:

> For slow connections that take a while to upload, 60s is not enough of a timeout. For example, lets say there's only one asset to upload, and it takes even 1 second to upload and 60s to process (the max of the cloud function), it'll time out. The p99 of the processing cloud function is 29s, so changing this timeout to 90s gives a upload timeout of 60s.

> We also change the semantics of when to reset the timeout, and now reset it when the upload is retried. So, in the example above, let's say the asset takes 59 seconds to upload, but fails at the 58th second, it will be retried and the timeout will reset to give it an additional 60 seconds to upload.

# Test Plan

- [ ] sanity check that `eas update` still works on a test project