### PR TITLE
[eas-cli] pass correct path to `vcsClient.isFileIgnoredAsync` check for custom build config for monorepos

### DIFF
--- a/packages/eas-cli/src/project/customBuildConfig.ts
+++ b/packages/eas-cli/src/project/customBuildConfig.ts
@@ -31,7 +31,9 @@ export async function validateCustomBuildConfigAsync({
       `Custom build configuration file ${chalk.bold(relativeConfigPath)} does not exist.`
     );
   }
-  if (await vcsClient.isFileIgnoredAsync(relativeConfigPath)) {
+
+  const rootDir = path.normalize(await vcsClient.getRootPathAsync());
+  if (await vcsClient.isFileIgnoredAsync(path.relative(rootDir, configPath))) {
     throw new Error(
       `Custom build configuration file ${chalk.bold(
         relativeConfigPath


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I noticed that when having a React Native app with custom builds configured in monorepo, the path passed to `vcsClient.isFileIgnoredAsync` to check whether the custom build config file is ignored is incorrect.

The path passed to `vcsClient.isFileIgnoredAsync` should be the path relative to the git repo root, but we used the path relative to the RN project directory.

Another place where we do this check correctly:
https://github.com/expo/eas-cli/blob/bc670162e5eee38f3ae5ddd92a05f4955ead6dd9/packages/eas-cli/src/build/validate.ts#L35

It resulted in `vcsClient.isFileIgnoredAsync` returning always false for monorepos.

# How

Use the correct relative directory

# Test Plan

Test manually
