### PR TITLE
[rfc][eas-cli] Add codepush commands

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1471,6 +1471,51 @@
             "deprecationReason": null
           },
           {
+            "name": "environmentVariablesIncludingSensitive",
+            "description": "Environment variables for an account with decrypted secret values",
+            "args": [
+              {
+                "name": "filterNames",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EnvironmentVariableWithSecret",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "githubAppInstallations",
             "description": "GitHub App installations for an account",
             "args": [],
@@ -2910,75 +2955,6 @@
         "description": null,
         "fields": [
           {
-            "name": "buyProduct",
-            "description": "Makes a one time purchase",
-            "args": [
-              {
-                "name": "accountName",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "autoRenew",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "paymentSource",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "productId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Account",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Build packs are no longer supported"
-          },
-          {
             "name": "cancelAllSubscriptionsImmediately",
             "description": "Cancels all subscriptions immediately",
             "args": [
@@ -3045,11 +3021,11 @@
             "deprecationReason": null
           },
           {
-            "name": "cancelSubscription",
-            "description": "Cancels the active subscription",
+            "name": "changeAdditionalConcurrenciesCount",
+            "description": "Buys or revokes account's additional concurrencies, charging the account the appropriate amount if needed.",
             "args": [
               {
-                "name": "accountName",
+                "name": "accountID",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -3057,6 +3033,22 @@
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "newAdditionalConcurrenciesCount",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
                     "ofType": null
                   }
                 },
@@ -3366,96 +3358,6 @@
                   "ofType": {
                     "kind": "ENUM",
                     "name": "Permission",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "setBuildAutoRenew",
-            "description": "Update setting to purchase new build packs when the current one is consumed",
-            "args": [
-              {
-                "name": "accountName",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "autoRenew",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Account",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Build packs are no longer supported"
-          },
-          {
-            "name": "setPaymentSource",
-            "description": "Set payment details",
-            "args": [
-              {
-                "name": "accountName",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "paymentSource",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
                     "ofType": null
                   }
                 },
@@ -5247,6 +5149,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "quantity",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8740,13 +8654,9 @@
                 "name": "environment",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "EnvironmentVariableEnvironment",
-                    "ofType": null
-                  }
+                  "kind": "ENUM",
+                  "name": "EnvironmentVariableEnvironment",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -8785,6 +8695,63 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "EnvironmentVariable",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environmentVariablesIncludingSensitive",
+            "description": "Environment variables for an app with decrypted secret values",
+            "args": [
+              {
+                "name": "environment",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "EnvironmentVariableEnvironment",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filterNames",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EnvironmentVariableWithSecret",
                     "ofType": null
                   }
                 }
@@ -9015,8 +8982,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use lastDeletionAttemptTime !== null instead"
           },
           {
             "name": "isDeprecated",
@@ -10270,6 +10237,137 @@
             "deprecationReason": null
           },
           {
+            "name": "workerCustomDomain",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerCustomDomain",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerDeployment",
+            "description": null,
+            "args": [
+              {
+                "name": "deploymentIdentifier",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "WorkerDeploymentIdentifier",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeployment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerDeploymentAlias",
+            "description": null,
+            "args": [
+              {
+                "name": "aliasName",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "WorkerDeploymentIdentifier",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentAlias",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerDeploymentAliases",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentAliasesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "workerDeployments",
             "description": null,
             "args": [
@@ -10330,6 +10428,125 @@
                 "name": "WorkerDeploymentsConnection",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerDeploymentsCrashes",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CrashesTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentCrashes",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerDeploymentsMetrics",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "MetricsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentMetrics",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerDeploymentsRequests",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "RequestsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentRequests",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -11156,7 +11373,7 @@
         "fields": [
           {
             "name": "createApp",
-            "description": "Create an unpublished app",
+            "description": "Create an app",
             "args": [
               {
                 "name": "appInput",
@@ -11189,7 +11406,7 @@
           },
           {
             "name": "createAppAndGithubRepository",
-            "description": "Create an unpublished app and GitHub repository if user desire to",
+            "description": "Create an app and GitHub repository if user desire to",
             "args": [
               {
                 "name": "appInput",
@@ -11260,6 +11477,39 @@
             },
             "isDeprecated": true,
             "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "scheduleAppDeletion",
+            "description": "Delete an App. Returns the ID of the background job receipt. Use BackgroundJobReceiptQuery to get the status of the job.",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceipt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "setAppInfo",
@@ -11628,6 +11878,92 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "NotificationsSentOverTimeData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "successFailureOverTime",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NotificationsSentOverTimeData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalNotificationsSent",
+            "description": null,
+            "args": [
+              {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "JSON",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": "[]",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -16059,7 +16395,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -16075,7 +16411,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -16225,39 +16561,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "byId",
-            "description": "Query an Audit Log by ID",
-            "args": [
-              {
-                "name": "auditLogId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AuditLog",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -16339,6 +16642,12 @@
           },
           {
             "name": "ONE_LOGIN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STUB_IDP",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -18215,6 +18524,18 @@
           },
           {
             "name": "buildUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fingerprintUrl",
             "description": null,
             "args": [],
             "type": {
@@ -21103,6 +21424,104 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "ContinentCode",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "AF",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "AN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "AS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EU",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "T1",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CrashesTimespan",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "end",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "CreateAccessTokenInput",
         "description": null,
@@ -21435,16 +21854,12 @@
             "deprecationReason": null
           },
           {
-            "name": "sensitive",
+            "name": "overwrite",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -21459,6 +21874,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "visibility",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EnvironmentVariableVisibility",
                 "ofType": null
               }
             },
@@ -22027,16 +22458,12 @@
             "deprecationReason": null
           },
           {
-            "name": "sensitive",
+            "name": "overwrite",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -22051,6 +22478,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "visibility",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EnvironmentVariableVisibility",
                 "ofType": null
               }
             },
@@ -22115,6 +22558,368 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CustomDomainDNSRecord",
+        "description": null,
+        "fields": [
+          {
+            "name": "dnsContent",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dnsName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dnsType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CustomDomainDNSRecordType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CustomDomainDNSRecordType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CNAME",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TXT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CustomDomainMetadata",
+        "description": null,
+        "fields": [
+          {
+            "name": "ownershipVerification",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CustomDomainDNSRecord",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CustomDomainStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "verificationErrors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CustomDomainMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "deleteCustomDomain",
+            "description": null,
+            "args": [
+              {
+                "name": "customDomainId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteCustomDomainResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "refreshCustomDomain",
+            "description": null,
+            "args": [
+              {
+                "name": "customDomainId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerCustomDomain",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "registerCustomDomain",
+            "description": null,
+            "args": [
+              {
+                "name": "aliasName",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "WorkerDeploymentIdentifier",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "hostname",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerCustomDomain",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CustomDomainStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ACTIVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ACTIVE_REDEPLOYING",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BLOCKED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DELETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MOVED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PENDING",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PENDING_BLOCKED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PENDING_DELETION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PENDING_MIGRATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PENDING_PROVISIONED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PROVISIONED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNKNOWN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -22186,6 +22991,45 @@
         "name": "DeleteAccountSSOConfigurationResult",
         "description": null,
         "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeleteAliasResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "aliasName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "WorkerDeploymentIdentifier",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "id",
             "description": null,
@@ -22350,6 +23194,65 @@
         "fields": [
           {
             "name": "buildAnnotationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeleteCustomDomainResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "appId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hostname",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
             "description": null,
             "args": [],
             "type": {
@@ -23400,6 +24303,67 @@
         "description": null,
         "fields": [
           {
+            "name": "assignAlias",
+            "description": null,
+            "args": [
+              {
+                "name": "aliasName",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "WorkerDeploymentIdentifier",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "deploymentIdentifier",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentAlias",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createSignedDeploymentUrl",
             "description": "Create a signed deployment URL",
             "args": [
@@ -23438,6 +24402,51 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "DeploymentSignedUrlResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteAlias",
+            "description": null,
+            "args": [
+              {
+                "name": "aliasName",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "WorkerDeploymentIdentifier",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteAliasResult",
                 "ofType": null
               }
             },
@@ -24312,6 +25321,30 @@
         "description": null,
         "fields": [
           {
+            "name": "apps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "App",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createdAt",
             "description": null,
             "args": [],
@@ -24414,6 +25447,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "visibility",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "EnvironmentVariableVisibility",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -24455,6 +25500,136 @@
         "name": "EnvironmentVariableMutation",
         "description": null,
         "fields": [
+          {
+            "name": "createBulkEnvironmentVariablesForAccount",
+            "description": "Create bulk env variables for an Account",
+            "args": [
+              {
+                "name": "accountId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "environmentVariablesData",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "CreateSharedEnvironmentVariableInput",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EnvironmentVariable",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createBulkEnvironmentVariablesForApp",
+            "description": "Create bulk env variables for an App",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "environmentVariablesData",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "CreateEnvironmentVariableInput",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EnvironmentVariable",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "createEnvironmentVariableForAccount",
             "description": "Create an environment variable for an Account",
@@ -24581,6 +25756,55 @@
                 "kind": "OBJECT",
                 "name": "DeleteEnvironmentVariableResult",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "linkBulkSharedEnvironmentVariables",
+            "description": "Bulk link shared environment variables",
+            "args": [
+              {
+                "name": "linkData",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "LinkSharedEnvironmentVariableInput",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EnvironmentVariable",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -24743,6 +25967,206 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EnvironmentVariableVisibility",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "PUBLIC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SECRET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SENSITIVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EnvironmentVariableWithSecret",
+        "description": null,
+        "fields": [
+          {
+            "name": "apps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "App",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "EnvironmentVariableEnvironment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scope",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EnvironmentVariableScope",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sensitive",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "visibility",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EnvironmentVariableVisibility",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -25360,6 +26784,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recurringCents",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -28057,6 +29493,66 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "InsightsFilter",
+        "description": "The value field is always sent from the client as a string,\nand then it's parsed server-side according to the filterType",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "filterType",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "InsightsFilterType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "InsightsFilterType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "PLATFORM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "InsightsTimespan",
         "description": null,
         "fields": null,
@@ -28479,6 +29975,22 @@
             "deprecationReason": null
           },
           {
+            "name": "metadata",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "period",
             "description": null,
             "args": [],
@@ -28506,6 +30018,18 @@
                 "name": "InvoiceLineItemPlan",
                 "ofType": null
               }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use 'price' instead"
+          },
+          {
+            "name": "price",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "StripePrice",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -28543,17 +30067,13 @@
             "deprecationReason": null
           },
           {
-            "name": "title",
-            "description": null,
+            "name": "unitAmountExcludingTax",
+            "description": "The unit amount excluding tax, in cents",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -28590,13 +30110,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -28655,6 +30171,51 @@
         "name": "InvoiceQuery",
         "description": null,
         "fields": [
+          {
+            "name": "previewInvoiceForAdditionalConcurrenciesCountUpdate",
+            "description": "Previews the invoice for the specified number of additional concurrencies.\nThis is the total number of concurrencies the customer wishes to purchase\non top of their base plan, not the relative change in concurrencies\nthe customer wishes to make. For example, specify \"3\" if the customer has\ntwo add-on concurrencies and wishes to purchase one more.",
+            "args": [
+              {
+                "name": "accountID",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "additionalConcurrenciesCount",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Invoice",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "previewInvoiceForSubscriptionUpdate",
             "description": "Preview an upgrade subscription invoice, with proration",
@@ -31559,6 +33120,104 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "LinkSharedEnvironmentVariableInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EnvironmentVariableEnvironment",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environmentVariableId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "LogsTimespan",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "end",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "MailchimpAudience",
         "description": null,
@@ -31680,13 +33339,9 @@
                 "name": "otp",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -31845,13 +33500,9 @@
                 "name": "otp",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -31927,13 +33578,9 @@
                 "name": "otp",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -32062,11 +33709,40 @@
                 "name": "otp",
                 "description": null,
                 "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SecondFactorRegenerateBackupCodesResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scheduleAccountDeletion",
+            "description": "Schedule deletion for Account created via createAccount",
+            "args": [
+              {
+                "name": "accountId",
+                "description": null,
+                "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "String",
+                    "name": "ID",
                     "ofType": null
                   }
                 },
@@ -32080,7 +33756,56 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "SecondFactorRegenerateBackupCodesResult",
+                "name": "BackgroundJobReceipt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scheduleCurrentUserDeletion",
+            "description": "Schedule deletion of the current regular user",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceipt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scheduleSSOUserDeletionAsSSOAccountOwner",
+            "description": "Schedule deletion of a SSO user. Actor must be an owner on the SSO user's SSO account.",
+            "args": [
+              {
+                "name": "ssoUserId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceipt",
                 "ofType": null
               }
             },
@@ -32208,39 +33933,6 @@
               },
               {
                 "name": "destinationAccountId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "App",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "unpublishApp",
-            "description": "Unpublish an App that the current user owns",
-            "args": [
-              {
-                "name": "appId",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -32413,6 +34105,49 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "MetricsTimespan",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "end",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -34251,6 +35986,45 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestsTimespan",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "end",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "RescindUserInvitationResult",
         "description": null,
@@ -34635,6 +36409,39 @@
             "deprecationReason": null
           },
           {
+            "name": "scheduleRobotDeletion",
+            "description": "Schedule deletion of a Robot",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceipt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updateRobot",
             "description": "Update a Robot",
             "args": [
@@ -34783,13 +36590,9 @@
                 "name": "accountName",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -35144,6 +36947,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "BuildAnnotationMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "customDomain",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CustomDomainMutation",
                 "ofType": null
               }
             },
@@ -36128,6 +37947,22 @@
             "deprecationReason": null
           },
           {
+            "name": "updates",
+            "description": "Top-level query object for querying Updates.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UpdateQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updatesByGroup",
             "description": "fetch all updates in a group",
             "args": [
@@ -36312,6 +38147,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "WebhookQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerDeployment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentQuery",
                 "ofType": null
               }
             },
@@ -38708,6 +40559,33 @@
       },
       {
         "kind": "OBJECT",
+        "name": "StripePrice",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Submission",
         "description": "Represents an EAS Submission",
         "fields": [
@@ -38975,6 +40853,18 @@
                 "name": "AppPlatform",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "SubmissionPriority",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -39422,6 +41312,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "SubmissionPriority",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "HIGH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NORMAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "SubmissionQuery",
         "description": null,
@@ -39569,7 +41482,7 @@
             "deprecationReason": null
           },
           {
-            "name": "cancelledAt",
+            "name": "cancelAt",
             "description": null,
             "args": [],
             "type": {
@@ -39697,6 +41610,18 @@
             "deprecationReason": null
           },
           {
+            "name": "nextInvoiceAmountDueCents",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "planEnablement",
             "description": null,
             "args": [
@@ -39754,6 +41679,18 @@
             "deprecationReason": null
           },
           {
+            "name": "recurringCents",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "status",
             "description": null,
             "args": [],
@@ -39772,6 +41709,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "upcomingInvoice",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Invoice",
               "ofType": null
             },
             "isDeprecated": false,
@@ -41687,6 +43636,50 @@
               {
                 "name": "updateId",
                 "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Update",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UpdateQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byId",
+            "description": "Query an Update by ID",
+            "args": [
+              {
+                "name": "updateId",
+                "description": "Update ID to use to look up update",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -45938,9 +47931,89 @@
       },
       {
         "kind": "OBJECT",
-        "name": "WorkerDeployment",
+        "name": "WorkerCustomDomain",
         "description": null,
         "fields": [
+          {
+            "name": "alias",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentAlias",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "devDomainName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DevDomainName",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dnsRecord",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CustomDomainDNSRecord",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hostname",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "id",
             "description": null,
@@ -45952,6 +48025,649 @@
                 "kind": "SCALAR",
                 "name": "ID",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CustomDomainMetadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeployment",
+        "description": null,
+        "fields": [
+          {
+            "name": "aliases",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WorkerDeploymentAlias",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deploymentDomain",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deploymentIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "WorkerDeploymentIdentifier",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "devDomainName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DevDomainName",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "logs",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "500",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "LogsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentLogs",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metrics",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "MetricsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentMetrics",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subdomain",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentAlias",
+        "description": null,
+        "fields": [
+          {
+            "name": "aliasName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "WorkerDeploymentIdentifier",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deploymentDomain",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "devDomainName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DevDomainName",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subdomain",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerDeployment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeployment",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentAliasEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentAlias",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentAliasesConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentAliasEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentCrashNode",
+        "description": null,
+        "fields": [
+          {
+            "name": "minOccurrences",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mostRecentlyOccurredAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sample",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentCrashSample",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sampleMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentCrashSample",
+        "description": null,
+        "fields": [
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestTimestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentCrashes",
+        "description": null,
+        "fields": [
+          {
+            "name": "minRowsWithoutLimit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentCrashNode",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -45995,6 +48711,591 @@
                 "kind": "OBJECT",
                 "name": "WorkerDeployment",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "WorkerDeploymentIdentifier",
+        "description": "A alias name for a serverless deployment",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WorkerDeploymentLogLevel",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DEBUG",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ERROR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FATAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INFO",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LOG",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "WARN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentLogNode",
+        "description": null,
+        "fields": [
+          {
+            "name": "level",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WorkerDeploymentLogLevel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentLogs",
+        "description": null,
+        "fields": [
+          {
+            "name": "minRowsWithoutLimit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentLogNode",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentMetrics",
+        "description": null,
+        "fields": [
+          {
+            "name": "groups",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WorkerDeploymentMetricsEdge",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentMetricsData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentMetricsData",
+        "description": null,
+        "fields": [
+          {
+            "name": "crashesSum",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "durationP50",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "durationP90",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "durationP99",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsSum",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentMetricsEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentMetricsData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byId",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeployment",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestLocation",
+        "description": null,
+        "fields": [
+          {
+            "name": "continent",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "ContinentCode",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "regionCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestNode",
+        "description": null,
+        "fields": [
+          {
+            "name": "location",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentRequestLocation",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "method",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pathname",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "search",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequests",
+        "description": null,
+        "fields": [
+          {
+            "name": "minRowsWithoutLimit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestNode",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,

--- a/packages/eas-cli/src/commands/channel/delete.ts
+++ b/packages/eas-cli/src/commands/channel/delete.ts
@@ -1,15 +1,6 @@
-import gql from 'graphql-tag';
-
-import { selectChannelOnAppAsync } from '../../channel/queries';
+import { deleteChannelOnAppAsync, selectChannelOnAppAsync } from '../../channel/queries';
 import EasCommand from '../../commandUtils/EasCommand';
-import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import { withErrorHandlingAsync } from '../../graphql/client';
-import {
-  DeleteUpdateChannelMutation,
-  DeleteUpdateChannelMutationVariables,
-  DeleteUpdateChannelResult,
-} from '../../graphql/generated';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
 import Log from '../../log';
 import { toggleConfirmAsync } from '../../prompts';
@@ -95,32 +86,7 @@ export default class ChannelDelete extends EasCommand {
     if (jsonFlag) {
       printJsonOnlyOutput(deletionResult);
     } else {
-      Log.withTick(`️Deleted channel "${channelName}".`);
+      Log.withTick(`Deleted channel "${channelName}".`);
     }
   }
-}
-
-async function deleteChannelOnAppAsync(
-  graphqlClient: ExpoGraphqlClient,
-  { channelId }: DeleteUpdateChannelMutationVariables
-): Promise<DeleteUpdateChannelResult> {
-  const data = await withErrorHandlingAsync(
-    graphqlClient
-      .mutation<DeleteUpdateChannelMutation, DeleteUpdateChannelMutationVariables>(
-        gql`
-          mutation DeleteUpdateChannel($channelId: ID!) {
-            updateChannel {
-              deleteUpdateChannel(channelId: $channelId) {
-                id
-              }
-            }
-          }
-        `,
-        {
-          channelId,
-        }
-      )
-      .toPromise()
-  );
-  return data.updateChannel.deleteUpdateChannel;
 }

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -1,7 +1,5 @@
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
-import { print } from 'graphql';
-import gql from 'graphql-tag';
 
 import { selectBranchOnAppAsync } from '../../branch/queries';
 import {
@@ -9,51 +7,14 @@ import {
   hasEmptyBranchMap,
   hasStandardBranchMap,
 } from '../../channel/branch-mapping';
-import { selectChannelOnAppAsync } from '../../channel/queries';
+import { selectChannelOnAppAsync, updateChannelBranchMappingAsync } from '../../channel/queries';
 import EasCommand from '../../commandUtils/EasCommand';
-import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import { withErrorHandlingAsync } from '../../graphql/client';
-import {
-  UpdateChannelBasicInfoFragment,
-  UpdateChannelBranchMappingMutation,
-  UpdateChannelBranchMappingMutationVariables,
-} from '../../graphql/generated';
 import { BranchQuery } from '../../graphql/queries/BranchQuery';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
-import { UpdateChannelBasicInfoFragmentNode } from '../../graphql/types/UpdateChannelBasicInfo';
 import Log from '../../log';
 import { isRollout } from '../../rollout/branch-mapping';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
-
-export async function updateChannelBranchMappingAsync(
-  graphqlClient: ExpoGraphqlClient,
-  { channelId, branchMapping }: UpdateChannelBranchMappingMutationVariables
-): Promise<UpdateChannelBasicInfoFragment> {
-  const data = await withErrorHandlingAsync(
-    graphqlClient
-      .mutation<UpdateChannelBranchMappingMutation, UpdateChannelBranchMappingMutationVariables>(
-        gql`
-          mutation UpdateChannelBranchMapping($channelId: ID!, $branchMapping: String!) {
-            updateChannel {
-              editUpdateChannel(channelId: $channelId, branchMapping: $branchMapping) {
-                id
-                ...UpdateChannelBasicInfoFragment
-              }
-            }
-          }
-          ${print(UpdateChannelBasicInfoFragmentNode)}
-        `,
-        { channelId, branchMapping }
-      )
-      .toPromise()
-  );
-  const channel = data.updateChannel.editUpdateChannel;
-  if (!channel) {
-    throw new Error(`Could not find a channel with id: ${channelId}`);
-  }
-  return channel;
-}
 
 export default class ChannelEdit extends EasCommand {
   static override description = 'point a channel at a new branch';

--- a/packages/eas-cli/src/commands/codepush/README.md
+++ b/packages/eas-cli/src/commands/codepush/README.md
@@ -1,0 +1,40 @@
+This set of commands does its best to map appcenter codepush commands to EAS update. Generally it works by mapping codepush deployments as EAS channels. Each release on a deployment corresponds to a branch with one update group. That release can be rolled out against the existing release on the deployment. Release history doesn't work too well, but that's ok I hope.
+
+deployment add - channel create
+deployment clear - channel edit, create empty branch, point to blank branch
+deployment history - branch view of current branch associated with the channel
+deployment list - channel list
+deployment remove - channel delete
+deployment rename - not possible, throw error
+
+release-react: creates new branch, rolls the channel out to N % on that branch.
+  --use-hermes: not supported
+  --extra-hermes-flag: not supported
+  --extra-bundler-option: not supported
+  --target-binary-version -> not supported, inferred runtime version
+  --output-dir -> same as eas update output dir
+  --sourcemap-output-dir -> not supported
+  --sourcemap-output -> not supported
+  --xcode-target-name -> not supported, use target-binary-version
+  --build-configuration-name -> not supported, use target-binary-version
+  --plist-file-prefix -> not supported
+  --xcode-project-file -> not supported
+  --plist-file -> not supported
+  --pod-file -> not supported
+  --gradle-file -> not supported, use target-binary-version
+  --entry-file -> not supported, same as eas update
+  --development -> not supported, think this is same as eas update
+  --bundle-name -> not supported
+  --rollout -> set N % to N
+  --disable-duplicate-release-error -> no idea
+  --private-key-path -> same as eas update
+  --mandatory -> not supported for now
+  --disabled -> set N % to 0
+  --description -> message
+  --deployment-name -> channel to put the new branch on
+
+promote: copies latest update on "latest branch" on channel to "latest branch" on other channel. it does this by creating a new branch with the update and pointing the channel to that new branch according to rollout or 100% if no rollout supplied.
+
+rollback: sets the rollout percentage of branch on channel to 0 (i.e. points to prev branch) and republishes the latest update on the prev branch to itself
+
+patch: only update the rollout percentage

--- a/packages/eas-cli/src/commands/codepush/deployment/add.ts
+++ b/packages/eas-cli/src/commands/codepush/deployment/add.ts
@@ -1,0 +1,86 @@
+/**
+ * $ appcenter codepush deployment add --help
+
+Add a new deployment to an app
+
+Usage: appcenter codepush deployment add [-a|--app <arg>] <new-deployment-name>
+
+Options:
+    new-deployment-name             New CodePush deployment name
+ */
+
+import chalk from 'chalk';
+
+import { createChannelOnAppWithNoBranchAsync } from '../../../channel/queries';
+import EasCommand from '../../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../../commandUtils/flags';
+import Log from '../../../log';
+import { getDisplayNameForProjectIdAsync } from '../../../project/projectUtils';
+import formatFields from '../../../utils/formatFields';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+
+export default class CodepushDeploymentAdd extends EasCommand {
+  static override hidden = true;
+  static override description = 'create a deployment';
+
+  static override args = [
+    {
+      name: 'name',
+      required: true,
+      description: 'Name of the deployment to create',
+    },
+  ];
+
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args: { name: deploymentName },
+      flags: { json: jsonFlag, 'non-interactive': nonInteractive },
+    } = await this.parse(CodepushDeploymentAdd);
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(CodepushDeploymentAdd, {
+      nonInteractive,
+    });
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    if (!deploymentName) {
+      throw new Error('Deployment name may not be empty.');
+    }
+
+    const createChannelResult = await createChannelOnAppWithNoBranchAsync(graphqlClient, {
+      appId: projectId,
+      channelName: deploymentName,
+    });
+
+    const newChannel = createChannelResult.updateChannel.createUpdateChannelForApp;
+
+    if (jsonFlag) {
+      printJsonOnlyOutput(newChannel);
+    } else {
+      Log.addNewLineIfNone();
+      Log.withTick(
+        `Created a new deployment on project ${chalk.bold(
+          await getDisplayNameForProjectIdAsync(graphqlClient, projectId)
+        )}`
+      );
+      Log.log(
+        formatFields([
+          { label: 'Name', value: newChannel.name },
+          { label: 'ID', value: newChannel.id },
+        ])
+      );
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/codepush/deployment/clear.ts
+++ b/packages/eas-cli/src/commands/codepush/deployment/clear.ts
@@ -1,0 +1,93 @@
+/**
+ * $ appcenter codepush deployment clear --help
+
+Clear the release history associated with a deployment
+
+Usage: appcenter codepush deployment clear [-a|--app <arg>] <deployment-name>
+
+Options:
+    -a|--app <arg>              Specify app in the <ownerName>/<appName> format
+    deployment-name             Specifies CodePush deployment name to be cleared
+
+Common Options (works on all commands):
+       --disable-telemetry             Disable telemetry for this command
+    -v|--version                       Display appcenter version
+       --quiet                         Auto-confirm any prompts without waiting for input
+    -h|--help                          Display help for current command
+       --env <arg>                     Environment when using API token
+       --token <arg>                   API token
+       --output <arg>                  Output format: json
+       --debug                         Display extra output for debugging
+ */
+
+import chalk from 'chalk';
+
+import { getEmptyBranchMapping } from '../../../channel/branch-mapping';
+import { updateChannelBranchMappingAsync } from '../../../channel/queries';
+import EasCommand from '../../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../../commandUtils/flags';
+import { ChannelQuery } from '../../../graphql/queries/ChannelQuery';
+import Log from '../../../log';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+
+export default class CodepushDeploymentClear extends EasCommand {
+  static override hidden = true;
+  static override description = 'clear a deployment';
+
+  static override args = [
+    {
+      name: 'name',
+      required: true,
+      description: 'Name of the deployment to clear',
+    },
+  ];
+
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args: { name: deploymentName },
+      flags: { json: jsonFlag, 'non-interactive': nonInteractive },
+    } = await this.parse(CodepushDeploymentClear);
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(CodepushDeploymentClear, {
+      nonInteractive,
+    });
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    if (!deploymentName) {
+      throw new Error('Deployment name may not be empty.');
+    }
+
+    const existingChannel = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      appId: projectId,
+      channelName: deploymentName,
+    });
+
+    const channel = await updateChannelBranchMappingAsync(graphqlClient, {
+      channelId: existingChannel.id,
+      branchMapping: JSON.stringify(getEmptyBranchMapping()),
+    });
+
+    if (jsonFlag) {
+      printJsonOnlyOutput(channel);
+    } else {
+      Log.withTick(chalk`Deployment {bold ${channel.name}} is now cleared.\n`);
+      Log.addNewLineIfNone();
+      Log.log(
+        chalk`Users with builds on deployment {bold ${channel.name}} will no longer have an available update.`
+      );
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/codepush/deployment/history.ts
+++ b/packages/eas-cli/src/commands/codepush/deployment/history.ts
@@ -1,0 +1,86 @@
+/**
+ * $ appcenter codepush deployment history --help
+
+Display the release history for a CodePush deployment
+
+Usage: appcenter codepush deployment history [-a|--app <arg>] <deployment-name>
+
+Options:
+    -a|--app <arg>              Specify app in the <ownerName>/<appName> format
+    deployment-name             Specifies CodePush deployment name to view history
+
+Common Options (works on all commands):
+       --disable-telemetry             Disable telemetry for this command
+    -v|--version                       Display appcenter version
+       --quiet                         Auto-confirm any prompts without waiting for input
+    -h|--help                          Display help for current command
+       --env <arg>                     Environment when using API token
+       --token <arg>                   API token
+       --output <arg>                  Output format: json
+       --debug                         Display extra output for debugging
+ */
+
+import chalk from 'chalk';
+
+import EasCommand from '../../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../../commandUtils/flags';
+import { ChannelQuery } from '../../../graphql/queries/ChannelQuery';
+import Log from '../../../log';
+import { printRollout } from '../../../rollout/utils';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+
+export default class CodepushDeploymentHistory extends EasCommand {
+  static override hidden = true;
+  static override description = 'get the release history for a deployment';
+
+  static override args = [
+    {
+      name: 'name',
+      required: true,
+      description: 'Name of the deployment',
+    },
+  ];
+
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args: { name: deploymentName },
+      flags: { json: jsonFlag, 'non-interactive': nonInteractive },
+    } = await this.parse(CodepushDeploymentHistory);
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(CodepushDeploymentHistory, {
+      nonInteractive,
+    });
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    if (!deploymentName) {
+      throw new Error('Deployment name may not be empty.');
+    }
+
+    const existingChannel = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      appId: projectId,
+      channelName: deploymentName,
+    });
+
+    if (jsonFlag) {
+      printJsonOnlyOutput(existingChannel);
+    } else {
+      Log.withTick(chalk`Deployment {bold ${existingChannel.name}} info:\n`);
+      Log.addNewLineIfNone();
+      printRollout(existingChannel);
+      Log.warn('For formatted output, add the --json flag to your command.');
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/codepush/deployment/list.ts
+++ b/packages/eas-cli/src/commands/codepush/deployment/list.ts
@@ -1,0 +1,69 @@
+/**
+ * $ appcenter codepush deployment list --help
+
+List the deployments associated with an app
+
+Usage: appcenter codepush deployment list [-s|--skipFetchingDeploymentMetrics] [-k|--displayKeys]
+         [-a|--app <arg>]
+
+Options:
+    -s|--skipFetchingDeploymentMetrics             Specifies whether to fetch deployment metrics
+    -k|--displayKeys                               Specifies whether to display the deployment keys
+    -a|--app <arg>                                 Specify app in the <ownerName>/<appName> format
+
+Common Options (works on all commands):
+       --disable-telemetry             Disable telemetry for this command
+    -v|--version                       Display appcenter version
+       --quiet                         Auto-confirm any prompts without waiting for input
+    -h|--help                          Display help for current command
+       --env <arg>                     Environment when using API token
+       --token <arg>                   API token
+       --output <arg>                  Output format: json
+       --debug                         Display extra output for debugging
+ */
+
+import { CHANNELS_LIMIT, listAndRenderChannelsOnAppAsync } from '../../../channel/queries';
+import EasCommand from '../../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../../commandUtils/flags';
+import {
+  EasPaginatedQueryFlags,
+  getLimitFlagWithCustomValues,
+  getPaginatedQueryOptions,
+} from '../../../commandUtils/pagination';
+import { enableJsonOutput } from '../../../utils/json';
+
+export default class CodepushDeploymentList extends EasCommand {
+  static override hidden = true;
+  static override description = 'list deployments';
+
+  static override flags = {
+    ...EasPaginatedQueryFlags,
+    limit: getLimitFlagWithCustomValues({ defaultTo: 10, limit: CHANNELS_LIMIT }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(CodepushDeploymentList);
+    const paginatedQueryOptions = getPaginatedQueryOptions(flags);
+    const { json: jsonFlag, 'non-interactive': nonInteractive } = flags;
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(CodepushDeploymentList, {
+      nonInteractive,
+    });
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    await listAndRenderChannelsOnAppAsync(graphqlClient, {
+      projectId,
+      paginatedQueryOptions,
+    });
+  }
+}

--- a/packages/eas-cli/src/commands/codepush/deployment/remove.ts
+++ b/packages/eas-cli/src/commands/codepush/deployment/remove.ts
@@ -1,0 +1,87 @@
+/**
+ * $ appcenter codepush deployment remove --help
+
+Remove CodePush deployment
+
+Usage: appcenter codepush deployment remove [-a|--app <arg>] <deployment-name>
+
+Options:
+    -a|--app <arg>              Specify app in the <ownerName>/<appName> format
+    deployment-name             Specifies CodePush deployment name to be removed
+
+Common Options (works on all commands):
+       --disable-telemetry             Disable telemetry for this command
+    -v|--version                       Display appcenter version
+       --quiet                         Auto-confirm any prompts without waiting for input
+    -h|--help                          Display help for current command
+       --env <arg>                     Environment when using API token
+       --token <arg>                   API token
+       --output <arg>                  Output format: json
+       --debug                         Display extra output for debugging
+ */
+
+import { deleteChannelOnAppAsync } from '../../../channel/queries';
+import EasCommand from '../../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../../commandUtils/flags';
+import { ChannelQuery } from '../../../graphql/queries/ChannelQuery';
+import Log from '../../../log';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+
+export default class CodepushDeploymentRemove extends EasCommand {
+  static override hidden = true;
+  static override description = 'Delete a deployment';
+
+  static override args = [
+    {
+      name: 'name',
+      required: true,
+      description: 'Name of the deployment to delete',
+    },
+  ];
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args: { name: deploymentName },
+      flags: { json: jsonFlag, 'non-interactive': nonInteractive },
+    } = await this.parse(CodepushDeploymentRemove);
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(CodepushDeploymentRemove, {
+      nonInteractive,
+    });
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    if (!deploymentName) {
+      throw new Error('Deployment name may not be empty.');
+    }
+
+    const { id: channelId, name: channelName } = await ChannelQuery.viewUpdateChannelAsync(
+      graphqlClient,
+      {
+        appId: projectId,
+        channelName: deploymentName,
+      }
+    );
+
+    const deletionResult = await deleteChannelOnAppAsync(graphqlClient, {
+      channelId,
+    });
+
+    if (jsonFlag) {
+      printJsonOnlyOutput(deletionResult);
+    } else {
+      Log.withTick(`Deleted deployment "${channelName}".`);
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/codepush/patch.ts
+++ b/packages/eas-cli/src/commands/codepush/patch.ts
@@ -1,0 +1,155 @@
+/**
+ * $ appcenter codepush patch --help
+
+Update the metadata for an existing CodePush release
+
+Usage: appcenter codepush patch [-r|--rollout <arg>] [-d|--description <arg>]
+         [-t|--target-binary-version <arg>] [-x|--disabled] [-m|--mandatory]
+         [-l|--existing-release-label <arg>] [-a|--app <arg>] <deployment-name>
+
+Options:
+    -r|--rollout <arg>                            Specifies percentage of users this release should be
+                                                  immediately available to. (The specified number must be
+                                                  an integer between 1 and 100)
+    -d|--description <arg>                        Specifies description of the changes made to the app with
+                                                  this release
+    -t|--target-binary-version <arg>              Specifies binary app version(s) that specifies this
+                                                  release is targeting for. (The value must be a semver
+                                                  expression such as 1.1.0, ~1.2.3)
+    -x|--disabled                                 Specifies whether this release should be immediately
+                                                  downloadable. (Putting -x flag means disabled)
+    -m|--mandatory                                Specifies whether this release should be considered
+                                                  mandatory. (Putting -m flag means mandatory)
+    -l|--existing-release-label <arg>             Specifies label of one existing release to update.
+                                                  (Defaults to the latest release within the specified
+                                                  deployment)
+    -a|--app <arg>                                Specify app in the <ownerName>/<appName> format
+    deployment-name                               Specifies one existing deployment name.
+
+Common Options (works on all commands):
+       --disable-telemetry             Disable telemetry for this command
+    -v|--version                       Display appcenter version
+       --quiet                         Auto-confirm any prompts without waiting for input
+    -h|--help                          Display help for current command
+       --env <arg>                     Environment when using API token
+       --token <arg>                   API token
+       --output <arg>                  Output format: json
+       --debug                         Display extra output for debugging
+ */
+
+import { Flags } from '@oclif/core';
+
+import {
+  BranchMapping,
+  getAlwaysTrueBranchMapping,
+  getBranchMapping,
+  isAlwaysTrueBranchMapping,
+  isEmptyBranchMapping,
+} from '../../channel/branch-mapping';
+import { updateChannelBranchMappingAsync } from '../../channel/queries';
+import EasCommand from '../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import Log from '../../log';
+import {
+  editRolloutBranchMapping,
+  getRolloutInfoFromBranchMapping,
+  isRolloutBranchMapping,
+} from '../../rollout/branch-mapping';
+import { enableJsonOutput } from '../../utils/json';
+
+export default class CodepushPatch extends EasCommand {
+  static override hidden = true;
+  static override description = 'update the metadata for the latest release on a deployment';
+
+  static override args = [
+    {
+      name: 'name',
+      required: true,
+      description: 'Name of the codepush deployment to patch the latest release on',
+    },
+  ];
+
+  static override flags = {
+    rollout: Flags.integer({
+      char: 'r',
+      description: 'Percentage of users this release should be available to',
+      required: false,
+    }),
+    disabled: Flags.boolean({
+      char: 'x',
+      description: 'Specifies whether this release should be immediately downloadable',
+      required: false,
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      flags: { rollout, disabled, json: jsonFlag, 'non-interactive': nonInteractive },
+      args: { name: deploymentName },
+    } = await this.parse(CodepushPatch);
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(CodepushPatch, {
+      nonInteractive,
+    });
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    if (!deploymentName) {
+      throw new Error('Deployment name may not be empty.');
+    }
+
+    const channel = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      appId: projectId,
+      channelName: deploymentName,
+    });
+
+    // set channel rollout
+    const rolloutPercent = disabled ? 0 : rollout ?? 100;
+
+    const existingBranchMappingString = channel.branchMapping;
+    let updatedBranchMapping: BranchMapping;
+    if (!existingBranchMappingString) {
+      throw new Error(
+        'No existing rollout on deployment. Publish an release with the `release-react` command.'
+      );
+    } else {
+      const existingBranchMapping = getBranchMapping(existingBranchMappingString);
+      if (isEmptyBranchMapping(existingBranchMapping)) {
+        throw new Error(
+          'No existing rollout on deployment. Publish an release with the `release-react` command.'
+        );
+      } else if (isAlwaysTrueBranchMapping(existingBranchMapping)) {
+        throw new Error(
+          'No existing rollout on deployment. Publish an release with the `release-react` command.'
+        );
+      } else if (isRolloutBranchMapping(existingBranchMapping)) {
+        const rolloutInfo = getRolloutInfoFromBranchMapping(existingBranchMapping);
+        const existingRolloutRolloutBranchId = rolloutInfo.rolledOutBranchId;
+        updatedBranchMapping =
+          rolloutPercent === 100
+            ? getAlwaysTrueBranchMapping(existingRolloutRolloutBranchId)
+            : editRolloutBranchMapping(existingBranchMapping, rolloutPercent);
+      } else {
+        throw new Error('Unrecognized custom deployment structure');
+      }
+    }
+
+    const newChannelInfo = await updateChannelBranchMappingAsync(graphqlClient, {
+      channelId: channel.id,
+      branchMapping: JSON.stringify(updatedBranchMapping),
+    });
+
+    Log.addNewLineIfNone();
+    Log.log(`✅ Successfuly updated rollout on ${newChannelInfo.name}`);
+  }
+}

--- a/packages/eas-cli/src/commands/codepush/promote.ts
+++ b/packages/eas-cli/src/commands/codepush/promote.ts
@@ -1,0 +1,250 @@
+/**
+ * $ appcenter codepush promote --help
+
+Create a new release for the destination deployment, which includes the exact code and metadata from the latest release of the source deployment
+
+Usage: appcenter codepush promote -s|--source-deployment-name <arg> -d|--destination-deployment-name <arg>
+         [-t|--target-binary-version <arg>] [-r|--rollout <arg>] [--disable-duplicate-release-error]
+         [-x|--disabled] [-m|--mandatory] [-l|--label <arg>] [--description <arg>] [-a|--app <arg>]
+
+Options:
+    -s|--source-deployment-name <arg>                  Specifies source deployment name
+    -d|--destination-deployment-name <arg>             Specifies destination deployment name
+    -t|--target-binary-version <arg>                   Specifies binary app version(s) that specifies this
+                                                       release is targeting for. (The value must be a
+                                                       semver expression such as 1.1.0, ~1.2.3)
+    -r|--rollout <arg>                                 Specifies percentage of users this release should be
+                                                       immediately available to. (The specified number must
+                                                       be an integer between 1 and 100)
+       --disable-duplicate-release-error               Specifies that if the update is identical to the
+                                                       latest release on the deployment, the CLI should
+                                                       generate a warning instead of an error
+    -x|--disabled                                      Specifies whether this release should be immediately
+                                                       downloadable. (Putting -x flag means disabled)
+    -m|--mandatory                                     Specifies whether this release should be considered
+                                                       mandatory. (Putting -m flag means mandatory)
+    -l|--label <arg>                                   Allows you to pick the specified label from the
+                                                       source deployment and promote it to the destination
+                                                       deployment
+       --description <arg>                             Specifies description of the changes made to the app
+                                                       with this release
+    -a|--app <arg>                                     Specify app in the <ownerName>/<appName> format
+
+Common Options (works on all commands):
+       --disable-telemetry             Disable telemetry for this command
+    -v|--version                       Display appcenter version
+       --quiet                         Auto-confirm any prompts without waiting for input
+    -h|--help                          Display help for current command
+       --env <arg>                     Environment when using API token
+       --token <arg>                   API token
+       --output <arg>                  Output format: json
+       --debug                         Display extra output for debugging
+ */
+
+import { Flags } from '@oclif/core';
+import nullthrows from 'nullthrows';
+
+import { createUpdateBranchOnAppAsync } from '../../branch/queries';
+import {
+  BranchMapping,
+  getAlwaysTrueBranchMapping,
+  getBranchMapping,
+  isAlwaysTrueBranchMapping,
+  isEmptyBranchMapping,
+} from '../../channel/branch-mapping';
+import { updateChannelBranchMappingAsync } from '../../channel/queries';
+import EasCommand from '../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import Log from '../../log';
+import {
+  createRolloutBranchMapping,
+  getRolloutInfoFromBranchMapping,
+  isRolloutBranchMapping,
+} from '../../rollout/branch-mapping';
+import { republishAsync } from '../../update/republish';
+import { getCodeSigningInfoAsync } from '../../utils/code-signing';
+import { enableJsonOutput } from '../../utils/json';
+
+export default class CodepushPromote extends EasCommand {
+  static override hidden = true;
+  static override description =
+    'republish latest release from source deployment to destination deployment';
+
+  static override flags = {
+    sourceDeploymentName: Flags.string({
+      char: 's',
+      description: 'Source deployment',
+      required: true,
+    }),
+    destinationDeploymentName: Flags.string({
+      char: 'd',
+      description: 'Destination deployment',
+      required: true,
+    }),
+    rollout: Flags.integer({
+      char: 'r',
+      description: 'Percentage of users this release should be available to',
+      required: false,
+    }),
+    disabled: Flags.boolean({
+      char: 'x',
+      description: 'Specifies whether this release should be immediately downloadable',
+      required: false,
+    }),
+    'private-key-path': Flags.string({
+      description: `File containing the PEM-encoded private key corresponding to the certificate in expo-updates' configuration. Defaults to a file named "private-key.pem" in the certificate's directory. Only relevant if you are using code signing: https://docs.expo.dev/eas-update/code-signing/`,
+      required: false,
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      flags: {
+        sourceDeploymentName,
+        destinationDeploymentName,
+        rollout,
+        disabled,
+        'private-key-path': privateKeyPath,
+        json: jsonFlag,
+        'non-interactive': nonInteractive,
+      },
+    } = await this.parse(CodepushPromote);
+    const {
+      privateProjectConfig: { projectId, exp },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(CodepushPromote, {
+      nonInteractive,
+    });
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    if (!sourceDeploymentName) {
+      throw new Error('Source deployment name may not be empty.');
+    }
+
+    if (!destinationDeploymentName) {
+      throw new Error('Source deployment name may not be empty.');
+    }
+
+    const [sourceChannel, destinationChannel] = await Promise.all([
+      ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+        appId: projectId,
+        channelName: sourceDeploymentName,
+      }),
+      ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+        appId: projectId,
+        channelName: destinationDeploymentName,
+      }),
+    ]);
+
+    const sourceBranchMappingString = sourceChannel.branchMapping;
+    let latestBranchIdOnSourceChannel: string;
+    if (!sourceBranchMappingString) {
+      throw new Error(
+        'No releases on source deployment. Publish an release with the `release-react` command.'
+      );
+    } else {
+      const existingBranchMapping = getBranchMapping(sourceBranchMappingString);
+      if (isEmptyBranchMapping(existingBranchMapping)) {
+        throw new Error(
+          'No releases on source deployment. Publish an update with the `release-react` command.'
+        );
+      } else if (isAlwaysTrueBranchMapping(existingBranchMapping)) {
+        latestBranchIdOnSourceChannel = existingBranchMapping.data[0].branchId;
+      } else if (isRolloutBranchMapping(existingBranchMapping)) {
+        const rolloutInfo = getRolloutInfoFromBranchMapping(existingBranchMapping);
+        latestBranchIdOnSourceChannel = rolloutInfo.rolledOutBranchId;
+      } else {
+        throw new Error('Unrecognized custom deployment structure');
+      }
+    }
+
+    const latestBranchOnSourceChannel = nullthrows(
+      sourceChannel.updateBranches.find(b => b.id === latestBranchIdOnSourceChannel)
+    );
+
+    // republish latest updates from source branch to new destination branch
+    const createdBranch = await createUpdateBranchOnAppAsync(graphqlClient, {
+      appId: projectId,
+      name: latestBranchOnSourceChannel.name, // maybe change name
+    });
+
+    const updateGroupToRepublish = latestBranchOnSourceChannel.updateGroups[0];
+    const codeSigningInfo = await getCodeSigningInfoAsync(exp, privateKeyPath ?? undefined);
+    const arbitraryUpdate = updateGroupToRepublish[0];
+    const { message: oldUpdateMessage, group: oldGroupId } = arbitraryUpdate;
+    const newUpdateMessage = `Republish "${oldUpdateMessage!}" - group: ${oldGroupId}`;
+    await republishAsync({
+      graphqlClient,
+      app: {
+        projectId,
+        exp,
+      },
+      updatesToPublish: updateGroupToRepublish.map(update => ({
+        ...update,
+        groupId: update.group,
+        branchId: update.branch.id,
+        branchName: update.branch.name,
+      })),
+      codeSigningInfo,
+      targetBranch: { branchId: createdBranch.id, branchName: createdBranch.name },
+      updateMessage: newUpdateMessage,
+    });
+
+    // set destination channel rollout
+    const destinationRolloutPercent = disabled ? 0 : rollout ?? 100;
+
+    const destinationBranchMappingString = destinationChannel.branchMapping;
+    let updatedBranchMapping: BranchMapping;
+    if (!destinationBranchMappingString) {
+      if (destinationRolloutPercent !== 100) {
+        throw new Error('Cannot roll out first release on deployment'); // TODO(wschurman): this needs to be possible
+      }
+      updatedBranchMapping = getAlwaysTrueBranchMapping(createdBranch.id);
+    } else {
+      const existingBranchMapping = getBranchMapping(destinationBranchMappingString);
+      if (isEmptyBranchMapping(existingBranchMapping)) {
+        if (destinationRolloutPercent !== 100) {
+          throw new Error('Cannot roll out first release on deployment'); // TODO(wschurman): this needs to be possible
+        }
+        updatedBranchMapping = getAlwaysTrueBranchMapping(createdBranch.id);
+      } else if (isAlwaysTrueBranchMapping(existingBranchMapping)) {
+        const existingDestinationBranchId = existingBranchMapping.data[0].branchId;
+        updatedBranchMapping =
+          destinationRolloutPercent === 100
+            ? getAlwaysTrueBranchMapping(existingDestinationBranchId)
+            : createRolloutBranchMapping({
+                defaultBranchId: existingBranchMapping.data[0].branchId,
+                rolloutBranchId: createdBranch.id,
+                runtimeVersion: arbitraryUpdate.runtimeVersion,
+                percent: destinationRolloutPercent,
+              });
+      } else if (isRolloutBranchMapping(existingBranchMapping)) {
+        if (destinationRolloutPercent !== 100) {
+          throw new Error(
+            'Cannot roll out first release on deployment that already has a roll out in progress'
+          ); // TODO(wschurman): handle runtime versions (only check for roll out for runtime version)
+        }
+        updatedBranchMapping = getAlwaysTrueBranchMapping(createdBranch.id);
+      } else {
+        throw new Error('Unrecognized custom deployment structure');
+      }
+    }
+
+    const newChannelInfo = await updateChannelBranchMappingAsync(graphqlClient, {
+      channelId: destinationChannel.id,
+      branchMapping: JSON.stringify(updatedBranchMapping),
+    });
+
+    Log.addNewLineIfNone();
+    Log.log(`✅ Successfuly updated rollout on ${newChannelInfo.name}`);
+  }
+}

--- a/packages/eas-cli/src/commands/codepush/release-react.ts
+++ b/packages/eas-cli/src/commands/codepush/release-react.ts
@@ -1,0 +1,369 @@
+/**
+ * $ appcenter codepush release-react --help
+
+Release a React Native update to an app deployment
+
+Usage: appcenter codepush release-react [--use-hermes] [--extra-hermes-flag <arg>] [--extra-bundler-option <arg>]
+         [-t|--target-binary-version <arg>] [-o|--output-dir <arg>] [--sourcemap-output-dir <arg>]
+         [-s|--sourcemap-output <arg>] [-xt|--xcode-target-name <arg>] [-c|--build-configuration-name <arg>]
+         [--plist-file-prefix <arg>] [-xp|--xcode-project-file <arg>] [-p|--plist-file <arg>] [--pod-file <arg>]
+         [-g|--gradle-file <arg>] [-e|--entry-file <arg>] [--development] [-b|--bundle-name <arg>]
+         [-r|--rollout <arg>] [--disable-duplicate-release-error] [-k|--private-key-path <arg>] [-m|--mandatory]
+         [-x|--disabled] [--description <arg>] [-d|--deployment-name <arg>] [-a|--app <arg>]
+
+Options:
+       --use-hermes                                  Enable hermes and bypass automatic checks
+       --extra-hermes-flag <arg>                     Flag that gets passed to Hermes, JavaScript to bytecode compiler. Can
+                                                     be specified multiple times
+       --extra-bundler-option <arg>                  Option that gets passed to react-native bundler. Can be specified
+                                                     multiple times
+    -t|--target-binary-version <arg>                 Semver expression that specifies the binary app version(s) this
+                                                     release is targeting (e.g. 1.1.0, ~1.2.3)
+    -o|--output-dir <arg>                            Path to where the bundle should be written. If omitted, the bundle
+                                                     will not be saved on your machine
+       --sourcemap-output-dir <arg>                  Path to folder where the sourcemap for the resulting bundle should be
+                                                     written. Name of sourcemap file will be generated automatically. This
+                                                     argument will be ignored if "sourcemap-output" argument is provided.
+                                                     If omitted, a sourcemap will not be generated
+    -s|--sourcemap-output <arg>                      Path to where the sourcemap for the resulting bundle should be
+                                                     written. If omitted, a sourcemap will not be generated
+    -xt|--xcode-target-name <arg>                    Name of target (PBXNativeTarget) which specifies the binary version
+                                                     you want to target this release at (iOS only)
+    -c|--build-configuration-name <arg>              Name of build configuration which specifies the binary version you
+                                                     want to target this release at. For example, "Debug" or "Release" (iOS
+                                                     only)
+       --plist-file-prefix <arg>                     Prefix to append to the file name when attempting to find your app's
+                                                     Info.plist file (iOS only)
+    -xp|--xcode-project-file <arg>                   Path to the Xcode project or project.pbxproj file
+    -p|--plist-file <arg>                            Path to the plist file which specifies the binary version you want to
+                                                     target this release at (iOS only)
+       --pod-file <arg>                              Path to the cocopods config file (iOS only)
+    -g|--gradle-file <arg>                           Path to the gradle file which specifies the binary version you want to
+                                                     target this release at (android only)
+    -e|--entry-file <arg>                            Path to the app's entry JavaScript file. If omitted,
+                                                     "index.<platform>.js" and then "index.js" will be used (if they exist)
+       --development                                 Specifies whether to generate a dev or release build
+    -b|--bundle-name <arg>                           Name of the generated JS bundle file. If unspecified, the standard
+                                                     bundle name will be used, depending on the specified platform:
+                                                     "main.jsbundle" (iOS), "index.android.bundle" (Android) or
+                                                     "index.windows.bundle" (Windows)
+    -r|--rollout <arg>                               Percentage of users this release should be available to
+       --disable-duplicate-release-error             When this flag is set, releasing a package that is identical to the
+                                                     latest release will produce a warning instead of an error
+    -k|--private-key-path <arg>                      Specifies the location of a RSA private key to sign the release
+                                                     with.NOTICE: use it for react native applications only, client SDK on
+                                                     other platforms will be ignoring signature verification for now!
+    -m|--mandatory                                   Specifies whether this release should be considered mandatory
+    -x|--disabled                                    Specifies whether this release should be immediately downloadable
+       --description <arg>                           Description of the changes made to the app in this release
+    -d|--deployment-name <arg>                       Deployment to release the update to
+    -a|--app <arg>                                   Specify app in the <ownerName>/<appName> format
+
+Common Options (works on all commands):
+       --disable-telemetry             Disable telemetry for this command
+    -v|--version                       Display appcenter version
+       --quiet                         Auto-confirm any prompts without waiting for input
+    -h|--help                          Display help for current command
+       --env <arg>                     Environment when using API token
+       --token <arg>                   API token
+       --output <arg>                  Output format: json
+       --debug                         Display extra output for debugging
+ */
+
+import { Workflow } from '@expo/eas-build-job';
+import { Flags } from '@oclif/core';
+
+import { createUpdateBranchOnAppAsync } from '../../branch/queries';
+import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
+import { getUpdateGroupUrl } from '../../build/utils/url';
+import {
+  BranchMapping,
+  getAlwaysTrueBranchMapping,
+  getBranchMapping,
+  isAlwaysTrueBranchMapping,
+  isEmptyBranchMapping,
+} from '../../channel/branch-mapping';
+import { updateChannelBranchMappingAsync } from '../../channel/queries';
+import EasCommand from '../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { StatuspageServiceName } from '../../graphql/generated';
+import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import Log, { learnMore, link } from '../../log';
+import { RequestedPlatform } from '../../platform';
+import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
+import {
+  buildAndUploadAssetsAsync,
+  getRuntimeVersionObjectAsync,
+  isUploadedAssetCountAboveWarningThreshold,
+  publishUpdateGroupsAsync,
+} from '../../project/publish';
+import { resolveWorkflowPerPlatformAsync } from '../../project/workflow';
+import { createRolloutBranchMapping, isRolloutBranchMapping } from '../../rollout/branch-mapping';
+import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
+import { getUpdateJsonInfosForUpdates } from '../../update/utils';
+import { getCodeSigningInfoAsync } from '../../utils/code-signing';
+import uniqBy from '../../utils/expodash/uniqBy';
+import formatFields from '../../utils/formatFields';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+import { maybeWarnAboutEasOutagesAsync } from '../../utils/statuspageService';
+
+export default class CodepushReleaseReact extends EasCommand {
+  static override hidden = true;
+  static override description = 'Release an update to a deployment';
+
+  static override flags = {
+    rollout: Flags.integer({
+      char: 'r',
+      description: 'Percentage of users this release should be available to',
+      required: false,
+    }),
+    description: Flags.string({
+      description: 'Description of the changes made to the app in this release',
+      required: true,
+    }),
+    deploymentName: Flags.string({
+      char: 'd',
+      description: 'Deployment to release the update to',
+      required: true,
+    }),
+    disabled: Flags.boolean({
+      char: 'x',
+      description: 'Specifies whether this release should be immediately downloadable',
+      required: false,
+    }),
+    'clear-cache': Flags.boolean({
+      description: `Clear the bundler cache before publishing`,
+      default: false,
+    }),
+    'private-key-path': Flags.string({
+      description: `File containing the PEM-encoded private key corresponding to the certificate in expo-updates' configuration. Defaults to a file named "private-key.pem" in the certificate's directory. Only relevant if you are using code signing: https://docs.expo.dev/eas-update/code-signing/`,
+      required: false,
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.DynamicProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+    ...this.ContextOptions.Vcs,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      flags: {
+        rollout,
+        description,
+        deploymentName,
+        disabled,
+        'clear-cache': clearCache,
+        'private-key-path': privateKeyPath,
+        json: jsonFlag,
+        'non-interactive': nonInteractive,
+      },
+    } = await this.parse(CodepushReleaseReact);
+    const {
+      getDynamicPublicProjectConfigAsync,
+      getDynamicPrivateProjectConfigAsync,
+      loggedIn: { graphqlClient },
+      vcsClient,
+    } = await this.getContextAsync(CodepushReleaseReact, {
+      nonInteractive,
+    });
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    if (!deploymentName) {
+      throw new Error('Deployment name may not be empty.');
+    }
+
+    await vcsClient.ensureRepoExistsAsync();
+    await ensureRepoIsCleanAsync(vcsClient, nonInteractive);
+
+    const {
+      exp: expPossiblyWithoutEasUpdateConfigured,
+      projectId,
+      projectDir,
+    } = await getDynamicPublicProjectConfigAsync();
+
+    await maybeWarnAboutEasOutagesAsync(graphqlClient, [StatuspageServiceName.EasUpdate]);
+
+    await ensureEASUpdateIsConfiguredAsync({
+      exp: expPossiblyWithoutEasUpdateConfigured,
+      platform: RequestedPlatform.All,
+      projectDir,
+      projectId,
+      vcsClient,
+      env: undefined,
+    });
+
+    const { exp } = await getDynamicPublicProjectConfigAsync();
+    const { exp: expPrivate } = await getDynamicPrivateProjectConfigAsync();
+    const codeSigningInfo = await getCodeSigningInfoAsync(expPrivate, privateKeyPath);
+
+    const channel = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      appId: projectId,
+      channelName: deploymentName,
+    });
+
+    const createdBranch = await createUpdateBranchOnAppAsync(graphqlClient, {
+      appId: projectId,
+      name: description, // TODO(wschurman): make this name something else maybe, maybe something with date or something
+    });
+
+    const {
+      realizedPlatforms,
+      unsortedUpdateInfoGroups,
+      uploadedAssetCount,
+      assetLimitPerUpdateGroup,
+    } = await buildAndUploadAssetsAsync({
+      graphqlClient,
+      projectId,
+      skipBundler: false,
+      projectDir,
+      inputDir: 'dist',
+      exp,
+      platformFlag: 'all',
+      clearCache,
+    });
+
+    const workflows = await resolveWorkflowPerPlatformAsync(projectDir, vcsClient);
+    const runtimeVersions = await getRuntimeVersionObjectAsync({
+      exp,
+      platforms: realizedPlatforms,
+      projectDir,
+      workflows: {
+        ...workflows,
+        web: Workflow.UNKNOWN,
+      },
+      env: undefined,
+    });
+
+    const runtimeVersionsArr = Array.from(new Set(runtimeVersions.map(r => r.runtimeVersion)));
+    if (runtimeVersionsArr.length > 1) {
+      throw new Error(
+        'Using codepush requires the runtime version to be the same for all platforms'
+      );
+    }
+
+    const gitCommitHash = await vcsClient.getCommitHashAsync();
+    const isGitWorkingTreeDirty = await vcsClient.hasUncommittedChangesAsync();
+
+    const { newUpdates } = await publishUpdateGroupsAsync({
+      graphqlClient,
+      branchId: createdBranch.id,
+      runtimeVersions,
+      gitCommitHash,
+      isGitWorkingTreeDirty,
+      unsortedUpdateInfoGroups,
+      updateMessage: description,
+      codeSigningInfo,
+    });
+
+    // set channel rollout
+    const rolloutPercent = disabled ? 0 : rollout ?? 100;
+    const existingBranchMappingString = channel.branchMapping;
+    let updatedBranchMapping: BranchMapping;
+    if (!existingBranchMappingString) {
+      updatedBranchMapping = getAlwaysTrueBranchMapping(createdBranch.id);
+    } else {
+      const existingBranchMapping = getBranchMapping(existingBranchMappingString);
+      if (isEmptyBranchMapping(existingBranchMapping)) {
+        updatedBranchMapping = getAlwaysTrueBranchMapping(createdBranch.id);
+      } else if (isAlwaysTrueBranchMapping(existingBranchMapping)) {
+        updatedBranchMapping =
+          rolloutPercent === 100
+            ? getAlwaysTrueBranchMapping(createdBranch.id)
+            : createRolloutBranchMapping({
+                defaultBranchId: existingBranchMapping.data[0].branchId,
+                rolloutBranchId: createdBranch.id,
+                runtimeVersion: runtimeVersionsArr[0],
+                percent: rolloutPercent,
+              });
+      } else if (isRolloutBranchMapping(existingBranchMapping)) {
+        if (rolloutPercent !== 100) {
+          throw new Error('Cannot start a rollout on a deployment when one is already in progress');
+        }
+        updatedBranchMapping = getAlwaysTrueBranchMapping(createdBranch.id);
+      } else {
+        throw new Error('Unrecognized custom deployment structure');
+      }
+    }
+
+    await updateChannelBranchMappingAsync(graphqlClient, {
+      channelId: channel.id,
+      branchMapping: JSON.stringify(updatedBranchMapping),
+    });
+
+    if (jsonFlag) {
+      printJsonOnlyOutput(getUpdateJsonInfosForUpdates(newUpdates));
+    } else {
+      if (new Set(newUpdates.map(update => update.group)).size > 1) {
+        Log.addNewLineIfNone();
+        Log.log(
+          '👉 Since multiple runtime versions are defined, multiple update groups have been published.'
+        );
+      }
+
+      Log.addNewLineIfNone();
+
+      for (const runtime of uniqBy(runtimeVersions, version => version.runtimeVersion)) {
+        const newUpdatesForRuntimeVersion = newUpdates.filter(
+          update => update.runtimeVersion === runtime.runtimeVersion
+        );
+        if (newUpdatesForRuntimeVersion.length === 0) {
+          throw new Error(
+            `Publish response is missing updates with runtime ${runtime.runtimeVersion}.`
+          );
+        }
+        const platforms = newUpdatesForRuntimeVersion.map(update => update.platform);
+        const newAndroidUpdate = newUpdatesForRuntimeVersion.find(
+          update => update.platform === 'android'
+        );
+        const newIosUpdate = newUpdatesForRuntimeVersion.find(update => update.platform === 'ios');
+        const updateGroupId = newUpdatesForRuntimeVersion[0].group;
+
+        const projectName = exp.slug;
+        const accountName = (await getOwnerAccountForProjectIdAsync(graphqlClient, projectId)).name;
+        const updateGroupUrl = getUpdateGroupUrl(accountName, projectName, updateGroupId);
+        const updateGroupLink = link(updateGroupUrl, { dim: false });
+
+        Log.log(
+          formatFields([
+            { label: 'Branch', value: createdBranch.name },
+            { label: 'Runtime version', value: runtime.runtimeVersion },
+            { label: 'Platform', value: platforms.join(', ') },
+            { label: 'Update group ID', value: updateGroupId },
+            ...(newAndroidUpdate
+              ? [{ label: 'Android update ID', value: newAndroidUpdate.id }]
+              : []),
+            ...(newIosUpdate ? [{ label: 'iOS update ID', value: newIosUpdate.id }] : []),
+            { label: 'Message', value: description ?? '' },
+            ...(gitCommitHash
+              ? [
+                  {
+                    label: 'Commit',
+                    value: `${gitCommitHash}${isGitWorkingTreeDirty ? '*' : ''}`,
+                  },
+                ]
+              : []),
+            { label: 'EAS Dashboard', value: updateGroupLink },
+          ])
+        );
+        Log.addNewLineIfNone();
+        if (
+          isUploadedAssetCountAboveWarningThreshold(uploadedAssetCount, assetLimitPerUpdateGroup)
+        ) {
+          Log.warn(
+            `This update group contains ${uploadedAssetCount} assets and is nearing the server cap of ${assetLimitPerUpdateGroup}.\n` +
+              `${learnMore('https://docs.expo.dev/eas-update/optimize-assets/', {
+                learnMoreMessage: 'Consider optimizing your usage of assets',
+                dim: false,
+              })}.`
+          );
+          Log.addNewLineIfNone();
+        }
+      }
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/codepush/rollback.ts
+++ b/packages/eas-cli/src/commands/codepush/rollback.ts
@@ -1,0 +1,116 @@
+/**
+ * $ appcenter codepush rollback --help
+
+Rollback a deployment to a previous release
+
+Usage: appcenter codepush rollback [--target-release <arg>] [-a|--app <arg>] <deployment-name>
+
+Options:
+       --target-release <arg>             Specifies the release label to be rolled back
+    -a|--app <arg>                        Specify app in the <ownerName>/<appName> format
+    deployment-name                       Specifies deployment name to be rolled back
+
+Common Options (works on all commands):
+       --disable-telemetry             Disable telemetry for this command
+    -v|--version                       Display appcenter version
+       --quiet                         Auto-confirm any prompts without waiting for input
+    -h|--help                          Display help for current command
+       --env <arg>                     Environment when using API token
+       --token <arg>                   API token
+       --output <arg>                  Output format: json
+       --debug                         Display extra output for debugging
+ */
+
+import {
+  BranchMapping,
+  getAlwaysTrueBranchMapping,
+  getBranchMapping,
+  isAlwaysTrueBranchMapping,
+  isEmptyBranchMapping,
+} from '../../channel/branch-mapping';
+import { updateChannelBranchMappingAsync } from '../../channel/queries';
+import EasCommand from '../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import Log from '../../log';
+import {
+  getRolloutInfoFromBranchMapping,
+  isRolloutBranchMapping,
+} from '../../rollout/branch-mapping';
+import { enableJsonOutput } from '../../utils/json';
+
+export default class CodepushRollback extends EasCommand {
+  static override hidden = true;
+  static override description = 'roll back a rollout on a deployment';
+
+  static override args = [
+    {
+      name: 'name',
+      required: true,
+      description: 'Name of the codepush deployment to roll back the current rollout on',
+    },
+  ];
+
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      flags: { json: jsonFlag, 'non-interactive': nonInteractive },
+      args: { name: deploymentName },
+    } = await this.parse(CodepushRollback);
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(CodepushRollback, {
+      nonInteractive,
+    });
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    if (!deploymentName) {
+      throw new Error('Deployment name may not be empty.');
+    }
+
+    const channel = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      appId: projectId,
+      channelName: deploymentName,
+    });
+
+    // set channel rollout
+
+    const existingBranchMappingString = channel.branchMapping;
+    let updatedBranchMapping: BranchMapping;
+    if (!existingBranchMappingString) {
+      throw new Error('No existing rollout on deployment.');
+    } else {
+      const existingBranchMapping = getBranchMapping(existingBranchMappingString);
+      if (isEmptyBranchMapping(existingBranchMapping)) {
+        throw new Error('No existing rollout on deployment.');
+      } else if (isAlwaysTrueBranchMapping(existingBranchMapping)) {
+        throw new Error('No existing rollout on deployment.');
+      } else if (isRolloutBranchMapping(existingBranchMapping)) {
+        const rolloutInfo = getRolloutInfoFromBranchMapping(existingBranchMapping);
+        const existingRolloutDefaultBranchId = rolloutInfo.defaultBranchId;
+        updatedBranchMapping = getAlwaysTrueBranchMapping(existingRolloutDefaultBranchId);
+      } else {
+        throw new Error('Unrecognized custom deployment structure');
+      }
+    }
+
+    const newChannelInfo = await updateChannelBranchMappingAsync(graphqlClient, {
+      channelId: channel.id,
+      branchMapping: JSON.stringify(updatedBranchMapping),
+    });
+
+    Log.addNewLineIfNone();
+    Log.log(`✅ Successfuly updated rollout on ${newChannelInfo.name}`);
+  }
+}

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -1,8 +1,6 @@
-import { Platform as PublishPlatform } from '@expo/config';
 import { Workflow } from '@expo/eas-build-job';
 import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
-import nullthrows from 'nullthrows';
 
 import { ensureBranchExistsAsync } from '../../branch/queries';
 import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
@@ -10,47 +8,26 @@ import { getUpdateGroupUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { getPaginatedQueryOptions } from '../../commandUtils/pagination';
-import fetch from '../../fetch';
-import {
-  PublishUpdateGroupInput,
-  StatuspageServiceName,
-  UpdateInfoGroup,
-  UpdatePublishMutation,
-} from '../../graphql/generated';
-import { PublishMutation } from '../../graphql/mutations/PublishMutation';
+import { StatuspageServiceName } from '../../graphql/generated';
 import Log, { learnMore, link } from '../../log';
-import { ora } from '../../ora';
 import { RequestedPlatform } from '../../platform';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import {
   ExpoCLIExportPlatformFlag,
-  RawAsset,
-  buildBundlesAsync,
-  buildUnsortedUpdateInfoGroupAsync,
-  collectAssetsAsync,
+  buildAndUploadAssetsAsync,
   defaultPublishPlatforms,
-  filterExportedPlatformsByFlag,
   generateEasMetadataAsync,
   getBranchNameForCommandAsync,
   getRequestedPlatform,
-  getRuntimeToPlatformMappingFromRuntimeVersions,
   getRuntimeVersionObjectAsync,
   getUpdateMessageForCommandAsync,
   isUploadedAssetCountAboveWarningThreshold,
-  platformDisplayNames,
-  resolveInputDirectoryAsync,
-  uploadAssetsAsync,
+  publishUpdateGroupsAsync,
 } from '../../project/publish';
 import { resolveWorkflowPerPlatformAsync } from '../../project/workflow';
 import { ensureEASUpdateIsConfiguredAsync } from '../../update/configure';
 import { getUpdateJsonInfosForUpdates } from '../../update/utils';
-import {
-  checkManifestBodyAgainstUpdateInfoGroup,
-  getCodeSigningInfoAsync,
-  getManifestBodyAsync,
-  signBody,
-} from '../../utils/code-signing';
-import areSetsEqual from '../../utils/expodash/areSetsEqual';
+import { getCodeSigningInfoAsync } from '../../utils/code-signing';
 import uniqBy from '../../utils/expodash/uniqBy';
 import formatFields from '../../utils/formatFields';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -233,141 +210,27 @@ export default class UpdatePublish extends EasCommand {
       jsonFlag,
     });
 
-    // build bundle and upload assets for a new publish
-    if (!skipBundler) {
-      const bundleSpinner = ora().start('Exporting...');
-      try {
-        await buildBundlesAsync({ projectDir, inputDir, exp, platformFlag, clearCache });
-        bundleSpinner.succeed('Exported bundle(s)');
-      } catch (e) {
-        bundleSpinner.fail('Export failed');
-        throw e;
-      }
-    }
+    const {
+      distRoot,
+      realizedPlatforms,
+      unsortedUpdateInfoGroups,
+      uploadedAssetCount,
+      assetLimitPerUpdateGroup,
+    } = await buildAndUploadAssetsAsync({
+      graphqlClient,
+      projectId,
+      skipBundler,
+      projectDir,
+      inputDir,
+      exp,
+      platformFlag,
+      clearCache,
+    });
 
-    // After possibly bundling, assert that the input directory can be found.
-    const distRoot = await resolveInputDirectoryAsync(inputDir, { skipBundler });
-
-    const assetSpinner = ora().start('Uploading...');
-    let unsortedUpdateInfoGroups: UpdateInfoGroup = {};
-    let uploadedAssetCount = 0;
-    let assetLimitPerUpdateGroup = 0;
-    let realizedPlatforms: PublishPlatform[] = [];
-
-    try {
-      const collectedAssets = await collectAssetsAsync(distRoot);
-      const assets = filterExportedPlatformsByFlag(collectedAssets, platformFlag);
-      realizedPlatforms = Object.keys(assets) as PublishPlatform[];
-
-      // Timeout mechanism:
-      // - Start with NO_ACTIVITY_TIMEOUT. 180 seconds is chosen because the cloud function that processes
-      //   uploaded assets has a timeout of 60 seconds and uploading can take some time on a slow connection.
-      // - Each time one or more assets reports as ready, reset the timeout.
-      // - Each time an asset upload begins, reset the timeout. This includes retries.
-      // - Start upload. Internally, uploadAssetsAsync uploads them all first and then checks for successful
-      //   processing every (5 + n) seconds with a linear backoff of n + 1 second.
-      // - At the same time as upload is started, start timeout checker which checks every 1 second to see
-      //   if timeout has been reached. When timeout expires, send a cancellation signal to currently running
-      //   upload function call to instruct it to stop uploading or checking for successful processing.
-      const NO_ACTIVITY_TIMEOUT = 180 * 1000; // 180 seconds
-      let lastUploadedStorageKeys = new Set<string>();
-      let lastAssetUploadResults: {
-        asset: RawAsset & { storageKey: string };
-        finished: boolean;
-      }[] = [];
-      let timeAtWhichToTimeout = Date.now() + NO_ACTIVITY_TIMEOUT;
-      const cancelationToken = { isCanceledOrFinished: false };
-
-      const uploadResults = await Promise.race([
-        uploadAssetsAsync(
-          graphqlClient,
-          assets,
-          projectId,
-          cancelationToken,
-          assetUploadResults => {
-            const currentUploadedStorageKeys = new Set(
-              assetUploadResults.filter(r => r.finished).map(r => r.asset.storageKey)
-            );
-            if (!areSetsEqual(currentUploadedStorageKeys, lastUploadedStorageKeys)) {
-              timeAtWhichToTimeout = Date.now() + NO_ACTIVITY_TIMEOUT; // reset timeout to NO_ACTIVITY_TIMEOUT
-              lastUploadedStorageKeys = currentUploadedStorageKeys;
-              lastAssetUploadResults = assetUploadResults;
-            }
-
-            const totalAssets = assetUploadResults.length;
-            const missingAssetCount = assetUploadResults.filter(a => !a.finished).length;
-            assetSpinner.text = `Uploading (${totalAssets - missingAssetCount}/${totalAssets})`;
-          },
-          () => {
-            // when an upload is retried, reset the timeout as we know this will now need more time
-            timeAtWhichToTimeout = Date.now() + NO_ACTIVITY_TIMEOUT; // reset timeout to NO_ACTIVITY_TIMEOUT
-          }
-        ),
-        (async () => {
-          while (Date.now() < timeAtWhichToTimeout) {
-            if (cancelationToken.isCanceledOrFinished) {
-              break;
-            }
-            await new Promise(res => setTimeout(res, 1000)); // wait 1 second
-          }
-          cancelationToken.isCanceledOrFinished = true;
-          const timedOutAssets = lastAssetUploadResults
-            .filter(r => !r.finished)
-            .map(r => `\n- ${r.asset.originalPath ?? r.asset.path}`);
-          throw new Error(`Asset processing timed out for assets: ${timedOutAssets}`);
-        })(),
-      ]);
-
-      uploadedAssetCount = uploadResults.uniqueUploadedAssetCount;
-      assetLimitPerUpdateGroup = uploadResults.assetLimitPerUpdateGroup;
-      unsortedUpdateInfoGroups = await buildUnsortedUpdateInfoGroupAsync(assets, exp);
-
-      // NOTE(cedric): we assume that bundles are always uploaded, and always are part of
-      // `uploadedAssetCount`, perferably we don't assume. For that, we need to refactor the
-      // `uploadAssetsAsync` and be able to determine asset type from the uploaded assets.
-      const uploadedBundleCount = uploadResults.launchAssetCount;
-      const uploadedNormalAssetCount = Math.max(0, uploadedAssetCount - uploadedBundleCount);
-      const reusedNormalAssetCount = uploadResults.uniqueAssetCount - uploadedNormalAssetCount;
-
-      assetSpinner.stop();
-      Log.withTick(
-        `Uploaded ${uploadedBundleCount} app ${uploadedBundleCount === 1 ? 'bundle' : 'bundles'}`
-      );
-      if (uploadedNormalAssetCount === 0) {
-        Log.withTick(`Uploading assets skipped - no new assets found`);
-      } else {
-        let message = `Uploaded ${uploadedNormalAssetCount} ${
-          uploadedNormalAssetCount === 1 ? 'asset' : 'assets'
-        }`;
-        if (reusedNormalAssetCount > 0) {
-          message += ` (reused ${reusedNormalAssetCount} ${
-            reusedNormalAssetCount === 1 ? 'asset' : 'assets'
-          })`;
-        }
-        Log.withTick(message);
-      }
-      for (const uploadedAssetPath of uploadResults.uniqueUploadedAssetPaths) {
-        Log.debug(chalk.dim(`- ${uploadedAssetPath}`));
-      }
-
-      const platformString = (Object.keys(assets) as PublishPlatform[])
-        .map(platform => {
-          const collectedAssetForPlatform = nullthrows(assets[platform]);
-          const totalAssetsForPlatform = collectedAssetForPlatform.assets.length + 1; // launch asset
-          const assetString = totalAssetsForPlatform === 1 ? 'asset' : 'assets';
-          return `${totalAssetsForPlatform} ${platformDisplayNames[platform]} ${assetString}`;
-        })
-        .join(', ');
-      Log.withInfo(
-        `${platformString} (maximum: ${assetLimitPerUpdateGroup} total per update). ${learnMore(
-          'https://expo.fyi/eas-update-asset-limits',
-          { learnMoreMessage: 'Learn more about asset limits' }
-        )}`
-      );
-    } catch (e) {
-      assetSpinner.fail('Failed to upload');
-      throw e;
-    }
+    const { branchId } = await ensureBranchExistsAsync(graphqlClient, {
+      appId: projectId,
+      branchName,
+    });
 
     const workflows = await resolveWorkflowPerPlatformAsync(projectDir, vcsClient);
     const runtimeVersions = await getRuntimeVersionObjectAsync({
@@ -380,95 +243,20 @@ export default class UpdatePublish extends EasCommand {
       },
       env: undefined,
     });
-    const runtimeToPlatformMapping =
-      getRuntimeToPlatformMappingFromRuntimeVersions(runtimeVersions);
-
-    const { branchId } = await ensureBranchExistsAsync(graphqlClient, {
-      appId: projectId,
-      branchName,
-    });
 
     const gitCommitHash = await vcsClient.getCommitHashAsync();
     const isGitWorkingTreeDirty = await vcsClient.hasUncommittedChangesAsync();
 
-    // Sort the updates into different groups based on their platform specific runtime versions
-    const updateGroups: PublishUpdateGroupInput[] = runtimeToPlatformMapping.map(
-      ({ runtimeVersion, platforms }) => {
-        const localUpdateInfoGroup = Object.fromEntries(
-          platforms.map(platform => [
-            platform,
-            unsortedUpdateInfoGroups[platform as keyof UpdateInfoGroup],
-          ])
-        );
-
-        return {
-          branchId,
-          updateInfoGroup: localUpdateInfoGroup,
-          runtimeVersion,
-          message: updateMessage,
-          gitCommitHash,
-          isGitWorkingTreeDirty,
-          awaitingCodeSigningInfo: !!codeSigningInfo,
-        };
-      }
-    );
-    let newUpdates: UpdatePublishMutation['updateBranch']['publishUpdateGroups'];
-    const publishSpinner = ora('Publishing...').start();
-    try {
-      newUpdates = await PublishMutation.publishUpdateGroupAsync(graphqlClient, updateGroups);
-
-      if (codeSigningInfo) {
-        Log.log('🔒 Signing updates');
-
-        const updatesTemp = [...newUpdates];
-        const updateGroupsAndTheirUpdates = updateGroups.map(updateGroup => {
-          const newUpdates = updatesTemp.splice(
-            0,
-            Object.keys(nullthrows(updateGroup.updateInfoGroup)).length
-          );
-          return {
-            updateGroup,
-            newUpdates,
-          };
-        });
-
-        await Promise.all(
-          updateGroupsAndTheirUpdates.map(async ({ updateGroup, newUpdates }) => {
-            await Promise.all(
-              newUpdates.map(async newUpdate => {
-                const response = await fetch(newUpdate.manifestPermalink, {
-                  method: 'GET',
-                  headers: { accept: 'multipart/mixed' },
-                });
-                const manifestBody = nullthrows(await getManifestBodyAsync(response));
-
-                checkManifestBodyAgainstUpdateInfoGroup(
-                  manifestBody,
-                  nullthrows(
-                    nullthrows(updateGroup.updateInfoGroup)[
-                      newUpdate.platform as keyof UpdateInfoGroup
-                    ]
-                  )
-                );
-
-                const manifestSignature = signBody(manifestBody, codeSigningInfo);
-
-                await PublishMutation.setCodeSigningInfoAsync(graphqlClient, newUpdate.id, {
-                  alg: codeSigningInfo.codeSigningMetadata.alg,
-                  keyid: codeSigningInfo.codeSigningMetadata.keyid,
-                  sig: manifestSignature,
-                });
-              })
-            );
-          })
-        );
-      }
-
-      publishSpinner.succeed('Published!');
-    } catch (e) {
-      publishSpinner.fail('Failed to publish updates');
-      throw e;
-    }
+    const { newUpdates } = await publishUpdateGroupsAsync({
+      graphqlClient,
+      branchId,
+      runtimeVersions,
+      gitCommitHash,
+      isGitWorkingTreeDirty,
+      unsortedUpdateInfoGroups,
+      updateMessage,
+      codeSigningInfo,
+    });
 
     if (!skipBundler && emitMetadata) {
       Log.log('Generating eas-update-metadata.json');

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -23,6 +23,7 @@ export type Scalars = {
   DevDomainName: { input: any; output: any; }
   JSON: { input: any; output: any; }
   JSONObject: { input: any; output: any; }
+  WorkerDeploymentIdentifier: { input: any; output: any; }
 };
 
 export type AcceptUserInvitationResult = {
@@ -119,6 +120,8 @@ export type Account = {
   environmentSecrets: Array<EnvironmentSecret>;
   /** Environment variables for an account */
   environmentVariables: Array<EnvironmentVariable>;
+  /** Environment variables for an account with decrypted secret values */
+  environmentVariablesIncludingSensitive: Array<EnvironmentVariableWithSecret>;
   /** GitHub App installations for an account */
   githubAppInstallations: Array<GitHubAppInstallation>;
   /** @deprecated Use googleServiceAccountKeysPaginated */
@@ -364,6 +367,15 @@ export type AccountEnvironmentVariablesArgs = {
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
  */
+export type AccountEnvironmentVariablesIncludingSensitiveArgs = {
+  filterNames?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+
+/**
+ * An account is a container owning projects, credentials, billing and other organization
+ * data and settings. Actors may own and be members of accounts.
+ */
 export type AccountGoogleServiceAccountKeysPaginatedArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -510,17 +522,12 @@ export type AccountGoogleServiceAccountKeysEdge = {
 
 export type AccountMutation = {
   __typename?: 'AccountMutation';
-  /**
-   * Makes a one time purchase
-   * @deprecated Build packs are no longer supported
-   */
-  buyProduct?: Maybe<Account>;
   /** Cancels all subscriptions immediately */
   cancelAllSubscriptionsImmediately: Account;
   /** Cancel scheduled subscription change */
   cancelScheduledSubscriptionChange: Account;
-  /** Cancels the active subscription */
-  cancelSubscription: Account;
+  /** Buys or revokes account's additional concurrencies, charging the account the appropriate amount if needed. */
+  changeAdditionalConcurrenciesCount: Account;
   /** Upgrades or downgrades the active subscription to the newPlanIdentifier, which must be one of the EAS plans (i.e., Production or Enterprise). */
   changePlan: Account;
   /** Add specified account Permissions for Actor. Actor must already have at least one permission on the account. */
@@ -531,23 +538,8 @@ export type AccountMutation = {
   requestRefund?: Maybe<Scalars['Boolean']['output']>;
   /** Revoke specified Permissions for Actor. Actor must already have at least one permission on the account. */
   revokeActorPermissions: Account;
-  /**
-   * Update setting to purchase new build packs when the current one is consumed
-   * @deprecated Build packs are no longer supported
-   */
-  setBuildAutoRenew?: Maybe<Account>;
-  /** Set payment details */
-  setPaymentSource: Account;
   /** Require authorization to send push notifications for experiences owned by this account */
   setPushSecurityEnabled: Account;
-};
-
-
-export type AccountMutationBuyProductArgs = {
-  accountName: Scalars['ID']['input'];
-  autoRenew?: InputMaybe<Scalars['Boolean']['input']>;
-  paymentSource?: InputMaybe<Scalars['ID']['input']>;
-  productId: Scalars['ID']['input'];
 };
 
 
@@ -561,8 +553,9 @@ export type AccountMutationCancelScheduledSubscriptionChangeArgs = {
 };
 
 
-export type AccountMutationCancelSubscriptionArgs = {
-  accountName: Scalars['ID']['input'];
+export type AccountMutationChangeAdditionalConcurrenciesCountArgs = {
+  accountID: Scalars['ID']['input'];
+  newAdditionalConcurrenciesCount: Scalars['Int']['input'];
 };
 
 
@@ -598,18 +591,6 @@ export type AccountMutationRevokeActorPermissionsArgs = {
   accountID: Scalars['ID']['input'];
   actorID: Scalars['ID']['input'];
   permissions?: InputMaybe<Array<InputMaybe<Permission>>>;
-};
-
-
-export type AccountMutationSetBuildAutoRenewArgs = {
-  accountName: Scalars['ID']['input'];
-  autoRenew?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-
-export type AccountMutationSetPaymentSourceArgs = {
-  accountName: Scalars['ID']['input'];
-  paymentSource: Scalars['ID']['input'];
 };
 
 
@@ -855,6 +836,7 @@ export type AddonDetails = {
   name: Scalars['String']['output'];
   nextInvoice?: Maybe<Scalars['DateTime']['output']>;
   planId: Scalars['String']['output'];
+  quantity?: Maybe<Scalars['Int']['output']>;
   willCancel?: Maybe<Scalars['Boolean']['output']>;
 };
 
@@ -1243,6 +1225,8 @@ export type App = Project & {
   environmentSecrets: Array<EnvironmentSecret>;
   /** Environment variables for an app */
   environmentVariables: Array<EnvironmentVariable>;
+  /** Environment variables for an app with decrypted secret values */
+  environmentVariablesIncludingSensitive: Array<EnvironmentVariableWithSecret>;
   fullName: Scalars['String']['output'];
   githubBuildTriggers: Array<GitHubBuildTrigger>;
   githubJobRunTriggers: Array<GitHubJobRunTrigger>;
@@ -1266,6 +1250,7 @@ export type App = Project & {
   internalDistributionBuildPrivacy: AppInternalDistributionBuildPrivacy;
   /** iOS app credentials for the project */
   iosAppCredentials: Array<IosAppCredentials>;
+  /** @deprecated Use lastDeletionAttemptTime !== null instead */
   isDeleting: Scalars['Boolean']['output'];
   /**
    * Whether the latest classic update publish is using a deprecated SDK version
@@ -1361,7 +1346,14 @@ export type App = Project & {
   users?: Maybe<Array<Maybe<User>>>;
   /** Webhooks for an app */
   webhooks: Array<Webhook>;
+  workerCustomDomain?: Maybe<WorkerCustomDomain>;
+  workerDeployment?: Maybe<WorkerDeployment>;
+  workerDeploymentAlias?: Maybe<WorkerDeploymentAlias>;
+  workerDeploymentAliases: WorkerDeploymentAliasesConnection;
   workerDeployments: WorkerDeploymentsConnection;
+  workerDeploymentsCrashes?: Maybe<WorkerDeploymentCrashes>;
+  workerDeploymentsMetrics?: Maybe<WorkerDeploymentMetrics>;
+  workerDeploymentsRequests?: Maybe<WorkerDeploymentRequests>;
 };
 
 
@@ -1447,7 +1439,14 @@ export type AppEnvironmentSecretsArgs = {
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppEnvironmentVariablesArgs = {
-  environment: EnvironmentVariableEnvironment;
+  environment?: InputMaybe<EnvironmentVariableEnvironment>;
+  filterNames?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppEnvironmentVariablesIncludingSensitiveArgs = {
+  environment?: InputMaybe<EnvironmentVariableEnvironment>;
   filterNames?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
@@ -1572,11 +1571,52 @@ export type AppWebhooksArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkerDeploymentArgs = {
+  deploymentIdentifier: Scalars['WorkerDeploymentIdentifier']['input'];
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkerDeploymentAliasArgs = {
+  aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkerDeploymentAliasesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkerDeploymentsCrashesArgs = {
+  limit?: Scalars['Int']['input'];
+  timespan: CrashesTimespan;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkerDeploymentsMetricsArgs = {
+  timespan: MetricsTimespan;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkerDeploymentsRequestsArgs = {
+  limit?: Scalars['Int']['input'];
+  timespan: RequestsTimespan;
 };
 
 export type AppBranchEdge = {
@@ -1698,12 +1738,14 @@ export enum AppInternalDistributionBuildPrivacy {
 
 export type AppMutation = {
   __typename?: 'AppMutation';
-  /** Create an unpublished app */
+  /** Create an app */
   createApp: App;
-  /** Create an unpublished app and GitHub repository if user desire to */
+  /** Create an app and GitHub repository if user desire to */
   createAppAndGithubRepository: CreateAppAndGithubRepositoryResponse;
   /** @deprecated No longer supported */
   grantAccess?: Maybe<App>;
+  /** Delete an App. Returns the ID of the background job receipt. Use BackgroundJobReceiptQuery to get the status of the job. */
+  scheduleAppDeletion: BackgroundJobReceipt;
   /** Set display info for app */
   setAppInfo: App;
   /** Require api token to send push notifs for experience */
@@ -1726,6 +1768,11 @@ export type AppMutationCreateAppAndGithubRepositoryArgs = {
 export type AppMutationGrantAccessArgs = {
   accessLevel?: InputMaybe<Scalars['String']['input']>;
   toUser: Scalars['ID']['input'];
+};
+
+
+export type AppMutationScheduleAppDeletionArgs = {
+  appId: Scalars['ID']['input'];
 };
 
 
@@ -1774,10 +1821,23 @@ export type AppPushNotificationsInsights = {
   __typename?: 'AppPushNotificationsInsights';
   id: Scalars['ID']['output'];
   notificationsSentOverTime: NotificationsSentOverTimeData;
+  successFailureOverTime: NotificationsSentOverTimeData;
+  totalNotificationsSent: Scalars['Int']['output'];
 };
 
 
 export type AppPushNotificationsInsightsNotificationsSentOverTimeArgs = {
+  timespan: InsightsTimespan;
+};
+
+
+export type AppPushNotificationsInsightsSuccessFailureOverTimeArgs = {
+  timespan: InsightsTimespan;
+};
+
+
+export type AppPushNotificationsInsightsTotalNotificationsSentArgs = {
+  filters?: InputMaybe<Array<Scalars['JSON']['input']>>;
   timespan: InsightsTimespan;
 };
 
@@ -2399,8 +2459,8 @@ export type AuditLog = {
 
 export type AuditLogExportInput = {
   accountId: Scalars['ID']['input'];
-  createdAfter: Scalars['Int']['input'];
-  createdBefore: Scalars['Int']['input'];
+  createdAfter: Scalars['String']['input'];
+  createdBefore: Scalars['String']['input'];
   format: AuditLogsExportFormat;
 };
 
@@ -2419,8 +2479,6 @@ export type AuditLogQuery = {
   __typename?: 'AuditLogQuery';
   /** Query Audit Logs by account ID */
   byAccountId: Array<AuditLog>;
-  /** Query an Audit Log by ID */
-  byId: AuditLog;
 };
 
 
@@ -2428,11 +2486,6 @@ export type AuditLogQueryByAccountIdArgs = {
   accountId: Scalars['ID']['input'];
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
-};
-
-
-export type AuditLogQueryByIdArgs = {
-  auditLogId: Scalars['ID']['input'];
 };
 
 export enum AuditLogsExportFormat {
@@ -2449,7 +2502,8 @@ export enum AuthProviderIdentifier {
   GoogleWs = 'GOOGLE_WS',
   MsEntraId = 'MS_ENTRA_ID',
   Okta = 'OKTA',
-  OneLogin = 'ONE_LOGIN'
+  OneLogin = 'ONE_LOGIN',
+  StubIdp = 'STUB_IDP'
 }
 
 export type BackgroundJobReceipt = {
@@ -2679,6 +2733,7 @@ export type BuildArtifacts = {
   applicationArchiveUrl?: Maybe<Scalars['String']['output']>;
   buildArtifactsUrl?: Maybe<Scalars['String']['output']>;
   buildUrl?: Maybe<Scalars['String']['output']>;
+  fingerprintUrl?: Maybe<Scalars['String']['output']>;
   xcodeBuildLogsUrl?: Maybe<Scalars['String']['output']>;
 };
 
@@ -3099,6 +3154,22 @@ export type Concurrencies = {
   total: Scalars['Int']['output'];
 };
 
+export enum ContinentCode {
+  Af = 'AF',
+  An = 'AN',
+  As = 'AS',
+  Eu = 'EU',
+  Na = 'NA',
+  Oc = 'OC',
+  Sa = 'SA',
+  T1 = 'T1'
+}
+
+export type CrashesTimespan = {
+  end: Scalars['DateTime']['input'];
+  start?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
 export type CreateAccessTokenInput = {
   actorID: Scalars['ID']['input'];
   note?: InputMaybe<Scalars['String']['input']>;
@@ -3141,8 +3212,9 @@ export type CreateEnvironmentSecretInput = {
 export type CreateEnvironmentVariableInput = {
   environment: EnvironmentVariableEnvironment;
   name: Scalars['String']['input'];
-  sensitive: Scalars['Boolean']['input'];
+  overwrite?: InputMaybe<Scalars['Boolean']['input']>;
   value: Scalars['String']['input'];
+  visibility: EnvironmentVariableVisibility;
 };
 
 export type CreateGitHubAppInstallationInput = {
@@ -3202,8 +3274,9 @@ export type CreateServerlessFunctionUploadUrlResult = {
 
 export type CreateSharedEnvironmentVariableInput = {
   name: Scalars['String']['input'];
-  sensitive: Scalars['Boolean']['input'];
+  overwrite?: InputMaybe<Scalars['Boolean']['input']>;
   value: Scalars['String']['input'];
+  visibility: EnvironmentVariableVisibility;
 };
 
 export type CreateSubmissionResult = {
@@ -3215,6 +3288,64 @@ export type CreateSubmissionResult = {
 export type CustomBuildConfigInput = {
   path: Scalars['String']['input'];
 };
+
+export type CustomDomainDnsRecord = {
+  __typename?: 'CustomDomainDNSRecord';
+  dnsContent: Scalars['String']['output'];
+  dnsName: Scalars['String']['output'];
+  dnsType: CustomDomainDnsRecordType;
+};
+
+export enum CustomDomainDnsRecordType {
+  Cname = 'CNAME',
+  Txt = 'TXT'
+}
+
+export type CustomDomainMetadata = {
+  __typename?: 'CustomDomainMetadata';
+  ownershipVerification?: Maybe<CustomDomainDnsRecord>;
+  status: CustomDomainStatus;
+  verificationErrors?: Maybe<Array<Scalars['String']['output']>>;
+};
+
+export type CustomDomainMutation = {
+  __typename?: 'CustomDomainMutation';
+  deleteCustomDomain: DeleteCustomDomainResult;
+  refreshCustomDomain: WorkerCustomDomain;
+  registerCustomDomain: WorkerCustomDomain;
+};
+
+
+export type CustomDomainMutationDeleteCustomDomainArgs = {
+  customDomainId: Scalars['ID']['input'];
+};
+
+
+export type CustomDomainMutationRefreshCustomDomainArgs = {
+  customDomainId: Scalars['ID']['input'];
+};
+
+
+export type CustomDomainMutationRegisterCustomDomainArgs = {
+  aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
+  appId: Scalars['ID']['input'];
+  hostname: Scalars['String']['input'];
+};
+
+export enum CustomDomainStatus {
+  Active = 'ACTIVE',
+  ActiveRedeploying = 'ACTIVE_REDEPLOYING',
+  Blocked = 'BLOCKED',
+  Deleted = 'DELETED',
+  Moved = 'MOVED',
+  Pending = 'PENDING',
+  PendingBlocked = 'PENDING_BLOCKED',
+  PendingDeletion = 'PENDING_DELETION',
+  PendingMigration = 'PENDING_MIGRATION',
+  PendingProvisioned = 'PENDING_PROVISIONED',
+  Provisioned = 'PROVISIONED',
+  Unknown = 'UNKNOWN'
+}
 
 export type DeleteAccessTokenResult = {
   __typename?: 'DeleteAccessTokenResult';
@@ -3228,6 +3359,12 @@ export type DeleteAccountResult = {
 
 export type DeleteAccountSsoConfigurationResult = {
   __typename?: 'DeleteAccountSSOConfigurationResult';
+  id: Scalars['ID']['output'];
+};
+
+export type DeleteAliasResult = {
+  __typename?: 'DeleteAliasResult';
+  aliasName?: Maybe<Scalars['WorkerDeploymentIdentifier']['output']>;
   id: Scalars['ID']['output'];
 };
 
@@ -3259,6 +3396,13 @@ export type DeleteAppleProvisioningProfileResult = {
 export type DeleteBuildAnnotationResult = {
   __typename?: 'DeleteBuildAnnotationResult';
   buildAnnotationId: Scalars['ID']['output'];
+};
+
+export type DeleteCustomDomainResult = {
+  __typename?: 'DeleteCustomDomainResult';
+  appId: Scalars['ID']['output'];
+  hostname: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
 };
 
 export type DeleteDiscordUserResult = {
@@ -3429,14 +3573,29 @@ export type DeploymentsConnection = {
 
 export type DeploymentsMutation = {
   __typename?: 'DeploymentsMutation';
+  assignAlias: WorkerDeploymentAlias;
   /** Create a signed deployment URL */
   createSignedDeploymentUrl: DeploymentSignedUrlResult;
+  deleteAlias: DeleteAliasResult;
+};
+
+
+export type DeploymentsMutationAssignAliasArgs = {
+  aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
+  appId: Scalars['ID']['input'];
+  deploymentIdentifier: Scalars['ID']['input'];
 };
 
 
 export type DeploymentsMutationCreateSignedDeploymentUrlArgs = {
   appId: Scalars['ID']['input'];
   deploymentIdentifier?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type DeploymentsMutationDeleteAliasArgs = {
+  aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
+  appId: Scalars['ID']['input'];
 };
 
 export type DiscordUser = {
@@ -3583,6 +3742,7 @@ export enum EnvironmentSecretType {
 
 export type EnvironmentVariable = {
   __typename?: 'EnvironmentVariable';
+  apps: Array<App>;
   createdAt: Scalars['DateTime']['output'];
   environment?: Maybe<EnvironmentVariableEnvironment>;
   id: Scalars['ID']['output'];
@@ -3590,6 +3750,7 @@ export type EnvironmentVariable = {
   scope: EnvironmentVariableScope;
   updatedAt: Scalars['DateTime']['output'];
   value?: Maybe<Scalars['String']['output']>;
+  visibility?: Maybe<EnvironmentVariableVisibility>;
 };
 
 export enum EnvironmentVariableEnvironment {
@@ -3600,16 +3761,34 @@ export enum EnvironmentVariableEnvironment {
 
 export type EnvironmentVariableMutation = {
   __typename?: 'EnvironmentVariableMutation';
+  /** Create bulk env variables for an Account */
+  createBulkEnvironmentVariablesForAccount: Array<EnvironmentVariable>;
+  /** Create bulk env variables for an App */
+  createBulkEnvironmentVariablesForApp: Array<EnvironmentVariable>;
   /** Create an environment variable for an Account */
   createEnvironmentVariableForAccount: EnvironmentVariable;
   /** Create an environment variable for an App */
   createEnvironmentVariableForApp: EnvironmentVariable;
   /** Delete an environment variable */
   deleteEnvironmentVariable: DeleteEnvironmentVariableResult;
+  /** Bulk link shared environment variables */
+  linkBulkSharedEnvironmentVariables: Array<EnvironmentVariable>;
   /** Link shared environment variable */
   linkSharedEnvironmentVariable: EnvironmentVariable;
   /** Unlink shared environment variable */
   unlinkSharedEnvironmentVariable: EnvironmentVariable;
+};
+
+
+export type EnvironmentVariableMutationCreateBulkEnvironmentVariablesForAccountArgs = {
+  accountId: Scalars['ID']['input'];
+  environmentVariablesData: Array<CreateSharedEnvironmentVariableInput>;
+};
+
+
+export type EnvironmentVariableMutationCreateBulkEnvironmentVariablesForAppArgs = {
+  appId: Scalars['ID']['input'];
+  environmentVariablesData: Array<CreateEnvironmentVariableInput>;
 };
 
 
@@ -3630,6 +3809,11 @@ export type EnvironmentVariableMutationDeleteEnvironmentVariableArgs = {
 };
 
 
+export type EnvironmentVariableMutationLinkBulkSharedEnvironmentVariablesArgs = {
+  linkData: Array<LinkSharedEnvironmentVariableInput>;
+};
+
+
 export type EnvironmentVariableMutationLinkSharedEnvironmentVariableArgs = {
   appId: Scalars['ID']['input'];
   environment: EnvironmentVariableEnvironment;
@@ -3647,6 +3831,26 @@ export enum EnvironmentVariableScope {
   Project = 'PROJECT',
   Shared = 'SHARED'
 }
+
+export enum EnvironmentVariableVisibility {
+  Public = 'PUBLIC',
+  Secret = 'SECRET',
+  Sensitive = 'SENSITIVE'
+}
+
+export type EnvironmentVariableWithSecret = {
+  __typename?: 'EnvironmentVariableWithSecret';
+  apps: Array<App>;
+  createdAt: Scalars['DateTime']['output'];
+  environment?: Maybe<EnvironmentVariableEnvironment>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  scope: EnvironmentVariableScope;
+  sensitive: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  value?: Maybe<Scalars['String']['output']>;
+  visibility: EnvironmentVariableVisibility;
+};
 
 export type EstimatedOverageAndCost = {
   __typename?: 'EstimatedOverageAndCost';
@@ -3728,6 +3932,7 @@ export type FutureSubscription = {
   id: Scalars['ID']['output'];
   meteredBillingStatus: MeteredBillingStatus;
   planId: Scalars['String']['output'];
+  recurringCents?: Maybe<Scalars['Int']['output']>;
   startDate: Scalars['DateTime']['output'];
 };
 
@@ -4102,6 +4307,19 @@ export type GoogleServiceAccountKeyMutationDeleteGoogleServiceAccountKeyArgs = {
   id: Scalars['ID']['input'];
 };
 
+/**
+ * The value field is always sent from the client as a string,
+ * and then it's parsed server-side according to the filterType
+ */
+export type InsightsFilter = {
+  filterType: InsightsFilterType;
+  value: Scalars['String']['input'];
+};
+
+export enum InsightsFilterType {
+  Platform = 'PLATFORM'
+}
+
 export type InsightsTimespan = {
   end: Scalars['DateTime']['input'];
   start: Scalars['DateTime']['input'];
@@ -4147,17 +4365,21 @@ export type InvoiceLineItem = {
   amount: Scalars['Int']['output'];
   description: Scalars['String']['output'];
   id: Scalars['ID']['output'];
+  metadata: Scalars['JSONObject']['output'];
   period: InvoicePeriod;
+  /** @deprecated Use 'price' instead */
   plan: InvoiceLineItemPlan;
+  price?: Maybe<StripePrice>;
   proration: Scalars['Boolean']['output'];
   quantity: Scalars['Int']['output'];
-  title: Scalars['String']['output'];
+  /** The unit amount excluding tax, in cents */
+  unitAmountExcludingTax?: Maybe<Scalars['Float']['output']>;
 };
 
 export type InvoiceLineItemPlan = {
   __typename?: 'InvoiceLineItemPlan';
   id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 export type InvoicePeriod = {
@@ -4168,8 +4390,22 @@ export type InvoicePeriod = {
 
 export type InvoiceQuery = {
   __typename?: 'InvoiceQuery';
+  /**
+   * Previews the invoice for the specified number of additional concurrencies.
+   * This is the total number of concurrencies the customer wishes to purchase
+   * on top of their base plan, not the relative change in concurrencies
+   * the customer wishes to make. For example, specify "3" if the customer has
+   * two add-on concurrencies and wishes to purchase one more.
+   */
+  previewInvoiceForAdditionalConcurrenciesCountUpdate?: Maybe<Invoice>;
   /** Preview an upgrade subscription invoice, with proration */
   previewInvoiceForSubscriptionUpdate: Invoice;
+};
+
+
+export type InvoiceQueryPreviewInvoiceForAdditionalConcurrenciesCountUpdateArgs = {
+  accountID: Scalars['ID']['input'];
+  additionalConcurrenciesCount: Scalars['Int']['input'];
 };
 
 
@@ -4551,6 +4787,17 @@ export type LineDataset = {
   label: Scalars['String']['output'];
 };
 
+export type LinkSharedEnvironmentVariableInput = {
+  appId: Scalars['ID']['input'];
+  environment: EnvironmentVariableEnvironment;
+  environmentVariableId: Scalars['ID']['input'];
+};
+
+export type LogsTimespan = {
+  end: Scalars['DateTime']['input'];
+  start?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
 export enum MailchimpAudience {
   ExpoDevelopers = 'EXPO_DEVELOPERS',
   ExpoDeveloperOnboarding = 'EXPO_DEVELOPER_ONBOARDING'
@@ -4595,6 +4842,12 @@ export type MeMutation = {
   purgeUnfinishedSecondFactorAuthentication: SecondFactorBooleanResult;
   /** Regenerate backup codes for the current user */
   regenerateSecondFactorBackupCodes: SecondFactorRegenerateBackupCodesResult;
+  /** Schedule deletion for Account created via createAccount */
+  scheduleAccountDeletion: BackgroundJobReceipt;
+  /** Schedule deletion of the current regular user */
+  scheduleCurrentUserDeletion: BackgroundJobReceipt;
+  /** Schedule deletion of a SSO user. Actor must be an owner on the SSO user's SSO account. */
+  scheduleSSOUserDeletionAsSSOAccountOwner: BackgroundJobReceipt;
   /** Send SMS OTP to a second factor device for use during device setup or during change confirmation */
   sendSMSOTPToSecondFactorDevice: SecondFactorBooleanResult;
   /**
@@ -4606,8 +4859,6 @@ export type MeMutation = {
   setPrimarySecondFactorDevice: SecondFactorBooleanResult;
   /** Transfer project to a different Account */
   transferApp: App;
-  /** Unpublish an App that the current user owns */
-  unpublishApp: App;
   /** Update an App that the current user owns */
   updateApp: App;
   /** Update the current regular user's data */
@@ -4619,7 +4870,7 @@ export type MeMutation = {
 
 export type MeMutationAddSecondFactorDeviceArgs = {
   deviceConfiguration: SecondFactorDeviceConfiguration;
-  otp: Scalars['String']['input'];
+  otp?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -4644,7 +4895,7 @@ export type MeMutationDeleteSsoUserArgs = {
 
 
 export type MeMutationDeleteSecondFactorDeviceArgs = {
-  otp: Scalars['String']['input'];
+  otp?: InputMaybe<Scalars['String']['input']>;
   userSecondFactorDeviceId: Scalars['ID']['input'];
 };
 
@@ -4655,7 +4906,7 @@ export type MeMutationDeleteSnackArgs = {
 
 
 export type MeMutationDisableSecondFactorAuthenticationArgs = {
-  otp: Scalars['String']['input'];
+  otp?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -4671,7 +4922,17 @@ export type MeMutationLeaveAccountArgs = {
 
 
 export type MeMutationRegenerateSecondFactorBackupCodesArgs = {
-  otp: Scalars['String']['input'];
+  otp?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type MeMutationScheduleAccountDeletionArgs = {
+  accountId: Scalars['ID']['input'];
+};
+
+
+export type MeMutationScheduleSsoUserDeletionAsSsoAccountOwnerArgs = {
+  ssoUserId: Scalars['ID']['input'];
 };
 
 
@@ -4696,11 +4957,6 @@ export type MeMutationTransferAppArgs = {
 };
 
 
-export type MeMutationUnpublishAppArgs = {
-  appId: Scalars['ID']['input'];
-};
-
-
 export type MeMutationUpdateAppArgs = {
   appData: AppDataInput;
 };
@@ -4719,6 +4975,11 @@ export type MeteredBillingStatus = {
   __typename?: 'MeteredBillingStatus';
   EAS_BUILD: Scalars['Boolean']['output'];
   EAS_UPDATE: Scalars['Boolean']['output'];
+};
+
+export type MetricsTimespan = {
+  end: Scalars['DateTime']['input'];
+  start: Scalars['DateTime']['input'];
 };
 
 export type Notification = {
@@ -4953,6 +5214,11 @@ export type PublishUpdateGroupInput = {
   updateInfoGroup?: InputMaybe<UpdateInfoGroup>;
 };
 
+export type RequestsTimespan = {
+  end: Scalars['DateTime']['input'];
+  start?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
 export type RescindUserInvitationResult = {
   __typename?: 'RescindUserInvitationResult';
   id: Scalars['ID']['output'];
@@ -5000,6 +5266,8 @@ export type RobotMutation = {
   createRobotForAccount: Robot;
   /** Delete a Robot */
   deleteRobot: DeleteRobotResult;
+  /** Schedule deletion of a Robot */
+  scheduleRobotDeletion: BackgroundJobReceipt;
   /** Update a Robot */
   updateRobot: Robot;
 };
@@ -5014,6 +5282,11 @@ export type RobotMutationCreateRobotForAccountArgs = {
 
 export type RobotMutationDeleteRobotArgs = {
   id: Scalars['String']['input'];
+};
+
+
+export type RobotMutationScheduleRobotDeletionArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -5081,6 +5354,7 @@ export type RootMutation = {
   build: BuildMutation;
   /** Mutations that create, update, and delete Build Annotations */
   buildAnnotation: BuildAnnotationMutation;
+  customDomain: CustomDomainMutation;
   deployments: DeploymentsMutation;
   /** Mutations that assign or modify DevDomainNames for apps */
   devDomainName: AppDevDomainNameMutation;
@@ -5139,7 +5413,7 @@ export type RootMutation = {
 
 
 export type RootMutationAccountArgs = {
-  accountName: Scalars['ID']['input'];
+  accountName?: InputMaybe<Scalars['ID']['input']>;
 };
 
 
@@ -5220,6 +5494,8 @@ export type RootQuery = {
   /** Top-level query object for querying Expo status page services. */
   statuspageService: StatuspageServiceQuery;
   submissions: SubmissionQuery;
+  /** Top-level query object for querying Updates. */
+  updates: UpdateQuery;
   /** fetch all updates in a group */
   updatesByGroup: Array<Update>;
   /**
@@ -5247,6 +5523,7 @@ export type RootQuery = {
   viewer?: Maybe<User>;
   /** Top-level query object for querying Webhooks. */
   webhook: WebhookQuery;
+  workerDeployment: WorkerDeploymentQuery;
 };
 
 
@@ -5629,6 +5906,11 @@ export type StripeCoupon = {
   valid: Scalars['Boolean']['output'];
 };
 
+export type StripePrice = {
+  __typename?: 'StripePrice';
+  id: Scalars['ID']['output'];
+};
+
 /** Represents an EAS Submission */
 export type Submission = ActivityTimelineProjectActivity & {
   __typename?: 'Submission';
@@ -5653,6 +5935,7 @@ export type Submission = ActivityTimelineProjectActivity & {
   maxRetryTimeMinutes: Scalars['Int']['output'];
   parentSubmission?: Maybe<Submission>;
   platform: AppPlatform;
+  priority?: Maybe<SubmissionPriority>;
   status: SubmissionStatus;
   submittedBuild?: Maybe<Build>;
   updatedAt: Scalars['DateTime']['output'];
@@ -5734,6 +6017,11 @@ export type SubmissionMutationRetrySubmissionArgs = {
   parentSubmissionId: Scalars['ID']['input'];
 };
 
+export enum SubmissionPriority {
+  High = 'HIGH',
+  Normal = 'NORMAL'
+}
+
 export type SubmissionQuery = {
   __typename?: 'SubmissionQuery';
   /** Look up EAS Submission by submission ID */
@@ -5762,7 +6050,7 @@ export type SubscribeToNotificationResult = {
 export type SubscriptionDetails = {
   __typename?: 'SubscriptionDetails';
   addons: Array<AddonDetails>;
-  cancelledAt?: Maybe<Scalars['DateTime']['output']>;
+  cancelAt?: Maybe<Scalars['DateTime']['output']>;
   concurrencies?: Maybe<Concurrencies>;
   coupon?: Maybe<StripeCoupon>;
   endedAt?: Maybe<Scalars['DateTime']['output']>;
@@ -5772,11 +6060,14 @@ export type SubscriptionDetails = {
   meteredBillingStatus: MeteredBillingStatus;
   name?: Maybe<Scalars['String']['output']>;
   nextInvoice?: Maybe<Scalars['DateTime']['output']>;
+  nextInvoiceAmountDueCents?: Maybe<Scalars['Int']['output']>;
   planEnablement?: Maybe<PlanEnablement>;
   planId?: Maybe<Scalars['String']['output']>;
   price: Scalars['Int']['output'];
+  recurringCents?: Maybe<Scalars['Int']['output']>;
   status?: Maybe<Scalars['String']['output']>;
   trialEnd?: Maybe<Scalars['DateTime']['output']>;
+  upcomingInvoice?: Maybe<Invoice>;
   willCancel?: Maybe<Scalars['Boolean']['output']>;
 };
 
@@ -6037,6 +6328,17 @@ export type UpdateMutationDeleteUpdateGroupArgs = {
 
 export type UpdateMutationSetCodeSigningInfoArgs = {
   codeSigningInfo: CodeSigningInfoInput;
+  updateId: Scalars['ID']['input'];
+};
+
+export type UpdateQuery = {
+  __typename?: 'UpdateQuery';
+  /** Query an Update by ID */
+  byId: Update;
+};
+
+
+export type UpdateQueryByIdArgs = {
   updateId: Scalars['ID']['input'];
 };
 
@@ -6677,15 +6979,169 @@ export type WebsiteNotificationsConnection = {
   pageInfo: PageInfo;
 };
 
+export type WorkerCustomDomain = {
+  __typename?: 'WorkerCustomDomain';
+  alias: WorkerDeploymentAlias;
+  createdAt: Scalars['DateTime']['output'];
+  devDomainName: Scalars['DevDomainName']['output'];
+  dnsRecord: CustomDomainDnsRecord;
+  hostname: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  metadata?: Maybe<CustomDomainMetadata>;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
 export type WorkerDeployment = {
   __typename?: 'WorkerDeployment';
+  aliases?: Maybe<Array<WorkerDeploymentAlias>>;
+  createdAt: Scalars['DateTime']['output'];
+  deploymentDomain: Scalars['String']['output'];
+  deploymentIdentifier: Scalars['WorkerDeploymentIdentifier']['output'];
+  devDomainName: Scalars['DevDomainName']['output'];
   id: Scalars['ID']['output'];
+  logs?: Maybe<WorkerDeploymentLogs>;
+  metrics?: Maybe<WorkerDeploymentMetrics>;
+  subdomain: Scalars['String']['output'];
+  url: Scalars['String']['output'];
+};
+
+
+export type WorkerDeploymentLogsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  timespan: LogsTimespan;
+};
+
+
+export type WorkerDeploymentMetricsArgs = {
+  timespan: MetricsTimespan;
+};
+
+export type WorkerDeploymentAlias = {
+  __typename?: 'WorkerDeploymentAlias';
+  aliasName?: Maybe<Scalars['WorkerDeploymentIdentifier']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  deploymentDomain: Scalars['String']['output'];
+  devDomainName: Scalars['DevDomainName']['output'];
+  id: Scalars['ID']['output'];
+  subdomain: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  url: Scalars['String']['output'];
+  workerDeployment: WorkerDeployment;
+};
+
+export type WorkerDeploymentAliasEdge = {
+  __typename?: 'WorkerDeploymentAliasEdge';
+  cursor: Scalars['String']['output'];
+  node: WorkerDeploymentAlias;
+};
+
+export type WorkerDeploymentAliasesConnection = {
+  __typename?: 'WorkerDeploymentAliasesConnection';
+  edges: Array<WorkerDeploymentAliasEdge>;
+  pageInfo: PageInfo;
+};
+
+export type WorkerDeploymentCrashNode = {
+  __typename?: 'WorkerDeploymentCrashNode';
+  minOccurrences: Scalars['Int']['output'];
+  mostRecentlyOccurredAt: Scalars['DateTime']['output'];
+  sample?: Maybe<WorkerDeploymentCrashSample>;
+  sampleMessage?: Maybe<Scalars['String']['output']>;
+};
+
+export type WorkerDeploymentCrashSample = {
+  __typename?: 'WorkerDeploymentCrashSample';
+  message: Scalars['String']['output'];
+  requestTimestamp: Scalars['DateTime']['output'];
+};
+
+export type WorkerDeploymentCrashes = {
+  __typename?: 'WorkerDeploymentCrashes';
+  minRowsWithoutLimit?: Maybe<Scalars['Int']['output']>;
+  nodes: Array<WorkerDeploymentCrashNode>;
 };
 
 export type WorkerDeploymentEdge = {
   __typename?: 'WorkerDeploymentEdge';
   cursor: Scalars['String']['output'];
   node: WorkerDeployment;
+};
+
+export enum WorkerDeploymentLogLevel {
+  Debug = 'DEBUG',
+  Error = 'ERROR',
+  Fatal = 'FATAL',
+  Info = 'INFO',
+  Log = 'LOG',
+  Warn = 'WARN'
+}
+
+export type WorkerDeploymentLogNode = {
+  __typename?: 'WorkerDeploymentLogNode';
+  level: WorkerDeploymentLogLevel;
+  message: Scalars['String']['output'];
+  timestamp: Scalars['DateTime']['output'];
+};
+
+export type WorkerDeploymentLogs = {
+  __typename?: 'WorkerDeploymentLogs';
+  minRowsWithoutLimit?: Maybe<Scalars['Int']['output']>;
+  nodes: Array<WorkerDeploymentLogNode>;
+};
+
+export type WorkerDeploymentMetrics = {
+  __typename?: 'WorkerDeploymentMetrics';
+  groups: Array<Maybe<WorkerDeploymentMetricsEdge>>;
+  id: Scalars['ID']['output'];
+  summary: WorkerDeploymentMetricsData;
+};
+
+export type WorkerDeploymentMetricsData = {
+  __typename?: 'WorkerDeploymentMetricsData';
+  crashesSum: Scalars['Int']['output'];
+  durationP50?: Maybe<Scalars['Float']['output']>;
+  durationP90?: Maybe<Scalars['Float']['output']>;
+  durationP99?: Maybe<Scalars['Float']['output']>;
+  requestsSum: Scalars['Int']['output'];
+};
+
+export type WorkerDeploymentMetricsEdge = {
+  __typename?: 'WorkerDeploymentMetricsEdge';
+  node: WorkerDeploymentMetricsData;
+  timestamp: Scalars['DateTime']['output'];
+};
+
+export type WorkerDeploymentQuery = {
+  __typename?: 'WorkerDeploymentQuery';
+  byId: WorkerDeployment;
+};
+
+
+export type WorkerDeploymentQueryByIdArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type WorkerDeploymentRequestLocation = {
+  __typename?: 'WorkerDeploymentRequestLocation';
+  continent?: Maybe<ContinentCode>;
+  countryCode?: Maybe<Scalars['String']['output']>;
+  regionCode?: Maybe<Scalars['String']['output']>;
+};
+
+export type WorkerDeploymentRequestNode = {
+  __typename?: 'WorkerDeploymentRequestNode';
+  location?: Maybe<WorkerDeploymentRequestLocation>;
+  method: Scalars['String']['output'];
+  pathname: Scalars['String']['output'];
+  search?: Maybe<Scalars['String']['output']>;
+  status: Scalars['Int']['output'];
+  timestamp: Scalars['DateTime']['output'];
+};
+
+export type WorkerDeploymentRequests = {
+  __typename?: 'WorkerDeploymentRequests';
+  minRowsWithoutLimit?: Maybe<Scalars['Int']['output']>;
+  nodes: Array<WorkerDeploymentRequestNode>;
 };
 
 export type WorkerDeploymentsConnection = {
@@ -6730,6 +7186,14 @@ export type CreateUpdateBranchForAppMutationVariables = Exact<{
 
 
 export type CreateUpdateBranchForAppMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', createUpdateBranchForApp: { __typename?: 'UpdateBranch', id: string, name: string } } };
+
+export type CreateUpdateChannelOnAppWithNoBranchMutationVariables = Exact<{
+  appId: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+}>;
+
+
+export type CreateUpdateChannelOnAppWithNoBranchMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', createUpdateChannelForApp: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
 
 export type CreateUpdateChannelOnAppMutationVariables = Exact<{
   appId: Scalars['ID']['input'];

--- a/packages/eas-cli/src/rollout/actions/CreateRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/CreateRollout.ts
@@ -7,8 +7,8 @@ import {
   hasEmptyBranchMap,
   hasStandardBranchMap,
 } from '../../channel/branch-mapping';
+import { updateChannelBranchMappingAsync } from '../../channel/queries';
 import { getUpdateBranch } from '../../channel/utils';
-import { updateChannelBranchMappingAsync } from '../../commands/channel/edit';
 import { EASUpdateAction, EASUpdateContext } from '../../eas-update/utils';
 import {
   UpdateBranchBasicInfoFragment,

--- a/packages/eas-cli/src/rollout/actions/EditRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/EditRollout.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import chalk from 'chalk';
 
-import { updateChannelBranchMappingAsync } from '../../commands/channel/edit';
+import { updateChannelBranchMappingAsync } from '../../channel/queries';
 import { EASUpdateAction, EASUpdateContext } from '../../eas-update/utils';
 import { UpdateChannelBasicInfoFragment } from '../../graphql/generated';
 import { ChannelQuery, UpdateChannelObject } from '../../graphql/queries/ChannelQuery';

--- a/packages/eas-cli/src/rollout/actions/EndRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/EndRollout.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 
 import { getAlwaysTrueBranchMapping } from '../../channel/branch-mapping';
-import { updateChannelBranchMappingAsync } from '../../commands/channel/edit';
+import { updateChannelBranchMappingAsync } from '../../channel/queries';
 import { EASUpdateAction, EASUpdateContext } from '../../eas-update/utils';
 import { UpdateChannelBasicInfoFragment } from '../../graphql/generated';
 import {

--- a/packages/eas-cli/src/rollout/actions/__tests__/EditRollout-test.ts
+++ b/packages/eas-cli/src/rollout/actions/__tests__/EditRollout-test.ts
@@ -1,6 +1,6 @@
 import { testBasicChannelInfo, testChannelObject } from '../../../channel/__tests__/fixtures';
 import { getAlwaysTrueBranchMapping, getBranchMapping } from '../../../channel/branch-mapping';
-import { updateChannelBranchMappingAsync } from '../../../commands/channel/edit';
+import { updateChannelBranchMappingAsync } from '../../../channel/queries';
 import { createCtxMock } from '../../../eas-update/__tests__/fixtures';
 import { ChannelQuery } from '../../../graphql/queries/ChannelQuery';
 import { confirmAsync } from '../../../prompts';


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We're seeing quite a lot of inbound from customers who previously used codepush and are trying to migrate to EAS Update. Main feedback is just that the two are so different that it feels like they're needing to learn a completely new system.

This PR is an exploration into whether we can just run "codepush" on EAS update. See the [readme](https://app.graphite.dev/github/pr/expo/eas-cli/2485/rfc-eas-cli-Add-codepush-commands#file-packages/eas-cli/src/commands/codepush/README.md) in this PR for more details.