### PR TITLE
[eas-cli] add new entitlements added after Xcode 15.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add support for syncing Journaling Suggestions, Managed App Installation UI, and 5G Network Slicing capabilities. ([#2525](https://github.com/expo/eas-cli/pull/2525) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "1.7.1",
+    "@expo/apple-utils": "1.8.0",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "8.5.4",
     "@expo/config-plugins": "7.8.4",

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -747,7 +747,47 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     validateOptions: validateBooleanOptions,
     getOptions: getBooleanOptions,
   },
-
+  {
+    entitlement: 'com.apple.developer.journal.allow',
+    name: 'Journaling Suggestions',
+    capability: CapabilityType.JOURNALING_SUGGESTIONS,
+    validateOptions: createValidateStringArrayOptions(['suggestions']),
+    getOptions: getDefinedOptions,
+  },
+  {
+    entitlement: 'com.apple.developer.managed-app-distribution.install-ui',
+    name: 'Managed App Installation UI',
+    capability: CapabilityType.MANAGED_APP_INSTALLATION_UI,
+    validateOptions: createValidateStringArrayOptions(['managed-app']),
+    getOptions: getDefinedOptions,
+  },
+  {
+    entitlement: 'com.apple.developer.networking.slicing.appcategory',
+    name: '5G Network Slicing',
+    capability: CapabilityType.NETWORK_SLICING,
+    validateOptions: createValidateStringArrayOptions([
+      'gaming-6014',
+      'communication-9000',
+      'streaming-9001',
+    ]),
+    getOptions: getDefinedOptions,
+  },
+  {
+    entitlement: 'com.apple.developer.networking.slicing.trafficcategory',
+    name: '5G Network Slicing',
+    capability: CapabilityType.NETWORK_SLICING,
+    validateOptions: createValidateStringArrayOptions([
+      'defaultslice-1',
+      'video-2',
+      'background-3',
+      'voice-4',
+      'callsignaling-5',
+      'responsivedata-6',
+      'avstreaming-7',
+      'responsiveav-8',
+    ]),
+    getOptions: getDefinedOptions,
+  },
   // VMNET
 
   // These don't appear to have entitlements, so it's unclear how we can automatically enable / disable them at this time.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.7.1.tgz#b072cc95ace4fed734d088740eff9945e8f4d22e"
-  integrity sha512-oKHKRMfpPsVIlMSwHsartqrFhxKR1PnwGzaM3i+d4/g9XE9A+bKMu5YIUT4IXX561E0YYoaeaRHuxiIzcmEmRw==
+"@expo/apple-utils@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.8.0.tgz#8a359cefbad000be66caa18235ecd4c03406a15d"
+  integrity sha512-JKGfPCCGko7GtLcvCj9VeyrSJGimgWsBJnR4G10kGY9sUQo3ykEgVrUBUaG2HJrCLzbeDUExmsbuZRWqJha77g==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

companion to https://github.com/expo/third-party/pull/104

# How

This is my first PR adding new capabilities so please double-check if I did everything correctly, I based it on 6389f52

I got new entitlements from https://developer.apple.com/documentation/bundleresources/entitlements?changes=latest_major and added all available capabilities corresponding to these.

# Test Plan

Run prod build manually, add new entitlements for new capabilities to app config, and verify that they were enabled on the provisioning profile
