### PR TITLE
[eas-cli] Change behavior for ending EAS Update channel rollout

### DIFF
--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -9,6 +9,11 @@ import {
   GeneralOptions as EndRolloutGeneralOptions,
   NonInteractiveOptions as EndRolloutNonInteractiveOptions,
 } from '../../rollout/actions/EndRollout';
+import {
+  GeneralOptions as EndRolloutNewGeneralOptions,
+  NonInteractiveOptions as EndRolloutNewNonInteractiveOptions,
+  NewEndOutcome,
+} from '../../rollout/actions/EndRolloutNew';
 import { ManageRolloutActions } from '../../rollout/actions/ManageRollout';
 import { NonInteractiveRollout } from '../../rollout/actions/NonInteractiveRollout';
 import {
@@ -28,7 +33,7 @@ type ChannelRolloutRawArgsAndFlags = {
   channel?: string;
   action?: ActionRawFlagValue;
   percent?: number;
-  outcome?: EndOutcome;
+  outcome?: EndOutcome | NewEndOutcome;
   'non-interactive': boolean;
   branch?: string;
   'runtime-version'?: string;
@@ -42,9 +47,13 @@ type ChannelRolloutArgsAndFlags = {
   nonInteractive: boolean;
   json?: boolean;
 } & Partial<EditRolloutNonInteractiveOptions> &
-  Partial<EndRolloutNonInteractiveOptions> &
+  Omit<Partial<EndRolloutNonInteractiveOptions>, 'outcome'> &
+  Omit<Partial<EndRolloutNewNonInteractiveOptions>, 'outcome'> &
   EndRolloutGeneralOptions &
-  Partial<CreateRolloutNonInteractiveOptions>;
+  EndRolloutNewGeneralOptions &
+  Partial<CreateRolloutNonInteractiveOptions> & {
+    outcome?: EndOutcome | NewEndOutcome;
+  };
 
 export default class ChannelRollout extends EasCommand {
   static override description = 'Roll a new branch out on a channel incrementally.';
@@ -105,7 +114,7 @@ export default class ChannelRollout extends EasCommand {
     }),
     outcome: Flags.enum({
       description: 'End outcome of rollout. Use with --action=end',
-      options: Object.values(EndOutcome),
+      options: [...Object.values(EndOutcome), ...Object.values(NewEndOutcome)],
       required: false,
     }),
     branch: Flags.string({

--- a/packages/eas-cli/src/rollout/actions/EditRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/EditRollout.ts
@@ -1,24 +1,28 @@
 import assert from 'assert';
 import chalk from 'chalk';
 
+import { getBranchMapping } from '../../channel/branch-mapping';
 import { updateChannelBranchMappingAsync } from '../../commands/channel/edit';
 import { EASUpdateAction, EASUpdateContext } from '../../eas-update/utils';
 import { UpdateChannelBasicInfoFragment } from '../../graphql/generated';
-import { ChannelQuery, UpdateChannelObject } from '../../graphql/queries/ChannelQuery';
+import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
 import Log from '../../log';
-import { confirmAsync } from '../../prompts';
+import { confirmAsync, promptAsync } from '../../prompts';
 import {
-  editRolloutBranchMapping,
-  getRollout,
-  getRolloutBranchMapping,
+  ConstrainedRolloutInfo,
+  editLegacyRollout,
+  editRtvConstrainedRolloutForRtv,
+  getConstrainedRolloutForRtv,
+  getLegacyRollout,
   getRolloutInfo,
-  isConstrainedRolloutInfo,
-  isRollout,
+  isLegacyRolloutInfo,
+  isUnconstrainedRollout,
 } from '../branch-mapping';
 import { promptForRolloutPercentAsync } from '../utils';
 
 export type NonInteractiveOptions = {
   percent: number;
+  runtimeVersion?: string;
 };
 function isNonInteractiveOptions(
   options: Partial<NonInteractiveOptions>
@@ -33,9 +37,22 @@ function assertNonInteractiveOptions(
     '--percent is required for editing a rollout in non-interactive mode.'
   );
 }
+function isConstrainedNonInteractiveOptions(
+  options: Partial<NonInteractiveOptions>
+): options is Required<NonInteractiveOptions> {
+  return !!options.percent && !!options.runtimeVersion;
+}
+function assertConstrainedRolloutNonInteractiveOptions(
+  options: Partial<NonInteractiveOptions>
+): asserts options is Required<NonInteractiveOptions> {
+  assert(
+    isConstrainedNonInteractiveOptions(options),
+    '--percent and --runtime-version are required for editing a rollout in non-interactive mode.'
+  );
+}
 
 /**
- * Edit an existing rollout for the project.
+ * Edit an existing rollout for the channel and runtime version.
  */
 export class EditRollout implements EASUpdateAction<UpdateChannelBasicInfoFragment> {
   constructor(
@@ -43,13 +60,18 @@ export class EditRollout implements EASUpdateAction<UpdateChannelBasicInfoFragme
     private options: Partial<NonInteractiveOptions> = {}
   ) {}
 
-  public async runAsync(ctx: EASUpdateContext): Promise<UpdateChannelBasicInfoFragment> {
-    const { nonInteractive, graphqlClient } = ctx;
-    if (nonInteractive) {
-      assertNonInteractiveOptions(this.options);
-    }
-    const channelObject = await this.getChannelObjectAsync(ctx);
-    const rollout = getRollout(channelObject);
+  private async runForLegacyRolloutAsync(
+    ctx: EASUpdateContext
+  ): Promise<UpdateChannelBasicInfoFragment> {
+    const { graphqlClient, app } = ctx;
+    const { projectId } = app;
+
+    const channelObject = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      appId: projectId,
+      channelName: this.channelInfo.name,
+    });
+    const rollout = getLegacyRollout(channelObject);
+
     const { rolledOutBranch, defaultBranch } = rollout;
     const promptMessage = `What percent of users should be rolled out to the ${rolledOutBranch.name} branch ?`;
     const percent = this.options.percent ?? (await promptForRolloutPercentAsync({ promptMessage }));
@@ -60,8 +82,12 @@ export class EditRollout implements EASUpdateAction<UpdateChannelBasicInfoFragme
       );
     }
 
-    const oldBranchMapping = getRolloutBranchMapping(channelObject.branchMapping);
-    const newBranchMapping = editRolloutBranchMapping(oldBranchMapping, percent);
+    const oldBranchMapping = getBranchMapping(channelObject.branchMapping);
+    if (!isUnconstrainedRollout(oldBranchMapping)) {
+      throw new Error('Not legacy rollout');
+    }
+
+    const newBranchMapping = editLegacyRollout(oldBranchMapping, percent);
 
     Log.newLine();
     Log.log(
@@ -86,6 +112,97 @@ export class EditRollout implements EASUpdateAction<UpdateChannelBasicInfoFragme
     return newChannelInfo;
   }
 
+  private async runForConstrainedRolloutAsync(
+    ctx: EASUpdateContext,
+    rolloutInfo: ConstrainedRolloutInfo[]
+  ): Promise<UpdateChannelBasicInfoFragment> {
+    const { graphqlClient, app } = ctx;
+    const { projectId } = app;
+
+    // check for no constrained rollout
+    if (rolloutInfo.length < 1) {
+      throw new Error(
+        `The channel ${chalk.bold(
+          this.channelInfo.name
+        )} does not have a rollout. To edit a rollout, you must specify a channel with an ongoing rollout.`
+      );
+    }
+
+    // if rollout length === 1, we can infer runtime version (to make addition of the flag a non-breaking change)
+    let inferredRuntimeVersion;
+    if (rolloutInfo.length === 1) {
+      inferredRuntimeVersion = this.options.runtimeVersion ?? rolloutInfo[0].runtimeVersion;
+    } else {
+      const { nonInteractive } = ctx;
+      if (nonInteractive) {
+        assertConstrainedRolloutNonInteractiveOptions(this.options);
+      }
+      inferredRuntimeVersion =
+        this.options.runtimeVersion ?? (await this.selectRuntimeVersionAsync(rolloutInfo));
+    }
+
+    const runtimeVersion = inferredRuntimeVersion;
+
+    const channelObject = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      appId: projectId,
+      channelName: this.channelInfo.name,
+      filter: { runtimeVersions: [runtimeVersion] },
+    });
+    const rollout = getConstrainedRolloutForRtv(channelObject, runtimeVersion);
+    const { rolledOutBranch, defaultBranch } = rollout;
+    const promptMessage = `What percent of users should be rolled out to the ${rolledOutBranch.name} branch ?`;
+    const percent = this.options.percent ?? (await promptForRolloutPercentAsync({ promptMessage }));
+
+    if (percent === 0 || percent === 100) {
+      Log.warn(
+        `Editing the percent to ${percent} will not end the rollout. You'll need to end the rollout from the main menu.`
+      );
+    }
+
+    const oldBranchMapping = getBranchMapping(channelObject.branchMapping);
+    const newBranchMapping = editRtvConstrainedRolloutForRtv(
+      oldBranchMapping,
+      runtimeVersion,
+      percent
+    );
+
+    Log.newLine();
+    Log.log(
+      `📝 ${chalk.bold(percent)}% of users will be rolled out to the ${chalk.bold(
+        rolledOutBranch.name
+      )} branch and ${chalk.bold(100 - percent)}% will remain on the ${chalk.bold(
+        defaultBranch.name
+      )} branch.`
+    );
+    const confirmEdit = await this.confirmEditAsync(ctx);
+    if (!confirmEdit) {
+      throw new Error('Aborting...');
+    }
+
+    const newChannelInfo = await updateChannelBranchMappingAsync(graphqlClient, {
+      channelId: channelObject.id,
+      branchMapping: JSON.stringify(newBranchMapping),
+    });
+
+    Log.addNewLineIfNone();
+    Log.log(`✅ Successfuly updated rollout`);
+    return newChannelInfo;
+  }
+
+  public async runAsync(ctx: EASUpdateContext): Promise<UpdateChannelBasicInfoFragment> {
+    const { nonInteractive } = ctx;
+    if (nonInteractive) {
+      assertNonInteractiveOptions(this.options);
+    }
+
+    const rolloutInfo = getRolloutInfo(this.channelInfo);
+    if (isLegacyRolloutInfo(rolloutInfo)) {
+      return this.runForLegacyRolloutAsync(ctx);
+    } else {
+      return this.runForConstrainedRolloutAsync(ctx, rolloutInfo);
+    }
+  }
+
   async confirmEditAsync(ctx: EASUpdateContext): Promise<boolean> {
     const { nonInteractive } = ctx;
     if (nonInteractive) {
@@ -96,23 +213,24 @@ export class EditRollout implements EASUpdateAction<UpdateChannelBasicInfoFragme
     });
   }
 
