### PR TITLE
[eas-cli] make `eas config` command not require authentication when running in `--eas-json-only`  mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Make `eas config` command not require authentication when running in `--eas-json-only` mode. ([#2517](https://github.com/expo/eas-cli/pull/2517) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [11.0.0](https://github.com/expo/eas-cli/releases/tag/v11.0.0) - 2024-08-26


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/CLQ58M23X/p1724709887450179

# How

Make sure that we require authentication only if not run in the `--eas-json-only` mode

# Test Plan

test manually
