### PR TITLE
feature(eas-cli): add `worker --prod` flag and hint for production deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add `worker:alias` command to assign aliases from the CLI. ([#2548](https://github.com/expo/eas-cli/pull/2548) by [@byCedric](https://github.com/byCedric))
+- Add `worker --prod` flag to deploy to production from the CLI. ([#2550](https://github.com/expo/eas-cli/pull/2550) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -1,3 +1,4 @@
+import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 import fs from 'node:fs';
 import * as path from 'node:path';
@@ -8,7 +9,10 @@ import Log from '../../log';
 import { ora } from '../../ora';
 import { createProgressTracker } from '../../utils/progress';
 import * as WorkerAssets from '../../worker/assets';
-import { getSignedDeploymentUrlAsync } from '../../worker/deployment';
+import {
+  assignWorkerDeploymentProductionAsync,
+  getSignedDeploymentUrlAsync,
+} from '../../worker/deployment';
 import { UploadParams, batchUploadAsync, uploadAsync } from '../../worker/upload';
 
 const isDirectory = (directoryPath: string): Promise<boolean> =>
@@ -20,11 +24,13 @@ const isDirectory = (directoryPath: string): Promise<boolean> =>
 interface DeployFlags {
   nonInteractive: boolean;
   json: boolean;
+  prod: boolean;
 }
 
 interface RawDeployFlags {
   'non-interactive': boolean;
   json: boolean;
+  prod?: boolean;
 }
 
 export default class WorkerDeploy extends EasCommand {
@@ -36,6 +42,10 @@ export default class WorkerDeploy extends EasCommand {
   static override state = 'beta';
 
   static override flags = {
+    prod: Flags.boolean({
+      description: 'Deploy to production',
+      type: 'boolean',
+    }),
     // TODO(@kitten): Allow deployment identifier to be specified
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -217,20 +227,65 @@ export default class WorkerDeploy extends EasCommand {
 
     await uploadAssetsAsync(assetMap, deployResult.uploads);
 
-    const baseDomain = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';
-    const deploymentURL = `https://${deployResult.fullName}.${baseDomain}.app`;
-    const deploymentsUrl = `https://${baseDomain}.dev/accounts/${exp.owner}/projects/${deployResult.name}/serverless/deployments`;
+    const expoBaseDomain = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';
+    const dashboardUrl = `https://${expoBaseDomain}.dev/projects/${projectId}/serverless/deployments`;
 
-    Log.addNewLineIfNone();
-    Log.log(`🎉 Your worker deployment is ready: ${deploymentURL}`);
-    Log.addNewLineIfNone();
-    Log.log(`🔗 Manage on EAS: ${deploymentsUrl}`);
+    if (!flags.prod) {
+      logDeployment({
+        dashboardUrl,
+        deploymentUrl: `https://${deployResult.fullName}.${expoBaseDomain}.app`,
+        isProduction: false,
+      });
+      return;
+    }
+
+    progress = ora('Assigning worker deployment to production');
+    try {
+      const workerProdAlias = await assignWorkerDeploymentProductionAsync({
+        graphqlClient,
+        appId: projectId,
+        deploymentId: deployResult.id,
+      });
+
+      progress.succeed('Assigned worker deployment to production');
+
+      logDeployment({
+        dashboardUrl,
+        deploymentUrl: workerProdAlias.url,
+        isProduction: true,
+      });
+    } catch (error: any) {
+      progress.fail('Failed to assign worker deployment to production');
+      throw error;
+    }
   }
 
   private sanitizeFlags(flags: RawDeployFlags): DeployFlags {
     return {
       nonInteractive: flags['non-interactive'],
       json: flags['json'],
+      prod: !!flags.prod,
     };
+  }
+}
+
+function logDeployment({
+  deploymentUrl,
+  dashboardUrl,
+  isProduction,
+}: {
+  deploymentUrl: string;
+  dashboardUrl: string;
+  isProduction: boolean;
+}): void {
+  Log.addNewLineIfNone();
+  Log.log(`🎉 Your worker deployment is ready: ${deploymentUrl}`);
+  Log.addNewLineIfNone();
+  Log.log(`🔗 Manage on EAS: ${dashboardUrl}`);
+
+  if (!isProduction) {
+    Log.addNewLineIfNone();
+    Log.log('🚀 If you are ready to deploy to production, run this command with "--prod"');
+    Log.log(chalk`  {dim $} eas deploy {bold --prod}`);
   }
 }

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -44,7 +44,6 @@ export default class WorkerDeploy extends EasCommand {
   static override flags = {
     prod: Flags.boolean({
       description: 'Deploy to production',
-      type: 'boolean',
     }),
     // TODO(@kitten): Allow deployment identifier to be specified
     ...EasNonInteractiveAndJsonFlags,

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -30,7 +30,7 @@ interface DeployFlags {
 interface RawDeployFlags {
   'non-interactive': boolean;
   json: boolean;
-  prod?: boolean;
+  prod: boolean;
 }
 
 export default class WorkerDeploy extends EasCommand {
@@ -44,6 +44,7 @@ export default class WorkerDeploy extends EasCommand {
   static override flags = {
     prod: Flags.boolean({
       description: 'Deploy to production',
+      default: false,
     }),
     // TODO(@kitten): Allow deployment identifier to be specified
     ...EasNonInteractiveAndJsonFlags,
@@ -238,7 +239,7 @@ export default class WorkerDeploy extends EasCommand {
       return;
     }
 
-    progress = ora('Assigning worker deployment to production');
+    progress = ora('Assigning worker deployment to production').start();
     try {
       const workerProdAlias = await assignWorkerDeploymentProductionAsync({
         graphqlClient,

--- a/packages/eas-cli/src/worker/deployment.ts
+++ b/packages/eas-cli/src/worker/deployment.ts
@@ -110,6 +110,22 @@ export async function assignWorkerDeploymentAliasAsync({
   });
 }
 
+export async function assignWorkerDeploymentProductionAsync({
+  graphqlClient,
+  appId,
+  deploymentId,
+}: {
+  graphqlClient: ExpoGraphqlClient;
+  appId: string;
+  deploymentId: string;
+}): ReturnType<typeof DeploymentsMutation.assignAliasAsync> {
+  return await DeploymentsMutation.assignAliasAsync(graphqlClient, {
+    appId,
+    deploymentId,
+    aliasName: null, // this will assign the deployment as production
+  });
+}
+
 export async function selectWorkerDeploymentOnAppAsync({
   graphqlClient,
   appId,

--- a/packages/eas-cli/src/worker/mutations.ts
+++ b/packages/eas-cli/src/worker/mutations.ts
@@ -73,7 +73,7 @@ export const DeploymentsMutation = {
 
   async assignAliasAsync(
     graphqlClient: ExpoGraphqlClient,
-    aliasVariables: { appId: string; deploymentId: string; aliasName: string }
+    aliasVariables: { appId: string; deploymentId: string; aliasName: string | null }
   ): Promise<AssignAliasMutation['deployments']['assignAlias']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
@@ -82,7 +82,7 @@ export const DeploymentsMutation = {
             mutation AssignAlias(
               $appId: ID!
               $deploymentId: ID!
-              $aliasName: WorkerDeploymentIdentifier!
+              $aliasName: WorkerDeploymentIdentifier
             ) {
               deployments {
                 assignAlias(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

This PR is stacked on top of #2548, since we use the alias mutation here too.

# Why

This adds the `--prod` flag to `eas worker`, assigning the deployment as production.

> Note, this also changes the URL of the project to use `/projects/<id>/serverless/deployments`. This is to avoid having to use or load `exp.owner` in these URLs.

# How

- Added hint when running `eas worker` without `--prod`
  ![without-prod](https://github.com/user-attachments/assets/fb9a4482-81ee-4023-b022-c8c0fb137971)
- Added optional `--prod` flag to `eas worker`
  ![with-prod](https://github.com/user-attachments/assets/87f01aee-d7d2-40a1-850e-30d99b17e750)

# Test Plan

- `$ eas worker`
- `$ eas worker --prod`