-  async getChannelObjectAsync(ctx: EASUpdateContext): Promise<UpdateChannelObject> {
-    const { graphqlClient, app } = ctx;
-    const { projectId } = app;
-    if (!isRollout(this.channelInfo)) {
-      throw new Error(
-        `The channel ${chalk.bold(
-          this.channelInfo.name
-        )} is not a rollout. To end a rollout, you must specify a channel with an ongoing rollout.`
-      );
-    }
-    const rolloutInfo = getRolloutInfo(this.channelInfo);
-    return await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
-      appId: projectId,
-      channelName: this.channelInfo.name,
-      ...(isConstrainedRolloutInfo(rolloutInfo)
-        ? { filter: { runtimeVersions: [rolloutInfo.runtimeVersion] } }
-        : {}),
+  async selectRuntimeVersionAsync(rolloutInfo: ConstrainedRolloutInfo[]): Promise<string> {
+    const runtimeVersions = rolloutInfo.map(
+      constrainedRolloutInfo => constrainedRolloutInfo.runtimeVersion
+    );
+    const { runtimeVersion } = await promptAsync({
+      type: 'select',
+      name: 'runtimeVersion',
+      message: `Which runtime version rollout would you like to edit?`,
+      choices: runtimeVersions.map(rtv => ({
+        value: rtv,
+        title: rtv,
+      })),
     });
+
+    if (!runtimeVersion) {
+      throw new Error('Must select a runtime version');
+    }
+
+    return runtimeVersion;
   }
 }

