### PR TITLE
[eas-cli] add support for `EAS_DANGEROUS_OVERRIDE_IOS_BUNDLE_IDENTIFIER` for bare workflow iOS builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add support for `EAS_DANGEROUS_OVERRIDE_IOS_BUNDLE_IDENTIFIER` for bare workflow iOS builds.([#2469](https://github.com/expo/eas-cli/pull/2469) by [@szdziedzic](https://github.com/szdziedzic))
 - Update images list in `eas.schema.json` and warn users when using the deprecated Android images. ([#2450](https://github.com/expo/eas-cli/pull/2450) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [10.2.2](https://github.com/expo/eas-cli/releases/tag/v10.2.2) - 2024-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Add support for `EAS_DANGEROUS_OVERRIDE_IOS_BUNDLE_IDENTIFIER` for bare workflow iOS builds.([#2469](https://github.com/expo/eas-cli/pull/2469) by [@szdziedzic](https://github.com/szdziedzic))
+- Add support for `EAS_DANGEROUS_OVERRIDE_IOS_BUNDLE_IDENTIFIER` for bare workflow iOS builds. ([#2469](https://github.com/expo/eas-cli/pull/2469) by [@szdziedzic](https://github.com/szdziedzic))
 - Update images list in `eas.schema.json` and warn users when using the deprecated Android images. ([#2450](https://github.com/expo/eas-cli/pull/2450) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [10.2.2](https://github.com/expo/eas-cli/releases/tag/v10.2.2) - 2024-07-31

--- a/packages/eas-cli/src/env.ts
+++ b/packages/eas-cli/src/env.ts
@@ -9,6 +9,11 @@ export default {
    */
   overrideAndroidApplicationId: process.env.EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID,
   /**
+   * Overrides bundleIdentifier from Xcode project for bare workflow.
+   * Setting this option will ignore failures thrown when bundle identifier can't be obtained from Xcode project.
+   */
+  overrideIosBundleIdentifier: process.env.EAS_DANGEROUS_OVERRIDE_IOS_BUNDLE_IDENTIFIER,
+  /**
    * Comma separated list of feature gate keys of feature gates to evaluate override to true.
    */
   featureGateEnable: process.env.EAS_FG_ENABLE,

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -7,6 +7,7 @@ import fs from 'fs-extra';
 
 import { readAppJson } from '../../build/utils/appJson';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import env from '../../env';
 import Log, { learnMore } from '../../log';
 import { promptAsync } from '../../prompts';
 import { Client } from '../../vcs/vcs';
@@ -61,6 +62,10 @@ export async function getBundleIdentifierAsync(
   const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
   if (workflow === Workflow.GENERIC) {
     warnIfBundleIdentifierDefinedInAppConfigForBareWorkflowProject(projectDir, exp);
+
+    if (env.overrideIosBundleIdentifier) {
+      return env.overrideIosBundleIdentifier;
+    }
 
     const xcodeProject = IOSConfig.XcodeUtils.getPbxproj(projectDir);
     const isMultiScheme = IOSConfig.BuildScheme.getSchemesFromXcodeproj(projectDir).length > 1;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1721767590752789

It seems like one of our users got blocked because we weren't able to read the bundle identifier from their Xcode project using the `IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj` function. While the root cause of this issue remains unknown we can add a dangerous override env to allow people to unblock themself if such an issue occurs.

We already have an env var that does the same for Android bare workflow builds:
https://github.com/expo/eas-cli/blob/39aff70e83370d694e9790d67ca225cbc8a96826/packages/eas-cli/src/project/android/applicationId.ts#L68-L70

# How

Add `EAS_DANGEROUS_OVERRIDE_IOS_BUNDLE_IDENTIFIER` and use it as bundle id override for bare workflow apps if provided.

# Test Plan

Test manually.
