### PR TITLE
feat(cli): Source `@expo/env` dotenv vars for worker deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Make error message for invalid CFBundleShortVersionString more descriptive and actionable. Improve CFBundleShortVersionString validation regex. ([#2542](https://github.com/expo/eas-cli/pull/2542) by [@szdziedzic](https://github.com/szdziedzic))
 - Add missing `--non-interactive` argument to `worker:deploy` command. ([#2544](https://github.com/expo/eas-cli/pull/2544) by [@kitten](https://github.com/kitten))
+- Source `@expo/env` dotenv files for worker deployments. ([#2545](https://github.com/expo/eas-cli/pull/2545) by [@kitten](https://github.com/kitten))
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -15,7 +15,7 @@
     "@expo/config-types": "50.0.0",
     "@expo/eas-build-job": "1.0.133",
     "@expo/eas-json": "12.0.0",
-    "@expo/env": "0.3.0",
+    "@expo/env": "^0.3.0",
     "@expo/json-file": "8.2.37",
     "@expo/logger": "1.0.117",
     "@expo/multipart-body-parser": "1.1.0",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -15,6 +15,7 @@
     "@expo/config-types": "50.0.0",
     "@expo/eas-build-job": "1.0.133",
     "@expo/eas-json": "12.0.0",
+    "@expo/env": "0.3.0",
     "@expo/json-file": "8.2.37",
     "@expo/logger": "1.0.117",
     "@expo/multipart-body-parser": "1.1.0",

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -92,8 +92,8 @@ export default class WorkerDeploy extends EasCommand {
     }
 
     async function* emitWorkerTarballAsync(params: {
-      assetMap: WorkerAssets.AssetMap,
-      manifest: WorkerAssets.Manifest,
+      assetMap: WorkerAssets.AssetMap;
+      manifest: WorkerAssets.Manifest;
     }): AsyncGenerator<WorkerAssets.FileEntry> {
       yield ['assets.json', JSON.stringify(params.assetMap)];
       yield ['manifest.json', JSON.stringify(params.manifest)];
@@ -193,10 +193,12 @@ export default class WorkerDeploy extends EasCommand {
     try {
       assetMap = await WorkerAssets.createAssetMapAsync(distClientPath);
       const manifest = await WorkerAssets.createManifestAsync(projectDir);
-      tarPath = await WorkerAssets.packFilesIterableAsync(emitWorkerTarballAsync({
-        assetMap,
-        manifest,
-      }));
+      tarPath = await WorkerAssets.packFilesIterableAsync(
+        emitWorkerTarballAsync({
+          assetMap,
+          manifest,
+        })
+      );
     } catch (error: any) {
       progress.fail('Failed to prepare worker upload');
       throw error;

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -91,15 +91,12 @@ export default class WorkerDeploy extends EasCommand {
       );
     }
 
-    async function* emitWorkerTarballAsync(
-      assetMap: WorkerAssets.AssetMap
-    ): AsyncGenerator<WorkerAssets.FileEntry> {
-      yield ['assets.json', JSON.stringify(assetMap)];
-
-      // TODO: Create manifest from user configuration
-      const manifest = { env: {} };
-      yield ['manifest.json', JSON.stringify(manifest)];
-
+    async function* emitWorkerTarballAsync(params: {
+      assetMap: WorkerAssets.AssetMap,
+      manifest: WorkerAssets.Manifest,
+    }): AsyncGenerator<WorkerAssets.FileEntry> {
+      yield ['assets.json', JSON.stringify(params.assetMap)];
+      yield ['manifest.json', JSON.stringify(params.manifest)];
       if (distServerPath) {
         const workerFiles = WorkerAssets.listWorkerFilesAsync(distServerPath);
         for await (const workerFile of workerFiles) {
@@ -195,7 +192,11 @@ export default class WorkerDeploy extends EasCommand {
     let tarPath: string;
     try {
       assetMap = await WorkerAssets.createAssetMapAsync(distClientPath);
-      tarPath = await WorkerAssets.packFilesIterableAsync(emitWorkerTarballAsync(assetMap));
+      const manifest = await WorkerAssets.createManifestAsync(projectDir);
+      tarPath = await WorkerAssets.packFilesIterableAsync(emitWorkerTarballAsync({
+        assetMap,
+        manifest,
+      }));
     } catch (error: any) {
       progress.fail('Failed to prepare worker upload');
       throw error;

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { pack } from 'tar-stream';
+import { get as getEnv } from '@expo/env';
 
 /** Returns whether a file or folder is ignored */
 function isIgnoredName(name: string): boolean {
@@ -85,6 +86,18 @@ async function createAssetMapAsync(
     map[file.normalizedPath] = await computeSha512HashAsync(file.path, options?.hashOptions);
   }
   return map;
+}
+
+export interface Manifest {
+  env: Record<string, string | undefined>;
+}
+
+/** Creates a manifest configuration sent up for deployment */
+export async function createManifestAsync(
+  projectDir: string
+): Promise<Manifest> {
+  const { env } = getEnv(projectDir);
+  return { env };
 }
 
 interface WorkerFileEntry {

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -1,3 +1,4 @@
+import { get as getEnv } from '@expo/env';
 import { Gzip, GzipOptions } from 'minizlib';
 import { HashOptions, createHash, randomBytes } from 'node:crypto';
 import fs, { createWriteStream } from 'node:fs';
@@ -5,7 +6,6 @@ import os from 'node:os';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { pack } from 'tar-stream';
-import { get as getEnv } from '@expo/env';
 
 /** Returns whether a file or folder is ignored */
 function isIgnoredName(name: string): boolean {
@@ -93,9 +93,7 @@ export interface Manifest {
 }
 
 /** Creates a manifest configuration sent up for deployment */
-export async function createManifestAsync(
-  projectDir: string
-): Promise<Manifest> {
+export async function createManifestAsync(projectDir: string): Promise<Manifest> {
   const { env } = getEnv(projectDir);
   return { env };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,6 +1477,17 @@
     semver "^7.6.2"
     zod "^3.23.8"
 
+"@expo/env@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@expo/env/-/env-0.3.0.tgz#a66064e5656e0e48197525f47f3398034fdf579e"
+  integrity sha512-OtB9XVHWaXidLbHvrVDeeXa09yvTl3+IQN884sO6PhIi2/StXfgSH/9zC7IvzrDB8kW3EBJ1PPLuCUJ2hxAT7Q==
+  dependencies:
+    chalk "^4.0.0"
+    debug "^4.3.4"
+    dotenv "~16.4.5"
+    dotenv-expand "~11.0.6"
+    getenv "^1.0.0"
+
 "@expo/fingerprint@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@expo/fingerprint/-/fingerprint-0.6.0.tgz#77366934673d4ecea37284109b4dd67f9e6a7487"
@@ -6188,6 +6199,13 @@ dotenv-expand@~10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
   integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
 
+dotenv-expand@~11.0.6:
+  version "11.0.6"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-11.0.6.tgz#f2c840fd924d7c77a94eff98f153331d876882d3"
+  integrity sha512-8NHi73otpWsZGBSZwwknTXS5pqMOrk9+Ssrna8xCaxkzEpU9OTf9R5ArQGVw03//Zmk9MOwLPng9WwndvpAJ5g==
+  dependencies:
+    dotenv "^16.4.4"
+
 dotenv@16.3.1, dotenv@~16.3.1:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
@@ -6197,6 +6215,11 @@ dotenv@^16.0.0:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"
   integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
+
+dotenv@^16.4.4, dotenv@~16.4.5:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
 
 dset@^3.1.2:
   version "3.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,7 +1477,7 @@
     semver "^7.6.2"
     zod "^3.23.8"
 
-"@expo/env@0.3.0":
+"@expo/env@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@expo/env/-/env-0.3.0.tgz#a66064e5656e0e48197525f47f3398034fdf579e"
   integrity sha512-OtB9XVHWaXidLbHvrVDeeXa09yvTl3+IQN884sO6PhIi2/StXfgSH/9zC7IvzrDB8kW3EBJ1PPLuCUJ2hxAT7Q==


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Deployments should allow environment variables to be added to them.

# How

Source environment variables using `@expo/env`, add them to the manifest, and send them to the deployment API to upload environment variables for deployments.

# Test Plan

- Manually tested