--- a/packages/eas-cli/src/rollout/actions/EndRolloutNew.ts
+++ b/packages/eas-cli/src/rollout/actions/EndRolloutNew.ts
@@ -1,0 +1,234 @@
+import assert from 'assert';
+import chalk from 'chalk';
+
+import { getAlwaysTrueBranchMapping } from '../../channel/branch-mapping';
+import { updateChannelBranchMappingAsync } from '../../commands/channel/edit';
+import { EASUpdateAction, EASUpdateContext } from '../../eas-update/utils';
+import { UpdateChannelBasicInfoFragment } from '../../graphql/generated';
+import {
+  ChannelQuery,
+  UpdateBranchObject,
+  UpdateChannelObject,
+} from '../../graphql/queries/ChannelQuery';
+import Log from '../../log';
+import { confirmAsync, promptAsync } from '../../prompts';
+import { republishAsync } from '../../update/republish';
+import { getCodeSigningInfoAsync } from '../../utils/code-signing';
+import formatFields from '../../utils/formatFields';
+import {
+  Rollout,
+  getRollout,
+  getRolloutInfo,
+  isConstrainedRolloutInfo,
+  isRollout,
+} from '../branch-mapping';
+import { formatBranchWithUpdateGroup } from '../utils';
+
+export enum NewEndOutcome {
+  ROLL_OUT_AND_REPUBLISH = 'roll-out-and-republish',
+  REVERT_AND_REPUBLISH = 'revert-and-republish',
+}
+
+export type GeneralOptions = {
+  privateKeyPath: string | null;
+};
+
+export type NonInteractiveOptions = {
+  outcome: NewEndOutcome;
+};
+function isNonInteractiveOptions(
+  options: Partial<NonInteractiveOptions>
+): options is NonInteractiveOptions {
+  return !!options.outcome;
+}
+function assertNonInteractiveOptions(
+  options: Partial<NonInteractiveOptions>
+): asserts options is NonInteractiveOptions {
+  assert(
+    isNonInteractiveOptions(options),
+    '--outcome is required for ending a rollout in non-interactive mode.'
+  );
+}
+
+/**
+ * End an existing rollout for the project.
+ */
+export class EndRolloutNew implements EASUpdateAction<UpdateChannelBasicInfoFragment> {
+  constructor(
+    private channelInfo: UpdateChannelBasicInfoFragment,
+    private options: Partial<NonInteractiveOptions> & GeneralOptions
+  ) {}
+
+  public async runAsync(ctx: EASUpdateContext): Promise<UpdateChannelBasicInfoFragment> {
+    const { nonInteractive } = ctx;
+    if (nonInteractive) {
+      assertNonInteractiveOptions(this.options);
+    }
+
+    const channelObject = await this.getChannelObjectAsync(ctx);
+    const rollout = getRollout(channelObject);
+    const { rolledOutBranch } = rollout;
+    const rolledOutUpdateGroup = rolledOutBranch.updateGroups[0];
+    let outcome: NewEndOutcome;
+    if (!rolledOutUpdateGroup) {
+      Log.log(`⚠️  There is no update group being served on the ${rolledOutBranch.name} branch.`);
+      assert(
+        this.options.outcome !== NewEndOutcome.REVERT_AND_REPUBLISH,
+        `The only valid outcome for this rollout is to revert users back to the ${rollout.defaultBranch.name} branch. `
+      );
+      outcome = NewEndOutcome.REVERT_AND_REPUBLISH;
+    } else {
+      outcome = this.options.outcome ?? (await this.selectOutcomeAsync(rollout));
+    }
+    const didConfirm = await this.confirmOutcomeAsync(ctx, outcome, rollout);
+    if (!didConfirm) {
+      throw new Error('Aborting...');
+    }
+    return await this.performOutcomeAsync(ctx, rollout, outcome);
+  }
+
+  async getChannelObjectAsync(ctx: EASUpdateContext): Promise<UpdateChannelObject> {
+    const { graphqlClient, app } = ctx;
+    const { projectId } = app;
+    if (!isRollout(this.channelInfo)) {
+      throw new Error(
+        `The channel ${chalk.bold(
+          this.channelInfo.name
+        )} is not a rollout. To end a rollout, you must specify a channel with an ongoing rollout.`
+      );
+    }
+    const rolloutInfo = getRolloutInfo(this.channelInfo);
+    return await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      appId: projectId,
+      channelName: this.channelInfo.name,
+      ...(isConstrainedRolloutInfo(rolloutInfo)
+        ? { filter: { runtimeVersions: [rolloutInfo.runtimeVersion] } }
+        : {}),
+    });
+  }
+
+  async selectOutcomeAsync(rollout: Rollout<UpdateBranchObject>): Promise<NewEndOutcome> {
+    const { rolledOutBranch, percentRolledOut, defaultBranch } = rollout;
+    const rolledOutUpdateGroup = rolledOutBranch.updateGroups[0];
+    const defaultUpdateGroup = defaultBranch.updateGroups[0];
+    const outcomes = [
+      {
+        value: NewEndOutcome.ROLL_OUT_AND_REPUBLISH,
+        title: formatBranchWithUpdateGroup(rolledOutUpdateGroup, rolledOutBranch, percentRolledOut),
+      },
+      {
+        value: NewEndOutcome.REVERT_AND_REPUBLISH,
+        title: formatBranchWithUpdateGroup(
+          defaultUpdateGroup,
+          defaultBranch,
+          100 - percentRolledOut
+        ),
+      },
+    ];
+    const { outcome: selectedOutcome } = await promptAsync({
+      type: 'select',
+      name: 'outcome',
+      message: `Which update group would you like to serve?`,
+      choices: outcomes,
+    });
+    Log.newLine();
+    if (selectedOutcome === NewEndOutcome.ROLL_OUT_AND_REPUBLISH) {
+      Log.log(
+        `➡️ 📱 The update group you chose is served by branch ${chalk.bold(rolledOutBranch.name)}`
+      );
+    } else {
+      Log.log(
+        `➡️ 📱 The update group you chose is served by branch ${chalk.bold(defaultBranch.name)}`
+      );
+    }
+    return selectedOutcome;
+  }
+
+  async performOutcomeAsync(
+    ctx: EASUpdateContext,
+    rollout: Rollout<UpdateBranchObject>,
+    outcome: NewEndOutcome
+  ): Promise<UpdateChannelBasicInfoFragment> {
+    const { graphqlClient, app } = ctx;
+    const { rolledOutBranch, defaultBranch } = rollout;
+
+    const branchToRepublishLatestAndPointChannelTo =
+      outcome === NewEndOutcome.ROLL_OUT_AND_REPUBLISH ? rolledOutBranch : defaultBranch;
+
+    const updateGroup = branchToRepublishLatestAndPointChannelTo.updateGroups[0];
+
+    const codeSigningInfo = await getCodeSigningInfoAsync(
+      ctx.app.exp,
+      this.options.privateKeyPath ?? undefined
+    );
+    const arbitraryUpdate = updateGroup[0];
+    const { message: oldUpdateMessage, group: oldGroupId } = arbitraryUpdate;
+    const newUpdateMessage = `Republish "${oldUpdateMessage!}" - group: ${oldGroupId}`;
+
+    await republishAsync({
+      graphqlClient,
+      app,
+      updatesToPublish: updateGroup.map(update => ({
+        ...update,
+        groupId: update.group,
+        branchId: update.branch.id,
+        branchName: update.branch.name,
+      })),
+      codeSigningInfo,
+      targetBranch: {
+        branchId: branchToRepublishLatestAndPointChannelTo.id,
+        branchName: branchToRepublishLatestAndPointChannelTo.name,
+      },
+      updateMessage: newUpdateMessage,
+    });
+
+    updated;
+
+    const alwaysTrueDefaultBranchMapping = getAlwaysTrueBranchMapping(
+      branchToRepublishLatestAndPointChannelTo.id
+    );
+    const newChannelInfo = await updateChannelBranchMappingAsync(graphqlClient, {
+      channelId: this.channelInfo.id,
+      branchMapping: JSON.stringify(alwaysTrueDefaultBranchMapping),
+    });
+    Log.addNewLineIfNone();
+    Log.log(`✅ Successfully ended rollout`);
+    return newChannelInfo;
+  }
+
+  async confirmOutcomeAsync(
+    ctx: EASUpdateContext,
+    selectedOutcome: NewEndOutcome,
+    rollout: Rollout<UpdateBranchObject>
+  ): Promise<boolean> {
+    const { nonInteractive } = ctx;
+    if (nonInteractive) {
+      return true;
+    }
+    const { rolledOutBranch, defaultBranch } = rollout;
+    const branchToRepublishLatestAndPointChannelTo =
+      selectedOutcome === NewEndOutcome.ROLL_OUT_AND_REPUBLISH ? rolledOutBranch : defaultBranch;
+    Log.newLine();
+    Log.log(`Ending the rollout will do the following:`);
+    const actions = formatFields([
+      {
+        label: '1.',
+        value: `🔁 Republish the latest update group from ${chalk.bold(
+          branchToRepublishLatestAndPointChannelTo.name
+        )} onto ${chalk.bold(
+          branchToRepublishLatestAndPointChannelTo.name
+        )} (the same branch) to ensure all users get the latest update`,
+      },
+      {
+        label: '2.',
+        value: `⬅️  Point all users to ${chalk.bold(
+          branchToRepublishLatestAndPointChannelTo.name
+        )}`,
+      },
+    ]);
+    Log.log(actions);
+    return await confirmAsync({
+      message: `Continue?`,
+    });
+  }
+}

