### PR TITLE
feature(eas-cli): add `worker:alias|promote --prod` flag to promote existing deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Source `@expo/env` dotenv files for worker deployments. ([#2545](https://github.com/expo/eas-cli/pull/2545) by [@kitten](https://github.com/kitten))
 - Support `worker --production` and clean up command output. ([#2555](https://github.com/expo/eas-cli/pull/2555) by [@byCedric](https://github.com/byCedric)))
 - Unify both `worker` and `worker:alias` command output. ([#2558](https://github.com/expo/eas-cli/pull/2558) by [@byCedric](https://github.com/byCedric)))
+- Share similar table/json output in both `worker` and `worker:alias` command outputs. ([#2563](https://github.com/expo/eas-cli/pull/2563) by [@byCedric](https://github.com/byCedric)))
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -23219,6 +23219,12 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "A",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CNAME",
             "description": null,
             "isDeprecated": false,
@@ -43888,7 +43894,7 @@
             "deprecationReason": null
           },
           {
-            "name": "deploymentsPaginated",
+            "name": "deployments",
             "description": null,
             "args": [
               {
@@ -52587,6 +52593,30 @@
             "deprecationReason": null
           },
           {
+            "name": "byCacheStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestsCacheStatusEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "byContinent",
             "description": null,
             "args": [],
@@ -52611,6 +52641,30 @@
             "deprecationReason": null
           },
           {
+            "name": "byMethod",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestsMethodEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "byOS",
             "description": null,
             "args": [],
@@ -52626,6 +52680,30 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "WorkerDeploymentRequestsOperatingSystemEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "byStatusType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestsStatusTypeEdge",
                     "ofType": null
                   }
                 }
@@ -53356,6 +53434,45 @@
       },
       {
         "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestsCacheStatusEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cacheStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "ResponseCacheStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestsAggregationNode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "WorkerDeploymentRequestsContinentEdge",
         "description": null,
         "fields": [
@@ -53369,6 +53486,49 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "ContinentCode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestsAggregationNode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestsMethodEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "method",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -53438,6 +53598,45 @@
       },
       {
         "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestsStatusTypeEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestsAggregationNode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "statusType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "ResponseStatusType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "WorkerDeploymentRequestsTimeseriesEdge",
         "description": null,
         "fields": [
@@ -53457,6 +53656,30 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "WorkerDeploymentRequestsBrowserEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "byCacheStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestsCacheStatusEdge",
                     "ofType": null
                   }
                 }
@@ -53490,6 +53713,30 @@
             "deprecationReason": null
           },
           {
+            "name": "byMethod",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestsMethodEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "byOS",
             "description": null,
             "args": [],
@@ -53505,6 +53752,30 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "WorkerDeploymentRequestsOperatingSystemEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "byStatusType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestsStatusTypeEdge",
                     "ofType": null
                   }
                 }

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -10445,39 +10445,6 @@
             "deprecationReason": null
           },
           {
-            "name": "workerDeploymentRequest",
-            "description": null,
-            "args": [
-              {
-                "name": "requestId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "WorkerDeploymentRequestEdge",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "workerDeployments",
             "description": null,
             "args": [
@@ -10633,30 +10600,18 @@
             "deprecationReason": null
           },
           {
-            "name": "workerDeploymentsMetrics",
+            "name": "workerDeploymentsRequest",
             "description": null,
             "args": [
               {
-                "name": "filters",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "MetricsFilters",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "timespan",
+                "name": "requestKey",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "MetricsTimespan",
+                    "kind": "SCALAR",
+                    "name": "ID",
                     "ofType": null
                   }
                 },
@@ -10666,9 +10621,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "WorkerDeploymentMetrics",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestEdge",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -10678,30 +10637,14 @@
             "description": null,
             "args": [
               {
-                "name": "filter",
+                "name": "filters",
                 "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "WorkerDeploymentRequestsFilter",
+                  "name": "RequestsFilters",
                   "ofType": null
                 },
                 "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": "100",
                 "isDeprecated": false,
                 "deprecationReason": null
               },
@@ -35041,351 +34984,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "ENUM",
-        "name": "MetricsCacheStatus",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "HIT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "MISS",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PASS",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "MetricsFilters",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "cacheStatus",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "MetricsCacheStatus",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "continent",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "ContinentCode",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasCustomDomainOrigin",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "isAsset",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "isCrash",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "isVerifiedBot",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "method",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "MetricsRequestMethod",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "os",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "UserAgentOS",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pathname",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "status",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "statusType",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "MetricsStatusType",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "MetricsRequestMethod",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "DELETE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "GET",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "OPTIONS",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "POST",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PUT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "MetricsStatusType",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "CLIENT_ERROR",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "NONE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "REDIRECT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SERVER_ERROR",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SUCCESSFUL",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "MetricsTimespan",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "end",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "start",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "OBJECT",
         "name": "Notification",
         "description": null,
@@ -37245,37 +36843,266 @@
       },
       {
         "kind": "ENUM",
-        "name": "RequestStatusPattern",
+        "name": "RequestMethod",
         "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
-            "name": "HTTP_2XX",
+            "name": "DELETE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "HTTP_3XX",
+            "name": "GET",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "HTTP_4XX",
+            "name": "HEAD",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "HTTP_5XX",
+            "name": "OPTIONS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PATCH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PUT",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestsFilters",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "cacheStatus",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ResponseCacheStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "continent",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ContinentCode",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasCustomDomainOrigin",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isAsset",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isCrash",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isVerifiedBot",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "method",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "RequestMethod",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "os",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "UserAgentOS",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pathname",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "responseType",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ResponseType",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "statusType",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ResponseStatusType",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -37304,9 +37131,13 @@
             "name": "start",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -37360,6 +37191,111 @@
           },
           {
             "name": "N2",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ResponseCacheStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "HIT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MISS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PASS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ResponseStatusType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CLIENT_ERROR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NONE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REDIRECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SERVER_ERROR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUCCESSFUL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ResponseType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASSET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CRASH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REJECTED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ROUTE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -43952,6 +43888,71 @@
             "deprecationReason": null
           },
           {
+            "name": "deploymentsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UpdateDeploymentsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "expoGoSDKVersion",
             "description": null,
             "args": [],
@@ -45054,6 +45055,100 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "UpdateChannel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UpdateDeploymentEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Deployment",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UpdateDeploymentsConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UpdateDeploymentEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
                 "ofType": null
               }
             },
@@ -51143,7 +51238,7 @@
             "deprecationReason": null
           },
           {
-            "name": "metrics",
+            "name": "requests",
             "description": null,
             "args": [
               {
@@ -51151,7 +51246,7 @@
                 "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "MetricsFilters",
+                  "name": "RequestsFilters",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -51166,7 +51261,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
-                    "name": "MetricsTimespan",
+                    "name": "RequestsTimespan",
                     "ofType": null
                   }
                 },
@@ -51177,7 +51272,7 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "WorkerDeploymentMetrics",
+              "name": "WorkerDeploymentRequests",
               "ofType": null
             },
             "isDeprecated": false,
@@ -51982,7 +52077,489 @@
       },
       {
         "kind": "OBJECT",
-        "name": "WorkerDeploymentMetrics",
+        "name": "WorkerDeploymentQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byId",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeployment",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "crash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkerDeploymentCrashSample",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "logs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentLogNode",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestNode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestNode",
+        "description": null,
+        "fields": [
+          {
+            "name": "browserKind",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "UserAgentBrowser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "browserVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cacheStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "ResponseCacheStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "continent",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "ContinentCode",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deploymentIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "duration",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasCustomDomainOrigin",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isAsset",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isCrash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isRejected",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isStaleIfError",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isStaleWhileRevalidate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isVerifiedBot",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "method",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "os",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "UserAgentOS",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pathname",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "region",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestTimestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "responseType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ResponseType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scriptName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "search",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "statusType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "ResponseStatusType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequests",
         "description": null,
         "fields": [
           {
@@ -52000,7 +52577,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "WorkerDeploymentMetricsBrowserEdge",
+                    "name": "WorkerDeploymentRequestsBrowserEdge",
                     "ofType": null
                   }
                 }
@@ -52024,7 +52601,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "WorkerDeploymentMetricsContinentEdge",
+                    "name": "WorkerDeploymentRequestsContinentEdge",
                     "ofType": null
                   }
                 }
@@ -52048,7 +52625,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "WorkerDeploymentMetricsOperatingSystemEdge",
+                    "name": "WorkerDeploymentRequestsOperatingSystemEdge",
                     "ofType": null
                   }
                 }
@@ -52074,6 +52651,46 @@
             "deprecationReason": null
           },
           {
+            "name": "minRowsWithoutLimit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestNode",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "summary",
             "description": null,
             "args": [],
@@ -52082,7 +52699,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "WorkerDeploymentMetricsNode",
+                "name": "WorkerDeploymentRequestsAggregationNode",
                 "ofType": null
               }
             },
@@ -52104,7 +52721,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "WorkerDeploymentMetricsTimeseriesEdge",
+                    "name": "WorkerDeploymentRequestsTimeseriesEdge",
                     "ofType": null
                   }
                 }
