### PR TITLE
feature(eas-cli): add `worker:alias --json` support for 3rd parties and custom tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add `worker --alias` flag to assign custom aliases when deploying. ([#2551](https://github.com/expo/eas-cli/pull/2551) by [@byCedric](https://github.com/byCedric)))
 - Add `worker --id` flag to use a custom deployment identifier. ([#2552](https://github.com/expo/eas-cli/pull/2552) by [@byCedric](https://github.com/byCedric)))
 - Add `worker --environment` flag to deploy with EAS environment variables. ([#2557](https://github.com/expo/eas-cli/pull/2557) by [@kitten](https://github.com/kitten)))
-- Add `worker:alias --json` flag to allow integrating with 3rd parties and custom tooling.
+- Add `worker:alias --json` flag to allow integrating with 3rd parties and custom tooling. ([#2562](https://github.com/expo/eas-cli/pull/2562) by [@byCedric](https://github.com/byCedric)))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add `worker --alias` flag to assign custom aliases when deploying. ([#2551](https://github.com/expo/eas-cli/pull/2551) by [@byCedric](https://github.com/byCedric)))
 - Add `worker --id` flag to use a custom deployment identifier. ([#2552](https://github.com/expo/eas-cli/pull/2552) by [@byCedric](https://github.com/byCedric)))
 - Add `worker --environment` flag to deploy with EAS environment variables. ([#2557](https://github.com/expo/eas-cli/pull/2557) by [@kitten](https://github.com/kitten)))
+- Add `worker:alias --json` flag to allow integrating with 3rd parties and custom tooling.
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/worker/alias.ts
+++ b/packages/eas-cli/src/commands/worker/alias.ts
@@ -136,7 +136,7 @@ export default class WorkerAlias extends EasCommand {
       nonInteractive: flags['non-interactive'],
       json: flags['json'],
       aliasName: flags.alias?.trim().toLowerCase(),
-      deploymentIdentifier: flags.id?.trim(),
+      deploymentIdentifier: flags.id?.trim().toLowerCase(),
     };
   }
 }

--- a/packages/eas-cli/src/commands/worker/alias.ts
+++ b/packages/eas-cli/src/commands/worker/alias.ts
@@ -3,16 +3,16 @@ import chalk from 'chalk';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import Log from '../../log';
 import { ora } from '../../ora';
 import { promptAsync } from '../../prompts';
 import formatFields from '../../utils/formatFields';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import {
   assignWorkerDeploymentAliasAsync,
   selectWorkerDeploymentOnAppAsync,
 } from '../../worker/deployment';
-import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 interface DeployAliasFlags {
   nonInteractive: boolean;
@@ -109,17 +109,20 @@ export default class WorkerAlias extends EasCommand {
     const expoDashboardUrl = `https://${expoBaseDomain}.dev/projects/${projectId}/serverless/deployments`;
 
     if (flags.json) {
-      return printJsonOnlyOutput({
+      printJsonOnlyOutput({
         dashboardUrl: expoDashboardUrl,
         deployment: {
           id: deploymentId,
-          aliases: [{
-            id: workerAlias.id,
-            name: workerAlias.aliasName,
-            url: workerAlias.url,
-          }]
+          aliases: [
+            {
+              id: workerAlias.id,
+              name: workerAlias.aliasName,
+              url: workerAlias.url,
+            },
+          ],
         },
       });
+      return;
     }
 
     Log.addNewLineIfNone();
@@ -147,9 +150,7 @@ async function resolveDeploymentAliasAsync(flags: DeployAliasFlags): Promise<str
   }
 
   if (flags.nonInteractive) {
-    throw new Error(
-      'The `--alias` flag must be set when running in `--non-interactive` mode.'
-    );
+    throw new Error('The `--alias` flag must be set when running in `--non-interactive` mode.');
   }
 
   const { alias: aliasName } = await promptAsync({
@@ -178,9 +179,7 @@ async function resolveDeploymentIdAsync({
   }
 
   if (nonInteractive) {
-    throw new Error(
-      'The `--id` flag must be set when running in `--non-interactive` mode.'
-    );
+    throw new Error('The `--id` flag must be set when running in `--non-interactive` mode.');
   }
 
   const deployment = await selectWorkerDeploymentOnAppAsync({


### PR DESCRIPTION
# Why

With `eas worker:alias --json`, we can integrate with other tooling (such as expo-github-action). This adds support for exactly that.

# How

- Swapped the beta warning from `Log.warn` to `console.warn`, avoiding polluting the JSON output
- Added `--json` only output to `eas worker:alias --json` command

# Test Plan

<details><summary><code>eas worker:alias --json</code></summary>

<img width="526" alt="image" src="https://github.com/user-attachments/assets/3c7d084e-6567-426a-bf6b-409cb6e4deef">

</details>

<details><summary><code>eas worker:alias --id xxx --json</code></summary>

<img width="529" alt="image" src="https://github.com/user-attachments/assets/7f573178-17d7-4e13-92c6-a711bfdbf6f3">

</details>

<details><summary><code>eas worker:alias --alias pr-test --json</code></summary>

<img width="508" alt="image" src="https://github.com/user-attachments/assets/b6613f50-729c-4df0-890f-5d5b67427e63">

</details>

<details><summary><code>eas worker:alias --id xxx --alias pr-test --json</code></summary>

<img width="818" alt="image" src="https://github.com/user-attachments/assets/4a17706e-bbfc-4b86-af18-4303bf5328e1">

</details>