--- a/packages/eas-cli/src/rollout/actions/RolloutMainMenu.ts
+++ b/packages/eas-cli/src/rollout/actions/RolloutMainMenu.ts
@@ -6,9 +6,15 @@ import {
 } from './CreateRollout';
 import { NonInteractiveOptions as EditRolloutNonInteractiveOptions } from './EditRollout';
 import {
+  EndOutcome,
   GeneralOptions as EndRolloutGeneralOptions,
   NonInteractiveOptions as EndRolloutNonInteractiveOptions,
 } from './EndRollout';
+import {
+  GeneralOptions as EndRolloutNewGeneralOptions,
+  NonInteractiveOptions as EndRolloutNewNonInteractiveOptions,
+  NewEndOutcome,
+} from './EndRolloutNew';
 import { ManageRollout, ManageRolloutActions } from './ManageRollout';
 import { SelectRollout } from './SelectRollout';
 import { SelectChannel } from '../../channel/actions/SelectChannel';
@@ -39,9 +45,13 @@ export class RolloutMainMenu implements EASUpdateAction<void> {
       channelName?: string;
       action?: RolloutActions;
     } & Partial<EditRolloutNonInteractiveOptions> &
-      Partial<EndRolloutNonInteractiveOptions> &
+      Omit<Partial<EndRolloutNonInteractiveOptions>, 'outcome'> &
+      Omit<Partial<EndRolloutNewNonInteractiveOptions>, 'outcome'> &
       EndRolloutGeneralOptions &