@@ -52121,89 +52738,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "WorkerDeploymentMetricsBrowserEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "browser",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "UserAgentBrowser",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "WorkerDeploymentMetricsNode",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "WorkerDeploymentMetricsContinentEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "continent",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "ContinentCode",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "WorkerDeploymentMetricsNode",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "WorkerDeploymentMetricsNode",
+        "name": "WorkerDeploymentRequestsAggregationNode",
         "description": null,
         "fields": [
           {
@@ -52782,7 +53317,89 @@
       },
       {
         "kind": "OBJECT",
-        "name": "WorkerDeploymentMetricsOperatingSystemEdge",
+        "name": "WorkerDeploymentRequestsBrowserEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "browser",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "UserAgentBrowser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestsAggregationNode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestsContinentEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "continent",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ContinentCode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestsAggregationNode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestsOperatingSystemEdge",
         "description": null,
         "fields": [
           {
@@ -52794,7 +53411,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "WorkerDeploymentMetricsNode",
+                "name": "WorkerDeploymentRequestsAggregationNode",
                 "ofType": null
               }
             },
@@ -52821,7 +53438,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "WorkerDeploymentMetricsTimeseriesEdge",
+        "name": "WorkerDeploymentRequestsTimeseriesEdge",
         "description": null,
         "fields": [
           {
@@ -52839,7 +53456,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "WorkerDeploymentMetricsBrowserEdge",
+                    "name": "WorkerDeploymentRequestsBrowserEdge",
                     "ofType": null
                   }
                 }
@@ -52863,7 +53480,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "WorkerDeploymentMetricsContinentEdge",
+                    "name": "WorkerDeploymentRequestsContinentEdge",
                     "ofType": null
                   }
                 }
@@ -52887,7 +53504,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "WorkerDeploymentMetricsOperatingSystemEdge",
+                    "name": "WorkerDeploymentRequestsOperatingSystemEdge",
                     "ofType": null
                   }
                 }
@@ -52902,7 +53519,7 @@
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "WorkerDeploymentMetricsNode",
+              "name": "WorkerDeploymentRequestsAggregationNode",
               "ofType": null
             },
             "isDeprecated": false,
