### PR TITLE
feature(eas-cli): add `worker --alias` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Add `worker:alias` command to assign aliases from the CLI. ([#2548](https://github.com/expo/eas-cli/pull/2548) by [@byCedric](https://github.com/byCedric))
 - Add `worker --prod` flag to deploy to production from the CLI. ([#2550](https://github.com/expo/eas-cli/pull/2550) by [@byCedric](https://github.com/byCedric))
+- Add `worker --alias` flag to assign custom aliases when deploying. ([#2551](https://github.com/expo/eas-cli/pull/2551) by [@byCedric](https://github.com/byCedric)))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -234,7 +234,7 @@ export default class WorkerDeploy extends EasCommand {
     await uploadAssetsAsync(assetMap, deployResult.uploads);
 
     if (flags.aliasName) {
-      progress = ora(chalk`Assigning alias {bold ${flags.aliasName}} to worker deployment`);
+      progress = ora(chalk`Assigning alias {bold ${flags.aliasName}} to worker deployment`).start();
       try {
         await assignWorkerDeploymentAliasAsync({
           graphqlClient,

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -10,6 +10,7 @@ import { ora } from '../../ora';
 import { createProgressTracker } from '../../utils/progress';
 import * as WorkerAssets from '../../worker/assets';
 import {
+  assignWorkerDeploymentAliasAsync,
   assignWorkerDeploymentProductionAsync,
   getSignedDeploymentUrlAsync,
 } from '../../worker/deployment';
@@ -25,12 +26,14 @@ interface DeployFlags {
   nonInteractive: boolean;
   json: boolean;
   prod: boolean;
+  aliasName?: string;
 }
 
 interface RawDeployFlags {
   'non-interactive': boolean;
   json: boolean;
   prod: boolean;
+  alias?: string;
 }
 
 export default class WorkerDeploy extends EasCommand {
@@ -42,6 +45,9 @@ export default class WorkerDeploy extends EasCommand {
   static override state = 'beta';
 
   static override flags = {
+    alias: Flags.string({
+      description: 'Custom alias for the deployment',
+    }),
     prod: Flags.boolean({
       description: 'Deploy to production',
       default: false,
@@ -227,6 +233,22 @@ export default class WorkerDeploy extends EasCommand {
 
     await uploadAssetsAsync(assetMap, deployResult.uploads);
 
+    if (flags.aliasName) {
+      progress = ora(chalk`Assigning alias {bold ${flags.aliasName}} to worker deployment`);
+      try {
+        await assignWorkerDeploymentAliasAsync({
+          graphqlClient,
+          appId: projectId,
+          deploymentId: deployResult.id,
+          aliasName: flags.aliasName,
+        });
+        progress.succeed(chalk`Assigned alias {bold ${flags.aliasName}} to worker deployment`);
+      } catch (error: any) {
+        progress.fail(chalk`Failed to assign {bold ${flags.aliasName}} alias to worker deployment`);
+        throw error;
+      }
+    }
+
     const expoBaseDomain = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';
     const dashboardUrl = `https://${expoBaseDomain}.dev/projects/${projectId}/serverless/deployments`;
 
@@ -265,6 +287,7 @@ export default class WorkerDeploy extends EasCommand {
       nonInteractive: flags['non-interactive'],
       json: flags['json'],
       prod: !!flags.prod,
+      aliasName: flags.alias?.trim().toLowerCase(),
     };
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

This PR is stacked on top of #2548, since we use the alias mutation here too.

# Why

This adds the `eas worker --alias <name>`, to assign a custom alias when deploying.

# How

- Added `--alias` and used the existing deployment alias mutation

# Test Plan

<details><summary><code>$ eas worker --alias <name></code></summary>

<img width="793" alt="image" src="https://github.com/user-attachments/assets/9d4487c9-b374-401c-be1f-56166836ca57">

</details>

<details><summary><code>$ eas worker --prod --alias <name></code></summary>

<img width="793" alt="image" src="https://github.com/user-attachments/assets/d2c54875-e56e-46f1-b8fe-83f0b0bcf33d">

</details>