### PR TITLE
Add environment to Metadata

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/config": "8.5.4",
     "@expo/config-plugins": "7.8.4",
     "@expo/config-types": "50.0.0",
-    "@expo/eas-build-job": "1.0.129",
+    "@expo/eas-build-job": "1.0.130",
     "@expo/eas-json": "10.2.2",
     "@expo/json-file": "8.2.37",
     "@expo/logger": "1.0.117",

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -60,6 +60,7 @@ export async function collectMetadataAsync<T extends Platform>(
     requiredPackageManager: ctx.requiredPackageManager ?? undefined,
     selectedImage: ctx.buildProfile.image,
     customNodeVersion: ctx.buildProfile.node,
+    environment: ctx.buildProfile.environment,
     simulator: 'simulator' in ctx.buildProfile && ctx.buildProfile.simulator,
   };
   return sanitizeMetadata(metadata);

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -100,6 +100,35 @@ test('valid eas.json for development client builds', async () => {
   });
 });
 
+test('valid eas.json with specified environment', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      development: {
+        environment: 'production',
+      },
+    },
+  });
+
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
+  const iosProfile = await EasJsonUtils.getBuildProfileAsync(accessor, Platform.IOS, 'development');
+  const androidProfile = await EasJsonUtils.getBuildProfileAsync(
+    accessor,
+    Platform.ANDROID,
+    'development'
+  );
+  expect(androidProfile).toEqual({
+    credentialsSource: 'remote',
+    distribution: 'store',
+    environment: 'production',
+  });
+
+  expect(iosProfile).toEqual({
+    credentialsSource: 'remote',
+    distribution: 'store',
+    environment: 'production',
+  });
+});
+
 test('valid eas.json with top level withoutCredentials property', async () => {
   await fs.writeJson('/project/eas.json', {
     build: {

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -69,6 +69,8 @@ const CommonBuildProfileSchema = Joi.object({
 
   // credentials
   withoutCredentials: Joi.boolean(),
+
+  environment: Joi.string().valid('preview', 'production', 'development'),
 });
 
 const PlatformBuildProfileSchema = CommonBuildProfileSchema.concat(

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -69,6 +69,8 @@ export interface CommonBuildProfile {
 
   // credentials
   withoutCredentials?: boolean;
+
+  environment?: string;
 }
 
 interface PlatformBuildProfile extends Omit<CommonBuildProfile, 'autoIncrement'> {

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -70,7 +70,7 @@ export interface CommonBuildProfile {
   // credentials
   withoutCredentials?: boolean;
 
-  environment?: string;
+  environment?: 'preview' | 'production' | 'development'
 }
 
 interface PlatformBuildProfile extends Omit<CommonBuildProfile, 'autoIncrement'> {

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -70,7 +70,7 @@ export interface CommonBuildProfile {
   // credentials
   withoutCredentials?: boolean;
 
-  environment?: 'preview' | 'production' | 'development'
+  environment?: 'preview' | 'production' | 'development';
 }
 
 interface PlatformBuildProfile extends Omit<CommonBuildProfile, 'autoIncrement'> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12691,16 +12691,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12817,7 +12808,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12830,13 +12821,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -13999,16 +13983,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1472,6 +1472,16 @@
     semver "^7.6.2"
     zod "^3.23.8"
 
+"@expo/eas-build-job@1.0.130":
+  version "1.0.130"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-1.0.130.tgz#698de0139d14cd339f9d0f37ad40a86f1e9acbc8"
+  integrity sha512-3amSYB9QC24ZqMjNAl/s2EHbF4Y3btKnSAafp5sp5t2g8GvU1sBZ/+rXQPKH/Ga+PcbqNT+pduGIGg4uUC7gnw==
+  dependencies:
+    "@expo/logger" "1.0.117"
+    joi "^17.13.1"
+    semver "^7.6.2"
+    zod "^3.23.8"
+
 "@expo/fingerprint@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@expo/fingerprint/-/fingerprint-0.6.0.tgz#77366934673d4ecea37284109b4dd67f9e6a7487"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

User should be able to specify `environment` in their build profile to select Environment Variables set to be used with their build

# How

* added `metadata` field to build `metadata` (`eas-build`)
* added `metadata` to build profile schema
* passed `metadata` from build profile to build metadata

# Test Plan

Added test
