### PR TITLE
[eas-cli] Add `--environment` argument to worker:deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add `worker --prod` flag to deploy to production from the CLI. ([#2550](https://github.com/expo/eas-cli/pull/2550) by [@byCedric](https://github.com/byCedric))
 - Add `worker --alias` flag to assign custom aliases when deploying. ([#2551](https://github.com/expo/eas-cli/pull/2551) by [@byCedric](https://github.com/byCedric)))
 - Add `worker --id` flag to use a custom deployment identifier. ([#2552](https://github.com/expo/eas-cli/pull/2552) by [@byCedric](https://github.com/byCedric)))
+- Add `worker --environment` flag to deploy with EAS environment variables. ([#2557](https://github.com/expo/eas-cli/pull/2557) by [@kitten](https://github.com/kitten)))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import * as path from 'node:path';
 
 import EasCommand from '../../commandUtils/EasCommand';
-import { EasNonInteractiveAndJsonFlags, EASEnvironmentFlag } from '../../commandUtils/flags';
+import { EASEnvironmentFlag, EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { EnvironmentVariableEnvironment } from '../../graphql/generated';
 import Log from '../../log';
 import { ora } from '../../ora';
@@ -226,11 +226,14 @@ export default class WorkerDeploy extends EasCommand {
     let progress = ora('Preparing project').start();
 
     try {
-      const manifest = await WorkerAssets.createManifestAsync({
-        environment: flags.environment,
-        projectDir,
-        projectId,
-      }, graphqlClient);
+      const manifest = await WorkerAssets.createManifestAsync(
+        {
+          environment: flags.environment,
+          projectDir,
+          projectId,
+        },
+        graphqlClient
+      );
       assetMap = await WorkerAssets.createAssetMapAsync(distClientPath);
       tarPath = await WorkerAssets.packFilesIterableAsync(
         emitWorkerTarballAsync({

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -7,6 +7,10 @@ import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { pack } from 'tar-stream';
 
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { EnvironmentVariablesQuery } from '../graphql/queries/EnvironmentVariablesQuery';
+import { EnvironmentVariableEnvironment } from '../graphql/generated';
+
 /** Returns whether a file or folder is ignored */
 function isIgnoredName(name: string): boolean {
   switch (name) {
@@ -92,9 +96,33 @@ export interface Manifest {
   env: Record<string, string | undefined>;
 }
 
+interface CreateManifestParams {
+  projectId: string;
+  projectDir: string;
+  environment?: EnvironmentVariableEnvironment;
+}
+
 /** Creates a manifest configuration sent up for deployment */
-export async function createManifestAsync(projectDir: string): Promise<Manifest> {
-  const { env } = getEnv(projectDir);
+export async function createManifestAsync(
+  params: CreateManifestParams,
+  graphqlClient: ExpoGraphqlClient,
+): Promise<Manifest> {
+  let env: Record<string, string | undefined>;
+  if (params.environment) {
+    env = Object.fromEntries(
+      (await EnvironmentVariablesQuery.byAppIdWithSensitiveAsync(
+        graphqlClient,
+        {
+          appId: params.projectId,
+          environment: params.environment,
+        }
+      )).map((variable) => [variable.name, variable.value ?? undefined])
+    );
+  } else {
+    // NOTE: This is required for the .env resolution
+    process.env.NODE_ENV = 'production';
+    env = getEnv(params.projectDir).env;
+  }
   return { env };
 }
 

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -8,8 +8,8 @@ import { pipeline } from 'node:stream/promises';
 import { pack } from 'tar-stream';
 
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
-import { EnvironmentVariablesQuery } from '../graphql/queries/EnvironmentVariablesQuery';
 import { EnvironmentVariableEnvironment } from '../graphql/generated';
+import { EnvironmentVariablesQuery } from '../graphql/queries/EnvironmentVariablesQuery';
 
 /** Returns whether a file or folder is ignored */
 function isIgnoredName(name: string): boolean {
@@ -105,18 +105,17 @@ interface CreateManifestParams {
 /** Creates a manifest configuration sent up for deployment */
 export async function createManifestAsync(
   params: CreateManifestParams,
-  graphqlClient: ExpoGraphqlClient,
+  graphqlClient: ExpoGraphqlClient
 ): Promise<Manifest> {
   let env: Record<string, string | undefined>;
   if (params.environment) {
     env = Object.fromEntries(
-      (await EnvironmentVariablesQuery.byAppIdWithSensitiveAsync(
-        graphqlClient,
-        {
+      (
+        await EnvironmentVariablesQuery.byAppIdWithSensitiveAsync(graphqlClient, {
           appId: params.projectId,
           environment: params.environment,
-        }
-      )).map((variable) => [variable.name, variable.value ?? undefined])
+        })
+      ).map(variable => [variable.name, variable.value ?? undefined])
     );
   } else {
     // NOTE: This is required for the .env resolution


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This adds EAS Env "pulling" to worker deployments, i.e. pipes environment variables from EAS into the worker deployment.

# How

Reuses existing `--environment` definition. Overriding the help description is TBD.

# Test Plan

Manually tested
