### PR TITLE
[eas-cli] improve error message when CFBundleShortVersionString has invalid format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Make error message for invalid CFBundleShortVersionString more descriptive and actionable. Improve CFBundleShortVersionString validation regex. ([#2542](https://github.com/expo/eas-cli/pull/2542) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 
 ### 🎉 New features

--- a/packages/eas-cli/src/build/ios/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/ios/__tests__/version-test.ts
@@ -317,7 +317,7 @@ describe(readShortVersionAsync, () => {
           vcsClient
         )
       ).rejects.toThrowError(
-        `The required format for "version" field from app.json/app.config.ts is one to three period-separated integers, such as 10.14.1. The string can only contain numeric characters (0-9) and periods. Current value: 0.0.7.1.028. Edit the "version" field in your app.json/app.config.ts to match the required format. ${learnMore(
+        `The required format for "CFBundleShortVersionString" in Info.plist is one to three period-separated integers, such as 10.14.1. The string can only contain numeric characters (0-9) and periods. Current value: 0.0.7.1.028. Edit the "CFBundleShortVersionString" in your Info.plist to match the required format. ${learnMore(
           'https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring'
         )}`
       );

--- a/packages/eas-cli/src/build/ios/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/ios/__tests__/version-test.ts
@@ -5,6 +5,7 @@ import { vol } from 'memfs';
 import os from 'os';
 import type { XCBuildConfiguration } from 'xcode';
 
+import { learnMore } from '../../../log';
 import { readPlistAsync } from '../../../utils/plist';
 import { resolveVcsClient } from '../../../vcs';
 import {
@@ -316,7 +317,9 @@ describe(readShortVersionAsync, () => {
           vcsClient
         )
       ).rejects.toThrowError(
-        'CFBundleShortVersionString (version field in app.json/app.config.js) must be a period-separated list of three non-negative integers. Current value: 0.0.7.1.028'
+        `The required format for "version" field from app.json/app.config.ts is one to three period-separated integers, such as 10.14.1. The string can only contain numeric characters (0-9) and periods. Current value: 0.0.7.1.028. Edit the "version" field in your app.json/app.config.ts to match the required format. ${learnMore(
+          'https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring'
+        )}`
       );
     });
   });

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -23,7 +23,7 @@ import { Client } from '../../vcs/vcs';
 import { updateAppJsonConfigAsync } from '../utils/appJson';
 import { bumpAppVersionAsync, ensureStaticConfigExists } from '../utils/version';
 
-const SHORT_VERSION_REGEX = /^\d+.\d+.\d+$/;
+const SHORT_VERSION_REGEX = /^\d+(\.\d+){0,2}$/;
 
 export enum BumpStrategy {
   APP_VERSION,
@@ -110,13 +110,13 @@ function validateShortVersion({
   if (shortVersion && !SHORT_VERSION_REGEX.test(shortVersion)) {
     if (workflow === Workflow.MANAGED) {
       throw new Error(
-        `The required format for "version" field from app.json/app.config.ts is three period-separated integers, such as 10.14.1. The string can only contain numeric characters (0-9) and periods. Current value: ${shortVersion}. Edit the "version" field in your app.json/app.config.ts to match the required format. ${learnMore(
+        `The required format for "version" field from app.json/app.config.ts is one to three period-separated integers, such as 10.14.1. The string can only contain numeric characters (0-9) and periods. Current value: ${shortVersion}. Edit the "version" field in your app.json/app.config.ts to match the required format. ${learnMore(
           'https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring'
         )}`
       );
     } else {
       throw new Error(
-        `The required format for "CFBundleShortVersionString" in Info.plist is three period-separated integers, such as 10.14.1. The string can only contain numeric characters (0-9) and periods. Current value: ${shortVersion}. Edit the "CFBundleShortVersionString" in your Info.plist to match the required format. ${learnMore(
+        `The required format for "CFBundleShortVersionString" in Info.plist is one to three period-separated integers, such as 10.14.1. The string can only contain numeric characters (0-9) and periods. Current value: ${shortVersion}. Edit the "CFBundleShortVersionString" in your Info.plist to match the required format. ${learnMore(
           'https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring'
         )}`
       );


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1725915931423649

# How

Improve error message to make it more actionable

# Test Plan

Test manually

![Screenshot 2024-09-10 at 12.39.27.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/0c5ad653-3e55-43e0-bc12-aa4b30f730eb.png)

![Screenshot 2024-09-10 at 12.34.51.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/2e8f9e21-1d06-4c6c-8cc0-f263c9455bae.png)