-      Partial<CreateRolloutNonInteractiveOptions>
+      EndRolloutNewGeneralOptions &
+      Partial<CreateRolloutNonInteractiveOptions> & {
+        outcome?: EndOutcome | NewEndOutcome;
+      }
   ) {}
 
   public async runAsync(ctx: EASUpdateContext): Promise<void> {

--- a/packages/eas-cli/src/rollout/branch-mapping.ts
+++ b/packages/eas-cli/src/rollout/branch-mapping.ts
@@ -3,7 +3,6 @@ import {
   BranchMappingAlwaysTrue,
   BranchMappingNode,
   BranchMappingValidationError,
-  alwaysTrue,
   assertNodeObject,
   assertNumber,
   assertStatement,
@@ -20,31 +19,32 @@ import {
   UpdateChannelInfoWithBranches,
   getUpdateBranch,
 } from '../channel/utils';
+import { truthy } from '../utils/expodash/filter';
 
 export type Rollout<Branch extends BranchBasicInfo> =
   | LegacyRollout<Branch>
   | ConstrainedRollout<Branch>;
-export type RolloutInfo = LegacyRolloutInfo | ConstrainedRolloutInfo;
+export type RolloutInfo = LegacyRolloutInfo | ConstrainedRolloutInfo[];
 type ConstrainedRollout<Branch extends BranchBasicInfo> = LegacyRollout<Branch> & {
   runtimeVersion: string;
 };
 
-type LegacyRollout<Branch extends BranchBasicInfo> = {
+export type LegacyRollout<Branch extends BranchBasicInfo> = {
   rolledOutBranch: Branch;
   defaultBranch: Branch;
 } & LegacyRolloutInfo;
 
-type ConstrainedRolloutInfo = LegacyRolloutInfo & {
+export type ConstrainedRolloutInfo = LegacyRolloutInfo & {
   runtimeVersion: string;
 };
 
-type LegacyRolloutInfo = {
+export type LegacyRolloutInfo = {
   rolledOutBranchId: string;
   percentRolledOut: number;
   defaultBranchId: string;
 };
 
-export type RolloutBranchMapping = LegacyRolloutBranchMapping | ConstrainedRolloutBranchMapping;
+export type RolloutBranchMapping = LegacyRolloutBranchMapping | BranchMapping;
 
 type RolloutNode = {
   clientKey: 'rolloutToken';
@@ -76,26 +76,24 @@ export type LegacyRolloutBranchMapping = {
   ];
 };
 
-export type ConstrainedRolloutBranchMapping = {
-  version: number;
-  data: [
-    {
-      branchId: string;
-      branchMappingLogic: RtvConstrainedRolloutNode;
-    },
-    {
-      branchId: string;
-      branchMappingLogic: BranchMappingAlwaysTrue;
-    },
-  ];
+export type RtvConstrainedRolloutDataItem = {
+  branchId: string;
+  branchMappingLogic: RtvConstrainedRolloutNode;
 };
 
-export function isLegacyRolloutInfo(rollout: RolloutInfo): rollout is LegacyRolloutInfo {
-  return !isConstrainedRolloutInfo(rollout);
+export type RtvConstrainedAlwaysTrueDataItem = {
+  branchId: string;
+  branchMappingLogic: RolloutNode;
+};
+
+export function isLegacyRolloutInfo(rolloutInfo: RolloutInfo): rolloutInfo is LegacyRolloutInfo {
+  return !Array.isArray(rolloutInfo);
 }
 
-export function isConstrainedRolloutInfo(rollout: RolloutInfo): rollout is ConstrainedRolloutInfo {
-  return 'runtimeVersion' in rollout;
+export function isConstrainedRolloutInfo(
+  rolloutInfo: RolloutInfo
+): rolloutInfo is ConstrainedRolloutInfo {
+  return Array.isArray(rolloutInfo);
 }
 
 export function isConstrainedRollout<Branch extends BranchBasicInfo>(
@@ -105,42 +103,14 @@ export function isConstrainedRollout<Branch extends BranchBasicInfo>(
 }
 
 export function getRolloutInfo(basicChannelInfo: ChannelBasicInfo): RolloutInfo {
-  const rolloutBranchMapping = getRolloutBranchMapping(basicChannelInfo.branchMapping);
-  return getRolloutInfoFromBranchMapping(rolloutBranchMapping);
+  return getRolloutInfoFromBranchMapping(getBranchMapping(basicChannelInfo.branchMapping));
 }
 
-export function getRolloutInfoFromBranchMapping(branchMapping: RolloutBranchMapping): RolloutInfo {
-  const rolledOutBranchId = branchMapping.data[0].branchId;
-  const defaultBranchId = branchMapping.data[1].branchId;
+export function getRolloutInfoFromBranchMapping(branchMapping: BranchMapping): RolloutInfo {
+  const defaultBranchId = branchMapping.data[branchMapping.data.length - 1].branchId;
 
-  if (isRtvConstrainedRollout(branchMapping)) {
-    const statementNode = branchMapping.data[0].branchMappingLogic;
-    assertStatement(statementNode);
-    const nodesFromStatement = getNodesFromStatement(statementNode);
-
-    const runtimeVersionNode = nodesFromStatement.find(isRuntimeVersionNode);
-    if (!runtimeVersionNode) {
-      throw new BranchMappingValidationError('Runtime version node must be defined.');
-    }
-
-    assertNodeObject(runtimeVersionNode);
-    const runtimeVersion = runtimeVersionNode.operand;
-    assertString(runtimeVersion);
-
-    const rolloutNode = nodesFromStatement.find(isRolloutNode);
-    if (!rolloutNode) {
-      throw new BranchMappingValidationError('Rollout node must be defined.');
-    }
-    assertNodeObject(rolloutNode);
-    const operand = rolloutNode.operand;
-    assertNumber(operand);
-    return {
-      rolledOutBranchId,
-      percentRolledOut: Math.round(operand * 100),
-      runtimeVersion,
-      defaultBranchId,
-    };
-  } else {
+  if (isUnconstrainedRollout(branchMapping)) {
+    const rolledOutBranchId = branchMapping.data[0].branchId;
     const rolloutNode = branchMapping.data[0].branchMappingLogic;
     assertNodeObject(rolloutNode);
     const operand = rolloutNode.operand;
@@ -151,22 +121,61 @@ export function getRolloutInfoFromBranchMapping(branchMapping: RolloutBranchMapp
       defaultBranchId,
     };
   }
+
+  return branchMapping.data
+    .map(dataItem => {
+      const rolledOutBranchId = dataItem.branchId;
+      const statementNode = dataItem.branchMappingLogic;
+      assertStatement(statementNode);
+      const nodesFromStatement = getNodesFromStatement(statementNode);
+      const runtimeVersionNode = nodesFromStatement.find(isRuntimeVersionNodeForAnyRtv);
+      if (!runtimeVersionNode) {
+        return null;
+      }
+
+      assertNodeObject(runtimeVersionNode);
+      const runtimeVersion = runtimeVersionNode.operand;
+      assertString(runtimeVersion);
+
+      const rolloutNode = nodesFromStatement.find(isRolloutNode);
+      if (!rolloutNode) {
+        throw new BranchMappingValidationError('Rollout node must be defined.');
+      }
+      assertNodeObject(rolloutNode);
+      const operand = rolloutNode.operand;
+      assertNumber(operand);
+      return {
+        rolledOutBranchId,
+        percentRolledOut: Math.round(operand * 100),
+        runtimeVersion,
+        defaultBranchId,
+      };
+    })
+    .filter(truthy);
 }
 
-export function getRollout<Branch extends BranchBasicInfo>(
+export function getLegacyRollout<Branch extends BranchBasicInfo>(
   channel: UpdateChannelInfoWithBranches<Branch>
-): Rollout<Branch> {
-  const rolloutBranchMapping = getRolloutBranchMapping(channel.branchMapping);
+): LegacyRollout<Branch> {
+  const branchMapping = getBranchMapping(channel.branchMapping);
+  if (!isUnconstrainedRollout(branchMapping)) {
+    throw new Error('Not legacy rollout.');
+  }
+
+  const rolloutBranchMapping = branchMapping;
   const rolledOutBranchId = rolloutBranchMapping.data[0].branchId;
   const rolledOutBranch = getUpdateBranch(channel, rolledOutBranchId);
   const defaultBranchId = rolloutBranchMapping.data[1].branchId;
   const defaultBranch = getUpdateBranch(channel, defaultBranchId);
   const rolloutInfo = getRolloutInfo(channel);
-  return composeRollout<Branch>(rolloutInfo, defaultBranch, rolledOutBranch);
+  if (!isLegacyRolloutInfo(rolloutInfo)) {
+    throw new Error('Not legacy rollout.');
+  }
+  return composeLegacyRollout<Branch>(rolloutInfo, defaultBranch, rolledOutBranch);
 }
 
-export function composeRollout<Branch extends BranchBasicInfo>(
-  rolloutInfo: RolloutInfo,
+export function composeLegacyRollout<Branch extends BranchBasicInfo>(
+  rolloutInfo: LegacyRolloutInfo,
   defaultBranch: Branch,
   rolledOutBranch: Branch
 ): Rollout<Branch> {
@@ -189,20 +198,79 @@ export function composeRollout<Branch extends BranchBasicInfo>(
   };
 }
 
-export function getRolloutBranchMapping(branchMappingString: string): RolloutBranchMapping {
+export function getConstrainedRolloutForRtv<Branch extends BranchBasicInfo>(
+  channel: UpdateChannelInfoWithBranches<Branch>,
+  rtv: string
+): ConstrainedRollout<Branch> {
+  const branchMapping = getBranchMapping(channel.branchMapping);
+  if (!hasRtvConstrainedRolloutForRtv(branchMapping, rtv)) {
+    throw new Error('No rollout for runtime version found.');
+  }
+
+  const constrainedRolloutDataItemForRtv = branchMapping.data.find(dataItem =>
+    isRtvConstrainedRolloutNodeForRtv(dataItem.branchMappingLogic, rtv)
+  );
+  if (!constrainedRolloutDataItemForRtv) {
+    throw new Error('No rollout for runtime version found');
+  }
+
+  const rolledOutBranchId = constrainedRolloutDataItemForRtv.branchId;
+  const rolledOutBranch = getUpdateBranch(channel, rolledOutBranchId);
+  const defaultBranchId = branchMapping.data[branchMapping.data.length - 1].branchId;
+  const defaultBranch = getUpdateBranch(channel, defaultBranchId);
+  const rolloutInfo = getRolloutInfo(channel);
+  if (isLegacyRolloutInfo(rolloutInfo)) {
+    throw new Error('Not constrained rollout.');
+  }
+  const constrainedRolloutInfo = rolloutInfo.find(cri => cri.runtimeVersion === rtv);
+  if (!constrainedRolloutInfo) {
+    throw new Error('No rollout for runtime version found.');
+  }
+
+  return composeConstrainedRollout<Branch>(constrainedRolloutInfo, defaultBranch, rolledOutBranch);
+}
+
+export function composeConstrainedRollout<Branch extends BranchBasicInfo>(
+  rolloutInfo: ConstrainedRolloutInfo,
+  defaultBranch: Branch,
+  rolledOutBranch: Branch
+): ConstrainedRollout<Branch> {
+  if (rolloutInfo.defaultBranchId !== defaultBranch.id) {
+    throw new BranchMappingValidationError(
+      `Default branch id must match. Received: ${JSON.stringify(rolloutInfo)} ${defaultBranch.id}`
+    );
+  }
+  if (rolloutInfo.rolledOutBranchId !== rolledOutBranch.id) {
+    throw new BranchMappingValidationError(
+      `Rolled out branch id must match. Received: ${JSON.stringify(rolloutInfo)} ${
+        rolledOutBranch.id
+      }`
+    );
+  }
+  return {
+    ...rolloutInfo,
+    rolledOutBranch,
+    defaultBranch,
+  };
+}
+
+export function getRolloutBranchMappingForRtv_DELETE(
+  branchMappingString: string,
+  rtv: string
+): RolloutBranchMapping {
   const branchMapping = getBranchMapping(branchMappingString);
-  assertRolloutBranchMapping(branchMapping);
+  assertRolloutBranchMappingForRtv(branchMapping, rtv);
   return branchMapping;
 }
 
 /**
  * Detect if a branch mapping is a rollout.
- * 
+ *
  * Types of rollout:
  * 1. Legacy unconstrained rollout:
  * Maps to a rollout branch via a rollout token
  * Falls back to a default branch
- * 
+ *
  * Example:
  * {
     version: 0,
@@ -222,7 +290,7 @@ export function getRolloutBranchMapping(branchMappingString: string): RolloutBra
   * 2. RTV constrained rollout:
   * Maps to a rollout branch via a rollout token, constrained by runtime version
   * Falls back to a default branch
-  * 
+  *
   * Example:
   * {
     version: 0,
@@ -244,17 +312,20 @@ export function getRolloutBranchMapping(branchMappingString: string): RolloutBra
       },
       { branchId: uuidv4(), branchMappingLogic: alwaysTrue() },
     ],
-  } 
+  }
  */
-export function isRolloutBranchMapping(
-  branchMapping: BranchMapping
+export function doesBranchMappingHaveRolloutForRtv(
+  branchMapping: BranchMapping,
+  rtv: string
 ): branchMapping is RolloutBranchMapping {
-  return isUnconstrainedRollout(branchMapping) || isRtvConstrainedRollout(branchMapping);
+  return (
+    isUnconstrainedRollout(branchMapping) || hasRtvConstrainedRolloutForRtv(branchMapping, rtv)
+  );
 }
 
-export function isRollout(channelInfo: ChannelBasicInfo): boolean {
+export function doesChannelHaveRolloutForRtv(channelInfo: ChannelBasicInfo, rtv: string): boolean {
   const branchMapping = getBranchMapping(channelInfo.branchMapping);
-  return isRolloutBranchMapping(branchMapping);
+  return doesBranchMappingHaveRolloutForRtv(branchMapping, rtv);
 }
 
 export function doesTargetRollout(
@@ -268,20 +339,21 @@ export function doesTargetRollout(
   return rolloutInfo.runtimeVersion === runtimeVersion;
 }
 
-export function createRolloutBranchMapping({
-  defaultBranchId,
-  rolloutBranchId,
-  percent,
-  runtimeVersion,
-}: {
-  defaultBranchId: string;
-  rolloutBranchId: string;
-  percent: number;
-  runtimeVersion: string;
-}): ConstrainedRolloutBranchMapping {
+export function insertConstrainedRolloutBranchMappingForRtv(
+  existingBranchMapping: BranchMapping,
+  {
+    rolloutBranchId,
+    percent,
+    runtimeVersion,
+  }: {
+    rolloutBranchId: string;
+    percent: number;
+    runtimeVersion: string;
+  }
+): BranchMapping {
   assertPercent(percent);
-  return {
-    version: 0,
+  const updatedBranchMapping: BranchMapping = {
+    ...existingBranchMapping,
     data: [
       {
         branchId: rolloutBranchId,
@@ -299,30 +371,31 @@ export function createRolloutBranchMapping({
           },
         ],
       },
-      { branchId: defaultBranchId, branchMappingLogic: alwaysTrue() },
+      ...existingBranchMapping.data,
     ],
   };
-}
 
-export function editRolloutBranchMapping(
-  branchMapping: RolloutBranchMapping,
-  percent: number
-): RolloutBranchMapping {
-  assertPercent(percent);
-  if (isRtvConstrainedRollout(branchMapping)) {
-    return editRtvConstrainedRollout(branchMapping, percent);
-  } else {
-    return editLegacyRollout(branchMapping, percent);
+  if (!hasRtvConstrainedRolloutForRtv(updatedBranchMapping, runtimeVersion)) {
+    throw new BranchMappingValidationError('Error creating rollout for runtime version');
   }
+  return updatedBranchMapping;
 }
 
-function editRtvConstrainedRollout(
-  branchMapping: ConstrainedRolloutBranchMapping,
+export function editRtvConstrainedRolloutForRtv(
+  branchMapping: BranchMapping,
+  rtv: string,
   percent: number
-): ConstrainedRolloutBranchMapping {
+): BranchMapping {
   const newBranchMapping = { ...branchMapping };
-  const statementNode = newBranchMapping.data[0].branchMappingLogic;
-  const nodesFromStatement = getNodesFromStatement(statementNode);
+  const statementNodeMatchingRtv = newBranchMapping.data
+    .map(d => d.branchMappingLogic)
+    .find((node): node is RtvConstrainedRolloutNode =>
+      isRtvConstrainedRolloutNodeForRtv(node, rtv)
+    );
+  if (!statementNodeMatchingRtv) {
+    throw new BranchMappingValidationError('No rollout data item matching runtime version found.');
+  }
+  const nodesFromStatement = getNodesFromStatement(statementNodeMatchingRtv);
 
   const rolloutNode = nodesFromStatement.find(isRolloutNode);
   if (!rolloutNode) {
@@ -332,7 +405,7 @@ function editRtvConstrainedRollout(
   return newBranchMapping;
 }
 
-function editLegacyRollout(
+export function editLegacyRollout(
   branchMapping: LegacyRolloutBranchMapping,
   percent: number
 ): LegacyRolloutBranchMapping {
@@ -342,18 +415,20 @@ function editLegacyRollout(
   return newBranchMapping;
 }
 
-function isRtvConstrainedRollout(
-  branchMapping: BranchMapping
-): branchMapping is ConstrainedRolloutBranchMapping {
-  if (branchMapping.data.length !== 2) {
-    return false;
-  }
-  const hasRtvRolloutNode = isRtvConstrainedRolloutNode(branchMapping.data[0].branchMappingLogic);
-  const defaultsToAlwaysTrueNode = isAlwaysTrue(branchMapping.data[1].branchMappingLogic);
-  return hasRtvRolloutNode && defaultsToAlwaysTrueNode;
+function hasRtvConstrainedRolloutForRtv(branchMapping: BranchMapping, rtv: string): boolean {
+  const hasRtvRolloutNodeForRtv = branchMapping.data.some(d =>
+    isRtvConstrainedRolloutNodeForRtv(d.branchMappingLogic, rtv)
+  );
+  const lastNodeIsDefaultsToAlwaysTrue = isAlwaysTrue(
+    branchMapping.data[branchMapping.data.length - 1].branchMappingLogic
+  );
+  return hasRtvRolloutNodeForRtv && lastNodeIsDefaultsToAlwaysTrue;
 }
 
-function isRtvConstrainedRolloutNode(node: BranchMappingNode): node is RtvConstrainedRolloutNode {
+function isRtvConstrainedRolloutNodeForRtv(
+  node: BranchMappingNode,
+  rtv: string
+): node is RtvConstrainedRolloutNode {
   if (!isStatement(node) || !isAndStatement(node)) {
     return false;
   }
@@ -362,12 +437,14 @@ function isRtvConstrainedRolloutNode(node: BranchMappingNode): node is RtvConstr
   if (statementNodes.length !== 2) {
     return false;
   }
-  const hasRuntimeVersionNode = statementNodes.some(isRuntimeVersionNode);
+  const hasMatchingRuntimeVersionNode = statementNodes.some(sn =>
+    isRuntimeVersionNodeForRtv(sn, rtv)
+  );
   const hasRolloutNode = statementNodes.some(isRolloutNode);
-  return hasRuntimeVersionNode && hasRolloutNode;
+  return hasMatchingRuntimeVersionNode && hasRolloutNode;
 }
 
-function isUnconstrainedRollout(
+export function isUnconstrainedRollout(
   branchMapping: BranchMapping
 ): branchMapping is LegacyRolloutBranchMapping {
   if (branchMapping.data.length !== 2) {
@@ -378,14 +455,35 @@ function isUnconstrainedRollout(
   return hasRolloutNode && defaultsToAlwaysTrueNode;
 }
 
-function isRuntimeVersionNode(node: BranchMappingNode): node is RuntimeVersionNode {
+function isRuntimeVersionNodeForAnyRtv(node: BranchMappingNode): node is RuntimeVersionNode {
   if (typeof node === 'string') {
     return false;
   }
   if (Array.isArray(node)) {
     return false;
   }
-  return node.clientKey === 'runtimeVersion' && node.branchMappingOperator === '==';
+  return (
+    node.clientKey === 'runtimeVersion' &&
+    node.branchMappingOperator === '==' &&
+    typeof node.operand === 'string'
+  );
+}
+
+function isRuntimeVersionNodeForRtv(
+  node: BranchMappingNode,
+  rtv: string
+): node is RuntimeVersionNode {
+  if (typeof node === 'string') {
+    return false;
+  }
+  if (Array.isArray(node)) {
+    return false;
+  }
+  return (
+    node.clientKey === 'runtimeVersion' &&
+    node.branchMappingOperator === '==' &&
+    node.operand === rtv
+  );
 }
 
 function isRolloutNode(node: BranchMappingNode): node is RolloutNode {
@@ -398,10 +496,11 @@ function isRolloutNode(node: BranchMappingNode): node is RolloutNode {
   return node.clientKey === 'rolloutToken' && node.branchMappingOperator === 'hash_lt';
 }
 
-export function assertRolloutBranchMapping(
-  branchMapping: BranchMapping
+export function assertRolloutBranchMappingForRtv(
+  branchMapping: BranchMapping,
+  rtv: string
 ): asserts branchMapping is RolloutBranchMapping {
-  if (!isRolloutBranchMapping(branchMapping)) {
+  if (!doesBranchMappingHaveRolloutForRtv(branchMapping, rtv)) {
     throw new BranchMappingValidationError(
       'Branch mapping node must be a rollout. Received: ' + JSON.stringify(branchMapping)
     );


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The previous behavior for ending a rollout on RTV 1 from branch `control` to branch `test` was to do one of the following outcomes:
- republish-and-revert: take the latest update from `test` and publish it to `control`, and set the channel pointer for all runtime versions to `control`.
- revert: just set the channel pointer for all runtime versions to `control`.

This was beneficial as it reverted the channel's branch mapping back to a constant branch pointer which can be better optimized on the backend.

But it also is a bit confusing from a UX perspective since when thinking about a rollout, it is most commonly that "rolling out a branch fully" puts all users on that branch.

# How

The fix to the UX problem is as follows:

The behavior for ending a rollout on RTV 1 from branch `control` to branch `test` is to do one of the following outcomes:
- roll-out-and-republish: take the latest update from `test` and re-publish it to `test`, and set the channel pointer for the rollout's runtime version to `test`.
- revert-and-republish: take the latest update from `control` and re-publish it to `control`, and set the channel pointer for the rollout's runtime version to `control`.

The tough part of this is that we end up with much more complex branch mappings for a channel once rollouts of multiple runtime versions have been run.

# Test Plan

Create rollout and end the rollout using interactive menu. See that in both scenarios the correct update is republished and the channel's branch mapping is correct.