@@ -52928,609 +53545,6 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "WorkerDeploymentQuery",
-        "description": null,
-        "fields": [
-          {
-            "name": "byId",
-            "description": null,
-            "args": [
-              {
-                "name": "id",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "WorkerDeployment",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "WorkerDeploymentRequestEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "crash",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "WorkerDeploymentCrashSample",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "logs",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "WorkerDeploymentLogNode",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "WorkerDeploymentRequestNode",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "WorkerDeploymentRequestKind",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "ASSET",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "CRASH",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "REJECTED",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "WorkerDeploymentRequestLocation",
-        "description": null,
-        "fields": [
-          {
-            "name": "continent",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "ContinentCode",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "countryCode",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "regionCode",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "WorkerDeploymentRequestNode",
-        "description": null,
-        "fields": [
-          {
-            "name": "browser",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "UserAgentBrowser",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "browserVersion",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deploymentIdentifier",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasCustomDomainOrigin",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "isVerifiedBot",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "kind",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "WorkerDeploymentRequestKind",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "location",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "WorkerDeploymentRequestLocation",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "method",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "os",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "UserAgentOS",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pathname",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "scriptName",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "search",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "status",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "timestamp",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "wallTime",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "WorkerDeploymentRequests",
-        "description": null,
-        "fields": [
-          {
-            "name": "minRowsWithoutLimit",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nodes",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "WorkerDeploymentRequestNode",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "WorkerDeploymentRequestsFilter",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "include",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "WorkerDeploymentRequestsInclude",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "includeBotRequests",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "methods",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pathname",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "statusCodes",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "statusPatterns",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "RequestStatusPattern",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "WorkerDeploymentRequestsInclude",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "ASSETS",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ROUTES",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/src/commands/worker/alias.ts
+++ b/packages/eas-cli/src/commands/worker/alias.ts
@@ -34,7 +34,7 @@ interface RawDeployAliasFlags {
 
 export default class WorkerAlias extends EasCommand {
   static override description = 'Assign deployment aliases';
-  static override aliases = ['deploy:alias'];
+  static override aliases = ['deploy:alias', 'deploy:promote'];
 
   // TODO(@kitten): Keep command hidden until worker deployments are live
   static override hidden = true;

--- a/packages/eas-cli/src/commands/worker/alias.ts
+++ b/packages/eas-cli/src/commands/worker/alias.ts
@@ -4,21 +4,24 @@ import chalk from 'chalk';
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { WorkerDeploymentAliasFragment } from '../../graphql/generated';
 import Log from '../../log';
-import { ora } from '../../ora';
+import { Ora, ora } from '../../ora';
 import { promptAsync } from '../../prompts';
-import formatFields from '../../utils/formatFields';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import {
   assignWorkerDeploymentAliasAsync,
+  assignWorkerDeploymentProductionAsync,
   selectWorkerDeploymentOnAppAsync,
 } from '../../worker/deployment';
+import { formatWorkerDeploymentJson, formatWorkerDeploymentTable } from '../../worker/utils/logs';
 
 interface DeployAliasFlags {
   nonInteractive: boolean;
   json: boolean;
-  aliasName?: string;
-  deploymentIdentifier?: string;
+  aliasName?: string | null;
+  deploymentIdentifier?: string | null;
+  isProduction: boolean;
 }
 
 interface RawDeployAliasFlags {
@@ -26,6 +29,7 @@ interface RawDeployAliasFlags {
   json: boolean;
   alias?: string;
   id?: string;
+  prod: boolean;
 }
 
 export default class WorkerAlias extends EasCommand {
@@ -37,6 +41,11 @@ export default class WorkerAlias extends EasCommand {
   static override state = 'beta';
 
   static override flags = {
+    prod: Flags.boolean({
+      aliases: ['production'],
+      description: 'Promote an existing deployment to production',
+      default: false,
+    }),
     alias: Flags.string({
       description: 'Custom alias to assign to the existing deployment',
       helpValue: 'name',
@@ -86,51 +95,75 @@ export default class WorkerAlias extends EasCommand {
       aliasName,
     });
 
-    const progress = ora(
-      chalk`Assigning alias {bold ${aliasName}} to deployment {bold ${deploymentId}}`
-    ).start();
-    const workerAlias = await assignWorkerDeploymentAliasAsync({
-      graphqlClient,
-      appId: projectId,
-      deploymentId,
-      aliasName,
-    }).catch(error => {
-      progress.fail(
-        chalk`Failed to assign {bold ${aliasName}} alias to deployment {bold ${deploymentId}}`
-      );
-      throw error;
-    });
+    let progress: null | Ora = null;
+    let deploymentAlias: null | Awaited<ReturnType<typeof assignWorkerDeploymentAliasAsync>> = null;
 
-    progress.succeed(
-      chalk`Assigned alias {bold ${aliasName}} to deployment {bold ${deploymentId}}`
+    if (aliasName) {
+      try {
+        progress = ora(chalk`Assigning alias {bold ${aliasName}} to deployment`).start();
+        deploymentAlias = await assignWorkerDeploymentAliasAsync({
+          graphqlClient,
+          appId: projectId,
+          deploymentId,
+          aliasName,
+        });
+        progress.text = chalk`Assigned alias {bold ${aliasName}} to deployment`;
+      } catch (error: any) {
+        progress?.fail(chalk`Failed to assign {bold ${aliasName}} alias to deployment`);
+        throw error;
+      }
+    }
+
+    let deploymentProdAlias: null | Awaited<
+      ReturnType<typeof assignWorkerDeploymentProductionAsync>
+    > = null;
+
+    if (flags.isProduction) {
+      try {
+        progress = (progress ?? ora()).start(chalk`Promoting deployment to {bold production}`);
+        deploymentProdAlias = await assignWorkerDeploymentProductionAsync({
+          graphqlClient,
+          appId: projectId,
+          deploymentId,
+        });
+        progress.text = chalk`Promoted deployment to {bold production}`;
+      } catch (error: any) {
+        progress?.fail(chalk`Failed to promote deployment to {bold production}`);
+        throw error;
+      }
+    }
+
+    progress?.succeed(
+      !deploymentAlias
+        ? chalk`Promoted deployment to {bold production}`
+        : chalk`Promoted deployment to {bold production} with alias {bold ${deploymentAlias.aliasName}}`
     );
 
-    const expoBaseDomain = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';
-    const expoDashboardUrl = `https://${expoBaseDomain}.dev/projects/${projectId}/serverless/deployments`;
+    // Either use the alias, or production deployment information
+    const deployment = deploymentAlias?.workerDeployment ?? deploymentProdAlias?.workerDeployment;
 
     if (flags.json) {
-      printJsonOnlyOutput({
-        dashboardUrl: expoDashboardUrl,
-        deployment: {
-          id: deploymentId,
-          aliases: [
-            {
-              id: workerAlias.id,
-              name: workerAlias.aliasName,
-              url: workerAlias.url,
-            },
-          ],
-        },
-      });
+      printJsonOnlyOutput(
+        formatWorkerDeploymentJson({
+          projectId,
+          deployment: deployment!,
+          aliases: [deploymentAlias].filter(Boolean) as WorkerDeploymentAliasFragment[],
+          production: deploymentProdAlias,
+        })
+      );
       return;
     }
 
     Log.addNewLineIfNone();
+    Log.log(`🎉 Your deployment is modified`);
+    Log.addNewLineIfNone();
     Log.log(
-      formatFields([
-        { label: 'Dashboard', value: expoDashboardUrl },
-        { label: 'Alias URL', value: chalk.cyan(workerAlias.url) },
-      ])
+      formatWorkerDeploymentTable({
+        projectId,
+        deployment: deployment!,
+        aliases: [deploymentAlias].filter(Boolean) as WorkerDeploymentAliasFragment[],
+        production: deploymentProdAlias,
+      })
     );
   }
 
@@ -140,13 +173,19 @@ export default class WorkerAlias extends EasCommand {
       json: flags['json'],
       aliasName: flags.alias?.trim().toLowerCase(),
       deploymentIdentifier: flags.id?.trim().toLowerCase(),
+      isProduction: flags.prod,
     };
   }
 }
 
-async function resolveDeploymentAliasAsync(flags: DeployAliasFlags): Promise<string> {
+async function resolveDeploymentAliasAsync(flags: DeployAliasFlags): Promise<string | null> {
   if (flags.aliasName?.trim()) {
     return flags.aliasName.trim().toLowerCase();
+  }
+
+  // Skip alias prompt when promoting deployments to prod
+  if (flags.isProduction) {
+    return null;
   }
 
   if (flags.nonInteractive) {

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -20,7 +20,11 @@ import {
   getSignedDeploymentUrlAsync,
 } from '../../worker/deployment';
 import { UploadParams, batchUploadAsync, uploadAsync } from '../../worker/upload';
-import { formatWorkerDeploymentJson, formatWorkerDeploymentTable, getDeploymentUrlFromFullName } from '../../worker/utils/logs';
+import {
+  formatWorkerDeploymentJson,
+  formatWorkerDeploymentTable,
+  getDeploymentUrlFromFullName,
+} from '../../worker/utils/logs';
 
 const isDirectory = (directoryPath: string): Promise<boolean> =>
   fs.promises

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3384,6 +3384,7 @@ export type CustomDomainDnsRecord = {
 };
 
 export enum CustomDomainDnsRecordType {
+  A = 'A',
   Cname = 'CNAME',
   Txt = 'TXT'
 }
@@ -6351,7 +6352,7 @@ export type Update = ActivityTimelineProjectActivity & {
   branchId: Scalars['ID']['output'];
   codeSigningInfo?: Maybe<CodeSigningInfo>;
   createdAt: Scalars['DateTime']['output'];
-  deploymentsPaginated: UpdateDeploymentsConnection;
+  deployments: UpdateDeploymentsConnection;
   expoGoSDKVersion?: Maybe<Scalars['String']['output']>;
   gitCommitHash?: Maybe<Scalars['String']['output']>;
   group: Scalars['String']['output'];
@@ -6374,7 +6375,7 @@ export type Update = ActivityTimelineProjectActivity & {
 };
 
 
-export type UpdateDeploymentsPaginatedArgs = {
+export type UpdateDeploymentsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -7545,8 +7546,11 @@ export type WorkerDeploymentRequestNode = {
 export type WorkerDeploymentRequests = {
   __typename?: 'WorkerDeploymentRequests';
   byBrowser: Array<WorkerDeploymentRequestsBrowserEdge>;
+  byCacheStatus: Array<WorkerDeploymentRequestsCacheStatusEdge>;
   byContinent: Array<WorkerDeploymentRequestsContinentEdge>;
+  byMethod: Array<WorkerDeploymentRequestsMethodEdge>;
   byOS: Array<WorkerDeploymentRequestsOperatingSystemEdge>;
+  byStatusType: Array<WorkerDeploymentRequestsStatusTypeEdge>;
   interval: Scalars['Int']['output'];
   minRowsWithoutLimit: Scalars['Int']['output'];
   nodes: Array<WorkerDeploymentRequestNode>;
@@ -7601,9 +7605,21 @@ export type WorkerDeploymentRequestsBrowserEdge = {
   node: WorkerDeploymentRequestsAggregationNode;
 };
 
+export type WorkerDeploymentRequestsCacheStatusEdge = {
+  __typename?: 'WorkerDeploymentRequestsCacheStatusEdge';
+  cacheStatus?: Maybe<ResponseCacheStatus>;
+  node: WorkerDeploymentRequestsAggregationNode;
+};
+
 export type WorkerDeploymentRequestsContinentEdge = {
   __typename?: 'WorkerDeploymentRequestsContinentEdge';
   continent: ContinentCode;
+  node: WorkerDeploymentRequestsAggregationNode;
+};
+
+export type WorkerDeploymentRequestsMethodEdge = {
+  __typename?: 'WorkerDeploymentRequestsMethodEdge';
+  method: Scalars['String']['output'];
   node: WorkerDeploymentRequestsAggregationNode;
 };
 
@@ -7613,11 +7629,20 @@ export type WorkerDeploymentRequestsOperatingSystemEdge = {
   os?: Maybe<UserAgentOs>;
 };
 
+export type WorkerDeploymentRequestsStatusTypeEdge = {
+  __typename?: 'WorkerDeploymentRequestsStatusTypeEdge';
+  node: WorkerDeploymentRequestsAggregationNode;
+  statusType?: Maybe<ResponseStatusType>;
+};
+
 export type WorkerDeploymentRequestsTimeseriesEdge = {
   __typename?: 'WorkerDeploymentRequestsTimeseriesEdge';
   byBrowser: Array<WorkerDeploymentRequestsBrowserEdge>;
+  byCacheStatus: Array<WorkerDeploymentRequestsCacheStatusEdge>;
   byContinent: Array<WorkerDeploymentRequestsContinentEdge>;
+  byMethod: Array<WorkerDeploymentRequestsMethodEdge>;
   byOS: Array<WorkerDeploymentRequestsOperatingSystemEdge>;
+  byStatusType: Array<WorkerDeploymentRequestsStatusTypeEdge>;
   node?: Maybe<WorkerDeploymentRequestsAggregationNode>;
   timestamp: Scalars['DateTime']['output'];
 };

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1365,11 +1365,10 @@ export type App = Project & {
   workerDeployment?: Maybe<WorkerDeployment>;
   workerDeploymentAlias?: Maybe<WorkerDeploymentAlias>;
   workerDeploymentAliases: WorkerDeploymentAliasesConnection;
-  workerDeploymentRequest: WorkerDeploymentRequestEdge;
   workerDeployments: WorkerDeploymentsConnection;
   workerDeploymentsCrash: WorkerDeploymentCrashEdge;
   workerDeploymentsCrashes?: Maybe<WorkerDeploymentCrashes>;
-  workerDeploymentsMetrics?: Maybe<WorkerDeploymentMetrics>;
+  workerDeploymentsRequest: WorkerDeploymentRequestEdge;
   workerDeploymentsRequests?: Maybe<WorkerDeploymentRequests>;
 };
 
@@ -1609,12 +1608,6 @@ export type AppWorkerDeploymentAliasesArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
-export type AppWorkerDeploymentRequestArgs = {
-  requestId: Scalars['ID']['input'];
-};
-
-
-/** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -1638,16 +1631,14 @@ export type AppWorkerDeploymentsCrashesArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
-export type AppWorkerDeploymentsMetricsArgs = {
-  filters?: InputMaybe<MetricsFilters>;
-  timespan: MetricsTimespan;
+export type AppWorkerDeploymentsRequestArgs = {
+  requestKey: Scalars['ID']['input'];
 };
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWorkerDeploymentsRequestsArgs = {
-  filter?: InputMaybe<WorkerDeploymentRequestsFilter>;
-  limit?: Scalars['Int']['input'];
+  filters?: InputMaybe<RequestsFilters>;
   timespan: RequestsTimespan;
 };
 
@@ -5107,47 +5098,6 @@ export type MeteredBillingStatus = {
   EAS_UPDATE: Scalars['Boolean']['output'];
 };
 
-export enum MetricsCacheStatus {
-  Hit = 'HIT',
-  Miss = 'MISS',
-  Pass = 'PASS'
-}
-
-export type MetricsFilters = {
-  cacheStatus?: InputMaybe<Array<MetricsCacheStatus>>;
-  continent?: InputMaybe<Array<ContinentCode>>;
-  hasCustomDomainOrigin?: InputMaybe<Scalars['Boolean']['input']>;
-  isAsset?: InputMaybe<Scalars['Boolean']['input']>;
-  isCrash?: InputMaybe<Scalars['Boolean']['input']>;
-  isVerifiedBot?: InputMaybe<Scalars['Boolean']['input']>;
-  method?: InputMaybe<Array<MetricsRequestMethod>>;
-  os?: InputMaybe<Array<UserAgentOs>>;
-  pathname?: InputMaybe<Scalars['String']['input']>;
-  status?: InputMaybe<Array<Scalars['Int']['input']>>;
-  statusType?: InputMaybe<Array<MetricsStatusType>>;
-};
-
-export enum MetricsRequestMethod {
-  Delete = 'DELETE',
-  Get = 'GET',
-  Options = 'OPTIONS',
-  Post = 'POST',
-  Put = 'PUT'
-}
-
-export enum MetricsStatusType {
-  ClientError = 'CLIENT_ERROR',
-  None = 'NONE',
-  Redirect = 'REDIRECT',
-  ServerError = 'SERVER_ERROR',
-  Successful = 'SUCCESSFUL'
-}
-
-export type MetricsTimespan = {
-  end: Scalars['DateTime']['input'];
-  start: Scalars['DateTime']['input'];
-};
-
 export type Notification = {
   __typename?: 'Notification';
   accountName: Scalars['String']['output'];
@@ -5382,16 +5332,34 @@ export type PublishUpdateGroupInput = {
   updateInfoGroup?: InputMaybe<UpdateInfoGroup>;
 };
 
-export enum RequestStatusPattern {
-  Http_2Xx = 'HTTP_2XX',
-  Http_3Xx = 'HTTP_3XX',
-  Http_4Xx = 'HTTP_4XX',
-  Http_5Xx = 'HTTP_5XX'
+export enum RequestMethod {
+  Delete = 'DELETE',
+  Get = 'GET',
+  Head = 'HEAD',
+  Options = 'OPTIONS',
+  Patch = 'PATCH',
+  Post = 'POST',
+  Put = 'PUT'
 }
+
+export type RequestsFilters = {
+  cacheStatus?: InputMaybe<Array<ResponseCacheStatus>>;
+  continent?: InputMaybe<Array<ContinentCode>>;
+  hasCustomDomainOrigin?: InputMaybe<Scalars['Boolean']['input']>;
+  isAsset?: InputMaybe<Scalars['Boolean']['input']>;
+  isCrash?: InputMaybe<Scalars['Boolean']['input']>;
+  isVerifiedBot?: InputMaybe<Scalars['Boolean']['input']>;
+  method?: InputMaybe<Array<RequestMethod>>;
+  os?: InputMaybe<Array<UserAgentOs>>;
+  pathname?: InputMaybe<Scalars['String']['input']>;
+  responseType?: InputMaybe<Array<ResponseType>>;
+  status?: InputMaybe<Array<Scalars['Int']['input']>>;
+  statusType?: InputMaybe<Array<ResponseStatusType>>;
+};
 
 export type RequestsTimespan = {
   end: Scalars['DateTime']['input'];
-  start?: InputMaybe<Scalars['DateTime']['input']>;
+  start: Scalars['DateTime']['input'];
 };
 
 export type RescindUserInvitationResult = {
@@ -5402,6 +5370,27 @@ export type RescindUserInvitationResult = {
 export enum ResourceClassExperiment {
   C3D = 'C3D',
   N2 = 'N2'
+}
+
+export enum ResponseCacheStatus {
+  Hit = 'HIT',
+  Miss = 'MISS',
+  Pass = 'PASS'
+}
+
+export enum ResponseStatusType {
+  ClientError = 'CLIENT_ERROR',
+  None = 'NONE',
+  Redirect = 'REDIRECT',
+  ServerError = 'SERVER_ERROR',
+  Successful = 'SUCCESSFUL'
+}
+
+export enum ResponseType {
+  Asset = 'ASSET',
+  Crash = 'CRASH',
+  Rejected = 'REJECTED',
+  Route = 'ROUTE'
 }
 
 /** Represents a robot (not human) actor. */
@@ -6362,6 +6351,7 @@ export type Update = ActivityTimelineProjectActivity & {
   branchId: Scalars['ID']['output'];
   codeSigningInfo?: Maybe<CodeSigningInfo>;
   createdAt: Scalars['DateTime']['output'];
+  deploymentsPaginated: UpdateDeploymentsConnection;
   expoGoSDKVersion?: Maybe<Scalars['String']['output']>;
   gitCommitHash?: Maybe<Scalars['String']['output']>;
   group: Scalars['String']['output'];
@@ -6381,6 +6371,14 @@ export type Update = ActivityTimelineProjectActivity & {
   /** @deprecated Use 'runtime' field . */
   runtimeVersion: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];
+};
+
+
+export type UpdateDeploymentsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type UpdateBranch = {
@@ -6510,6 +6508,18 @@ export type UpdateChannelMutationDeleteUpdateChannelArgs = {
 export type UpdateChannelMutationEditUpdateChannelArgs = {
   branchMapping: Scalars['String']['input'];
   channelId: Scalars['ID']['input'];
+};
+
+export type UpdateDeploymentEdge = {
+  __typename?: 'UpdateDeploymentEdge';
+  cursor: Scalars['String']['output'];
+  node: Deployment;
+};
+
+export type UpdateDeploymentsConnection = {
+  __typename?: 'UpdateDeploymentsConnection';
+  edges: Array<UpdateDeploymentEdge>;
+  pageInfo: PageInfo;
 };
 
 export type UpdateGitHubBuildTriggerInput = {
@@ -7384,7 +7394,7 @@ export type WorkerDeployment = {
   devDomainName: Scalars['DevDomainName']['output'];
   id: Scalars['ID']['output'];
   logs?: Maybe<WorkerDeploymentLogs>;
-  metrics?: Maybe<WorkerDeploymentMetrics>;
+  requests?: Maybe<WorkerDeploymentRequests>;
   subdomain: Scalars['String']['output'];
   url: Scalars['String']['output'];
 };
@@ -7396,9 +7406,9 @@ export type WorkerDeploymentLogsArgs = {
 };
 
 
-export type WorkerDeploymentMetricsArgs = {
-  filters?: InputMaybe<MetricsFilters>;
-  timespan: MetricsTimespan;
+export type WorkerDeploymentRequestsArgs = {
+  filters?: InputMaybe<RequestsFilters>;
+  timespan: RequestsTimespan;
 };
 
 export type WorkerDeploymentAlias = {
@@ -7486,30 +7496,66 @@ export type WorkerDeploymentLogs = {
   nodes: Array<WorkerDeploymentLogNode>;
 };
 
-export type WorkerDeploymentMetrics = {
-  __typename?: 'WorkerDeploymentMetrics';
-  byBrowser: Array<WorkerDeploymentMetricsBrowserEdge>;
-  byContinent: Array<WorkerDeploymentMetricsContinentEdge>;
-  byOS: Array<WorkerDeploymentMetricsOperatingSystemEdge>;
+export type WorkerDeploymentQuery = {
+  __typename?: 'WorkerDeploymentQuery';
+  byId: WorkerDeployment;
+};
+
+
+export type WorkerDeploymentQueryByIdArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type WorkerDeploymentRequestEdge = {
+  __typename?: 'WorkerDeploymentRequestEdge';
+  crash?: Maybe<WorkerDeploymentCrashSample>;
+  logs: Array<WorkerDeploymentLogNode>;
+  node: WorkerDeploymentRequestNode;
+};
+
+export type WorkerDeploymentRequestNode = {
+  __typename?: 'WorkerDeploymentRequestNode';
+  browserKind?: Maybe<UserAgentBrowser>;
+  browserVersion?: Maybe<Scalars['String']['output']>;
+  cacheStatus?: Maybe<ResponseCacheStatus>;
+  continent?: Maybe<ContinentCode>;
+  country?: Maybe<Scalars['String']['output']>;
+  deploymentIdentifier: Scalars['String']['output'];
+  duration: Scalars['Int']['output'];
+  hasCustomDomainOrigin: Scalars['Boolean']['output'];
+  isAsset: Scalars['Boolean']['output'];
+  isCrash: Scalars['Boolean']['output'];
+  isRejected: Scalars['Boolean']['output'];
+  isStaleIfError: Scalars['Boolean']['output'];
+  isStaleWhileRevalidate: Scalars['Boolean']['output'];
+  isVerifiedBot: Scalars['Boolean']['output'];
+  key: Scalars['ID']['output'];
+  method: Scalars['String']['output'];
+  os?: Maybe<UserAgentOs>;
+  pathname: Scalars['String']['output'];
+  region?: Maybe<Scalars['String']['output']>;
+  requestTimestamp: Scalars['DateTime']['output'];
+  responseType: ResponseType;
+  scriptName: Scalars['String']['output'];
+  search?: Maybe<Scalars['String']['output']>;
+  status: Scalars['Int']['output'];
+  statusType?: Maybe<ResponseStatusType>;
+};
+
+export type WorkerDeploymentRequests = {
+  __typename?: 'WorkerDeploymentRequests';
+  byBrowser: Array<WorkerDeploymentRequestsBrowserEdge>;
+  byContinent: Array<WorkerDeploymentRequestsContinentEdge>;
+  byOS: Array<WorkerDeploymentRequestsOperatingSystemEdge>;
   interval: Scalars['Int']['output'];
-  summary: WorkerDeploymentMetricsNode;
-  timeseries: Array<WorkerDeploymentMetricsTimeseriesEdge>;
+  minRowsWithoutLimit: Scalars['Int']['output'];
+  nodes: Array<WorkerDeploymentRequestNode>;
+  summary: WorkerDeploymentRequestsAggregationNode;
+  timeseries: Array<WorkerDeploymentRequestsTimeseriesEdge>;
 };
 
-export type WorkerDeploymentMetricsBrowserEdge = {
-  __typename?: 'WorkerDeploymentMetricsBrowserEdge';
-  browser?: Maybe<UserAgentBrowser>;
-  node: WorkerDeploymentMetricsNode;
-};
-
-export type WorkerDeploymentMetricsContinentEdge = {
-  __typename?: 'WorkerDeploymentMetricsContinentEdge';
-  continent: ContinentCode;
-  node: WorkerDeploymentMetricsNode;
-};
-
-export type WorkerDeploymentMetricsNode = {
-  __typename?: 'WorkerDeploymentMetricsNode';
+export type WorkerDeploymentRequestsAggregationNode = {
+  __typename?: 'WorkerDeploymentRequestsAggregationNode';
   assetsPerMs?: Maybe<Scalars['Float']['output']>;
   assetsSum: Scalars['Int']['output'];
   cacheHitRatio: Scalars['Float']['output'];
@@ -7549,90 +7595,32 @@ export type WorkerDeploymentMetricsNode = {
   staleWhileRevalidateSum: Scalars['Int']['output'];
 };
 
-export type WorkerDeploymentMetricsOperatingSystemEdge = {
-  __typename?: 'WorkerDeploymentMetricsOperatingSystemEdge';
-  node: WorkerDeploymentMetricsNode;
-  os?: Maybe<UserAgentOs>;
-};
-
-export type WorkerDeploymentMetricsTimeseriesEdge = {
-  __typename?: 'WorkerDeploymentMetricsTimeseriesEdge';
-  byBrowser: Array<WorkerDeploymentMetricsBrowserEdge>;
-  byContinent: Array<WorkerDeploymentMetricsContinentEdge>;
-  byOS: Array<WorkerDeploymentMetricsOperatingSystemEdge>;
-  node?: Maybe<WorkerDeploymentMetricsNode>;
-  timestamp: Scalars['DateTime']['output'];
-};
-
-export type WorkerDeploymentQuery = {
-  __typename?: 'WorkerDeploymentQuery';
-  byId: WorkerDeployment;
-};
-
-
-export type WorkerDeploymentQueryByIdArgs = {
-  id: Scalars['ID']['input'];
-};
-
-export type WorkerDeploymentRequestEdge = {
-  __typename?: 'WorkerDeploymentRequestEdge';
-  crash?: Maybe<WorkerDeploymentCrashSample>;
-  logs: Array<WorkerDeploymentLogNode>;
-  node: WorkerDeploymentRequestNode;
-};
-
-export enum WorkerDeploymentRequestKind {
-  Asset = 'ASSET',
-  Crash = 'CRASH',
-  Rejected = 'REJECTED'
-}
-
-export type WorkerDeploymentRequestLocation = {
-  __typename?: 'WorkerDeploymentRequestLocation';
-  continent?: Maybe<ContinentCode>;
-  countryCode?: Maybe<Scalars['String']['output']>;
-  regionCode?: Maybe<Scalars['String']['output']>;
-};
-
-export type WorkerDeploymentRequestNode = {
-  __typename?: 'WorkerDeploymentRequestNode';
+export type WorkerDeploymentRequestsBrowserEdge = {
+  __typename?: 'WorkerDeploymentRequestsBrowserEdge';
   browser?: Maybe<UserAgentBrowser>;
-  browserVersion?: Maybe<Scalars['String']['output']>;
-  deploymentIdentifier: Scalars['String']['output'];
-  hasCustomDomainOrigin: Scalars['Boolean']['output'];
-  id: Scalars['ID']['output'];
-  isVerifiedBot: Scalars['Boolean']['output'];
-  kind?: Maybe<WorkerDeploymentRequestKind>;
-  location?: Maybe<WorkerDeploymentRequestLocation>;
-  method: Scalars['String']['output'];
+  node: WorkerDeploymentRequestsAggregationNode;
+};
+
+export type WorkerDeploymentRequestsContinentEdge = {
+  __typename?: 'WorkerDeploymentRequestsContinentEdge';
+  continent: ContinentCode;
+  node: WorkerDeploymentRequestsAggregationNode;
+};
+
+export type WorkerDeploymentRequestsOperatingSystemEdge = {
+  __typename?: 'WorkerDeploymentRequestsOperatingSystemEdge';
+  node: WorkerDeploymentRequestsAggregationNode;
   os?: Maybe<UserAgentOs>;
-  pathname: Scalars['String']['output'];
-  scriptName: Scalars['String']['output'];
-  search?: Maybe<Scalars['String']['output']>;
-  status: Scalars['Int']['output'];
+};
+
+export type WorkerDeploymentRequestsTimeseriesEdge = {
+  __typename?: 'WorkerDeploymentRequestsTimeseriesEdge';
+  byBrowser: Array<WorkerDeploymentRequestsBrowserEdge>;
+  byContinent: Array<WorkerDeploymentRequestsContinentEdge>;
+  byOS: Array<WorkerDeploymentRequestsOperatingSystemEdge>;
+  node?: Maybe<WorkerDeploymentRequestsAggregationNode>;
   timestamp: Scalars['DateTime']['output'];
-  wallTime: Scalars['Int']['output'];
 };
-
-export type WorkerDeploymentRequests = {
-  __typename?: 'WorkerDeploymentRequests';
-  minRowsWithoutLimit?: Maybe<Scalars['Int']['output']>;
-  nodes: Array<WorkerDeploymentRequestNode>;
-};
-
-export type WorkerDeploymentRequestsFilter = {
-  include?: InputMaybe<WorkerDeploymentRequestsInclude>;
-  includeBotRequests?: InputMaybe<Scalars['Boolean']['input']>;
-  methods?: InputMaybe<Array<Scalars['String']['input']>>;
-  pathname?: InputMaybe<Scalars['String']['input']>;
-  statusCodes?: InputMaybe<Array<Scalars['Int']['input']>>;
-  statusPatterns?: InputMaybe<Array<RequestStatusPattern>>;
-};
-
-export enum WorkerDeploymentRequestsInclude {
-  Assets = 'ASSETS',
-  Routes = 'ROUTES'
-}
 
 export type WorkerDeploymentsConnection = {
   __typename?: 'WorkerDeploymentsConnection';
@@ -8705,6 +8693,8 @@ export type CommonIosAppCredentialsFragment = { __typename?: 'IosAppCredentials'
 
 export type WorkerDeploymentFragment = { __typename?: 'WorkerDeployment', id: string, url: string, deploymentIdentifier: any, deploymentDomain: string, createdAt: any };
 
+export type WorkerDeploymentAliasFragment = { __typename?: 'WorkerDeploymentAlias', id: string, aliasName?: any | null, url: string };
+
 export type CreateDeploymentUrlMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
   deploymentIdentifier?: InputMaybe<Scalars['ID']['input']>;
@@ -8724,11 +8714,11 @@ export type AssignDevDomainNameMutation = { __typename?: 'RootMutation', devDoma
 export type AssignAliasMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
   deploymentId: Scalars['ID']['input'];
-  aliasName: Scalars['WorkerDeploymentIdentifier']['input'];
+  aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
 }>;
 
 
-export type AssignAliasMutation = { __typename?: 'RootMutation', deployments: { __typename?: 'DeploymentsMutation', assignAlias: { __typename?: 'WorkerDeploymentAlias', id: string, aliasName?: any | null, url: string } } };
+export type AssignAliasMutation = { __typename?: 'RootMutation', deployments: { __typename?: 'DeploymentsMutation', assignAlias: { __typename?: 'WorkerDeploymentAlias', id: string, aliasName?: any | null, url: string, workerDeployment: { __typename?: 'WorkerDeployment', id: string, url: string, deploymentIdentifier: any, deploymentDomain: string, createdAt: any } } } };
 
 export type PaginatedWorkerDeploymentsQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -8739,4 +8729,4 @@ export type PaginatedWorkerDeploymentsQueryVariables = Exact<{
 }>;
 
 
-export type PaginatedWorkerDeploymentsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', workerDeployments: { __typename?: 'WorkerDeploymentsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ __typename?: 'WorkerDeploymentEdge', cursor: string, node: { __typename?: 'WorkerDeployment', id: string, url: string, deploymentIdentifier: any, deploymentDomain: string, createdAt: any } }> } } } };
+export type PaginatedWorkerDeploymentsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, workerDeployments: { __typename?: 'WorkerDeploymentsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ __typename?: 'WorkerDeploymentEdge', cursor: string, node: { __typename?: 'WorkerDeployment', id: string, url: string, deploymentIdentifier: any, deploymentDomain: string, createdAt: any } }> } } } };

--- a/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchNameFromChannelNameAsync-test.ts
@@ -1,7 +1,14 @@
 import { instance, mock } from 'ts-mockito';
 
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
-import { App, Runtime, UpdateBranch, UpdateChannel, UpdateInsights } from '../../graphql/generated';
+import {
+  App,
+  Runtime,
+  UpdateBranch,
+  UpdateChannel,
+  UpdateDeploymentsConnection,
+  UpdateInsights,
+} from '../../graphql/generated';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
 import { getBranchNameFromChannelNameAsync } from '../getBranchNameFromChannelNameAsync';
 
@@ -127,6 +134,7 @@ function mockUpdateBranches(branchNames: string[]): UpdateBranch[] {
           runtimeVersion: '1.0.0',
           runtime: {} as Runtime, // Temporary fix to resolve type errors
           insights: {} as UpdateInsights, // Temporary fix to resolve type errors
+          deployments: {} as UpdateDeploymentsConnection, // Temporary fix to resolve type errors
           platform: 'ios',
           manifestFragment: '...',
           isRollBackToEmbedded: false,

--- a/packages/eas-cli/src/worker/fragments/WorkerDeploymentAlias.ts
+++ b/packages/eas-cli/src/worker/fragments/WorkerDeploymentAlias.ts
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag';
+
+export const WorkerDeploymentAliasFragmentNode = gql`
+  fragment WorkerDeploymentAliasFragment on WorkerDeploymentAlias {
+    id
+    aliasName
+    url
+  }
+`;

--- a/packages/eas-cli/src/worker/mutations.ts
+++ b/packages/eas-cli/src/worker/mutations.ts
@@ -1,6 +1,9 @@
 import assert from 'assert';
+import { print } from 'graphql';
 import gql from 'graphql-tag';
 
+import { WorkerDeploymentFragmentNode } from './fragments/WorkerDeployment';
+import { WorkerDeploymentAliasFragmentNode } from './fragments/WorkerDeploymentAlias';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../graphql/client';
 import {
@@ -91,11 +94,17 @@ export const DeploymentsMutation = {
                   aliasName: $aliasName
                 ) {
                   id
-                  aliasName
-                  url
+                  ...WorkerDeploymentAliasFragment
+                  workerDeployment {
+                    id
+                    ...WorkerDeploymentFragment
+                  }
                 }
               }
             }
+
+            ${print(WorkerDeploymentFragmentNode)}
+            ${print(WorkerDeploymentAliasFragmentNode)}
           `,
           aliasVariables
         )

--- a/packages/eas-cli/src/worker/utils/logs.ts
+++ b/packages/eas-cli/src/worker/utils/logs.ts
@@ -1,0 +1,82 @@
+import chalk from 'chalk';
+
+import type {
+  WorkerDeploymentAliasFragment,
+  WorkerDeploymentFragment,
+} from '../../graphql/generated';
+import formatFields, { type FormatFieldsItem } from '../../utils/formatFields';
+
+const EXPO_BASE_DOMAIN = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';
+
+export function getDeploymentUrlFromFullName(deploymentFullName: string): string {
+  return `https://${deploymentFullName}.${EXPO_BASE_DOMAIN}.app`;
+}
+
+export function getDashboardUrl(projectId: string): string {
+  return `https://${EXPO_BASE_DOMAIN}.dev/projects/${projectId}/serverless/deployments`;
+}
+
+type WorkerDeploymentData = {
+  /** Used to generate the dashboard URL to `expo.dev` */
+  projectId: string;
+  /** The actual deployment information */
+  deployment: Pick<WorkerDeploymentFragment, 'deploymentIdentifier' | 'url'>;
+  /** All modified aliases of the deployment, if any */
+  aliases?: WorkerDeploymentAliasFragment[];
+  /** The production promoting alias of the deployment, if any */
+  production?: WorkerDeploymentAliasFragment | null;
+};
+
+export function formatWorkerDeploymentTable(data: WorkerDeploymentData): string {
+  const fields: FormatFieldsItem[] = [
+    { label: 'Dashboard', value: getDashboardUrl(data.projectId) },
+    { label: 'Deployment URL', value: data.deployment.url },
+  ];
+
+  if (data.aliases?.length) {
+    fields.push({ label: 'Alias URL', value: data.aliases[0].url });
+  }
+  if (data.production) {
+    fields.push({ label: 'Production URL', value: data.production.url });
+  }
+
+  const lastUrlField = fields[fields.length - 1];
+  lastUrlField.value = chalk.cyan(lastUrlField.value);
+
+  return formatFields(fields);
+}
+
+type WorkerDeploymentOutput = {
+  /** The absolute URL to the dashboard on `expo.dev` */
+  dashboardUrl: string;
+  /** The deployment information */
+  deployment: {
+    identifier: string;
+    url: string;
+    aliases?: { id: string; name: string; url: string }[];
+    production?: { id: string; url: string };
+  };
+};
+
+export function formatWorkerDeploymentJson(data: WorkerDeploymentData): WorkerDeploymentOutput {
+  return {
+    dashboardUrl: getDashboardUrl(data.projectId),
+    deployment: {
+      identifier: data.deployment.deploymentIdentifier,
+      url: data.deployment.url,
+      aliases: !data.aliases?.length
+        ? undefined
+        : data.aliases.map(alias => ({
+            id: alias.id,
+            name: alias.aliasName,
+            url: alias.url,
+          })),
+      production: !data.production
+        ? undefined
+        : {
+            id: data.production.id,
+            url: data.production.url,
+          },
+    },
+  };
+}

--- a/packages/eas-cli/src/worker/utils/logs.ts
+++ b/packages/eas-cli/src/worker/utils/logs.ts
@@ -13,7 +13,7 @@ export function getDeploymentUrlFromFullName(deploymentFullName: string): string
 }
 
 export function getDashboardUrl(projectId: string): string {
-  return `https://${EXPO_BASE_DOMAIN}.dev/projects/${projectId}/serverless/deployments`;
+  return `https://${EXPO_BASE_DOMAIN}.dev/projects/${projectId}/hosting/deployments`;
 }
 
 type WorkerDeploymentData = {


### PR DESCRIPTION
# Why

This adds `worker:alias --prod` and supports `worker:promote --prod` (we can document either one) to promote existing deployments to production. We could split the command later, if people ask for this use case a lot.

# How

- Added `--prod(uction)` to `worker:alias`
- Added `worker:promote` alias of `worker:alias`
- Pulled both table and json output format into `src/worker/utils/logs.ts`
- Re-implemented table/json output in both `worker` and `worker:alias`
- Updated the dashboard URL from `serverless` to `hosting`

# Test Plan

- `$ eas worker`
- `$ eas worker:alias --id <deployment> --alias test-alias`
- `$ eas worker:alias --id <deployment> --alias test-alias --json --non-interactive | jq`
- `$ eas worker:promote --prod --id <deployment> --json --non-interactive | jq`
