### PR TITLE
refactor(eas-cli): always default to static uploads and add modified time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Support `worker --production` and clean up command output. ([#2555](https://github.com/expo/eas-cli/pull/2555) by [@byCedric](https://github.com/byCedric)))
 - Unify both `worker` and `worker:alias` command output. ([#2558](https://github.com/expo/eas-cli/pull/2558) by [@byCedric](https://github.com/byCedric)))
 - Share similar table/json output in both `worker` and `worker:alias` command outputs. ([#2563](https://github.com/expo/eas-cli/pull/2563) by [@byCedric](https://github.com/byCedric)))
+- Always assume `static` exports in `eas deploy` and add modified time. ([#2565](https://github.com/expo/eas-cli/pull/2565) by [@byCedric](https://github.com/byCedric)))
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/packages/eas-cli/src/commands/worker/alias.ts
+++ b/packages/eas-cli/src/commands/worker/alias.ts
@@ -227,5 +227,11 @@ async function resolveDeploymentIdAsync({
     selectTitle: chalk`deployment to assign the {underline ${aliasName}} alias`,
   });
 
-  return deployment?.deploymentIdentifier;
+  if (!deployment) {
+    throw new Error(
+      'No deployments found for this project, create a new deployment with "eas deploy"'
+    );
+  }
+
+  return deployment.deploymentIdentifier;
 }

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -145,7 +145,10 @@ export default class WorkerDeploy extends EasCommand {
       if (response.status === 413) {
         throw new Error(
           'Upload failed! (Payload too large)\n' +
-            `The files in "${path.relative(projectDir, projectDist.path)}" (at: ${projectDir}) exceed the maximum file size (10MB gzip).`
+            `The files in "${path.relative(
+              projectDir,
+              projectDist.path
+            )}" (at: ${projectDir}) exceed the maximum file size (10MB gzip).`
         );
       } else if (!response.ok) {
         throw new Error(`Upload failed! (${response.statusText})`);
@@ -376,7 +379,9 @@ async function resolveExportedProjectAsync(
   return { type: 'static', path: exportPath, modifiedAt };
 }
 
-function logExportedProjectInfo(project: Awaited<ReturnType<typeof resolveExportedProjectAsync>>): void {
+function logExportedProjectInfo(
+  project: Awaited<ReturnType<typeof resolveExportedProjectAsync>>
+): void {
   const modifiedAgo = formatTimeAgo(project.modifiedAt);
   Log.log(chalk`{dim > Project export: ${project.type} - created ${modifiedAgo}}`);
 }

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -112,7 +112,7 @@ export default class WorkerDeploy extends EasCommand {
       projectDir,
     } = await this.getContextAsync(WorkerDeploy, flags);
 
-    const [{ projectId, exp }, projectDist] = await Promise.all([
+    const [{ projectId }, projectDist] = await Promise.all([
       getDynamicPrivateProjectConfigAsync(),
       resolveExportedProjectAsync(flags, projectDir),
     ]);

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -1,3 +1,4 @@
+import { format as formatTimeAgo } from '@expo/timeago.js';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 import fs from 'node:fs';
@@ -111,40 +112,12 @@ export default class WorkerDeploy extends EasCommand {
       projectDir,
     } = await this.getContextAsync(WorkerDeploy, flags);
 
-    const { projectId, exp } = await getDynamicPrivateProjectConfigAsync();
-    const distPath = path.join(projectDir, flags.exportDir);
+    const [{ projectId, exp }, projectDist] = await Promise.all([
+      getDynamicPrivateProjectConfigAsync(),
+      resolveExportedProjectAsync(flags, projectDir),
+    ]);
 
-    let distServerPath: string | null;
-    let distClientPath: string;
-    if (exp.web?.output === 'static') {
-      distClientPath = distPath;
-      distServerPath = null;
-      if (!(await isDirectory(distClientPath))) {
-        throw new Error(
-          `No "${flags.exportDir}/" folder found. Prepare your project for deployment with "npx expo export"`
-        );
-      }
-
-      logDeploymentType('static');
-    } else if (exp.web?.output === 'server') {
-      distClientPath = path.join(distPath, 'client');
-      distServerPath = path.join(distPath, 'server');
-      if (!(await isDirectory(distClientPath))) {
-        throw new Error(
-          `No "${flags.exportDir}/client/" folder found. Prepare your project for deployment with "npx expo export"`
-        );
-      } else if (!(await isDirectory(distServerPath))) {
-        throw new Error(
-          `No "${flags.exportDir}/server/" folder found. Prepare your project for deployment with "npx expo export"`
-        );
-      }
-
-      logDeploymentType('server');
-    } else {
-      throw new Error(
-        `Single-page apps are not supported. Ensure that app.json key "expo.web.output" is set to "server" or "static".`
-      );
-    }
+    logExportedProjectInfo(projectDist);
 
     async function* emitWorkerTarballAsync(params: {
       assetMap: WorkerAssets.AssetMap;
@@ -152,8 +125,8 @@ export default class WorkerDeploy extends EasCommand {
     }): AsyncGenerator<WorkerAssets.FileEntry> {
       yield ['assets.json', JSON.stringify(params.assetMap)];
       yield ['manifest.json', JSON.stringify(params.manifest)];
-      if (distServerPath) {
-        const workerFiles = WorkerAssets.listWorkerFilesAsync(distServerPath);
+      if (projectDist.type === 'server' && projectDist.serverPath) {
+        const workerFiles = WorkerAssets.listWorkerFilesAsync(projectDist.serverPath);
         for await (const workerFile of workerFiles) {
           yield [`server/${workerFile.normalizedPath}`, workerFile.data];
         }
@@ -172,7 +145,7 @@ export default class WorkerDeploy extends EasCommand {
       if (response.status === 413) {
         throw new Error(
           'Upload failed! (Payload too large)\n' +
-            `The files in "dist/server/" (at: ${distServerPath}) exceed the maximum file size (10MB gzip).`
+            `The files in "${path.relative(projectDir, projectDist.path)}" (at: ${projectDir}) exceed the maximum file size (10MB gzip).`
         );
       } else if (!response.ok) {
         throw new Error(`Upload failed! (${response.statusText})`);
@@ -195,7 +168,8 @@ export default class WorkerDeploy extends EasCommand {
 
       // TODO(@kitten): Batch and upload multiple files in parallel
       const uploadParams: UploadParams[] = [];
-      for await (const asset of WorkerAssets.listAssetMapFilesAsync(distClientPath, assetMap)) {
+      const assetPath = projectDist.type === 'server' ? projectDist.clientPath : projectDist.path;
+      for await (const asset of WorkerAssets.listAssetMapFilesAsync(assetPath, assetMap)) {
         const uploadURL = uploads[asset.normalizedPath];
         if (uploadURL) {
           uploadParams.push({ url: uploadURL, filePath: asset.path });
@@ -252,7 +226,9 @@ export default class WorkerDeploy extends EasCommand {
         },
         graphqlClient
       );
-      assetMap = await WorkerAssets.createAssetMapAsync(distClientPath);
+      assetMap = await WorkerAssets.createAssetMapAsync(
+        projectDist.type === 'server' ? projectDist.clientPath : projectDist.path
+      );
       tarPath = await WorkerAssets.packFilesIterableAsync(
         emitWorkerTarballAsync({
           assetMap,
@@ -376,7 +352,31 @@ export default class WorkerDeploy extends EasCommand {
   }
 }
 
-/** Log the detected of Expo export */
-function logDeploymentType(type: 'static' | 'server'): void {
-  Log.log(chalk`{dim > output: ${type}}`);
+async function resolveExportedProjectAsync(
+  flags: DeployFlags,
+  projectDir: string
+): Promise<
+  | { type: 'static'; modifiedAt: Date; path: string }
+  | { type: 'server'; modifiedAt: Date; path: string; serverPath: string; clientPath: string }
+> {
+  const exportPath = path.join(projectDir, flags.exportDir);
+  const serverPath = path.join(exportPath, 'server');
+  const clientPath = path.join(exportPath, 'client');
+
+  const [hasServerPath, hasClientPath, modifiedAt] = await Promise.all([
+    isDirectory(serverPath),
+    isDirectory(clientPath),
+    fs.promises.stat(exportPath).then(stat => stat.mtime),
+  ]);
+
+  if (hasServerPath && hasClientPath) {
+    return { type: 'server', path: exportPath, modifiedAt, serverPath, clientPath };
+  }
+
+  return { type: 'static', path: exportPath, modifiedAt };
+}
+
+function logExportedProjectInfo(project: Awaited<ReturnType<typeof resolveExportedProjectAsync>>): void {
+  const modifiedAgo = formatTimeAgo(project.modifiedAt);
+  Log.log(chalk`{dim > Project export: ${project.type} - created ${modifiedAgo}}`);
 }

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -245,6 +245,7 @@ export default class WorkerDeploy extends EasCommand {
         // NOTE(cedric): this function might ask the user for a dev-domain name,
         // when that happens, no ora spinner should be running.
         onSetupDevDomain: () => progress.stop(),
+        nonInteractive: flags.nonInteractive,
       });
 
       progress.start('Creating deployment');


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This change makes `eas deploy` always assume we are uploading a static project. That means you could upload just a folder with `output/index.html` file in an Expo project.

# How

- Rewrote project detection to assume `static` projects by default (making `single` also work)
- Only switch to `server` when `output: server` is detected, just by folder names
- Add `created X ago` to the project type in deploy output

# Test Plan

<img width="980" alt="image" src="https://github.com/user-attachments/assets/9bba4637-76ff-471c-9e07-3e855cdd5f17">
