### PR TITLE
[eas-cli] Include debug info in fingerprint metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Upgrade packages to SDK 51 release. ([#2498](https://github.com/expo/eas-cli/pull/2498) by [@wschurman](https://github.com/wschurman))
 - Enable typescript linting and various lint rules. ([#2505](https://github.com/expo/eas-cli/pull/2505), [#2507](https://github.com/expo/eas-cli/pull/2507), [#2508](https://github.com/expo/eas-cli/pull/2508), [#2509](https://github.com/expo/eas-cli/pull/2509), [#2510](https://github.com/expo/eas-cli/pull/2510) by [@wschurman](https://github.com/wschurman))
+- Include debug info in fingerprint metadata during build. ([#2513](https://github.com/expo/eas-cli/pull/2513) by [@wschurman](https://github.com/wschurman))
 
 ## [10.2.4](https://github.com/expo/eas-cli/releases/tag/v10.2.4) - 2024-08-19
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -13,7 +13,7 @@
     "@expo/config": "9.0.3",
     "@expo/config-plugins": "8.0.8",
     "@expo/config-types": "51.0.2",
-    "@expo/eas-build-job": "1.0.130",
+    "@expo/eas-build-job": "1.0.133",
     "@expo/eas-json": "10.2.4",
     "@expo/json-file": "8.3.3",
     "@expo/logger": "1.0.117",

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -680,13 +680,17 @@ async function createAndMaybeUploadFingerprintAsync<T extends Platform>(
     cwd: ctx.projectDir,
   });
 
+  if (!resolvedRuntimeVersion) {
+    return {};
+  }
+
   /**
    * It's ok for fingerprintSources to be empty
    * fingerprintSources only exist if the project is using runtimeVersion.policy: fingerprint
    */
-  if (!resolvedRuntimeVersion?.fingerprintSources) {
+  if (!resolvedRuntimeVersion.fingerprint) {
     return {
-      runtimeVersion: resolvedRuntimeVersion?.runtimeVersion ?? undefined,
+      runtimeVersion: resolvedRuntimeVersion.runtimeVersion ?? undefined,
     };
   }
 
@@ -695,15 +699,16 @@ async function createAndMaybeUploadFingerprintAsync<T extends Platform>(
 
   await fs.writeJSON(fingerprintLocation, {
     hash: resolvedRuntimeVersion.runtimeVersion,
-    sources: resolvedRuntimeVersion.fingerprintSources,
+    sources: resolvedRuntimeVersion.fingerprint.fingerprintSources,
   });
 
   if (ctx.localBuildOptions.localBuildMode === LocalBuildMode.LOCAL_BUILD_PLUGIN) {
     return {
-      runtimeVersion: resolvedRuntimeVersion?.runtimeVersion ?? undefined,
+      runtimeVersion: resolvedRuntimeVersion.runtimeVersion ?? undefined,
       fingerprintSource: {
         type: FingerprintSourceType.PATH,
         path: fingerprintLocation,
+        isDebugFingerprint: resolvedRuntimeVersion.fingerprint.isDebugFingerprintSource,
       },
     };
   }
@@ -724,17 +729,18 @@ async function createAndMaybeUploadFingerprintAsync<T extends Platform>(
 
     Log.warn(errMessage);
     return {
-      runtimeVersion: resolvedRuntimeVersion?.runtimeVersion ?? undefined,
+      runtimeVersion: resolvedRuntimeVersion.runtimeVersion ?? undefined,
     };
   } finally {
     await fs.remove(fingerprintLocation);
   }
 
   return {
-    runtimeVersion: resolvedRuntimeVersion?.runtimeVersion ?? undefined,
+    runtimeVersion: resolvedRuntimeVersion.runtimeVersion ?? undefined,
     fingerprintSource: {
       type: FingerprintSourceType.GCS,
       bucketKey: fingerprintGCSBucketKey,
+      isDebugFingerprint: resolvedRuntimeVersion.fingerprint.isDebugFingerprintSource,
     },
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,6 +1435,16 @@
     semver "^7.6.2"
     zod "^3.23.8"
 
+"@expo/eas-build-job@1.0.133":
+  version "1.0.133"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-1.0.133.tgz#342a58c79d523cb1364f6329a9aec07ffb019021"
+  integrity sha512-dlY3tl1A0GDIGs4WOOuvK08jvR6cfXCmCKTCqZ9ioePscZ3jbeGmadLa1nTvMSe9k8vFdfrHgkKmfs78hI7sbw==
+  dependencies:
+    "@expo/logger" "1.0.117"
+    joi "^17.13.1"
+    semver "^7.6.2"
+    zod "^3.23.8"
+
 "@expo/image-utils@^0.5.0":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.5.1.tgz#06fade141facebcd8431355923d30f3839309942"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://app.graphite.dev/github/pr/expo/eas-build/437/eas-build-job-Add-field-to-fingerprint-metadata-indicating-whether-it-is-a-debug-fingerprint added this field to the build job object.

This PR writes the field as part of the build command.

Note that that PR needs to be landed, published, and updated here for this to work in CI.

# How

Update function that generates, uploads, and includes fingerprint info.

# Test Plan

Run regular and debug build for app that uses fingerprint, inspect the entity created, see the metadata has the boolean set correctly.
