### PR TITLE
[eas-cli] Remove long-deprecated update flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Remove long-deprecated `eas update` flags. ([#2501](https://github.com/expo/eas-cli/pull/2501) by [@wschurman](https://github.com/wschurman))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -70,20 +70,6 @@ describe(UpdatePublish.name, () => {
     jest.mocked(PublishMutation.publishUpdateGroupAsync).mockClear();
   });
 
-  // Deprecated and split to a new command: update:republish
-  it('errors with --republish', async () => {
-    await expect(new UpdatePublish(['--republish'], commandOptions).run()).rejects.toThrow(
-      '--group and --republish flags are deprecated'
-    );
-  });
-
-  // Deprecated and split to a new command: update:republish
-  it('errors with --group', async () => {
-    await expect(new UpdatePublish(['--group=abc123'], commandOptions).run()).rejects.toThrow(
-      '--group and --republish flags are deprecated'
-    );
-  });
-
   it('errors with both --channel and --branch', async () => {
     const flags = ['--channel=channel123', '--branch=branch123'];
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -69,10 +69,6 @@ type RawUpdateFlags = {
   'non-interactive': boolean;
   'emit-metadata': boolean;
   json: boolean;
-  /** @deprecated see UpdateRepublish command */
-  group?: string;
-  /** @deprecated see UpdateRepublish command */
-  republish?: boolean;
 };
 
 type UpdateFlags = {
@@ -106,14 +102,6 @@ export default class UpdatePublish extends EasCommand {
       char: 'm',
       description: 'A short message describing the update',
       required: false,
-    }),
-    republish: Flags.boolean({
-      description: 'Republish an update group (deprecated, see republish command)',
-      exclusive: ['input-dir', 'skip-bundler'],
-    }),
-    group: Flags.string({
-      description: 'Update group to republish (deprecated, see republish command)',
-      exclusive: ['input-dir', 'skip-bundler'],
     }),
     'input-dir': Flags.string({
       description: 'Location of the bundle',
@@ -555,23 +543,6 @@ export default class UpdatePublish extends EasCommand {
         '--branch and --message, or --channel and --message are required when updating in non-interactive mode unless --auto is specified',
         { exit: 1 }
       );
-    }
-
-    if (flags.group || flags.republish) {
-      // Pick the first flag set that is defined, in this specific order
-      const args = [
-        ['--group', flags.group],
-        ['--branch', flags.branch],
-      ].filter(([_, value]) => value)[0];
-
-      Log.newLine();
-      Log.warn(
-        'The --group and --republish flags are deprecated, use the republish command instead:'
-      );
-      Log.warn(`  ${chalk.bold([`eas update:republish`, ...(args ?? [])].join(' '))}`);
-      Log.newLine();
-
-      Errors.error('--group and --republish flags are deprecated', { exit: 1 });
     }
 
     const skipBundler = flags['skip-bundler'] ?? false;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

These were deprecated two years ago in https://app.graphite.dev/github/pr/expo/eas-cli/1535/refactor-update-remove-republish-from-update-command?utm_source=chrome-extension. That PR also threw with a descriptive error when one was provided.

Now that it's multiple years later we can remove the code. This is a step towards adding two new flags to this function for rollout updates.

# How

Remove, `yarn tsc`

# Test Plan

`yarn tsc`
