### PR TITLE
[eas-cli] remove unnecessary static project config context definition from eas build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Remove unncessary static project config context definition from `eas build` command context, to fix resolving dynamic projest ID and slug for dynamic app configs. ([#2521](https://github.com/expo/eas-cli/pull/2521) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [11.0.1](https://github.com/expo/eas-cli/releases/tag/v11.0.1) - 2024-08-26

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -124,7 +124,6 @@ export default class Build extends EasCommand {
     ...this.ContextOptions.LoggedIn,
     ...this.ContextOptions.DynamicProjectConfig,
     ...this.ContextOptions.ProjectDir,
-    ...this.ContextOptions.ProjectConfig,
     ...this.ContextOptions.Analytics,
     ...this.ContextOptions.Vcs,
   };


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://github.com/expo/eas-cli/issues/2519

I was able to reproduce the issue and it is indeed true. It seems like we mistakenly added a static project config definition to the `eas build` command context in https://github.com/expo/eas-cli/commit/56510f092527e458aa9dca19feac0b5d425dac56#diff-cd2e00f4d286a4714f8736e14c635f4c3b98c402367cd71a83e4cd743034bd79. The output from it wasn't really used anywhere, but adding it caused the app configs to be evaluated without `buildProfile.env` in the first pass when trying the resolve project ID and slug at the begging of command execution and our slug/project ID assertions to fail. It only affected people with dynamic project IDs and slug fields.

# How

Remove unnecessary static context from context definitions, therefore avoid resolving project ID and slug from app config without env vars as a first thing when the `eas build` command is executed.

# Test Plan

Tested manually