### PR TITLE
[eas-cli] Upload fingeprint source as part of eas update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Upload fingeprint source as part of eas update command. ([#2533](https://github.com/expo/eas-cli/pull/2533) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores
@@ -21,6 +23,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add support for syncing Journaling Suggestions, Managed App Installation UI, and 5G Network Slicing capabilities. ([#2525](https://github.com/expo/eas-cli/pull/2525) by [@szdziedzic](https://github.com/szdziedzic))
+
 
 ## [11.0.3](https://github.com/expo/eas-cli/releases/tag/v11.0.3) - 2024-08-31
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -10445,6 +10445,39 @@
             "deprecationReason": null
           },
           {
+            "name": "workerDeploymentRequest",
+            "description": null,
+            "args": [
+              {
+                "name": "requestId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestEdge",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "workerDeployments",
             "description": null,
             "args": [
@@ -10503,6 +10536,51 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "WorkerDeploymentsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workerDeploymentsCrash",
+            "description": null,
+            "args": [
+              {
+                "name": "crashId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sampleFor",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "CrashSampleFor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentCrashEdge",
                 "ofType": null
               }
             },
@@ -21753,6 +21831,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "CrashSampleFor",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "NEWEST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OLDEST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "CrashesTimespan",
         "description": null,
@@ -22264,6 +22365,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "EnvironmentVariableEnvironment",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -22820,6 +22933,81 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "CumulativeMetricsOverTimeData",
+        "description": null,
+        "fields": [
+          {
+            "name": "data",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "LineChartData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricsAtLastTimestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "LineDatapoint",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mostPopularUpdates",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Update",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "CustomBuildConfigInput",
         "description": null,
@@ -22898,6 +23086,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "isConfigured",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -22926,65 +23130,6 @@
             "deprecationReason": null
           }
         ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "CustomDomainMetadata",
-        "description": null,
-        "fields": [
-          {
-            "name": "ownershipVerification",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "CustomDomainDNSRecord",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "status",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "CustomDomainStatus",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "verificationErrors",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -23126,6 +23271,97 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "CustomDomainSetup",
+        "description": null,
+        "fields": [
+          {
+            "name": "sslErrors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sslStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "CustomDomainStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CustomDomainStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "verificationErrors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "verificationStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "CustomDomainStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "CustomDomainStatus",
         "description": null,
@@ -23140,25 +23376,7 @@
             "deprecationReason": null
           },
           {
-            "name": "ACTIVE_REDEPLOYING",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "BLOCKED",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "DELETED",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "MOVED",
+            "name": "ERROR",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -23170,37 +23388,7 @@
             "deprecationReason": null
           },
           {
-            "name": "PENDING_BLOCKED",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PENDING_DELETION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PENDING_MIGRATION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PENDING_PROVISIONED",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PROVISIONED",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "UNKNOWN",
+            "name": "TIMED_OUT",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -24312,6 +24500,39 @@
         "description": null,
         "fields": [
           {
+            "name": "cumulativeMetricsOverTime",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CumulativeMetricsOverTimeData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "embeddedUpdateTotalUniqueUsers",
             "description": null,
             "args": [
@@ -24395,47 +24616,6 @@
           },
           {
             "name": "mostPopularUpdates",
-            "description": null,
-            "args": [
-              {
-                "name": "timespan",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "InsightsTimespan",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Update",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "mostPopularUpdatesNew",
             "description": null,
             "args": [
               {
@@ -27940,6 +28120,18 @@
             "deprecationReason": null
           },
           {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "EnvironmentVariableEnvironment",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "gitRef",
             "description": null,
             "type": {
@@ -28065,6 +28257,18 @@
                 "name": "DateTime",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "EnvironmentVariableEnvironment",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -33528,6 +33732,65 @@
       },
       {
         "kind": "OBJECT",
+        "name": "LineDatapoint",
+        "description": null,
+        "fields": [
+          {
+            "name": "data",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "LineDataset",
         "description": null,
         "fields": [
@@ -36423,6 +36686,18 @@
             "deprecationReason": null
           },
           {
+            "name": "runtimeFingerprintSource",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "FingerprintSourceInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "runtimeVersion",
             "description": null,
             "type": {
@@ -36578,6 +36853,12 @@
         "enumValues": [
           {
             "name": "C3D",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "N2",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -38709,6 +38990,18 @@
                 "name": "App",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fingerprintDebugInfoUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -43835,6 +44128,18 @@
             "deprecationReason": null
           },
           {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "EnvironmentVariableEnvironment",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "executionBehavior",
             "description": null,
             "type": {
@@ -46725,6 +47030,160 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "UserAgentBrowser",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ANDROID_MOBILE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CHROME",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CHROME_IOS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EDGE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FACEBOOK_MOBILE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FIREFOX",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FIREFOX_IOS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INTERNET_EXPLORER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "KONQUEROR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MOZILLA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OPERA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SAFARI",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SAFARI_MOBILE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SAMSUNG_INTERNET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UC_BROWSER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "UserAgentOS",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ANDROID",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CHROME_OS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IOS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IPAD_OS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LINUX",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MAC_OS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "WINDOWS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "UserAppPinMutation",
         "description": null,
@@ -48663,6 +49122,18 @@
             "deprecationReason": null
           },
           {
+            "name": "dcvDelegationRecord",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CustomDomainDNSRecord",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "devDomainName",
             "description": null,
             "args": [],
@@ -48727,12 +49198,12 @@
             "deprecationReason": null
           },
           {
-            "name": "metadata",
+            "name": "setup",
             "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "CustomDomainMetadata",
+              "name": "CustomDomainSetup",
               "ofType": null
             },
             "isDeprecated": false,
@@ -48750,6 +49221,18 @@
                 "name": "DateTime",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "verificationRecord",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CustomDomainDNSRecord",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -49220,9 +49703,92 @@
       },
       {
         "kind": "OBJECT",
+        "name": "WorkerDeploymentCrashEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "logs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentLogNode",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "request",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestNode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sample",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentCrashSample",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "WorkerDeploymentCrashNode",
         "description": null,
         "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "minOccurrences",
             "description": null,
@@ -49256,25 +49822,33 @@
             "deprecationReason": null
           },
           {
-            "name": "sample",
+            "name": "oldestOccurredAt",
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "WorkerDeploymentCrashSample",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "sampleMessage",
+            "name": "sample",
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentCrashSample",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -49290,6 +49864,18 @@
         "name": "WorkerDeploymentCrashSample",
         "description": null,
         "fields": [
+          {
+            "name": "firstStackLine",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "message",
             "description": null,
@@ -49323,7 +49909,7 @@
             "deprecationReason": null
           },
           {
-            "name": "requestTimestamp",
+            "name": "scriptName",
             "description": null,
             "args": [],
             "type": {
@@ -49331,7 +49917,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "DateTime",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -49353,6 +49939,22 @@
                   "name": "String",
                   "ofType": null
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -49659,6 +50261,22 @@
             "deprecationReason": null
           },
           {
+            "name": "interval",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "summary",
             "description": null,
             "args": [],
@@ -49690,13 +50308,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -49742,13 +50356,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -49848,6 +50458,98 @@
       },
       {
         "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "crash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentCrashSample",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "logs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentLogNode",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestNode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WorkerDeploymentRequestKind",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASSET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CRASH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REJECTED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "WorkerDeploymentRequestLocation",
         "description": null,
         "fields": [
@@ -49899,6 +50601,90 @@
         "description": null,
         "fields": [
           {
+            "name": "browser",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "UserAgentBrowser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "browserVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasCustomDomainOrigin",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isVerifiedBot",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "WorkerDeploymentRequestKind",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "location",
             "description": null,
             "args": [],
@@ -49927,7 +50713,35 @@
             "deprecationReason": null
           },
           {
+            "name": "os",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "UserAgentOS",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "pathname",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scriptName",
             "description": null,
             "args": [],
             "type": {
@@ -49980,6 +50794,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "wallTime",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -50045,6 +50875,30 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "include",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "WorkerDeploymentRequestsInclude",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "includeBotRequests",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "methods",
             "description": null,
@@ -50120,6 +50974,29 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WorkerDeploymentRequestsInclude",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASSETS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ROUTES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/src/build/graphql.ts
+++ b/packages/eas-cli/src/build/graphql.ts
@@ -3,6 +3,7 @@ import {
   ArchiveSourceType,
   BuildMode,
   BuildTrigger,
+  FingerprintSourceType,
   Metadata,
   Workflow,
 } from '@expo/eas-build-job';
@@ -15,8 +16,10 @@ import {
   BuildMetadataInput,
   BuildWorkflow,
   DistributionType,
+  FingerprintSourceInput,
   BuildMode as GraphQLBuildMode,
   BuildTrigger as GraphQLBuildTrigger,
+  FingerprintSourceType as GraphQLFingeprintSourceType,
   ProjectArchiveSourceInput,
   ProjectArchiveSourceType,
   WorkerLoggerLevel,
@@ -42,7 +45,8 @@ export function transformProjectArchive(archiveSource: ArchiveSource): ProjectAr
 export function transformMetadata(metadata: Metadata): BuildMetadataInput {
   return {
     ...metadata,
-    fingerprintSource: metadata.fingerprintSource as BuildMetadataInput['fingerprintSource'],
+    fingerprintSource:
+      metadata.fingerprintSource && transformFingerprintSource(metadata.fingerprintSource),
     credentialsSource:
       metadata.credentialsSource && transformCredentialsSource(metadata.credentialsSource),
     distribution: metadata.distribution && transformDistribution(metadata.distribution),
@@ -50,6 +54,20 @@ export function transformMetadata(metadata: Metadata): BuildMetadataInput {
     iosEnterpriseProvisioning:
       metadata.iosEnterpriseProvisioning &&
       transformIosEnterpriseProvisioning(metadata.iosEnterpriseProvisioning),
+  };
+}
+
+export function transformFingerprintSource(
+  fingerprintSource: NonNullable<Metadata['fingerprintSource']>
+): FingerprintSourceInput | null {
+  if (fingerprintSource.type !== FingerprintSourceType.GCS) {
+    return null;
+  }
+
+  return {
+    type: GraphQLFingeprintSourceType.Gcs,
+    bucketKey: fingerprintSource.bucketKey,
+    isDebugFingerprint: fingerprintSource.isDebugFingerprint,
   };
 }
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -10,24 +10,20 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
-  [_ in K]?: never;
-};
-export type Incremental<T> =
-  | T
-  | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string };
-  String: { input: string; output: string };
-  Boolean: { input: boolean; output: boolean };
-  Int: { input: number; output: number };
-  Float: { input: number; output: number };
-  DateTime: { input: any; output: any };
-  DevDomainName: { input: any; output: any };
-  JSON: { input: any; output: any };
-  JSONObject: { input: any; output: any };
-  WorkerDeploymentIdentifier: { input: any; output: any };
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DateTime: { input: any; output: any; }
+  DevDomainName: { input: any; output: any; }
+  JSON: { input: any; output: any; }
+  JSONObject: { input: any; output: any; }
+  WorkerDeploymentIdentifier: { input: any; output: any; }
 };
 
 export type AcceptUserInvitationResult = {
@@ -58,13 +54,16 @@ export type AccessTokenMutation = {
   setAccessTokenRevoked: AccessToken;
 };
 
+
 export type AccessTokenMutationCreateAccessTokenArgs = {
   createAccessTokenData: CreateAccessTokenInput;
 };
 
+
 export type AccessTokenMutationDeleteAccessTokenArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type AccessTokenMutationSetAccessTokenRevokedArgs = {
   id: Scalars['ID']['input'];
@@ -177,6 +176,7 @@ export type Account = {
   willAutoRenewBuilds?: Maybe<Scalars['Boolean']['output']>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -186,6 +186,7 @@ export type AccountActivityTimelineProjectActivitiesArgs = {
   filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
   limit: Scalars['Int']['input'];
 };
+
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -198,6 +199,7 @@ export type AccountAppStoreConnectApiKeysPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -205,6 +207,7 @@ export type AccountAppStoreConnectApiKeysPaginatedArgs = {
 export type AccountAppleAppIdentifiersArgs = {
   bundleIdentifier?: InputMaybe<Scalars['String']['input']>;
 };
+
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -215,6 +218,7 @@ export type AccountAppleDevicesArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
+
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -228,6 +232,7 @@ export type AccountAppleDevicesPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -239,6 +244,7 @@ export type AccountAppleDistributionCertificatesPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -246,6 +252,7 @@ export type AccountAppleDistributionCertificatesPaginatedArgs = {
 export type AccountAppleProvisioningProfilesArgs = {
   appleAppIdentifierId?: InputMaybe<Scalars['ID']['input']>;
 };
+
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -258,6 +265,7 @@ export type AccountAppleProvisioningProfilesPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -269,6 +277,7 @@ export type AccountApplePushKeysPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -278,6 +287,7 @@ export type AccountAppleTeamsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
+
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -291,6 +301,7 @@ export type AccountAppleTeamsPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -300,6 +311,7 @@ export type AccountAppsArgs = {
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
 };
+
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -313,6 +325,7 @@ export type AccountAppsPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -325,6 +338,7 @@ export type AccountAuditLogsPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -332,6 +346,7 @@ export type AccountAuditLogsPaginatedArgs = {
 export type AccountBillingPeriodArgs = {
   date: Scalars['DateTime']['input'];
 };
+
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -344,6 +359,7 @@ export type AccountBuildsArgs = {
   status?: InputMaybe<BuildStatus>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -351,6 +367,7 @@ export type AccountBuildsArgs = {
 export type AccountEnvironmentSecretsArgs = {
   filterNames?: InputMaybe<Array<Scalars['String']['input']>>;
 };
+
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -360,6 +377,7 @@ export type AccountEnvironmentVariablesArgs = {
   filterNames?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -367,6 +385,7 @@ export type AccountEnvironmentVariablesArgs = {
 export type AccountEnvironmentVariablesIncludingSensitiveArgs = {
   filterNames?: InputMaybe<Array<Scalars['String']['input']>>;
 };
+
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -379,6 +398,7 @@ export type AccountGoogleServiceAccountKeysPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -387,6 +407,7 @@ export type AccountSnacksArgs = {
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
 };
+
 
 /**
  * An account is a container owning projects, credentials, billing and other organization
@@ -495,7 +516,7 @@ export enum AccountAppsSortByField {
    * Name prefers the display name but falls back to full_name with @account/
    * part stripped.
    */
-  Name = 'NAME',
+  Name = 'NAME'
 }
 
 export type AccountDataInput = {
@@ -536,18 +557,22 @@ export type AccountMutation = {
   setPushSecurityEnabled: Account;
 };
 
+
 export type AccountMutationCancelAllSubscriptionsImmediatelyArgs = {
   accountID: Scalars['ID']['input'];
 };
+
 
 export type AccountMutationCancelScheduledSubscriptionChangeArgs = {
   accountID: Scalars['ID']['input'];
 };
 
+
 export type AccountMutationChangeAdditionalConcurrenciesCountArgs = {
   accountID: Scalars['ID']['input'];
   newAdditionalConcurrenciesCount: Scalars['Int']['input'];
 };
+
 
 export type AccountMutationChangePlanArgs = {
   accountID: Scalars['ID']['input'];
@@ -555,16 +580,19 @@ export type AccountMutationChangePlanArgs = {
   newPlanIdentifier: Scalars['String']['input'];
 };
 
+
 export type AccountMutationGrantActorPermissionsArgs = {
   accountID: Scalars['ID']['input'];
   actorID: Scalars['ID']['input'];
   permissions?: InputMaybe<Array<InputMaybe<Permission>>>;
 };
 
+
 export type AccountMutationRenameArgs = {
   accountID: Scalars['ID']['input'];
   newName: Scalars['String']['input'];
 };
+
 
 export type AccountMutationRequestRefundArgs = {
   accountID: Scalars['ID']['input'];
@@ -573,11 +601,13 @@ export type AccountMutationRequestRefundArgs = {
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 
+
 export type AccountMutationRevokeActorPermissionsArgs = {
   accountID: Scalars['ID']['input'];
   actorID: Scalars['ID']['input'];
   permissions?: InputMaybe<Array<InputMaybe<Permission>>>;
 };
+
 
 export type AccountMutationSetPushSecurityEnabledArgs = {
   accountID: Scalars['ID']['input'];
@@ -599,9 +629,11 @@ export type AccountQuery = {
   byName: Account;
 };
 
+
 export type AccountQueryByIdArgs = {
   accountId: Scalars['String']['input'];
 };
+
 
 export type AccountQueryByNameArgs = {
   accountName: Scalars['String']['input'];
@@ -638,14 +670,17 @@ export type AccountSsoConfigurationMutation = {
   updateAccountSSOConfiguration: AccountSsoConfiguration;
 };
 
+
 export type AccountSsoConfigurationMutationCreateAccountSsoConfigurationArgs = {
   accountId: Scalars['ID']['input'];
   accountSSOConfigurationData: AccountSsoConfigurationData;
 };
 
+
 export type AccountSsoConfigurationMutationDeleteAccountSsoConfigurationArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type AccountSsoConfigurationMutationUpdateAccountSsoConfigurationArgs = {
   accountSSOConfigurationData: AccountSsoConfigurationData;
@@ -667,6 +702,7 @@ export type AccountSsoConfigurationPublicDataQuery = {
   /** Get AccountSSOConfiguration public data by account name */
   publicDataByAccountName: AccountSsoConfigurationPublicData;
 };
+
 
 export type AccountSsoConfigurationPublicDataQueryPublicDataByAccountNameArgs = {
   accountName: Scalars['String']['input'];
@@ -701,10 +737,12 @@ export type AccountUsageMetrics = {
   metricsForServiceMetric: Array<AccountUsageMetric>;
 };
 
+
 export type AccountUsageMetricsByBillingPeriodArgs = {
   date: Scalars['DateTime']['input'];
   service?: InputMaybe<EasService>;
 };
+
 
 export type AccountUsageMetricsMetricsForServiceMetricArgs = {
   filterParams?: InputMaybe<Scalars['JSONObject']['input']>;
@@ -722,7 +760,7 @@ export type ActivityTimelineProjectActivity = {
 export enum ActivityTimelineProjectActivityType {
   Build = 'BUILD',
   Submission = 'SUBMISSION',
-  Update = 'UPDATE',
+  Update = 'UPDATE'
 }
 
 /** A regular user, SSO user, or robot that can authenticate with Expo services and be a member of accounts. */
@@ -750,6 +788,7 @@ export type Actor = {
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
 };
 
+
 /** A regular user, SSO user, or robot that can authenticate with Expo services and be a member of accounts. */
 export type ActorFeatureGatesArgs = {
   filter?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -770,6 +809,7 @@ export type ActorExperimentMutation = {
   createOrUpdateActorExperiment: ActorExperiment;
 };
 
+
 export type ActorExperimentMutationCreateOrUpdateActorExperimentArgs = {
   enabled: Scalars['Boolean']['input'];
   experiment: Experiment;
@@ -783,6 +823,7 @@ export type ActorQuery = {
    */
   byId: Actor;
 };
+
 
 export type ActorQueryByIdArgs = {
   id: Scalars['ID']['input'];
@@ -853,24 +894,29 @@ export type AndroidAppBuildCredentialsMutation = {
   setName: AndroidAppBuildCredentials;
 };
 
+
 export type AndroidAppBuildCredentialsMutationCreateAndroidAppBuildCredentialsArgs = {
   androidAppBuildCredentialsInput: AndroidAppBuildCredentialsInput;
   androidAppCredentialsId: Scalars['ID']['input'];
 };
 
+
 export type AndroidAppBuildCredentialsMutationDeleteAndroidAppBuildCredentialsArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type AndroidAppBuildCredentialsMutationSetDefaultArgs = {
   id: Scalars['ID']['input'];
   isDefault: Scalars['Boolean']['input'];
 };
 
+
 export type AndroidAppBuildCredentialsMutationSetKeystoreArgs = {
   id: Scalars['ID']['input'];
   keystoreId: Scalars['ID']['input'];
 };
+
 
 export type AndroidAppBuildCredentialsMutationSetNameArgs = {
   id: Scalars['ID']['input'];
@@ -921,11 +967,13 @@ export type AndroidAppCredentialsMutation = {
   setGoogleServiceAccountKeyForSubmissions: AndroidAppCredentials;
 };
 
+
 export type AndroidAppCredentialsMutationCreateAndroidAppCredentialsArgs = {
   androidAppCredentialsInput: AndroidAppCredentialsInput;
   appId: Scalars['ID']['input'];
   applicationIdentifier: Scalars['String']['input'];
 };
+
 
 export type AndroidAppCredentialsMutationCreateFcmV1CredentialArgs = {
   accountId: Scalars['ID']['input'];
@@ -933,19 +981,23 @@ export type AndroidAppCredentialsMutationCreateFcmV1CredentialArgs = {
   credential: Scalars['String']['input'];
 };
 
+
 export type AndroidAppCredentialsMutationDeleteAndroidAppCredentialsArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type AndroidAppCredentialsMutationSetFcmArgs = {
   fcmId: Scalars['ID']['input'];
   id: Scalars['ID']['input'];
 };
 
+
 export type AndroidAppCredentialsMutationSetGoogleServiceAccountKeyForFcmV1Args = {
   googleServiceAccountKeyId: Scalars['ID']['input'];
   id: Scalars['ID']['input'];
 };
+
 
 export type AndroidAppCredentialsMutationSetGoogleServiceAccountKeyForSubmissionsArgs = {
   googleServiceAccountKeyId: Scalars['ID']['input'];
@@ -956,7 +1008,7 @@ export enum AndroidBuildType {
   Apk = 'APK',
   AppBundle = 'APP_BUNDLE',
   /** @deprecated Use developmentClient option instead. */
-  DevelopmentClient = 'DEVELOPMENT_CLIENT',
+  DevelopmentClient = 'DEVELOPMENT_CLIENT'
 }
 
 export type AndroidBuilderEnvironmentInput = {
@@ -998,10 +1050,12 @@ export type AndroidFcmMutation = {
   deleteAndroidFcm: DeleteAndroidFcmResult;
 };
 
+
 export type AndroidFcmMutationCreateAndroidFcmArgs = {
   accountId: Scalars['ID']['input'];
   androidFcmInput: AndroidFcmInput;
 };
+
 
 export type AndroidFcmMutationDeleteAndroidFcmArgs = {
   id: Scalars['ID']['input'];
@@ -1009,7 +1063,7 @@ export type AndroidFcmMutationDeleteAndroidFcmArgs = {
 
 export enum AndroidFcmVersion {
   Legacy = 'LEGACY',
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type AndroidJobBuildCredentialsInput = {
@@ -1111,10 +1165,12 @@ export type AndroidKeystoreMutation = {
   deleteAndroidKeystore: DeleteAndroidKeystoreResult;
 };
 
+
 export type AndroidKeystoreMutationCreateAndroidKeystoreArgs = {
   accountId: Scalars['ID']['input'];
   androidKeystoreInput: AndroidKeystoreInput;
 };
+
 
 export type AndroidKeystoreMutationDeleteAndroidKeystoreArgs = {
   id: Scalars['ID']['input'];
@@ -1123,7 +1179,7 @@ export type AndroidKeystoreMutationDeleteAndroidKeystoreArgs = {
 export enum AndroidKeystoreType {
   Jks = 'JKS',
   Pkcs12 = 'PKCS12',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 export type AndroidSubmissionConfig = {
@@ -1309,11 +1365,14 @@ export type App = Project & {
   workerDeployment?: Maybe<WorkerDeployment>;
   workerDeploymentAlias?: Maybe<WorkerDeploymentAlias>;
   workerDeploymentAliases: WorkerDeploymentAliasesConnection;
+  workerDeploymentRequest: WorkerDeploymentRequestEdge;
   workerDeployments: WorkerDeploymentsConnection;
+  workerDeploymentsCrash: WorkerDeploymentCrashEdge;
   workerDeploymentsCrashes?: Maybe<WorkerDeploymentCrashes>;
   workerDeploymentsMetrics?: Maybe<WorkerDeploymentMetrics>;
   workerDeploymentsRequests?: Maybe<WorkerDeploymentRequests>;
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppActivityTimelineProjectActivitiesArgs = {
@@ -1325,10 +1384,12 @@ export type AppActivityTimelineProjectActivitiesArgs = {
   limit: Scalars['Int']['input'];
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppAndroidAppCredentialsArgs = {
   filter?: InputMaybe<AndroidAppCredentialsFilter>;
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppBranchesPaginatedArgs = {
@@ -1339,6 +1400,7 @@ export type AppBranchesPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppBuildsArgs = {
   filter?: InputMaybe<BuildFilter>;
@@ -1347,6 +1409,7 @@ export type AppBuildsArgs = {
   platform?: InputMaybe<AppPlatform>;
   status?: InputMaybe<BuildStatus>;
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppBuildsPaginatedArgs = {
@@ -1357,6 +1420,7 @@ export type AppBuildsPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppChannelsPaginatedArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1366,11 +1430,13 @@ export type AppChannelsPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppDeploymentArgs = {
   channel: Scalars['String']['input'];
   runtimeVersion: Scalars['String']['input'];
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppDeploymentsArgs = {
@@ -1381,10 +1447,12 @@ export type AppDeploymentsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppEnvironmentSecretsArgs = {
   filterNames?: InputMaybe<Array<Scalars['String']['input']>>;
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppEnvironmentVariablesArgs = {
@@ -1392,16 +1460,19 @@ export type AppEnvironmentVariablesArgs = {
   filterNames?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppEnvironmentVariablesIncludingSensitiveArgs = {
   environment?: InputMaybe<EnvironmentVariableEnvironment>;
   filterNames?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppIosAppCredentialsArgs = {
   filter?: InputMaybe<IosAppCredentialsFilter>;
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppLatestAppVersionByPlatformAndApplicationIdentifierArgs = {
@@ -1409,17 +1480,20 @@ export type AppLatestAppVersionByPlatformAndApplicationIdentifierArgs = {
   platform: AppPlatform;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppLatestReleaseForReleaseChannelArgs = {
   platform: AppPlatform;
   releaseChannel: Scalars['String']['input'];
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppLikedByArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppRuntimesArgs = {
@@ -1429,12 +1503,14 @@ export type AppRuntimesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppSubmissionsArgs = {
   filter: SubmissionFilter;
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppSubmissionsPaginatedArgs = {
@@ -1443,6 +1519,7 @@ export type AppSubmissionsPaginatedArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppTimelineActivityArgs = {
@@ -1453,10 +1530,12 @@ export type AppTimelineActivityArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateBranchByNameArgs = {
   name: Scalars['String']['input'];
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateBranchesArgs = {
@@ -1464,16 +1543,19 @@ export type AppUpdateBranchesArgs = {
   offset: Scalars['Int']['input'];
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateChannelByNameArgs = {
   name: Scalars['String']['input'];
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateChannelsArgs = {
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateGroupsArgs = {
@@ -1482,11 +1564,13 @@ export type AppUpdateGroupsArgs = {
   offset: Scalars['Int']['input'];
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdatesArgs = {
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdatesPaginatedArgs = {
@@ -1496,20 +1580,24 @@ export type AppUpdatesPaginatedArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWebhooksArgs = {
   filter?: InputMaybe<WebhookFilter>;
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentArgs = {
   deploymentIdentifier: Scalars['WorkerDeploymentIdentifier']['input'];
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentAliasArgs = {
   aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentAliasesArgs = {
@@ -1519,6 +1607,13 @@ export type AppWorkerDeploymentAliasesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkerDeploymentRequestArgs = {
+  requestId: Scalars['ID']['input'];
+};
+
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1527,16 +1622,26 @@ export type AppWorkerDeploymentsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkerDeploymentsCrashArgs = {
+  crashId: Scalars['ID']['input'];
+  sampleFor?: InputMaybe<CrashSampleFor>;
+};
+
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentsCrashesArgs = {
   limit?: Scalars['Int']['input'];
   timespan: CrashesTimespan;
 };
 
+
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentsMetricsArgs = {
   timespan: MetricsTimespan;
 };
+
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentsRequestsArgs = {
@@ -1602,10 +1707,12 @@ export type AppDevDomainNameMutation = {
   changeDevDomainName: AppDevDomainName;
 };
 
+
 export type AppDevDomainNameMutationAssignDevDomainNameArgs = {
   appId: Scalars['ID']['input'];
   name: Scalars['DevDomainName']['input'];
 };
+
 
 export type AppDevDomainNameMutationChangeDevDomainNameArgs = {
   appId: Scalars['ID']['input'];
@@ -1640,13 +1747,16 @@ export type AppInsights = {
   uniqueUsersByPlatformOverTime: UniqueUsersOverTimeData;
 };
 
+
 export type AppInsightsTotalUniqueUsersArgs = {
   timespan: InsightsTimespan;
 };
 
+
 export type AppInsightsUniqueUsersByAppVersionOverTimeArgs = {
   timespan: InsightsTimespan;
 };
+
 
 export type AppInsightsUniqueUsersByPlatformOverTimeArgs = {
   timespan: InsightsTimespan;
@@ -1654,7 +1764,7 @@ export type AppInsightsUniqueUsersByPlatformOverTimeArgs = {
 
 export enum AppInternalDistributionBuildPrivacy {
   Private = 'PRIVATE',
-  Public = 'PUBLIC',
+  Public = 'PUBLIC'
 }
 
 export type AppMutation = {
@@ -1675,32 +1785,39 @@ export type AppMutation = {
   setResourceClassExperiment: App;
 };
 
+
 export type AppMutationCreateAppArgs = {
   appInput: AppInput;
 };
 
+
 export type AppMutationCreateAppAndGithubRepositoryArgs = {
   appInput: AppWithGithubRepositoryInput;
 };
+
 
 export type AppMutationGrantAccessArgs = {
   accessLevel?: InputMaybe<Scalars['String']['input']>;
   toUser: Scalars['ID']['input'];
 };
 
+
 export type AppMutationScheduleAppDeletionArgs = {
   appId: Scalars['ID']['input'];
 };
+
 
 export type AppMutationSetAppInfoArgs = {
   appId: Scalars['ID']['input'];
   appInfo: AppInfoInput;
 };
 
+
 export type AppMutationSetPushSecurityEnabledArgs = {
   appId: Scalars['ID']['input'];
   pushSecurityEnabled: Scalars['Boolean']['input'];
 };
+
 
 export type AppMutationSetResourceClassExperimentArgs = {
   appId: Scalars['ID']['input'];
@@ -1716,13 +1833,13 @@ export type AppNotificationSubscriptionInput = {
 
 export enum AppPlatform {
   Android = 'ANDROID',
-  Ios = 'IOS',
+  Ios = 'IOS'
 }
 
 export enum AppPrivacy {
   Hidden = 'HIDDEN',
   Public = 'PUBLIC',
-  Unlisted = 'UNLISTED',
+  Unlisted = 'UNLISTED'
 }
 
 export type AppPushNotifications = {
@@ -1739,13 +1856,16 @@ export type AppPushNotificationsInsights = {
   totalNotificationsSent: Scalars['Int']['output'];
 };
 
+
 export type AppPushNotificationsInsightsNotificationsSentOverTimeArgs = {
   timespan: InsightsTimespan;
 };
 
+
 export type AppPushNotificationsInsightsSuccessFailureOverTimeArgs = {
   timespan: InsightsTimespan;
 };
+
 
 export type AppPushNotificationsInsightsTotalNotificationsSentArgs = {
   filters?: InputMaybe<Array<Scalars['JSON']['input']>>;
@@ -1766,6 +1886,7 @@ export type AppQuery = {
   byId: App;
 };
 
+
 export type AppQueryAllArgs = {
   filter: AppsFilter;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -1773,13 +1894,16 @@ export type AppQueryAllArgs = {
   sort: AppSort;
 };
 
+
 export type AppQueryByDevDomainNameArgs = {
   name: Scalars['DevDomainName']['input'];
 };
 
+
 export type AppQueryByFullNameArgs = {
   fullName: Scalars['String']['input'];
 };
+
 
 export type AppQueryByIdArgs = {
   appId: Scalars['String']['input'];
@@ -1803,7 +1927,7 @@ export enum AppSort {
   /** Sort by recently published */
   RecentlyPublished = 'RECENTLY_PUBLISHED',
   /** Sort by highest trendScore */
-  Viewed = 'VIEWED',
+  Viewed = 'VIEWED'
 }
 
 export type AppStoreConnectApiKey = {
@@ -1839,14 +1963,17 @@ export type AppStoreConnectApiKeyMutation = {
   updateAppStoreConnectApiKey: AppStoreConnectApiKey;
 };
 
+
 export type AppStoreConnectApiKeyMutationCreateAppStoreConnectApiKeyArgs = {
   accountId: Scalars['ID']['input'];
   appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput;
 };
 
+
 export type AppStoreConnectApiKeyMutationDeleteAppStoreConnectApiKeyArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type AppStoreConnectApiKeyMutationUpdateAppStoreConnectApiKeyArgs = {
   appStoreConnectApiKeyUpdateInput: AppStoreConnectApiKeyUpdateInput;
@@ -1873,7 +2000,7 @@ export enum AppStoreConnectUserRole {
   ReadOnly = 'READ_ONLY',
   Sales = 'SALES',
   Technical = 'TECHNICAL',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 export type AppSubmissionEdge = {
@@ -1941,6 +2068,7 @@ export type AppVersionMutation = {
   createAppVersion: AppVersion;
 };
 
+
 export type AppVersionMutationCreateAppVersionArgs = {
   appVersionInput: AppVersionInput;
 };
@@ -1974,6 +2102,7 @@ export type AppleAppIdentifierMutation = {
   createAppleAppIdentifier: AppleAppIdentifier;
 };
 
+
 export type AppleAppIdentifierMutationCreateAppleAppIdentifierArgs = {
   accountId: Scalars['ID']['input'];
   appleAppIdentifierInput: AppleAppIdentifierInput;
@@ -1997,7 +2126,7 @@ export enum AppleDeviceClass {
   Ipad = 'IPAD',
   Iphone = 'IPHONE',
   Mac = 'MAC',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 export type AppleDeviceFilterInput = {
@@ -2026,14 +2155,17 @@ export type AppleDeviceMutation = {
   updateAppleDevice: AppleDevice;
 };
 
+
 export type AppleDeviceMutationCreateAppleDeviceArgs = {
   accountId: Scalars['ID']['input'];
   appleDeviceInput: AppleDeviceInput;
 };
 
+
 export type AppleDeviceMutationDeleteAppleDeviceArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type AppleDeviceMutationUpdateAppleDeviceArgs = {
   appleDeviceUpdateInput: AppleDeviceUpdateInput;
@@ -2053,6 +2185,7 @@ export type AppleDeviceRegistrationRequestMutation = {
   createAppleDeviceRegistrationRequest: AppleDeviceRegistrationRequest;
 };
 
+
 export type AppleDeviceRegistrationRequestMutationCreateAppleDeviceRegistrationRequestArgs = {
   accountId: Scalars['ID']['input'];
   appleTeamId: Scalars['ID']['input'];
@@ -2062,6 +2195,7 @@ export type AppleDeviceRegistrationRequestQuery = {
   __typename?: 'AppleDeviceRegistrationRequestQuery';
   byId: AppleDeviceRegistrationRequest;
 };
+
 
 export type AppleDeviceRegistrationRequestQueryByIdArgs = {
   id: Scalars['ID']['input'];
@@ -2104,10 +2238,12 @@ export type AppleDistributionCertificateMutation = {
   deleteAppleDistributionCertificate: DeleteAppleDistributionCertificateResult;
 };
 
+
 export type AppleDistributionCertificateMutationCreateAppleDistributionCertificateArgs = {
   accountId: Scalars['ID']['input'];
   appleDistributionCertificateInput: AppleDistributionCertificateInput;
 };
+
 
 export type AppleDistributionCertificateMutationDeleteAppleDistributionCertificateArgs = {
   id: Scalars['ID']['input'];
@@ -2146,19 +2282,23 @@ export type AppleProvisioningProfileMutation = {
   updateAppleProvisioningProfile: AppleProvisioningProfile;
 };
 
+
 export type AppleProvisioningProfileMutationCreateAppleProvisioningProfileArgs = {
   accountId: Scalars['ID']['input'];
   appleAppIdentifierId: Scalars['ID']['input'];
   appleProvisioningProfileInput: AppleProvisioningProfileInput;
 };
 
+
 export type AppleProvisioningProfileMutationDeleteAppleProvisioningProfileArgs = {
   id: Scalars['ID']['input'];
 };
 
+
 export type AppleProvisioningProfileMutationDeleteAppleProvisioningProfilesArgs = {
   ids: Array<Scalars['ID']['input']>;
 };
+
 
 export type AppleProvisioningProfileMutationUpdateAppleProvisioningProfileArgs = {
   appleProvisioningProfileInput: AppleProvisioningProfileInput;
@@ -2191,10 +2331,12 @@ export type ApplePushKeyMutation = {
   deleteApplePushKey: DeleteApplePushKeyResult;
 };
 
+
 export type ApplePushKeyMutationCreateApplePushKeyArgs = {
   accountId: Scalars['ID']['input'];
   applePushKeyInput: ApplePushKeyInput;
 };
+
 
 export type ApplePushKeyMutationDeleteApplePushKeyArgs = {
   id: Scalars['ID']['input'];
@@ -2214,14 +2356,17 @@ export type AppleTeam = {
   id: Scalars['ID']['output'];
 };
 
+
 export type AppleTeamAppleAppIdentifiersArgs = {
   bundleIdentifier?: InputMaybe<Scalars['String']['input']>;
 };
+
 
 export type AppleTeamAppleDevicesArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
+
 
 export type AppleTeamAppleProvisioningProfilesArgs = {
   appleAppIdentifierId?: InputMaybe<Scalars['ID']['input']>;
@@ -2245,10 +2390,12 @@ export type AppleTeamMutation = {
   updateAppleTeam: AppleTeam;
 };
 
+
 export type AppleTeamMutationCreateAppleTeamArgs = {
   accountId: Scalars['ID']['input'];
   appleTeamInput: AppleTeamInput;
 };
+
 
 export type AppleTeamMutationUpdateAppleTeamArgs = {
   appleTeamUpdateInput: AppleTeamUpdateInput;
@@ -2260,6 +2407,7 @@ export type AppleTeamQuery = {
   byAppleTeamIdentifier?: Maybe<AppleTeam>;
 };
 
+
 export type AppleTeamQueryByAppleTeamIdentifierArgs = {
   accountId: Scalars['ID']['input'];
   identifier: Scalars['String']['input'];
@@ -2268,7 +2416,7 @@ export type AppleTeamQueryByAppleTeamIdentifierArgs = {
 export enum AppleTeamType {
   CompanyOrOrganization = 'COMPANY_OR_ORGANIZATION',
   Individual = 'INDIVIDUAL',
-  InHouse = 'IN_HOUSE',
+  InHouse = 'IN_HOUSE'
 }
 
 export type AppleTeamUpdateInput = {
@@ -2280,7 +2428,7 @@ export enum AppsFilter {
   /** Featured Projects */
   Featured = 'FEATURED',
   /** New Projects */
-  New = 'NEW',
+  New = 'NEW'
 }
 
 export type AscApiKeyInput = {
@@ -2297,7 +2445,7 @@ export type AssetMetadataResult = {
 
 export enum AssetMetadataStatus {
   DoesNotExist = 'DOES_NOT_EXIST',
-  Exists = 'EXISTS',
+  Exists = 'EXISTS'
 }
 
 export type AssetMutation = {
@@ -2309,6 +2457,7 @@ export type AssetMutation = {
   getSignedAssetUploadSpecifications: GetSignedAssetUploadSpecificationsResult;
 };
 
+
 export type AssetMutationGetSignedAssetUploadSpecificationsArgs = {
   assetContentTypes: Array<InputMaybe<Scalars['String']['input']>>;
 };
@@ -2318,6 +2467,7 @@ export type AssetQuery = {
   __typename?: 'AssetQuery';
   metadata: Array<AssetMetadataResult>;
 };
+
 
 /** Check to see if assets with given storageKeys exist */
 export type AssetQueryMetadataArgs = {
@@ -2367,6 +2517,7 @@ export type AuditLogMutation = {
   exportAuditLogs: BackgroundJobReceipt;
 };
 
+
 export type AuditLogMutationExportAuditLogsArgs = {
   exportInput: AuditLogExportInput;
 };
@@ -2376,6 +2527,7 @@ export type AuditLogQuery = {
   /** Query Audit Logs by account ID */
   byAccountId: Array<AuditLog>;
 };
+
 
 export type AuditLogQueryByAccountIdArgs = {
   accountId: Scalars['ID']['input'];
@@ -2388,11 +2540,11 @@ export type AuditLogQueryByAccountIdArgs = {
 export enum AuditLogsExportFormat {
   Csv = 'CSV',
   Json = 'JSON',
-  Jsonl = 'JSONL',
+  Jsonl = 'JSONL'
 }
 
 export enum AuthProtocolType {
-  Oidc = 'OIDC',
+  Oidc = 'OIDC'
 }
 
 export enum AuthProviderIdentifier {
@@ -2400,7 +2552,7 @@ export enum AuthProviderIdentifier {
   MsEntraId = 'MS_ENTRA_ID',
   Okta = 'OKTA',
   OneLogin = 'ONE_LOGIN',
-  StubIdp = 'STUB_IDP',
+  StubIdp = 'STUB_IDP'
 }
 
 export type BackgroundJobReceipt = {
@@ -2425,6 +2577,7 @@ export type BackgroundJobReceiptQuery = {
   byId: BackgroundJobReceipt;
 };
 
+
 export type BackgroundJobReceiptQueryByIdArgs = {
   id: Scalars['ID']['input'];
 };
@@ -2432,14 +2585,14 @@ export type BackgroundJobReceiptQueryByIdArgs = {
 export enum BackgroundJobResultType {
   AuditLogsExport = 'AUDIT_LOGS_EXPORT',
   GithubBuild = 'GITHUB_BUILD',
-  Void = 'VOID',
+  Void = 'VOID'
 }
 
 export enum BackgroundJobState {
   Failure = 'FAILURE',
   InProgress = 'IN_PROGRESS',
   Queued = 'QUEUED',
-  Success = 'SUCCESS',
+  Success = 'SUCCESS'
 }
 
 export type Billing = {
@@ -2465,87 +2618,88 @@ export type BranchFilterInput = {
 };
 
 /** Represents an EAS Build */
-export type Build = ActivityTimelineProjectActivity &
-  BuildOrBuildJob & {
-    __typename?: 'Build';
-    activityTimestamp: Scalars['DateTime']['output'];
-    actor?: Maybe<Actor>;
-    app: App;
-    appBuildVersion?: Maybe<Scalars['String']['output']>;
-    appIdentifier?: Maybe<Scalars['String']['output']>;
-    appVersion?: Maybe<Scalars['String']['output']>;
-    artifacts?: Maybe<BuildArtifacts>;
-    buildMode?: Maybe<BuildMode>;
-    buildProfile?: Maybe<Scalars['String']['output']>;
-    canRetry: Scalars['Boolean']['output'];
-    cancelingActor?: Maybe<Actor>;
-    channel?: Maybe<Scalars['String']['output']>;
-    childBuild?: Maybe<Build>;
-    completedAt?: Maybe<Scalars['DateTime']['output']>;
-    createdAt: Scalars['DateTime']['output'];
-    customNodeVersion?: Maybe<Scalars['String']['output']>;
-    customWorkflowName?: Maybe<Scalars['String']['output']>;
-    developmentClient?: Maybe<Scalars['Boolean']['output']>;
-    distribution?: Maybe<DistributionType>;
-    enqueuedAt?: Maybe<Scalars['DateTime']['output']>;
-    error?: Maybe<BuildError>;
-    estimatedWaitTimeLeftSeconds?: Maybe<Scalars['Int']['output']>;
-    expirationDate?: Maybe<Scalars['DateTime']['output']>;
-    gitCommitHash?: Maybe<Scalars['String']['output']>;
-    gitCommitMessage?: Maybe<Scalars['String']['output']>;
-    gitRef?: Maybe<Scalars['String']['output']>;
-    githubRepositoryOwnerAndName?: Maybe<Scalars['String']['output']>;
-    id: Scalars['ID']['output'];
-    /** Queue position is 1-indexed */
-    initialQueuePosition?: Maybe<Scalars['Int']['output']>;
-    initiatingActor?: Maybe<Actor>;
-    /** @deprecated User type is deprecated */
-    initiatingUser?: Maybe<User>;
-    iosEnterpriseProvisioning?: Maybe<BuildIosEnterpriseProvisioning>;
-    isForIosSimulator: Scalars['Boolean']['output'];
-    isGitWorkingTreeDirty?: Maybe<Scalars['Boolean']['output']>;
-    isWaived: Scalars['Boolean']['output'];
-    logFiles: Array<Scalars['String']['output']>;
-    maxBuildTimeSeconds: Scalars['Int']['output'];
-    /** Retry time starts after completedAt */
-    maxRetryTimeMinutes?: Maybe<Scalars['Int']['output']>;
-    message?: Maybe<Scalars['String']['output']>;
-    metrics?: Maybe<BuildMetrics>;
-    parentBuild?: Maybe<Build>;
-    platform: AppPlatform;
-    priority: BuildPriority;
-    /** @deprecated Use app field instead */
-    project: Project;
-    projectMetadataFileUrl?: Maybe<Scalars['String']['output']>;
-    projectRootDirectory?: Maybe<Scalars['String']['output']>;
-    provisioningStartedAt?: Maybe<Scalars['DateTime']['output']>;
-    /** Queue position is 1-indexed */
-    queuePosition?: Maybe<Scalars['Int']['output']>;
-    reactNativeVersion?: Maybe<Scalars['String']['output']>;
-    releaseChannel?: Maybe<Scalars['String']['output']>;
-    requiredPackageManager?: Maybe<Scalars['String']['output']>;
-    /**
-     * The builder resource class requested by the developer
-     * @deprecated Use resourceClassDisplayName instead
-     */
-    resourceClass: BuildResourceClass;
-    /** String describing the resource class used to run the build */
-    resourceClassDisplayName: Scalars['String']['output'];
-    retryDisabledReason?: Maybe<BuildRetryDisabledReason>;
-    runFromCI?: Maybe<Scalars['Boolean']['output']>;
-    runtimeVersion?: Maybe<Scalars['String']['output']>;
-    sdkVersion?: Maybe<Scalars['String']['output']>;
-    selectedImage?: Maybe<Scalars['String']['output']>;
-    status: BuildStatus;
-    submissions: Array<Submission>;
-    updatedAt: Scalars['DateTime']['output'];
-    workerStartedAt?: Maybe<Scalars['DateTime']['output']>;
-  };
+export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
+  __typename?: 'Build';
+  activityTimestamp: Scalars['DateTime']['output'];
+  actor?: Maybe<Actor>;
+  app: App;
+  appBuildVersion?: Maybe<Scalars['String']['output']>;
+  appIdentifier?: Maybe<Scalars['String']['output']>;
+  appVersion?: Maybe<Scalars['String']['output']>;
+  artifacts?: Maybe<BuildArtifacts>;
+  buildMode?: Maybe<BuildMode>;
+  buildProfile?: Maybe<Scalars['String']['output']>;
+  canRetry: Scalars['Boolean']['output'];
+  cancelingActor?: Maybe<Actor>;
+  channel?: Maybe<Scalars['String']['output']>;
+  childBuild?: Maybe<Build>;
+  completedAt?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  customNodeVersion?: Maybe<Scalars['String']['output']>;
+  customWorkflowName?: Maybe<Scalars['String']['output']>;
+  developmentClient?: Maybe<Scalars['Boolean']['output']>;
+  distribution?: Maybe<DistributionType>;
+  enqueuedAt?: Maybe<Scalars['DateTime']['output']>;
+  error?: Maybe<BuildError>;
+  estimatedWaitTimeLeftSeconds?: Maybe<Scalars['Int']['output']>;
+  expirationDate?: Maybe<Scalars['DateTime']['output']>;
+  gitCommitHash?: Maybe<Scalars['String']['output']>;
+  gitCommitMessage?: Maybe<Scalars['String']['output']>;
+  gitRef?: Maybe<Scalars['String']['output']>;
+  githubRepositoryOwnerAndName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  /** Queue position is 1-indexed */
+  initialQueuePosition?: Maybe<Scalars['Int']['output']>;
+  initiatingActor?: Maybe<Actor>;
+  /** @deprecated User type is deprecated */
+  initiatingUser?: Maybe<User>;
+  iosEnterpriseProvisioning?: Maybe<BuildIosEnterpriseProvisioning>;
+  isForIosSimulator: Scalars['Boolean']['output'];
+  isGitWorkingTreeDirty?: Maybe<Scalars['Boolean']['output']>;
+  isWaived: Scalars['Boolean']['output'];
+  logFiles: Array<Scalars['String']['output']>;
+  maxBuildTimeSeconds: Scalars['Int']['output'];
+  /** Retry time starts after completedAt */
+  maxRetryTimeMinutes?: Maybe<Scalars['Int']['output']>;
+  message?: Maybe<Scalars['String']['output']>;
+  metrics?: Maybe<BuildMetrics>;
+  parentBuild?: Maybe<Build>;
+  platform: AppPlatform;
+  priority: BuildPriority;
+  /** @deprecated Use app field instead */
+  project: Project;
+  projectMetadataFileUrl?: Maybe<Scalars['String']['output']>;
+  projectRootDirectory?: Maybe<Scalars['String']['output']>;
+  provisioningStartedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** Queue position is 1-indexed */
+  queuePosition?: Maybe<Scalars['Int']['output']>;
+  reactNativeVersion?: Maybe<Scalars['String']['output']>;
+  releaseChannel?: Maybe<Scalars['String']['output']>;
+  requiredPackageManager?: Maybe<Scalars['String']['output']>;
+  /**
+   * The builder resource class requested by the developer
+   * @deprecated Use resourceClassDisplayName instead
+   */
+  resourceClass: BuildResourceClass;
+  /** String describing the resource class used to run the build */
+  resourceClassDisplayName: Scalars['String']['output'];
+  retryDisabledReason?: Maybe<BuildRetryDisabledReason>;
+  runFromCI?: Maybe<Scalars['Boolean']['output']>;
+  runtimeVersion?: Maybe<Scalars['String']['output']>;
+  sdkVersion?: Maybe<Scalars['String']['output']>;
+  selectedImage?: Maybe<Scalars['String']['output']>;
+  status: BuildStatus;
+  submissions: Array<Submission>;
+  updatedAt: Scalars['DateTime']['output'];
+  workerStartedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
 
 /** Represents an EAS Build */
 export type BuildCanRetryArgs = {
   newMode?: InputMaybe<BuildMode>;
 };
+
 
 /** Represents an EAS Build */
 export type BuildRetryDisabledReasonArgs = {
@@ -2589,13 +2743,16 @@ export type BuildAnnotationMutation = {
   updateBuildAnnotation: BuildAnnotation;
 };
 
+
 export type BuildAnnotationMutationCreateBuildAnnotationArgs = {
   buildAnnotationData: BuildAnnotationDataInput;
 };
 
+
 export type BuildAnnotationMutationDeleteBuildAnnotationArgs = {
   buildAnnotationId: Scalars['ID']['input'];
 };
+
 
 export type BuildAnnotationMutationUpdateBuildAnnotationArgs = {
   buildAnnotationData: BuildAnnotationDataInput;
@@ -2610,9 +2767,11 @@ export type BuildAnnotationsQuery = {
   byId: BuildAnnotation;
 };
 
+
 export type BuildAnnotationsQueryAllArgs = {
   filters?: InputMaybe<BuildAnnotationFiltersInput>;
 };
+
 
 export type BuildAnnotationsQueryByIdArgs = {
   buildAnnotationId: Scalars['ID']['input'];
@@ -2636,7 +2795,7 @@ export type BuildCacheInput = {
 
 export enum BuildCredentialsSource {
   Local = 'LOCAL',
-  Remote = 'REMOTE',
+  Remote = 'REMOTE'
 }
 
 export type BuildError = {
@@ -2674,7 +2833,7 @@ export type BuildFilterInput = {
 
 export enum BuildIosEnterpriseProvisioning {
   Adhoc = 'ADHOC',
-  Universal = 'UNIVERSAL',
+  Universal = 'UNIVERSAL'
 }
 
 export type BuildLimitThresholdExceededMetadata = {
@@ -2685,7 +2844,7 @@ export type BuildLimitThresholdExceededMetadata = {
 
 export enum BuildLimitThresholdExceededMetadataType {
   Ios = 'IOS',
-  Total = 'TOTAL',
+  Total = 'TOTAL'
 }
 
 export type BuildMetadataInput = {
@@ -2733,7 +2892,7 @@ export enum BuildMode {
   Build = 'BUILD',
   Custom = 'CUSTOM',
   Repack = 'REPACK',
-  Resign = 'RESIGN',
+  Resign = 'RESIGN'
 }
 
 export type BuildMutation = {
@@ -2764,9 +2923,11 @@ export type BuildMutation = {
   updateBuildMetadata: Build;
 };
 
+
 export type BuildMutationCancelBuildArgs = {
   buildId: Scalars['ID']['input'];
 };
+
 
 export type BuildMutationCreateAndroidBuildArgs = {
   appId: Scalars['ID']['input'];
@@ -2775,6 +2936,7 @@ export type BuildMutationCreateAndroidBuildArgs = {
   metadata?: InputMaybe<BuildMetadataInput>;
 };
 
+
 export type BuildMutationCreateIosBuildArgs = {
   appId: Scalars['ID']['input'];
   buildParams?: InputMaybe<BuildParamsInput>;
@@ -2782,23 +2944,28 @@ export type BuildMutationCreateIosBuildArgs = {
   metadata?: InputMaybe<BuildMetadataInput>;
 };
 
+
 export type BuildMutationDeleteBuildArgs = {
   buildId: Scalars['ID']['input'];
 };
+
 
 export type BuildMutationRetryAndroidBuildArgs = {
   buildId: Scalars['ID']['input'];
   jobOverrides?: InputMaybe<AndroidJobOverridesInput>;
 };
 
+
 export type BuildMutationRetryBuildArgs = {
   buildId: Scalars['ID']['input'];
 };
+
 
 export type BuildMutationRetryIosBuildArgs = {
   buildId: Scalars['ID']['input'];
   jobOverrides?: InputMaybe<IosJobOverridesInput>;
 };
+
 
 export type BuildMutationUpdateBuildMetadataArgs = {
   buildId: Scalars['ID']['input'];
@@ -2856,7 +3023,7 @@ export enum BuildPhase {
   UploadApplicationArchive = 'UPLOAD_APPLICATION_ARCHIVE',
   /** @deprecated No longer supported */
   UploadArtifacts = 'UPLOAD_ARTIFACTS',
-  UploadBuildArtifacts = 'UPLOAD_BUILD_ARTIFACTS',
+  UploadBuildArtifacts = 'UPLOAD_BUILD_ARTIFACTS'
 }
 
 export type BuildPlanCreditThresholdExceededMetadata = {
@@ -2870,7 +3037,7 @@ export type BuildPlanCreditThresholdExceededMetadata = {
 export enum BuildPriority {
   High = 'HIGH',
   Normal = 'NORMAL',
-  NormalPlus = 'NORMAL_PLUS',
+  NormalPlus = 'NORMAL_PLUS'
 }
 
 /** Publicly visible data for a Build. */
@@ -2890,6 +3057,7 @@ export type BuildPublicDataQuery = {
   /** Get BuildPublicData by ID */
   byId?: Maybe<BuildPublicData>;
 };
+
 
 export type BuildPublicDataQueryByIdArgs = {
   id: Scalars['ID']['input'];
@@ -2913,12 +3081,14 @@ export type BuildQuery = {
   byId: Build;
 };
 
+
 export type BuildQueryAllArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Order>;
   statuses?: InputMaybe<Array<BuildStatus>>;
 };
+
 
 export type BuildQueryAllForAppArgs = {
   appId: Scalars['String']['input'];
@@ -2927,6 +3097,7 @@ export type BuildQueryAllForAppArgs = {
   platform?: InputMaybe<AppPlatform>;
   status?: InputMaybe<BuildStatus>;
 };
+
 
 export type BuildQueryByIdArgs = {
   buildId: Scalars['ID']['input'];
@@ -2953,7 +3124,7 @@ export enum BuildResourceClass {
   IosMedium = 'IOS_MEDIUM',
   IosMLarge = 'IOS_M_LARGE',
   IosMMedium = 'IOS_M_MEDIUM',
-  Legacy = 'LEGACY',
+  Legacy = 'LEGACY'
 }
 
 export enum BuildRetryDisabledReason {
@@ -2961,7 +3132,7 @@ export enum BuildRetryDisabledReason {
   InvalidStatus = 'INVALID_STATUS',
   IsGithubBuild = 'IS_GITHUB_BUILD',
   NotCompletedYet = 'NOT_COMPLETED_YET',
-  TooMuchTimeElapsed = 'TOO_MUCH_TIME_ELAPSED',
+  TooMuchTimeElapsed = 'TOO_MUCH_TIME_ELAPSED'
 }
 
 export enum BuildStatus {
@@ -2971,12 +3142,12 @@ export enum BuildStatus {
   InProgress = 'IN_PROGRESS',
   InQueue = 'IN_QUEUE',
   New = 'NEW',
-  PendingCancel = 'PENDING_CANCEL',
+  PendingCancel = 'PENDING_CANCEL'
 }
 
 export enum BuildTrigger {
   EasCli = 'EAS_CLI',
-  GitBasedIntegration = 'GIT_BASED_INTEGRATION',
+  GitBasedIntegration = 'GIT_BASED_INTEGRATION'
 }
 
 export type BuildUpdatesInput = {
@@ -2986,7 +3157,7 @@ export type BuildUpdatesInput = {
 export enum BuildWorkflow {
   Generic = 'GENERIC',
   Managed = 'MANAGED',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 export type Card = {
@@ -3041,7 +3212,12 @@ export enum ContinentCode {
   Na = 'NA',
   Oc = 'OC',
   Sa = 'SA',
-  T1 = 'T1',
+  T1 = 'T1'
+}
+
+export enum CrashSampleFor {
+  Newest = 'NEWEST',
+  Oldest = 'OLDEST'
 }
 
 export type CrashesTimespan = {
@@ -3105,6 +3281,7 @@ export type CreateGitHubBuildTriggerInput = {
   appId: Scalars['ID']['input'];
   autoSubmit: Scalars['Boolean']['input'];
   buildProfile: Scalars['String']['input'];
+  environment?: InputMaybe<EnvironmentVariableEnvironment>;
   executionBehavior: GitHubBuildTriggerExecutionBehavior;
   isActive: Scalars['Boolean']['input'];
   platform: AppPlatform;
@@ -3165,6 +3342,13 @@ export type CreateSubmissionResult = {
   submission: Submission;
 };
 
+export type CumulativeMetricsOverTimeData = {
+  __typename?: 'CumulativeMetricsOverTimeData';
+  data: LineChartData;
+  metricsAtLastTimestamp: Array<LineDatapoint>;
+  mostPopularUpdates: Array<Update>;
+};
+
 export type CustomBuildConfigInput = {
   path: Scalars['String']['input'];
 };
@@ -3174,19 +3358,13 @@ export type CustomDomainDnsRecord = {
   dnsContent: Scalars['String']['output'];
   dnsName: Scalars['String']['output'];
   dnsType: CustomDomainDnsRecordType;
+  isConfigured: Scalars['Boolean']['output'];
 };
 
 export enum CustomDomainDnsRecordType {
   Cname = 'CNAME',
-  Txt = 'TXT',
+  Txt = 'TXT'
 }
-
-export type CustomDomainMetadata = {
-  __typename?: 'CustomDomainMetadata';
-  ownershipVerification?: Maybe<CustomDomainDnsRecord>;
-  status: CustomDomainStatus;
-  verificationErrors?: Maybe<Array<Scalars['String']['output']>>;
-};
 
 export type CustomDomainMutation = {
   __typename?: 'CustomDomainMutation';
@@ -3195,13 +3373,16 @@ export type CustomDomainMutation = {
   registerCustomDomain: WorkerCustomDomain;
 };
 
+
 export type CustomDomainMutationDeleteCustomDomainArgs = {
   customDomainId: Scalars['ID']['input'];
 };
 
+
 export type CustomDomainMutationRefreshCustomDomainArgs = {
   customDomainId: Scalars['ID']['input'];
 };
+
 
 export type CustomDomainMutationRegisterCustomDomainArgs = {
   aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
@@ -3209,19 +3390,20 @@ export type CustomDomainMutationRegisterCustomDomainArgs = {
   hostname: Scalars['String']['input'];
 };
 
+export type CustomDomainSetup = {
+  __typename?: 'CustomDomainSetup';
+  sslErrors?: Maybe<Array<Scalars['String']['output']>>;
+  sslStatus?: Maybe<CustomDomainStatus>;
+  status: CustomDomainStatus;
+  verificationErrors?: Maybe<Array<Scalars['String']['output']>>;
+  verificationStatus?: Maybe<CustomDomainStatus>;
+};
+
 export enum CustomDomainStatus {
   Active = 'ACTIVE',
-  ActiveRedeploying = 'ACTIVE_REDEPLOYING',
-  Blocked = 'BLOCKED',
-  Deleted = 'DELETED',
-  Moved = 'MOVED',
+  Error = 'ERROR',
   Pending = 'PENDING',
-  PendingBlocked = 'PENDING_BLOCKED',
-  PendingDeletion = 'PENDING_DELETION',
-  PendingMigration = 'PENDING_MIGRATION',
-  PendingProvisioned = 'PENDING_PROVISIONED',
-  Provisioned = 'PROVISIONED',
-  Unknown = 'UNKNOWN',
+  TimedOut = 'TIMED_OUT'
 }
 
 export type DeleteAccessTokenResult = {
@@ -3365,6 +3547,7 @@ export type Deployment = {
   runtime: Runtime;
 };
 
+
 /** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
 export type DeploymentBuildsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -3372,6 +3555,7 @@ export type DeploymentBuildsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
 };
+
 
 /** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
 export type DeploymentLatestUpdatesPerBranchArgs = {
@@ -3405,29 +3589,34 @@ export type DeploymentFilterInput = {
 
 export type DeploymentInsights = {
   __typename?: 'DeploymentInsights';
+  cumulativeMetricsOverTime: CumulativeMetricsOverTimeData;
   embeddedUpdateTotalUniqueUsers: Scalars['Int']['output'];
   embeddedUpdateUniqueUsersOverTime: UniqueUsersOverTimeData;
   id: Scalars['ID']['output'];
   mostPopularUpdates: Array<Update>;
-  mostPopularUpdatesNew: Array<Update>;
   uniqueUsersOverTime: UniqueUsersOverTimeData;
 };
+
+
+export type DeploymentInsightsCumulativeMetricsOverTimeArgs = {
+  timespan: InsightsTimespan;
+};
+
 
 export type DeploymentInsightsEmbeddedUpdateTotalUniqueUsersArgs = {
   timespan: InsightsTimespan;
 };
 
+
 export type DeploymentInsightsEmbeddedUpdateUniqueUsersOverTimeArgs = {
   timespan: InsightsTimespan;
 };
+
 
 export type DeploymentInsightsMostPopularUpdatesArgs = {
   timespan: InsightsTimespan;
 };
 
-export type DeploymentInsightsMostPopularUpdatesNewArgs = {
-  timespan: InsightsTimespan;
-};
 
 export type DeploymentInsightsUniqueUsersOverTimeArgs = {
   timespan: InsightsTimespan;
@@ -3455,16 +3644,19 @@ export type DeploymentsMutation = {
   deleteAlias: DeleteAliasResult;
 };
 
+
 export type DeploymentsMutationAssignAliasArgs = {
   aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
   appId: Scalars['ID']['input'];
   deploymentIdentifier: Scalars['ID']['input'];
 };
 
+
 export type DeploymentsMutationCreateSignedDeploymentUrlArgs = {
   appId: Scalars['ID']['input'];
   deploymentIdentifier?: InputMaybe<Scalars['ID']['input']>;
 };
+
 
 export type DeploymentsMutationDeleteAliasArgs = {
   aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
@@ -3492,6 +3684,7 @@ export type DiscordUserMutation = {
   deleteDiscordUser: DeleteDiscordUserResult;
 };
 
+
 export type DiscordUserMutationDeleteDiscordUserArgs = {
   id: Scalars['ID']['input'];
 };
@@ -3499,12 +3692,12 @@ export type DiscordUserMutationDeleteDiscordUserArgs = {
 export enum DistributionType {
   Internal = 'INTERNAL',
   Simulator = 'SIMULATOR',
-  Store = 'STORE',
+  Store = 'STORE'
 }
 
 export enum EasBuildBillingResourceClass {
   Large = 'LARGE',
-  Medium = 'MEDIUM',
+  Medium = 'MEDIUM'
 }
 
 export type EasBuildDeprecationInfo = {
@@ -3515,18 +3708,18 @@ export type EasBuildDeprecationInfo = {
 
 export enum EasBuildDeprecationInfoType {
   Internal = 'INTERNAL',
-  UserFacing = 'USER_FACING',
+  UserFacing = 'USER_FACING'
 }
 
 export enum EasBuildWaiverType {
   FastFailedBuild = 'FAST_FAILED_BUILD',
-  SystemError = 'SYSTEM_ERROR',
+  SystemError = 'SYSTEM_ERROR'
 }
 
 export enum EasService {
   Builds = 'BUILDS',
   Jobs = 'JOBS',
-  Updates = 'UPDATES',
+  Updates = 'UPDATES'
 }
 
 export enum EasServiceMetric {
@@ -3536,7 +3729,7 @@ export enum EasServiceMetric {
   ManifestRequests = 'MANIFEST_REQUESTS',
   RunTime = 'RUN_TIME',
   UniqueUpdaters = 'UNIQUE_UPDATERS',
-  UniqueUsers = 'UNIQUE_USERS',
+  UniqueUsers = 'UNIQUE_USERS'
 }
 
 export type EasTotalPlanEnablement = {
@@ -3551,7 +3744,7 @@ export enum EasTotalPlanEnablementUnit {
   Concurrency = 'CONCURRENCY',
   Request = 'REQUEST',
   Updater = 'UPDATER',
-  User = 'USER',
+  User = 'USER'
 }
 
 export type EditUpdateBranchInput = {
@@ -3565,6 +3758,7 @@ export type EmailSubscriptionMutation = {
   __typename?: 'EmailSubscriptionMutation';
   addUser: AddUserPayload;
 };
+
 
 export type EmailSubscriptionMutationAddUserArgs = {
   addUserInput: AddUserInput;
@@ -3589,7 +3783,7 @@ export enum EntityTypeName {
   TurtleBuild = 'TurtleBuild',
   Update = 'Update',
   UserInvitation = 'UserInvitation',
-  UserPermission = 'UserPermission',
+  UserPermission = 'UserPermission'
 }
 
 export type EnvironmentSecret = {
@@ -3611,15 +3805,18 @@ export type EnvironmentSecretMutation = {
   deleteEnvironmentSecret: DeleteEnvironmentSecretResult;
 };
 
+
 export type EnvironmentSecretMutationCreateEnvironmentSecretForAccountArgs = {
   accountId: Scalars['String']['input'];
   environmentSecretData: CreateEnvironmentSecretInput;
 };
 
+
 export type EnvironmentSecretMutationCreateEnvironmentSecretForAppArgs = {
   appId: Scalars['String']['input'];
   environmentSecretData: CreateEnvironmentSecretInput;
 };
+
 
 export type EnvironmentSecretMutationDeleteEnvironmentSecretArgs = {
   id: Scalars['String']['input'];
@@ -3627,7 +3824,7 @@ export type EnvironmentSecretMutationDeleteEnvironmentSecretArgs = {
 
 export enum EnvironmentSecretType {
   FileBase64 = 'FILE_BASE64',
-  String = 'STRING',
+  String = 'STRING'
 }
 
 export type EnvironmentVariable = {
@@ -3646,7 +3843,7 @@ export type EnvironmentVariable = {
 export enum EnvironmentVariableEnvironment {
   Development = 'DEVELOPMENT',
   Preview = 'PREVIEW',
-  Production = 'PRODUCTION',
+  Production = 'PRODUCTION'
 }
 
 export type EnvironmentVariableMutation = {
@@ -3669,39 +3866,47 @@ export type EnvironmentVariableMutation = {
   unlinkSharedEnvironmentVariable: EnvironmentVariable;
 };
 
+
 export type EnvironmentVariableMutationCreateBulkEnvironmentVariablesForAccountArgs = {
   accountId: Scalars['ID']['input'];
   environmentVariablesData: Array<CreateSharedEnvironmentVariableInput>;
 };
+
 
 export type EnvironmentVariableMutationCreateBulkEnvironmentVariablesForAppArgs = {
   appId: Scalars['ID']['input'];
   environmentVariablesData: Array<CreateEnvironmentVariableInput>;
 };
 
+
 export type EnvironmentVariableMutationCreateEnvironmentVariableForAccountArgs = {
   accountId: Scalars['ID']['input'];
   environmentVariableData: CreateSharedEnvironmentVariableInput;
 };
+
 
 export type EnvironmentVariableMutationCreateEnvironmentVariableForAppArgs = {
   appId: Scalars['ID']['input'];
   environmentVariableData: CreateEnvironmentVariableInput;
 };
 
+
 export type EnvironmentVariableMutationDeleteEnvironmentVariableArgs = {
   id: Scalars['ID']['input'];
 };
 
+
 export type EnvironmentVariableMutationLinkBulkSharedEnvironmentVariablesArgs = {
   linkData: Array<LinkSharedEnvironmentVariableInput>;
 };
+
 
 export type EnvironmentVariableMutationLinkSharedEnvironmentVariableArgs = {
   appId: Scalars['ID']['input'];
   environment: EnvironmentVariableEnvironment;
   environmentVariableId: Scalars['ID']['input'];
 };
+
 
 export type EnvironmentVariableMutationUnlinkSharedEnvironmentVariableArgs = {
   appId: Scalars['ID']['input'];
@@ -3711,13 +3916,13 @@ export type EnvironmentVariableMutationUnlinkSharedEnvironmentVariableArgs = {
 
 export enum EnvironmentVariableScope {
   Project = 'PROJECT',
-  Shared = 'SHARED',
+  Shared = 'SHARED'
 }
 
 export enum EnvironmentVariableVisibility {
   Public = 'PUBLIC',
   Secret = 'SECRET',
-  Sensitive = 'SENSITIVE',
+  Sensitive = 'SENSITIVE'
 }
 
 export type EnvironmentVariableWithSecret = {
@@ -3759,7 +3964,7 @@ export type EstimatedUsage = {
 };
 
 export enum Experiment {
-  Orbit = 'ORBIT',
+  Orbit = 'ORBIT'
 }
 
 export type ExperimentationQuery = {
@@ -3796,7 +4001,7 @@ export enum Feature {
   /** Top Tier Support */
   Support = 'SUPPORT',
   /** Share access to projects */
-  Teams = 'TEAMS',
+  Teams = 'TEAMS'
 }
 
 export type FingerprintSourceInput = {
@@ -3806,7 +4011,7 @@ export type FingerprintSourceInput = {
 };
 
 export enum FingerprintSourceType {
-  Gcs = 'GCS',
+  Gcs = 'GCS'
 }
 
 export type FutureSubscription = {
@@ -3827,7 +4032,7 @@ export type GetSignedAssetUploadSpecificationsResult = {
 export enum GitHubAppEnvironment {
   Development = 'DEVELOPMENT',
   Production = 'PRODUCTION',
-  Staging = 'STAGING',
+  Staging = 'STAGING'
 }
 
 export type GitHubAppInstallation = {
@@ -3866,9 +4071,11 @@ export type GitHubAppInstallationMutation = {
   deleteGitHubAppInstallation: GitHubAppInstallation;
 };
 
+
 export type GitHubAppInstallationMutationCreateGitHubAppInstallationForAccountArgs = {
   githubAppInstallationData: CreateGitHubAppInstallationInput;
 };
+
 
 export type GitHubAppInstallationMutationDeleteGitHubAppInstallationArgs = {
   githubAppInstallationId: Scalars['ID']['input'];
@@ -3877,7 +4084,7 @@ export type GitHubAppInstallationMutationDeleteGitHubAppInstallationArgs = {
 export enum GitHubAppInstallationStatus {
   Active = 'ACTIVE',
   NotInstalled = 'NOT_INSTALLED',
-  Suspended = 'SUSPENDED',
+  Suspended = 'SUSPENDED'
 }
 
 export type GitHubAppMutation = {
@@ -3885,6 +4092,7 @@ export type GitHubAppMutation = {
   /** Create a GitHub build for an app. Returns the ID of the background job receipt. Use BackgroundJobReceiptQuery to get the status of the job. */
   createGitHubBuild: BackgroundJobReceipt;
 };
+
 
 export type GitHubAppMutationCreateGitHubBuildArgs = {
   buildInput: GitHubBuildInput;
@@ -3899,6 +4107,7 @@ export type GitHubAppQuery = {
   name: Scalars['String']['output'];
 };
 
+
 export type GitHubAppQueryInstallationArgs = {
   id: Scalars['ID']['input'];
 };
@@ -3908,6 +4117,7 @@ export type GitHubBuildInput = {
   autoSubmit?: InputMaybe<Scalars['Boolean']['input']>;
   baseDirectory?: InputMaybe<Scalars['String']['input']>;
   buildProfile: Scalars['String']['input'];
+  environment?: InputMaybe<EnvironmentVariableEnvironment>;
   gitRef: Scalars['String']['input'];
   platform: AppPlatform;
   /** Repack the golden dev client build instead of running full build process. Used for onboarding. Do not use outside of onboarding flow, as for now it's only created with this specific use case in mind. */
@@ -3921,6 +4131,7 @@ export type GitHubBuildTrigger = {
   autoSubmit: Scalars['Boolean']['output'];
   buildProfile: Scalars['String']['output'];
   createdAt: Scalars['DateTime']['output'];
+  environment?: Maybe<EnvironmentVariableEnvironment>;
   executionBehavior: GitHubBuildTriggerExecutionBehavior;
   id: Scalars['ID']['output'];
   isActive: Scalars['Boolean']['output'];
@@ -3939,7 +4150,7 @@ export type GitHubBuildTrigger = {
 
 export enum GitHubBuildTriggerExecutionBehavior {
   Always = 'ALWAYS',
-  BaseDirectoryChanged = 'BASE_DIRECTORY_CHANGED',
+  BaseDirectoryChanged = 'BASE_DIRECTORY_CHANGED'
 }
 
 export type GitHubBuildTriggerMutation = {
@@ -3952,13 +4163,16 @@ export type GitHubBuildTriggerMutation = {
   updateGitHubBuildTrigger: GitHubBuildTrigger;
 };
 
+
 export type GitHubBuildTriggerMutationCreateGitHubBuildTriggerArgs = {
   githubBuildTriggerData: CreateGitHubBuildTriggerInput;
 };
 
+
 export type GitHubBuildTriggerMutationDeleteGitHubBuildTriggerArgs = {
   githubBuildTriggerId: Scalars['ID']['input'];
 };
+
 
 export type GitHubBuildTriggerMutationUpdateGitHubBuildTriggerArgs = {
   githubBuildTriggerData: UpdateGitHubBuildTriggerInput;
@@ -3967,17 +4181,17 @@ export type GitHubBuildTriggerMutationUpdateGitHubBuildTriggerArgs = {
 
 export enum GitHubBuildTriggerRunStatus {
   Errored = 'ERRORED',
-  Success = 'SUCCESS',
+  Success = 'SUCCESS'
 }
 
 export enum GitHubBuildTriggerType {
   PullRequestUpdated = 'PULL_REQUEST_UPDATED',
   PushToBranch = 'PUSH_TO_BRANCH',
-  TagUpdated = 'TAG_UPDATED',
+  TagUpdated = 'TAG_UPDATED'
 }
 
 export enum GitHubJobRunJobType {
-  PublishUpdate = 'PUBLISH_UPDATE',
+  PublishUpdate = 'PUBLISH_UPDATE'
 }
 
 export type GitHubJobRunTrigger = {
@@ -4003,13 +4217,16 @@ export type GitHubJobRunTriggerMutation = {
   updateGitHubJobRunTrigger: GitHubJobRunTrigger;
 };
 
+
 export type GitHubJobRunTriggerMutationCreateGitHubJobRunTriggerArgs = {
   gitHubJobRunTriggerData: CreateGitHubJobRunTriggerInput;
 };
 
+
 export type GitHubJobRunTriggerMutationDeleteGitHubJobRunTriggerArgs = {
   gitHubJobRunTriggerId: Scalars['ID']['input'];
 };
+
 
 export type GitHubJobRunTriggerMutationUpdateGitHubJobRunTriggerArgs = {
   gitHubJobRunTriggerData: UpdateGitHubJobRunTriggerInput;
@@ -4018,12 +4235,12 @@ export type GitHubJobRunTriggerMutationUpdateGitHubJobRunTriggerArgs = {
 
 export enum GitHubJobRunTriggerRunStatus {
   Errored = 'ERRORED',
-  Success = 'SUCCESS',
+  Success = 'SUCCESS'
 }
 
 export enum GitHubJobRunTriggerType {
   PullRequestUpdated = 'PULL_REQUEST_UPDATED',
-  PushToBranch = 'PUSH_TO_BRANCH',
+  PushToBranch = 'PUSH_TO_BRANCH'
 }
 
 export type GitHubRepository = {
@@ -4060,13 +4277,16 @@ export type GitHubRepositoryMutation = {
   deleteGitHubRepository: GitHubRepository;
 };
 
+
 export type GitHubRepositoryMutationConfigureEasArgs = {
   githubRepositoryId: Scalars['ID']['input'];
 };
 
+
 export type GitHubRepositoryMutationCreateGitHubRepositoryArgs = {
   githubRepositoryData: CreateGitHubRepositoryInput;
 };
+
 
 export type GitHubRepositoryMutationDeleteGitHubRepositoryArgs = {
   githubRepositoryId: Scalars['ID']['input'];
@@ -4103,13 +4323,16 @@ export type GitHubRepositorySettingsMutation = {
   updateGitHubRepositorySettings: GitHubRepositorySettings;
 };
 
+
 export type GitHubRepositorySettingsMutationCreateGitHubRepositorySettingsArgs = {
   githubRepositorySettingsData: CreateGitHubRepositorySettingsInput;
 };
 
+
 export type GitHubRepositorySettingsMutationDeleteGitHubRepositorySettingsArgs = {
   githubRepositorySettingsId: Scalars['ID']['input'];
 };
+
 
 export type GitHubRepositorySettingsMutationUpdateGitHubRepositorySettingsArgs = {
   githubRepositorySettingsData: UpdateGitHubRepositorySettingsInput;
@@ -4140,6 +4363,7 @@ export type GitHubUserMutation = {
   generateGitHubUserAccessToken?: Maybe<Scalars['String']['output']>;
 };
 
+
 export type GitHubUserMutationDeleteGitHubUserArgs = {
   id: Scalars['ID']['input'];
 };
@@ -4168,10 +4392,12 @@ export type GoogleServiceAccountKeyMutation = {
   deleteGoogleServiceAccountKey: DeleteGoogleServiceAccountKeyResult;
 };
 
+
 export type GoogleServiceAccountKeyMutationCreateGoogleServiceAccountKeyArgs = {
   accountId: Scalars['ID']['input'];
   googleServiceAccountKeyInput: GoogleServiceAccountKeyInput;
 };
+
 
 export type GoogleServiceAccountKeyMutationDeleteGoogleServiceAccountKeyArgs = {
   id: Scalars['ID']['input'];
@@ -4187,7 +4413,7 @@ export type InsightsFilter = {
 };
 
 export enum InsightsFilterType {
-  Platform = 'PLATFORM',
+  Platform = 'PLATFORM'
 }
 
 export type InsightsTimespan = {
@@ -4226,7 +4452,7 @@ export type InvoiceDiscount = {
 
 export enum InvoiceDiscountType {
   Amount = 'AMOUNT',
-  Percentage = 'PERCENTAGE',
+  Percentage = 'PERCENTAGE'
 }
 
 export type InvoiceLineItem = {
@@ -4272,10 +4498,12 @@ export type InvoiceQuery = {
   previewInvoiceForSubscriptionUpdate: Invoice;
 };
 
+
 export type InvoiceQueryPreviewInvoiceForAdditionalConcurrenciesCountUpdateArgs = {
   accountID: Scalars['ID']['input'];
   additionalConcurrenciesCount: Scalars['Int']['input'];
 };
+
 
 export type InvoiceQueryPreviewInvoiceForSubscriptionUpdateArgs = {
   accountId: Scalars['String']['input'];
@@ -4316,19 +4544,23 @@ export type IosAppBuildCredentialsMutation = {
   setProvisioningProfile: IosAppBuildCredentials;
 };
 
+
 export type IosAppBuildCredentialsMutationCreateIosAppBuildCredentialsArgs = {
   iosAppBuildCredentialsInput: IosAppBuildCredentialsInput;
   iosAppCredentialsId: Scalars['ID']['input'];
 };
 
+
 export type IosAppBuildCredentialsMutationDeleteIosAppBuildCredentialsArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type IosAppBuildCredentialsMutationSetDistributionCertificateArgs = {
   distributionCertificateId: Scalars['ID']['input'];
   id: Scalars['ID']['input'];
 };
+
 
 export type IosAppBuildCredentialsMutationSetProvisioningProfileArgs = {
   id: Scalars['ID']['input'];
@@ -4349,9 +4581,11 @@ export type IosAppCredentials = {
   pushKey?: Maybe<ApplePushKey>;
 };
 
+
 export type IosAppCredentialsIosAppBuildCredentialsArrayArgs = {
   filter?: InputMaybe<IosAppBuildCredentialsFilter>;
 };
+
 
 export type IosAppCredentialsIosAppBuildCredentialsListArgs = {
   filter?: InputMaybe<IosAppBuildCredentialsFilter>;
@@ -4382,25 +4616,30 @@ export type IosAppCredentialsMutation = {
   updateIosAppCredentials: IosAppCredentials;
 };
 
+
 export type IosAppCredentialsMutationCreateIosAppCredentialsArgs = {
   appId: Scalars['ID']['input'];
   appleAppIdentifierId: Scalars['ID']['input'];
   iosAppCredentialsInput: IosAppCredentialsInput;
 };
 
+
 export type IosAppCredentialsMutationDeleteIosAppCredentialsArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type IosAppCredentialsMutationSetAppStoreConnectApiKeyForSubmissionsArgs = {
   ascApiKeyId: Scalars['ID']['input'];
   id: Scalars['ID']['input'];
 };
 
+
 export type IosAppCredentialsMutationSetPushKeyArgs = {
   id: Scalars['ID']['input'];
   pushKeyId: Scalars['ID']['input'];
 };
+
 
 export type IosAppCredentialsMutationUpdateIosAppCredentialsArgs = {
   id: Scalars['ID']['input'];
@@ -4410,7 +4649,7 @@ export type IosAppCredentialsMutationUpdateIosAppCredentialsArgs = {
 /** @deprecated Use developmentClient option instead. */
 export enum IosBuildType {
   DevelopmentClient = 'DEVELOPMENT_CLIENT',
-  Release = 'RELEASE',
+  Release = 'RELEASE'
 }
 
 export type IosBuilderEnvironmentInput = {
@@ -4430,7 +4669,7 @@ export enum IosDistributionType {
   AdHoc = 'AD_HOC',
   AppStore = 'APP_STORE',
   Development = 'DEVELOPMENT',
-  Enterprise = 'ENTERPRISE',
+  Enterprise = 'ENTERPRISE'
 }
 
 export type IosJobDistributionCertificateInput = {
@@ -4516,12 +4755,12 @@ export type IosJobVersionInput = {
 /** @deprecated Use developmentClient option instead. */
 export enum IosManagedBuildType {
   DevelopmentClient = 'DEVELOPMENT_CLIENT',
-  Release = 'RELEASE',
+  Release = 'RELEASE'
 }
 
 export enum IosSchemeBuildConfiguration {
   Debug = 'DEBUG',
-  Release = 'RELEASE',
+  Release = 'RELEASE'
 }
 
 export type IosSubmissionConfig = {
@@ -4571,13 +4810,14 @@ export type JobRunMutation = {
   cancelJobRun: JobRun;
 };
 
+
 export type JobRunMutationCancelJobRunArgs = {
   jobRunId: Scalars['ID']['input'];
 };
 
 export enum JobRunPriority {
   High = 'HIGH',
-  Normal = 'NORMAL',
+  Normal = 'NORMAL'
 }
 
 export type JobRunQuery = {
@@ -4585,6 +4825,7 @@ export type JobRunQuery = {
   /** Look up EAS Job Run by ID */
   byId: JobRun;
 };
+
 
 export type JobRunQueryByIdArgs = {
   jobRunId: Scalars['ID']['input'];
@@ -4597,7 +4838,7 @@ export enum JobRunStatus {
   InProgress = 'IN_PROGRESS',
   InQueue = 'IN_QUEUE',
   New = 'NEW',
-  PendingCancel = 'PENDING_CANCEL',
+  PendingCancel = 'PENDING_CANCEL'
 }
 
 export type KeystoreGenerationUrl = {
@@ -4629,6 +4870,13 @@ export type LineChartData = {
   labels: Array<Scalars['String']['output']>;
 };
 
+export type LineDatapoint = {
+  __typename?: 'LineDatapoint';
+  data: Scalars['Int']['output'];
+  id: Scalars['ID']['output'];
+  label: Scalars['String']['output'];
+};
+
 export type LineDataset = {
   __typename?: 'LineDataset';
   data: Array<Maybe<Scalars['Int']['output']>>;
@@ -4649,14 +4897,14 @@ export type LogsTimespan = {
 
 export enum MailchimpAudience {
   ExpoDevelopers = 'EXPO_DEVELOPERS',
-  ExpoDeveloperOnboarding = 'EXPO_DEVELOPER_ONBOARDING',
+  ExpoDeveloperOnboarding = 'EXPO_DEVELOPER_ONBOARDING'
 }
 
 export enum MailchimpTag {
   DevClientUsers = 'DEV_CLIENT_USERS',
   DidSubscribeToEasAtLeastOnce = 'DID_SUBSCRIBE_TO_EAS_AT_LEAST_ONCE',
   EasMasterList = 'EAS_MASTER_LIST',
-  NewsletterSignupList = 'NEWSLETTER_SIGNUP_LIST',
+  NewsletterSignupList = 'NEWSLETTER_SIGNUP_LIST'
 }
 
 export type MailchimpTagPayload = {
@@ -4716,85 +4964,105 @@ export type MeMutation = {
   updateSSOProfile: SsoUser;
 };
 
+
 export type MeMutationAddSecondFactorDeviceArgs = {
   deviceConfiguration: SecondFactorDeviceConfiguration;
   otp?: InputMaybe<Scalars['String']['input']>;
 };
 
+
 export type MeMutationCertifySecondFactorDeviceArgs = {
   otp: Scalars['String']['input'];
 };
+
 
 export type MeMutationCreateAccountArgs = {
   accountData: AccountDataInput;
 };
 
+
 export type MeMutationDeleteAccountArgs = {
   accountId: Scalars['ID']['input'];
 };
 
+
 export type MeMutationDeleteSsoUserArgs = {
   ssoUserId: Scalars['ID']['input'];
 };
+
 
 export type MeMutationDeleteSecondFactorDeviceArgs = {
   otp?: InputMaybe<Scalars['String']['input']>;
   userSecondFactorDeviceId: Scalars['ID']['input'];
 };
 
+
 export type MeMutationDeleteSnackArgs = {
   snackId: Scalars['ID']['input'];
 };
 
+
 export type MeMutationDisableSecondFactorAuthenticationArgs = {
   otp?: InputMaybe<Scalars['String']['input']>;
 };
+
 
 export type MeMutationInitiateSecondFactorAuthenticationArgs = {
   deviceConfigurations: Array<SecondFactorDeviceConfiguration>;
   recaptchaResponseToken?: InputMaybe<Scalars['String']['input']>;
 };
 
+
 export type MeMutationLeaveAccountArgs = {
   accountId: Scalars['ID']['input'];
 };
+
 
 export type MeMutationRegenerateSecondFactorBackupCodesArgs = {
   otp?: InputMaybe<Scalars['String']['input']>;
 };
 
+
 export type MeMutationScheduleAccountDeletionArgs = {
   accountId: Scalars['ID']['input'];
 };
+
 
 export type MeMutationScheduleSsoUserDeletionAsSsoAccountOwnerArgs = {
   ssoUserId: Scalars['ID']['input'];
 };
 
+
 export type MeMutationSendSmsotpToSecondFactorDeviceArgs = {
   userSecondFactorDeviceId: Scalars['ID']['input'];
 };
+
 
 export type MeMutationSetPreferencesArgs = {
   preferences: UserPreferencesInput;
 };
 
+
 export type MeMutationSetPrimarySecondFactorDeviceArgs = {
   userSecondFactorDeviceId: Scalars['ID']['input'];
 };
+
 
 export type MeMutationTransferAppArgs = {
   appId: Scalars['ID']['input'];
   destinationAccountId: Scalars['ID']['input'];
 };
 
+
 export type MeMutationUpdateAppArgs = {
   appData: AppDataInput;
 };
 
+
 export type MeMutationUpdateProfileArgs = {
   userData: UserDataInput;
 };
+
 
 export type MeMutationUpdateSsoProfileArgs = {
   userData: SsoUserDataInput;
@@ -4831,13 +5099,10 @@ export enum NotificationEvent {
   BuildPlanCreditThresholdExceeded = 'BUILD_PLAN_CREDIT_THRESHOLD_EXCEEDED',
   SubmissionComplete = 'SUBMISSION_COMPLETE',
   SubmissionErrored = 'SUBMISSION_ERRORED',
-  Test = 'TEST',
+  Test = 'TEST'
 }
 
-export type NotificationMetadata =
-  | BuildLimitThresholdExceededMetadata
-  | BuildPlanCreditThresholdExceededMetadata
-  | TestNotificationMetadata;
+export type NotificationMetadata = BuildLimitThresholdExceededMetadata | BuildPlanCreditThresholdExceededMetadata | TestNotificationMetadata;
 
 export type NotificationSubscription = {
   __typename?: 'NotificationSubscription';
@@ -4864,13 +5129,16 @@ export type NotificationSubscriptionMutation = {
   unsubscribe: UnsubscribeFromNotificationResult;
 };
 
+
 export type NotificationSubscriptionMutationSubscribeToEventForAccountArgs = {
   input: AccountNotificationSubscriptionInput;
 };
 
+
 export type NotificationSubscriptionMutationSubscribeToEventForAppArgs = {
   input: AppNotificationSubscriptionInput;
 };
+
 
 export type NotificationSubscriptionMutationUnsubscribeArgs = {
   id: Scalars['ID']['input'];
@@ -4886,7 +5154,7 @@ export type NotificationThresholdExceeded = {
 
 export enum NotificationType {
   Email = 'EMAIL',
-  Web = 'WEB',
+  Web = 'WEB'
 }
 
 export type NotificationsSentOverTimeData = {
@@ -4918,22 +5186,22 @@ export enum OfferType {
   /** Advanced Purchase of Paid Resource */
   Prepaid = 'PREPAID',
   /** Term subscription */
-  Subscription = 'SUBSCRIPTION',
+  Subscription = 'SUBSCRIPTION'
 }
 
 export enum OnboardingDeviceType {
   Device = 'DEVICE',
-  Simulator = 'SIMULATOR',
+  Simulator = 'SIMULATOR'
 }
 
 export enum OnboardingEnvironment {
   DevBuild = 'DEV_BUILD',
-  ExpoGo = 'EXPO_GO',
+  ExpoGo = 'EXPO_GO'
 }
 
 export enum Order {
   Asc = 'ASC',
-  Desc = 'DESC',
+  Desc = 'DESC'
 }
 
 export type PageInfo = {
@@ -4969,7 +5237,7 @@ export enum Permission {
   Admin = 'ADMIN',
   Own = 'OWN',
   Publish = 'PUBLISH',
-  View = 'VIEW',
+  View = 'VIEW'
 }
 
 export type PlanEnablement = Concurrencies | EasTotalPlanEnablement;
@@ -5001,7 +5269,7 @@ export enum ProjectArchiveSourceType {
   Git = 'GIT',
   None = 'NONE',
   S3 = 'S3',
-  Url = 'URL',
+  Url = 'URL'
 }
 
 export type ProjectPublicData = {
@@ -5015,6 +5283,7 @@ export type ProjectQuery = {
   /** @deprecated See byAccountNameAndSlug */
   byUsernameAndSlug: Project;
 };
+
 
 export type ProjectQueryByUsernameAndSlugArgs = {
   platform?: InputMaybe<Scalars['String']['input']>;
@@ -5038,6 +5307,7 @@ export type PublishUpdateGroupInput = {
   message?: InputMaybe<Scalars['String']['input']>;
   rollBackToEmbeddedInfoGroup?: InputMaybe<UpdateRollBackToEmbeddedGroup>;
   rolloutInfoGroup?: InputMaybe<UpdateRolloutInfoGroup>;
+  runtimeFingerprintSource?: InputMaybe<FingerprintSourceInput>;
   runtimeVersion: Scalars['String']['input'];
   turtleJobRunId?: InputMaybe<Scalars['String']['input']>;
   updateInfoGroup?: InputMaybe<UpdateInfoGroup>;
@@ -5047,7 +5317,7 @@ export enum RequestStatusPattern {
   Http_2Xx = 'HTTP_2XX',
   Http_3Xx = 'HTTP_3XX',
   Http_4Xx = 'HTTP_4XX',
-  Http_5Xx = 'HTTP_5XX',
+  Http_5Xx = 'HTTP_5XX'
 }
 
 export type RequestsTimespan = {
@@ -5062,6 +5332,7 @@ export type RescindUserInvitationResult = {
 
 export enum ResourceClassExperiment {
   C3D = 'C3D',
+  N2 = 'N2'
 }
 
 /** Represents a robot (not human) actor. */
@@ -5086,6 +5357,7 @@ export type Robot = Actor & {
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
 };
 
+
 /** Represents a robot (not human) actor. */
 export type RobotFeatureGatesArgs = {
   filter?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -5107,19 +5379,23 @@ export type RobotMutation = {
   updateRobot: Robot;
 };
 
+
 export type RobotMutationCreateRobotForAccountArgs = {
   accountID: Scalars['String']['input'];
   permissions: Array<InputMaybe<Permission>>;
   robotData?: InputMaybe<RobotDataInput>;
 };
 
+
 export type RobotMutationDeleteRobotArgs = {
   id: Scalars['String']['input'];
 };
 
+
 export type RobotMutationScheduleRobotDeletionArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type RobotMutationUpdateRobotArgs = {
   id: Scalars['String']['input'];
@@ -5133,7 +5409,7 @@ export enum Role {
   HasAdmin = 'HAS_ADMIN',
   NotAdmin = 'NOT_ADMIN',
   Owner = 'OWNER',
-  ViewOnly = 'VIEW_ONLY',
+  ViewOnly = 'VIEW_ONLY'
 }
 
 export type RootMutation = {
@@ -5242,13 +5518,16 @@ export type RootMutation = {
   websiteNotifications: WebsiteNotificationMutation;
 };
 
+
 export type RootMutationAccountArgs = {
   accountName?: InputMaybe<Scalars['ID']['input']>;
 };
 
+
 export type RootMutationAppArgs = {
   appId?: InputMaybe<Scalars['ID']['input']>;
 };
+
 
 export type RootMutationBuildArgs = {
   buildId?: InputMaybe<Scalars['ID']['input']>;
@@ -5354,6 +5633,7 @@ export type RootQuery = {
   workerDeployment: WorkerDeploymentQuery;
 };
 
+
 export type RootQueryAllPublicAppsArgs = {
   filter: AppsFilter;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -5361,17 +5641,21 @@ export type RootQueryAllPublicAppsArgs = {
   sort: AppSort;
 };
 
+
 export type RootQueryAppByAppIdArgs = {
   appId: Scalars['String']['input'];
 };
+
 
 export type RootQueryUpdatesByGroupArgs = {
   group: Scalars['ID']['input'];
 };
 
+
 export type RootQueryUserByUserIdArgs = {
   userId: Scalars['String']['input'];
 };
+
 
 export type RootQueryUserByUsernameArgs = {
   username: Scalars['String']['input'];
@@ -5380,6 +5664,7 @@ export type RootQueryUserByUsernameArgs = {
 export type Runtime = {
   __typename?: 'Runtime';
   app: App;
+  fingerprintDebugInfoUrl?: Maybe<Scalars['String']['output']>;
   firstBuildCreatedAt: Scalars['DateTime']['output'];
   id: Scalars['ID']['output'];
   version: Scalars['String']['output'];
@@ -5404,58 +5689,58 @@ export type RuntimesConnection = {
 };
 
 /** Represents a human SSO (not robot) actor. */
-export type SsoUser = Actor &
-  UserActor & {
-    __typename?: 'SSOUser';
-    /** Access Tokens belonging to this actor, none at present */
-    accessTokens: Array<AccessToken>;
-    accounts: Array<Account>;
-    /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
-    activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
-    appCount: Scalars['Int']['output'];
-    /** @deprecated No longer supported */
-    appetizeCode?: Maybe<Scalars['String']['output']>;
-    /** Apps this user has published. If this user is the viewer, this field returns the apps the user has access to. */
-    apps: Array<App>;
-    bestContactEmail?: Maybe<Scalars['String']['output']>;
-    created: Scalars['DateTime']['output'];
-    /** Discord account linked to a user */
-    discordUser?: Maybe<DiscordUser>;
-    displayName: Scalars['String']['output'];
-    /** Experiments associated with this actor */
-    experiments: Array<ActorExperiment>;
-    /**
-     * Server feature gate values for this actor, optionally filtering by desired gates.
-     * Only resolves for the viewer.
-     */
-    featureGates: Scalars['JSONObject']['output'];
-    firstName?: Maybe<Scalars['String']['output']>;
-    fullName?: Maybe<Scalars['String']['output']>;
-    /** GitHub account linked to a user */
-    githubUser?: Maybe<GitHubUser>;
-    /** @deprecated No longer supported */
-    githubUsername?: Maybe<Scalars['String']['output']>;
-    id: Scalars['ID']['output'];
-    /** @deprecated No longer supported */
-    industry?: Maybe<Scalars['String']['output']>;
-    isExpoAdmin: Scalars['Boolean']['output'];
-    lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
-    lastName?: Maybe<Scalars['String']['output']>;
-    /** @deprecated No longer supported */
-    location?: Maybe<Scalars['String']['output']>;
-    notificationSubscriptions: Array<NotificationSubscription>;
-    pinnedApps: Array<App>;
-    preferences: UserPreferences;
-    /** Associated accounts */
-    primaryAccount: Account;
-    profilePhoto: Scalars['String']['output'];
-    /** Snacks associated with this account */
-    snacks: Array<Snack>;
-    /** @deprecated No longer supported */
-    twitterUsername?: Maybe<Scalars['String']['output']>;
-    username: Scalars['String']['output'];
-    websiteNotificationsPaginated: WebsiteNotificationsConnection;
-  };
+export type SsoUser = Actor & UserActor & {
+  __typename?: 'SSOUser';
+  /** Access Tokens belonging to this actor, none at present */
+  accessTokens: Array<AccessToken>;
+  accounts: Array<Account>;
+  /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
+  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
+  appCount: Scalars['Int']['output'];
+  /** @deprecated No longer supported */
+  appetizeCode?: Maybe<Scalars['String']['output']>;
+  /** Apps this user has published. If this user is the viewer, this field returns the apps the user has access to. */
+  apps: Array<App>;
+  bestContactEmail?: Maybe<Scalars['String']['output']>;
+  created: Scalars['DateTime']['output'];
+  /** Discord account linked to a user */
+  discordUser?: Maybe<DiscordUser>;
+  displayName: Scalars['String']['output'];
+  /** Experiments associated with this actor */
+  experiments: Array<ActorExperiment>;
+  /**
+   * Server feature gate values for this actor, optionally filtering by desired gates.
+   * Only resolves for the viewer.
+   */
+  featureGates: Scalars['JSONObject']['output'];
+  firstName?: Maybe<Scalars['String']['output']>;
+  fullName?: Maybe<Scalars['String']['output']>;
+  /** GitHub account linked to a user */
+  githubUser?: Maybe<GitHubUser>;
+  /** @deprecated No longer supported */
+  githubUsername?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  /** @deprecated No longer supported */
+  industry?: Maybe<Scalars['String']['output']>;
+  isExpoAdmin: Scalars['Boolean']['output'];
+  lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
+  lastName?: Maybe<Scalars['String']['output']>;
+  /** @deprecated No longer supported */
+  location?: Maybe<Scalars['String']['output']>;
+  notificationSubscriptions: Array<NotificationSubscription>;
+  pinnedApps: Array<App>;
+  preferences: UserPreferences;
+  /** Associated accounts */
+  primaryAccount: Account;
+  profilePhoto: Scalars['String']['output'];
+  /** Snacks associated with this account */
+  snacks: Array<Snack>;
+  /** @deprecated No longer supported */
+  twitterUsername?: Maybe<Scalars['String']['output']>;
+  username: Scalars['String']['output'];
+  websiteNotificationsPaginated: WebsiteNotificationsConnection;
+};
+
 
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserActivityTimelineProjectActivitiesArgs = {
@@ -5464,6 +5749,7 @@ export type SsoUserActivityTimelineProjectActivitiesArgs = {
   limit: Scalars['Int']['input'];
 };
 
+
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserAppsArgs = {
   includeUnpublished?: InputMaybe<Scalars['Boolean']['input']>;
@@ -5471,21 +5757,25 @@ export type SsoUserAppsArgs = {
   offset: Scalars['Int']['input'];
 };
 
+
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserFeatureGatesArgs = {
   filter?: InputMaybe<Array<Scalars['String']['input']>>;
 };
+
 
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserNotificationSubscriptionsArgs = {
   filter?: InputMaybe<NotificationSubscriptionFilter>;
 };
 
+
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserSnacksArgs = {
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
 };
+
 
 /** Represents a human SSO (not robot) actor. */
 export type SsoUserWebsiteNotificationsPaginatedArgs = {
@@ -5529,7 +5819,7 @@ export enum SecondFactorMethod {
   /** Google Authenticator (TOTP) */
   Authenticator = 'AUTHENTICATOR',
   /** SMS */
-  Sms = 'SMS',
+  Sms = 'SMS'
 }
 
 export type SecondFactorRegenerateBackupCodesResult = {
@@ -5547,10 +5837,12 @@ export type ServerlessFunctionMutation = {
   createUploadPresignedUrl: CreateServerlessFunctionUploadUrlResult;
 };
 
+
 export type ServerlessFunctionMutationCreateDeploymentArgs = {
   appId: Scalars['ID']['input'];
   serverlessFunctionIdentifierInput: ServerlessFunctionIdentifierInput;
 };
+
 
 export type ServerlessFunctionMutationCreateUploadPresignedUrlArgs = {
   appId: Scalars['ID']['input'];
@@ -5595,9 +5887,11 @@ export type SnackQuery = {
   byId: Snack;
 };
 
+
 export type SnackQueryByHashIdArgs = {
   hashId: Scalars['ID']['input'];
 };
+
 
 export type SnackQueryByIdArgs = {
   id: Scalars['ID']['input'];
@@ -5611,7 +5905,7 @@ export enum StandardOffer {
   /** $29 USD per month, 1 year trial */
   YcDeals = 'YC_DEALS',
   /** $348 USD per year, 30 day trial */
-  YearlySub = 'YEARLY_SUB',
+  YearlySub = 'YEARLY_SUB'
 }
 
 /** Incident for a given component from Expo status page API. */
@@ -5638,7 +5932,7 @@ export enum StatuspageIncidentImpact {
   Maintenance = 'MAINTENANCE',
   Major = 'MAJOR',
   Minor = 'MINOR',
-  None = 'NONE',
+  None = 'NONE'
 }
 
 /** Possible Incident statuses from Expo status page API. */
@@ -5650,7 +5944,7 @@ export enum StatuspageIncidentStatus {
   Monitoring = 'MONITORING',
   Resolved = 'RESOLVED',
   Scheduled = 'SCHEDULED',
-  Verifying = 'VERIFYING',
+  Verifying = 'VERIFYING'
 }
 
 /** Update for an Incident from Expo status page API. */
@@ -5687,7 +5981,7 @@ export enum StatuspageServiceName {
   EasSubmit = 'EAS_SUBMIT',
   EasUpdate = 'EAS_UPDATE',
   GithubApiRequests = 'GITHUB_API_REQUESTS',
-  GithubWebhooks = 'GITHUB_WEBHOOKS',
+  GithubWebhooks = 'GITHUB_WEBHOOKS'
 }
 
 export type StatuspageServiceQuery = {
@@ -5695,6 +5989,7 @@ export type StatuspageServiceQuery = {
   /** Query services from Expo status page by names. */
   byServiceNames: Array<StatuspageService>;
 };
+
 
 export type StatuspageServiceQueryByServiceNamesArgs = {
   serviceNames: Array<StatuspageServiceName>;
@@ -5706,7 +6001,7 @@ export enum StatuspageServiceStatus {
   MajorOutage = 'MAJOR_OUTAGE',
   Operational = 'OPERATIONAL',
   PartialOutage = 'PARTIAL_OUTAGE',
-  UnderMaintenance = 'UNDER_MAINTENANCE',
+  UnderMaintenance = 'UNDER_MAINTENANCE'
 }
 
 export type StripeCoupon = {
@@ -5756,21 +6051,21 @@ export type Submission = ActivityTimelineProjectActivity & {
 
 export enum SubmissionAndroidArchiveType {
   Aab = 'AAB',
-  Apk = 'APK',
+  Apk = 'APK'
 }
 
 export enum SubmissionAndroidReleaseStatus {
   Completed = 'COMPLETED',
   Draft = 'DRAFT',
   Halted = 'HALTED',
-  InProgress = 'IN_PROGRESS',
+  InProgress = 'IN_PROGRESS'
 }
 
 export enum SubmissionAndroidTrack {
   Alpha = 'ALPHA',
   Beta = 'BETA',
   Internal = 'INTERNAL',
-  Production = 'PRODUCTION',
+  Production = 'PRODUCTION'
 }
 
 export type SubmissionArchiveSourceInput = {
@@ -5784,7 +6079,7 @@ export type SubmissionArchiveSourceInput = {
 export enum SubmissionArchiveSourceType {
   GcsBuildApplicationArchive = 'GCS_BUILD_APPLICATION_ARCHIVE',
   GcsSubmitArchive = 'GCS_SUBMIT_ARCHIVE',
-  Url = 'URL',
+  Url = 'URL'
 }
 
 export type SubmissionError = {
@@ -5810,17 +6105,21 @@ export type SubmissionMutation = {
   retrySubmission: CreateSubmissionResult;
 };
 
+
 export type SubmissionMutationCancelSubmissionArgs = {
   submissionId: Scalars['ID']['input'];
 };
+
 
 export type SubmissionMutationCreateAndroidSubmissionArgs = {
   input: CreateAndroidSubmissionInput;
 };
 
+
 export type SubmissionMutationCreateIosSubmissionArgs = {
   input: CreateIosSubmissionInput;
 };
+
 
 export type SubmissionMutationRetrySubmissionArgs = {
   parentSubmissionId: Scalars['ID']['input'];
@@ -5828,7 +6127,7 @@ export type SubmissionMutationRetrySubmissionArgs = {
 
 export enum SubmissionPriority {
   High = 'HIGH',
-  Normal = 'NORMAL',
+  Normal = 'NORMAL'
 }
 
 export type SubmissionQuery = {
@@ -5836,6 +6135,7 @@ export type SubmissionQuery = {
   /** Look up EAS Submission by submission ID */
   byId: Submission;
 };
+
 
 export type SubmissionQueryByIdArgs = {
   submissionId: Scalars['ID']['input'];
@@ -5847,7 +6147,7 @@ export enum SubmissionStatus {
   Errored = 'ERRORED',
   Finished = 'FINISHED',
   InProgress = 'IN_PROGRESS',
-  InQueue = 'IN_QUEUE',
+  InQueue = 'IN_QUEUE'
 }
 
 export type SubscribeToNotificationResult = {
@@ -5879,6 +6179,7 @@ export type SubscriptionDetails = {
   willCancel?: Maybe<Scalars['Boolean']['output']>;
 };
 
+
 export type SubscriptionDetailsPlanEnablementArgs = {
   serviceMetric: EasServiceMetric;
 };
@@ -5886,7 +6187,7 @@ export type SubscriptionDetailsPlanEnablementArgs = {
 export enum TargetEntityMutationType {
   Create = 'CREATE',
   Delete = 'DELETE',
-  Update = 'UPDATE',
+  Update = 'UPDATE'
 }
 
 export type TestNotificationMetadata = {
@@ -5968,6 +6269,7 @@ export type UpdateBranch = {
   updates: Array<Update>;
 };
 
+
 export type UpdateBranchRuntimesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -5976,11 +6278,13 @@ export type UpdateBranchRuntimesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type UpdateBranchUpdateGroupsArgs = {
   filter?: InputMaybe<UpdatesFilter>;
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
 };
+
 
 export type UpdateBranchUpdatesArgs = {
   filter?: InputMaybe<UpdatesFilter>;
@@ -6003,18 +6307,22 @@ export type UpdateBranchMutation = {
   publishUpdateGroups: Array<Update>;
 };
 
+
 export type UpdateBranchMutationCreateUpdateBranchForAppArgs = {
   appId: Scalars['ID']['input'];
   name: Scalars['String']['input'];
 };
 
+
 export type UpdateBranchMutationDeleteUpdateBranchArgs = {
   branchId: Scalars['ID']['input'];
 };
 
+
 export type UpdateBranchMutationEditUpdateBranchArgs = {
   input: EditUpdateBranchInput;
 };
+
 
 export type UpdateBranchMutationPublishUpdateGroupsArgs = {
   publishUpdateGroupsInput: Array<PublishUpdateGroupInput>;
@@ -6031,6 +6339,7 @@ export type UpdateChannel = {
   updateBranches: Array<UpdateBranch>;
   updatedAt: Scalars['DateTime']['output'];
 };
+
 
 export type UpdateChannelUpdateBranchesArgs = {
   limit: Scalars['Int']['input'];
@@ -6057,15 +6366,18 @@ export type UpdateChannelMutation = {
   editUpdateChannel: UpdateChannel;
 };
 
+
 export type UpdateChannelMutationCreateUpdateChannelForAppArgs = {
   appId: Scalars['ID']['input'];
   branchMapping?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
 };
 
+
 export type UpdateChannelMutationDeleteUpdateChannelArgs = {
   channelId: Scalars['ID']['input'];
 };
+
 
 export type UpdateChannelMutationEditUpdateChannelArgs = {
   branchMapping: Scalars['String']['input'];
@@ -6075,6 +6387,7 @@ export type UpdateChannelMutationEditUpdateChannelArgs = {
 export type UpdateGitHubBuildTriggerInput = {
   autoSubmit: Scalars['Boolean']['input'];
   buildProfile: Scalars['String']['input'];
+  environment?: InputMaybe<EnvironmentVariableEnvironment>;
   executionBehavior: GitHubBuildTriggerExecutionBehavior;
   isActive: Scalars['Boolean']['input'];
   platform: AppPlatform;
@@ -6106,6 +6419,7 @@ export type UpdateInsights = {
   totalUniqueUsers: Scalars['Int']['output'];
 };
 
+
 export type UpdateInsightsTotalUniqueUsersArgs = {
   timespan: InsightsTimespan;
 };
@@ -6120,14 +6434,17 @@ export type UpdateMutation = {
   setRolloutPercentage: Update;
 };
 
+
 export type UpdateMutationDeleteUpdateGroupArgs = {
   group: Scalars['ID']['input'];
 };
+
 
 export type UpdateMutationSetCodeSigningInfoArgs = {
   codeSigningInfo: CodeSigningInfoInput;
   updateId: Scalars['ID']['input'];
 };
+
 
 export type UpdateMutationSetRolloutPercentageArgs = {
   percentage: Scalars['Int']['input'];
@@ -6139,6 +6456,7 @@ export type UpdateQuery = {
   /** Query an Update by ID */
   byId: Update;
 };
+
 
 export type UpdateQueryByIdArgs = {
   updateId: Scalars['ID']['input'];
@@ -6173,6 +6491,7 @@ export type UploadSession = {
   createUploadSession: Scalars['JSONObject']['output'];
 };
 
+
 export type UploadSessionCreateUploadSessionArgs = {
   type: UploadSessionType;
 };
@@ -6185,7 +6504,7 @@ export enum UploadSessionType {
   /** @deprecated Use EAS_SUBMIT_GCS_APP_ARCHIVE instead. */
   EasSubmitAppArchive = 'EAS_SUBMIT_APP_ARCHIVE',
   EasSubmitGcsAppArchive = 'EAS_SUBMIT_GCS_APP_ARCHIVE',
-  EasUpdateFingerprint = 'EAS_UPDATE_FINGERPRINT',
+  EasUpdateFingerprint = 'EAS_UPDATE_FINGERPRINT'
 }
 
 export type UsageMetricTotal = {
@@ -6204,14 +6523,14 @@ export enum UsageMetricType {
   Minute = 'MINUTE',
   Request = 'REQUEST',
   Update = 'UPDATE',
-  User = 'USER',
+  User = 'USER'
 }
 
 export enum UsageMetricsGranularity {
   Day = 'DAY',
   Hour = 'HOUR',
   Minute = 'MINUTE',
-  Total = 'TOTAL',
+  Total = 'TOTAL'
 }
 
 export type UsageMetricsTimespan = {
@@ -6220,69 +6539,69 @@ export type UsageMetricsTimespan = {
 };
 
 /** Represents a human (not robot) actor. */
-export type User = Actor &
-  UserActor & {
-    __typename?: 'User';
-    /** Access Tokens belonging to this actor */
-    accessTokens: Array<AccessToken>;
-    accounts: Array<Account>;
-    /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
-    activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
-    appCount: Scalars['Int']['output'];
-    /** @deprecated No longer supported */
-    appetizeCode?: Maybe<Scalars['String']['output']>;
-    /** Apps this user has published */
-    apps: Array<App>;
-    bestContactEmail?: Maybe<Scalars['String']['output']>;
-    created: Scalars['DateTime']['output'];
-    /** Discord account linked to a user */
-    discordUser?: Maybe<DiscordUser>;
-    displayName: Scalars['String']['output'];
-    email: Scalars['String']['output'];
-    emailVerified: Scalars['Boolean']['output'];
-    /** Experiments associated with this actor */
-    experiments: Array<ActorExperiment>;
-    /**
-     * Server feature gate values for this actor, optionally filtering by desired gates.
-     * Only resolves for the viewer.
-     */
-    featureGates: Scalars['JSONObject']['output'];
-    firstName?: Maybe<Scalars['String']['output']>;
-    fullName?: Maybe<Scalars['String']['output']>;
-    /** GitHub account linked to a user */
-    githubUser?: Maybe<GitHubUser>;
-    /** @deprecated No longer supported */
-    githubUsername?: Maybe<Scalars['String']['output']>;
-    /** Whether this user has any pending user invitations. Only resolves for the viewer. */
-    hasPendingUserInvitations: Scalars['Boolean']['output'];
-    id: Scalars['ID']['output'];
-    /** @deprecated No longer supported */
-    industry?: Maybe<Scalars['String']['output']>;
-    isExpoAdmin: Scalars['Boolean']['output'];
-    /** @deprecated No longer supported */
-    isLegacy: Scalars['Boolean']['output'];
-    isSecondFactorAuthenticationEnabled: Scalars['Boolean']['output'];
-    lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
-    lastName?: Maybe<Scalars['String']['output']>;
-    /** @deprecated No longer supported */
-    location?: Maybe<Scalars['String']['output']>;
-    notificationSubscriptions: Array<NotificationSubscription>;
-    /** Pending UserInvitations for this user. Only resolves for the viewer. */
-    pendingUserInvitations: Array<UserInvitation>;
-    pinnedApps: Array<App>;
-    preferences: UserPreferences;
-    /** Associated accounts */
-    primaryAccount: Account;
-    profilePhoto: Scalars['String']['output'];
-    /** Get all certified second factor authentication methods */
-    secondFactorDevices: Array<UserSecondFactorDevice>;
-    /** Snacks associated with this account */
-    snacks: Array<Snack>;
-    /** @deprecated No longer supported */
-    twitterUsername?: Maybe<Scalars['String']['output']>;
-    username: Scalars['String']['output'];
-    websiteNotificationsPaginated: WebsiteNotificationsConnection;
-  };
+export type User = Actor & UserActor & {
+  __typename?: 'User';
+  /** Access Tokens belonging to this actor */
+  accessTokens: Array<AccessToken>;
+  accounts: Array<Account>;
+  /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
+  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
+  appCount: Scalars['Int']['output'];
+  /** @deprecated No longer supported */
+  appetizeCode?: Maybe<Scalars['String']['output']>;
+  /** Apps this user has published */
+  apps: Array<App>;
+  bestContactEmail?: Maybe<Scalars['String']['output']>;
+  created: Scalars['DateTime']['output'];
+  /** Discord account linked to a user */
+  discordUser?: Maybe<DiscordUser>;
+  displayName: Scalars['String']['output'];
+  email: Scalars['String']['output'];
+  emailVerified: Scalars['Boolean']['output'];
+  /** Experiments associated with this actor */
+  experiments: Array<ActorExperiment>;
+  /**
+   * Server feature gate values for this actor, optionally filtering by desired gates.
+   * Only resolves for the viewer.
+   */
+  featureGates: Scalars['JSONObject']['output'];
+  firstName?: Maybe<Scalars['String']['output']>;
+  fullName?: Maybe<Scalars['String']['output']>;
+  /** GitHub account linked to a user */
+  githubUser?: Maybe<GitHubUser>;
+  /** @deprecated No longer supported */
+  githubUsername?: Maybe<Scalars['String']['output']>;
+  /** Whether this user has any pending user invitations. Only resolves for the viewer. */
+  hasPendingUserInvitations: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  /** @deprecated No longer supported */
+  industry?: Maybe<Scalars['String']['output']>;
+  isExpoAdmin: Scalars['Boolean']['output'];
+  /** @deprecated No longer supported */
+  isLegacy: Scalars['Boolean']['output'];
+  isSecondFactorAuthenticationEnabled: Scalars['Boolean']['output'];
+  lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
+  lastName?: Maybe<Scalars['String']['output']>;
+  /** @deprecated No longer supported */
+  location?: Maybe<Scalars['String']['output']>;
+  notificationSubscriptions: Array<NotificationSubscription>;
+  /** Pending UserInvitations for this user. Only resolves for the viewer. */
+  pendingUserInvitations: Array<UserInvitation>;
+  pinnedApps: Array<App>;
+  preferences: UserPreferences;
+  /** Associated accounts */
+  primaryAccount: Account;
+  profilePhoto: Scalars['String']['output'];
+  /** Get all certified second factor authentication methods */
+  secondFactorDevices: Array<UserSecondFactorDevice>;
+  /** Snacks associated with this account */
+  snacks: Array<Snack>;
+  /** @deprecated No longer supported */
+  twitterUsername?: Maybe<Scalars['String']['output']>;
+  username: Scalars['String']['output'];
+  websiteNotificationsPaginated: WebsiteNotificationsConnection;
+};
+
 
 /** Represents a human (not robot) actor. */
 export type UserActivityTimelineProjectActivitiesArgs = {
@@ -6291,6 +6610,7 @@ export type UserActivityTimelineProjectActivitiesArgs = {
   limit: Scalars['Int']['input'];
 };
 
+
 /** Represents a human (not robot) actor. */
 export type UserAppsArgs = {
   includeUnpublished?: InputMaybe<Scalars['Boolean']['input']>;
@@ -6298,21 +6618,25 @@ export type UserAppsArgs = {
   offset: Scalars['Int']['input'];
 };
 
+
 /** Represents a human (not robot) actor. */
 export type UserFeatureGatesArgs = {
   filter?: InputMaybe<Array<Scalars['String']['input']>>;
 };
+
 
 /** Represents a human (not robot) actor. */
 export type UserNotificationSubscriptionsArgs = {
   filter?: InputMaybe<NotificationSubscriptionFilter>;
 };
 
+
 /** Represents a human (not robot) actor. */
 export type UserSnacksArgs = {
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
 };
+
 
 /** Represents a human (not robot) actor. */
 export type UserWebsiteNotificationsPaginatedArgs = {
@@ -6381,12 +6705,14 @@ export type UserActor = {
   websiteNotificationsPaginated: WebsiteNotificationsConnection;
 };
 
+
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorActivityTimelineProjectActivitiesArgs = {
   createdBefore?: InputMaybe<Scalars['DateTime']['input']>;
   filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
   limit: Scalars['Int']['input'];
 };
+
 
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorAppsArgs = {
@@ -6395,21 +6721,25 @@ export type UserActorAppsArgs = {
   offset: Scalars['Int']['input'];
 };
 
+
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorFeatureGatesArgs = {
   filter?: InputMaybe<Array<Scalars['String']['input']>>;
 };
+
 
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorNotificationSubscriptionsArgs = {
   filter?: InputMaybe<NotificationSubscriptionFilter>;
 };
 
+
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorSnacksArgs = {
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
 };
+
 
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorWebsiteNotificationsPaginatedArgs = {
@@ -6431,6 +6761,7 @@ export type UserActorPublicData = {
   username: Scalars['String']['output'];
 };
 
+
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActorPublicDataSnacksArgs = {
   limit: Scalars['Int']['input'];
@@ -6442,6 +6773,7 @@ export type UserActorPublicDataQuery = {
   /** Get UserActorPublicData by username */
   byUsername: UserActorPublicData;
 };
+
 
 export type UserActorPublicDataQueryByUsernameArgs = {
   username: Scalars['String']['input'];
@@ -6461,13 +6793,43 @@ export type UserActorQuery = {
   byUsername: UserActor;
 };
 
+
 export type UserActorQueryByIdArgs = {
   id: Scalars['ID']['input'];
 };
 
+
 export type UserActorQueryByUsernameArgs = {
   username: Scalars['String']['input'];
 };
+
+export enum UserAgentBrowser {
+  AndroidMobile = 'ANDROID_MOBILE',
+  Chrome = 'CHROME',
+  ChromeIos = 'CHROME_IOS',
+  Edge = 'EDGE',
+  FacebookMobile = 'FACEBOOK_MOBILE',
+  Firefox = 'FIREFOX',
+  FirefoxIos = 'FIREFOX_IOS',
+  InternetExplorer = 'INTERNET_EXPLORER',
+  Konqueror = 'KONQUEROR',
+  Mozilla = 'MOZILLA',
+  Opera = 'OPERA',
+  Safari = 'SAFARI',
+  SafariMobile = 'SAFARI_MOBILE',
+  SamsungInternet = 'SAMSUNG_INTERNET',
+  UcBrowser = 'UC_BROWSER'
+}
+
+export enum UserAgentOs {
+  Android = 'ANDROID',
+  ChromeOs = 'CHROME_OS',
+  Ios = 'IOS',
+  IpadOs = 'IPAD_OS',
+  Linux = 'LINUX',
+  MacOs = 'MAC_OS',
+  Windows = 'WINDOWS'
+}
 
 export type UserAppPinMutation = {
   __typename?: 'UserAppPinMutation';
@@ -6475,9 +6837,11 @@ export type UserAppPinMutation = {
   unpinApp?: Maybe<Scalars['ID']['output']>;
 };
 
+
 export type UserAppPinMutationPinAppArgs = {
   appId: Scalars['ID']['input'];
 };
+
 
 export type UserAppPinMutationUnpinAppArgs = {
   appId: Scalars['ID']['input'];
@@ -6538,13 +6902,16 @@ export type UserInvitationMutation = {
   resendUserInvitation: UserInvitation;
 };
 
+
 export type UserInvitationMutationAcceptUserInvitationAsViewerArgs = {
   id: Scalars['ID']['input'];
 };
 
+
 export type UserInvitationMutationAcceptUserInvitationByTokenAsViewerArgs = {
   token: Scalars['ID']['input'];
 };
+
 
 export type UserInvitationMutationCreateUserInvitationForAccountArgs = {
   accountID: Scalars['ID']['input'];
@@ -6552,13 +6919,16 @@ export type UserInvitationMutationCreateUserInvitationForAccountArgs = {
   permissions: Array<InputMaybe<Permission>>;
 };
 
+
 export type UserInvitationMutationDeleteUserInvitationArgs = {
   id: Scalars['ID']['input'];
 };
 
+
 export type UserInvitationMutationDeleteUserInvitationByTokenArgs = {
   token: Scalars['ID']['input'];
 };
+
 
 export type UserInvitationMutationResendUserInvitationArgs = {
   id: Scalars['ID']['input'];
@@ -6582,6 +6952,7 @@ export type UserInvitationPublicDataQuery = {
   /** Get UserInvitationPublicData by token */
   byToken: UserInvitationPublicData;
 };
+
 
 export type UserInvitationPublicDataQueryByTokenArgs = {
   token: Scalars['ID']['input'];
@@ -6653,9 +7024,11 @@ export type UserQuery = {
   byUsername: User;
 };
 
+
 export type UserQueryByIdArgs = {
   userId: Scalars['ID']['input'];
 };
+
 
 export type UserQueryByUsernameArgs = {
   username: Scalars['String']['input'];
@@ -6710,14 +7083,17 @@ export type WebhookMutation = {
   updateWebhook: Webhook;
 };
 
+
 export type WebhookMutationCreateWebhookArgs = {
   appId: Scalars['String']['input'];
   webhookInput: WebhookInput;
 };
 
+
 export type WebhookMutationDeleteWebhookArgs = {
   webhookId: Scalars['ID']['input'];
 };
+
 
 export type WebhookMutationUpdateWebhookArgs = {
   webhookId: Scalars['ID']['input'];
@@ -6729,13 +7105,14 @@ export type WebhookQuery = {
   byId: Webhook;
 };
 
+
 export type WebhookQueryByIdArgs = {
   id: Scalars['ID']['input'];
 };
 
 export enum WebhookType {
   Build = 'BUILD',
-  Submit = 'SUBMIT',
+  Submit = 'SUBMIT'
 }
 
 export type WebsiteNotificationEdge = {
@@ -6749,6 +7126,7 @@ export type WebsiteNotificationMutation = {
   updateAllWebsiteNotificationReadStateAsRead: Scalars['Boolean']['output'];
   updateNotificationReadState: Notification;
 };
+
 
 export type WebsiteNotificationMutationUpdateNotificationReadStateArgs = {
   input: WebNotificationUpdateReadStateInput;
@@ -6764,12 +7142,14 @@ export type WorkerCustomDomain = {
   __typename?: 'WorkerCustomDomain';
   alias: WorkerDeploymentAlias;
   createdAt: Scalars['DateTime']['output'];
+  dcvDelegationRecord?: Maybe<CustomDomainDnsRecord>;
   devDomainName: Scalars['DevDomainName']['output'];
   dnsRecord: CustomDomainDnsRecord;
   hostname: Scalars['String']['output'];
   id: Scalars['ID']['output'];
-  metadata?: Maybe<CustomDomainMetadata>;
+  setup?: Maybe<CustomDomainSetup>;
   updatedAt: Scalars['DateTime']['output'];
+  verificationRecord?: Maybe<CustomDomainDnsRecord>;
 };
 
 export type WorkerDeployment = {
@@ -6786,10 +7166,12 @@ export type WorkerDeployment = {
   url: Scalars['String']['output'];
 };
 
+
 export type WorkerDeploymentLogsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   timespan: LogsTimespan;
 };
+
 
 export type WorkerDeploymentMetricsArgs = {
   timespan: MetricsTimespan;
@@ -6820,20 +7202,30 @@ export type WorkerDeploymentAliasesConnection = {
   pageInfo: PageInfo;
 };
 
+export type WorkerDeploymentCrashEdge = {
+  __typename?: 'WorkerDeploymentCrashEdge';
+  logs: Array<WorkerDeploymentLogNode>;
+  request: WorkerDeploymentRequestNode;
+  sample: WorkerDeploymentCrashSample;
+};
+
 export type WorkerDeploymentCrashNode = {
   __typename?: 'WorkerDeploymentCrashNode';
+  id: Scalars['ID']['output'];
   minOccurrences: Scalars['Int']['output'];
   mostRecentlyOccurredAt: Scalars['DateTime']['output'];
-  sample?: Maybe<WorkerDeploymentCrashSample>;
-  sampleMessage?: Maybe<Scalars['String']['output']>;
+  oldestOccurredAt: Scalars['DateTime']['output'];
+  sample: WorkerDeploymentCrashSample;
 };
 
 export type WorkerDeploymentCrashSample = {
   __typename?: 'WorkerDeploymentCrashSample';
+  firstStackLine?: Maybe<Scalars['String']['output']>;
   message: Scalars['String']['output'];
   name: Scalars['String']['output'];
-  requestTimestamp: Scalars['DateTime']['output'];
+  scriptName: Scalars['String']['output'];
   stack?: Maybe<Array<Scalars['String']['output']>>;
+  timestamp: Scalars['DateTime']['output'];
 };
 
 export type WorkerDeploymentCrashes = {
@@ -6854,7 +7246,7 @@ export enum WorkerDeploymentLogLevel {
   Fatal = 'FATAL',
   Info = 'INFO',
   Log = 'LOG',
-  Warn = 'WARN',
+  Warn = 'WARN'
 }
 
 export type WorkerDeploymentLogNode = {
@@ -6874,16 +7266,17 @@ export type WorkerDeploymentMetrics = {
   __typename?: 'WorkerDeploymentMetrics';
   groups: Array<Maybe<WorkerDeploymentMetricsEdge>>;
   id: Scalars['ID']['output'];
+  interval: Scalars['Int']['output'];
   summary: WorkerDeploymentMetricsData;
 };
 
 export type WorkerDeploymentMetricsData = {
   __typename?: 'WorkerDeploymentMetricsData';
-  crashesSum: Scalars['Int']['output'];
+  crashesSum?: Maybe<Scalars['Int']['output']>;
   durationP50?: Maybe<Scalars['Float']['output']>;
   durationP90?: Maybe<Scalars['Float']['output']>;
   durationP99?: Maybe<Scalars['Float']['output']>;
-  requestsSum: Scalars['Int']['output'];
+  requestsSum?: Maybe<Scalars['Int']['output']>;
 };
 
 export type WorkerDeploymentMetricsEdge = {
@@ -6897,9 +7290,23 @@ export type WorkerDeploymentQuery = {
   byId: WorkerDeployment;
 };
 
+
 export type WorkerDeploymentQueryByIdArgs = {
   id: Scalars['ID']['input'];
 };
+
+export type WorkerDeploymentRequestEdge = {
+  __typename?: 'WorkerDeploymentRequestEdge';
+  crash?: Maybe<WorkerDeploymentCrashSample>;
+  logs: Array<WorkerDeploymentLogNode>;
+  node: WorkerDeploymentRequestNode;
+};
+
+export enum WorkerDeploymentRequestKind {
+  Asset = 'ASSET',
+  Crash = 'CRASH',
+  Rejected = 'REJECTED'
+}
 
 export type WorkerDeploymentRequestLocation = {
   __typename?: 'WorkerDeploymentRequestLocation';
@@ -6910,12 +7317,21 @@ export type WorkerDeploymentRequestLocation = {
 
 export type WorkerDeploymentRequestNode = {
   __typename?: 'WorkerDeploymentRequestNode';
+  browser?: Maybe<UserAgentBrowser>;
+  browserVersion?: Maybe<Scalars['String']['output']>;
+  hasCustomDomainOrigin: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  isVerifiedBot: Scalars['Boolean']['output'];
+  kind?: Maybe<WorkerDeploymentRequestKind>;
   location?: Maybe<WorkerDeploymentRequestLocation>;
   method: Scalars['String']['output'];
+  os?: Maybe<UserAgentOs>;
   pathname: Scalars['String']['output'];
+  scriptName: Scalars['String']['output'];
   search?: Maybe<Scalars['String']['output']>;
   status: Scalars['Int']['output'];
   timestamp: Scalars['DateTime']['output'];
+  wallTime: Scalars['Int']['output'];
 };
 
 export type WorkerDeploymentRequests = {
@@ -6925,11 +7341,18 @@ export type WorkerDeploymentRequests = {
 };
 
 export type WorkerDeploymentRequestsFilter = {
+  include?: InputMaybe<WorkerDeploymentRequestsInclude>;
+  includeBotRequests?: InputMaybe<Scalars['Boolean']['input']>;
   methods?: InputMaybe<Array<Scalars['String']['input']>>;
   pathname?: InputMaybe<Scalars['String']['input']>;
   statusCodes?: InputMaybe<Array<Scalars['Int']['input']>>;
   statusPatterns?: InputMaybe<Array<RequestStatusPattern>>;
 };
+
+export enum WorkerDeploymentRequestsInclude {
+  Assets = 'ASSETS',
+  Routes = 'ROUTES'
+}
 
 export type WorkerDeploymentsConnection = {
   __typename?: 'WorkerDeploymentsConnection';
@@ -6943,7 +7366,7 @@ export enum WorkerLoggerLevel {
   Fatal = 'FATAL',
   Info = 'INFO',
   Trace = 'TRACE',
-  Warn = 'WARN',
+  Warn = 'WARN'
 }
 
 export type DeleteAndroidAppBuildCredentialsResult = {
@@ -6971,13 +7394,8 @@ export type CreateUpdateBranchForAppMutationVariables = Exact<{
   name: Scalars['String']['input'];
 }>;
 
-export type CreateUpdateBranchForAppMutation = {
-  __typename?: 'RootMutation';
-  updateBranch: {
-    __typename?: 'UpdateBranchMutation';
-    createUpdateBranchForApp: { __typename?: 'UpdateBranch'; id: string; name: string };
-  };
-};
+
+export type CreateUpdateBranchForAppMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', createUpdateBranchForApp: { __typename?: 'UpdateBranch', id: string, name: string } } };
 
 export type CreateUpdateChannelOnAppMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
@@ -6985,230 +7403,97 @@ export type CreateUpdateChannelOnAppMutationVariables = Exact<{
   branchMapping: Scalars['String']['input'];
 }>;
 
-export type CreateUpdateChannelOnAppMutation = {
-  __typename?: 'RootMutation';
-  updateChannel: {
-    __typename?: 'UpdateChannelMutation';
-    createUpdateChannelForApp: {
-      __typename?: 'UpdateChannel';
-      id: string;
-      name: string;
-      branchMapping: string;
-    };
-  };
-};
+
+export type CreateUpdateChannelOnAppMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', createUpdateChannelForApp: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
 
 export type GetBranchInfoQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   name: Scalars['String']['input'];
 }>;
 
-export type GetBranchInfoQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      updateBranchByName?: { __typename?: 'UpdateBranch'; id: string; name: string } | null;
-    };
-  };
-};
+
+export type GetBranchInfoQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, name: string } | null } } };
 
 export type DeleteUpdateBranchMutationVariables = Exact<{
   branchId: Scalars['ID']['input'];
 }>;
 
-export type DeleteUpdateBranchMutation = {
-  __typename?: 'RootMutation';
-  updateBranch: {
-    __typename?: 'UpdateBranchMutation';
-    deleteUpdateBranch: { __typename?: 'DeleteUpdateBranchResult'; id: string };
-  };
-};
+
+export type DeleteUpdateBranchMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', deleteUpdateBranch: { __typename?: 'DeleteUpdateBranchResult', id: string } } };
 
 export type EditUpdateBranchMutationVariables = Exact<{
   input: EditUpdateBranchInput;
 }>;
 
-export type EditUpdateBranchMutation = {
-  __typename?: 'RootMutation';
-  updateBranch: {
-    __typename?: 'UpdateBranchMutation';
-    editUpdateBranch: { __typename?: 'UpdateBranch'; id: string; name: string };
-  };
-};
+
+export type EditUpdateBranchMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', editUpdateBranch: { __typename?: 'UpdateBranch', id: string, name: string } } };
 
 export type CancelBuildMutationVariables = Exact<{
   buildId: Scalars['ID']['input'];
 }>;
 
-export type CancelBuildMutation = {
-  __typename?: 'RootMutation';
-  build: {
-    __typename?: 'BuildMutation';
-    cancel: { __typename?: 'Build'; id: string; status: BuildStatus };
-  };
-};
+
+export type CancelBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', cancel: { __typename?: 'Build', id: string, status: BuildStatus } } };
 
 export type DeleteBuildMutationVariables = Exact<{
   buildId: Scalars['ID']['input'];
 }>;
 
-export type DeleteBuildMutation = {
-  __typename?: 'RootMutation';
-  build: { __typename?: 'BuildMutation'; deleteBuild: { __typename?: 'Build'; id: string } };
-};
+
+export type DeleteBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', deleteBuild: { __typename?: 'Build', id: string } } };
 
 export type DeleteUpdateChannelMutationVariables = Exact<{
   channelId: Scalars['ID']['input'];
 }>;
 
-export type DeleteUpdateChannelMutation = {
-  __typename?: 'RootMutation';
-  updateChannel: {
-    __typename?: 'UpdateChannelMutation';
-    deleteUpdateChannel: { __typename?: 'DeleteUpdateChannelResult'; id: string };
-  };
-};
+
+export type DeleteUpdateChannelMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', deleteUpdateChannel: { __typename?: 'DeleteUpdateChannelResult', id: string } } };
 
 export type UpdateChannelBranchMappingMutationVariables = Exact<{
   channelId: Scalars['ID']['input'];
   branchMapping: Scalars['String']['input'];
 }>;
 
-export type UpdateChannelBranchMappingMutation = {
-  __typename?: 'RootMutation';
-  updateChannel: {
-    __typename?: 'UpdateChannelMutation';
-    editUpdateChannel: {
-      __typename?: 'UpdateChannel';
-      id: string;
-      name: string;
-      branchMapping: string;
-    };
-  };
-};
+
+export type UpdateChannelBranchMappingMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', editUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
 
 export type AppInfoQueryVariables = Exact<{
   appId: Scalars['String']['input'];
 }>;
 
-export type AppInfoQuery = {
-  __typename?: 'RootQuery';
-  app: { __typename?: 'AppQuery'; byId: { __typename?: 'App'; id: string; fullName: string } };
-};
+
+export type AppInfoQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, fullName: string } } };
 
 export type DeleteUpdateGroupMutationVariables = Exact<{
   group: Scalars['ID']['input'];
 }>;
 
-export type DeleteUpdateGroupMutation = {
-  __typename?: 'RootMutation';
-  update: {
-    __typename?: 'UpdateMutation';
-    deleteUpdateGroup: { __typename?: 'DeleteUpdateGroupResult'; group: string };
-  };
-};
+
+export type DeleteUpdateGroupMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', deleteUpdateGroup: { __typename?: 'DeleteUpdateGroupResult', group: string } } };
 
 export type CreateAndroidAppBuildCredentialsMutationVariables = Exact<{
   androidAppBuildCredentialsInput: AndroidAppBuildCredentialsInput;
   androidAppCredentialsId: Scalars['ID']['input'];
 }>;
 
-export type CreateAndroidAppBuildCredentialsMutation = {
-  __typename?: 'RootMutation';
-  androidAppBuildCredentials: {
-    __typename?: 'AndroidAppBuildCredentialsMutation';
-    createAndroidAppBuildCredentials: {
-      __typename?: 'AndroidAppBuildCredentials';
-      id: string;
-      isDefault: boolean;
-      isLegacy: boolean;
-      name: string;
-      androidKeystore?: {
-        __typename?: 'AndroidKeystore';
-        id: string;
-        type: AndroidKeystoreType;
-        keystore: string;
-        keystorePassword: string;
-        keyAlias: string;
-        keyPassword?: string | null;
-        md5CertificateFingerprint?: string | null;
-        sha1CertificateFingerprint?: string | null;
-        sha256CertificateFingerprint?: string | null;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-    };
-  };
-};
+
+export type CreateAndroidAppBuildCredentialsMutation = { __typename?: 'RootMutation', androidAppBuildCredentials: { __typename?: 'AndroidAppBuildCredentialsMutation', createAndroidAppBuildCredentials: { __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null } } };
 
 export type SetDefaultAndroidAppBuildCredentialsMutationVariables = Exact<{
   androidAppBuildCredentialsId: Scalars['ID']['input'];
   isDefault: Scalars['Boolean']['input'];
 }>;
 
-export type SetDefaultAndroidAppBuildCredentialsMutation = {
-  __typename?: 'RootMutation';
-  androidAppBuildCredentials: {
-    __typename?: 'AndroidAppBuildCredentialsMutation';
-    setDefault: {
-      __typename?: 'AndroidAppBuildCredentials';
-      id: string;
-      isDefault: boolean;
-      isLegacy: boolean;
-      name: string;
-      androidKeystore?: {
-        __typename?: 'AndroidKeystore';
-        id: string;
-        type: AndroidKeystoreType;
-        keystore: string;
-        keystorePassword: string;
-        keyAlias: string;
-        keyPassword?: string | null;
-        md5CertificateFingerprint?: string | null;
-        sha1CertificateFingerprint?: string | null;
-        sha256CertificateFingerprint?: string | null;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-    };
-  };
-};
+
+export type SetDefaultAndroidAppBuildCredentialsMutation = { __typename?: 'RootMutation', androidAppBuildCredentials: { __typename?: 'AndroidAppBuildCredentialsMutation', setDefault: { __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null } } };
 
 export type SetKeystoreMutationVariables = Exact<{
   androidAppBuildCredentialsId: Scalars['ID']['input'];
   keystoreId: Scalars['ID']['input'];
 }>;
 
-export type SetKeystoreMutation = {
-  __typename?: 'RootMutation';
-  androidAppBuildCredentials: {
-    __typename?: 'AndroidAppBuildCredentialsMutation';
-    setKeystore: {
-      __typename?: 'AndroidAppBuildCredentials';
-      id: string;
-      isDefault: boolean;
-      isLegacy: boolean;
-      name: string;
-      androidKeystore?: {
-        __typename?: 'AndroidKeystore';
-        id: string;
-        type: AndroidKeystoreType;
-        keystore: string;
-        keystorePassword: string;
-        keyAlias: string;
-        keyPassword?: string | null;
-        md5CertificateFingerprint?: string | null;
-        sha1CertificateFingerprint?: string | null;
-        sha256CertificateFingerprint?: string | null;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-    };
-  };
-};
+
+export type SetKeystoreMutation = { __typename?: 'RootMutation', androidAppBuildCredentials: { __typename?: 'AndroidAppBuildCredentialsMutation', setKeystore: { __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null } } };
 
 export type CreateAndroidAppCredentialsMutationVariables = Exact<{
   androidAppCredentialsInput: AndroidAppCredentialsInput;
@@ -7216,691 +7501,86 @@ export type CreateAndroidAppCredentialsMutationVariables = Exact<{
   applicationIdentifier: Scalars['String']['input'];
 }>;
 
-export type CreateAndroidAppCredentialsMutation = {
-  __typename?: 'RootMutation';
-  androidAppCredentials: {
-    __typename?: 'AndroidAppCredentialsMutation';
-    createAndroidAppCredentials: {
-      __typename?: 'AndroidAppCredentials';
-      id: string;
-      applicationIdentifier?: string | null;
-      isLegacy: boolean;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        fullName: string;
-        slug: string;
-        ownerAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        githubRepository?: {
-          __typename?: 'GitHubRepository';
-          id: string;
-          metadata: {
-            __typename?: 'GitHubRepositoryMetadata';
-            githubRepoOwnerName: string;
-            githubRepoName: string;
-          };
-        } | null;
-      };
-      androidFcm?: {
-        __typename?: 'AndroidFcm';
-        id: string;
-        credential: any;
-        version: AndroidFcmVersion;
-        createdAt: any;
-        updatedAt: any;
-        snippet:
-          | {
-              __typename?: 'FcmSnippetLegacy';
-              firstFourCharacters: string;
-              lastFourCharacters: string;
-            }
-          | {
-              __typename?: 'FcmSnippetV1';
-              projectId: string;
-              keyId: string;
-              serviceAccountEmail: string;
-              clientId?: string | null;
-            };
-      } | null;
-      googleServiceAccountKeyForFcmV1?: {
-        __typename?: 'GoogleServiceAccountKey';
-        id: string;
-        projectIdentifier: string;
-        privateKeyIdentifier: string;
-        clientEmail: string;
-        clientIdentifier: string;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-      googleServiceAccountKeyForSubmissions?: {
-        __typename?: 'GoogleServiceAccountKey';
-        id: string;
-        projectIdentifier: string;
-        privateKeyIdentifier: string;
-        clientEmail: string;
-        clientIdentifier: string;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-      androidAppBuildCredentialsList: Array<{
-        __typename?: 'AndroidAppBuildCredentials';
-        id: string;
-        isDefault: boolean;
-        isLegacy: boolean;
-        name: string;
-        androidKeystore?: {
-          __typename?: 'AndroidKeystore';
-          id: string;
-          type: AndroidKeystoreType;
-          keystore: string;
-          keystorePassword: string;
-          keyAlias: string;
-          keyPassword?: string | null;
-          md5CertificateFingerprint?: string | null;
-          sha1CertificateFingerprint?: string | null;
-          sha256CertificateFingerprint?: string | null;
-          createdAt: any;
-          updatedAt: any;
-        } | null;
-      }>;
-    };
-  };
-};
+
+export type CreateAndroidAppCredentialsMutation = { __typename?: 'RootMutation', androidAppCredentials: { __typename?: 'AndroidAppCredentialsMutation', createAndroidAppCredentials: { __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForFcmV1?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> } } };
 
 export type SetFcmMutationVariables = Exact<{
   androidAppCredentialsId: Scalars['ID']['input'];
   fcmId: Scalars['ID']['input'];
 }>;
 
-export type SetFcmMutation = {
-  __typename?: 'RootMutation';
-  androidAppCredentials: {
-    __typename?: 'AndroidAppCredentialsMutation';
-    setFcm: {
-      __typename?: 'AndroidAppCredentials';
-      id: string;
-      applicationIdentifier?: string | null;
-      isLegacy: boolean;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        fullName: string;
-        slug: string;
-        ownerAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        githubRepository?: {
-          __typename?: 'GitHubRepository';
-          id: string;
-          metadata: {
-            __typename?: 'GitHubRepositoryMetadata';
-            githubRepoOwnerName: string;
-            githubRepoName: string;
-          };
-        } | null;
-      };
-      androidFcm?: {
-        __typename?: 'AndroidFcm';
-        id: string;
-        credential: any;
-        version: AndroidFcmVersion;
-        createdAt: any;
-        updatedAt: any;
-        snippet:
-          | {
-              __typename?: 'FcmSnippetLegacy';
-              firstFourCharacters: string;
-              lastFourCharacters: string;
-            }
-          | {
-              __typename?: 'FcmSnippetV1';
-              projectId: string;
-              keyId: string;
-              serviceAccountEmail: string;
-              clientId?: string | null;
-            };
-      } | null;
-      googleServiceAccountKeyForFcmV1?: {
-        __typename?: 'GoogleServiceAccountKey';
-        id: string;
-        projectIdentifier: string;
-        privateKeyIdentifier: string;
-        clientEmail: string;
-        clientIdentifier: string;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-      googleServiceAccountKeyForSubmissions?: {
-        __typename?: 'GoogleServiceAccountKey';
-        id: string;
-        projectIdentifier: string;
-        privateKeyIdentifier: string;
-        clientEmail: string;
-        clientIdentifier: string;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-      androidAppBuildCredentialsList: Array<{
-        __typename?: 'AndroidAppBuildCredentials';
-        id: string;
-        isDefault: boolean;
-        isLegacy: boolean;
-        name: string;
-        androidKeystore?: {
-          __typename?: 'AndroidKeystore';
-          id: string;
-          type: AndroidKeystoreType;
-          keystore: string;
-          keystorePassword: string;
-          keyAlias: string;
-          keyPassword?: string | null;
-          md5CertificateFingerprint?: string | null;
-          sha1CertificateFingerprint?: string | null;
-          sha256CertificateFingerprint?: string | null;
-          createdAt: any;
-          updatedAt: any;
-        } | null;
-      }>;
-    };
-  };
-};
+
+export type SetFcmMutation = { __typename?: 'RootMutation', androidAppCredentials: { __typename?: 'AndroidAppCredentialsMutation', setFcm: { __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForFcmV1?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> } } };
 
 export type SetGoogleServiceAccountKeyForSubmissionsMutationVariables = Exact<{
   androidAppCredentialsId: Scalars['ID']['input'];
   googleServiceAccountKeyId: Scalars['ID']['input'];
 }>;
 
-export type SetGoogleServiceAccountKeyForSubmissionsMutation = {
-  __typename?: 'RootMutation';
-  androidAppCredentials: {
-    __typename?: 'AndroidAppCredentialsMutation';
-    setGoogleServiceAccountKeyForSubmissions: {
-      __typename?: 'AndroidAppCredentials';
-      id: string;
-      applicationIdentifier?: string | null;
-      isLegacy: boolean;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        fullName: string;
-        slug: string;
-        ownerAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        githubRepository?: {
-          __typename?: 'GitHubRepository';
-          id: string;
-          metadata: {
-            __typename?: 'GitHubRepositoryMetadata';
-            githubRepoOwnerName: string;
-            githubRepoName: string;
-          };
-        } | null;
-      };
-      androidFcm?: {
-        __typename?: 'AndroidFcm';
-        id: string;
-        credential: any;
-        version: AndroidFcmVersion;
-        createdAt: any;
-        updatedAt: any;
-        snippet:
-          | {
-              __typename?: 'FcmSnippetLegacy';
-              firstFourCharacters: string;
-              lastFourCharacters: string;
-            }
-          | {
-              __typename?: 'FcmSnippetV1';
-              projectId: string;
-              keyId: string;
-              serviceAccountEmail: string;
-              clientId?: string | null;
-            };
-      } | null;
-      googleServiceAccountKeyForFcmV1?: {
-        __typename?: 'GoogleServiceAccountKey';
-        id: string;
-        projectIdentifier: string;
-        privateKeyIdentifier: string;
-        clientEmail: string;
-        clientIdentifier: string;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-      googleServiceAccountKeyForSubmissions?: {
-        __typename?: 'GoogleServiceAccountKey';
-        id: string;
-        projectIdentifier: string;
-        privateKeyIdentifier: string;
-        clientEmail: string;
-        clientIdentifier: string;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-      androidAppBuildCredentialsList: Array<{
-        __typename?: 'AndroidAppBuildCredentials';
-        id: string;
-        isDefault: boolean;
-        isLegacy: boolean;
-        name: string;
-        androidKeystore?: {
-          __typename?: 'AndroidKeystore';
-          id: string;
-          type: AndroidKeystoreType;
-          keystore: string;
-          keystorePassword: string;
-          keyAlias: string;
-          keyPassword?: string | null;
-          md5CertificateFingerprint?: string | null;
-          sha1CertificateFingerprint?: string | null;
-          sha256CertificateFingerprint?: string | null;
-          createdAt: any;
-          updatedAt: any;
-        } | null;
-      }>;
-    };
-  };
-};
+
+export type SetGoogleServiceAccountKeyForSubmissionsMutation = { __typename?: 'RootMutation', androidAppCredentials: { __typename?: 'AndroidAppCredentialsMutation', setGoogleServiceAccountKeyForSubmissions: { __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForFcmV1?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> } } };
 
 export type SetGoogleServiceAccountKeyForFcmV1MutationVariables = Exact<{
   androidAppCredentialsId: Scalars['ID']['input'];
   googleServiceAccountKeyId: Scalars['ID']['input'];
 }>;
 
-export type SetGoogleServiceAccountKeyForFcmV1Mutation = {
-  __typename?: 'RootMutation';
-  androidAppCredentials: {
-    __typename?: 'AndroidAppCredentialsMutation';
-    setGoogleServiceAccountKeyForFcmV1: {
-      __typename?: 'AndroidAppCredentials';
-      id: string;
-      applicationIdentifier?: string | null;
-      isLegacy: boolean;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        fullName: string;
-        slug: string;
-        ownerAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        githubRepository?: {
-          __typename?: 'GitHubRepository';
-          id: string;
-          metadata: {
-            __typename?: 'GitHubRepositoryMetadata';
-            githubRepoOwnerName: string;
-            githubRepoName: string;
-          };
-        } | null;
-      };
-      androidFcm?: {
-        __typename?: 'AndroidFcm';
-        id: string;
-        credential: any;
-        version: AndroidFcmVersion;
-        createdAt: any;
-        updatedAt: any;
-        snippet:
-          | {
-              __typename?: 'FcmSnippetLegacy';
-              firstFourCharacters: string;
-              lastFourCharacters: string;
-            }
-          | {
-              __typename?: 'FcmSnippetV1';
-              projectId: string;
-              keyId: string;
-              serviceAccountEmail: string;
-              clientId?: string | null;
-            };
-      } | null;
-      googleServiceAccountKeyForFcmV1?: {
-        __typename?: 'GoogleServiceAccountKey';
-        id: string;
-        projectIdentifier: string;
-        privateKeyIdentifier: string;
-        clientEmail: string;
-        clientIdentifier: string;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-      googleServiceAccountKeyForSubmissions?: {
-        __typename?: 'GoogleServiceAccountKey';
-        id: string;
-        projectIdentifier: string;
-        privateKeyIdentifier: string;
-        clientEmail: string;
-        clientIdentifier: string;
-        createdAt: any;
-        updatedAt: any;
-      } | null;
-      androidAppBuildCredentialsList: Array<{
-        __typename?: 'AndroidAppBuildCredentials';
-        id: string;
-        isDefault: boolean;
-        isLegacy: boolean;
-        name: string;
-        androidKeystore?: {
-          __typename?: 'AndroidKeystore';
-          id: string;
-          type: AndroidKeystoreType;
-          keystore: string;
-          keystorePassword: string;
-          keyAlias: string;
-          keyPassword?: string | null;
-          md5CertificateFingerprint?: string | null;
-          sha1CertificateFingerprint?: string | null;
-          sha256CertificateFingerprint?: string | null;
-          createdAt: any;
-          updatedAt: any;
-        } | null;
-      }>;
-    };
-  };
-};
+
+export type SetGoogleServiceAccountKeyForFcmV1Mutation = { __typename?: 'RootMutation', androidAppCredentials: { __typename?: 'AndroidAppCredentialsMutation', setGoogleServiceAccountKeyForFcmV1: { __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForFcmV1?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> } } };
 
 export type CreateAndroidFcmMutationVariables = Exact<{
   androidFcmInput: AndroidFcmInput;
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateAndroidFcmMutation = {
-  __typename?: 'RootMutation';
-  androidFcm: {
-    __typename?: 'AndroidFcmMutation';
-    createAndroidFcm: {
-      __typename?: 'AndroidFcm';
-      id: string;
-      credential: any;
-      version: AndroidFcmVersion;
-      createdAt: any;
-      updatedAt: any;
-      snippet:
-        | {
-            __typename?: 'FcmSnippetLegacy';
-            firstFourCharacters: string;
-            lastFourCharacters: string;
-          }
-        | {
-            __typename?: 'FcmSnippetV1';
-            projectId: string;
-            keyId: string;
-            serviceAccountEmail: string;
-            clientId?: string | null;
-          };
-    };
-  };
-};
+
+export type CreateAndroidFcmMutation = { __typename?: 'RootMutation', androidFcm: { __typename?: 'AndroidFcmMutation', createAndroidFcm: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } } };
 
 export type DeleteAndroidFcmMutationVariables = Exact<{
   androidFcmId: Scalars['ID']['input'];
 }>;
 
-export type DeleteAndroidFcmMutation = {
-  __typename?: 'RootMutation';
-  androidFcm: {
-    __typename?: 'AndroidFcmMutation';
-    deleteAndroidFcm: { __typename?: 'deleteAndroidFcmResult'; id: string };
-  };
-};
+
+export type DeleteAndroidFcmMutation = { __typename?: 'RootMutation', androidFcm: { __typename?: 'AndroidFcmMutation', deleteAndroidFcm: { __typename?: 'deleteAndroidFcmResult', id: string } } };
 
 export type CreateAndroidKeystoreMutationVariables = Exact<{
   androidKeystoreInput: AndroidKeystoreInput;
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateAndroidKeystoreMutation = {
-  __typename?: 'RootMutation';
-  androidKeystore: {
-    __typename?: 'AndroidKeystoreMutation';
-    createAndroidKeystore?: {
-      __typename?: 'AndroidKeystore';
-      id: string;
-      type: AndroidKeystoreType;
-      keystore: string;
-      keystorePassword: string;
-      keyAlias: string;
-      keyPassword?: string | null;
-      md5CertificateFingerprint?: string | null;
-      sha1CertificateFingerprint?: string | null;
-      sha256CertificateFingerprint?: string | null;
-      createdAt: any;
-      updatedAt: any;
-    } | null;
-  };
-};
+
+export type CreateAndroidKeystoreMutation = { __typename?: 'RootMutation', androidKeystore: { __typename?: 'AndroidKeystoreMutation', createAndroidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null } };
 
 export type DeleteAndroidKeystoreMutationVariables = Exact<{
   androidKeystoreId: Scalars['ID']['input'];
 }>;
 
-export type DeleteAndroidKeystoreMutation = {
-  __typename?: 'RootMutation';
-  androidKeystore: {
-    __typename?: 'AndroidKeystoreMutation';
-    deleteAndroidKeystore: { __typename?: 'DeleteAndroidKeystoreResult'; id: string };
-  };
-};
+
+export type DeleteAndroidKeystoreMutation = { __typename?: 'RootMutation', androidKeystore: { __typename?: 'AndroidKeystoreMutation', deleteAndroidKeystore: { __typename?: 'DeleteAndroidKeystoreResult', id: string } } };
 
 export type CreateGoogleServiceAccountKeyMutationVariables = Exact<{
   googleServiceAccountKeyInput: GoogleServiceAccountKeyInput;
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateGoogleServiceAccountKeyMutation = {
-  __typename?: 'RootMutation';
-  googleServiceAccountKey: {
-    __typename?: 'GoogleServiceAccountKeyMutation';
-    createGoogleServiceAccountKey: {
-      __typename?: 'GoogleServiceAccountKey';
-      id: string;
-      projectIdentifier: string;
-      privateKeyIdentifier: string;
-      clientEmail: string;
-      clientIdentifier: string;
-      createdAt: any;
-      updatedAt: any;
-    };
-  };
-};
+
+export type CreateGoogleServiceAccountKeyMutation = { __typename?: 'RootMutation', googleServiceAccountKey: { __typename?: 'GoogleServiceAccountKeyMutation', createGoogleServiceAccountKey: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } } };
 
 export type DeleteGoogleServiceAccountKeyMutationVariables = Exact<{
   googleServiceAccountKeyId: Scalars['ID']['input'];
 }>;
 
-export type DeleteGoogleServiceAccountKeyMutation = {
-  __typename?: 'RootMutation';
-  googleServiceAccountKey: {
-    __typename?: 'GoogleServiceAccountKeyMutation';
-    deleteGoogleServiceAccountKey: {
-      __typename?: 'DeleteGoogleServiceAccountKeyResult';
-      id: string;
-    };
-  };
-};
 
-export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQueryVariables =
-  Exact<{
-    projectFullName: Scalars['String']['input'];
-    applicationIdentifier?: InputMaybe<Scalars['String']['input']>;
-    legacyOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  }>;
+export type DeleteGoogleServiceAccountKeyMutation = { __typename?: 'RootMutation', googleServiceAccountKey: { __typename?: 'GoogleServiceAccountKeyMutation', deleteGoogleServiceAccountKey: { __typename?: 'DeleteGoogleServiceAccountKeyResult', id: string } } };
 
-export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byFullName: {
-      __typename?: 'App';
-      id: string;
-      androidAppCredentials: Array<{
-        __typename?: 'AndroidAppCredentials';
-        id: string;
-        applicationIdentifier?: string | null;
-        isLegacy: boolean;
-        app: {
-          __typename?: 'App';
-          id: string;
-          name: string;
-          fullName: string;
-          slug: string;
-          ownerAccount: {
-            __typename?: 'Account';
-            id: string;
-            name: string;
-            ownerUserActor?:
-              | { __typename?: 'SSOUser'; id: string; username: string }
-              | { __typename?: 'User'; id: string; username: string }
-              | null;
-            users: Array<{
-              __typename?: 'UserPermission';
-              role: Role;
-              actor:
-                | { __typename?: 'Robot'; id: string }
-                | { __typename?: 'SSOUser'; id: string }
-                | { __typename?: 'User'; id: string };
-            }>;
-          };
-          githubRepository?: {
-            __typename?: 'GitHubRepository';
-            id: string;
-            metadata: {
-              __typename?: 'GitHubRepositoryMetadata';
-              githubRepoOwnerName: string;
-              githubRepoName: string;
-            };
-          } | null;
-        };
-        androidFcm?: {
-          __typename?: 'AndroidFcm';
-          id: string;
-          credential: any;
-          version: AndroidFcmVersion;
-          createdAt: any;
-          updatedAt: any;
-          snippet:
-            | {
-                __typename?: 'FcmSnippetLegacy';
-                firstFourCharacters: string;
-                lastFourCharacters: string;
-              }
-            | {
-                __typename?: 'FcmSnippetV1';
-                projectId: string;
-                keyId: string;
-                serviceAccountEmail: string;
-                clientId?: string | null;
-              };
-        } | null;
-        googleServiceAccountKeyForFcmV1?: {
-          __typename?: 'GoogleServiceAccountKey';
-          id: string;
-          projectIdentifier: string;
-          privateKeyIdentifier: string;
-          clientEmail: string;
-          clientIdentifier: string;
-          createdAt: any;
-          updatedAt: any;
-        } | null;
-        googleServiceAccountKeyForSubmissions?: {
-          __typename?: 'GoogleServiceAccountKey';
-          id: string;
-          projectIdentifier: string;
-          privateKeyIdentifier: string;
-          clientEmail: string;
-          clientIdentifier: string;
-          createdAt: any;
-          updatedAt: any;
-        } | null;
-        androidAppBuildCredentialsList: Array<{
-          __typename?: 'AndroidAppBuildCredentials';
-          id: string;
-          isDefault: boolean;
-          isLegacy: boolean;
-          name: string;
-          androidKeystore?: {
-            __typename?: 'AndroidKeystore';
-            id: string;
-            type: AndroidKeystoreType;
-            keystore: string;
-            keystorePassword: string;
-            keyAlias: string;
-            keyPassword?: string | null;
-            md5CertificateFingerprint?: string | null;
-            sha1CertificateFingerprint?: string | null;
-            sha256CertificateFingerprint?: string | null;
-            createdAt: any;
-            updatedAt: any;
-          } | null;
-        }>;
-      }>;
-    };
-  };
-};
+export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQueryVariables = Exact<{
+  projectFullName: Scalars['String']['input'];
+  applicationIdentifier?: InputMaybe<Scalars['String']['input']>;
+  legacyOnly?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
+
+
+export type CommonAndroidAppCredentialsWithBuildCredentialsByApplicationIdentifierQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, androidAppCredentials: Array<{ __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForFcmV1?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> }> } } };
 
 export type GoogleServiceAccountKeysPaginatedByAccountQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
@@ -7910,262 +7590,77 @@ export type GoogleServiceAccountKeysPaginatedByAccountQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GoogleServiceAccountKeysPaginatedByAccountQuery = {
-  __typename?: 'RootQuery';
-  account: {
-    __typename?: 'AccountQuery';
-    byName: {
-      __typename?: 'Account';
-      id: string;
-      googleServiceAccountKeysPaginated: {
-        __typename?: 'AccountGoogleServiceAccountKeysConnection';
-        edges: Array<{
-          __typename?: 'AccountGoogleServiceAccountKeysEdge';
-          cursor: string;
-          node: {
-            __typename?: 'GoogleServiceAccountKey';
-            id: string;
-            projectIdentifier: string;
-            privateKeyIdentifier: string;
-            clientEmail: string;
-            clientIdentifier: string;
-            createdAt: any;
-            updatedAt: any;
-          };
-        }>;
-        pageInfo: {
-          __typename?: 'PageInfo';
-          hasNextPage: boolean;
-          hasPreviousPage: boolean;
-          startCursor?: string | null;
-          endCursor?: string | null;
-        };
-      };
-    };
-  };
-};
+
+export type GoogleServiceAccountKeysPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, googleServiceAccountKeysPaginated: { __typename?: 'AccountGoogleServiceAccountKeysConnection', edges: Array<{ __typename?: 'AccountGoogleServiceAccountKeysEdge', cursor: string, node: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type CreateAppStoreConnectApiKeyMutationVariables = Exact<{
   appStoreConnectApiKeyInput: AppStoreConnectApiKeyInput;
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateAppStoreConnectApiKeyMutation = {
-  __typename?: 'RootMutation';
-  appStoreConnectApiKey: {
-    __typename?: 'AppStoreConnectApiKeyMutation';
-    createAppStoreConnectApiKey: {
-      __typename?: 'AppStoreConnectApiKey';
-      id: string;
-      issuerIdentifier: string;
-      keyIdentifier: string;
-      name?: string | null;
-      roles?: Array<AppStoreConnectUserRole> | null;
-      createdAt: any;
-      updatedAt: any;
-      appleTeam?: {
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      } | null;
-    };
-  };
-};
+
+export type CreateAppStoreConnectApiKeyMutation = { __typename?: 'RootMutation', appStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKeyMutation', createAppStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } } };
 
 export type DeleteAppStoreConnectApiKeyMutationVariables = Exact<{
   appStoreConnectApiKeyId: Scalars['ID']['input'];
 }>;
 
-export type DeleteAppStoreConnectApiKeyMutation = {
-  __typename?: 'RootMutation';
-  appStoreConnectApiKey: {
-    __typename?: 'AppStoreConnectApiKeyMutation';
-    deleteAppStoreConnectApiKey: { __typename?: 'deleteAppStoreConnectApiKeyResult'; id: string };
-  };
-};
+
+export type DeleteAppStoreConnectApiKeyMutation = { __typename?: 'RootMutation', appStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKeyMutation', deleteAppStoreConnectApiKey: { __typename?: 'deleteAppStoreConnectApiKeyResult', id: string } } };
 
 export type CreateAppleAppIdentifierMutationVariables = Exact<{
   appleAppIdentifierInput: AppleAppIdentifierInput;
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateAppleAppIdentifierMutation = {
-  __typename?: 'RootMutation';
-  appleAppIdentifier: {
-    __typename?: 'AppleAppIdentifierMutation';
-    createAppleAppIdentifier: {
-      __typename?: 'AppleAppIdentifier';
-      id: string;
-      bundleIdentifier: string;
-    };
-  };
-};
+
+export type CreateAppleAppIdentifierMutation = { __typename?: 'RootMutation', appleAppIdentifier: { __typename?: 'AppleAppIdentifierMutation', createAppleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } } };
 
 export type CreateAppleDeviceMutationVariables = Exact<{
   appleDeviceInput: AppleDeviceInput;
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateAppleDeviceMutation = {
-  __typename?: 'RootMutation';
-  appleDevice: {
-    __typename?: 'AppleDeviceMutation';
-    createAppleDevice: {
-      __typename?: 'AppleDevice';
-      id: string;
-      identifier: string;
-      name?: string | null;
-      model?: string | null;
-      deviceClass?: AppleDeviceClass | null;
-      createdAt: any;
-    };
-  };
-};
+
+export type CreateAppleDeviceMutation = { __typename?: 'RootMutation', appleDevice: { __typename?: 'AppleDeviceMutation', createAppleDevice: { __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any } } };
 
 export type DeleteAppleDeviceMutationVariables = Exact<{
   deviceId: Scalars['ID']['input'];
 }>;
 
-export type DeleteAppleDeviceMutation = {
-  __typename?: 'RootMutation';
-  appleDevice: {
-    __typename?: 'AppleDeviceMutation';
-    deleteAppleDevice: { __typename?: 'DeleteAppleDeviceResult'; id: string };
-  };
-};
+
+export type DeleteAppleDeviceMutation = { __typename?: 'RootMutation', appleDevice: { __typename?: 'AppleDeviceMutation', deleteAppleDevice: { __typename?: 'DeleteAppleDeviceResult', id: string } } };
 
 export type UpdateAppleDeviceMutationVariables = Exact<{
   id: Scalars['ID']['input'];
   appleDeviceUpdateInput: AppleDeviceUpdateInput;
 }>;
 
-export type UpdateAppleDeviceMutation = {
-  __typename?: 'RootMutation';
-  appleDevice: {
-    __typename?: 'AppleDeviceMutation';
-    updateAppleDevice: {
-      __typename?: 'AppleDevice';
-      id: string;
-      identifier: string;
-      name?: string | null;
-      model?: string | null;
-      deviceClass?: AppleDeviceClass | null;
-      createdAt: any;
-    };
-  };
-};
+
+export type UpdateAppleDeviceMutation = { __typename?: 'RootMutation', appleDevice: { __typename?: 'AppleDeviceMutation', updateAppleDevice: { __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any } } };
 
 export type CreateAppleDeviceRegistrationRequestMutationVariables = Exact<{
   appleTeamId: Scalars['ID']['input'];
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateAppleDeviceRegistrationRequestMutation = {
-  __typename?: 'RootMutation';
-  appleDeviceRegistrationRequest: {
-    __typename?: 'AppleDeviceRegistrationRequestMutation';
-    createAppleDeviceRegistrationRequest: {
-      __typename?: 'AppleDeviceRegistrationRequest';
-      id: string;
-    };
-  };
-};
+
+export type CreateAppleDeviceRegistrationRequestMutation = { __typename?: 'RootMutation', appleDeviceRegistrationRequest: { __typename?: 'AppleDeviceRegistrationRequestMutation', createAppleDeviceRegistrationRequest: { __typename?: 'AppleDeviceRegistrationRequest', id: string } } };
 
 export type CreateAppleDistributionCertificateMutationVariables = Exact<{
   appleDistributionCertificateInput: AppleDistributionCertificateInput;
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateAppleDistributionCertificateMutation = {
-  __typename?: 'RootMutation';
-  appleDistributionCertificate: {
-    __typename?: 'AppleDistributionCertificateMutation';
-    createAppleDistributionCertificate?: {
-      __typename?: 'AppleDistributionCertificate';
-      id: string;
-      certificateP12?: string | null;
-      certificatePassword?: string | null;
-      serialNumber: string;
-      developerPortalIdentifier?: string | null;
-      validityNotBefore: any;
-      validityNotAfter: any;
-      updatedAt: any;
-      appleTeam?: {
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      } | null;
-      iosAppBuildCredentialsList: Array<{
-        __typename?: 'IosAppBuildCredentials';
-        id: string;
-        iosAppCredentials: {
-          __typename?: 'IosAppCredentials';
-          id: string;
-          app: {
-            __typename?: 'App';
-            id: string;
-            name: string;
-            fullName: string;
-            slug: string;
-            ownerAccount: {
-              __typename?: 'Account';
-              id: string;
-              name: string;
-              ownerUserActor?:
-                | { __typename?: 'SSOUser'; id: string; username: string }
-                | { __typename?: 'User'; id: string; username: string }
-                | null;
-              users: Array<{
-                __typename?: 'UserPermission';
-                role: Role;
-                actor:
-                  | { __typename?: 'Robot'; id: string }
-                  | { __typename?: 'SSOUser'; id: string }
-                  | { __typename?: 'User'; id: string };
-              }>;
-            };
-            githubRepository?: {
-              __typename?: 'GitHubRepository';
-              id: string;
-              metadata: {
-                __typename?: 'GitHubRepositoryMetadata';
-                githubRepoOwnerName: string;
-                githubRepoName: string;
-              };
-            } | null;
-          };
-          appleAppIdentifier: {
-            __typename?: 'AppleAppIdentifier';
-            id: string;
-            bundleIdentifier: string;
-          };
-        };
-        provisioningProfile?: {
-          __typename?: 'AppleProvisioningProfile';
-          id: string;
-          developerPortalIdentifier?: string | null;
-        } | null;
-      }>;
-    } | null;
-  };
-};
+
+export type CreateAppleDistributionCertificateMutation = { __typename?: 'RootMutation', appleDistributionCertificate: { __typename?: 'AppleDistributionCertificateMutation', createAppleDistributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null } };
 
 export type DeleteAppleDistributionCertificateMutationVariables = Exact<{
   appleDistributionCertificateId: Scalars['ID']['input'];
 }>;
 
-export type DeleteAppleDistributionCertificateMutation = {
-  __typename?: 'RootMutation';
-  appleDistributionCertificate: {
-    __typename?: 'AppleDistributionCertificateMutation';
-    deleteAppleDistributionCertificate: {
-      __typename?: 'DeleteAppleDistributionCertificateResult';
-      id: string;
-    };
-  };
-};
+
+export type DeleteAppleDistributionCertificateMutation = { __typename?: 'RootMutation', appleDistributionCertificate: { __typename?: 'AppleDistributionCertificateMutation', deleteAppleDistributionCertificate: { __typename?: 'DeleteAppleDistributionCertificateResult', id: string } } };
 
 export type CreateAppleProvisioningProfileMutationVariables = Exact<{
   appleProvisioningProfileInput: AppleProvisioningProfileInput;
@@ -8173,527 +7668,70 @@ export type CreateAppleProvisioningProfileMutationVariables = Exact<{
   appleAppIdentifierId: Scalars['ID']['input'];
 }>;
 
-export type CreateAppleProvisioningProfileMutation = {
-  __typename?: 'RootMutation';
-  appleProvisioningProfile: {
-    __typename?: 'AppleProvisioningProfileMutation';
-    createAppleProvisioningProfile: {
-      __typename?: 'AppleProvisioningProfile';
-      id: string;
-      expiration: any;
-      developerPortalIdentifier?: string | null;
-      provisioningProfile?: string | null;
-      updatedAt: any;
-      status: string;
-      appleTeam?: {
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      } | null;
-      appleDevices: Array<{
-        __typename?: 'AppleDevice';
-        id: string;
-        identifier: string;
-        name?: string | null;
-        model?: string | null;
-        deviceClass?: AppleDeviceClass | null;
-        createdAt: any;
-      }>;
-    };
-  };
-};
+
+export type CreateAppleProvisioningProfileMutation = { __typename?: 'RootMutation', appleProvisioningProfile: { __typename?: 'AppleProvisioningProfileMutation', createAppleProvisioningProfile: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } } };
 
 export type UpdateAppleProvisioningProfileMutationVariables = Exact<{
   appleProvisioningProfileId: Scalars['ID']['input'];
   appleProvisioningProfileInput: AppleProvisioningProfileInput;
 }>;
 
-export type UpdateAppleProvisioningProfileMutation = {
-  __typename?: 'RootMutation';
-  appleProvisioningProfile: {
-    __typename?: 'AppleProvisioningProfileMutation';
-    updateAppleProvisioningProfile: {
-      __typename?: 'AppleProvisioningProfile';
-      id: string;
-      expiration: any;
-      developerPortalIdentifier?: string | null;
-      provisioningProfile?: string | null;
-      updatedAt: any;
-      status: string;
-      appleTeam?: {
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      } | null;
-      appleDevices: Array<{
-        __typename?: 'AppleDevice';
-        id: string;
-        identifier: string;
-        name?: string | null;
-        model?: string | null;
-        deviceClass?: AppleDeviceClass | null;
-        createdAt: any;
-      }>;
-    };
-  };
-};
+
+export type UpdateAppleProvisioningProfileMutation = { __typename?: 'RootMutation', appleProvisioningProfile: { __typename?: 'AppleProvisioningProfileMutation', updateAppleProvisioningProfile: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } } };
 
 export type DeleteAppleProvisioningProfilesMutationVariables = Exact<{
   appleProvisioningProfileIds: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
 }>;
 
-export type DeleteAppleProvisioningProfilesMutation = {
-  __typename?: 'RootMutation';
-  appleProvisioningProfile: {
-    __typename?: 'AppleProvisioningProfileMutation';
-    deleteAppleProvisioningProfiles: Array<{
-      __typename?: 'DeleteAppleProvisioningProfileResult';
-      id: string;
-    }>;
-  };
-};
+
+export type DeleteAppleProvisioningProfilesMutation = { __typename?: 'RootMutation', appleProvisioningProfile: { __typename?: 'AppleProvisioningProfileMutation', deleteAppleProvisioningProfiles: Array<{ __typename?: 'DeleteAppleProvisioningProfileResult', id: string }> } };
 
 export type CreateApplePushKeyMutationVariables = Exact<{
   applePushKeyInput: ApplePushKeyInput;
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateApplePushKeyMutation = {
-  __typename?: 'RootMutation';
-  applePushKey: {
-    __typename?: 'ApplePushKeyMutation';
-    createApplePushKey: {
-      __typename?: 'ApplePushKey';
-      id: string;
-      keyIdentifier: string;
-      updatedAt: any;
-      appleTeam?: {
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      } | null;
-      iosAppCredentialsList: Array<{
-        __typename?: 'IosAppCredentials';
-        id: string;
-        app: {
-          __typename?: 'App';
-          id: string;
-          name: string;
-          fullName: string;
-          slug: string;
-          ownerAccount: {
-            __typename?: 'Account';
-            id: string;
-            name: string;
-            ownerUserActor?:
-              | { __typename?: 'SSOUser'; id: string; username: string }
-              | { __typename?: 'User'; id: string; username: string }
-              | null;
-            users: Array<{
-              __typename?: 'UserPermission';
-              role: Role;
-              actor:
-                | { __typename?: 'Robot'; id: string }
-                | { __typename?: 'SSOUser'; id: string }
-                | { __typename?: 'User'; id: string };
-            }>;
-          };
-          githubRepository?: {
-            __typename?: 'GitHubRepository';
-            id: string;
-            metadata: {
-              __typename?: 'GitHubRepositoryMetadata';
-              githubRepoOwnerName: string;
-              githubRepoName: string;
-            };
-          } | null;
-        };
-        appleAppIdentifier: {
-          __typename?: 'AppleAppIdentifier';
-          id: string;
-          bundleIdentifier: string;
-        };
-      }>;
-    };
-  };
-};
+
+export type CreateApplePushKeyMutation = { __typename?: 'RootMutation', applePushKey: { __typename?: 'ApplePushKeyMutation', createApplePushKey: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } } };
 
 export type DeleteApplePushKeyMutationVariables = Exact<{
   applePushKeyId: Scalars['ID']['input'];
 }>;
 
-export type DeleteApplePushKeyMutation = {
-  __typename?: 'RootMutation';
-  applePushKey: {
-    __typename?: 'ApplePushKeyMutation';
-    deleteApplePushKey: { __typename?: 'deleteApplePushKeyResult'; id: string };
-  };
-};
+
+export type DeleteApplePushKeyMutation = { __typename?: 'RootMutation', applePushKey: { __typename?: 'ApplePushKeyMutation', deleteApplePushKey: { __typename?: 'deleteApplePushKeyResult', id: string } } };
 
 export type CreateAppleTeamMutationVariables = Exact<{
   appleTeamInput: AppleTeamInput;
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateAppleTeamMutation = {
-  __typename?: 'RootMutation';
-  appleTeam: {
-    __typename?: 'AppleTeamMutation';
-    createAppleTeam: {
-      __typename?: 'AppleTeam';
-      id: string;
-      appleTeamIdentifier: string;
-      appleTeamName?: string | null;
-      account: {
-        __typename?: 'Account';
-        id: string;
-        name: string;
-        ownerUserActor?:
-          | { __typename?: 'SSOUser'; id: string; username: string }
-          | { __typename?: 'User'; id: string; username: string }
-          | null;
-        users: Array<{
-          __typename?: 'UserPermission';
-          role: Role;
-          actor:
-            | { __typename?: 'Robot'; id: string }
-            | { __typename?: 'SSOUser'; id: string }
-            | { __typename?: 'User'; id: string };
-        }>;
-      };
-    };
-  };
-};
+
+export type CreateAppleTeamMutation = { __typename?: 'RootMutation', appleTeam: { __typename?: 'AppleTeamMutation', createAppleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null, account: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> } } } };
 
 export type CreateIosAppBuildCredentialsMutationVariables = Exact<{
   iosAppBuildCredentialsInput: IosAppBuildCredentialsInput;
   iosAppCredentialsId: Scalars['ID']['input'];
 }>;
 
-export type CreateIosAppBuildCredentialsMutation = {
-  __typename?: 'RootMutation';
-  iosAppBuildCredentials: {
-    __typename?: 'IosAppBuildCredentialsMutation';
-    createIosAppBuildCredentials: {
-      __typename?: 'IosAppBuildCredentials';
-      id: string;
-      iosDistributionType: IosDistributionType;
-      distributionCertificate?: {
-        __typename?: 'AppleDistributionCertificate';
-        id: string;
-        certificateP12?: string | null;
-        certificatePassword?: string | null;
-        serialNumber: string;
-        developerPortalIdentifier?: string | null;
-        validityNotBefore: any;
-        validityNotAfter: any;
-        updatedAt: any;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        iosAppBuildCredentialsList: Array<{
-          __typename?: 'IosAppBuildCredentials';
-          id: string;
-          iosAppCredentials: {
-            __typename?: 'IosAppCredentials';
-            id: string;
-            app: {
-              __typename?: 'App';
-              id: string;
-              name: string;
-              fullName: string;
-              slug: string;
-              ownerAccount: {
-                __typename?: 'Account';
-                id: string;
-                name: string;
-                ownerUserActor?:
-                  | { __typename?: 'SSOUser'; id: string; username: string }
-                  | { __typename?: 'User'; id: string; username: string }
-                  | null;
-                users: Array<{
-                  __typename?: 'UserPermission';
-                  role: Role;
-                  actor:
-                    | { __typename?: 'Robot'; id: string }
-                    | { __typename?: 'SSOUser'; id: string }
-                    | { __typename?: 'User'; id: string };
-                }>;
-              };
-              githubRepository?: {
-                __typename?: 'GitHubRepository';
-                id: string;
-                metadata: {
-                  __typename?: 'GitHubRepositoryMetadata';
-                  githubRepoOwnerName: string;
-                  githubRepoName: string;
-                };
-              } | null;
-            };
-            appleAppIdentifier: {
-              __typename?: 'AppleAppIdentifier';
-              id: string;
-              bundleIdentifier: string;
-            };
-          };
-          provisioningProfile?: {
-            __typename?: 'AppleProvisioningProfile';
-            id: string;
-            developerPortalIdentifier?: string | null;
-          } | null;
-        }>;
-      } | null;
-      provisioningProfile?: {
-        __typename?: 'AppleProvisioningProfile';
-        id: string;
-        expiration: any;
-        developerPortalIdentifier?: string | null;
-        provisioningProfile?: string | null;
-        updatedAt: any;
-        status: string;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        appleDevices: Array<{
-          __typename?: 'AppleDevice';
-          id: string;
-          identifier: string;
-          name?: string | null;
-          model?: string | null;
-          deviceClass?: AppleDeviceClass | null;
-          createdAt: any;
-        }>;
-      } | null;
-    };
-  };
-};
+
+export type CreateIosAppBuildCredentialsMutation = { __typename?: 'RootMutation', iosAppBuildCredentials: { __typename?: 'IosAppBuildCredentialsMutation', createIosAppBuildCredentials: { __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null } } };
 
 export type SetDistributionCertificateMutationVariables = Exact<{
   iosAppBuildCredentialsId: Scalars['ID']['input'];
   distributionCertificateId: Scalars['ID']['input'];
 }>;
 
-export type SetDistributionCertificateMutation = {
-  __typename?: 'RootMutation';
-  iosAppBuildCredentials: {
-    __typename?: 'IosAppBuildCredentialsMutation';
-    setDistributionCertificate: {
-      __typename?: 'IosAppBuildCredentials';
-      id: string;
-      iosDistributionType: IosDistributionType;
-      distributionCertificate?: {
-        __typename?: 'AppleDistributionCertificate';
-        id: string;
-        certificateP12?: string | null;
-        certificatePassword?: string | null;
-        serialNumber: string;
-        developerPortalIdentifier?: string | null;
-        validityNotBefore: any;
-        validityNotAfter: any;
-        updatedAt: any;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        iosAppBuildCredentialsList: Array<{
-          __typename?: 'IosAppBuildCredentials';
-          id: string;
-          iosAppCredentials: {
-            __typename?: 'IosAppCredentials';
-            id: string;
-            app: {
-              __typename?: 'App';
-              id: string;
-              name: string;
-              fullName: string;
-              slug: string;
-              ownerAccount: {
-                __typename?: 'Account';
-                id: string;
-                name: string;
-                ownerUserActor?:
-                  | { __typename?: 'SSOUser'; id: string; username: string }
-                  | { __typename?: 'User'; id: string; username: string }
-                  | null;
-                users: Array<{
-                  __typename?: 'UserPermission';
-                  role: Role;
-                  actor:
-                    | { __typename?: 'Robot'; id: string }
-                    | { __typename?: 'SSOUser'; id: string }
-                    | { __typename?: 'User'; id: string };
-                }>;
-              };
-              githubRepository?: {
-                __typename?: 'GitHubRepository';
-                id: string;
-                metadata: {
-                  __typename?: 'GitHubRepositoryMetadata';
-                  githubRepoOwnerName: string;
-                  githubRepoName: string;
-                };
-              } | null;
-            };
-            appleAppIdentifier: {
-              __typename?: 'AppleAppIdentifier';
-              id: string;
-              bundleIdentifier: string;
-            };
-          };
-          provisioningProfile?: {
-            __typename?: 'AppleProvisioningProfile';
-            id: string;
-            developerPortalIdentifier?: string | null;
-          } | null;
-        }>;
-      } | null;
-      provisioningProfile?: {
-        __typename?: 'AppleProvisioningProfile';
-        id: string;
-        expiration: any;
-        developerPortalIdentifier?: string | null;
-        provisioningProfile?: string | null;
-        updatedAt: any;
-        status: string;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        appleDevices: Array<{
-          __typename?: 'AppleDevice';
-          id: string;
-          identifier: string;
-          name?: string | null;
-          model?: string | null;
-          deviceClass?: AppleDeviceClass | null;
-          createdAt: any;
-        }>;
-      } | null;
-    };
-  };
-};
+
+export type SetDistributionCertificateMutation = { __typename?: 'RootMutation', iosAppBuildCredentials: { __typename?: 'IosAppBuildCredentialsMutation', setDistributionCertificate: { __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null } } };
 
 export type SetProvisioningProfileMutationVariables = Exact<{
   iosAppBuildCredentialsId: Scalars['ID']['input'];
   provisioningProfileId: Scalars['ID']['input'];
 }>;
 
-export type SetProvisioningProfileMutation = {
-  __typename?: 'RootMutation';
-  iosAppBuildCredentials: {
-    __typename?: 'IosAppBuildCredentialsMutation';
-    setProvisioningProfile: {
-      __typename?: 'IosAppBuildCredentials';
-      id: string;
-      iosDistributionType: IosDistributionType;
-      distributionCertificate?: {
-        __typename?: 'AppleDistributionCertificate';
-        id: string;
-        certificateP12?: string | null;
-        certificatePassword?: string | null;
-        serialNumber: string;
-        developerPortalIdentifier?: string | null;
-        validityNotBefore: any;
-        validityNotAfter: any;
-        updatedAt: any;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        iosAppBuildCredentialsList: Array<{
-          __typename?: 'IosAppBuildCredentials';
-          id: string;
-          iosAppCredentials: {
-            __typename?: 'IosAppCredentials';
-            id: string;
-            app: {
-              __typename?: 'App';
-              id: string;
-              name: string;
-              fullName: string;
-              slug: string;
-              ownerAccount: {
-                __typename?: 'Account';
-                id: string;
-                name: string;
-                ownerUserActor?:
-                  | { __typename?: 'SSOUser'; id: string; username: string }
-                  | { __typename?: 'User'; id: string; username: string }
-                  | null;
-                users: Array<{
-                  __typename?: 'UserPermission';
-                  role: Role;
-                  actor:
-                    | { __typename?: 'Robot'; id: string }
-                    | { __typename?: 'SSOUser'; id: string }
-                    | { __typename?: 'User'; id: string };
-                }>;
-              };
-              githubRepository?: {
-                __typename?: 'GitHubRepository';
-                id: string;
-                metadata: {
-                  __typename?: 'GitHubRepositoryMetadata';
-                  githubRepoOwnerName: string;
-                  githubRepoName: string;
-                };
-              } | null;
-            };
-            appleAppIdentifier: {
-              __typename?: 'AppleAppIdentifier';
-              id: string;
-              bundleIdentifier: string;
-            };
-          };
-          provisioningProfile?: {
-            __typename?: 'AppleProvisioningProfile';
-            id: string;
-            developerPortalIdentifier?: string | null;
-          } | null;
-        }>;
-      } | null;
-      provisioningProfile?: {
-        __typename?: 'AppleProvisioningProfile';
-        id: string;
-        expiration: any;
-        developerPortalIdentifier?: string | null;
-        provisioningProfile?: string | null;
-        updatedAt: any;
-        status: string;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        appleDevices: Array<{
-          __typename?: 'AppleDevice';
-          id: string;
-          identifier: string;
-          name?: string | null;
-          model?: string | null;
-          deviceClass?: AppleDeviceClass | null;
-          createdAt: any;
-        }>;
-      } | null;
-    };
-  };
-};
+
+export type SetProvisioningProfileMutation = { __typename?: 'RootMutation', iosAppBuildCredentials: { __typename?: 'IosAppBuildCredentialsMutation', setProvisioningProfile: { __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null } } };
 
 export type CreateIosAppCredentialsMutationVariables = Exact<{
   iosAppCredentialsInput: IosAppCredentialsInput;
@@ -8701,681 +7739,24 @@ export type CreateIosAppCredentialsMutationVariables = Exact<{
   appleAppIdentifierId: Scalars['ID']['input'];
 }>;
 
-export type CreateIosAppCredentialsMutation = {
-  __typename?: 'RootMutation';
-  iosAppCredentials: {
-    __typename?: 'IosAppCredentialsMutation';
-    createIosAppCredentials: {
-      __typename?: 'IosAppCredentials';
-      id: string;
-      iosAppBuildCredentialsList: Array<{
-        __typename?: 'IosAppBuildCredentials';
-        id: string;
-        iosDistributionType: IosDistributionType;
-        distributionCertificate?: {
-          __typename?: 'AppleDistributionCertificate';
-          id: string;
-          certificateP12?: string | null;
-          certificatePassword?: string | null;
-          serialNumber: string;
-          developerPortalIdentifier?: string | null;
-          validityNotBefore: any;
-          validityNotAfter: any;
-          updatedAt: any;
-          appleTeam?: {
-            __typename?: 'AppleTeam';
-            id: string;
-            appleTeamIdentifier: string;
-            appleTeamName?: string | null;
-          } | null;
-          iosAppBuildCredentialsList: Array<{
-            __typename?: 'IosAppBuildCredentials';
-            id: string;
-            iosAppCredentials: {
-              __typename?: 'IosAppCredentials';
-              id: string;
-              app: {
-                __typename?: 'App';
-                id: string;
-                name: string;
-                fullName: string;
-                slug: string;
-                ownerAccount: {
-                  __typename?: 'Account';
-                  id: string;
-                  name: string;
-                  ownerUserActor?:
-                    | { __typename?: 'SSOUser'; id: string; username: string }
-                    | { __typename?: 'User'; id: string; username: string }
-                    | null;
-                  users: Array<{
-                    __typename?: 'UserPermission';
-                    role: Role;
-                    actor:
-                      | { __typename?: 'Robot'; id: string }
-                      | { __typename?: 'SSOUser'; id: string }
-                      | { __typename?: 'User'; id: string };
-                  }>;
-                };
-                githubRepository?: {
-                  __typename?: 'GitHubRepository';
-                  id: string;
-                  metadata: {
-                    __typename?: 'GitHubRepositoryMetadata';
-                    githubRepoOwnerName: string;
-                    githubRepoName: string;
-                  };
-                } | null;
-              };
-              appleAppIdentifier: {
-                __typename?: 'AppleAppIdentifier';
-                id: string;
-                bundleIdentifier: string;
-              };
-            };
-            provisioningProfile?: {
-              __typename?: 'AppleProvisioningProfile';
-              id: string;
-              developerPortalIdentifier?: string | null;
-            } | null;
-          }>;
-        } | null;
-        provisioningProfile?: {
-          __typename?: 'AppleProvisioningProfile';
-          id: string;
-          expiration: any;
-          developerPortalIdentifier?: string | null;
-          provisioningProfile?: string | null;
-          updatedAt: any;
-          status: string;
-          appleTeam?: {
-            __typename?: 'AppleTeam';
-            id: string;
-            appleTeamIdentifier: string;
-            appleTeamName?: string | null;
-          } | null;
-          appleDevices: Array<{
-            __typename?: 'AppleDevice';
-            id: string;
-            identifier: string;
-            name?: string | null;
-            model?: string | null;
-            deviceClass?: AppleDeviceClass | null;
-            createdAt: any;
-          }>;
-        } | null;
-      }>;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        fullName: string;
-        slug: string;
-        ownerAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        githubRepository?: {
-          __typename?: 'GitHubRepository';
-          id: string;
-          metadata: {
-            __typename?: 'GitHubRepositoryMetadata';
-            githubRepoOwnerName: string;
-            githubRepoName: string;
-          };
-        } | null;
-      };
-      appleTeam?: {
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      } | null;
-      appleAppIdentifier: {
-        __typename?: 'AppleAppIdentifier';
-        id: string;
-        bundleIdentifier: string;
-      };
-      pushKey?: {
-        __typename?: 'ApplePushKey';
-        id: string;
-        keyIdentifier: string;
-        updatedAt: any;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        iosAppCredentialsList: Array<{
-          __typename?: 'IosAppCredentials';
-          id: string;
-          app: {
-            __typename?: 'App';
-            id: string;
-            name: string;
-            fullName: string;
-            slug: string;
-            ownerAccount: {
-              __typename?: 'Account';
-              id: string;
-              name: string;
-              ownerUserActor?:
-                | { __typename?: 'SSOUser'; id: string; username: string }
-                | { __typename?: 'User'; id: string; username: string }
-                | null;
-              users: Array<{
-                __typename?: 'UserPermission';
-                role: Role;
-                actor:
-                  | { __typename?: 'Robot'; id: string }
-                  | { __typename?: 'SSOUser'; id: string }
-                  | { __typename?: 'User'; id: string };
-              }>;
-            };
-            githubRepository?: {
-              __typename?: 'GitHubRepository';
-              id: string;
-              metadata: {
-                __typename?: 'GitHubRepositoryMetadata';
-                githubRepoOwnerName: string;
-                githubRepoName: string;
-              };
-            } | null;
-          };
-          appleAppIdentifier: {
-            __typename?: 'AppleAppIdentifier';
-            id: string;
-            bundleIdentifier: string;
-          };
-        }>;
-      } | null;
-      appStoreConnectApiKeyForSubmissions?: {
-        __typename?: 'AppStoreConnectApiKey';
-        id: string;
-        issuerIdentifier: string;
-        keyIdentifier: string;
-        name?: string | null;
-        roles?: Array<AppStoreConnectUserRole> | null;
-        createdAt: any;
-        updatedAt: any;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-      } | null;
-    };
-  };
-};
+
+export type CreateIosAppCredentialsMutation = { __typename?: 'RootMutation', iosAppCredentials: { __typename?: 'IosAppCredentialsMutation', createIosAppCredentials: { __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null }>, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
 
 export type SetPushKeyMutationVariables = Exact<{
   iosAppCredentialsId: Scalars['ID']['input'];
   pushKeyId: Scalars['ID']['input'];
 }>;
 
-export type SetPushKeyMutation = {
-  __typename?: 'RootMutation';
-  iosAppCredentials: {
-    __typename?: 'IosAppCredentialsMutation';
-    setPushKey: {
-      __typename?: 'IosAppCredentials';
-      id: string;
-      iosAppBuildCredentialsList: Array<{
-        __typename?: 'IosAppBuildCredentials';
-        id: string;
-        iosDistributionType: IosDistributionType;
-        distributionCertificate?: {
-          __typename?: 'AppleDistributionCertificate';
-          id: string;
-          certificateP12?: string | null;
-          certificatePassword?: string | null;
-          serialNumber: string;
-          developerPortalIdentifier?: string | null;
-          validityNotBefore: any;
-          validityNotAfter: any;
-          updatedAt: any;
-          appleTeam?: {
-            __typename?: 'AppleTeam';
-            id: string;
-            appleTeamIdentifier: string;
-            appleTeamName?: string | null;
-          } | null;
-          iosAppBuildCredentialsList: Array<{
-            __typename?: 'IosAppBuildCredentials';
-            id: string;
-            iosAppCredentials: {
-              __typename?: 'IosAppCredentials';
-              id: string;
-              app: {
-                __typename?: 'App';
-                id: string;
-                name: string;
-                fullName: string;
-                slug: string;
-                ownerAccount: {
-                  __typename?: 'Account';
-                  id: string;
-                  name: string;
-                  ownerUserActor?:
-                    | { __typename?: 'SSOUser'; id: string; username: string }
-                    | { __typename?: 'User'; id: string; username: string }
-                    | null;
-                  users: Array<{
-                    __typename?: 'UserPermission';
-                    role: Role;
-                    actor:
-                      | { __typename?: 'Robot'; id: string }
-                      | { __typename?: 'SSOUser'; id: string }
-                      | { __typename?: 'User'; id: string };
-                  }>;
-                };
-                githubRepository?: {
-                  __typename?: 'GitHubRepository';
-                  id: string;
-                  metadata: {
-                    __typename?: 'GitHubRepositoryMetadata';
-                    githubRepoOwnerName: string;
-                    githubRepoName: string;
-                  };
-                } | null;
-              };
-              appleAppIdentifier: {
-                __typename?: 'AppleAppIdentifier';
-                id: string;
-                bundleIdentifier: string;
-              };
-            };
-            provisioningProfile?: {
-              __typename?: 'AppleProvisioningProfile';
-              id: string;
-              developerPortalIdentifier?: string | null;
-            } | null;
-          }>;
-        } | null;
-        provisioningProfile?: {
-          __typename?: 'AppleProvisioningProfile';
-          id: string;
-          expiration: any;
-          developerPortalIdentifier?: string | null;
-          provisioningProfile?: string | null;
-          updatedAt: any;
-          status: string;
-          appleTeam?: {
-            __typename?: 'AppleTeam';
-            id: string;
-            appleTeamIdentifier: string;
-            appleTeamName?: string | null;
-          } | null;
-          appleDevices: Array<{
-            __typename?: 'AppleDevice';
-            id: string;
-            identifier: string;
-            name?: string | null;
-            model?: string | null;
-            deviceClass?: AppleDeviceClass | null;
-            createdAt: any;
-          }>;
-        } | null;
-      }>;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        fullName: string;
-        slug: string;
-        ownerAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        githubRepository?: {
-          __typename?: 'GitHubRepository';
-          id: string;
-          metadata: {
-            __typename?: 'GitHubRepositoryMetadata';
-            githubRepoOwnerName: string;
-            githubRepoName: string;
-          };
-        } | null;
-      };
-      appleTeam?: {
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      } | null;
-      appleAppIdentifier: {
-        __typename?: 'AppleAppIdentifier';
-        id: string;
-        bundleIdentifier: string;
-      };
-      pushKey?: {
-        __typename?: 'ApplePushKey';
-        id: string;
-        keyIdentifier: string;
-        updatedAt: any;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        iosAppCredentialsList: Array<{
-          __typename?: 'IosAppCredentials';
-          id: string;
-          app: {
-            __typename?: 'App';
-            id: string;
-            name: string;
-            fullName: string;
-            slug: string;
-            ownerAccount: {
-              __typename?: 'Account';
-              id: string;
-              name: string;
-              ownerUserActor?:
-                | { __typename?: 'SSOUser'; id: string; username: string }
-                | { __typename?: 'User'; id: string; username: string }
-                | null;
-              users: Array<{
-                __typename?: 'UserPermission';
-                role: Role;
-                actor:
-                  | { __typename?: 'Robot'; id: string }
-                  | { __typename?: 'SSOUser'; id: string }
-                  | { __typename?: 'User'; id: string };
-              }>;
-            };
-            githubRepository?: {
-              __typename?: 'GitHubRepository';
-              id: string;
-              metadata: {
-                __typename?: 'GitHubRepositoryMetadata';
-                githubRepoOwnerName: string;
-                githubRepoName: string;
-              };
-            } | null;
-          };
-          appleAppIdentifier: {
-            __typename?: 'AppleAppIdentifier';
-            id: string;
-            bundleIdentifier: string;
-          };
-        }>;
-      } | null;
-      appStoreConnectApiKeyForSubmissions?: {
-        __typename?: 'AppStoreConnectApiKey';
-        id: string;
-        issuerIdentifier: string;
-        keyIdentifier: string;
-        name?: string | null;
-        roles?: Array<AppStoreConnectUserRole> | null;
-        createdAt: any;
-        updatedAt: any;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-      } | null;
-    };
-  };
-};
+
+export type SetPushKeyMutation = { __typename?: 'RootMutation', iosAppCredentials: { __typename?: 'IosAppCredentialsMutation', setPushKey: { __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null }>, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
 
 export type SetAppStoreConnectApiKeyForSubmissionsMutationVariables = Exact<{
   iosAppCredentialsId: Scalars['ID']['input'];
   ascApiKeyId: Scalars['ID']['input'];
 }>;
 
-export type SetAppStoreConnectApiKeyForSubmissionsMutation = {
-  __typename?: 'RootMutation';
-  iosAppCredentials: {
-    __typename?: 'IosAppCredentialsMutation';
-    setAppStoreConnectApiKeyForSubmissions: {
-      __typename?: 'IosAppCredentials';
-      id: string;
-      iosAppBuildCredentialsList: Array<{
-        __typename?: 'IosAppBuildCredentials';
-        id: string;
-        iosDistributionType: IosDistributionType;
-        distributionCertificate?: {
-          __typename?: 'AppleDistributionCertificate';
-          id: string;
-          certificateP12?: string | null;
-          certificatePassword?: string | null;
-          serialNumber: string;
-          developerPortalIdentifier?: string | null;
-          validityNotBefore: any;
-          validityNotAfter: any;
-          updatedAt: any;
-          appleTeam?: {
-            __typename?: 'AppleTeam';
-            id: string;
-            appleTeamIdentifier: string;
-            appleTeamName?: string | null;
-          } | null;
-          iosAppBuildCredentialsList: Array<{
-            __typename?: 'IosAppBuildCredentials';
-            id: string;
-            iosAppCredentials: {
-              __typename?: 'IosAppCredentials';
-              id: string;
-              app: {
-                __typename?: 'App';
-                id: string;
-                name: string;
-                fullName: string;
-                slug: string;
-                ownerAccount: {
-                  __typename?: 'Account';
-                  id: string;
-                  name: string;
-                  ownerUserActor?:
-                    | { __typename?: 'SSOUser'; id: string; username: string }
-                    | { __typename?: 'User'; id: string; username: string }
-                    | null;
-                  users: Array<{
-                    __typename?: 'UserPermission';
-                    role: Role;
-                    actor:
-                      | { __typename?: 'Robot'; id: string }
-                      | { __typename?: 'SSOUser'; id: string }
-                      | { __typename?: 'User'; id: string };
-                  }>;
-                };
-                githubRepository?: {
-                  __typename?: 'GitHubRepository';
-                  id: string;
-                  metadata: {
-                    __typename?: 'GitHubRepositoryMetadata';
-                    githubRepoOwnerName: string;
-                    githubRepoName: string;
-                  };
-                } | null;
-              };
-              appleAppIdentifier: {
-                __typename?: 'AppleAppIdentifier';
-                id: string;
-                bundleIdentifier: string;
-              };
-            };
-            provisioningProfile?: {
-              __typename?: 'AppleProvisioningProfile';
-              id: string;
-              developerPortalIdentifier?: string | null;
-            } | null;
-          }>;
-        } | null;
-        provisioningProfile?: {
-          __typename?: 'AppleProvisioningProfile';
-          id: string;
-          expiration: any;
-          developerPortalIdentifier?: string | null;
-          provisioningProfile?: string | null;
-          updatedAt: any;
-          status: string;
-          appleTeam?: {
-            __typename?: 'AppleTeam';
-            id: string;
-            appleTeamIdentifier: string;
-            appleTeamName?: string | null;
-          } | null;
-          appleDevices: Array<{
-            __typename?: 'AppleDevice';
-            id: string;
-            identifier: string;
-            name?: string | null;
-            model?: string | null;
-            deviceClass?: AppleDeviceClass | null;
-            createdAt: any;
-          }>;
-        } | null;
-      }>;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        fullName: string;
-        slug: string;
-        ownerAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        githubRepository?: {
-          __typename?: 'GitHubRepository';
-          id: string;
-          metadata: {
-            __typename?: 'GitHubRepositoryMetadata';
-            githubRepoOwnerName: string;
-            githubRepoName: string;
-          };
-        } | null;
-      };
-      appleTeam?: {
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      } | null;
-      appleAppIdentifier: {
-        __typename?: 'AppleAppIdentifier';
-        id: string;
-        bundleIdentifier: string;
-      };
-      pushKey?: {
-        __typename?: 'ApplePushKey';
-        id: string;
-        keyIdentifier: string;
-        updatedAt: any;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        iosAppCredentialsList: Array<{
-          __typename?: 'IosAppCredentials';
-          id: string;
-          app: {
-            __typename?: 'App';
-            id: string;
-            name: string;
-            fullName: string;
-            slug: string;
-            ownerAccount: {
-              __typename?: 'Account';
-              id: string;
-              name: string;
-              ownerUserActor?:
-                | { __typename?: 'SSOUser'; id: string; username: string }
-                | { __typename?: 'User'; id: string; username: string }
-                | null;
-              users: Array<{
-                __typename?: 'UserPermission';
-                role: Role;
-                actor:
-                  | { __typename?: 'Robot'; id: string }
-                  | { __typename?: 'SSOUser'; id: string }
-                  | { __typename?: 'User'; id: string };
-              }>;
-            };
-            githubRepository?: {
-              __typename?: 'GitHubRepository';
-              id: string;
-              metadata: {
-                __typename?: 'GitHubRepositoryMetadata';
-                githubRepoOwnerName: string;
-                githubRepoName: string;
-              };
-            } | null;
-          };
-          appleAppIdentifier: {
-            __typename?: 'AppleAppIdentifier';
-            id: string;
-            bundleIdentifier: string;
-          };
-        }>;
-      } | null;
-      appStoreConnectApiKeyForSubmissions?: {
-        __typename?: 'AppStoreConnectApiKey';
-        id: string;
-        issuerIdentifier: string;
-        keyIdentifier: string;
-        name?: string | null;
-        roles?: Array<AppStoreConnectUserRole> | null;
-        createdAt: any;
-        updatedAt: any;
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-      } | null;
-    };
-  };
-};
+
+export type SetAppStoreConnectApiKeyForSubmissionsMutation = { __typename?: 'RootMutation', iosAppCredentials: { __typename?: 'IosAppCredentialsMutation', setAppStoreConnectApiKeyForSubmissions: { __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null }>, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
 
 export type AppStoreConnectApiKeysPaginatedByAccountQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
@@ -9385,67 +7766,16 @@ export type AppStoreConnectApiKeysPaginatedByAccountQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type AppStoreConnectApiKeysPaginatedByAccountQuery = {
-  __typename?: 'RootQuery';
-  account: {
-    __typename?: 'AccountQuery';
-    byName: {
-      __typename?: 'Account';
-      id: string;
-      appStoreConnectApiKeysPaginated: {
-        __typename?: 'AccountAppStoreConnectApiKeysConnection';
-        edges: Array<{
-          __typename?: 'AccountAppStoreConnectApiKeysEdge';
-          cursor: string;
-          node: {
-            __typename?: 'AppStoreConnectApiKey';
-            id: string;
-            issuerIdentifier: string;
-            keyIdentifier: string;
-            name?: string | null;
-            roles?: Array<AppStoreConnectUserRole> | null;
-            createdAt: any;
-            updatedAt: any;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-          };
-        }>;
-        pageInfo: {
-          __typename?: 'PageInfo';
-          hasNextPage: boolean;
-          hasPreviousPage: boolean;
-          startCursor?: string | null;
-          endCursor?: string | null;
-        };
-      };
-    };
-  };
-};
+
+export type AppStoreConnectApiKeysPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appStoreConnectApiKeysPaginated: { __typename?: 'AccountAppStoreConnectApiKeysConnection', edges: Array<{ __typename?: 'AccountAppStoreConnectApiKeysEdge', cursor: string, node: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type AppleAppIdentifierByBundleIdQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
   bundleIdentifier: Scalars['String']['input'];
 }>;
 
-export type AppleAppIdentifierByBundleIdQuery = {
-  __typename?: 'RootQuery';
-  account: {
-    __typename?: 'AccountQuery';
-    byName: {
-      __typename?: 'Account';
-      id: string;
-      appleAppIdentifiers: Array<{
-        __typename?: 'AppleAppIdentifier';
-        id: string;
-        bundleIdentifier: string;
-      }>;
-    };
-  };
-};
+
+export type AppleAppIdentifierByBundleIdQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleAppIdentifiers: Array<{ __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }> } } };
 
 export type AppleDevicesByTeamIdentifierQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
@@ -9454,32 +7784,8 @@ export type AppleDevicesByTeamIdentifierQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type AppleDevicesByTeamIdentifierQuery = {
-  __typename?: 'RootQuery';
-  account: {
-    __typename?: 'AccountQuery';
-    byName: {
-      __typename?: 'Account';
-      id: string;
-      appleTeams: Array<{
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-        appleDevices: Array<{
-          __typename?: 'AppleDevice';
-          id: string;
-          identifier: string;
-          name?: string | null;
-          deviceClass?: AppleDeviceClass | null;
-          enabled?: boolean | null;
-          model?: string | null;
-          createdAt: any;
-        }>;
-      }>;
-    };
-  };
-};
+
+export type AppleDevicesByTeamIdentifierQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleTeams: Array<{ __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, deviceClass?: AppleDeviceClass | null, enabled?: boolean | null, model?: string | null, createdAt: any }> }> } } };
 
 export type AppleDevicesPaginatedByAccountQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
@@ -9490,45 +7796,8 @@ export type AppleDevicesPaginatedByAccountQueryVariables = Exact<{
   filter?: InputMaybe<AppleDeviceFilterInput>;
 }>;
 
-export type AppleDevicesPaginatedByAccountQuery = {
-  __typename?: 'RootQuery';
-  account: {
-    __typename?: 'AccountQuery';
-    byName: {
-      __typename?: 'Account';
-      id: string;
-      appleDevicesPaginated: {
-        __typename?: 'AccountAppleDevicesConnection';
-        edges: Array<{
-          __typename?: 'AccountAppleDevicesEdge';
-          cursor: string;
-          node: {
-            __typename?: 'AppleDevice';
-            id: string;
-            identifier: string;
-            name?: string | null;
-            model?: string | null;
-            deviceClass?: AppleDeviceClass | null;
-            createdAt: any;
-            appleTeam: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            };
-          };
-        }>;
-        pageInfo: {
-          __typename?: 'PageInfo';
-          hasNextPage: boolean;
-          hasPreviousPage: boolean;
-          startCursor?: string | null;
-          endCursor?: string | null;
-        };
-      };
-    };
-  };
-};
+
+export type AppleDevicesPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDevicesPaginated: { __typename?: 'AccountAppleDevicesConnection', edges: Array<{ __typename?: 'AccountAppleDevicesEdge', cursor: string, node: { __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any, appleTeam: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type AppleDistributionCertificateByAppQueryVariables = Exact<{
   projectFullName: Scalars['String']['input'];
@@ -9536,92 +7805,8 @@ export type AppleDistributionCertificateByAppQueryVariables = Exact<{
   iosDistributionType: IosDistributionType;
 }>;
 
-export type AppleDistributionCertificateByAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byFullName: {
-      __typename?: 'App';
-      id: string;
-      iosAppCredentials: Array<{
-        __typename?: 'IosAppCredentials';
-        id: string;
-        iosAppBuildCredentialsList: Array<{
-          __typename?: 'IosAppBuildCredentials';
-          id: string;
-          distributionCertificate?: {
-            __typename?: 'AppleDistributionCertificate';
-            id: string;
-            certificateP12?: string | null;
-            certificatePassword?: string | null;
-            serialNumber: string;
-            developerPortalIdentifier?: string | null;
-            validityNotBefore: any;
-            validityNotAfter: any;
-            updatedAt: any;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-            iosAppBuildCredentialsList: Array<{
-              __typename?: 'IosAppBuildCredentials';
-              id: string;
-              iosAppCredentials: {
-                __typename?: 'IosAppCredentials';
-                id: string;
-                app: {
-                  __typename?: 'App';
-                  id: string;
-                  name: string;
-                  fullName: string;
-                  slug: string;
-                  ownerAccount: {
-                    __typename?: 'Account';
-                    id: string;
-                    name: string;
-                    ownerUserActor?:
-                      | { __typename?: 'SSOUser'; id: string; username: string }
-                      | { __typename?: 'User'; id: string; username: string }
-                      | null;
-                    users: Array<{
-                      __typename?: 'UserPermission';
-                      role: Role;
-                      actor:
-                        | { __typename?: 'Robot'; id: string }
-                        | { __typename?: 'SSOUser'; id: string }
-                        | { __typename?: 'User'; id: string };
-                    }>;
-                  };
-                  githubRepository?: {
-                    __typename?: 'GitHubRepository';
-                    id: string;
-                    metadata: {
-                      __typename?: 'GitHubRepositoryMetadata';
-                      githubRepoOwnerName: string;
-                      githubRepoName: string;
-                    };
-                  } | null;
-                };
-                appleAppIdentifier: {
-                  __typename?: 'AppleAppIdentifier';
-                  id: string;
-                  bundleIdentifier: string;
-                };
-              };
-              provisioningProfile?: {
-                __typename?: 'AppleProvisioningProfile';
-                id: string;
-                developerPortalIdentifier?: string | null;
-              } | null;
-            }>;
-          } | null;
-        }>;
-      }>;
-    };
-  };
-};
+
+export type AppleDistributionCertificateByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null }> }> } } };
 
 export type AppleDistributionCertificatesPaginatedByAccountQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
@@ -9631,98 +7816,8 @@ export type AppleDistributionCertificatesPaginatedByAccountQueryVariables = Exac
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type AppleDistributionCertificatesPaginatedByAccountQuery = {
-  __typename?: 'RootQuery';
-  account: {
-    __typename?: 'AccountQuery';
-    byName: {
-      __typename?: 'Account';
-      id: string;
-      appleDistributionCertificatesPaginated: {
-        __typename?: 'AccountAppleDistributionCertificatesConnection';
-        edges: Array<{
-          __typename?: 'AccountAppleDistributionCertificatesEdge';
-          cursor: string;
-          node: {
-            __typename?: 'AppleDistributionCertificate';
-            id: string;
-            certificateP12?: string | null;
-            certificatePassword?: string | null;
-            serialNumber: string;
-            developerPortalIdentifier?: string | null;
-            validityNotBefore: any;
-            validityNotAfter: any;
-            updatedAt: any;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-            iosAppBuildCredentialsList: Array<{
-              __typename?: 'IosAppBuildCredentials';
-              id: string;
-              iosAppCredentials: {
-                __typename?: 'IosAppCredentials';
-                id: string;
-                app: {
-                  __typename?: 'App';
-                  id: string;
-                  name: string;
-                  fullName: string;
-                  slug: string;
-                  ownerAccount: {
-                    __typename?: 'Account';
-                    id: string;
-                    name: string;
-                    ownerUserActor?:
-                      | { __typename?: 'SSOUser'; id: string; username: string }
-                      | { __typename?: 'User'; id: string; username: string }
-                      | null;
-                    users: Array<{
-                      __typename?: 'UserPermission';
-                      role: Role;
-                      actor:
-                        | { __typename?: 'Robot'; id: string }
-                        | { __typename?: 'SSOUser'; id: string }
-                        | { __typename?: 'User'; id: string };
-                    }>;
-                  };
-                  githubRepository?: {
-                    __typename?: 'GitHubRepository';
-                    id: string;
-                    metadata: {
-                      __typename?: 'GitHubRepositoryMetadata';
-                      githubRepoOwnerName: string;
-                      githubRepoName: string;
-                    };
-                  } | null;
-                };
-                appleAppIdentifier: {
-                  __typename?: 'AppleAppIdentifier';
-                  id: string;
-                  bundleIdentifier: string;
-                };
-              };
-              provisioningProfile?: {
-                __typename?: 'AppleProvisioningProfile';
-                id: string;
-                developerPortalIdentifier?: string | null;
-              } | null;
-            }>;
-          };
-        }>;
-        pageInfo: {
-          __typename?: 'PageInfo';
-          hasNextPage: boolean;
-          hasPreviousPage: boolean;
-          startCursor?: string | null;
-          endCursor?: string | null;
-        };
-      };
-    };
-  };
-};
+
+export type AppleDistributionCertificatesPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleDistributionCertificatesPaginated: { __typename?: 'AccountAppleDistributionCertificatesConnection', edges: Array<{ __typename?: 'AccountAppleDistributionCertificatesEdge', cursor: string, node: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type AppleProvisioningProfilesByAppQueryVariables = Exact<{
   projectFullName: Scalars['String']['input'];
@@ -9730,53 +7825,8 @@ export type AppleProvisioningProfilesByAppQueryVariables = Exact<{
   iosDistributionType: IosDistributionType;
 }>;
 
-export type AppleProvisioningProfilesByAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byFullName: {
-      __typename?: 'App';
-      id: string;
-      iosAppCredentials: Array<{
-        __typename?: 'IosAppCredentials';
-        id: string;
-        iosAppBuildCredentialsList: Array<{
-          __typename?: 'IosAppBuildCredentials';
-          id: string;
-          provisioningProfile?: {
-            __typename?: 'AppleProvisioningProfile';
-            id: string;
-            expiration: any;
-            developerPortalIdentifier?: string | null;
-            provisioningProfile?: string | null;
-            updatedAt: any;
-            status: string;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-            appleDevices: Array<{
-              __typename?: 'AppleDevice';
-              id: string;
-              identifier: string;
-              name?: string | null;
-              model?: string | null;
-              deviceClass?: AppleDeviceClass | null;
-              createdAt: any;
-            }>;
-            appleAppIdentifier: {
-              __typename?: 'AppleAppIdentifier';
-              id: string;
-              bundleIdentifier: string;
-            };
-          } | null;
-        }>;
-      }>;
-    };
-  };
-};
+
+export type AppleProvisioningProfilesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }>, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } } | null }> }> } } };
 
 export type ApplePushKeysPaginatedByAccountQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
@@ -9786,84 +7836,8 @@ export type ApplePushKeysPaginatedByAccountQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type ApplePushKeysPaginatedByAccountQuery = {
-  __typename?: 'RootQuery';
-  account: {
-    __typename?: 'AccountQuery';
-    byName: {
-      __typename?: 'Account';
-      id: string;
-      applePushKeysPaginated: {
-        __typename?: 'AccountApplePushKeysConnection';
-        edges: Array<{
-          __typename?: 'AccountApplePushKeysEdge';
-          cursor: string;
-          node: {
-            __typename?: 'ApplePushKey';
-            id: string;
-            keyIdentifier: string;
-            updatedAt: any;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-            iosAppCredentialsList: Array<{
-              __typename?: 'IosAppCredentials';
-              id: string;
-              app: {
-                __typename?: 'App';
-                id: string;
-                name: string;
-                fullName: string;
-                slug: string;
-                ownerAccount: {
-                  __typename?: 'Account';
-                  id: string;
-                  name: string;
-                  ownerUserActor?:
-                    | { __typename?: 'SSOUser'; id: string; username: string }
-                    | { __typename?: 'User'; id: string; username: string }
-                    | null;
-                  users: Array<{
-                    __typename?: 'UserPermission';
-                    role: Role;
-                    actor:
-                      | { __typename?: 'Robot'; id: string }
-                      | { __typename?: 'SSOUser'; id: string }
-                      | { __typename?: 'User'; id: string };
-                  }>;
-                };
-                githubRepository?: {
-                  __typename?: 'GitHubRepository';
-                  id: string;
-                  metadata: {
-                    __typename?: 'GitHubRepositoryMetadata';
-                    githubRepoOwnerName: string;
-                    githubRepoName: string;
-                  };
-                } | null;
-              };
-              appleAppIdentifier: {
-                __typename?: 'AppleAppIdentifier';
-                id: string;
-                bundleIdentifier: string;
-              };
-            }>;
-          };
-        }>;
-        pageInfo: {
-          __typename?: 'PageInfo';
-          hasNextPage: boolean;
-          hasPreviousPage: boolean;
-          startCursor?: string | null;
-          endCursor?: string | null;
-        };
-      };
-    };
-  };
-};
+
+export type ApplePushKeysPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, applePushKeysPaginated: { __typename?: 'AccountApplePushKeysConnection', edges: Array<{ __typename?: 'AccountApplePushKeysEdge', cursor: string, node: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type AppleTeamsByAccountNameQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
@@ -9871,40 +7845,16 @@ export type AppleTeamsByAccountNameQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type AppleTeamsByAccountNameQuery = {
-  __typename?: 'RootQuery';
-  account: {
-    __typename?: 'AccountQuery';
-    byName: {
-      __typename?: 'Account';
-      id: string;
-      appleTeams: Array<{
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      }>;
-    };
-  };
-};
+
+export type AppleTeamsByAccountNameQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appleTeams: Array<{ __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null }> } } };
 
 export type AppleTeamByIdentifierQueryVariables = Exact<{
   accountId: Scalars['ID']['input'];
   appleTeamIdentifier: Scalars['String']['input'];
 }>;
 
-export type AppleTeamByIdentifierQuery = {
-  __typename?: 'RootQuery';
-  appleTeam: {
-    __typename?: 'AppleTeamQuery';
-    byAppleTeamIdentifier?: {
-      __typename?: 'AppleTeam';
-      id: string;
-      appleTeamIdentifier: string;
-      appleTeamName?: string | null;
-    } | null;
-  };
-};
+
+export type AppleTeamByIdentifierQuery = { __typename?: 'RootQuery', appleTeam: { __typename?: 'AppleTeamQuery', byAppleTeamIdentifier?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } };
 
 export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQueryVariables = Exact<{
   projectFullName: Scalars['String']['input'];
@@ -9912,117 +7862,8 @@ export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQueryVariabl
   iosDistributionType: IosDistributionType;
 }>;
 
-export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byFullName: {
-      __typename?: 'App';
-      id: string;
-      iosAppCredentials: Array<{
-        __typename?: 'IosAppCredentials';
-        id: string;
-        iosAppBuildCredentialsList: Array<{
-          __typename?: 'IosAppBuildCredentials';
-          id: string;
-          iosDistributionType: IosDistributionType;
-          distributionCertificate?: {
-            __typename?: 'AppleDistributionCertificate';
-            id: string;
-            certificateP12?: string | null;
-            certificatePassword?: string | null;
-            serialNumber: string;
-            developerPortalIdentifier?: string | null;
-            validityNotBefore: any;
-            validityNotAfter: any;
-            updatedAt: any;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-            iosAppBuildCredentialsList: Array<{
-              __typename?: 'IosAppBuildCredentials';
-              id: string;
-              iosAppCredentials: {
-                __typename?: 'IosAppCredentials';
-                id: string;
-                app: {
-                  __typename?: 'App';
-                  id: string;
-                  name: string;
-                  fullName: string;
-                  slug: string;
-                  ownerAccount: {
-                    __typename?: 'Account';
-                    id: string;
-                    name: string;
-                    ownerUserActor?:
-                      | { __typename?: 'SSOUser'; id: string; username: string }
-                      | { __typename?: 'User'; id: string; username: string }
-                      | null;
-                    users: Array<{
-                      __typename?: 'UserPermission';
-                      role: Role;
-                      actor:
-                        | { __typename?: 'Robot'; id: string }
-                        | { __typename?: 'SSOUser'; id: string }
-                        | { __typename?: 'User'; id: string };
-                    }>;
-                  };
-                  githubRepository?: {
-                    __typename?: 'GitHubRepository';
-                    id: string;
-                    metadata: {
-                      __typename?: 'GitHubRepositoryMetadata';
-                      githubRepoOwnerName: string;
-                      githubRepoName: string;
-                    };
-                  } | null;
-                };
-                appleAppIdentifier: {
-                  __typename?: 'AppleAppIdentifier';
-                  id: string;
-                  bundleIdentifier: string;
-                };
-              };
-              provisioningProfile?: {
-                __typename?: 'AppleProvisioningProfile';
-                id: string;
-                developerPortalIdentifier?: string | null;
-              } | null;
-            }>;
-          } | null;
-          provisioningProfile?: {
-            __typename?: 'AppleProvisioningProfile';
-            id: string;
-            expiration: any;
-            developerPortalIdentifier?: string | null;
-            provisioningProfile?: string | null;
-            updatedAt: any;
-            status: string;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-            appleDevices: Array<{
-              __typename?: 'AppleDevice';
-              id: string;
-              identifier: string;
-              name?: string | null;
-              model?: string | null;
-              deviceClass?: AppleDeviceClass | null;
-              createdAt: any;
-            }>;
-          } | null;
-        }>;
-      }>;
-    };
-  };
-};
+
+export type IosAppBuildCredentialsByAppleAppIdentiferAndDistributionQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null }> }> } } };
 
 export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQueryVariables = Exact<{
   projectFullName: Scalars['String']['input'];
@@ -10030,483 +7871,30 @@ export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQueryVariables
   iosDistributionType?: InputMaybe<IosDistributionType>;
 }>;
 
-export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byFullName: {
-      __typename?: 'App';
-      id: string;
-      iosAppCredentials: Array<{
-        __typename?: 'IosAppCredentials';
-        id: string;
-        iosAppBuildCredentialsList: Array<{
-          __typename?: 'IosAppBuildCredentials';
-          id: string;
-          iosDistributionType: IosDistributionType;
-          distributionCertificate?: {
-            __typename?: 'AppleDistributionCertificate';
-            id: string;
-            certificateP12?: string | null;
-            certificatePassword?: string | null;
-            serialNumber: string;
-            developerPortalIdentifier?: string | null;
-            validityNotBefore: any;
-            validityNotAfter: any;
-            updatedAt: any;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-            iosAppBuildCredentialsList: Array<{
-              __typename?: 'IosAppBuildCredentials';
-              id: string;
-              iosAppCredentials: {
-                __typename?: 'IosAppCredentials';
-                id: string;
-                app: {
-                  __typename?: 'App';
-                  id: string;
-                  name: string;
-                  fullName: string;
-                  slug: string;
-                  ownerAccount: {
-                    __typename?: 'Account';
-                    id: string;
-                    name: string;
-                    ownerUserActor?:
-                      | { __typename?: 'SSOUser'; id: string; username: string }
-                      | { __typename?: 'User'; id: string; username: string }
-                      | null;
-                    users: Array<{
-                      __typename?: 'UserPermission';
-                      role: Role;
-                      actor:
-                        | { __typename?: 'Robot'; id: string }
-                        | { __typename?: 'SSOUser'; id: string }
-                        | { __typename?: 'User'; id: string };
-                    }>;
-                  };
-                  githubRepository?: {
-                    __typename?: 'GitHubRepository';
-                    id: string;
-                    metadata: {
-                      __typename?: 'GitHubRepositoryMetadata';
-                      githubRepoOwnerName: string;
-                      githubRepoName: string;
-                    };
-                  } | null;
-                };
-                appleAppIdentifier: {
-                  __typename?: 'AppleAppIdentifier';
-                  id: string;
-                  bundleIdentifier: string;
-                };
-              };
-              provisioningProfile?: {
-                __typename?: 'AppleProvisioningProfile';
-                id: string;
-                developerPortalIdentifier?: string | null;
-              } | null;
-            }>;
-          } | null;
-          provisioningProfile?: {
-            __typename?: 'AppleProvisioningProfile';
-            id: string;
-            expiration: any;
-            developerPortalIdentifier?: string | null;
-            provisioningProfile?: string | null;
-            updatedAt: any;
-            status: string;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-            appleDevices: Array<{
-              __typename?: 'AppleDevice';
-              id: string;
-              identifier: string;
-              name?: string | null;
-              model?: string | null;
-              deviceClass?: AppleDeviceClass | null;
-              createdAt: any;
-            }>;
-          } | null;
-        }>;
-        app: {
-          __typename?: 'App';
-          id: string;
-          name: string;
-          fullName: string;
-          slug: string;
-          ownerAccount: {
-            __typename?: 'Account';
-            id: string;
-            name: string;
-            ownerUserActor?:
-              | { __typename?: 'SSOUser'; id: string; username: string }
-              | { __typename?: 'User'; id: string; username: string }
-              | null;
-            users: Array<{
-              __typename?: 'UserPermission';
-              role: Role;
-              actor:
-                | { __typename?: 'Robot'; id: string }
-                | { __typename?: 'SSOUser'; id: string }
-                | { __typename?: 'User'; id: string };
-            }>;
-          };
-          githubRepository?: {
-            __typename?: 'GitHubRepository';
-            id: string;
-            metadata: {
-              __typename?: 'GitHubRepositoryMetadata';
-              githubRepoOwnerName: string;
-              githubRepoName: string;
-            };
-          } | null;
-        };
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        appleAppIdentifier: {
-          __typename?: 'AppleAppIdentifier';
-          id: string;
-          bundleIdentifier: string;
-        };
-        pushKey?: {
-          __typename?: 'ApplePushKey';
-          id: string;
-          keyIdentifier: string;
-          updatedAt: any;
-          appleTeam?: {
-            __typename?: 'AppleTeam';
-            id: string;
-            appleTeamIdentifier: string;
-            appleTeamName?: string | null;
-          } | null;
-          iosAppCredentialsList: Array<{
-            __typename?: 'IosAppCredentials';
-            id: string;
-            app: {
-              __typename?: 'App';
-              id: string;
-              name: string;
-              fullName: string;
-              slug: string;
-              ownerAccount: {
-                __typename?: 'Account';
-                id: string;
-                name: string;
-                ownerUserActor?:
-                  | { __typename?: 'SSOUser'; id: string; username: string }
-                  | { __typename?: 'User'; id: string; username: string }
-                  | null;
-                users: Array<{
-                  __typename?: 'UserPermission';
-                  role: Role;
-                  actor:
-                    | { __typename?: 'Robot'; id: string }
-                    | { __typename?: 'SSOUser'; id: string }
-                    | { __typename?: 'User'; id: string };
-                }>;
-              };
-              githubRepository?: {
-                __typename?: 'GitHubRepository';
-                id: string;
-                metadata: {
-                  __typename?: 'GitHubRepositoryMetadata';
-                  githubRepoOwnerName: string;
-                  githubRepoName: string;
-                };
-              } | null;
-            };
-            appleAppIdentifier: {
-              __typename?: 'AppleAppIdentifier';
-              id: string;
-              bundleIdentifier: string;
-            };
-          }>;
-        } | null;
-        appStoreConnectApiKeyForSubmissions?: {
-          __typename?: 'AppStoreConnectApiKey';
-          id: string;
-          issuerIdentifier: string;
-          keyIdentifier: string;
-          name?: string | null;
-          roles?: Array<AppStoreConnectUserRole> | null;
-          createdAt: any;
-          updatedAt: any;
-          appleTeam?: {
-            __typename?: 'AppleTeam';
-            id: string;
-            appleTeamIdentifier: string;
-            appleTeamName?: string | null;
-          } | null;
-        } | null;
-      }>;
-    };
-  };
-};
+
+export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null }>, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null }> } } };
 
 export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQueryVariables = Exact<{
   projectFullName: Scalars['String']['input'];
   appleAppIdentifierId: Scalars['String']['input'];
 }>;
 
-export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byFullName: {
-      __typename?: 'App';
-      id: string;
-      iosAppCredentials: Array<{
-        __typename?: 'IosAppCredentials';
-        id: string;
-        iosAppBuildCredentialsList: Array<{
-          __typename?: 'IosAppBuildCredentials';
-          id: string;
-          iosDistributionType: IosDistributionType;
-          distributionCertificate?: {
-            __typename?: 'AppleDistributionCertificate';
-            id: string;
-            certificateP12?: string | null;
-            certificatePassword?: string | null;
-            serialNumber: string;
-            developerPortalIdentifier?: string | null;
-            validityNotBefore: any;
-            validityNotAfter: any;
-            updatedAt: any;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-            iosAppBuildCredentialsList: Array<{
-              __typename?: 'IosAppBuildCredentials';
-              id: string;
-              iosAppCredentials: {
-                __typename?: 'IosAppCredentials';
-                id: string;
-                app: {
-                  __typename?: 'App';
-                  id: string;
-                  name: string;
-                  fullName: string;
-                  slug: string;
-                  ownerAccount: {
-                    __typename?: 'Account';
-                    id: string;
-                    name: string;
-                    ownerUserActor?:
-                      | { __typename?: 'SSOUser'; id: string; username: string }
-                      | { __typename?: 'User'; id: string; username: string }
-                      | null;
-                    users: Array<{
-                      __typename?: 'UserPermission';
-                      role: Role;
-                      actor:
-                        | { __typename?: 'Robot'; id: string }
-                        | { __typename?: 'SSOUser'; id: string }
-                        | { __typename?: 'User'; id: string };
-                    }>;
-                  };
-                  githubRepository?: {
-                    __typename?: 'GitHubRepository';
-                    id: string;
-                    metadata: {
-                      __typename?: 'GitHubRepositoryMetadata';
-                      githubRepoOwnerName: string;
-                      githubRepoName: string;
-                    };
-                  } | null;
-                };
-                appleAppIdentifier: {
-                  __typename?: 'AppleAppIdentifier';
-                  id: string;
-                  bundleIdentifier: string;
-                };
-              };
-              provisioningProfile?: {
-                __typename?: 'AppleProvisioningProfile';
-                id: string;
-                developerPortalIdentifier?: string | null;
-              } | null;
-            }>;
-          } | null;
-          provisioningProfile?: {
-            __typename?: 'AppleProvisioningProfile';
-            id: string;
-            expiration: any;
-            developerPortalIdentifier?: string | null;
-            provisioningProfile?: string | null;
-            updatedAt: any;
-            status: string;
-            appleTeam?: {
-              __typename?: 'AppleTeam';
-              id: string;
-              appleTeamIdentifier: string;
-              appleTeamName?: string | null;
-            } | null;
-            appleDevices: Array<{
-              __typename?: 'AppleDevice';
-              id: string;
-              identifier: string;
-              name?: string | null;
-              model?: string | null;
-              deviceClass?: AppleDeviceClass | null;
-              createdAt: any;
-            }>;
-          } | null;
-        }>;
-        app: {
-          __typename?: 'App';
-          id: string;
-          name: string;
-          fullName: string;
-          slug: string;
-          ownerAccount: {
-            __typename?: 'Account';
-            id: string;
-            name: string;
-            ownerUserActor?:
-              | { __typename?: 'SSOUser'; id: string; username: string }
-              | { __typename?: 'User'; id: string; username: string }
-              | null;
-            users: Array<{
-              __typename?: 'UserPermission';
-              role: Role;
-              actor:
-                | { __typename?: 'Robot'; id: string }
-                | { __typename?: 'SSOUser'; id: string }
-                | { __typename?: 'User'; id: string };
-            }>;
-          };
-          githubRepository?: {
-            __typename?: 'GitHubRepository';
-            id: string;
-            metadata: {
-              __typename?: 'GitHubRepositoryMetadata';
-              githubRepoOwnerName: string;
-              githubRepoName: string;
-            };
-          } | null;
-        };
-        appleTeam?: {
-          __typename?: 'AppleTeam';
-          id: string;
-          appleTeamIdentifier: string;
-          appleTeamName?: string | null;
-        } | null;
-        appleAppIdentifier: {
-          __typename?: 'AppleAppIdentifier';
-          id: string;
-          bundleIdentifier: string;
-        };
-        pushKey?: {
-          __typename?: 'ApplePushKey';
-          id: string;
-          keyIdentifier: string;
-          updatedAt: any;
-          appleTeam?: {
-            __typename?: 'AppleTeam';
-            id: string;
-            appleTeamIdentifier: string;
-            appleTeamName?: string | null;
-          } | null;
-          iosAppCredentialsList: Array<{
-            __typename?: 'IosAppCredentials';
-            id: string;
-            app: {
-              __typename?: 'App';
-              id: string;
-              name: string;
-              fullName: string;
-              slug: string;
-              ownerAccount: {
-                __typename?: 'Account';
-                id: string;
-                name: string;
-                ownerUserActor?:
-                  | { __typename?: 'SSOUser'; id: string; username: string }
-                  | { __typename?: 'User'; id: string; username: string }
-                  | null;
-                users: Array<{
-                  __typename?: 'UserPermission';
-                  role: Role;
-                  actor:
-                    | { __typename?: 'Robot'; id: string }
-                    | { __typename?: 'SSOUser'; id: string }
-                    | { __typename?: 'User'; id: string };
-                }>;
-              };
-              githubRepository?: {
-                __typename?: 'GitHubRepository';
-                id: string;
-                metadata: {
-                  __typename?: 'GitHubRepositoryMetadata';
-                  githubRepoOwnerName: string;
-                  githubRepoName: string;
-                };
-              } | null;
-            };
-            appleAppIdentifier: {
-              __typename?: 'AppleAppIdentifier';
-              id: string;
-              bundleIdentifier: string;
-            };
-          }>;
-        } | null;
-        appStoreConnectApiKeyForSubmissions?: {
-          __typename?: 'AppStoreConnectApiKey';
-          id: string;
-          issuerIdentifier: string;
-          keyIdentifier: string;
-          name?: string | null;
-          roles?: Array<AppStoreConnectUserRole> | null;
-          createdAt: any;
-          updatedAt: any;
-          appleTeam?: {
-            __typename?: 'AppleTeam';
-            id: string;
-            appleTeamIdentifier: string;
-            appleTeamName?: string | null;
-          } | null;
-        } | null;
-      }>;
-    };
-  };
-};
+
+export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, iosAppCredentials: Array<{ __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null }>, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null }> } } };
 
 export type CreateAppMutationVariables = Exact<{
   appInput: AppInput;
 }>;
 
-export type CreateAppMutation = {
-  __typename?: 'RootMutation';
-  app?: { __typename?: 'AppMutation'; createApp: { __typename?: 'App'; id: string } } | null;
-};
+
+export type CreateAppMutation = { __typename?: 'RootMutation', app?: { __typename?: 'AppMutation', createApp: { __typename?: 'App', id: string } } | null };
 
 export type CreateAppVersionMutationVariables = Exact<{
   appVersionInput: AppVersionInput;
 }>;
 
-export type CreateAppVersionMutation = {
-  __typename?: 'RootMutation';
-  appVersion: {
-    __typename?: 'AppVersionMutation';
-    createAppVersion: { __typename?: 'AppVersion'; id: string };
-  };
-};
+
+export type CreateAppVersionMutation = { __typename?: 'RootMutation', appVersion: { __typename?: 'AppVersionMutation', createAppVersion: { __typename?: 'AppVersion', id: string } } };
 
 export type CreateAndroidBuildMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
@@ -10515,73 +7903,8 @@ export type CreateAndroidBuildMutationVariables = Exact<{
   buildParams?: InputMaybe<BuildParamsInput>;
 }>;
 
-export type CreateAndroidBuildMutation = {
-  __typename?: 'RootMutation';
-  build: {
-    __typename?: 'BuildMutation';
-    createAndroidBuild: {
-      __typename?: 'CreateBuildResult';
-      build: {
-        __typename?: 'Build';
-        id: string;
-        status: BuildStatus;
-        platform: AppPlatform;
-        channel?: string | null;
-        distribution?: DistributionType | null;
-        iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
-        buildProfile?: string | null;
-        sdkVersion?: string | null;
-        appVersion?: string | null;
-        appBuildVersion?: string | null;
-        runtimeVersion?: string | null;
-        gitCommitHash?: string | null;
-        gitCommitMessage?: string | null;
-        initialQueuePosition?: number | null;
-        queuePosition?: number | null;
-        estimatedWaitTimeLeftSeconds?: number | null;
-        priority: BuildPriority;
-        createdAt: any;
-        updatedAt: any;
-        message?: string | null;
-        completedAt?: any | null;
-        expirationDate?: any | null;
-        isForIosSimulator: boolean;
-        error?: {
-          __typename?: 'BuildError';
-          errorCode: string;
-          message: string;
-          docsUrl?: string | null;
-        } | null;
-        artifacts?: {
-          __typename?: 'BuildArtifacts';
-          buildUrl?: string | null;
-          xcodeBuildLogsUrl?: string | null;
-          applicationArchiveUrl?: string | null;
-          buildArtifactsUrl?: string | null;
-        } | null;
-        initiatingActor?:
-          | { __typename: 'Robot'; id: string; displayName: string }
-          | { __typename: 'SSOUser'; id: string; displayName: string }
-          | { __typename: 'User'; id: string; displayName: string }
-          | null;
-        project:
-          | {
-              __typename: 'App';
-              id: string;
-              name: string;
-              slug: string;
-              ownerAccount: { __typename?: 'Account'; id: string; name: string };
-            }
-          | { __typename: 'Snack'; id: string; name: string; slug: string };
-      };
-      deprecationInfo?: {
-        __typename?: 'EASBuildDeprecationInfo';
-        type: EasBuildDeprecationInfoType;
-        message: string;
-      } | null;
-    };
-  };
-};
+
+export type CreateAndroidBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createAndroidBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }, deprecationInfo?: { __typename?: 'EASBuildDeprecationInfo', type: EasBuildDeprecationInfoType, message: string } | null } } };
 
 export type CreateIosBuildMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
@@ -10590,253 +7913,47 @@ export type CreateIosBuildMutationVariables = Exact<{
   buildParams?: InputMaybe<BuildParamsInput>;
 }>;
 
-export type CreateIosBuildMutation = {
-  __typename?: 'RootMutation';
-  build: {
-    __typename?: 'BuildMutation';
-    createIosBuild: {
-      __typename?: 'CreateBuildResult';
-      build: {
-        __typename?: 'Build';
-        id: string;
-        status: BuildStatus;
-        platform: AppPlatform;
-        channel?: string | null;
-        distribution?: DistributionType | null;
-        iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
-        buildProfile?: string | null;
-        sdkVersion?: string | null;
-        appVersion?: string | null;
-        appBuildVersion?: string | null;
-        runtimeVersion?: string | null;
-        gitCommitHash?: string | null;
-        gitCommitMessage?: string | null;
-        initialQueuePosition?: number | null;
-        queuePosition?: number | null;
-        estimatedWaitTimeLeftSeconds?: number | null;
-        priority: BuildPriority;
-        createdAt: any;
-        updatedAt: any;
-        message?: string | null;
-        completedAt?: any | null;
-        expirationDate?: any | null;
-        isForIosSimulator: boolean;
-        error?: {
-          __typename?: 'BuildError';
-          errorCode: string;
-          message: string;
-          docsUrl?: string | null;
-        } | null;
-        artifacts?: {
-          __typename?: 'BuildArtifacts';
-          buildUrl?: string | null;
-          xcodeBuildLogsUrl?: string | null;
-          applicationArchiveUrl?: string | null;
-          buildArtifactsUrl?: string | null;
-        } | null;
-        initiatingActor?:
-          | { __typename: 'Robot'; id: string; displayName: string }
-          | { __typename: 'SSOUser'; id: string; displayName: string }
-          | { __typename: 'User'; id: string; displayName: string }
-          | null;
-        project:
-          | {
-              __typename: 'App';
-              id: string;
-              name: string;
-              slug: string;
-              ownerAccount: { __typename?: 'Account'; id: string; name: string };
-            }
-          | { __typename: 'Snack'; id: string; name: string; slug: string };
-      };
-      deprecationInfo?: {
-        __typename?: 'EASBuildDeprecationInfo';
-        type: EasBuildDeprecationInfoType;
-        message: string;
-      } | null;
-    };
-  };
-};
+
+export type CreateIosBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createIosBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }, deprecationInfo?: { __typename?: 'EASBuildDeprecationInfo', type: EasBuildDeprecationInfoType, message: string } | null } } };
 
 export type UpdateBuildMetadataMutationVariables = Exact<{
   buildId: Scalars['ID']['input'];
   metadata: BuildMetadataInput;
 }>;
 
-export type UpdateBuildMetadataMutation = {
-  __typename?: 'RootMutation';
-  build: {
-    __typename?: 'BuildMutation';
-    updateBuildMetadata: {
-      __typename?: 'Build';
-      id: string;
-      status: BuildStatus;
-      platform: AppPlatform;
-      channel?: string | null;
-      distribution?: DistributionType | null;
-      iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
-      buildProfile?: string | null;
-      sdkVersion?: string | null;
-      appVersion?: string | null;
-      appBuildVersion?: string | null;
-      runtimeVersion?: string | null;
-      gitCommitHash?: string | null;
-      gitCommitMessage?: string | null;
-      initialQueuePosition?: number | null;
-      queuePosition?: number | null;
-      estimatedWaitTimeLeftSeconds?: number | null;
-      priority: BuildPriority;
-      createdAt: any;
-      updatedAt: any;
-      message?: string | null;
-      completedAt?: any | null;
-      expirationDate?: any | null;
-      isForIosSimulator: boolean;
-      error?: {
-        __typename?: 'BuildError';
-        errorCode: string;
-        message: string;
-        docsUrl?: string | null;
-      } | null;
-      artifacts?: {
-        __typename?: 'BuildArtifacts';
-        buildUrl?: string | null;
-        xcodeBuildLogsUrl?: string | null;
-        applicationArchiveUrl?: string | null;
-        buildArtifactsUrl?: string | null;
-      } | null;
-      initiatingActor?:
-        | { __typename: 'Robot'; id: string; displayName: string }
-        | { __typename: 'SSOUser'; id: string; displayName: string }
-        | { __typename: 'User'; id: string; displayName: string }
-        | null;
-      project:
-        | {
-            __typename: 'App';
-            id: string;
-            name: string;
-            slug: string;
-            ownerAccount: { __typename?: 'Account'; id: string; name: string };
-          }
-        | { __typename: 'Snack'; id: string; name: string; slug: string };
-    };
-  };
-};
+
+export type UpdateBuildMetadataMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', updateBuildMetadata: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
 
 export type RetryIosBuildMutationVariables = Exact<{
   buildId: Scalars['ID']['input'];
   jobOverrides: IosJobOverridesInput;
 }>;
 
-export type RetryIosBuildMutation = {
-  __typename?: 'RootMutation';
-  build: {
-    __typename?: 'BuildMutation';
-    retryIosBuild: {
-      __typename?: 'Build';
-      id: string;
-      status: BuildStatus;
-      platform: AppPlatform;
-      channel?: string | null;
-      distribution?: DistributionType | null;
-      iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
-      buildProfile?: string | null;
-      sdkVersion?: string | null;
-      appVersion?: string | null;
-      appBuildVersion?: string | null;
-      runtimeVersion?: string | null;
-      gitCommitHash?: string | null;
-      gitCommitMessage?: string | null;
-      initialQueuePosition?: number | null;
-      queuePosition?: number | null;
-      estimatedWaitTimeLeftSeconds?: number | null;
-      priority: BuildPriority;
-      createdAt: any;
-      updatedAt: any;
-      message?: string | null;
-      completedAt?: any | null;
-      expirationDate?: any | null;
-      isForIosSimulator: boolean;
-      error?: {
-        __typename?: 'BuildError';
-        errorCode: string;
-        message: string;
-        docsUrl?: string | null;
-      } | null;
-      artifacts?: {
-        __typename?: 'BuildArtifacts';
-        buildUrl?: string | null;
-        xcodeBuildLogsUrl?: string | null;
-        applicationArchiveUrl?: string | null;
-        buildArtifactsUrl?: string | null;
-      } | null;
-      initiatingActor?:
-        | { __typename: 'Robot'; id: string; displayName: string }
-        | { __typename: 'SSOUser'; id: string; displayName: string }
-        | { __typename: 'User'; id: string; displayName: string }
-        | null;
-      project:
-        | {
-            __typename: 'App';
-            id: string;
-            name: string;
-            slug: string;
-            ownerAccount: { __typename?: 'Account'; id: string; name: string };
-          }
-        | { __typename: 'Snack'; id: string; name: string; slug: string };
-    };
-  };
-};
+
+export type RetryIosBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', retryIosBuild: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
 
 export type CreateEnvironmentSecretForAccountMutationVariables = Exact<{
   input: CreateEnvironmentSecretInput;
   accountId: Scalars['String']['input'];
 }>;
 
-export type CreateEnvironmentSecretForAccountMutation = {
-  __typename?: 'RootMutation';
-  environmentSecret: {
-    __typename?: 'EnvironmentSecretMutation';
-    createEnvironmentSecretForAccount: {
-      __typename?: 'EnvironmentSecret';
-      id: string;
-      name: string;
-      type: EnvironmentSecretType;
-      createdAt: any;
-    };
-  };
-};
+
+export type CreateEnvironmentSecretForAccountMutation = { __typename?: 'RootMutation', environmentSecret: { __typename?: 'EnvironmentSecretMutation', createEnvironmentSecretForAccount: { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any } } };
 
 export type CreateEnvironmentSecretForAppMutationVariables = Exact<{
   input: CreateEnvironmentSecretInput;
   appId: Scalars['String']['input'];
 }>;
 
-export type CreateEnvironmentSecretForAppMutation = {
-  __typename?: 'RootMutation';
-  environmentSecret: {
-    __typename?: 'EnvironmentSecretMutation';
-    createEnvironmentSecretForApp: {
-      __typename?: 'EnvironmentSecret';
-      id: string;
-      name: string;
-      type: EnvironmentSecretType;
-      createdAt: any;
-    };
-  };
-};
+
+export type CreateEnvironmentSecretForAppMutation = { __typename?: 'RootMutation', environmentSecret: { __typename?: 'EnvironmentSecretMutation', createEnvironmentSecretForApp: { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any } } };
 
 export type DeleteEnvironmentSecretMutationVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
-export type DeleteEnvironmentSecretMutation = {
-  __typename?: 'RootMutation';
-  environmentSecret: {
-    __typename?: 'EnvironmentSecretMutation';
-    deleteEnvironmentSecret: { __typename?: 'DeleteEnvironmentSecretResult'; id: string };
-  };
-};
+
+export type DeleteEnvironmentSecretMutation = { __typename?: 'RootMutation', environmentSecret: { __typename?: 'EnvironmentSecretMutation', deleteEnvironmentSecret: { __typename?: 'DeleteEnvironmentSecretResult', id: string } } };
 
 export type LinkSharedEnvironmentVariableMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
@@ -10844,22 +7961,8 @@ export type LinkSharedEnvironmentVariableMutationVariables = Exact<{
   environmentVariableId: Scalars['ID']['input'];
 }>;
 
-export type LinkSharedEnvironmentVariableMutation = {
-  __typename?: 'RootMutation';
-  environmentVariable: {
-    __typename?: 'EnvironmentVariableMutation';
-    linkSharedEnvironmentVariable: {
-      __typename?: 'EnvironmentVariable';
-      id: string;
-      name: string;
-      value?: string | null;
-      environment?: EnvironmentVariableEnvironment | null;
-      createdAt: any;
-      scope: EnvironmentVariableScope;
-      visibility?: EnvironmentVariableVisibility | null;
-    };
-  };
-};
+
+export type LinkSharedEnvironmentVariableMutation = { __typename?: 'RootMutation', environmentVariable: { __typename?: 'EnvironmentVariableMutation', linkSharedEnvironmentVariable: { __typename?: 'EnvironmentVariable', id: string, name: string, value?: string | null, environment?: EnvironmentVariableEnvironment | null, createdAt: any, scope: EnvironmentVariableScope, visibility?: EnvironmentVariableVisibility | null } } };
 
 export type UnlinkSharedEnvironmentVariableMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
@@ -10867,217 +7970,74 @@ export type UnlinkSharedEnvironmentVariableMutationVariables = Exact<{
   environmentVariableId: Scalars['ID']['input'];
 }>;
 
-export type UnlinkSharedEnvironmentVariableMutation = {
-  __typename?: 'RootMutation';
-  environmentVariable: {
-    __typename?: 'EnvironmentVariableMutation';
-    unlinkSharedEnvironmentVariable: {
-      __typename?: 'EnvironmentVariable';
-      id: string;
-      name: string;
-      value?: string | null;
-      environment?: EnvironmentVariableEnvironment | null;
-      createdAt: any;
-      scope: EnvironmentVariableScope;
-      visibility?: EnvironmentVariableVisibility | null;
-    };
-  };
-};
+
+export type UnlinkSharedEnvironmentVariableMutation = { __typename?: 'RootMutation', environmentVariable: { __typename?: 'EnvironmentVariableMutation', unlinkSharedEnvironmentVariable: { __typename?: 'EnvironmentVariable', id: string, name: string, value?: string | null, environment?: EnvironmentVariableEnvironment | null, createdAt: any, scope: EnvironmentVariableScope, visibility?: EnvironmentVariableVisibility | null } } };
 
 export type CreateEnvironmentVariableForAccountMutationVariables = Exact<{
   input: CreateSharedEnvironmentVariableInput;
   accountId: Scalars['ID']['input'];
 }>;
 
-export type CreateEnvironmentVariableForAccountMutation = {
-  __typename?: 'RootMutation';
-  environmentVariable: {
-    __typename?: 'EnvironmentVariableMutation';
-    createEnvironmentVariableForAccount: {
-      __typename?: 'EnvironmentVariable';
-      id: string;
-      name: string;
-      value?: string | null;
-      environment?: EnvironmentVariableEnvironment | null;
-      createdAt: any;
-      scope: EnvironmentVariableScope;
-      visibility?: EnvironmentVariableVisibility | null;
-    };
-  };
-};
+
+export type CreateEnvironmentVariableForAccountMutation = { __typename?: 'RootMutation', environmentVariable: { __typename?: 'EnvironmentVariableMutation', createEnvironmentVariableForAccount: { __typename?: 'EnvironmentVariable', id: string, name: string, value?: string | null, environment?: EnvironmentVariableEnvironment | null, createdAt: any, scope: EnvironmentVariableScope, visibility?: EnvironmentVariableVisibility | null } } };
 
 export type CreateEnvironmentVariableForAppMutationVariables = Exact<{
   input: CreateEnvironmentVariableInput;
   appId: Scalars['ID']['input'];
 }>;
 
-export type CreateEnvironmentVariableForAppMutation = {
-  __typename?: 'RootMutation';
-  environmentVariable: {
-    __typename?: 'EnvironmentVariableMutation';
-    createEnvironmentVariableForApp: {
-      __typename?: 'EnvironmentVariable';
-      id: string;
-      name: string;
-      value?: string | null;
-      environment?: EnvironmentVariableEnvironment | null;
-      createdAt: any;
-      scope: EnvironmentVariableScope;
-      visibility?: EnvironmentVariableVisibility | null;
-    };
-  };
-};
+
+export type CreateEnvironmentVariableForAppMutation = { __typename?: 'RootMutation', environmentVariable: { __typename?: 'EnvironmentVariableMutation', createEnvironmentVariableForApp: { __typename?: 'EnvironmentVariable', id: string, name: string, value?: string | null, environment?: EnvironmentVariableEnvironment | null, createdAt: any, scope: EnvironmentVariableScope, visibility?: EnvironmentVariableVisibility | null } } };
 
 export type DeleteEnvironmentVariableMutationVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
-export type DeleteEnvironmentVariableMutation = {
-  __typename?: 'RootMutation';
-  environmentVariable: {
-    __typename?: 'EnvironmentVariableMutation';
-    deleteEnvironmentVariable: { __typename?: 'DeleteEnvironmentVariableResult'; id: string };
-  };
-};
+
+export type DeleteEnvironmentVariableMutation = { __typename?: 'RootMutation', environmentVariable: { __typename?: 'EnvironmentVariableMutation', deleteEnvironmentVariable: { __typename?: 'DeleteEnvironmentVariableResult', id: string } } };
 
 export type CreateBulkEnvironmentVariablesForAppMutationVariables = Exact<{
   input: Array<CreateEnvironmentVariableInput> | CreateEnvironmentVariableInput;
   appId: Scalars['ID']['input'];
 }>;
 
-export type CreateBulkEnvironmentVariablesForAppMutation = {
-  __typename?: 'RootMutation';
-  environmentVariable: {
-    __typename?: 'EnvironmentVariableMutation';
-    createBulkEnvironmentVariablesForApp: Array<{ __typename?: 'EnvironmentVariable'; id: string }>;
-  };
-};
 
-export type CreateKeystoreGenerationUrlMutationVariables = Exact<{ [key: string]: never }>;
+export type CreateBulkEnvironmentVariablesForAppMutation = { __typename?: 'RootMutation', environmentVariable: { __typename?: 'EnvironmentVariableMutation', createBulkEnvironmentVariablesForApp: Array<{ __typename?: 'EnvironmentVariable', id: string }> } };
 
-export type CreateKeystoreGenerationUrlMutation = {
-  __typename?: 'RootMutation';
-  keystoreGenerationUrl: {
-    __typename?: 'KeystoreGenerationUrlMutation';
-    createKeystoreGenerationUrl: { __typename?: 'KeystoreGenerationUrl'; id: string; url: string };
-  };
-};
+export type CreateKeystoreGenerationUrlMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type CreateKeystoreGenerationUrlMutation = { __typename?: 'RootMutation', keystoreGenerationUrl: { __typename?: 'KeystoreGenerationUrlMutation', createKeystoreGenerationUrl: { __typename?: 'KeystoreGenerationUrl', id: string, url: string } } };
 
 export type GetSignedUploadMutationVariables = Exact<{
   contentTypes: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;
 
-export type GetSignedUploadMutation = {
-  __typename?: 'RootMutation';
-  asset: {
-    __typename?: 'AssetMutation';
-    getSignedAssetUploadSpecifications: {
-      __typename?: 'GetSignedAssetUploadSpecificationsResult';
-      specifications: Array<string>;
-    };
-  };
-};
+
+export type GetSignedUploadMutation = { __typename?: 'RootMutation', asset: { __typename?: 'AssetMutation', getSignedAssetUploadSpecifications: { __typename?: 'GetSignedAssetUploadSpecificationsResult', specifications: Array<string> } } };
 
 export type UpdatePublishMutationVariables = Exact<{
   publishUpdateGroupsInput: Array<PublishUpdateGroupInput> | PublishUpdateGroupInput;
 }>;
 
-export type UpdatePublishMutation = {
-  __typename?: 'RootMutation';
-  updateBranch: {
-    __typename?: 'UpdateBranchMutation';
-    publishUpdateGroups: Array<{
-      __typename?: 'Update';
-      id: string;
-      group: string;
-      message?: string | null;
-      createdAt: any;
-      runtimeVersion: string;
-      platform: string;
-      manifestFragment: string;
-      isRollBackToEmbedded: boolean;
-      manifestPermalink: string;
-      gitCommitHash?: string | null;
-      rolloutPercentage?: number | null;
-      actor?:
-        | { __typename: 'Robot'; firstName?: string | null; id: string }
-        | { __typename: 'SSOUser'; username: string; id: string }
-        | { __typename: 'User'; username: string; id: string }
-        | null;
-      branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-      codeSigningInfo?: {
-        __typename?: 'CodeSigningInfo';
-        keyid: string;
-        sig: string;
-        alg: string;
-      } | null;
-      rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-    }>;
-  };
-};
+
+export type UpdatePublishMutation = { __typename?: 'RootMutation', updateBranch: { __typename?: 'UpdateBranchMutation', publishUpdateGroups: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }> } };
 
 export type SetCodeSigningInfoMutationVariables = Exact<{
   updateId: Scalars['ID']['input'];
   codeSigningInfo: CodeSigningInfoInput;
 }>;
 
-export type SetCodeSigningInfoMutation = {
-  __typename?: 'RootMutation';
-  update: {
-    __typename?: 'UpdateMutation';
-    setCodeSigningInfo: {
-      __typename?: 'Update';
-      id: string;
-      group: string;
-      awaitingCodeSigningInfo: boolean;
-      codeSigningInfo?: {
-        __typename?: 'CodeSigningInfo';
-        keyid: string;
-        alg: string;
-        sig: string;
-      } | null;
-    };
-  };
-};
+
+export type SetCodeSigningInfoMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', setCodeSigningInfo: { __typename?: 'Update', id: string, group: string, awaitingCodeSigningInfo: boolean, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, alg: string, sig: string } | null } } };
 
 export type SetRolloutPercentageMutationVariables = Exact<{
   updateId: Scalars['ID']['input'];
   rolloutPercentage: Scalars['Int']['input'];
 }>;
 
-export type SetRolloutPercentageMutation = {
-  __typename?: 'RootMutation';
-  update: {
-    __typename?: 'UpdateMutation';
-    setRolloutPercentage: {
-      __typename?: 'Update';
-      id: string;
-      group: string;
-      message?: string | null;
-      createdAt: any;
-      runtimeVersion: string;
-      platform: string;
-      manifestFragment: string;
-      isRollBackToEmbedded: boolean;
-      manifestPermalink: string;
-      gitCommitHash?: string | null;
-      rolloutPercentage?: number | null;
-      actor?:
-        | { __typename: 'Robot'; firstName?: string | null; id: string }
-        | { __typename: 'SSOUser'; username: string; id: string }
-        | { __typename: 'User'; username: string; id: string }
-        | null;
-      branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-      codeSigningInfo?: {
-        __typename?: 'CodeSigningInfo';
-        keyid: string;
-        sig: string;
-        alg: string;
-      } | null;
-      rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-    };
-  };
-};
+
+export type SetRolloutPercentageMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', setRolloutPercentage: { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null } } };
 
 export type CreateAndroidSubmissionMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
@@ -11086,46 +8046,8 @@ export type CreateAndroidSubmissionMutationVariables = Exact<{
   archiveSource?: InputMaybe<SubmissionArchiveSourceInput>;
 }>;
 
-export type CreateAndroidSubmissionMutation = {
-  __typename?: 'RootMutation';
-  submission: {
-    __typename?: 'SubmissionMutation';
-    createAndroidSubmission: {
-      __typename?: 'CreateSubmissionResult';
-      submission: {
-        __typename?: 'Submission';
-        id: string;
-        status: SubmissionStatus;
-        platform: AppPlatform;
-        logsUrl?: string | null;
-        app: {
-          __typename?: 'App';
-          id: string;
-          name: string;
-          slug: string;
-          ownerAccount: { __typename?: 'Account'; id: string; name: string };
-        };
-        androidConfig?: {
-          __typename?: 'AndroidSubmissionConfig';
-          applicationIdentifier?: string | null;
-          track: SubmissionAndroidTrack;
-          releaseStatus?: SubmissionAndroidReleaseStatus | null;
-          rollout?: number | null;
-        } | null;
-        iosConfig?: {
-          __typename?: 'IosSubmissionConfig';
-          ascAppIdentifier: string;
-          appleIdUsername?: string | null;
-        } | null;
-        error?: {
-          __typename?: 'SubmissionError';
-          errorCode?: string | null;
-          message?: string | null;
-        } | null;
-      };
-    };
-  };
-};
+
+export type CreateAndroidSubmissionMutation = { __typename?: 'RootMutation', submission: { __typename?: 'SubmissionMutation', createAndroidSubmission: { __typename?: 'CreateSubmissionResult', submission: { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null, rollout?: number | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null } } } };
 
 export type CreateIosSubmissionMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
@@ -11134,214 +8056,59 @@ export type CreateIosSubmissionMutationVariables = Exact<{
   archiveSource?: InputMaybe<SubmissionArchiveSourceInput>;
 }>;
 
-export type CreateIosSubmissionMutation = {
-  __typename?: 'RootMutation';
-  submission: {
-    __typename?: 'SubmissionMutation';
-    createIosSubmission: {
-      __typename?: 'CreateSubmissionResult';
-      submission: {
-        __typename?: 'Submission';
-        id: string;
-        status: SubmissionStatus;
-        platform: AppPlatform;
-        logsUrl?: string | null;
-        app: {
-          __typename?: 'App';
-          id: string;
-          name: string;
-          slug: string;
-          ownerAccount: { __typename?: 'Account'; id: string; name: string };
-        };
-        androidConfig?: {
-          __typename?: 'AndroidSubmissionConfig';
-          applicationIdentifier?: string | null;
-          track: SubmissionAndroidTrack;
-          releaseStatus?: SubmissionAndroidReleaseStatus | null;
-          rollout?: number | null;
-        } | null;
-        iosConfig?: {
-          __typename?: 'IosSubmissionConfig';
-          ascAppIdentifier: string;
-          appleIdUsername?: string | null;
-        } | null;
-        error?: {
-          __typename?: 'SubmissionError';
-          errorCode?: string | null;
-          message?: string | null;
-        } | null;
-      };
-    };
-  };
-};
+
+export type CreateIosSubmissionMutation = { __typename?: 'RootMutation', submission: { __typename?: 'SubmissionMutation', createIosSubmission: { __typename?: 'CreateSubmissionResult', submission: { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null, rollout?: number | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null } } } };
 
 export type CreateUploadSessionMutationVariables = Exact<{
   type: UploadSessionType;
 }>;
 
-export type CreateUploadSessionMutation = {
-  __typename?: 'RootMutation';
-  uploadSession: { __typename?: 'UploadSession'; createUploadSession: any };
-};
+
+export type CreateUploadSessionMutation = { __typename?: 'RootMutation', uploadSession: { __typename?: 'UploadSession', createUploadSession: any } };
 
 export type MarkCliDoneInOnboardingUserPreferencesMutationVariables = Exact<{
   preferences: UserPreferencesInput;
 }>;
 
-export type MarkCliDoneInOnboardingUserPreferencesMutation = {
-  __typename?: 'RootMutation';
-  me: {
-    __typename?: 'MeMutation';
-    setPreferences: {
-      __typename?: 'UserPreferences';
-      onboarding?: {
-        __typename?: 'UserPreferencesOnboarding';
-        appId: string;
-        isCLIDone?: boolean | null;
-      } | null;
-    };
-  };
-};
+
+export type MarkCliDoneInOnboardingUserPreferencesMutation = { __typename?: 'RootMutation', me: { __typename?: 'MeMutation', setPreferences: { __typename?: 'UserPreferences', onboarding?: { __typename?: 'UserPreferencesOnboarding', appId: string, isCLIDone?: boolean | null } | null } } };
 
 export type CreateWebhookMutationVariables = Exact<{
   appId: Scalars['String']['input'];
   webhookInput: WebhookInput;
 }>;
 
-export type CreateWebhookMutation = {
-  __typename?: 'RootMutation';
-  webhook: {
-    __typename?: 'WebhookMutation';
-    createWebhook: {
-      __typename?: 'Webhook';
-      id: string;
-      event: WebhookType;
-      url: string;
-      createdAt: any;
-      updatedAt: any;
-    };
-  };
-};
+
+export type CreateWebhookMutation = { __typename?: 'RootMutation', webhook: { __typename?: 'WebhookMutation', createWebhook: { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any } } };
 
 export type UpdateWebhookMutationVariables = Exact<{
   webhookId: Scalars['ID']['input'];
   webhookInput: WebhookInput;
 }>;
 
-export type UpdateWebhookMutation = {
-  __typename?: 'RootMutation';
-  webhook: {
-    __typename?: 'WebhookMutation';
-    updateWebhook: {
-      __typename?: 'Webhook';
-      id: string;
-      event: WebhookType;
-      url: string;
-      createdAt: any;
-      updatedAt: any;
-    };
-  };
-};
+
+export type UpdateWebhookMutation = { __typename?: 'RootMutation', webhook: { __typename?: 'WebhookMutation', updateWebhook: { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any } } };
 
 export type DeleteWebhookMutationVariables = Exact<{
   webhookId: Scalars['ID']['input'];
 }>;
 
-export type DeleteWebhookMutation = {
-  __typename?: 'RootMutation';
-  webhook: {
-    __typename?: 'WebhookMutation';
-    deleteWebhook: { __typename?: 'DeleteWebhookResult'; id: string };
-  };
-};
+
+export type DeleteWebhookMutation = { __typename?: 'RootMutation', webhook: { __typename?: 'WebhookMutation', deleteWebhook: { __typename?: 'DeleteWebhookResult', id: string } } };
 
 export type AppByIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];
 }>;
 
-export type AppByIdQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      name: string;
-      fullName: string;
-      slug: string;
-      ownerAccount: {
-        __typename?: 'Account';
-        id: string;
-        name: string;
-        ownerUserActor?:
-          | { __typename?: 'SSOUser'; id: string; username: string }
-          | { __typename?: 'User'; id: string; username: string }
-          | null;
-        users: Array<{
-          __typename?: 'UserPermission';
-          role: Role;
-          actor:
-            | { __typename?: 'Robot'; id: string }
-            | { __typename?: 'SSOUser'; id: string }
-            | { __typename?: 'User'; id: string };
-        }>;
-      };
-      githubRepository?: {
-        __typename?: 'GitHubRepository';
-        id: string;
-        metadata: {
-          __typename?: 'GitHubRepositoryMetadata';
-          githubRepoOwnerName: string;
-          githubRepoName: string;
-        };
-      } | null;
-    };
-  };
-};
+
+export type AppByIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null } } };
 
 export type AppByFullNameQueryVariables = Exact<{
   fullName: Scalars['String']['input'];
 }>;
 
-export type AppByFullNameQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byFullName: {
-      __typename?: 'App';
-      id: string;
-      name: string;
-      fullName: string;
-      slug: string;
-      ownerAccount: {
-        __typename?: 'Account';
-        id: string;
-        name: string;
-        ownerUserActor?:
-          | { __typename?: 'SSOUser'; id: string; username: string }
-          | { __typename?: 'User'; id: string; username: string }
-          | null;
-        users: Array<{
-          __typename?: 'UserPermission';
-          role: Role;
-          actor:
-            | { __typename?: 'Robot'; id: string }
-            | { __typename?: 'SSOUser'; id: string }
-            | { __typename?: 'User'; id: string };
-        }>;
-      };
-      githubRepository?: {
-        __typename?: 'GitHubRepository';
-        id: string;
-        metadata: {
-          __typename?: 'GitHubRepositoryMetadata';
-          githubRepoOwnerName: string;
-          githubRepoName: string;
-        };
-      } | null;
-    };
-  };
-};
+
+export type AppByFullNameQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byFullName: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null } } };
 
 export type LatestAppVersionQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11349,39 +8116,16 @@ export type LatestAppVersionQueryVariables = Exact<{
   applicationIdentifier: Scalars['String']['input'];
 }>;
 
-export type LatestAppVersionQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      latestAppVersionByPlatformAndApplicationIdentifier?: {
-        __typename?: 'AppVersion';
-        id: string;
-        storeVersion: string;
-        buildVersion: string;
-      } | null;
-    };
-  };
-};
+
+export type LatestAppVersionQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, latestAppVersionByPlatformAndApplicationIdentifier?: { __typename?: 'AppVersion', id: string, storeVersion: string, buildVersion: string } | null } } };
 
 export type ViewBranchQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   name: Scalars['String']['input'];
 }>;
 
-export type ViewBranchQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      updateBranchByName?: { __typename?: 'UpdateBranch'; id: string; name: string } | null;
-    };
-  };
-};
+
+export type ViewBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, name: string } | null } } };
 
 export type ViewLatestUpdateOnBranchQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11390,21 +8134,8 @@ export type ViewLatestUpdateOnBranchQueryVariables = Exact<{
   runtimeVersion: Scalars['String']['input'];
 }>;
 
-export type ViewLatestUpdateOnBranchQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      updateBranchByName?: {
-        __typename?: 'UpdateBranch';
-        id: string;
-        updates: Array<{ __typename?: 'Update'; id: string }>;
-      } | null;
-    };
-  };
-};
+
+export type ViewLatestUpdateOnBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, updates: Array<{ __typename?: 'Update', id: string }> } | null } } };
 
 export type BranchesByAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11412,48 +8143,8 @@ export type BranchesByAppQueryVariables = Exact<{
   offset: Scalars['Int']['input'];
 }>;
 
-export type BranchesByAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      updateBranches: Array<{
-        __typename?: 'UpdateBranch';
-        id: string;
-        name: string;
-        updates: Array<{
-          __typename?: 'Update';
-          id: string;
-          group: string;
-          message?: string | null;
-          createdAt: any;
-          runtimeVersion: string;
-          platform: string;
-          manifestFragment: string;
-          isRollBackToEmbedded: boolean;
-          manifestPermalink: string;
-          gitCommitHash?: string | null;
-          rolloutPercentage?: number | null;
-          actor?:
-            | { __typename: 'Robot'; firstName?: string | null; id: string }
-            | { __typename: 'SSOUser'; username: string; id: string }
-            | { __typename: 'User'; username: string; id: string }
-            | null;
-          branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-          codeSigningInfo?: {
-            __typename?: 'CodeSigningInfo';
-            keyid: string;
-            sig: string;
-            alg: string;
-          } | null;
-          rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-        }>;
-      }>;
-    };
-  };
-};
+
+export type BranchesByAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }> }> } } };
 
 export type BranchesBasicPaginatedOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11463,31 +8154,8 @@ export type BranchesBasicPaginatedOnAppQueryVariables = Exact<{
   before?: InputMaybe<Scalars['String']['input']>;
 }>;
 
-export type BranchesBasicPaginatedOnAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      branchesPaginated: {
-        __typename?: 'AppBranchesConnection';
-        edges: Array<{
-          __typename?: 'AppBranchEdge';
-          cursor: string;
-          node: { __typename?: 'UpdateBranch'; id: string; name: string };
-        }>;
-        pageInfo: {
-          __typename?: 'PageInfo';
-          hasNextPage: boolean;
-          hasPreviousPage: boolean;
-          startCursor?: string | null;
-          endCursor?: string | null;
-        };
-      };
-    };
-  };
-};
+
+export type BranchesBasicPaginatedOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, branchesPaginated: { __typename?: 'AppBranchesConnection', edges: Array<{ __typename?: 'AppBranchEdge', cursor: string, node: { __typename?: 'UpdateBranch', id: string, name: string } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type ViewBranchesOnUpdateChannelQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11496,213 +8164,22 @@ export type ViewBranchesOnUpdateChannelQueryVariables = Exact<{
   limit: Scalars['Int']['input'];
 }>;
 
-export type ViewBranchesOnUpdateChannelQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      updateChannelByName?: {
-        __typename?: 'UpdateChannel';
-        id: string;
-        updateBranches: Array<{
-          __typename?: 'UpdateBranch';
-          id: string;
-          name: string;
-          updateGroups: Array<
-            Array<{
-              __typename?: 'Update';
-              id: string;
-              group: string;
-              message?: string | null;
-              createdAt: any;
-              runtimeVersion: string;
-              platform: string;
-              manifestFragment: string;
-              isRollBackToEmbedded: boolean;
-              manifestPermalink: string;
-              gitCommitHash?: string | null;
-              rolloutPercentage?: number | null;
-              actor?:
-                | { __typename: 'Robot'; firstName?: string | null; id: string }
-                | { __typename: 'SSOUser'; username: string; id: string }
-                | { __typename: 'User'; username: string; id: string }
-                | null;
-              branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-              codeSigningInfo?: {
-                __typename?: 'CodeSigningInfo';
-                keyid: string;
-                sig: string;
-                alg: string;
-              } | null;
-              rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-            }>
-          >;
-        }>;
-      } | null;
-    };
-  };
-};
+
+export type ViewBranchesOnUpdateChannelQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }>> }> } | null } } };
 
 export type BuildsByIdQueryVariables = Exact<{
   buildId: Scalars['ID']['input'];
 }>;
 
-export type BuildsByIdQuery = {
-  __typename?: 'RootQuery';
-  builds: {
-    __typename?: 'BuildQuery';
-    byId: {
-      __typename?: 'Build';
-      id: string;
-      status: BuildStatus;
-      platform: AppPlatform;
-      channel?: string | null;
-      distribution?: DistributionType | null;
-      iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
-      buildProfile?: string | null;
-      sdkVersion?: string | null;
-      appVersion?: string | null;
-      appBuildVersion?: string | null;
-      runtimeVersion?: string | null;
-      gitCommitHash?: string | null;
-      gitCommitMessage?: string | null;
-      initialQueuePosition?: number | null;
-      queuePosition?: number | null;
-      estimatedWaitTimeLeftSeconds?: number | null;
-      priority: BuildPriority;
-      createdAt: any;
-      updatedAt: any;
-      message?: string | null;
-      completedAt?: any | null;
-      expirationDate?: any | null;
-      isForIosSimulator: boolean;
-      error?: {
-        __typename?: 'BuildError';
-        errorCode: string;
-        message: string;
-        docsUrl?: string | null;
-      } | null;
-      artifacts?: {
-        __typename?: 'BuildArtifacts';
-        buildUrl?: string | null;
-        xcodeBuildLogsUrl?: string | null;
-        applicationArchiveUrl?: string | null;
-        buildArtifactsUrl?: string | null;
-      } | null;
-      initiatingActor?:
-        | { __typename: 'Robot'; id: string; displayName: string }
-        | { __typename: 'SSOUser'; id: string; displayName: string }
-        | { __typename: 'User'; id: string; displayName: string }
-        | null;
-      project:
-        | {
-            __typename: 'App';
-            id: string;
-            name: string;
-            slug: string;
-            ownerAccount: { __typename?: 'Account'; id: string; name: string };
-          }
-        | { __typename: 'Snack'; id: string; name: string; slug: string };
-    };
-  };
-};
+
+export type BuildsByIdQuery = { __typename?: 'RootQuery', builds: { __typename?: 'BuildQuery', byId: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
 
 export type BuildsWithSubmissionsByIdQueryVariables = Exact<{
   buildId: Scalars['ID']['input'];
 }>;
 
-export type BuildsWithSubmissionsByIdQuery = {
-  __typename?: 'RootQuery';
-  builds: {
-    __typename?: 'BuildQuery';
-    byId: {
-      __typename?: 'Build';
-      id: string;
-      status: BuildStatus;
-      platform: AppPlatform;
-      channel?: string | null;
-      distribution?: DistributionType | null;
-      iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
-      buildProfile?: string | null;
-      sdkVersion?: string | null;
-      appVersion?: string | null;
-      appBuildVersion?: string | null;
-      runtimeVersion?: string | null;
-      gitCommitHash?: string | null;
-      gitCommitMessage?: string | null;
-      initialQueuePosition?: number | null;
-      queuePosition?: number | null;
-      estimatedWaitTimeLeftSeconds?: number | null;
-      priority: BuildPriority;
-      createdAt: any;
-      updatedAt: any;
-      message?: string | null;
-      completedAt?: any | null;
-      expirationDate?: any | null;
-      isForIosSimulator: boolean;
-      submissions: Array<{
-        __typename?: 'Submission';
-        id: string;
-        status: SubmissionStatus;
-        platform: AppPlatform;
-        logsUrl?: string | null;
-        app: {
-          __typename?: 'App';
-          id: string;
-          name: string;
-          slug: string;
-          ownerAccount: { __typename?: 'Account'; id: string; name: string };
-        };
-        androidConfig?: {
-          __typename?: 'AndroidSubmissionConfig';
-          applicationIdentifier?: string | null;
-          track: SubmissionAndroidTrack;
-          releaseStatus?: SubmissionAndroidReleaseStatus | null;
-          rollout?: number | null;
-        } | null;
-        iosConfig?: {
-          __typename?: 'IosSubmissionConfig';
-          ascAppIdentifier: string;
-          appleIdUsername?: string | null;
-        } | null;
-        error?: {
-          __typename?: 'SubmissionError';
-          errorCode?: string | null;
-          message?: string | null;
-        } | null;
-      }>;
-      error?: {
-        __typename?: 'BuildError';
-        errorCode: string;
-        message: string;
-        docsUrl?: string | null;
-      } | null;
-      artifacts?: {
-        __typename?: 'BuildArtifacts';
-        buildUrl?: string | null;
-        xcodeBuildLogsUrl?: string | null;
-        applicationArchiveUrl?: string | null;
-        buildArtifactsUrl?: string | null;
-      } | null;
-      initiatingActor?:
-        | { __typename: 'Robot'; id: string; displayName: string }
-        | { __typename: 'SSOUser'; id: string; displayName: string }
-        | { __typename: 'User'; id: string; displayName: string }
-        | null;
-      project:
-        | {
-            __typename: 'App';
-            id: string;
-            name: string;
-            slug: string;
-            ownerAccount: { __typename?: 'Account'; id: string; name: string };
-          }
-        | { __typename: 'Snack'; id: string; name: string; slug: string };
-    };
-  };
-};
+
+export type BuildsWithSubmissionsByIdQuery = { __typename?: 'RootQuery', builds: { __typename?: 'BuildQuery', byId: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, submissions: Array<{ __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null, rollout?: number | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null }>, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } } } };
 
 export type ViewBuildsOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11711,69 +8188,8 @@ export type ViewBuildsOnAppQueryVariables = Exact<{
   filter?: InputMaybe<BuildFilter>;
 }>;
 
-export type ViewBuildsOnAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      builds: Array<{
-        __typename?: 'Build';
-        id: string;
-        status: BuildStatus;
-        platform: AppPlatform;
-        channel?: string | null;
-        distribution?: DistributionType | null;
-        iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
-        buildProfile?: string | null;
-        sdkVersion?: string | null;
-        appVersion?: string | null;
-        appBuildVersion?: string | null;
-        runtimeVersion?: string | null;
-        gitCommitHash?: string | null;
-        gitCommitMessage?: string | null;
-        initialQueuePosition?: number | null;
-        queuePosition?: number | null;
-        estimatedWaitTimeLeftSeconds?: number | null;
-        priority: BuildPriority;
-        createdAt: any;
-        updatedAt: any;
-        message?: string | null;
-        completedAt?: any | null;
-        expirationDate?: any | null;
-        isForIosSimulator: boolean;
-        error?: {
-          __typename?: 'BuildError';
-          errorCode: string;
-          message: string;
-          docsUrl?: string | null;
-        } | null;
-        artifacts?: {
-          __typename?: 'BuildArtifacts';
-          buildUrl?: string | null;
-          xcodeBuildLogsUrl?: string | null;
-          applicationArchiveUrl?: string | null;
-          buildArtifactsUrl?: string | null;
-        } | null;
-        initiatingActor?:
-          | { __typename: 'Robot'; id: string; displayName: string }
-          | { __typename: 'SSOUser'; id: string; displayName: string }
-          | { __typename: 'User'; id: string; displayName: string }
-          | null;
-        project:
-          | {
-              __typename: 'App';
-              id: string;
-              name: string;
-              slug: string;
-              ownerAccount: { __typename?: 'Account'; id: string; name: string };
-            }
-          | { __typename: 'Snack'; id: string; name: string; slug: string };
-      }>;
-    };
-  };
-};
+
+export type ViewBuildsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, builds: Array<{ __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } }> } } };
 
 export type ViewUpdateChannelOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11781,58 +8197,8 @@ export type ViewUpdateChannelOnAppQueryVariables = Exact<{
   filter?: InputMaybe<UpdatesFilter>;
 }>;
 
-export type ViewUpdateChannelOnAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      updateChannelByName?: {
-        __typename?: 'UpdateChannel';
-        id: string;
-        name: string;
-        updatedAt: any;
-        createdAt: any;
-        branchMapping: string;
-        updateBranches: Array<{
-          __typename?: 'UpdateBranch';
-          id: string;
-          name: string;
-          updateGroups: Array<
-            Array<{
-              __typename?: 'Update';
-              id: string;
-              group: string;
-              message?: string | null;
-              createdAt: any;
-              runtimeVersion: string;
-              platform: string;
-              manifestFragment: string;
-              isRollBackToEmbedded: boolean;
-              manifestPermalink: string;
-              gitCommitHash?: string | null;
-              rolloutPercentage?: number | null;
-              actor?:
-                | { __typename: 'Robot'; firstName?: string | null; id: string }
-                | { __typename: 'SSOUser'; username: string; id: string }
-                | { __typename: 'User'; username: string; id: string }
-                | null;
-              branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-              codeSigningInfo?: {
-                __typename?: 'CodeSigningInfo';
-                keyid: string;
-                sig: string;
-                alg: string;
-              } | null;
-              rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-            }>
-          >;
-        }>;
-      } | null;
-    };
-  };
-};
+
+export type ViewUpdateChannelOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, updatedAt: any, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }>> }> } | null } } };
 
 export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11840,58 +8206,8 @@ export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
   limit: Scalars['Int']['input'];
 }>;
 
-export type ViewUpdateChannelsOnAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      updateChannels: Array<{
-        __typename?: 'UpdateChannel';
-        id: string;
-        name: string;
-        updatedAt: any;
-        createdAt: any;
-        branchMapping: string;
-        updateBranches: Array<{
-          __typename?: 'UpdateBranch';
-          id: string;
-          name: string;
-          updateGroups: Array<
-            Array<{
-              __typename?: 'Update';
-              id: string;
-              group: string;
-              message?: string | null;
-              createdAt: any;
-              runtimeVersion: string;
-              platform: string;
-              manifestFragment: string;
-              isRollBackToEmbedded: boolean;
-              manifestPermalink: string;
-              gitCommitHash?: string | null;
-              rolloutPercentage?: number | null;
-              actor?:
-                | { __typename: 'Robot'; firstName?: string | null; id: string }
-                | { __typename: 'SSOUser'; username: string; id: string }
-                | { __typename: 'User'; username: string; id: string }
-                | null;
-              branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-              codeSigningInfo?: {
-                __typename?: 'CodeSigningInfo';
-                keyid: string;
-                sig: string;
-                alg: string;
-              } | null;
-              rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-            }>
-          >;
-        }>;
-      }>;
-    };
-  };
-};
+
+export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, updatedAt: any, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }>> }> }> } } };
 
 export type ViewUpdateChannelsPaginatedOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11901,64 +8217,15 @@ export type ViewUpdateChannelsPaginatedOnAppQueryVariables = Exact<{
   before?: InputMaybe<Scalars['String']['input']>;
 }>;
 
-export type ViewUpdateChannelsPaginatedOnAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      channelsPaginated: {
-        __typename?: 'AppChannelsConnection';
-        edges: Array<{
-          __typename?: 'AppChannelEdge';
-          cursor: string;
-          node: { __typename?: 'UpdateChannel'; id: string; name: string; branchMapping: string };
-        }>;
-        pageInfo: {
-          __typename?: 'PageInfo';
-          hasNextPage: boolean;
-          hasPreviousPage: boolean;
-          startCursor?: string | null;
-          endCursor?: string | null;
-        };
-      };
-    };
-  };
-};
+
+export type ViewUpdateChannelsPaginatedOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, channelsPaginated: { __typename?: 'AppChannelsConnection', edges: Array<{ __typename?: 'AppChannelEdge', cursor: string, node: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];
 }>;
 
-export type EnvironmentSecretsByAppIdQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      ownerAccount: {
-        __typename?: 'Account';
-        id: string;
-        environmentSecrets: Array<{
-          __typename?: 'EnvironmentSecret';
-          id: string;
-          name: string;
-          type: EnvironmentSecretType;
-          createdAt: any;
-        }>;
-      };
-      environmentSecrets: Array<{
-        __typename?: 'EnvironmentSecret';
-        id: string;
-        name: string;
-        type: EnvironmentSecretType;
-        createdAt: any;
-      }>;
-    };
-  };
-};
+
+export type EnvironmentSecretsByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, ownerAccount: { __typename?: 'Account', id: string, environmentSecrets: Array<{ __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any }> }, environmentSecrets: Array<{ __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any }> } } };
 
 export type EnvironmentVariablesIncludingSensitiveByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11966,22 +8233,8 @@ export type EnvironmentVariablesIncludingSensitiveByAppIdQueryVariables = Exact<
   environment: EnvironmentVariableEnvironment;
 }>;
 
-export type EnvironmentVariablesIncludingSensitiveByAppIdQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      environmentVariablesIncludingSensitive: Array<{
-        __typename?: 'EnvironmentVariableWithSecret';
-        id: string;
-        name: string;
-        value?: string | null;
-      }>;
-    };
-  };
-};
+
+export type EnvironmentVariablesIncludingSensitiveByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, environmentVariablesIncludingSensitive: Array<{ __typename?: 'EnvironmentVariableWithSecret', id: string, name: string, value?: string | null }> } } };
 
 export type EnvironmentVariablesByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -11989,110 +8242,38 @@ export type EnvironmentVariablesByAppIdQueryVariables = Exact<{
   environment: EnvironmentVariableEnvironment;
 }>;
 
-export type EnvironmentVariablesByAppIdQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      environmentVariables: Array<{
-        __typename?: 'EnvironmentVariable';
-        id: string;
-        name: string;
-        value?: string | null;
-        environment?: EnvironmentVariableEnvironment | null;
-        createdAt: any;
-        scope: EnvironmentVariableScope;
-        visibility?: EnvironmentVariableVisibility | null;
-      }>;
-    };
-  };
-};
+
+export type EnvironmentVariablesByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, environmentVariables: Array<{ __typename?: 'EnvironmentVariable', id: string, name: string, value?: string | null, environment?: EnvironmentVariableEnvironment | null, createdAt: any, scope: EnvironmentVariableScope, visibility?: EnvironmentVariableVisibility | null }> } } };
 
 export type EnvironmentVariablesSharedQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   filterNames?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
 }>;
 
-export type EnvironmentVariablesSharedQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      ownerAccount: {
-        __typename?: 'Account';
-        id: string;
-        environmentVariables: Array<{
-          __typename?: 'EnvironmentVariable';
-          id: string;
-          name: string;
-          value?: string | null;
-          environment?: EnvironmentVariableEnvironment | null;
-          createdAt: any;
-          scope: EnvironmentVariableScope;
-          visibility?: EnvironmentVariableVisibility | null;
-        }>;
-      };
-    };
-  };
-};
+
+export type EnvironmentVariablesSharedQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, ownerAccount: { __typename?: 'Account', id: string, environmentVariables: Array<{ __typename?: 'EnvironmentVariable', id: string, name: string, value?: string | null, environment?: EnvironmentVariableEnvironment | null, createdAt: any, scope: EnvironmentVariableScope, visibility?: EnvironmentVariableVisibility | null }> } } } };
 
 export type EnvironmentVariablesSharedWithSensitiveQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   filterNames?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
 }>;
 
-export type EnvironmentVariablesSharedWithSensitiveQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      ownerAccount: {
-        __typename?: 'Account';
-        id: string;
-        environmentVariablesIncludingSensitive: Array<{
-          __typename?: 'EnvironmentVariableWithSecret';
-          id: string;
-          name: string;
-          value?: string | null;
-        }>;
-      };
-    };
-  };
-};
+
+export type EnvironmentVariablesSharedWithSensitiveQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, ownerAccount: { __typename?: 'Account', id: string, environmentVariablesIncludingSensitive: Array<{ __typename?: 'EnvironmentVariableWithSecret', id: string, name: string, value?: string | null }> } } } };
 
 export type GetAssetMetadataQueryVariables = Exact<{
   storageKeys: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;
 
-export type GetAssetMetadataQuery = {
-  __typename?: 'RootQuery';
-  asset: {
-    __typename?: 'AssetQuery';
-    metadata: Array<{
-      __typename?: 'AssetMetadataResult';
-      storageKey: string;
-      status: AssetMetadataStatus;
-    }>;
-  };
-};
+
+export type GetAssetMetadataQuery = { __typename?: 'RootQuery', asset: { __typename?: 'AssetQuery', metadata: Array<{ __typename?: 'AssetMetadataResult', storageKey: string, status: AssetMetadataStatus }> } };
 
 export type GetAssetLimitPerUpdateGroupForAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
 }>;
 
-export type GetAssetLimitPerUpdateGroupForAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: { __typename?: 'App'; id: string; assetLimitPerUpdateGroup: number };
-  };
-};
+
+export type GetAssetLimitPerUpdateGroupForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, assetLimitPerUpdateGroup: number } } };
 
 export type ViewRuntimesOnBranchQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -12104,102 +8285,22 @@ export type ViewRuntimesOnBranchQueryVariables = Exact<{
   filter?: InputMaybe<RuntimeFilterInput>;
 }>;
 
-export type ViewRuntimesOnBranchQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      updateBranchByName?: {
-        __typename?: 'UpdateBranch';
-        id: string;
-        runtimes: {
-          __typename?: 'RuntimesConnection';
-          edges: Array<{
-            __typename?: 'RuntimeEdge';
-            cursor: string;
-            node: { __typename?: 'Runtime'; id: string; version: string };
-          }>;
-          pageInfo: {
-            __typename?: 'PageInfo';
-            hasNextPage: boolean;
-            hasPreviousPage: boolean;
-            startCursor?: string | null;
-            endCursor?: string | null;
-          };
-        };
-      } | null;
-    };
-  };
-};
+
+export type ViewRuntimesOnBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, runtimes: { __typename?: 'RuntimesConnection', edges: Array<{ __typename?: 'RuntimeEdge', cursor: string, node: { __typename?: 'Runtime', id: string, version: string } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } | null } } };
 
 export type StatuspageServiceByServiceNamesQueryVariables = Exact<{
   serviceNames: Array<StatuspageServiceName> | StatuspageServiceName;
 }>;
 
-export type StatuspageServiceByServiceNamesQuery = {
-  __typename?: 'RootQuery';
-  statuspageService: {
-    __typename?: 'StatuspageServiceQuery';
-    byServiceNames: Array<{
-      __typename?: 'StatuspageService';
-      id: string;
-      name: StatuspageServiceName;
-      status: StatuspageServiceStatus;
-      incidents: Array<{
-        __typename?: 'StatuspageIncident';
-        id: string;
-        status: StatuspageIncidentStatus;
-        name: string;
-        impact: StatuspageIncidentImpact;
-        shortlink: string;
-      }>;
-    }>;
-  };
-};
+
+export type StatuspageServiceByServiceNamesQuery = { __typename?: 'RootQuery', statuspageService: { __typename?: 'StatuspageServiceQuery', byServiceNames: Array<{ __typename?: 'StatuspageService', id: string, name: StatuspageServiceName, status: StatuspageServiceStatus, incidents: Array<{ __typename?: 'StatuspageIncident', id: string, status: StatuspageIncidentStatus, name: string, impact: StatuspageIncidentImpact, shortlink: string }> }> } };
 
 export type SubmissionsByIdQueryVariables = Exact<{
   submissionId: Scalars['ID']['input'];
 }>;
 
-export type SubmissionsByIdQuery = {
-  __typename?: 'RootQuery';
-  submissions: {
-    __typename?: 'SubmissionQuery';
-    byId: {
-      __typename?: 'Submission';
-      id: string;
-      status: SubmissionStatus;
-      platform: AppPlatform;
-      logsUrl?: string | null;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        slug: string;
-        ownerAccount: { __typename?: 'Account'; id: string; name: string };
-      };
-      androidConfig?: {
-        __typename?: 'AndroidSubmissionConfig';
-        applicationIdentifier?: string | null;
-        track: SubmissionAndroidTrack;
-        releaseStatus?: SubmissionAndroidReleaseStatus | null;
-        rollout?: number | null;
-      } | null;
-      iosConfig?: {
-        __typename?: 'IosSubmissionConfig';
-        ascAppIdentifier: string;
-        appleIdUsername?: string | null;
-      } | null;
-      error?: {
-        __typename?: 'SubmissionError';
-        errorCode?: string | null;
-        message?: string | null;
-      } | null;
-    };
-  };
-};
+
+export type SubmissionsByIdQuery = { __typename?: 'RootQuery', submissions: { __typename?: 'SubmissionQuery', byId: { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null, rollout?: number | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null } } };
 
 export type GetAllSubmissionsForAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -12209,82 +8310,15 @@ export type GetAllSubmissionsForAppQueryVariables = Exact<{
   platform?: InputMaybe<AppPlatform>;
 }>;
 
-export type GetAllSubmissionsForAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      submissions: Array<{
-        __typename?: 'Submission';
-        id: string;
-        status: SubmissionStatus;
-        platform: AppPlatform;
-        logsUrl?: string | null;
-        app: {
-          __typename?: 'App';
-          id: string;
-          name: string;
-          slug: string;
-          ownerAccount: { __typename?: 'Account'; id: string; name: string };
-        };
-        androidConfig?: {
-          __typename?: 'AndroidSubmissionConfig';
-          applicationIdentifier?: string | null;
-          track: SubmissionAndroidTrack;
-          releaseStatus?: SubmissionAndroidReleaseStatus | null;
-          rollout?: number | null;
-        } | null;
-        iosConfig?: {
-          __typename?: 'IosSubmissionConfig';
-          ascAppIdentifier: string;
-          appleIdUsername?: string | null;
-        } | null;
-        error?: {
-          __typename?: 'SubmissionError';
-          errorCode?: string | null;
-          message?: string | null;
-        } | null;
-      }>;
-    };
-  };
-};
+
+export type GetAllSubmissionsForAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, submissions: Array<{ __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null, rollout?: number | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null }> } } };
 
 export type ViewUpdatesByGroupQueryVariables = Exact<{
   groupId: Scalars['ID']['input'];
 }>;
 
-export type ViewUpdatesByGroupQuery = {
-  __typename?: 'RootQuery';
-  updatesByGroup: Array<{
-    __typename?: 'Update';
-    id: string;
-    group: string;
-    message?: string | null;
-    createdAt: any;
-    runtimeVersion: string;
-    platform: string;
-    manifestFragment: string;
-    isRollBackToEmbedded: boolean;
-    manifestPermalink: string;
-    gitCommitHash?: string | null;
-    rolloutPercentage?: number | null;
-    actor?:
-      | { __typename: 'Robot'; firstName?: string | null; id: string }
-      | { __typename: 'SSOUser'; username: string; id: string }
-      | { __typename: 'User'; username: string; id: string }
-      | null;
-    branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-    codeSigningInfo?: {
-      __typename?: 'CodeSigningInfo';
-      keyid: string;
-      sig: string;
-      alg: string;
-    } | null;
-    rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-  }>;
-};
+
+export type ViewUpdatesByGroupQuery = { __typename?: 'RootQuery', updatesByGroup: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }> };
 
 export type ViewUpdateGroupsOnBranchQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -12294,49 +8328,8 @@ export type ViewUpdateGroupsOnBranchQueryVariables = Exact<{
   filter?: InputMaybe<UpdatesFilter>;
 }>;
 
-export type ViewUpdateGroupsOnBranchQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      updateBranchByName?: {
-        __typename?: 'UpdateBranch';
-        id: string;
-        updateGroups: Array<
-          Array<{
-            __typename?: 'Update';
-            id: string;
-            group: string;
-            message?: string | null;
-            createdAt: any;
-            runtimeVersion: string;
-            platform: string;
-            manifestFragment: string;
-            isRollBackToEmbedded: boolean;
-            manifestPermalink: string;
-            gitCommitHash?: string | null;
-            rolloutPercentage?: number | null;
-            actor?:
-              | { __typename: 'Robot'; firstName?: string | null; id: string }
-              | { __typename: 'SSOUser'; username: string; id: string }
-              | { __typename: 'User'; username: string; id: string }
-              | null;
-            branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-            codeSigningInfo?: {
-              __typename?: 'CodeSigningInfo';
-              keyid: string;
-              sig: string;
-              alg: string;
-            } | null;
-            rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-          }>
-        >;
-      } | null;
-    };
-  };
-};
+
+export type ViewUpdateGroupsOnBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }>> } | null } } };
 
 export type ViewUpdateGroupsOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -12345,1350 +8338,87 @@ export type ViewUpdateGroupsOnAppQueryVariables = Exact<{
   filter?: InputMaybe<UpdatesFilter>;
 }>;
 
-export type ViewUpdateGroupsOnAppQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      updateGroups: Array<
-        Array<{
-          __typename?: 'Update';
-          id: string;
-          group: string;
-          message?: string | null;
-          createdAt: any;
-          runtimeVersion: string;
-          platform: string;
-          manifestFragment: string;
-          isRollBackToEmbedded: boolean;
-          manifestPermalink: string;
-          gitCommitHash?: string | null;
-          rolloutPercentage?: number | null;
-          actor?:
-            | { __typename: 'Robot'; firstName?: string | null; id: string }
-            | { __typename: 'SSOUser'; username: string; id: string }
-            | { __typename: 'User'; username: string; id: string }
-            | null;
-          branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-          codeSigningInfo?: {
-            __typename?: 'CodeSigningInfo';
-            keyid: string;
-            sig: string;
-            alg: string;
-          } | null;
-          rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-        }>
-      >;
-    };
-  };
-};
 
-export type CurrentUserQueryVariables = Exact<{ [key: string]: never }>;
+export type ViewUpdateGroupsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }>> } } };
 
-export type CurrentUserQuery = {
-  __typename?: 'RootQuery';
-  meActor?:
-    | {
-        __typename: 'Robot';
-        firstName?: string | null;
-        id: string;
-        featureGates: any;
-        isExpoAdmin: boolean;
-        accounts: Array<{
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        }>;
-      }
-    | {
-        __typename: 'SSOUser';
-        username: string;
-        id: string;
-        featureGates: any;
-        isExpoAdmin: boolean;
-        primaryAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        preferences: {
-          __typename?: 'UserPreferences';
-          onboarding?: {
-            __typename?: 'UserPreferencesOnboarding';
-            appId: string;
-            platform?: AppPlatform | null;
-            deviceType?: OnboardingDeviceType | null;
-            environment?: OnboardingEnvironment | null;
-            isCLIDone?: boolean | null;
-            lastUsed: string;
-          } | null;
-        };
-        accounts: Array<{
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        }>;
-      }
-    | {
-        __typename: 'User';
-        username: string;
-        id: string;
-        featureGates: any;
-        isExpoAdmin: boolean;
-        primaryAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        preferences: {
-          __typename?: 'UserPreferences';
-          onboarding?: {
-            __typename?: 'UserPreferencesOnboarding';
-            appId: string;
-            platform?: AppPlatform | null;
-            deviceType?: OnboardingDeviceType | null;
-            environment?: OnboardingEnvironment | null;
-            isCLIDone?: boolean | null;
-            lastUsed: string;
-          } | null;
-        };
-        accounts: Array<{
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        }>;
-      }
-    | null;
-};
+export type CurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type CurrentUserQuery = { __typename?: 'RootQuery', meActor?: { __typename: 'Robot', firstName?: string | null, id: string, featureGates: any, isExpoAdmin: boolean, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | { __typename: 'SSOUser', username: string, id: string, featureGates: any, isExpoAdmin: boolean, primaryAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, preferences: { __typename?: 'UserPreferences', onboarding?: { __typename?: 'UserPreferencesOnboarding', appId: string, platform?: AppPlatform | null, deviceType?: OnboardingDeviceType | null, environment?: OnboardingEnvironment | null, isCLIDone?: boolean | null, lastUsed: string } | null }, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | { __typename: 'User', username: string, id: string, featureGates: any, isExpoAdmin: boolean, primaryAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, preferences: { __typename?: 'UserPreferences', onboarding?: { __typename?: 'UserPreferencesOnboarding', appId: string, platform?: AppPlatform | null, deviceType?: OnboardingDeviceType | null, environment?: OnboardingEnvironment | null, isCLIDone?: boolean | null, lastUsed: string } | null }, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }> } | null };
 
 export type WebhooksByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   webhookFilter?: InputMaybe<WebhookFilter>;
 }>;
 
-export type WebhooksByAppIdQuery = {
-  __typename?: 'RootQuery';
-  app: {
-    __typename?: 'AppQuery';
-    byId: {
-      __typename?: 'App';
-      id: string;
-      webhooks: Array<{
-        __typename?: 'Webhook';
-        id: string;
-        event: WebhookType;
-        url: string;
-        createdAt: any;
-        updatedAt: any;
-      }>;
-    };
-  };
-};
+
+export type WebhooksByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, webhooks: Array<{ __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any }> } } };
 
 export type WebhookByIdQueryVariables = Exact<{
   webhookId: Scalars['ID']['input'];
 }>;
 
-export type WebhookByIdQuery = {
-  __typename?: 'RootQuery';
-  webhook: {
-    __typename?: 'WebhookQuery';
-    byId: {
-      __typename?: 'Webhook';
-      id: string;
-      event: WebhookType;
-      url: string;
-      createdAt: any;
-      updatedAt: any;
-    };
-  };
-};
 
-export type AccountFragment = {
-  __typename?: 'Account';
-  id: string;
-  name: string;
-  ownerUserActor?:
-    | { __typename?: 'SSOUser'; id: string; username: string }
-    | { __typename?: 'User'; id: string; username: string }
-    | null;
-  users: Array<{
-    __typename?: 'UserPermission';
-    role: Role;
-    actor:
-      | { __typename?: 'Robot'; id: string }
-      | { __typename?: 'SSOUser'; id: string }
-      | { __typename?: 'User'; id: string };
-  }>;
-};
+export type WebhookByIdQuery = { __typename?: 'RootQuery', webhook: { __typename?: 'WebhookQuery', byId: { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any } } };
 
-export type AppFragment = {
-  __typename?: 'App';
-  id: string;
-  name: string;
-  fullName: string;
-  slug: string;
-  ownerAccount: {
-    __typename?: 'Account';
-    id: string;
-    name: string;
-    ownerUserActor?:
-      | { __typename?: 'SSOUser'; id: string; username: string }
-      | { __typename?: 'User'; id: string; username: string }
-      | null;
-    users: Array<{
-      __typename?: 'UserPermission';
-      role: Role;
-      actor:
-        | { __typename?: 'Robot'; id: string }
-        | { __typename?: 'SSOUser'; id: string }
-        | { __typename?: 'User'; id: string };
-    }>;
-  };
-  githubRepository?: {
-    __typename?: 'GitHubRepository';
-    id: string;
-    metadata: {
-      __typename?: 'GitHubRepositoryMetadata';
-      githubRepoOwnerName: string;
-      githubRepoName: string;
-    };
-  } | null;
-};
+export type AccountFragment = { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> };
 
-export type BuildFragment = {
-  __typename?: 'Build';
-  id: string;
-  status: BuildStatus;
-  platform: AppPlatform;
-  channel?: string | null;
-  distribution?: DistributionType | null;
-  iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
-  buildProfile?: string | null;
-  sdkVersion?: string | null;
-  appVersion?: string | null;
-  appBuildVersion?: string | null;
-  runtimeVersion?: string | null;
-  gitCommitHash?: string | null;
-  gitCommitMessage?: string | null;
-  initialQueuePosition?: number | null;
-  queuePosition?: number | null;
-  estimatedWaitTimeLeftSeconds?: number | null;
-  priority: BuildPriority;
-  createdAt: any;
-  updatedAt: any;
-  message?: string | null;
-  completedAt?: any | null;
-  expirationDate?: any | null;
-  isForIosSimulator: boolean;
-  error?: {
-    __typename?: 'BuildError';
-    errorCode: string;
-    message: string;
-    docsUrl?: string | null;
-  } | null;
-  artifacts?: {
-    __typename?: 'BuildArtifacts';
-    buildUrl?: string | null;
-    xcodeBuildLogsUrl?: string | null;
-    applicationArchiveUrl?: string | null;
-    buildArtifactsUrl?: string | null;
-  } | null;
-  initiatingActor?:
-    | { __typename: 'Robot'; id: string; displayName: string }
-    | { __typename: 'SSOUser'; id: string; displayName: string }
-    | { __typename: 'User'; id: string; displayName: string }
-    | null;
-  project:
-    | {
-        __typename: 'App';
-        id: string;
-        name: string;
-        slug: string;
-        ownerAccount: { __typename?: 'Account'; id: string; name: string };
-      }
-    | { __typename: 'Snack'; id: string; name: string; slug: string };
-};
+export type AppFragment = { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null };
 
-export type BuildWithSubmissionsFragment = {
-  __typename?: 'Build';
-  id: string;
-  status: BuildStatus;
-  platform: AppPlatform;
-  channel?: string | null;
-  distribution?: DistributionType | null;
-  iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null;
-  buildProfile?: string | null;
-  sdkVersion?: string | null;
-  appVersion?: string | null;
-  appBuildVersion?: string | null;
-  runtimeVersion?: string | null;
-  gitCommitHash?: string | null;
-  gitCommitMessage?: string | null;
-  initialQueuePosition?: number | null;
-  queuePosition?: number | null;
-  estimatedWaitTimeLeftSeconds?: number | null;
-  priority: BuildPriority;
-  createdAt: any;
-  updatedAt: any;
-  message?: string | null;
-  completedAt?: any | null;
-  expirationDate?: any | null;
-  isForIosSimulator: boolean;
-  submissions: Array<{
-    __typename?: 'Submission';
-    id: string;
-    status: SubmissionStatus;
-    platform: AppPlatform;
-    logsUrl?: string | null;
-    app: {
-      __typename?: 'App';
-      id: string;
-      name: string;
-      slug: string;
-      ownerAccount: { __typename?: 'Account'; id: string; name: string };
-    };
-    androidConfig?: {
-      __typename?: 'AndroidSubmissionConfig';
-      applicationIdentifier?: string | null;
-      track: SubmissionAndroidTrack;
-      releaseStatus?: SubmissionAndroidReleaseStatus | null;
-      rollout?: number | null;
-    } | null;
-    iosConfig?: {
-      __typename?: 'IosSubmissionConfig';
-      ascAppIdentifier: string;
-      appleIdUsername?: string | null;
-    } | null;
-    error?: {
-      __typename?: 'SubmissionError';
-      errorCode?: string | null;
-      message?: string | null;
-    } | null;
-  }>;
-  error?: {
-    __typename?: 'BuildError';
-    errorCode: string;
-    message: string;
-    docsUrl?: string | null;
-  } | null;
-  artifacts?: {
-    __typename?: 'BuildArtifacts';
-    buildUrl?: string | null;
-    xcodeBuildLogsUrl?: string | null;
-    applicationArchiveUrl?: string | null;
-    buildArtifactsUrl?: string | null;
-  } | null;
-  initiatingActor?:
-    | { __typename: 'Robot'; id: string; displayName: string }
-    | { __typename: 'SSOUser'; id: string; displayName: string }
-    | { __typename: 'User'; id: string; displayName: string }
-    | null;
-  project:
-    | {
-        __typename: 'App';
-        id: string;
-        name: string;
-        slug: string;
-        ownerAccount: { __typename?: 'Account'; id: string; name: string };
-      }
-    | { __typename: 'Snack'; id: string; name: string; slug: string };
-};
+export type BuildFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } };
 
-export type EnvironmentSecretFragment = {
-  __typename?: 'EnvironmentSecret';
-  id: string;
-  name: string;
-  type: EnvironmentSecretType;
-  createdAt: any;
-};
+export type BuildWithSubmissionsFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, submissions: Array<{ __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null, rollout?: number | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null }>, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string } };
 
-export type EnvironmentVariableFragment = {
-  __typename?: 'EnvironmentVariable';
-  id: string;
-  name: string;
-  value?: string | null;
-  environment?: EnvironmentVariableEnvironment | null;
-  createdAt: any;
-  scope: EnvironmentVariableScope;
-  visibility?: EnvironmentVariableVisibility | null;
-};
+export type EnvironmentSecretFragment = { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any };
 
-export type RuntimeFragment = { __typename?: 'Runtime'; id: string; version: string };
+export type EnvironmentVariableFragment = { __typename?: 'EnvironmentVariable', id: string, name: string, value?: string | null, environment?: EnvironmentVariableEnvironment | null, createdAt: any, scope: EnvironmentVariableScope, visibility?: EnvironmentVariableVisibility | null };
 
-export type StatuspageServiceFragment = {
-  __typename?: 'StatuspageService';
-  id: string;
-  name: StatuspageServiceName;
-  status: StatuspageServiceStatus;
-  incidents: Array<{
-    __typename?: 'StatuspageIncident';
-    id: string;
-    status: StatuspageIncidentStatus;
-    name: string;
-    impact: StatuspageIncidentImpact;
-    shortlink: string;
-  }>;
-};
+export type RuntimeFragment = { __typename?: 'Runtime', id: string, version: string };
 
-export type SubmissionFragment = {
-  __typename?: 'Submission';
-  id: string;
-  status: SubmissionStatus;
-  platform: AppPlatform;
-  logsUrl?: string | null;
-  app: {
-    __typename?: 'App';
-    id: string;
-    name: string;
-    slug: string;
-    ownerAccount: { __typename?: 'Account'; id: string; name: string };
-  };
-  androidConfig?: {
-    __typename?: 'AndroidSubmissionConfig';
-    applicationIdentifier?: string | null;
-    track: SubmissionAndroidTrack;
-    releaseStatus?: SubmissionAndroidReleaseStatus | null;
-    rollout?: number | null;
-  } | null;
-  iosConfig?: {
-    __typename?: 'IosSubmissionConfig';
-    ascAppIdentifier: string;
-    appleIdUsername?: string | null;
-  } | null;
-  error?: {
-    __typename?: 'SubmissionError';
-    errorCode?: string | null;
-    message?: string | null;
-  } | null;
-};
+export type StatuspageServiceFragment = { __typename?: 'StatuspageService', id: string, name: StatuspageServiceName, status: StatuspageServiceStatus, incidents: Array<{ __typename?: 'StatuspageIncident', id: string, status: StatuspageIncidentStatus, name: string, impact: StatuspageIncidentImpact, shortlink: string }> };
 
-export type UpdateFragment = {
-  __typename?: 'Update';
-  id: string;
-  group: string;
-  message?: string | null;
-  createdAt: any;
-  runtimeVersion: string;
-  platform: string;
-  manifestFragment: string;
-  isRollBackToEmbedded: boolean;
-  manifestPermalink: string;
-  gitCommitHash?: string | null;
-  rolloutPercentage?: number | null;
-  actor?:
-    | { __typename: 'Robot'; firstName?: string | null; id: string }
-    | { __typename: 'SSOUser'; username: string; id: string }
-    | { __typename: 'User'; username: string; id: string }
-    | null;
-  branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-  codeSigningInfo?: {
-    __typename?: 'CodeSigningInfo';
-    keyid: string;
-    sig: string;
-    alg: string;
-  } | null;
-  rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-};
+export type SubmissionFragment = { __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logsUrl?: string | null, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: SubmissionAndroidTrack, releaseStatus?: SubmissionAndroidReleaseStatus | null, rollout?: number | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null };
 
-export type UpdateBranchFragment = {
-  __typename?: 'UpdateBranch';
-  id: string;
-  name: string;
-  updates: Array<{
-    __typename?: 'Update';
-    id: string;
-    group: string;
-    message?: string | null;
-    createdAt: any;
-    runtimeVersion: string;
-    platform: string;
-    manifestFragment: string;
-    isRollBackToEmbedded: boolean;
-    manifestPermalink: string;
-    gitCommitHash?: string | null;
-    rolloutPercentage?: number | null;
-    actor?:
-      | { __typename: 'Robot'; firstName?: string | null; id: string }
-      | { __typename: 'SSOUser'; username: string; id: string }
-      | { __typename: 'User'; username: string; id: string }
-      | null;
-    branch: { __typename?: 'UpdateBranch'; id: string; name: string };
-    codeSigningInfo?: {
-      __typename?: 'CodeSigningInfo';
-      keyid: string;
-      sig: string;
-      alg: string;
-    } | null;
-    rolloutControlUpdate?: { __typename?: 'Update'; id: string } | null;
-  }>;
-};
+export type UpdateFragment = { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null };
 
-export type UpdateBranchBasicInfoFragment = {
-  __typename?: 'UpdateBranch';
-  id: string;
-  name: string;
-};
+export type UpdateBranchFragment = { __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }> };
 
-export type UpdateChannelBasicInfoFragment = {
-  __typename?: 'UpdateChannel';
-  id: string;
-  name: string;
-  branchMapping: string;
-};
+export type UpdateBranchBasicInfoFragment = { __typename?: 'UpdateBranch', id: string, name: string };
 
-export type WebhookFragment = {
-  __typename?: 'Webhook';
-  id: string;
-  event: WebhookType;
-  url: string;
-  createdAt: any;
-  updatedAt: any;
-};
+export type UpdateChannelBasicInfoFragment = { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string };
 
-export type AndroidAppBuildCredentialsFragment = {
-  __typename?: 'AndroidAppBuildCredentials';
-  id: string;
-  isDefault: boolean;
-  isLegacy: boolean;
-  name: string;
-  androidKeystore?: {
-    __typename?: 'AndroidKeystore';
-    id: string;
-    type: AndroidKeystoreType;
-    keystore: string;
-    keystorePassword: string;
-    keyAlias: string;
-    keyPassword?: string | null;
-    md5CertificateFingerprint?: string | null;
-    sha1CertificateFingerprint?: string | null;
-    sha256CertificateFingerprint?: string | null;
-    createdAt: any;
-    updatedAt: any;
-  } | null;
-};
+export type WebhookFragment = { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any };
 
-export type CommonAndroidAppCredentialsFragment = {
-  __typename?: 'AndroidAppCredentials';
-  id: string;
-  applicationIdentifier?: string | null;
-  isLegacy: boolean;
-  app: {
-    __typename?: 'App';
-    id: string;
-    name: string;
-    fullName: string;
-    slug: string;
-    ownerAccount: {
-      __typename?: 'Account';
-      id: string;
-      name: string;
-      ownerUserActor?:
-        | { __typename?: 'SSOUser'; id: string; username: string }
-        | { __typename?: 'User'; id: string; username: string }
-        | null;
-      users: Array<{
-        __typename?: 'UserPermission';
-        role: Role;
-        actor:
-          | { __typename?: 'Robot'; id: string }
-          | { __typename?: 'SSOUser'; id: string }
-          | { __typename?: 'User'; id: string };
-      }>;
-    };
-    githubRepository?: {
-      __typename?: 'GitHubRepository';
-      id: string;
-      metadata: {
-        __typename?: 'GitHubRepositoryMetadata';
-        githubRepoOwnerName: string;
-        githubRepoName: string;
-      };
-    } | null;
-  };
-  androidFcm?: {
-    __typename?: 'AndroidFcm';
-    id: string;
-    credential: any;
-    version: AndroidFcmVersion;
-    createdAt: any;
-    updatedAt: any;
-    snippet:
-      | { __typename?: 'FcmSnippetLegacy'; firstFourCharacters: string; lastFourCharacters: string }
-      | {
-          __typename?: 'FcmSnippetV1';
-          projectId: string;
-          keyId: string;
-          serviceAccountEmail: string;
-          clientId?: string | null;
-        };
-  } | null;
-  googleServiceAccountKeyForFcmV1?: {
-    __typename?: 'GoogleServiceAccountKey';
-    id: string;
-    projectIdentifier: string;
-    privateKeyIdentifier: string;
-    clientEmail: string;
-    clientIdentifier: string;
-    createdAt: any;
-    updatedAt: any;
-  } | null;
-  googleServiceAccountKeyForSubmissions?: {
-    __typename?: 'GoogleServiceAccountKey';
-    id: string;
-    projectIdentifier: string;
-    privateKeyIdentifier: string;
-    clientEmail: string;
-    clientIdentifier: string;
-    createdAt: any;
-    updatedAt: any;
-  } | null;
-  androidAppBuildCredentialsList: Array<{
-    __typename?: 'AndroidAppBuildCredentials';
-    id: string;
-    isDefault: boolean;
-    isLegacy: boolean;
-    name: string;
-    androidKeystore?: {
-      __typename?: 'AndroidKeystore';
-      id: string;
-      type: AndroidKeystoreType;
-      keystore: string;
-      keystorePassword: string;
-      keyAlias: string;
-      keyPassword?: string | null;
-      md5CertificateFingerprint?: string | null;
-      sha1CertificateFingerprint?: string | null;
-      sha256CertificateFingerprint?: string | null;
-      createdAt: any;
-      updatedAt: any;
-    } | null;
-  }>;
-};
+export type AndroidAppBuildCredentialsFragment = { __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null };
 
-export type AndroidFcmFragment = {
-  __typename?: 'AndroidFcm';
-  id: string;
-  credential: any;
-  version: AndroidFcmVersion;
-  createdAt: any;
-  updatedAt: any;
-  snippet:
-    | { __typename?: 'FcmSnippetLegacy'; firstFourCharacters: string; lastFourCharacters: string }
-    | {
-        __typename?: 'FcmSnippetV1';
-        projectId: string;
-        keyId: string;
-        serviceAccountEmail: string;
-        clientId?: string | null;
-      };
-};
+export type CommonAndroidAppCredentialsFragment = { __typename?: 'AndroidAppCredentials', id: string, applicationIdentifier?: string | null, isLegacy: boolean, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, androidFcm?: { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } } | null, googleServiceAccountKeyForFcmV1?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, googleServiceAccountKeyForSubmissions?: { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any } | null, androidAppBuildCredentialsList: Array<{ __typename?: 'AndroidAppBuildCredentials', id: string, isDefault: boolean, isLegacy: boolean, name: string, androidKeystore?: { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any } | null }> };
 
-export type AndroidKeystoreFragment = {
-  __typename?: 'AndroidKeystore';
-  id: string;
-  type: AndroidKeystoreType;
-  keystore: string;
-  keystorePassword: string;
-  keyAlias: string;
-  keyPassword?: string | null;
-  md5CertificateFingerprint?: string | null;
-  sha1CertificateFingerprint?: string | null;
-  sha256CertificateFingerprint?: string | null;
-  createdAt: any;
-  updatedAt: any;
-};
+export type AndroidFcmFragment = { __typename?: 'AndroidFcm', id: string, credential: any, version: AndroidFcmVersion, createdAt: any, updatedAt: any, snippet: { __typename?: 'FcmSnippetLegacy', firstFourCharacters: string, lastFourCharacters: string } | { __typename?: 'FcmSnippetV1', projectId: string, keyId: string, serviceAccountEmail: string, clientId?: string | null } };
 
-export type AppStoreConnectApiKeyFragment = {
-  __typename?: 'AppStoreConnectApiKey';
-  id: string;
-  issuerIdentifier: string;
-  keyIdentifier: string;
-  name?: string | null;
-  roles?: Array<AppStoreConnectUserRole> | null;
-  createdAt: any;
-  updatedAt: any;
-  appleTeam?: {
-    __typename?: 'AppleTeam';
-    id: string;
-    appleTeamIdentifier: string;
-    appleTeamName?: string | null;
-  } | null;
-};
+export type AndroidKeystoreFragment = { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any };
 
-export type AppleAppIdentifierFragment = {
-  __typename?: 'AppleAppIdentifier';
-  id: string;
-  bundleIdentifier: string;
-};
+export type AppStoreConnectApiKeyFragment = { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null };
 
-export type AppleDeviceFragment = {
-  __typename?: 'AppleDevice';
-  id: string;
-  identifier: string;
-  name?: string | null;
-  model?: string | null;
-  deviceClass?: AppleDeviceClass | null;
-  createdAt: any;
-};
+export type AppleAppIdentifierFragment = { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string };
 
-export type AppleDeviceRegistrationRequestFragment = {
-  __typename?: 'AppleDeviceRegistrationRequest';
-  id: string;
-};
+export type AppleDeviceFragment = { __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any };
 
-export type AppleDistributionCertificateFragment = {
-  __typename?: 'AppleDistributionCertificate';
-  id: string;
-  certificateP12?: string | null;
-  certificatePassword?: string | null;
-  serialNumber: string;
-  developerPortalIdentifier?: string | null;
-  validityNotBefore: any;
-  validityNotAfter: any;
-  updatedAt: any;
-  appleTeam?: {
-    __typename?: 'AppleTeam';
-    id: string;
-    appleTeamIdentifier: string;
-    appleTeamName?: string | null;
-  } | null;
-  iosAppBuildCredentialsList: Array<{
-    __typename?: 'IosAppBuildCredentials';
-    id: string;
-    iosAppCredentials: {
-      __typename?: 'IosAppCredentials';
-      id: string;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        fullName: string;
-        slug: string;
-        ownerAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        githubRepository?: {
-          __typename?: 'GitHubRepository';
-          id: string;
-          metadata: {
-            __typename?: 'GitHubRepositoryMetadata';
-            githubRepoOwnerName: string;
-            githubRepoName: string;
-          };
-        } | null;
-      };
-      appleAppIdentifier: {
-        __typename?: 'AppleAppIdentifier';
-        id: string;
-        bundleIdentifier: string;
-      };
-    };
-    provisioningProfile?: {
-      __typename?: 'AppleProvisioningProfile';
-      id: string;
-      developerPortalIdentifier?: string | null;
-    } | null;
-  }>;
-};
+export type AppleDeviceRegistrationRequestFragment = { __typename?: 'AppleDeviceRegistrationRequest', id: string };
 
-export type AppleProvisioningProfileFragment = {
-  __typename?: 'AppleProvisioningProfile';
-  id: string;
-  expiration: any;
-  developerPortalIdentifier?: string | null;
-  provisioningProfile?: string | null;
-  updatedAt: any;
-  status: string;
-  appleTeam?: {
-    __typename?: 'AppleTeam';
-    id: string;
-    appleTeamIdentifier: string;
-    appleTeamName?: string | null;
-  } | null;
-  appleDevices: Array<{
-    __typename?: 'AppleDevice';
-    id: string;
-    identifier: string;
-    name?: string | null;
-    model?: string | null;
-    deviceClass?: AppleDeviceClass | null;
-    createdAt: any;
-  }>;
-};
+export type AppleDistributionCertificateFragment = { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> };
 
-export type AppleProvisioningProfileIdentifiersFragment = {
-  __typename?: 'AppleProvisioningProfile';
-  id: string;
-  developerPortalIdentifier?: string | null;
-};
+export type AppleProvisioningProfileFragment = { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> };
 
-export type ApplePushKeyFragment = {
-  __typename?: 'ApplePushKey';
-  id: string;
-  keyIdentifier: string;
-  updatedAt: any;
-  appleTeam?: {
-    __typename?: 'AppleTeam';
-    id: string;
-    appleTeamIdentifier: string;
-    appleTeamName?: string | null;
-  } | null;
-  iosAppCredentialsList: Array<{
-    __typename?: 'IosAppCredentials';
-    id: string;
-    app: {
-      __typename?: 'App';
-      id: string;
-      name: string;
-      fullName: string;
-      slug: string;
-      ownerAccount: {
-        __typename?: 'Account';
-        id: string;
-        name: string;
-        ownerUserActor?:
-          | { __typename?: 'SSOUser'; id: string; username: string }
-          | { __typename?: 'User'; id: string; username: string }
-          | null;
-        users: Array<{
-          __typename?: 'UserPermission';
-          role: Role;
-          actor:
-            | { __typename?: 'Robot'; id: string }
-            | { __typename?: 'SSOUser'; id: string }
-            | { __typename?: 'User'; id: string };
-        }>;
-      };
-      githubRepository?: {
-        __typename?: 'GitHubRepository';
-        id: string;
-        metadata: {
-          __typename?: 'GitHubRepositoryMetadata';
-          githubRepoOwnerName: string;
-          githubRepoName: string;
-        };
-      } | null;
-    };
-    appleAppIdentifier: { __typename?: 'AppleAppIdentifier'; id: string; bundleIdentifier: string };
-  }>;
-};
+export type AppleProvisioningProfileIdentifiersFragment = { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null };
 
-export type AppleTeamFragment = {
-  __typename?: 'AppleTeam';
-  id: string;
-  appleTeamIdentifier: string;
-  appleTeamName?: string | null;
-};
+export type ApplePushKeyFragment = { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> };
 
-export type GoogleServiceAccountKeyFragment = {
-  __typename?: 'GoogleServiceAccountKey';
-  id: string;
-  projectIdentifier: string;
-  privateKeyIdentifier: string;
-  clientEmail: string;
-  clientIdentifier: string;
-  createdAt: any;
-  updatedAt: any;
-};
+export type AppleTeamFragment = { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null };
 
-export type IosAppBuildCredentialsFragment = {
-  __typename?: 'IosAppBuildCredentials';
-  id: string;
-  iosDistributionType: IosDistributionType;
-  distributionCertificate?: {
-    __typename?: 'AppleDistributionCertificate';
-    id: string;
-    certificateP12?: string | null;
-    certificatePassword?: string | null;
-    serialNumber: string;
-    developerPortalIdentifier?: string | null;
-    validityNotBefore: any;
-    validityNotAfter: any;
-    updatedAt: any;
-    appleTeam?: {
-      __typename?: 'AppleTeam';
-      id: string;
-      appleTeamIdentifier: string;
-      appleTeamName?: string | null;
-    } | null;
-    iosAppBuildCredentialsList: Array<{
-      __typename?: 'IosAppBuildCredentials';
-      id: string;
-      iosAppCredentials: {
-        __typename?: 'IosAppCredentials';
-        id: string;
-        app: {
-          __typename?: 'App';
-          id: string;
-          name: string;
-          fullName: string;
-          slug: string;
-          ownerAccount: {
-            __typename?: 'Account';
-            id: string;
-            name: string;
-            ownerUserActor?:
-              | { __typename?: 'SSOUser'; id: string; username: string }
-              | { __typename?: 'User'; id: string; username: string }
-              | null;
-            users: Array<{
-              __typename?: 'UserPermission';
-              role: Role;
-              actor:
-                | { __typename?: 'Robot'; id: string }
-                | { __typename?: 'SSOUser'; id: string }
-                | { __typename?: 'User'; id: string };
-            }>;
-          };
-          githubRepository?: {
-            __typename?: 'GitHubRepository';
-            id: string;
-            metadata: {
-              __typename?: 'GitHubRepositoryMetadata';
-              githubRepoOwnerName: string;
-              githubRepoName: string;
-            };
-          } | null;
-        };
-        appleAppIdentifier: {
-          __typename?: 'AppleAppIdentifier';
-          id: string;
-          bundleIdentifier: string;
-        };
-      };
-      provisioningProfile?: {
-        __typename?: 'AppleProvisioningProfile';
-        id: string;
-        developerPortalIdentifier?: string | null;
-      } | null;
-    }>;
-  } | null;
-  provisioningProfile?: {
-    __typename?: 'AppleProvisioningProfile';
-    id: string;
-    expiration: any;
-    developerPortalIdentifier?: string | null;
-    provisioningProfile?: string | null;
-    updatedAt: any;
-    status: string;
-    appleTeam?: {
-      __typename?: 'AppleTeam';
-      id: string;
-      appleTeamIdentifier: string;
-      appleTeamName?: string | null;
-    } | null;
-    appleDevices: Array<{
-      __typename?: 'AppleDevice';
-      id: string;
-      identifier: string;
-      name?: string | null;
-      model?: string | null;
-      deviceClass?: AppleDeviceClass | null;
-      createdAt: any;
-    }>;
-  } | null;
-};
+export type GoogleServiceAccountKeyFragment = { __typename?: 'GoogleServiceAccountKey', id: string, projectIdentifier: string, privateKeyIdentifier: string, clientEmail: string, clientIdentifier: string, createdAt: any, updatedAt: any };
 
-export type CommonIosAppCredentialsWithoutBuildCredentialsFragment = {
-  __typename?: 'IosAppCredentials';
-  id: string;
-  app: {
-    __typename?: 'App';
-    id: string;
-    name: string;
-    fullName: string;
-    slug: string;
-    ownerAccount: {
-      __typename?: 'Account';
-      id: string;
-      name: string;
-      ownerUserActor?:
-        | { __typename?: 'SSOUser'; id: string; username: string }
-        | { __typename?: 'User'; id: string; username: string }
-        | null;
-      users: Array<{
-        __typename?: 'UserPermission';
-        role: Role;
-        actor:
-          | { __typename?: 'Robot'; id: string }
-          | { __typename?: 'SSOUser'; id: string }
-          | { __typename?: 'User'; id: string };
-      }>;
-    };
-    githubRepository?: {
-      __typename?: 'GitHubRepository';
-      id: string;
-      metadata: {
-        __typename?: 'GitHubRepositoryMetadata';
-        githubRepoOwnerName: string;
-        githubRepoName: string;
-      };
-    } | null;
-  };
-  appleTeam?: {
-    __typename?: 'AppleTeam';
-    id: string;
-    appleTeamIdentifier: string;
-    appleTeamName?: string | null;
-  } | null;
-  appleAppIdentifier: { __typename?: 'AppleAppIdentifier'; id: string; bundleIdentifier: string };
-  pushKey?: {
-    __typename?: 'ApplePushKey';
-    id: string;
-    keyIdentifier: string;
-    updatedAt: any;
-    appleTeam?: {
-      __typename?: 'AppleTeam';
-      id: string;
-      appleTeamIdentifier: string;
-      appleTeamName?: string | null;
-    } | null;
-    iosAppCredentialsList: Array<{
-      __typename?: 'IosAppCredentials';
-      id: string;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        fullName: string;
-        slug: string;
-        ownerAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        githubRepository?: {
-          __typename?: 'GitHubRepository';
-          id: string;
-          metadata: {
-            __typename?: 'GitHubRepositoryMetadata';
-            githubRepoOwnerName: string;
-            githubRepoName: string;
-          };
-        } | null;
-      };
-      appleAppIdentifier: {
-        __typename?: 'AppleAppIdentifier';
-        id: string;
-        bundleIdentifier: string;
-      };
-    }>;
-  } | null;
-  appStoreConnectApiKeyForSubmissions?: {
-    __typename?: 'AppStoreConnectApiKey';
-    id: string;
-    issuerIdentifier: string;
-    keyIdentifier: string;
-    name?: string | null;
-    roles?: Array<AppStoreConnectUserRole> | null;
-    createdAt: any;
-    updatedAt: any;
-    appleTeam?: {
-      __typename?: 'AppleTeam';
-      id: string;
-      appleTeamIdentifier: string;
-      appleTeamName?: string | null;
-    } | null;
-  } | null;
-};
+export type IosAppBuildCredentialsFragment = { __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null };
 
-export type CommonIosAppCredentialsFragment = {
-  __typename?: 'IosAppCredentials';
-  id: string;
-  iosAppBuildCredentialsList: Array<{
-    __typename?: 'IosAppBuildCredentials';
-    id: string;
-    iosDistributionType: IosDistributionType;
-    distributionCertificate?: {
-      __typename?: 'AppleDistributionCertificate';
-      id: string;
-      certificateP12?: string | null;
-      certificatePassword?: string | null;
-      serialNumber: string;
-      developerPortalIdentifier?: string | null;
-      validityNotBefore: any;
-      validityNotAfter: any;
-      updatedAt: any;
-      appleTeam?: {
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      } | null;
-      iosAppBuildCredentialsList: Array<{
-        __typename?: 'IosAppBuildCredentials';
-        id: string;
-        iosAppCredentials: {
-          __typename?: 'IosAppCredentials';
-          id: string;
-          app: {
-            __typename?: 'App';
-            id: string;
-            name: string;
-            fullName: string;
-            slug: string;
-            ownerAccount: {
-              __typename?: 'Account';
-              id: string;
-              name: string;
-              ownerUserActor?:
-                | { __typename?: 'SSOUser'; id: string; username: string }
-                | { __typename?: 'User'; id: string; username: string }
-                | null;
-              users: Array<{
-                __typename?: 'UserPermission';
-                role: Role;
-                actor:
-                  | { __typename?: 'Robot'; id: string }
-                  | { __typename?: 'SSOUser'; id: string }
-                  | { __typename?: 'User'; id: string };
-              }>;
-            };
-            githubRepository?: {
-              __typename?: 'GitHubRepository';
-              id: string;
-              metadata: {
-                __typename?: 'GitHubRepositoryMetadata';
-                githubRepoOwnerName: string;
-                githubRepoName: string;
-              };
-            } | null;
-          };
-          appleAppIdentifier: {
-            __typename?: 'AppleAppIdentifier';
-            id: string;
-            bundleIdentifier: string;
-          };
-        };
-        provisioningProfile?: {
-          __typename?: 'AppleProvisioningProfile';
-          id: string;
-          developerPortalIdentifier?: string | null;
-        } | null;
-      }>;
-    } | null;
-    provisioningProfile?: {
-      __typename?: 'AppleProvisioningProfile';
-      id: string;
-      expiration: any;
-      developerPortalIdentifier?: string | null;
-      provisioningProfile?: string | null;
-      updatedAt: any;
-      status: string;
-      appleTeam?: {
-        __typename?: 'AppleTeam';
-        id: string;
-        appleTeamIdentifier: string;
-        appleTeamName?: string | null;
-      } | null;
-      appleDevices: Array<{
-        __typename?: 'AppleDevice';
-        id: string;
-        identifier: string;
-        name?: string | null;
-        model?: string | null;
-        deviceClass?: AppleDeviceClass | null;
-        createdAt: any;
-      }>;
-    } | null;
-  }>;
-  app: {
-    __typename?: 'App';
-    id: string;
-    name: string;
-    fullName: string;
-    slug: string;
-    ownerAccount: {
-      __typename?: 'Account';
-      id: string;
-      name: string;
-      ownerUserActor?:
-        | { __typename?: 'SSOUser'; id: string; username: string }
-        | { __typename?: 'User'; id: string; username: string }
-        | null;
-      users: Array<{
-        __typename?: 'UserPermission';
-        role: Role;
-        actor:
-          | { __typename?: 'Robot'; id: string }
-          | { __typename?: 'SSOUser'; id: string }
-          | { __typename?: 'User'; id: string };
-      }>;
-    };
-    githubRepository?: {
-      __typename?: 'GitHubRepository';
-      id: string;
-      metadata: {
-        __typename?: 'GitHubRepositoryMetadata';
-        githubRepoOwnerName: string;
-        githubRepoName: string;
-      };
-    } | null;
-  };
-  appleTeam?: {
-    __typename?: 'AppleTeam';
-    id: string;
-    appleTeamIdentifier: string;
-    appleTeamName?: string | null;
-  } | null;
-  appleAppIdentifier: { __typename?: 'AppleAppIdentifier'; id: string; bundleIdentifier: string };
-  pushKey?: {
-    __typename?: 'ApplePushKey';
-    id: string;
-    keyIdentifier: string;
-    updatedAt: any;
-    appleTeam?: {
-      __typename?: 'AppleTeam';
-      id: string;
-      appleTeamIdentifier: string;
-      appleTeamName?: string | null;
-    } | null;
-    iosAppCredentialsList: Array<{
-      __typename?: 'IosAppCredentials';
-      id: string;
-      app: {
-        __typename?: 'App';
-        id: string;
-        name: string;
-        fullName: string;
-        slug: string;
-        ownerAccount: {
-          __typename?: 'Account';
-          id: string;
-          name: string;
-          ownerUserActor?:
-            | { __typename?: 'SSOUser'; id: string; username: string }
-            | { __typename?: 'User'; id: string; username: string }
-            | null;
-          users: Array<{
-            __typename?: 'UserPermission';
-            role: Role;
-            actor:
-              | { __typename?: 'Robot'; id: string }
-              | { __typename?: 'SSOUser'; id: string }
-              | { __typename?: 'User'; id: string };
-          }>;
-        };
-        githubRepository?: {
-          __typename?: 'GitHubRepository';
-          id: string;
-          metadata: {
-            __typename?: 'GitHubRepositoryMetadata';
-            githubRepoOwnerName: string;
-            githubRepoName: string;
-          };
-        } | null;
-      };
-      appleAppIdentifier: {
-        __typename?: 'AppleAppIdentifier';
-        id: string;
-        bundleIdentifier: string;
-      };
-    }>;
-  } | null;
-  appStoreConnectApiKeyForSubmissions?: {
-    __typename?: 'AppStoreConnectApiKey';
-    id: string;
-    issuerIdentifier: string;
-    keyIdentifier: string;
-    name?: string | null;
-    roles?: Array<AppStoreConnectUserRole> | null;
-    createdAt: any;
-    updatedAt: any;
-    appleTeam?: {
-      __typename?: 'AppleTeam';
-      id: string;
-      appleTeamIdentifier: string;
-      appleTeamName?: string | null;
-    } | null;
-  } | null;
-};
+export type CommonIosAppCredentialsWithoutBuildCredentialsFragment = { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null };
+
+export type CommonIosAppCredentialsFragment = { __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, developerPortalIdentifier?: string | null } | null }> } | null, provisioningProfile?: { __typename?: 'AppleProvisioningProfile', id: string, expiration: any, developerPortalIdentifier?: string | null, provisioningProfile?: string | null, updatedAt: any, status: string, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleDevices: Array<{ __typename?: 'AppleDevice', id: string, identifier: string, name?: string | null, model?: string | null, deviceClass?: AppleDeviceClass | null, createdAt: any }> } | null }>, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null };

--- a/packages/eas-cli/src/project/maybeUploadFingerprintAsync.ts
+++ b/packages/eas-cli/src/project/maybeUploadFingerprintAsync.ts
@@ -1,0 +1,79 @@
+import { FingerprintSource, FingerprintSourceType } from '@expo/eas-build-job';
+import fs from 'fs-extra';
+import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+import { LocalBuildMode } from '../build/local';
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { UploadSessionType } from '../graphql/generated';
+import Log from '../log';
+import { uploadFileAtPathToGCSAsync } from '../uploads';
+import { getTmpDirectory } from '../utils/paths';
+
+export async function maybeUploadFingerprintAsync({
+  runtimeVersion,
+  fingerprint,
+  graphqlClient,
+  localBuildMode,
+}: {
+  runtimeVersion: string;
+  fingerprint: {
+    fingerprintSources: object[];
+    isDebugFingerprintSource: boolean;
+  };
+  graphqlClient: ExpoGraphqlClient;
+  localBuildMode?: LocalBuildMode;
+}): Promise<{
+  runtimeVersion: string;
+  fingerprintSource?: FingerprintSource;
+}> {
+  await fs.mkdirp(getTmpDirectory());
+  const fingerprintLocation = path.join(getTmpDirectory(), `${uuidv4()}-runtime-fingerprint.json`);
+
+  await fs.writeJSON(fingerprintLocation, {
+    hash: runtimeVersion,
+    sources: fingerprint.fingerprintSources,
+  });
+
+  if (localBuildMode === LocalBuildMode.LOCAL_BUILD_PLUGIN) {
+    return {
+      runtimeVersion,
+      fingerprintSource: {
+        type: FingerprintSourceType.PATH,
+        path: fingerprintLocation,
+        isDebugFingerprint: fingerprint.isDebugFingerprintSource,
+      },
+    };
+  }
+
+  let fingerprintGCSBucketKey = undefined;
+  try {
+    fingerprintGCSBucketKey = await uploadFileAtPathToGCSAsync(
+      graphqlClient,
+      UploadSessionType.EasUpdateFingerprint,
+      fingerprintLocation
+    );
+  } catch (err: any) {
+    let errMessage = 'Failed to upload fingerprint to EAS';
+
+    if (err.message) {
+      errMessage += `\n\nReason: ${err.message}`;
+    }
+
+    Log.warn(errMessage);
+    return {
+      runtimeVersion,
+    };
+  } finally {
+    await fs.remove(fingerprintLocation);
+  }
+
+  return {
+    runtimeVersion,
+    fingerprintSource: {
+      type: FingerprintSourceType.GCS,
+      bucketKey: fingerprintGCSBucketKey,
+      isDebugFingerprint: fingerprint.isDebugFingerprintSource,
+    },
+  };
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Fingerprints are generated at build time and update time, and associated with runtime versions in EAS. Therefore, the fingerprint needs to be supplied as part of publishing an update.

This PR adds support for this.

Closes ENG-12855.

# How

Refactor code to do the upload for both builds and updates.

# Test Plan

In a project that uses the fingerprint rtv policy:
1. `neas update`
2. open update on website
3. Query in graphiql:
```
query {
  updates {
    byId(updateId: "...") {
      runtime {
        fingerprintDebugInfoUrl
      }
    }
  }
}
```

See that the runtime has the fingerprint debug info and going to the URL appropriately downloads it.