### PR TITLE
feature(eas-cli): add `worker --id` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add `worker:alias` command to assign aliases from the CLI. ([#2548](https://github.com/expo/eas-cli/pull/2548) by [@byCedric](https://github.com/byCedric))
 - Add `worker --prod` flag to deploy to production from the CLI. ([#2550](https://github.com/expo/eas-cli/pull/2550) by [@byCedric](https://github.com/byCedric))
 - Add `worker --alias` flag to assign custom aliases when deploying. ([#2551](https://github.com/expo/eas-cli/pull/2551) by [@byCedric](https://github.com/byCedric)))
+- Add `worker --id` flag to use a custom deployment identifier. ([#2552](https://github.com/expo/eas-cli/pull/2552) by [@byCedric](https://github.com/byCedric)))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -27,6 +27,7 @@ interface DeployFlags {
   json: boolean;
   prod: boolean;
   aliasName?: string;
+  deploymentIdentifier?: string;
 }
 
 interface RawDeployFlags {
@@ -34,6 +35,7 @@ interface RawDeployFlags {
   json: boolean;
   prod: boolean;
   alias?: string;
+  id?: string;
 }
 
 export default class WorkerDeploy extends EasCommand {
@@ -51,6 +53,9 @@ export default class WorkerDeploy extends EasCommand {
     prod: Flags.boolean({
       description: 'Deploy to production',
       default: false,
+    }),
+    id: Flags.string({
+      description: 'A custom deployment identifier for the new deployment',
     }),
     // TODO(@kitten): Allow deployment identifier to be specified
     ...EasNonInteractiveAndJsonFlags,
@@ -124,6 +129,7 @@ export default class WorkerDeploy extends EasCommand {
     async function uploadTarballAsync(tarPath: string): Promise<any> {
       const uploadUrl = await getSignedDeploymentUrlAsync(graphqlClient, exp, {
         appId: projectId,
+        deploymentIdentifier: flags.deploymentIdentifier,
       });
 
       const { response } = await uploadAsync({
@@ -288,6 +294,7 @@ export default class WorkerDeploy extends EasCommand {
       json: flags['json'],
       prod: !!flags.prod,
       aliasName: flags.alias?.trim().toLowerCase(),
+      deploymentIdentifier: flags.id?.trim(),
     };
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This adds `eas worker --id` to define a custom deployment identifier for the new deployment.

# How

- Added `--id` flag

# Test Plan

<details><summary><code>eas worker --id [identifier]</code></summary>

<img width="797" alt="image" src="https://github.com/user-attachments/assets/59a4a97b-c178-422d-b853-b537f7452cfe">

</details>
