### PR TITLE
refactor(eas-cli): support `eas worker --production` and clean up command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Make error message for invalid CFBundleShortVersionString more descriptive and actionable. Improve CFBundleShortVersionString validation regex. ([#2542](https://github.com/expo/eas-cli/pull/2542) by [@szdziedzic](https://github.com/szdziedzic))
 - Add missing `--non-interactive` argument to `worker:deploy` command. ([#2544](https://github.com/expo/eas-cli/pull/2544) by [@kitten](https://github.com/kitten))
 - Source `@expo/env` dotenv files for worker deployments. ([#2545](https://github.com/expo/eas-cli/pull/2545) by [@kitten](https://github.com/kitten))
-- Support `worker --production` in addition to `worker --prod`.
+- Support `worker --production` and clean up command output. ([#2555](https://github.com/expo/eas-cli/pull/2555) by [@byCedric](https://github.com/byCedric)))
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Make error message for invalid CFBundleShortVersionString more descriptive and actionable. Improve CFBundleShortVersionString validation regex. ([#2542](https://github.com/expo/eas-cli/pull/2542) by [@szdziedzic](https://github.com/szdziedzic))
 - Add missing `--non-interactive` argument to `worker:deploy` command. ([#2544](https://github.com/expo/eas-cli/pull/2544) by [@kitten](https://github.com/kitten))
 - Source `@expo/env` dotenv files for worker deployments. ([#2545](https://github.com/expo/eas-cli/pull/2545) by [@kitten](https://github.com/kitten))
+- Support `worker --production` in addition to `worker --prod`.
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -329,7 +329,7 @@ function logDeployment(options: LogDeploymentOptions): void {
   ];
 
   if (options.aliasedUrl) {
-    fields.push({ label: 'Aliased URL', value: options.aliasedUrl });
+    fields.push({ label: 'Alias URL', value: options.aliasedUrl });
   }
   if (options.productionUrl) {
     fields.push({ label: 'Production URL', value: options.productionUrl });

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -267,9 +267,9 @@ export default class WorkerDeploy extends EasCommand {
     if (flags.isProduction) {
       try {
         if (!flags.aliasName) {
-          progress = ora('Promoting deployment to production').start();
+          progress = ora(chalk`Promoting deployment to {bold production}`).start();
         } else {
-          progress.text = 'Promoting deployment to production';
+          progress.text = chalk`Promoting deployment to {bold production}`;
         }
 
         const workerProdAlias = await assignWorkerDeploymentProductionAsync({

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -7,6 +7,7 @@ import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import Log from '../../log';
 import { ora } from '../../ora';
+import formatFields, { FormatFieldsItem } from '../../utils/formatFields';
 import { createProgressTracker } from '../../utils/progress';
 import * as WorkerAssets from '../../worker/assets';
 import {
@@ -15,7 +16,6 @@ import {
   getSignedDeploymentUrlAsync,
 } from '../../worker/deployment';
 import { UploadParams, batchUploadAsync, uploadAsync } from '../../worker/upload';
-import formatFields, { FormatFieldsItem } from '../../utils/formatFields';
 
 const isDirectory = (directoryPath: string): Promise<boolean> =>
   fs.promises
@@ -42,10 +42,7 @@ interface RawDeployFlags {
 export default class WorkerDeploy extends EasCommand {
   static override description = 'Deploy your Expo web build';
   static override aliases = ['deploy'];
-  static override usage = [
-    chalk`deploy {dim [options]}`,
-    `deploy --prod`,
-  ];
+  static override usage = [chalk`deploy {dim [options]}`, `deploy --prod`];
 
   // TODO(@kitten): Keep command hidden until worker deployments are live
   static override hidden = true;
@@ -321,7 +318,7 @@ type LogDeploymentOptions = {
   productionUrl?: string | null;
 };
 
-function logDeployment(options: LogDeploymentOptions) {
+function logDeployment(options: LogDeploymentOptions): void {
   Log.addNewLineIfNone();
   Log.log(`🎉 Your deployment is ready`);
   Log.addNewLineIfNone();
@@ -345,12 +342,12 @@ function logDeployment(options: LogDeploymentOptions) {
 
   if (!options.productionUrl) {
     Log.addNewLineIfNone();
-    Log.log('🚀 If you are ready to deploy to production:');
+    Log.log('🚀 When you are ready to deploy to production:');
     Log.log(chalk`  $ eas deploy {bold --prod}`);
   }
 }
 
 /** Log the detected of Expo export */
-function logDeploymentType(type: 'static' | 'server') {
+function logDeploymentType(type: 'static' | 'server'): void {
   Log.log(chalk`{dim > output: ${type}}`);
 }

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -346,7 +346,7 @@ function logDeployment(options: LogDeploymentOptions) {
   if (!options.productionUrl) {
     Log.addNewLineIfNone();
     Log.log('🚀 If you are ready to deploy to production:');
-    Log.log(chalk`  $ eas deploy {underline --prod}`);
+    Log.log(chalk`  $ eas deploy {bold --prod}`);
   }
 }
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -25,7 +25,7 @@ const isDirectory = (directoryPath: string): Promise<boolean> =>
 interface DeployFlags {
   nonInteractive: boolean;
   json: boolean;
-  prod: boolean;
+  isProduction: boolean;
   aliasName?: string;
   deploymentIdentifier?: string;
 }
@@ -33,7 +33,7 @@ interface DeployFlags {
 interface RawDeployFlags {
   'non-interactive': boolean;
   json: boolean;
-  prod: boolean;
+  production: boolean;
   alias?: string;
   id?: string;
 }
@@ -50,7 +50,8 @@ export default class WorkerDeploy extends EasCommand {
     alias: Flags.string({
       description: 'Custom alias for the deployment',
     }),
-    prod: Flags.boolean({
+    production: Flags.boolean({
+      aliases: ['prod'],
       description: 'Deploy to production',
       default: false,
     }),
@@ -258,7 +259,7 @@ export default class WorkerDeploy extends EasCommand {
     const expoBaseDomain = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';
     const dashboardUrl = `https://${expoBaseDomain}.dev/projects/${projectId}/serverless/deployments`;
 
-    if (!flags.prod) {
+    if (!flags.isProduction) {
       logDeployment({
         dashboardUrl,
         deploymentUrl: `https://${deployResult.fullName}.${expoBaseDomain}.app`,
@@ -292,7 +293,7 @@ export default class WorkerDeploy extends EasCommand {
     return {
       nonInteractive: flags['non-interactive'],
       json: flags['json'],
-      prod: !!flags.prod,
+      isProduction: !!flags.production,
       aliasName: flags.alias?.trim().toLowerCase(),
       deploymentIdentifier: flags.id?.trim(),
     };

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -47,14 +47,14 @@ export default class WorkerDeploy extends EasCommand {
   static override state = 'beta';
 
   static override flags = {
-    alias: Flags.string({
-      description: 'Custom alias to assign to the new deployment',
-      helpValue: 'name',
-    }),
     prod: Flags.boolean({
       aliases: ['production'],
       description: 'Create a new production deployment',
       default: false,
+    }),
+    alias: Flags.string({
+      description: 'Custom alias to assign to the new deployment',
+      helpValue: 'name',
     }),
     id: Flags.string({
       description: 'Custom unique identifier for the new deployment',

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -33,13 +33,13 @@ interface DeployFlags {
 interface RawDeployFlags {
   'non-interactive': boolean;
   json: boolean;
-  production: boolean;
+  prod: boolean;
   alias?: string;
   id?: string;
 }
 
 export default class WorkerDeploy extends EasCommand {
-  static override description = 'deploy an Expo web build';
+  static override description = 'Deploy your Expo web build';
   static override aliases = ['deploy'];
 
   // TODO(@kitten): Keep command hidden until worker deployments are live
@@ -48,15 +48,17 @@ export default class WorkerDeploy extends EasCommand {
 
   static override flags = {
     alias: Flags.string({
-      description: 'Custom alias for the deployment',
+      description: 'Custom alias to assign to the new deployment',
+      helpValue: 'name',
     }),
-    production: Flags.boolean({
-      aliases: ['prod'],
-      description: 'Deploy to production',
+    prod: Flags.boolean({
+      aliases: ['production'],
+      description: 'Create a new production deployment',
       default: false,
     }),
     id: Flags.string({
-      description: 'A custom deployment identifier for the new deployment',
+      description: 'Custom unique identifier for the new deployment',
+      helpValue: 'xyz123'
     }),
     // TODO(@kitten): Allow deployment identifier to be specified
     ...EasNonInteractiveAndJsonFlags,
@@ -293,7 +295,7 @@ export default class WorkerDeploy extends EasCommand {
     return {
       nonInteractive: flags['non-interactive'],
       json: flags['json'],
-      isProduction: !!flags.production,
+      isProduction: !!flags.prod,
       aliasName: flags.alias?.trim().toLowerCase(),
       deploymentIdentifier: flags.id?.trim(),
     };

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -100,7 +100,8 @@ export default class WorkerDeploy extends EasCommand {
           `No "dist/" folder found. Prepare your project for deployment with "npx expo export"`
         );
       }
-      Log.log('Detected "static" worker deployment');
+
+      logDeploymentType('static');
     } else if (exp.web?.output === 'server') {
       distClientPath = path.resolve(distPath, 'client');
       distServerPath = path.resolve(distPath, 'server');
@@ -113,7 +114,8 @@ export default class WorkerDeploy extends EasCommand {
           `No "dist/server/" folder found. Prepare your project for deployment with "npx expo export"`
         );
       }
-      Log.log('Detected "server" worker deployment');
+
+      logDeploymentType('server');
     } else {
       throw new Error(
         `Single-page apps are not supported. Ensure that app.json key "expo.web.output" is set to "server" or "static".`
@@ -313,11 +315,11 @@ function logDeployment(options: LogDeploymentOptions) {
 
   Log.log(
     formatFields([
-      { label: '🎛️ Dashboard URL', value: options.expoDashboardUrl },
-      { label: '🔗 Deployment URL', value: options.deploymentUrl },
-      ...(options.aliasedUrl ? [{ label: '🔗 Aliased URL', value: options.aliasedUrl }] : []),
+      { label: 'Dashboard URL', value: options.expoDashboardUrl },
+      { label: 'Deployment URL', value: options.deploymentUrl },
+      ...(options.aliasedUrl ? [{ label: 'Aliased URL', value: options.aliasedUrl }] : []),
       ...(options.productionUrl
-        ? [{ label: '🌐 Production URL', value: options.productionUrl }]
+        ? [{ label: 'Production URL', value: options.productionUrl }]
         : []),
     ])
   );
@@ -327,4 +329,9 @@ function logDeployment(options: LogDeploymentOptions) {
     Log.log('🚢 If you are ready to deploy to production:');
     Log.log(chalk`  {dim $} eas deploy {bold --prod}`);
   }
+}
+
+/** Log the detected of Expo export */
+function logDeploymentType(type: 'static' | 'server') {
+  Log.log(chalk`{dim > output: ${type}}`);
 }


### PR DESCRIPTION
# Why

Support both `eas worker --prod` and `eas worker --production`, as we use the full "Production" terminology on the dashboard.

# How

- Added `--production` as an alias of `--prod`
- Reduced the amount of spinners
- Dimmed important context but irrelevant info to view a deployment
- Cleaned up command output text

# Test Plan

<details><summary><code>$ eas deploy --help</code></summary>

<img width="619" alt="image" src="https://github.com/user-attachments/assets/f99e48b9-d31f-4464-ac01-4d9ac2dd0be3">

</details>

<details><summary><code>$ eas deploy</code></summary>

<img width="784" alt="image" src="https://github.com/user-attachments/assets/6218d99d-4ae5-4720-9333-4516b718a293">

</details>

<details><summary><code>$ eas deploy --alias pr-test</code></summary>

<img width="786" alt="image" src="https://github.com/user-attachments/assets/03a8d1af-c73a-49cd-b814-e72a7c214639">

</details>

<details><summary><code>$ eas deploy --prod</code></summary>

<img width="784" alt="image" src="https://github.com/user-attachments/assets/c6db9841-5666-4c4c-aa1e-6a3a2eeef753">

</details>

<details><summary><code>$ eas deploy --production --alias pr-test</code></summary>

<img width="784" alt="image" src="https://github.com/user-attachments/assets/dad26b47-33de-436e-8f70-643c54f91070">

</details>