### PR TITLE
fix(eas-cli): avoid adding `expo.extra` data from config plugins in `eas init`

### DIFF
--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -18,13 +18,15 @@ import { Actor, getActorUsername } from '../../../user/User';
  * Save an EAS project ID to the appropriate field in the app config.
  *
  * @deprecated Should not be used outside of context functions except in the init command.
+ * @deprecated Starting from `@expo/config` from SDK 52, the `modifyConfigAsync` function is merging existing data. Once this is released, we can use that instead of manually merging.
  */
 export async function saveProjectIdToAppConfigAsync(
   projectDir: string,
   projectId: string,
   options: { env?: Env } = {}
 ): Promise<void> {
-  const exp = getPrivateExpoConfig(projectDir, options);
+  // NOTE(cedric): we disable plugins to avoid writing plugin-generated content to `expo.extra`
+  const exp = getPrivateExpoConfig(projectDir, { skipPlugins: true, ...options });
   const result = await createOrModifyExpoConfigAsync(
     projectDir,
     {

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -18,6 +18,7 @@ export type PublicExpoConfig = Omit<
 export interface ExpoConfigOptions {
   env?: Env;
   skipSDKVersionRequirement?: boolean;
+  skipPlugins?: boolean;
 }
 
 interface ExpoConfigOptionsInternal extends ExpoConfigOptions {
@@ -52,6 +53,7 @@ function getExpoConfigInternal(
     const { exp } = getConfig(projectDir, {
       skipSDKVersionRequirement: true,
       ...(opts.isPublicConfig ? { isPublicConfig: true } : {}),
+      ...(opts.skipPlugins ? { skipPlugins: true } : {}),
     });
 
     const { error } = MinimalAppConfigSchema.validate(exp, {


### PR DESCRIPTION
# Why

This fixes the `eas init` command, where we currently merge the `expo.extra` data in the manifest with plugin-generated data. You can repro this through the steps defined in the test plan.

> Note that in the newer `@expo/config` package, modifying now also merges existing properties. Once thats released, we can use that instead of manually merging this data.
>
> See: expo/expo#30782, expo/expo#30783

# How

How did you build this feature or fix this bug and why?

# Test Plan

- `$ bun create expo ./test-eas-init`
- `$ cd ./test-eas-init`
- Check **app.json**, ensure it does NOT have `expo.extra` but does have `expo.plugins[expo-router]`
- `$ eas init`
- Check **app.json**'s `expo.extra` only contains `expo.extra.eas.projectId`, and nothing from the router plugin
