### PR TITLE
feature(eas-cli): add `worker --json` support for 3rd parties and custom tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add `worker --alias` flag to assign custom aliases when deploying. ([#2551](https://github.com/expo/eas-cli/pull/2551) by [@byCedric](https://github.com/byCedric)))
 - Add `worker --id` flag to use a custom deployment identifier. ([#2552](https://github.com/expo/eas-cli/pull/2552) by [@byCedric](https://github.com/byCedric)))
 - Add `worker --environment` flag to deploy with EAS environment variables. ([#2557](https://github.com/expo/eas-cli/pull/2557) by [@kitten](https://github.com/kitten)))
+- Add `worker --json` flag to allow integrating with 3rd parties and custom tooling.
 
 ### 🐛 Bug fixes
 


### PR DESCRIPTION
# Why

With `eas worker --json`, we can integrate with other tooling (such as expo-github-action). This adds support for exactly that.

# How

- Swapped the beta warning from `Log.warn` to `console.warn`, avoiding polluting the JSON output
- Added `--json` only output to `eas worker --json` command

# Test Plan

<details><summary><code>eas worker --prod --alias test-json --json --non-interactive</code></summary>

<img width="852" alt="image" src="https://github.com/user-attachments/assets/d9dca61c-ce43-4112-b5fe-846d4bcda4ea">

</details>