### PR TITLE
fix(eas-cli): restore "export not found" error and hide recent exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Avoid merging `expo.extra` plugin-generated data with `expo.extra.eas.projectId` in `eas init`. ([#2554](https://github.com/expo/eas-cli/pull/2554) by [@byCedric](https://github.com/byCedric)))
+- Restore "export not found" error and hide recent export timestamps.
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Avoid merging `expo.extra` plugin-generated data with `expo.extra.eas.projectId` in `eas init`. ([#2554](https://github.com/expo/eas-cli/pull/2554) by [@byCedric](https://github.com/byCedric)))
-- Restore "export not found" error and hide recent export timestamps.
+- Restore "export not found" error and hide recent export timestamps. ([#2566](https://github.com/expo/eas-cli/pull/2566) by [@byCedric](https://github.com/byCedric)))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -381,7 +381,7 @@ async function resolveExportedProjectAsync(
 
   if (!exportStat?.isDirectory()) {
     throw new Error(
-      `No "${flags.exportDir}/" folder found. Prepare your project for deployment with "npx expo export"`
+      `No "${flags.exportDir}/" folder found. Prepare your project for deployment with "npx expo export --platform web"`
     );
   }
 


### PR DESCRIPTION
# Why

After user testing `eas-cli@12.4.0` we found out that this is still a bit confusing.

# How

- Restored the "export not found, export with <command>" error
- Reword `created X ago` to `exported X ago`
- Hide `exported X ago` for exports within 1m

# Test Plan

- `$ eas deploy`
- `$ npx expo export --platform web && eas deploy`
- `$ eas deploy --export-dir non-existing`