### PR TITLE
refactor(worker): Implement batched uploads and improved progress output

### DIFF
--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -2,13 +2,13 @@ import chalk from 'chalk';
 import fs from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { ora } from '../../ora';
-import { createProgressTracker } from '../../utils/progress';
 import EasCommand from '../../commandUtils/EasCommand';
 import Log from '../../log';
+import { ora } from '../../ora';
+import { createProgressTracker } from '../../utils/progress';
 import * as WorkerAssets from '../../worker/assets';
-import { uploadAsync, batchUploadAsync, UploadParams } from '../../worker/upload';
 import { getSignedDeploymentUrlAsync } from '../../worker/deployment';
+import { UploadParams, batchUploadAsync, uploadAsync } from '../../worker/upload';
 
 const isDirectory = (directoryPath: string): Promise<boolean> =>
   fs
@@ -114,7 +114,9 @@ export default class WorkerDeploy extends EasCommand {
       const uploadParams: UploadParams[] = [];
       for await (const asset of WorkerAssets.listAssetMapFiles(distClientPath, assetMap)) {
         const uploadURL = uploads[asset.normalizedPath];
-        if (uploadURL) uploadParams.push({ url: uploadURL, filePath: asset.path });
+        if (uploadURL) {
+          uploadParams.push({ url: uploadURL, filePath: asset.path });
+        }
       }
 
       const progress = {
@@ -128,7 +130,9 @@ export default class WorkerDeploy extends EasCommand {
         total: progress.total,
         message(ratio) {
           const percent = `${Math.floor(ratio * 100)}`;
-          const details = chalk.dim(`(${progress.pending} Pending, ${progress.transferred} Completed, ${progress.total} Total)`);
+          const details = chalk.dim(
+            `(${progress.pending} Pending, ${progress.transferred} Completed, ${progress.total} Total)`
+          );
           return `Uploading client assets: ${percent.padStart(3)}% ${details}`;
         },
         completedMessage: 'Uploaded client assets for worker deployment',

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -1,6 +1,9 @@
+import chalk from 'chalk';
 import fs from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { ora } from '../../ora';
+import { createProgressTracker } from '../../utils/progress';
 import EasCommand from '../../commandUtils/EasCommand';
 import Log from '../../log';
 import * as WorkerAssets from '../../worker/assets';
@@ -74,6 +77,7 @@ export default class WorkerDeploy extends EasCommand {
       const uploadUrl = await getSignedDeploymentUrlAsync(graphqlClient, exp, {
         appId: projectId,
       });
+
       const { response } = await uploadAsync({
         url: uploadUrl,
         filePath: tarPath,
@@ -113,14 +117,64 @@ export default class WorkerDeploy extends EasCommand {
         if (uploadURL) uploadParams.push({ url: uploadURL, filePath: asset.path });
       }
 
-      for await (const _signal of batchUploadAsync(uploadParams)) {
-        // TODO(@kitten): Log pending and completed to console
+      const progress = {
+        total: uploadParams.length,
+        pending: 0,
+        percent: 0,
+        transferred: 0,
+      };
+
+      const updateProgress = createProgressTracker({
+        total: progress.total,
+        message(ratio) {
+          const percent = `${Math.floor(ratio * 100)}`;
+          const details = chalk.dim(`(${progress.pending} Pending, ${progress.transferred} Completed, ${progress.total} Total)`);
+          return `Uploading client assets: ${percent.padStart(3)}% ${details}`;
+        },
+        completedMessage: 'Uploaded client assets for worker deployment',
+      });
+
+      try {
+        for await (const signal of batchUploadAsync(uploadParams)) {
+          if ('response' in signal) {
+            progress.pending--;
+            progress.percent = ++progress.transferred / progress.total;
+          } else {
+            progress.pending++;
+          }
+          updateProgress({ progress });
+        }
+      } catch (error: any) {
+        updateProgress({ isComplete: true, error });
+      } finally {
+        updateProgress({ isComplete: true });
       }
     }
 
-    const assetMap = await WorkerAssets.createAssetMap(distClientPath);
-    const tarPath = await WorkerAssets.packFilesIterable(emitWorkerTarballAsync(assetMap));
-    const deployResult = await uploadTarballAsync(tarPath);
+    let progress = ora('Preparing worker upload');
+    let assetMap: WorkerAssets.AssetMap;
+    let tarPath: string;
+    try {
+      assetMap = await WorkerAssets.createAssetMap(distClientPath);
+      tarPath = await WorkerAssets.packFilesIterable(emitWorkerTarballAsync(assetMap));
+    } catch (error: any) {
+      progress.fail(error);
+      return;
+    } finally {
+      progress.succeed('Prepared worker upload');
+    }
+
+    progress = ora('Creating worker deployment');
+    let deployResult: any;
+    try {
+      deployResult = await uploadTarballAsync(tarPath);
+    } catch (error: any) {
+      progress.fail(error);
+      return;
+    } finally {
+      progress.succeed('Created worker deploymnt');
+    }
+
     await uploadAssetsAsync(assetMap, deployResult.uploads);
 
     const baseDomain = process.env.EXPO_STAGING ? 'staging.expo.app' : 'expo.app';

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -1,0 +1,166 @@
+import mime from 'mime';
+import { Gzip } from 'minizlib';
+import path from 'node:path';
+import fs, { createReadStream } from 'node:fs';
+import fetch, { RequestInit, HeadersInit, Headers, Response } from 'node-fetch';
+import createHttpsProxyAgent from 'https-proxy-agent';
+import promiseRetry from 'promise-retry';
+import * as https from 'https';
+
+const MAX_RETRIES = 4;
+const MAX_CONCURRENCY = 10;
+const MIN_RETRY_TIMEOUT = 100;
+const MAX_UPLOAD_SIZE = 5e8; // 5MB
+const MIN_COMPRESSION_SIZE = 5e4; // 50kB
+
+const isCompressible = (contentType: string | null, size: number): boolean => {
+  if (size < MIN_COMPRESSION_SIZE) {
+    // Don't compress small files
+    return false;
+  } else if (contentType && /^(?:audio|video|image)\//i.test(contentType)) {
+    // Never compress images, audio, or videos as they're presumably precompressed
+    return false;
+  } else if (contentType && /^application\//i.test(contentType)) {
+    // Only compress `application/` files if they're marked as XML/JSON/JS
+    return /(?:xml|json5?|javascript)$/i.test(contentType);
+  } else {
+    return true;
+  }
+};
+
+export interface UploadParams extends Omit<RequestInit, 'signal' | 'body'> {
+  filePath: string;
+  compress?: boolean;
+  url: string;
+  method?: string;
+  headers?: HeadersInit;
+  body?: undefined;
+  signal?: AbortSignal;
+}
+
+export interface UploadResult {
+  params: UploadParams;
+  response: Response;
+}
+
+let sharedAgent: https.Agent | undefined;
+
+const getAgent = () => {
+  if (sharedAgent) {
+    return sharedAgent;
+  } else if (process.env.https_proxy) {
+    return (sharedAgent = createHttpsProxyAgent(process.env.https_proxy));
+  } else {
+    return (sharedAgent = new https.Agent({
+      keepAlive: true,
+      maxSockets: MAX_CONCURRENCY,
+      maxTotalSockets: MAX_CONCURRENCY,
+      scheduling: 'lifo',
+      timeout: 4_000,
+    }));
+  }
+};
+
+export async function uploadAsync(params: UploadParams): Promise<UploadResult> {
+  const { filePath, signal, compress, method = 'POST', url, headers: headersInit, ...requestInit } = params;
+  const stat = await fs.promises.stat(params.filePath);
+  if (stat.size > MAX_UPLOAD_SIZE) {
+    throw new Error(
+      `Upload of "${params.filePath}" aborted: File size is greater than the upload limit (>500MB)`
+    );
+  }
+
+  const contentType = mime.getType(path.basename(params.filePath));
+  return await promiseRetry(
+    async retry => {
+      const headers = new Headers(headersInit);
+      if (contentType) {
+        headers.set('content-type', contentType);
+      }
+
+      let bodyStream: NodeJS.ReadableStream = createReadStream(filePath);
+      if (compress && isCompressible(contentType, stat.size)) {
+        const gzip = new Gzip({ portable: true });
+        bodyStream.on('error', error => gzip.emit('error', error));
+        // @ts-ignore: Gzip implements a Readable-like interface
+        bodyStream = bodyStream.pipe(gzip) as NodeJS.ReadableStream;
+        headers.set('content-encoding', 'gzip');
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(params.url, {
+          ...requestInit,
+          method,
+          body: bodyStream,
+          headers,
+          agent: getAgent(),
+          // @ts-ignore: Internal types don't match
+          signal,
+        });
+      } catch (error) {
+        return retry(error);
+      }
+
+      if (
+        response.status === 408 ||
+        response.status === 409 ||
+        response.status === 429 ||
+        (response.status >= 500 && response.status <= 599)
+      ) {
+        const message = `Upload of "${filePath}" failed: ${response.statusText}`;
+        const text = await response.text().catch(() => null);
+        return retry(new Error(text ? `${message}\n${text}` : message));
+      } else if (response.status === 413) {
+        const message = `Upload of "${filePath}" failed: File size exceeded the upload limit`;
+        throw new Error(message);
+      } else if (!response.ok) {
+        throw new Error(`Upload of "${filePath}" failed: ${response.statusText}`);
+      }
+
+      return {
+        params,
+        response
+      };
+    },
+    {
+      retries: MAX_RETRIES,
+      minTimeout: MIN_RETRY_TIMEOUT,
+      randomize: true,
+      factor: 2,
+    }
+  );
+}
+
+export interface UploadPending {
+  params: UploadParams;
+}
+
+export type BatchUploadSignal =
+  | UploadResult
+  | UploadPending;
+
+export async function* batchUploadAsync(uploads: readonly UploadParams[]): AsyncGenerator<BatchUploadSignal> {
+  const controller = new AbortController();
+  const queue = new Set<Promise<UploadResult>>();
+  try {
+    let index = 0;
+    while (index < uploads.length || queue.size > 0) {
+      while (queue.size < MAX_CONCURRENCY && index < uploads.length) {
+        const uploadParams = uploads[index++];
+        let uploadPromise: Promise<UploadResult>;
+        queue.add(
+          uploadPromise = uploadAsync({ ...uploadParams, signal: controller.signal })
+            .finally(() => queue.delete(uploadPromise))
+        );
+      }
+      yield await Promise.race(queue);
+    }
+  } catch (error: any) {
+    if (typeof error !== 'object' || error.name !== 'AbortError') {
+      throw error;
+    }
+  } finally {
+    if (queue.size > 0) controller.abort();
+  }
+}

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -153,6 +153,7 @@ export async function* batchUploadAsync(uploads: readonly UploadParams[]): Async
           uploadPromise = uploadAsync({ ...uploadParams, signal: controller.signal })
             .finally(() => queue.delete(uploadPromise))
         );
+        yield { params: uploadParams };
       }
       yield await Promise.race(queue);
     }


### PR DESCRIPTION
- Adds batched upload
  - This uses a shared `https.Agent` with max sockets limits and `keepAlive` set
  - Attempts concurrent uploads up to a maximum of `10` and aborts on any failed upload
  - Starts new uploads concurrently as soon as another finishes to keep up concurrency count
- Adds progress bar (reused from `utils/progress`) for file upload progress
- Adds several ora step progress messages

**Note:** This is still not the final output we'll need, but gets us close enough that it's presentable