### PR TITLE
[eas-cli] use `npx expo config` command to resolve expo config if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Resolve versioned expo config using `npx expo config` command instead of using fixed `@expo/config` version shipped with EAS CLI, if available. ([#2529](https://github.com/expo/eas-cli/pull/2529) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/commandUtils/context/DynamicProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/DynamicProjectConfigContextField.ts
@@ -48,7 +48,7 @@ export class DynamicPublicProjectConfigContextField extends ContextField<Dynamic
           },
         };
       }
-      const exp = getPublicExpoConfigAsync(projectDir, options);
+      const exp = await getPublicExpoConfigAsync(projectDir, options);
       return {
         exp,
         projectDir,
@@ -89,7 +89,7 @@ export class DynamicPrivateProjectConfigContextField extends ContextField<Dynami
           },
         };
       }
-      const exp = getPrivateExpoConfigAsync(projectDir, options);
+      const exp = await getPrivateExpoConfigAsync(projectDir, options);
       return {
         exp,
         projectDir,

--- a/packages/eas-cli/src/commandUtils/context/DynamicProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/DynamicProjectConfigContextField.ts
@@ -7,8 +7,8 @@ import { getProjectIdAsync } from './contextUtils/getProjectIdAsync';
 import { loadServerSideEnvironmentVariablesAsync } from './contextUtils/loadServerSideEnvironmentVariablesAsync';
 import {
   ExpoConfigOptions,
-  getPrivateExpoConfig,
-  getPublicExpoConfig,
+  getPrivateExpoConfigAsync,
+  getPublicExpoConfigAsync,
 } from '../../project/expoConfig';
 
 export type DynamicConfigContextFn = (options?: ExpoConfigOptions) => Promise<{
@@ -25,7 +25,7 @@ export class DynamicPublicProjectConfigContextField extends ContextField<Dynamic
   }: ContextOptions): Promise<DynamicConfigContextFn> {
     const projectDir = await findProjectDirAndVerifyProjectSetupAsync();
     return async (options?: ExpoConfigOptions) => {
-      const expBefore = getPublicExpoConfig(projectDir, options);
+      const expBefore = await getPublicExpoConfigAsync(projectDir, options);
       const projectId = await getProjectIdAsync(sessionManager, expBefore, {
         nonInteractive,
         env: options?.env,
@@ -48,7 +48,7 @@ export class DynamicPublicProjectConfigContextField extends ContextField<Dynamic
           },
         };
       }
-      const exp = getPublicExpoConfig(projectDir, options);
+      const exp = getPublicExpoConfigAsync(projectDir, options);
       return {
         exp,
         projectDir,
@@ -66,7 +66,7 @@ export class DynamicPrivateProjectConfigContextField extends ContextField<Dynami
   }: ContextOptions): Promise<DynamicConfigContextFn> {
     const projectDir = await findProjectDirAndVerifyProjectSetupAsync();
     return async (options?: ExpoConfigOptions) => {
-      const expBefore = getPrivateExpoConfig(projectDir, options);
+      const expBefore = await getPrivateExpoConfigAsync(projectDir, options);
       const projectId = await getProjectIdAsync(sessionManager, expBefore, {
         nonInteractive,
         env: options?.env,
@@ -89,7 +89,7 @@ export class DynamicPrivateProjectConfigContextField extends ContextField<Dynami
           },
         };
       }
-      const exp = getPrivateExpoConfig(projectDir, options);
+      const exp = getPrivateExpoConfigAsync(projectDir, options);
       return {
         exp,
         projectDir,

--- a/packages/eas-cli/src/commandUtils/context/OptionalPrivateProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/OptionalPrivateProjectConfigContextField.ts
@@ -6,7 +6,7 @@ import { createGraphqlClient } from './contextUtils/createGraphqlClient';
 import { findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
 import { getProjectIdAsync } from './contextUtils/getProjectIdAsync';
 import { loadServerSideEnvironmentVariablesAsync } from './contextUtils/loadServerSideEnvironmentVariablesAsync';
-import { getPrivateExpoConfig } from '../../project/expoConfig';
+import { getPrivateExpoConfigAsync } from '../../project/expoConfig';
 
 export class OptionalPrivateProjectConfigContextField extends ContextField<
   | {
@@ -41,7 +41,7 @@ export class OptionalPrivateProjectConfigContextField extends ContextField<
       return undefined;
     }
 
-    const expBefore = getPrivateExpoConfig(projectDir);
+    const expBefore = await getPrivateExpoConfigAsync(projectDir);
     const projectId = await getProjectIdAsync(sessionManager, expBefore, {
       nonInteractive,
     });
@@ -58,7 +58,7 @@ export class OptionalPrivateProjectConfigContextField extends ContextField<
       });
       serverSideEnvVars = serverSideEnvironmentVariables;
     }
