### PR TITLE
[eas-cli] use environment.toLowerCase() in all logs

### DIFF
--- a/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
+++ b/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
@@ -106,7 +106,9 @@ async function resolveEnvVarsAsync({
 
     return { ...serverEnvVars, ...buildProfile.env };
   } catch (e) {
-    Log.error(`Failed to pull env variables for environment ${environment} from EAS servers`);
+    Log.error(
+      `Failed to pull env variables for environment ${environment.toLowerCase()} from EAS servers`
+    );
     Log.error(e);
     Log.error(
       'This can possibly be a bug in EAS/EAS CLI. Report it here: https://github.com/expo/eas-cli/issues'

--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -74,7 +74,9 @@ export default class EnvironmentValueList extends EasCommand {
       if (scope === EnvironmentVariableScope.Shared) {
         Log.log(chalk.bold('Shared variables for this account:'));
       } else {
-        Log.log(chalk.bold(`Variables for this project for environment ${environment}:`));
+        Log.log(
+          chalk.bold(`Variables for this project for environment ${environment?.toLowerCase()}:`)
+        );
       }
       Log.log(
         variables.map(variable => formatVariable(variable)).join(`\n\n${chalk.dim('———')}\n\n`)

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -75,6 +75,8 @@ export default class EnvironmentValuePull extends EasCommand {
       .join('\n');
     await fs.writeFile(targetPath, filePrefix + envFileContent);
 
-    Log.log(`Pulled environment variables from ${environment} environment to ${targetPath}.`);
+    Log.log(
+      `Pulled environment variables from ${environment.toLowerCase()} environment to ${targetPath}.`
+    );
   }
 }

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -98,8 +98,10 @@ export default class EnvironmentVariablePush extends EasCommand {
         variableNames.length > 1
           ? `The ${variableNames.join(
               ', '
-            )} environment variables already exist in ${environment} environment. Do you want to override them all?`
-          : `The ${variableNames[0]} environment variable already exists in ${environment} environment. Do you want to override it?`;
+            )} environment variables already exist in ${environment.toLowerCase()} environment. Do you want to override them all?`
+          : `The ${
+              variableNames[0]
+            } environment variable already exists in ${environment.toLowerCase()} environment. Do you want to override it?`;
 
       const confirm = await confirmAsync({
         message: confirmationMessage,
@@ -172,7 +174,7 @@ export default class EnvironmentVariablePush extends EasCommand {
       projectId
     );
 
-    Log.log(`Uploaded env file to ${environment} environment.`);
+    Log.log(`Uploaded env file to ${environment.toLowerCase()} environment.`);
   }
 
   private async parseEnvFileAsync(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C06FK950085/p1725586296781109

for consistency, it's better to use lowercase env names

# How

do `.toLowerCase()` in every log we print the environment

