### PR TITLE
[eas-cli] stop using environment flag in build related commands

### DIFF
--- a/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
+++ b/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
@@ -13,14 +13,12 @@ function isEnvironment(env: string): env is EnvironmentVariableEnvironment {
 }
 
 export async function evaluateConfigWithEnvVarsAsync<Config extends { projectId: string }, Opts>({
-  flags,
   buildProfile,
   buildProfileName,
   graphqlClient,
   getProjectConfig,
   opts,
 }: {
-  flags: { environment?: string };
   buildProfile: BuildProfile;
   buildProfileName: string;
   graphqlClient: ExpoGraphqlClient | null;
@@ -34,7 +32,6 @@ export async function evaluateConfigWithEnvVarsAsync<Config extends { projectId:
   }
   const { projectId } = await getProjectConfig({ env: buildProfile.env, ...opts });
   const env = await resolveEnvVarsAsync({
-    flags,
     buildProfile,
     buildProfileName,
     graphqlClient,
@@ -46,22 +43,18 @@ export async function evaluateConfigWithEnvVarsAsync<Config extends { projectId:
 }
 
 async function resolveEnvVarsAsync({
-  flags,
   buildProfile,
   buildProfileName,
   graphqlClient,
   projectId,
 }: {
-  flags: { environment?: string };
   buildProfile: BuildProfile;
   buildProfileName: string;
   graphqlClient: ExpoGraphqlClient;
   projectId: string;
 }): Promise<Env> {
   const environment =
-    flags.environment ??
-    buildProfile.environment?.toUpperCase() ??
-    process.env.EAS_CURRENT_ENVIRONMENT;
+    buildProfile.environment?.toUpperCase() ?? process.env.EAS_CURRENT_ENVIRONMENT;
 
   if (!environment || !isEnvironment(environment)) {
     Log.log(

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -33,7 +33,6 @@ import {
   BuildFragment,
   BuildStatus,
   BuildWithSubmissionsFragment,
-  EnvironmentVariableEnvironment,
   SubmissionFragment,
 } from '../graphql/generated';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
@@ -98,7 +97,6 @@ export interface BuildFlags {
   buildLoggerLevel?: LoggerLevel;
   freezeCredentials: boolean;
   repack: boolean;
-  environment?: EnvironmentVariableEnvironment;
 }
 
 export async function runBuildAndSubmitAsync(
@@ -195,7 +193,6 @@ export async function runBuildAndSubmitAsync(
     const platform = toAppPlatform(buildProfile.platform);
 
     const { env } = await evaluateConfigWithEnvVarsAsync({
-      flags,
       buildProfile: buildProfile.profile,
       buildProfileName: buildProfile.profileName,
       graphqlClient,

--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -38,21 +38,6 @@ export const EASEnvironmentFlag = {
   }),
 };
 
-// NOTE: Used in build commands, should be replaced with EASEnvironmentFlag when
-// the feature is public
-export const EASEnvironmentFlagHidden = {
-  environment: Flags.enum<EnvironmentVariableEnvironment>({
-    description: "Environment variable's environment",
-    parse: upperCaseAsync,
-    hidden: true,
-    options: mapToLowercase([
-      EnvironmentVariableEnvironment.Development,
-      EnvironmentVariableEnvironment.Preview,
-      EnvironmentVariableEnvironment.Production,
-    ]),
-  }),
-};
-
 export const EASVariableFormatFlag = {
   format: Flags.enum({
     description: 'Output format',

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -10,8 +10,8 @@ import path from 'path';
 import { LocalBuildMode } from '../../build/local';
 import { BuildFlags, runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import EasCommand from '../../commandUtils/EasCommand';
-import { EASEnvironmentFlagHidden, EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import { EnvironmentVariableEnvironment, StatuspageServiceName } from '../../graphql/generated';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { StatuspageServiceName } from '../../graphql/generated';
 import Log, { link } from '../../log';
 import { RequestedPlatform, selectRequestedPlatformAsync } from '../../platform';
 import { selectAsync } from '../../prompts';
@@ -37,7 +37,6 @@ interface RawBuildFlags {
   'build-logger-level'?: LoggerLevel;
   'freeze-credentials': boolean;
   repack: boolean;
-  environment?: EnvironmentVariableEnvironment;
 }
 
 export default class Build extends EasCommand {
@@ -117,7 +116,6 @@ export default class Build extends EasCommand {
       description: 'Use the golden dev client build repack flow as it works for onboarding',
     }),
     ...EasNonInteractiveAndJsonFlags,
-    ...EASEnvironmentFlagHidden,
   };
 
   static override contextDefinition = {
@@ -232,7 +230,6 @@ export default class Build extends EasCommand {
       buildLoggerLevel: flags['build-logger-level'],
       freezeCredentials: flags['freeze-credentials'],
       repack: flags.repack,
-      environment: flags.environment,
     };
   }
 

--- a/packages/eas-cli/src/commands/build/resign.ts
+++ b/packages/eas-cli/src/commands/build/resign.ts
@@ -13,7 +13,7 @@ import { listAndSelectBuildOnAppAsync } from '../../build/queries';
 import { printBuildResults, printLogsUrls } from '../../build/utils/printBuildInfo';
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
-import { EASEnvironmentFlagHidden, EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { EasPaginatedQueryFlags } from '../../commandUtils/pagination';
 import { CredentialsContext } from '../../credentials/context';
 import {
@@ -93,7 +93,6 @@ export default class BuildResign extends EasCommand {
     }),
     ...EasPaginatedQueryFlags,
     ...EasNonInteractiveAndJsonFlags,
-    ...EASEnvironmentFlagHidden,
   };
 
   static override contextDefinition = {
@@ -147,7 +146,6 @@ export default class BuildResign extends EasCommand {
     );
 
     const { exp, projectId, env } = await evaluateConfigWithEnvVarsAsync({
-      flags,
       buildProfile,
       buildProfileName: flags.targetProfile ?? 'production',
       graphqlClient,

--- a/packages/eas-cli/src/commands/build/version/get.ts
+++ b/packages/eas-cli/src/commands/build/version/get.ts
@@ -5,10 +5,7 @@ import chalk from 'chalk';
 
 import { evaluateConfigWithEnvVarsAsync } from '../../../build/evaluateConfigWithEnvVarsAsync';
 import EasCommand from '../../../commandUtils/EasCommand';
-import {
-  EASEnvironmentFlagHidden,
-  EasNonInteractiveAndJsonFlags,
-} from '../../../commandUtils/flags';
+import { EasNonInteractiveAndJsonFlags } from '../../../commandUtils/flags';
 import { AppVersionQuery } from '../../../graphql/queries/AppVersionQuery';
 import { toAppPlatform } from '../../../graphql/types/AppPlatform';
 import Log from '../../../log';
@@ -35,7 +32,6 @@ export default class BuildVersionGetView extends EasCommand {
         'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
       helpValue: 'PROFILE_NAME',
     }),
-    ...EASEnvironmentFlagHidden,
     ...EasNonInteractiveAndJsonFlags,
   };
 
@@ -80,7 +76,6 @@ export default class BuildVersionGetView extends EasCommand {
     const results: { [key in Platform]?: string } = {};
     for (const { profile, platform } of buildProfiles) {
       const { exp, projectId, env } = await evaluateConfigWithEnvVarsAsync({
-        flags,
         buildProfile: profile,
         buildProfileName: flags.profile ?? 'production',
         graphqlClient,

--- a/packages/eas-cli/src/commands/build/version/set.ts
+++ b/packages/eas-cli/src/commands/build/version/set.ts
@@ -6,7 +6,6 @@ import chalk from 'chalk';
 
 import { evaluateConfigWithEnvVarsAsync } from '../../../build/evaluateConfigWithEnvVarsAsync';
 import EasCommand from '../../../commandUtils/EasCommand';
-import { EASEnvironmentFlagHidden } from '../../../commandUtils/flags';
 import { AppVersionMutation } from '../../../graphql/mutations/AppVersionMutation';
 import { AppVersionQuery } from '../../../graphql/queries/AppVersionQuery';
 import { toAppPlatform } from '../../../graphql/types/AppPlatform';
@@ -37,7 +36,6 @@ export default class BuildVersionSetView extends EasCommand {
         'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
       helpValue: 'PROFILE_NAME',
     }),
-    ...EASEnvironmentFlagHidden,
   };
 
   static override contextDefinition = {
@@ -68,7 +66,6 @@ export default class BuildVersionSetView extends EasCommand {
     );
 
     const { exp, projectId, env } = await evaluateConfigWithEnvVarsAsync({
-      flags,
       buildProfile: profile,
       buildProfileName: flags.profile ?? 'production',
       graphqlClient,

--- a/packages/eas-cli/src/commands/build/version/sync.ts
+++ b/packages/eas-cli/src/commands/build/version/sync.ts
@@ -8,7 +8,6 @@ import { updateNativeVersionsAsync as updateAndroidNativeVersionsAsync } from '.
 import { evaluateConfigWithEnvVarsAsync } from '../../../build/evaluateConfigWithEnvVarsAsync';
 import { updateNativeVersionsAsync as updateIosNativeVersionsAsync } from '../../../build/ios/version';
 import EasCommand from '../../../commandUtils/EasCommand';
-import { EASEnvironmentFlagHidden } from '../../../commandUtils/flags';
 import { AppVersionQuery } from '../../../graphql/queries/AppVersionQuery';
 import { toAppPlatform } from '../../../graphql/types/AppPlatform';
 import Log from '../../../log';
@@ -56,7 +55,6 @@ export default class BuildVersionSyncView extends EasCommand {
         'Name of the build profile from eas.json. Defaults to "production" if defined in eas.json.',
       helpValue: 'PROFILE_NAME',
     }),
-    ...EASEnvironmentFlagHidden,
   };
 
   static override contextDefinition = {
@@ -91,7 +89,6 @@ export default class BuildVersionSyncView extends EasCommand {
     });
     for (const profileInfo of buildProfiles) {
       const { exp, projectId, env } = await evaluateConfigWithEnvVarsAsync({
-        flags,
         buildProfile: profileInfo.profile,
         buildProfileName: profileInfo.profileName,
         graphqlClient,

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk';
 import { evaluateConfigWithEnvVarsAsync } from '../build/evaluateConfigWithEnvVarsAsync';
 import EasCommand from '../commandUtils/EasCommand';
 import { createGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
-import { EASEnvironmentFlagHidden, EasNonInteractiveAndJsonFlags } from '../commandUtils/flags';
+import { EasNonInteractiveAndJsonFlags } from '../commandUtils/flags';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log from '../log';
 import { appPlatformEmojis } from '../platform';
@@ -29,7 +29,6 @@ export default class Config extends EasCommand {
     'eas-json-only': Flags.boolean({
       hidden: true,
     }),
-    ...EASEnvironmentFlagHidden,
     ...EasNonInteractiveAndJsonFlags,
   };
 
@@ -94,7 +93,6 @@ export default class Config extends EasCommand {
       });
       const graphqlClient = createGraphqlClient(authenticationInfo);
       const { exp: appConfig } = await evaluateConfigWithEnvVarsAsync({
-        flags,
         buildProfile: profile,
         buildProfileName: profileName,
         graphqlClient,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

On Friday's meeting, we agreed that having both a flag and a field in the build profile for setting the environment might be too much. Additionally, we already have a `--profile` flag that has a `-e` alias which makes it even more confusing. We decided to delete the flag to avoid confusion and make it as straightforward as possible.

# How

Delete the `--environment` flag for build-related commands, rely only on the `environment` field in eas.json.

# Test Plan

Tests