### PR TITLE
refactor(eas-cli): polish the dev domain prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Support `worker --production` and clean up command output. ([#2555](https://github.com/expo/eas-cli/pull/2555) by [@byCedric](https://github.com/byCedric)))
 - Unify both `worker` and `worker:alias` command output. ([#2558](https://github.com/expo/eas-cli/pull/2558) by [@byCedric](https://github.com/byCedric)))
 - Share similar table/json output in both `worker` and `worker:alias` command outputs. ([#2563](https://github.com/expo/eas-cli/pull/2563) by [@byCedric](https://github.com/byCedric)))
+- Polish the project URL prompt when setting up new projects. ([#2564](https://github.com/expo/eas-cli/pull/2564) by [@byCedric](https://github.com/byCedric)))
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -9765,6 +9765,22 @@
             "deprecationReason": null
           },
           {
+            "name": "suggestedDevDomainName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "timelineActivity",
             "description": "Coalesced project activity for an app using pagination",
             "args": [
@@ -51198,6 +51214,18 @@
                 "name": "ID",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiatingActor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Actor",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -260,12 +260,12 @@ export default class WorkerDeploy extends EasCommand {
         })
       );
 
-      // NOTE(cedric): this function might ask the user for a dev-domain name,
-      // when that happens, no ora spinner should be running.
-      progress.stop();
-      const uploadUrl = await getSignedDeploymentUrlAsync(graphqlClient, exp, {
+      const uploadUrl = await getSignedDeploymentUrlAsync(graphqlClient, {
         appId: projectId,
         deploymentIdentifier: flags.deploymentIdentifier,
+        // NOTE(cedric): this function might ask the user for a dev-domain name,
+        // when that happens, no ora spinner should be running.
+        onSetupDevDomain: () => progress.stop(),
       });
 
       progress.start('Creating deployment');

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1333,6 +1333,7 @@ export type App = Project & {
   /** EAS Submissions associated with this app */
   submissions: Array<Submission>;
   submissionsPaginated: AppSubmissionsConnection;
+  suggestedDevDomainName: Scalars['String']['output'];
   /** Coalesced project activity for an app using pagination */
   timelineActivity: TimelineActivityConnection;
   /** @deprecated 'likes' have been deprecated. */
@@ -7394,6 +7395,7 @@ export type WorkerDeployment = {
   deploymentIdentifier: Scalars['WorkerDeploymentIdentifier']['output'];
   devDomainName: Scalars['DevDomainName']['output'];
   id: Scalars['ID']['output'];
+  initiatingActor?: Maybe<Actor>;
   logs?: Maybe<WorkerDeploymentLogs>;
   requests?: Maybe<WorkerDeploymentRequests>;
   subdomain: Scalars['String']['output'];
@@ -8755,3 +8757,10 @@ export type PaginatedWorkerDeploymentsQueryVariables = Exact<{
 
 
 export type PaginatedWorkerDeploymentsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, workerDeployments: { __typename?: 'WorkerDeploymentsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ __typename?: 'WorkerDeploymentEdge', cursor: string, node: { __typename?: 'WorkerDeployment', id: string, url: string, deploymentIdentifier: any, deploymentDomain: string, createdAt: any } }> } } } };
+
+export type SuggestedDevDomainNameQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+}>;
+
+
+export type SuggestedDevDomainNameQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, suggestedDevDomainName: string } } };

--- a/packages/eas-cli/src/worker/deployment.ts
+++ b/packages/eas-cli/src/worker/deployment.ts
@@ -139,7 +139,7 @@ async function chooseDevDomainNameAsync({
     );
 
     if (isChosenNameTaken) {
-      Log.error(`The entered project URL "${name}" is already taken, choose a different name.`);
+      Log.error(`The project URL "${name}" is already taken, choose a different name.`);
       await chooseDevDomainNameAsync({ graphqlClient, appId, slug });
     }
 

--- a/packages/eas-cli/src/worker/queries.ts
+++ b/packages/eas-cli/src/worker/queries.ts
@@ -4,10 +4,12 @@ import gql from 'graphql-tag';
 import { WorkerDeploymentFragmentNode } from './fragments/WorkerDeployment';
 import type { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../graphql/client';
-import type {
-  PaginatedWorkerDeploymentsQuery,
-  PaginatedWorkerDeploymentsQueryVariables,
-  WorkerDeploymentFragment,
+import {
+  type PaginatedWorkerDeploymentsQuery,
+  type PaginatedWorkerDeploymentsQueryVariables,
+  SuggestedDevDomainNameQuery,
+  SuggestedDevDomainNameQueryVariables,
+  type WorkerDeploymentFragment,
 } from '../graphql/generated';
 import type { Connection } from '../utils/relay';
 
@@ -57,5 +59,31 @@ export const DeploymentsQuery = {
     );
 
     return data.app.byId.workerDeployments;
+  },
+
+  async getSuggestedDevDomainByAppIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { appId }: SuggestedDevDomainNameQueryVariables
+  ): Promise<string> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<SuggestedDevDomainNameQuery, SuggestedDevDomainNameQueryVariables>(
+          gql`
+            query SuggestedDevDomainName($appId: String!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  suggestedDevDomainName
+                }
+              }
+            }
+          `,
+          { appId },
+          { additionalTypenames: ['App'] }
+        )
+        .toPromise()
+    );
+
+    return data.app.byId.suggestedDevDomainName;
   },
 };

--- a/packages/eas-cli/src/worker/utils/logs.ts
+++ b/packages/eas-cli/src/worker/utils/logs.ts
@@ -6,7 +6,7 @@ import type {
 } from '../../graphql/generated';
 import formatFields, { type FormatFieldsItem } from '../../utils/formatFields';
 
-const EXPO_BASE_DOMAIN = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';
+export const EXPO_BASE_DOMAIN = process.env.EXPO_STAGING ? 'staging.expo' : 'expo';
 
 export function getDeploymentUrlFromFullName(deploymentFullName: string): string {
   return `https://${deploymentFullName}.${EXPO_BASE_DOMAIN}.app`;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

In early user testing it showed that "dev domain" is too ambiguous. Just polished the prompt to make it more clear what it is, and what's allowed.

# How

- Added `.(staging.)expo.app` suffix to show the base URL
- Renamed `dev domain` to `project URL`
- Updated validation messages

# Test Plan

https://github.com/user-attachments/assets/eda37e7c-d0f4-47be-9553-edcb46f6eb16

