### PR TITLE
[chore] Enable remaining lint rules and fix lots of bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Upgrade packages to SDK 51 release. ([#2498](https://github.com/expo/eas-cli/pull/2498) by [@wschurman](https://github.com/wschurman))
+- Enable typescript linting and various lint rules. ([#2505](https://github.com/expo/eas-cli/pull/2505), [#2507](https://github.com/expo/eas-cli/pull/2507), [#2508](https://github.com/expo/eas-cli/pull/2508), [#2509](https://github.com/expo/eas-cli/pull/2509), [#2510](https://github.com/expo/eas-cli/pull/2510) by [@wschurman](https://github.com/wschurman))
 
 ## [10.2.4](https://github.com/expo/eas-cli/releases/tag/v10.2.4) - 2024-08-19
 

--- a/packages/eas-cli/src/.eslintrc.js
+++ b/packages/eas-cli/src/.eslintrc.js
@@ -15,15 +15,15 @@ module.exports = {
         ],
         '@typescript-eslint/prefer-nullish-coalescing': ['warn', { ignorePrimitives: true }],
         '@typescript-eslint/no-confusing-void-expression': 'warn',
-        // '@typescript-eslint/await-thenable': 'error',
-        // '@typescript-eslint/no-misused-promises': [
-        //   'error',
-        //   {
-        //     checksVoidReturn: false,
-        //   },
-        // ],
-        // '@typescript-eslint/no-floating-promises': 'error',
-        // 'no-void': ['warn', { allowAsStatement: true }],
+        '@typescript-eslint/await-thenable': 'error',
+        '@typescript-eslint/no-misused-promises': [
+          'error',
+          {
+            checksVoidReturn: false,
+          },
+        ],
+        '@typescript-eslint/no-floating-promises': 'error',
+        'no-void': ['warn', { allowAsStatement: true }],
         'no-return-await': 'off',
         '@typescript-eslint/return-await': ['error', 'always'],
         '@typescript-eslint/no-confusing-non-null-assertion': 'warn',

--- a/packages/eas-cli/src/build/__tests__/cancel-test.ts
+++ b/packages/eas-cli/src/build/__tests__/cancel-test.ts
@@ -47,14 +47,14 @@ describe(selectBuildToCancelAsync.name, () => {
   it('does not return build id when confirmation is rejected', async () => {
     const graphqlClient = instance(mock<ExpoGraphqlClient>());
     jest.mocked(confirmAsync).mockResolvedValueOnce(false);
-    expect(selectBuildToCancelAsync(graphqlClient, projectId, 'blah')).resolves.toEqual(null);
+    await expect(selectBuildToCancelAsync(graphqlClient, projectId, 'blah')).resolves.toEqual(null);
   });
 
   it('returns build id when confirmation is confirmed', async () => {
     const graphqlClient = instance(mock<ExpoGraphqlClient>());
     jest.mocked(selectAsync).mockResolvedValueOnce(selectedBuildId);
     jest.mocked(confirmAsync).mockResolvedValueOnce(true);
-    expect(selectBuildToCancelAsync(graphqlClient, projectId, 'blah')).resolves.toEqual(
+    await expect(selectBuildToCancelAsync(graphqlClient, projectId, 'blah')).resolves.toEqual(
       selectedBuildId
     );
   });

--- a/packages/eas-cli/src/build/__tests__/delete-test.ts
+++ b/packages/eas-cli/src/build/__tests__/delete-test.ts
@@ -47,14 +47,14 @@ describe(selectBuildToDeleteAsync.name, () => {
   it('does not return build id when confirmation is rejected', async () => {
     const graphqlClient = instance(mock<ExpoGraphqlClient>());
     jest.mocked(confirmAsync).mockResolvedValueOnce(false);
-    expect(selectBuildToDeleteAsync(graphqlClient, projectId, 'blah')).resolves.toEqual(null);
+    await expect(selectBuildToDeleteAsync(graphqlClient, projectId, 'blah')).resolves.toEqual(null);
   });
 
   it('returns build id when confirmation is confirmed', async () => {
     const graphqlClient = instance(mock<ExpoGraphqlClient>());
     jest.mocked(selectAsync).mockResolvedValueOnce(selectedBuildId);
     jest.mocked(confirmAsync).mockResolvedValueOnce(true);
-    expect(selectBuildToDeleteAsync(graphqlClient, projectId, 'blah')).resolves.toEqual(
+    await expect(selectBuildToDeleteAsync(graphqlClient, projectId, 'blah')).resolves.toEqual(
       selectedBuildId
     );
   });

--- a/packages/eas-cli/src/commands/analytics.ts
+++ b/packages/eas-cli/src/commands/analytics.ts
@@ -10,7 +10,7 @@ export default class AnalyticsView extends EasCommand {
   async runAsync(): Promise<void> {
     const { STATUS: status } = (await this.parse(AnalyticsView)).args;
     if (status) {
-      setAnalyticsEnabledAsync(status === 'on');
+      await setAnalyticsEnabledAsync(status === 'on');
       Log.withTick(`${status === 'on' ? 'Enabling' : 'Disabling'} analytics.`);
     } else {
       const analyticsEnabled = await getAnalyticsEnabledAsync();

--- a/packages/eas-cli/src/commands/build/version/sync.ts
+++ b/packages/eas-cli/src/commands/build/version/sync.ts
@@ -128,7 +128,7 @@ export default class BuildVersionSyncView extends EasCommand {
         continue;
       }
       if (profileInfo.platform === Platform.ANDROID) {
-        this.syncAndroidAsync({
+        await this.syncAndroidAsync({
           projectDir,
           exp,
           profile: profileInfo.profile as BuildProfile<Platform.ANDROID>,
@@ -137,7 +137,7 @@ export default class BuildVersionSyncView extends EasCommand {
           vcsClient,
         });
       } else {
-        this.syncIosAsync({
+        await this.syncIosAsync({
           projectDir,
           exp,
           profile: profileInfo.profile as BuildProfile<Platform.IOS>,

--- a/packages/eas-cli/src/commands/update/list.ts
+++ b/packages/eas-cli/src/commands/update/list.ts
@@ -53,10 +53,13 @@ export default class UpdateList extends EasCommand {
     }
 
     if (all) {
-      listAndRenderUpdateGroupsOnAppAsync(graphqlClient, { projectId, paginatedQueryOptions });
+      await listAndRenderUpdateGroupsOnAppAsync(graphqlClient, {
+        projectId,
+        paginatedQueryOptions,
+      });
     } else {
       if (branchFlag) {
-        listAndRenderUpdateGroupsOnBranchAsync(graphqlClient, {
+        await listAndRenderUpdateGroupsOnBranchAsync(graphqlClient, {
           projectId,
           branchName: branchFlag,
           paginatedQueryOptions,
@@ -81,7 +84,7 @@ export default class UpdateList extends EasCommand {
               offset: 0,
             },
         });
-        listAndRenderUpdateGroupsOnBranchAsync(graphqlClient, {
+        await listAndRenderUpdateGroupsOnBranchAsync(graphqlClient, {
           projectId,
           branchName: selectedBranch.name,
           paginatedQueryOptions,

--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -108,7 +108,7 @@ export default class IosCredentialsProvider {
       return null;
     } else if (
       ctx.easJsonCliConfig?.promptToConfigurePushNotifications === undefined &&
-      !(await isExpoNotificationsInstalled(ctx.projectDir))
+      !isExpoNotificationsInstalled(ctx.projectDir)
     ) {
       return null;
     }

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -105,7 +105,7 @@ export async function selectDistributionCertificateWithDependenciesAsync(
 
   // get valid certs on the developer portal
   const certInfoFromApple = await ctx.appStore.listDistributionCertificatesAsync();
-  const validDistCerts = await filterRevokedDistributionCertsFromEasServers(
+  const validDistCerts = filterRevokedDistributionCertsFromEasServers(
     distCertsForAccount,
     certInfoFromApple
   );

--- a/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/ProvisioningProfileUtils.ts
@@ -29,7 +29,7 @@ export async function generateProvisioningProfileAsync(
   const appleAuthCtx = await ctx.appStore.ensureAuthenticatedAsync();
   const type = appleAuthCtx.team.inHouse ? 'Enterprise ' : 'AppStore';
   const profileName = `*[expo] ${bundleIdentifier} ${type} ${new Date().toISOString()}`; // Apple drops [ if its the first char (!!)
-  const applePlatform = await getApplePlatformFromTarget(target);
+  const applePlatform = getApplePlatformFromTarget(target);
   return await ctx.appStore.createProvisioningProfileAsync(
     bundleIdentifier,
     distCert,

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
@@ -133,7 +133,7 @@ export class SetUpAdhocProvisioningProfile {
     );
 
     // 4. Reuse or create the profile on Apple Developer Portal
-    const applePlatform = await getApplePlatformFromTarget(target);
+    const applePlatform = getApplePlatformFromTarget(target);
     const profileType =
       applePlatform === ApplePlatform.TV_OS
         ? ProfileType.TVOS_APP_ADHOC

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpProvisioningProfile.ts
@@ -128,7 +128,7 @@ export class SetUpProvisioningProfile {
     }
 
     // See if the profile we have exists on the Apple Servers
-    const applePlatform = await getApplePlatformFromTarget(this.target);
+    const applePlatform = getApplePlatformFromTarget(this.target);
     const existingProfiles = await ctx.appStore.listProvisioningProfilesAsync(
       this.app.bundleIdentifier,
       applePlatform

--- a/packages/eas-cli/src/credentials/ios/credentials.ts
+++ b/packages/eas-cli/src/credentials/ios/credentials.ts
@@ -170,7 +170,7 @@ export const provisioningProfileSchema: CredentialSchema<ProvisioningProfile> = 
   transformResultAsync: async answers => {
     return {
       ...answers,
-      ...(await readAppleTeamFromProvisioningProfile(answers.provisioningProfile!)),
+      ...readAppleTeamFromProvisioningProfile(answers.provisioningProfile!),
     } as ProvisioningProfile;
   },
 };

--- a/packages/eas-cli/src/credentials/ios/validators/validateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/validators/validateProvisioningProfile.ts
@@ -90,7 +90,7 @@ async function validateProvisioningProfileWithAppleAsync(
   assert(buildCredentials.provisioningProfile, 'Provisioning Profile must be defined');
   const { developerPortalIdentifier, provisioningProfile } = buildCredentials.provisioningProfile;
 
-  const applePlatform = await getApplePlatformFromTarget(target);
+  const applePlatform = getApplePlatformFromTarget(target);
   const profilesFromApple = await ctx.appStore.listProvisioningProfilesAsync(
     app.bundleIdentifier,
     applePlatform,

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -327,7 +327,7 @@ export class ManageIos {
         return;
       }
       case IosActionType.SetUpPushKey: {
-        const setupPushKeyAction = await new SetUpPushKey(appLookupParams);
+        const setupPushKeyAction = new SetUpPushKey(appLookupParams);
         const isPushKeySetup = await setupPushKeyAction.isPushKeySetupAsync(ctx);
         if (isPushKeySetup) {
           Log.log(

--- a/packages/eas-cli/src/run/ios/systemRequirements.ts
+++ b/packages/eas-cli/src/run/ios/systemRequirements.ts
@@ -46,7 +46,7 @@ async function assertCorrectXcodeVersionInstalledAsync(): Promise<void> {
 }
 
 async function ensureXcrunInstalledAsync(): Promise<void> {
-  if (!isXcrunInstalledAsync()) {
+  if (!(await isXcrunInstalledAsync())) {
     const { installXcrun } = await promptAsync({
       type: 'select',
       message: 'Xcode Command Line Tools need to be installed, continue?',

--- a/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
@@ -41,7 +41,7 @@ describe(getBranchNameFromChannelNameAsync, () => {
         }) as any
     );
 
-    expect(
+    await expect(
       getBranchNameFromChannelNameAsync(graphqlClient, 'test-project-id', 'test-channel-name')
     ).rejects.toThrow(
       "Channel has no branches associated with it. Run 'eas channel:edit' to map a branch"
@@ -58,7 +58,7 @@ describe(getBranchNameFromChannelNameAsync, () => {
         }) as any
     );
 
-    expect(
+    await expect(
       getBranchNameFromChannelNameAsync(graphqlClient, 'test-project-id', 'test-channel-name')
     ).rejects.toThrow(
       "Channel has multiple branches associated with it. Instead, use '--branch' instead of '--channel'"

--- a/packages/eas-cli/src/update/__tests__/update-queries-test.ts
+++ b/packages/eas-cli/src/update/__tests__/update-queries-test.ts
@@ -30,8 +30,8 @@ describe('update queries', () => {
 
     it('to throw when no items are available', async () => {
       const graphqlClient = instance(mock<ExpoGraphqlClient>());
-      expect(async () => {
-        await selectUpdateGroupOnBranchAsync(graphqlClient, {
+      await expect(
+        selectUpdateGroupOnBranchAsync(graphqlClient, {
           branchName,
           projectId: appId,
           paginatedQueryOptions: {
@@ -40,14 +40,14 @@ describe('update queries', () => {
             offset: 0,
             limit: 50,
           },
-        });
-      }).rejects.toThrowError(`Could not find any branches for project "${appId}`);
+        })
+      ).rejects.toThrowError(`Could not find any branches for project "${appId}`);
     });
 
     it('to throw when in non-interactive mode', async () => {
       const graphqlClient = instance(mock<ExpoGraphqlClient>());
-      expect(async () => {
-        await selectUpdateGroupOnBranchAsync(graphqlClient, {
+      await expect(
+        selectUpdateGroupOnBranchAsync(graphqlClient, {
           branchName,
           projectId: appId,
           paginatedQueryOptions: {
@@ -56,8 +56,8 @@ describe('update queries', () => {
             offset: 0,
             limit: 50,
           },
-        });
-      }).rejects.toThrowError(`Unable to select an update in non-interactive mode.`);
+        })
+      ).rejects.toThrowError(`Unable to select an update in non-interactive mode.`);
     });
   });
 });

--- a/packages/eas-cli/src/user/expoSsoLauncher.ts
+++ b/packages/eas-cli/src/user/expoSsoLauncher.ts
@@ -96,7 +96,7 @@ export async function getSessionUsingBrowserAuthFlowAsync({
         );
         const port = address.port;
         const authorizeUrl = buildExpoSsoLoginUrl(port);
-        openBrowserAsync(authorizeUrl);
+        void openBrowserAsync(authorizeUrl);
       });
 
       server.on('connection', connection => {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This is the real PR I wanted to get to: it uses lint to fix a lot of bugs where promises should have been awaited but weren't. This also fixes bugs where a promise was being accidentally used as a boolean rather than the awaited boolean value.

Closes ENG-13213.

# How

Apply rules, fix manually.

# Test Plan

`yarn lint`