### PR TITLE
[eas-cli] Add update:edit command for editing rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add new rollout update type for `eas update` and `eas update:edit`. ([#2502](https://github.com/expo/eas-cli/pull/2502), [#2503](https://github.com/expo/eas-cli/pull/2503) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/update/edit.ts
+++ b/packages/eas-cli/src/commands/update/edit.ts
@@ -1,0 +1,143 @@
+import { Flags } from '@oclif/core';
+import assert from 'assert';
+import chalk from 'chalk';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { PublishMutation } from '../../graphql/mutations/PublishMutation';
+import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
+import Log from '../../log';
+import { promptAsync } from '../../prompts';
+import {
+  formatUpdateGroup,
+  getUpdateGroupDescriptions,
+  getUpdateJsonInfosForUpdates,
+} from '../../update/utils';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+export default class UpdateEdit extends EasCommand {
+  static override description = 'edit all the updates in an update group';
+  static override hidden = true;
+
+  static override args = [
+    {
+      name: 'groupId',
+      required: true,
+      description: 'The ID of an update group to edit.',
+    },
+  ];
+
+  static override flags = {
+    'rollout-percentage': Flags.integer({
+      description: `Rollout percentage to set for a rollout update. The specified number must be an integer between 1 and 100.`,
+      required: false,
+      min: 0,
+      max: 100,
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args: { groupId },
+      flags: {
+        'rollout-percentage': rolloutPercentage,
+        json: jsonFlag,
+        'non-interactive': nonInteractive,
+      },
+    } = await this.parse(UpdateEdit);
+
+    const {
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(UpdateEdit, { nonInteractive });
+
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    const proposedUpdatesToEdit = (
+      await UpdateQuery.viewUpdateGroupAsync(graphqlClient, { groupId })
+    ).map(u => ({ updateId: u.id, rolloutPercentage: u.rolloutPercentage }));
+
+    const updatesToEdit = proposedUpdatesToEdit.filter(
+      (u): u is { updateId: string; rolloutPercentage: number } =>
+        u.rolloutPercentage !== null && u.rolloutPercentage !== undefined
+    );
+
+    if (updatesToEdit.length === 0) {
+      throw new Error('Cannot edit rollout percentage on update group that is not a rollout.');
+    }
+
+    const rolloutPercentagesSet = new Set(updatesToEdit.map(u => u.rolloutPercentage));
+    if (rolloutPercentagesSet.size !== 1) {
+      throw new Error(
+        'Cannot edit rollout percentage for a group with non-equal percentages for updates in the group.'
+      );
+    }
+
+    const previousPercentage = updatesToEdit[0].rolloutPercentage;
+
+    if (nonInteractive && rolloutPercentage === undefined) {
+      throw new Error('Must specify --rollout-percentage in non-interactive mode');
+    }
+
+    let rolloutPercentageToSet = rolloutPercentage;
+    if (rolloutPercentageToSet === undefined) {
+      const { percentage } = await promptAsync({
+        type: 'number',
+        message: `New rollout percentage (min: ${previousPercentage}, max: 100)`,
+        validate: value => {
+          if (value <= previousPercentage) {
+            return `Rollout percentage must be greater than previous rollout percentage (${previousPercentage})`;
+          } else if (value > 100) {
+            return `Rollout percentage must not be greater than 100`;
+          } else {
+            return true;
+          }
+        },
+        name: 'percentage',
+      });
+
+      if (!percentage) {
+        Log.log('Aborted.');
+        return;
+      }
+
+      rolloutPercentageToSet = percentage;
+    }
+
+    assert(rolloutPercentageToSet !== undefined);
+
+    if (rolloutPercentageToSet < previousPercentage) {
+      throw new Error(
+        `Rollout percentage must be greater than previous rollout percentage (${previousPercentage})`
+      );
+    } else if (rolloutPercentageToSet > 100) {
+      throw new Error('Rollout percentage must not be greater than 100');
+    }
+
+    const updatedUpdates = await Promise.all(
+      updatesToEdit.map(async u => {
+        return await PublishMutation.setRolloutPercentageAsync(
+          graphqlClient,
+          u.updateId,
+          rolloutPercentageToSet!
+        );
+      })
+    );
+
+    if (jsonFlag) {
+      printJsonOnlyOutput(getUpdateJsonInfosForUpdates(updatedUpdates));
+    } else {
+      const [updateGroupDescription] = getUpdateGroupDescriptions([updatedUpdates]);
+
+      Log.log(chalk.bold('Update group:'));
+
+      Log.log(formatUpdateGroup(updateGroupDescription));
+    }
+  }
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -7859,6 +7859,14 @@ export type SetCodeSigningInfoMutationVariables = Exact<{
 
 export type SetCodeSigningInfoMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', setCodeSigningInfo: { __typename?: 'Update', id: string, group: string, awaitingCodeSigningInfo: boolean, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, alg: string, sig: string } | null } } };
 
+export type SetRolloutPercentageMutationVariables = Exact<{
+  updateId: Scalars['ID']['input'];
+  rolloutPercentage: Scalars['Int']['input'];
+}>;
+
+
+export type SetRolloutPercentageMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', setRolloutPercentage: { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null } } };
+
 export type CreateAndroidSubmissionMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
   config: AndroidSubmissionConfigInput;

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -9,6 +9,9 @@ import {
   GetSignedUploadMutationVariables,
   PublishUpdateGroupInput,
   SetCodeSigningInfoMutation,
+  SetCodeSigningInfoMutationVariables,
+  SetRolloutPercentageMutation,
+  SetRolloutPercentageMutationVariables,
   UpdateFragment,
   UpdatePublishMutation,
 } from '../generated';
@@ -78,7 +81,7 @@ export const PublishMutation = {
   ): Promise<SetCodeSigningInfoMutation['update']['setCodeSigningInfo']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .mutation<SetCodeSigningInfoMutation>(
+        .mutation<SetCodeSigningInfoMutation, SetCodeSigningInfoMutationVariables>(
           gql`
             mutation SetCodeSigningInfoMutation(
               $updateId: ID!
@@ -103,5 +106,32 @@ export const PublishMutation = {
         .toPromise()
     );
     return data.update.setCodeSigningInfo;
+  },
+
+  async setRolloutPercentageAsync(
+    graphqlClient: ExpoGraphqlClient,
+    updateId: string,
+    rolloutPercentage: number
+  ): Promise<UpdateFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<SetRolloutPercentageMutation, SetRolloutPercentageMutationVariables>(
+          gql`
+            mutation SetRolloutPercentageMutation($updateId: ID!, $rolloutPercentage: Int!) {
+              update {
+                setRolloutPercentage(updateId: $updateId, percentage: $rolloutPercentage) {
+                  id
+                  ...UpdateFragment
+                }
+              }
+            }
+            ${print(UpdateFragmentNode)}
+          `,
+          { updateId, rolloutPercentage },
+          { additionalTypenames: ['Update'] }
+        )
+        .toPromise()
+    );
+    return data.update.setRolloutPercentage;
   },
 };


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This adds the ability to increase a rollout for an update.

# How

Add new command, `update:edit` that takes the rollout-percentage flag.

# Test Plan

```
$ neas update:edit 63809081-ee5f-4216-add2-b3412aae7a16
✔ New rollout percentage (min: 30, max: 100) … 31
Update group:
Platforms                 android, ios
Runtime Version           1.0.0
Message                   "wat2" (1 hour ago by wschurman)
Code Signing Key          N/A
Is Roll Back to Embedded  No
Rollout Percentage        31%
Group ID                  63809081-ee5f-4216-add2-b3412aae7a16

$ neas update:view 63809081-ee5f-4216-add2-b3412aae7a16
Update group:
Platforms                 android, ios
Runtime Version           1.0.0
Message                   "wat2" (1 hour ago by wschurman)
Code Signing Key          N/A
Is Roll Back to Embedded  No
Rollout Percentage        31%
Group ID                  63809081-ee5f-4216-add2-b3412aae7a16
```