### PR TITLE
refactor(eas-cli): update `eas worker:alias` with same polishes from `eas worker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add missing `--non-interactive` argument to `worker:deploy` command. ([#2544](https://github.com/expo/eas-cli/pull/2544) by [@kitten](https://github.com/kitten))
 - Source `@expo/env` dotenv files for worker deployments. ([#2545](https://github.com/expo/eas-cli/pull/2545) by [@kitten](https://github.com/kitten))
 - Support `worker --production` and clean up command output. ([#2555](https://github.com/expo/eas-cli/pull/2555) by [@byCedric](https://github.com/byCedric)))
+- Unify both `worker` and `worker:alias` command output. ([#2558](https://github.com/expo/eas-cli/pull/2558) by [@byCedric](https://github.com/byCedric)))
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/packages/eas-cli/src/commands/worker/alias.ts
+++ b/packages/eas-cli/src/commands/worker/alias.ts
@@ -6,6 +6,7 @@ import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/creat
 import Log from '../../log';
 import { ora } from '../../ora';
 import { promptAsync } from '../../prompts';
+import formatFields from '../../utils/formatFields';
 import {
   assignWorkerDeploymentAliasAsync,
   selectWorkerDeploymentOnAppAsync,
@@ -58,29 +59,35 @@ export default class WorkerAlias extends EasCommand {
       flagId: flags.id,
     });
 
-    const progress = ora(chalk`Assigning alias {bold ${aliasName}} to deployment {bold ${deploymentId}}`).start();
+    const progress = ora(
+      chalk`Assigning alias {bold ${aliasName}} to deployment {bold ${deploymentId}}`
+    ).start();
     const workerAlias = await assignWorkerDeploymentAliasAsync({
       graphqlClient,
       appId: projectId,
       deploymentId,
       aliasName,
-    })
-      .catch((error) => {
-        progress.fail(chalk`Failed to assign {bold ${flags.aliasName}} alias to deployment {bold ${deploymentId}}`);
-        throw error;
-      });
+    }).catch(error => {
+      progress.fail(
+        chalk`Failed to assign {bold ${aliasName}} alias to deployment {bold ${deploymentId}}`
+      );
+      throw error;
+    });
 
     progress.succeed(
-      chalk`Assigned alias {bold ${flags.aliasName}} to deployment {bold ${deploymentId}}`
+      chalk`Assigned alias {bold ${aliasName}} to deployment {bold ${deploymentId}}`
     );
 
-    const baseDomain = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';
-    const aliasUrl = `https://${baseDomain}.dev/projects/${projectId}/serverless/deployments`;
+    const expoBaseDomain = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';
+    const expoDashboardUrl = `https://${expoBaseDomain}.dev/projects/${projectId}/serverless/deployments`;
 
     Log.addNewLineIfNone();
-    Log.log(`🎉 Your deployment is now available on: ${workerAlias.url}`);
-    Log.addNewLineIfNone();
-    Log.log(`🔗 Manage on EAS: ${aliasUrl}`);
+    Log.log(
+      formatFields([
+        { label: 'Dashboard', value: expoDashboardUrl },
+        { label: 'Aliased URL', value: chalk.cyan(workerAlias.url) },
+      ])
+    );
   }
 }
 

--- a/packages/eas-cli/src/commands/worker/alias.ts
+++ b/packages/eas-cli/src/commands/worker/alias.ts
@@ -85,7 +85,7 @@ export default class WorkerAlias extends EasCommand {
     Log.log(
       formatFields([
         { label: 'Dashboard', value: expoDashboardUrl },
-        { label: 'Aliased URL', value: chalk.cyan(workerAlias.url) },
+        { label: 'Alias URL', value: chalk.cyan(workerAlias.url) },
       ])
     );
   }

--- a/packages/eas-cli/src/commands/worker/alias.ts
+++ b/packages/eas-cli/src/commands/worker/alias.ts
@@ -20,12 +20,14 @@ export default class WorkerAlias extends EasCommand {
   static override state = 'beta';
 
   static override flags = {
-    id: Flags.string({
-      description: 'Worker deployment identifier',
+    alias: Flags.string({
+      description: 'Custom alias to assign to the existing deployment',
+      helpValue: 'name',
       required: false,
     }),
-    alias: Flags.string({
-      description: 'Worker deployment alias name to assign',
+    id: Flags.string({
+      description: 'Unique identifier of an existing deployment',
+      helpValue: 'xyz123',
       required: false,
     }),
   };
@@ -56,16 +58,20 @@ export default class WorkerAlias extends EasCommand {
       flagId: flags.id,
     });
 
-    const progress = ora('Assigning alias to worker deployment').start();
+    const progress = ora(chalk`Assigning alias {bold ${aliasName}} to deployment {bold ${deploymentId}}`).start();
     const workerAlias = await assignWorkerDeploymentAliasAsync({
       graphqlClient,
       appId: projectId,
       deploymentId,
       aliasName,
-    });
+    })
+      .catch((error) => {
+        progress.fail(chalk`Failed to assign {bold ${flags.aliasName}} alias to deployment {bold ${deploymentId}}`);
+        throw error;
+      });
 
     progress.succeed(
-      chalk`Alias {bold ${workerAlias.aliasName}} assigned to deployment {bold ${deploymentId}}`
+      chalk`Assigned alias {bold ${flags.aliasName}} to deployment {bold ${deploymentId}}`
     );
 
     const baseDomain = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';


### PR DESCRIPTION
# Why

See #2555, this applies the same polishes in terms of help and normal command output.

# How

See #2555

# Test Plan

<details><summary><code>easd deploy:alias --help</code></summary>

<img width="482" alt="image" src="https://github.com/user-attachments/assets/c5ab4a88-5594-4c85-ae4c-74f1070dae9c">

</details>

<details><summary><code>easd deploy:alias --id xxx --alias pr-test</code></summary>

<img width="749" alt="image" src="https://github.com/user-attachments/assets/c69a0a9c-9b86-41fb-a4ec-eab1956f155c">

</details>