### PR TITLE
[eas-cli] fix env vars loading issue and be more verbose about where the given env var comes from

### DIFF
--- a/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
+++ b/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
@@ -4,23 +4,25 @@ import { BuildProfile } from '@expo/eas-json';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { EnvironmentVariableEnvironment } from '../graphql/generated';
 import { EnvironmentVariablesQuery } from '../graphql/queries/EnvironmentVariablesQuery';
-import Log from '../log';
+import Log, { learnMore } from '../log';
 
 function isEnvironment(env: string): env is EnvironmentVariableEnvironment {
   return Object.values(EnvironmentVariableEnvironment).includes(
-    env.toUpperCase() as EnvironmentVariableEnvironment
+    env as EnvironmentVariableEnvironment
   );
 }
 
 export async function evaluateConfigWithEnvVarsAsync<Config extends { projectId: string }, Opts>({
   flags,
   buildProfile,
+  buildProfileName,
   graphqlClient,
   getProjectConfig,
   opts,
 }: {
   flags: { environment?: string };
   buildProfile: BuildProfile;
+  buildProfileName: string;
   graphqlClient: ExpoGraphqlClient | null;
   opts: Opts;
   getProjectConfig(opts: Opts): Promise<Config>;
@@ -31,7 +33,13 @@ export async function evaluateConfigWithEnvVarsAsync<Config extends { projectId:
     return { env: buildProfile.env ?? {}, ...config };
   }
   const { projectId } = await getProjectConfig({ env: buildProfile.env, ...opts });
-  const env = await resolveEnvVarsAsync({ flags, buildProfile, graphqlClient, projectId });
+  const env = await resolveEnvVarsAsync({
+    flags,
+    buildProfile,
+    buildProfileName,
+    graphqlClient,
+    projectId,
+  });
   const config = await getProjectConfig({ ...opts, env });
 
   return { env, ...config };
@@ -40,18 +48,29 @@ export async function evaluateConfigWithEnvVarsAsync<Config extends { projectId:
 async function resolveEnvVarsAsync({
   flags,
   buildProfile,
+  buildProfileName,
   graphqlClient,
   projectId,
 }: {
   flags: { environment?: string };
   buildProfile: BuildProfile;
+  buildProfileName: string;
   graphqlClient: ExpoGraphqlClient;
   projectId: string;
 }): Promise<Env> {
   const environment =
-    flags.environment ?? buildProfile.environment ?? process.env.EAS_CURRENT_ENVIRONMENT;
+    flags.environment ??
+    buildProfile.environment?.toUpperCase() ??
+    process.env.EAS_CURRENT_ENVIRONMENT;
 
   if (!environment || !isEnvironment(environment)) {
+    Log.log(
+      `Loaded "env" configuration for the "${buildProfileName}" profile: ${
+        buildProfile.env && Object.keys(buildProfile.env).length > 0
+          ? Object.keys(buildProfile.env).join(', ')
+          : 'no environment variables specified'
+      }. ${learnMore('https://docs.expo.dev/build-reference/variables/')}`
+    );
     return { ...buildProfile.env };
   }
 
@@ -63,15 +82,31 @@ async function resolveEnvVarsAsync({
         environment,
       }
     );
-    const envVars = Object.fromEntries(
+    const serverEnvVars = Object.fromEntries(
       environmentVariables
         .filter(({ name, value }) => name && value)
         .map(({ name, value }) => [name, value])
     ) as Record<string, string>;
 
-    return { ...envVars, ...buildProfile.env };
+    const envVarsWithSource: Record<string, 'build profile' | 'EAS server'> = {
+      ...Object.fromEntries(Object.keys(serverEnvVars).map(key => [key, 'EAS server'])),
+      ...(buildProfile.env
+        ? Object.fromEntries(Object.keys(buildProfile.env).map(key => [key, 'build profile']))
+        : null),
+    };
+    Log.log(
+      `Loaded "env" configuration for the "${buildProfileName}" profile and "${environment.toLowerCase()}" environment: ${
+        Object.keys(envVarsWithSource).length > 0
+          ? Object.keys(envVarsWithSource)
+              .map(key => `${key} (source: ${envVarsWithSource[key]})`)
+              .join('\n')
+          : 'no environment variables specified'
+      }\n${learnMore('https://docs.expo.dev/build-reference/variables/')}`
+    );
+
+    return { ...serverEnvVars, ...buildProfile.env };
   } catch (e) {
-    Log.error('Failed to pull env variables for environment ${environment} from EAS servers');
+    Log.error(`Failed to pull env variables for environment ${environment} from EAS servers`);
     Log.error(e);
     Log.error(
       'This can possibly be a bug in EAS/EAS CLI. Report it here: https://github.com/expo/eas-cli/issues'

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -197,16 +197,11 @@ export async function runBuildAndSubmitAsync(
     const { env } = await evaluateConfigWithEnvVarsAsync({
       flags,
       buildProfile: buildProfile.profile,
+      buildProfileName: buildProfile.profileName,
       graphqlClient,
       getProjectConfig: getDynamicPrivateProjectConfigAsync,
       opts: { env: buildProfile.profile.env },
     });
-
-    Log.log(
-      `Loaded "env" configuration for the "${buildProfile.profileName}" profile: ${
-        env ? Object.keys(env).join(', ') : 'no environment variables specified'
-      }. ${learnMore('https://docs.expo.dev/build-reference/variables/')}`
-    );
 
     const { build: maybeBuild, buildCtx } = await prepareAndStartBuildAsync({
       projectDir,

--- a/packages/eas-cli/src/commands/build/resign.ts
+++ b/packages/eas-cli/src/commands/build/resign.ts
@@ -149,6 +149,7 @@ export default class BuildResign extends EasCommand {
     const { exp, projectId, env } = await evaluateConfigWithEnvVarsAsync({
       flags,
       buildProfile,
+      buildProfileName: flags.targetProfile ?? 'production',
       graphqlClient,
       getProjectConfig: getDynamicPrivateProjectConfigAsync,
       opts: { env: buildProfile.env },

--- a/packages/eas-cli/src/commands/build/version/get.ts
+++ b/packages/eas-cli/src/commands/build/version/get.ts
@@ -82,6 +82,7 @@ export default class BuildVersionGetView extends EasCommand {
       const { exp, projectId, env } = await evaluateConfigWithEnvVarsAsync({
         flags,
         buildProfile: profile,
+        buildProfileName: flags.profile ?? 'production',
         graphqlClient,
         getProjectConfig: getDynamicPrivateProjectConfigAsync,
         opts: { env: profile.env },

--- a/packages/eas-cli/src/commands/build/version/set.ts
+++ b/packages/eas-cli/src/commands/build/version/set.ts
@@ -70,6 +70,7 @@ export default class BuildVersionSetView extends EasCommand {
     const { exp, projectId, env } = await evaluateConfigWithEnvVarsAsync({
       flags,
       buildProfile: profile,
+      buildProfileName: flags.profile ?? 'production',
       graphqlClient,
       getProjectConfig: getDynamicPrivateProjectConfigAsync,
       opts: { env: profile.env },

--- a/packages/eas-cli/src/commands/build/version/sync.ts
+++ b/packages/eas-cli/src/commands/build/version/sync.ts
@@ -93,6 +93,7 @@ export default class BuildVersionSyncView extends EasCommand {
       const { exp, projectId, env } = await evaluateConfigWithEnvVarsAsync({
         flags,
         buildProfile: profileInfo.profile,
+        buildProfileName: profileInfo.profileName,
         graphqlClient,
         getProjectConfig: getDynamicPrivateProjectConfigAsync,
         opts: { env: profileInfo.profile.env },

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -96,6 +96,7 @@ export default class Config extends EasCommand {
       const { exp: appConfig } = await evaluateConfigWithEnvVarsAsync({
         flags,
         buildProfile: profile,
+        buildProfileName: profileName,
         graphqlClient,
         getProjectConfig: getDynamicPublicProjectConfigAsync,
         opts: { env: profile.env },


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We had an invalid type guard that caused our GQL requests to fetch env vars to fail because of the environment enum option being in lowercase vs uppercase.

# How

Fix the issue and type guard.

Be more verbose about the source of the env vars being loaded to make it easier to understand what's going on

# Test Plan

Before

![Screenshot 2024-09-04 at 12.40.15.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/32d06cbf-c605-4a34-a336-9a715792da9c.png)

After

![Screenshot 2024-09-04 at 13.51.01.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/9a1451c3-c6b7-4f2f-9f86-e1254e0580a8.png)

![Screenshot 2024-09-04 at 13.54.12.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/c5da456a-7c9e-4c42-b69d-592f3e76909a.png)