-    const exp = getPrivateExpoConfig(projectDir, { env: serverSideEnvVars });
+    const exp = getPrivateExpoConfigAsync(projectDir, { env: serverSideEnvVars });
     return {
       exp,
       projectDir,

--- a/packages/eas-cli/src/commandUtils/context/OptionalPrivateProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/OptionalPrivateProjectConfigContextField.ts
@@ -58,7 +58,7 @@ export class OptionalPrivateProjectConfigContextField extends ContextField<
       });
       serverSideEnvVars = serverSideEnvironmentVariables;
     }
-    const exp = getPrivateExpoConfigAsync(projectDir, { env: serverSideEnvVars });
+    const exp = await getPrivateExpoConfigAsync(projectDir, { env: serverSideEnvVars });
     return {
       exp,
       projectDir,

--- a/packages/eas-cli/src/commandUtils/context/PrivateProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/PrivateProjectConfigContextField.ts
@@ -5,7 +5,7 @@ import { createGraphqlClient } from './contextUtils/createGraphqlClient';
 import { findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
 import { getProjectIdAsync } from './contextUtils/getProjectIdAsync';
 import { loadServerSideEnvironmentVariablesAsync } from './contextUtils/loadServerSideEnvironmentVariablesAsync';
-import { getPrivateExpoConfig } from '../../project/expoConfig';
+import { getPrivateExpoConfigAsync } from '../../project/expoConfig';
 
 export class PrivateProjectConfigContextField extends ContextField<{
   projectId: string;
@@ -22,7 +22,7 @@ export class PrivateProjectConfigContextField extends ContextField<{
     projectDir: string;
   }> {
     const projectDir = await findProjectDirAndVerifyProjectSetupAsync();
-    const expBefore = getPrivateExpoConfig(projectDir);
+    const expBefore = await getPrivateExpoConfigAsync(projectDir);
     const projectId = await getProjectIdAsync(sessionManager, expBefore, {
       nonInteractive,
     });
@@ -39,7 +39,7 @@ export class PrivateProjectConfigContextField extends ContextField<{
       });
       serverSideEnvVars = serverSideEnvironmentVariables;
     }
-    const exp = getPrivateExpoConfig(projectDir, { env: serverSideEnvVars });
+    const exp = getPrivateExpoConfigAsync(projectDir, { env: serverSideEnvVars });
 
     return {
       projectId,

--- a/packages/eas-cli/src/commandUtils/context/PrivateProjectConfigContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/PrivateProjectConfigContextField.ts
@@ -39,7 +39,7 @@ export class PrivateProjectConfigContextField extends ContextField<{
       });
       serverSideEnvVars = serverSideEnvironmentVariables;
     }
-    const exp = getPrivateExpoConfigAsync(projectDir, { env: serverSideEnvVars });
+    const exp = await getPrivateExpoConfigAsync(projectDir, { env: serverSideEnvVars });
 
     return {
       projectId,

--- a/packages/eas-cli/src/commandUtils/context/ProjectIdContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/ProjectIdContextField.ts
@@ -1,12 +1,12 @@
 import ContextField, { ContextOptions } from './ContextField';
 import { findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
 import { getProjectIdAsync } from './contextUtils/getProjectIdAsync';
-import { getPrivateExpoConfig } from '../../project/expoConfig';
+import { getPrivateExpoConfigAsync } from '../../project/expoConfig';
 
 export class ProjectIdContextField extends ContextField<string> {
   async getValueAsync({ nonInteractive, sessionManager }: ContextOptions): Promise<string> {
     const projectDir = await findProjectDirAndVerifyProjectSetupAsync();
-    const expBefore = getPrivateExpoConfig(projectDir);
+    const expBefore = await getPrivateExpoConfigAsync(projectDir);
     const projectId = await getProjectIdAsync(sessionManager, expBefore, {
       nonInteractive,
     });

--- a/packages/eas-cli/src/commandUtils/context/ServerSideEnvironmentVariablesContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/ServerSideEnvironmentVariablesContextField.ts
@@ -3,7 +3,7 @@ import { createGraphqlClient } from './contextUtils/createGraphqlClient';
 import { findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
 import { getProjectIdAsync } from './contextUtils/getProjectIdAsync';
 import { loadServerSideEnvironmentVariablesAsync } from './contextUtils/loadServerSideEnvironmentVariablesAsync';
-import { getPublicExpoConfig } from '../../project/expoConfig';
+import { getPublicExpoConfigAsync } from '../../project/expoConfig';
 
 type GetServerSideEnvironmentVariablesFn = (
   maybeEnv?: Record<string, string>
@@ -22,7 +22,7 @@ export class ServerSideEnvironmentVariablesContextField extends ContextField<Get
           'withServerSideEnvironment parameter is required to evaluate ServerSideEnvironmentVariablesContextField'
         );
       }
-      const exp = getPublicExpoConfig(projectDir, { env: maybeEnv });
+      const exp = await getPublicExpoConfigAsync(projectDir, { env: maybeEnv });
       const projectId = await getProjectIdAsync(sessionManager, exp, {
         nonInteractive,
         env: maybeEnv,

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
@@ -6,6 +6,7 @@ import { Role } from '../../../../graphql/generated';
 import { AppQuery } from '../../../../graphql/queries/AppQuery';
 import { learnMore } from '../../../../log';
 import { fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync } from '../../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
+import { isExpoInstalled } from '../../../../project/projectUtils';
 import SessionManager from '../../../../user/SessionManager';
 import { findProjectRootAsync } from '../findProjectDirAndVerifyProjectSetupAsync';
 import { getProjectIdAsync } from '../getProjectIdAsync';
@@ -21,6 +22,7 @@ jest.mock('../../../../ora', () => ({
   }),
 }));
 jest.mock('../../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync');
+jest.mock('../../../../project/projectUtils');
 
 describe(getProjectIdAsync, () => {
   let sessionManager: SessionManager;
@@ -71,6 +73,7 @@ describe(getProjectIdAsync, () => {
     );
 
     jest.mocked(findProjectRootAsync).mockResolvedValue('/app');
+    jest.mocked(isExpoInstalled).mockReturnValue(true);
   });
 
   it('gets the project ID from app config if exists', async () => {

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -7,7 +7,10 @@ import { findProjectRootAsync } from './findProjectDirAndVerifyProjectSetupAsync
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import Log, { learnMore } from '../../../log';
 import { ora } from '../../../ora';
-import { createOrModifyExpoConfigAsync, getPrivateExpoConfig } from '../../../project/expoConfig';
+import {
+  createOrModifyExpoConfigAsync,
+  getPrivateExpoConfigAsync,
+} from '../../../project/expoConfig';
 import { fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync } from '../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 import { toAppPrivacy } from '../../../project/projectUtils';
 import SessionManager from '../../../user/SessionManager';
@@ -25,7 +28,7 @@ export async function saveProjectIdToAppConfigAsync(
   options: { env?: Env } = {}
 ): Promise<void> {
   // NOTE(cedric): we disable plugins to avoid writing plugin-generated content to `expo.extra`
-  const exp = getPrivateExpoConfig(projectDir, { skipPlugins: true, ...options });
+  const exp = await getPrivateExpoConfigAsync(projectDir, { skipPlugins: true, ...options });
   const result = await createOrModifyExpoConfigAsync(
     projectDir,
     {

--- a/packages/eas-cli/src/commands/project/__tests__/init.test.ts
+++ b/packages/eas-cli/src/commands/project/__tests__/init.test.ts
@@ -14,6 +14,7 @@ import { AppMutation } from '../../../graphql/mutations/AppMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { createOrModifyExpoConfigAsync } from '../../../project/expoConfig';
 import { findProjectIdByAccountNameAndSlugNullableAsync } from '../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
+import { isExpoInstalled } from '../../../project/projectUtils';
 import { confirmAsync, promptAsync } from '../../../prompts';
 import ProjectInit from '../init';
 
@@ -34,6 +35,7 @@ jest.mock('../../../ora', () => ({
 }));
 jest.mock('../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync');
 jest.mock('../../../commandUtils/context/contextUtils/getProjectIdAsync');
+jest.mock('../../../project/projectUtils');
 
 let originalProcessArgv: string[];
 
@@ -92,6 +94,7 @@ function mockTestProject(options: {
     graphqlClient,
     authenticationInfo: { accessToken: null, sessionSecret: '1234' },
   });
+  jest.mocked(isExpoInstalled).mockReturnValue(true);
 }
 
 const commandOptions = { root: '/test-project' } as any;

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -13,7 +13,7 @@ import { AppMutation } from '../../graphql/mutations/AppMutation';
 import { AppQuery } from '../../graphql/queries/AppQuery';
 import Log, { link } from '../../log';
 import { ora } from '../../ora';
-import { createOrModifyExpoConfigAsync, getPrivateExpoConfig } from '../../project/expoConfig';
+import { createOrModifyExpoConfigAsync, getPrivateExpoConfigAsync } from '../../project/expoConfig';
 import { findProjectIdByAccountNameAndSlugNullableAsync } from '../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 import { toAppPrivacy } from '../../project/projectUtils';
 import { Choice, confirmAsync, promptAsync } from '../../prompts';
@@ -106,7 +106,7 @@ export default class ProjectInit extends EasCommand {
     projectDir: string,
     { force, nonInteractive }: InitializeMethodOptions
   ): Promise<void> {
-    const exp = getPrivateExpoConfig(projectDir);
+    const exp = await getPrivateExpoConfigAsync(projectDir);
     const appForProjectId = await AppQuery.byIdAsync(graphqlClient, projectId);
     const correctOwner = appForProjectId.ownerAccount.name;
     const correctSlug = appForProjectId.slug;
@@ -161,7 +161,7 @@ export default class ProjectInit extends EasCommand {
     projectDir: string,
     { force, nonInteractive }: InitializeMethodOptions
   ): Promise<void> {
-    const exp = getPrivateExpoConfig(projectDir);
+    const exp = await getPrivateExpoConfigAsync(projectDir);
     const existingProjectId = exp.extra?.eas?.projectId;
 
     if (projectId === existingProjectId) {
@@ -218,7 +218,7 @@ export default class ProjectInit extends EasCommand {
     projectDir: string,
     { force, nonInteractive }: InitializeMethodOptions
   ): Promise<string> {
-    const exp = getPrivateExpoConfig(projectDir);
+    const exp = await getPrivateExpoConfigAsync(projectDir);
     const existingProjectId = exp.extra?.eas?.projectId;
 
     if (existingProjectId) {

--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -31,7 +31,7 @@ import {
 import { installDependenciesAsync } from '../../onboarding/installDependencies';
 import { runCommandAsync } from '../../onboarding/runCommand';
 import { RequestedPlatform } from '../../platform';
-import { ExpoConfigOptions, getPrivateExpoConfig } from '../../project/expoConfig';
+import { ExpoConfigOptions, getPrivateExpoConfigAsync } from '../../project/expoConfig';
 import { promptAsync } from '../../prompts';
 import { Actor } from '../../user/User';
 import { easCliVersion } from '../../utils/easCli';
@@ -339,7 +339,7 @@ async function getPrivateExpoConfigWithProjectIdAsync({
   actor: Actor;
   options?: ExpoConfigOptions;
 }): Promise<CredentialsContextProjectInfo> {
-  const expBefore = getPrivateExpoConfig(projectDir, options);
+  const expBefore = await getPrivateExpoConfigAsync(projectDir, options);
   const projectId = await validateOrSetProjectIdAsync({
     exp: expBefore,
     graphqlClient,
@@ -349,7 +349,7 @@ async function getPrivateExpoConfigWithProjectIdAsync({
     },
     cwd: projectDir,
   });
-  const exp = getPrivateExpoConfig(projectDir, options);
+  const exp = await getPrivateExpoConfigAsync(projectDir, options);
   return {
     exp,
     projectId,

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -141,16 +141,7 @@ describe(UpdatePublish.name, () => {
 
     // Add configuration to the project that should not be included in the update
     const { appJson } = mockTestProject({
-      expoConfig: {
-        hooks: {
-          postPublish: [
-            {
-              file: 'custom-hook.js',
-              config: { some: 'config' },
-            },
-          ],
-        },
-      },
+      expoConfig: {},
     });
 
     const { platforms, runtimeVersion } = mockTestExport({ platforms: ['ios'] });

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -140,9 +140,7 @@ describe(UpdatePublish.name, () => {
     const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
 
     // Add configuration to the project that should not be included in the update
-    const { appJson } = mockTestProject({
-      expoConfig: {},
-    });
+    const { appJson } = mockTestProject();
 
     const { platforms, runtimeVersion } = mockTestExport({ platforms: ['ios'] });
 

--- a/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
@@ -146,16 +146,7 @@ describe(UpdateRollBackToEmbedded.name, () => {
 
     // Add configuration to the project that should not be included in the update
     mockTestProject({
-      expoConfig: {
-        hooks: {
-          postPublish: [
-            {
-              file: 'custom-hook.js',
-              config: { some: 'config' },
-            },
-          ],
-        },
-      },
+      expoConfig: {},
     });
 
     const platforms = ['ios'];

--- a/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
@@ -145,9 +145,7 @@ describe(UpdateRollBackToEmbedded.name, () => {
     const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
 
     // Add configuration to the project that should not be included in the update
-    mockTestProject({
-      expoConfig: {},
-    });
+    mockTestProject();
 
     const platforms = ['ios'];
     const runtimeVersion = 'exposdk:47.0.0';

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-context.ts
@@ -21,8 +21,9 @@ export function createCtxMock(mockOverride: Record<string, any> = {}): Credentia
     },
     hasAppleCtx: jest.fn(() => true),
     hasProjectContext: true,
-    exp: testAppJson,
+    getExpoConfigAsync: async () => testAppJson,
     projectDir: '.',
+    getProjectIdAsync: async () => 'test-project-id',
   };
   return merge(defaultMock, mockOverride) as any;
 }

--- a/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
@@ -101,14 +101,14 @@ export async function getAppLookupParamsFromContextAsync(
   ctx: CredentialsContext,
   gradleContext?: GradleBuildContext
 ): Promise<AppLookupParams> {
-  ctx.ensureProjectContext();
-  const projectName = ctx.exp.slug;
-  const projectId = ctx.projectId;
+  const exp = await ctx.getExpoConfigAsync();
+  const projectName = exp.slug;
+  const projectId = await ctx.getProjectIdAsync();
   const account = await getOwnerAccountForProjectIdAsync(ctx.graphqlClient, projectId);
 
   const androidApplicationIdentifier = await getApplicationIdAsync(
     ctx.projectDir,
-    ctx.exp,
+    exp,
     ctx.vcsClient,
     gradleContext
   );

--- a/packages/eas-cli/src/credentials/android/actions/CreateKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/CreateKeystore.ts
@@ -16,7 +16,7 @@ export class CreateKeystore {
       throw new Error(`New keystore cannot be created in non-interactive mode.`);
     }
 
-    const projectId = ctx.projectId;
+    const projectId = await ctx.getProjectIdAsync();
     const keystore = await this.provideOrGenerateAsync(ctx.graphqlClient, ctx.analytics, projectId);
     const keystoreFragment = await ctx.android.createKeystoreAsync(
       ctx.graphqlClient,

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -10,7 +10,7 @@ import { AuthenticationMode } from './ios/appstore/authenticateTypes';
 import { Analytics } from '../analytics/AnalyticsManager';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import Log from '../log';
-import { getPrivateExpoConfig } from '../project/expoConfig';
+import { getPrivateExpoConfigAsync } from '../project/expoConfig';
 import { confirmAsync } from '../prompts';
 import { Actor } from '../user/User';
 import { Client } from '../vcs/vcs';
@@ -67,22 +67,22 @@ export class CredentialsContext {
     return !!this.projectInfo;
   }
 
-  get exp(): ExpoConfig {
-    this.ensureProjectContext();
+  public async getExpoConfigAsync(): Promise<ExpoConfig> {
+    await this.ensureProjectContextAsync();
     return this.projectInfo!.exp;
   }
 
-  get projectId(): string {
-    this.ensureProjectContext();
+  public async getProjectIdAsync(): Promise<string> {
+    await this.ensureProjectContextAsync();
     return this.projectInfo!.projectId;
   }
 
-  public ensureProjectContext(): void {
+  public async ensureProjectContextAsync(): Promise<void> {
     if (this.hasProjectContext) {
       return;
     }
     // trigger getConfig error
-    getPrivateExpoConfig(this.options.projectDir);
+    await getPrivateExpoConfigAsync(this.options.projectDir);
   }
 
   async bestEffortAppStoreAuthenticateAsync(): Promise<void> {

--- a/packages/eas-cli/src/credentials/ios/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/BuildCredentialsUtils.ts
@@ -91,9 +91,9 @@ export async function assignBuildCredentialsAsync(
 }
 
 export async function getAppFromContextAsync(ctx: CredentialsContext): Promise<App> {
-  ctx.ensureProjectContext();
-  const projectName = ctx.exp.slug;
-  const projectId = ctx.projectId;
+  const exp = await ctx.getExpoConfigAsync();
+  const projectName = exp.slug;
+  const projectId = await ctx.getProjectIdAsync();
   const account = await getOwnerAccountForProjectIdAsync(ctx.graphqlClient, projectId);
   return {
     account,

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -94,7 +94,7 @@ export class ManageIos {
     };
 
     const account = ctx.hasProjectContext
-      ? await getAccountForProjectAsync(ctx.projectId)
+      ? await getAccountForProjectAsync(await ctx.getProjectIdAsync())
       : ensureActorHasPrimaryAccount(ctx.user);
 
     let app = null;
@@ -195,18 +195,19 @@ export class ManageIos {
   }> {
     assert(ctx.hasProjectContext, 'createProjectContextAsync: must have project context.');
 
-    const app = { account, projectName: ctx.exp.slug };
+    const exp = await ctx.getExpoConfigAsync();
+    const app = { account, projectName: exp.slug };
     const xcodeBuildContext = await resolveXcodeBuildContextAsync(
       {
         projectDir: ctx.projectDir,
         nonInteractive: ctx.nonInteractive,
-        exp: ctx.exp,
+        exp,
         vcsClient: ctx.vcsClient,
       },
       buildProfile
     );
     const targets = await resolveTargetsAsync({
-      exp: ctx.exp,
+      exp,
       projectDir: ctx.projectDir,
       xcodeBuildContext,
       env: buildProfile.env,

--- a/packages/eas-cli/src/credentials/manager/SetUpIosBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/manager/SetUpIosBuildCredentials.ts
@@ -55,7 +55,7 @@ export class SetUpIosBuildCredentials extends ManageIos {
     };
 
     const account = ctx.hasProjectContext
-      ? await getAccountForProjectAsync(ctx.projectId)
+      ? await getAccountForProjectAsync(await ctx.getProjectIdAsync())
       : ensureActorHasPrimaryAccount(ctx.user);
 
     let app = null;

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -44,6 +44,8 @@ export async function createOrModifyExpoConfigAsync(
   }
 }
 
+let wasExpoConfigWarnPrinted = false;
+
 function getExpoConfigInternal(
   projectDir: string,
   opts: ExpoConfigOptionsInternal = {}
@@ -59,9 +61,12 @@ function getExpoConfigInternal(
     try {
       const expoConfig = require(projectExpoConfigPath);
       getConfig = expoConfig.getConfig;
-    } catch (error: any) {
-      Log.warn(`Failed to load getConfig function from ${projectExpoConfigPath}: ${error.message}`);
-      Log.warn('Falling back to the version of @expo/config shipped with the EAS CLI.');
+    } catch {
+      if (!wasExpoConfigWarnPrinted) {
+        Log.warn(`Failed to load getConfig function from ${projectExpoConfigPath}`);
+        Log.warn('Falling back to the version of @expo/config shipped with the EAS CLI.');
+        wasExpoConfigWarnPrinted = true;
+      }
       getConfig = _getConfig;
     }
     const { exp } = getConfig(projectDir, {

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -54,14 +54,13 @@ function getExpoConfigInternal(
       ...process.env,
       ...opts.env,
     };
+    const projectExpoConfigPath = path.join(projectDir, 'node_modules', '@expo', 'config');
     let getConfig: typeof _getConfig;
     try {
-      const expoConfig = require(`${projectDir}/node_modules/@expo/config`);
+      const expoConfig = require(projectExpoConfigPath);
       getConfig = expoConfig.getConfig;
     } catch (error: any) {
-      Log.warn(
-        `Failed to load getConfig function from ${projectDir}/node_modules/@expo/config: ${error.message}`
-      );
+      Log.warn(`Failed to load getConfig function from ${projectExpoConfigPath}: ${error.message}`);
       Log.warn('Falling back to the version of @expo/config shipped with the EAS CLI.');
       getConfig = _getConfig;
     }

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -62,6 +62,7 @@ function getExpoConfigInternal(
       Log.warn(
         `Failed to load getConfig function from ${projectDir}/node_modules/@expo/config: ${error.message}`
       );
+      Log.warn('Falling back to the version of @expo/config shipped with the EAS CLI.');
       getConfig = _getConfig;
     }
     const { exp } = getConfig(projectDir, {

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -1,8 +1,15 @@
-import { ExpoConfig, getConfig, getConfigFilePaths, modifyConfigAsync } from '@expo/config';
+import {
+  ExpoConfig,
+  getConfig as _getConfig,
+  getConfigFilePaths,
+  modifyConfigAsync,
+} from '@expo/config';
 import { Env } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 import Joi from 'joi';
 import path from 'path';
+
+import Log from '../log';
 
 export type PublicExpoConfig = Omit<
   ExpoConfig,
@@ -47,6 +54,16 @@ function getExpoConfigInternal(
       ...process.env,
       ...opts.env,
     };
+    let getConfig: typeof _getConfig;
+    try {
+      const expoConfig = require(`${projectDir}/node_modules/@expo/config`);
+      getConfig = expoConfig.getConfig;
+    } catch (error: any) {
+      Log.warn(
+        `Failed to load getConfig function from ${projectDir}/node_modules/@expo/config: ${error.message}`
+      );
+      getConfig = _getConfig;
+    }
     const { exp } = getConfig(projectDir, {
       skipSDKVersionRequirement: true,
       ...(opts.isPublicConfig ? { isPublicConfig: true } : {}),

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -77,12 +77,14 @@ async function getExpoConfigInternalAsync(
         exp = getConfig(projectDir, {
           skipSDKVersionRequirement: true,
           ...(opts.isPublicConfig ? { isPublicConfig: true } : {}),
+          ...(opts.skipPlugins ? { skipPlugins: true } : {}),
         }).exp;
       }
     } else {
       exp = getConfig(projectDir, {
         skipSDKVersionRequirement: true,
         ...(opts.isPublicConfig ? { isPublicConfig: true } : {}),
+        ...(opts.skipPlugins ? { skipPlugins: true } : {}),
       }).exp;
     }
 

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -63,6 +63,10 @@ async function getExpoConfigInternalAsync(
 
           {
             cwd: projectDir,
+            env: {
+              ...process.env,
+              ...opts.env,
+            },
           }
         );
         exp = JSON.parse(stdout);

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -66,6 +66,7 @@ async function getExpoConfigInternalAsync(
             env: {
               ...process.env,
               ...opts.env,
+              EXPO_NO_DOTENV: '1',
             },
           }
         );

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -74,9 +74,9 @@ async function getExpoConfigInternalAsync(
       } catch (err: any) {
         if (!wasExpoConfigWarnPrinted) {
           Log.warn(
-            `Failed to read the app config from the project using npx expo config command: ${err.message}.`
+            `Failed to read the app config from the project using "npx expo config" command: ${err.message}.`
           );
-          Log.warn('Falling back to the version of @expo/config shipped with the EAS CLI.');
+          Log.warn('Falling back to the version of "@expo/config" shipped with the EAS CLI.');
           wasExpoConfigWarnPrinted = true;
         }
         exp = getConfig(projectDir, {

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -1,7 +1,9 @@
-import { IOSConfig, compileModsAsync } from '@expo/config-plugins';
+import { IOSConfig, compileModsAsync as _compileModsAsync } from '@expo/config-plugins';
 import { JSONObject } from '@expo/json-file';
-import { getPrebuildConfigAsync } from '@expo/prebuild-config';
+import { getPrebuildConfigAsync as _getPrebuildConfigAsync } from '@expo/prebuild-config';
+import path from 'path';
 
+import Log from '../../log';
 import { readPlistAsync } from '../../utils/plist';
 import { Client } from '../../vcs/vcs';
 import { hasIgnoredIosProjectAsync } from '../workflow';
@@ -22,8 +24,42 @@ export async function getManagedApplicationTargetEntitlementsAsync(
       ...process.env,
       ...env,
     };
+    const projectExpoPrebuildConfigPath = path.join(
+      projectDir,
+      'node_modules',
+      '@expo',
+      'prebuild-config'
+    );
+    let getPrebuildConfigAsync: typeof _getPrebuildConfigAsync;
+    try {
+      const expoPrebuildConfig = require(projectExpoPrebuildConfigPath);
+      getPrebuildConfigAsync = expoPrebuildConfig.getPrebuildConfigAsync;
+    } catch (error: any) {
+      Log.warn(
+        `Failed to load getPrebuildConfigAsync function from ${projectExpoPrebuildConfigPath}: ${error.message}`
+      );
+      Log.warn('Falling back to the version of @expo/prebuild-config shipped with the EAS CLI.');
+      getPrebuildConfigAsync = _getPrebuildConfigAsync;
+    }
     const { exp } = await getPrebuildConfigAsync(projectDir, { platforms: ['ios'] });
 
+    const projectExpoConfigPluginsPath = path.join(
+      projectDir,
+      'node_modules',
+      '@expo',
+      'config-plugins'
+    );
+    let compileModsAsync: typeof _compileModsAsync;
+    try {
+      const expoConfigPlugins = require(projectExpoConfigPluginsPath);
+      compileModsAsync = expoConfigPlugins.compileModsAsync;
+    } catch (error: any) {
+      Log.warn(
+        `Failed to load compileModsAsync function from ${projectExpoConfigPluginsPath}: ${error.message}`
+      );
+      Log.warn('Falling back to the version of @expo/confi-plugins shipped with the EAS CLI.');
+      compileModsAsync = _compileModsAsync;
+    }
     const expWithMods = await compileModsAsync(exp, {
       projectRoot: projectDir,
       platforms: ['ios'],

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -36,6 +36,10 @@ export async function getManagedApplicationTargetEntitlementsAsync(
 
         {
           cwd: projectDir,
+          env: {
+            ...process.env,
+            ...env,
+          },
         }
       );
       expWithMods = JSON.parse(stdout);

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -47,9 +47,9 @@ export async function getManagedApplicationTargetEntitlementsAsync(
     } catch (err: any) {
       if (!wasExpoConfigPluginsWarnPrinted) {
         Log.warn(
-          `Failed to read the app config from the project using npx expo config command: ${err.message}.`
+          `Failed to read the app config from the project using "npx expo config" command: ${err.message}.`
         );
-        Log.warn('Falling back to the version of @expo/config shipped with the EAS CLI.');
+        Log.warn('Falling back to the version of "@expo/config" shipped with the EAS CLI.');
         wasExpoConfigPluginsWarnPrinted = true;
       }
       const { exp } = await getPrebuildConfigAsync(projectDir, { platforms: ['ios'] });

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -39,6 +39,7 @@ export async function getManagedApplicationTargetEntitlementsAsync(
           env: {
             ...process.env,
             ...env,
+            EXPO_NO_DOTENV: '1',
           },
         }
       );

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -72,6 +72,11 @@ export function isExpoNotificationsInstalled(projectDir: string): boolean {
   return !!(packageJson.dependencies && 'expo-notifications' in packageJson.dependencies);
 }
 
+export function isExpoInstalled(projectDir: string): boolean {
+  const packageJson = getPackageJson(projectDir);
+  return !!(packageJson.dependencies && 'expo' in packageJson.dependencies);
+}
+
 export function isExpoUpdatesInstalledAsDevDependency(projectDir: string): boolean {
   const packageJson = getPackageJson(projectDir);
   return !!(packageJson.devDependencies && 'expo-updates' in packageJson.devDependencies);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1724970663050089?thread_ts=1724924614.773089&cid=C02123T524U
https://exponent-internal.slack.com/archives/C5ERY0TAR/p1725002816077089

Generally `@expo/config`, `@expo/prebuild-config`, and `@expo/config-plugins` are per SDK concept. Currently, in EAS CLI, we rely on one version of the `@expo/...` package to work well globally for all SDKs. It seems to sometimes bite us like in the case of https://exponent-internal.slack.com/archives/C02123T524U/p1724909908574979, because SDK 51 config wasn't compatible with SDK 50.

It's better to switch to using config-related functions shipped with `@expo/config`, `@expo/prebuild-config`, and `@expo/config-plugins`.  I believe we can assume that `getConfig`, `getPrebuildConfig`, and `compileModsAsync` shipped with these packages have stable API https://exponent-internal.slack.com/archives/C5ERY0TAR/p1725293002128849?thread_ts=1725002816.077089&cid=C5ERY0TAR.

# How

Use `getConfig`, `getPrebuildConfig`, and `compileModsAsync` from `@expo/config`, `@expo/prebuild-config`, and `@expo/config-plugins` shipped with Expo SDK installed in the user's project. If not available, fallback to versions installed per SDK. If we can assume that these guarantee stable API we can use types of these functions from packages installed for EAS CLI as well.

# Test Plan

Run builds for repro case of https://exponent-internal.slack.com/archives/C02123T524U/p1724909908574979 with SDK 51 config packages installed for EAS CLI (that previously broke it), see that it works and capabilities are correctly synced.

Initiate a new bare RN project using community CLI, and check that it works as well using fallback config loading. 
