### PR TITLE
refactor(eas-cli): enhance the `--environment` help description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Share similar table/json output in both `worker` and `worker:alias` command outputs. ([#2563](https://github.com/expo/eas-cli/pull/2563) by [@byCedric](https://github.com/byCedric)))
 - Polish the project URL prompt when setting up new projects. ([#2564](https://github.com/expo/eas-cli/pull/2564) by [@byCedric](https://github.com/byCedric)))
 - Always assume `static` exports in `eas deploy` and add modified time. ([#2565](https://github.com/expo/eas-cli/pull/2565) by [@byCedric](https://github.com/byCedric)))
+- Update the `eas worker --help` `--environment` description. ([#2567](https://github.com/expo/eas-cli/pull/2567) by [@byCedric](https://github.com/byCedric)))
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/packages/eas-cli/src/commands/worker/alias.ts
+++ b/packages/eas-cli/src/commands/worker/alias.ts
@@ -66,18 +66,14 @@ export default class WorkerAlias extends EasCommand {
   };
 
   override async runAsync(): Promise<void> {
-    // NOTE(cedric): `Log.warn` uses `console.log`, which is incorrect when running with `--json`
-    // eslint-disable-next-line no-console
-    console.warn(
-      chalk.yellow('EAS Worker Deployments are in beta and subject to breaking changes.')
-    );
-
     const { flags: rawFlags } = await this.parse(WorkerAlias);
     const flags = this.sanitizeFlags(rawFlags);
 
     if (flags.json) {
       enableJsonOutput();
     }
+
+    Log.warn('EAS Worker Deployments are in beta and subject to breaking changes.');
 
     const {
       getDynamicPrivateProjectConfigAsync,

--- a/packages/eas-cli/src/commands/worker/alias.ts
+++ b/packages/eas-cli/src/commands/worker/alias.ts
@@ -43,16 +43,16 @@ export default class WorkerAlias extends EasCommand {
   static override flags = {
     prod: Flags.boolean({
       aliases: ['production'],
-      description: 'Promote an existing deployment to production',
+      description: 'Promote an existing deployment to production.',
       default: false,
     }),
     alias: Flags.string({
-      description: 'Custom alias to assign to the existing deployment',
+      description: 'Custom alias to assign to the existing deployment.',
       helpValue: 'name',
       required: false,
     }),
     id: Flags.string({
-      description: 'Unique identifier of an existing deployment',
+      description: 'Unique identifier of an existing deployment.',
       helpValue: 'xyz123',
       required: false,
     }),

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -65,25 +65,27 @@ export default class WorkerDeploy extends EasCommand {
   static override flags = {
     prod: Flags.boolean({
       aliases: ['production'],
-      description: 'Create a new production deployment',
+      description: 'Create a new production deployment.',
       default: false,
     }),
     alias: Flags.string({
-      description: 'Custom alias to assign to the new deployment',
+      description: 'Custom alias to assign to the new deployment.',
       helpValue: 'name',
     }),
     id: Flags.string({
-      description: 'Custom unique identifier for the new deployment',
+      description: 'Custom unique identifier for the new deployment.',
       helpValue: 'xyz123',
     }),
     'export-dir': Flags.string({
-      description: 'Directory where the Expo project was exported',
+      description: 'Directory where the Expo project was exported.',
       helpValue: 'dir',
       default: 'dist',
     }),
-    // TODO(@kitten): Allow deployment identifier to be specified
+    environment: {
+      ...EASEnvironmentFlag.environment,
+      description: 'Use EAS secret variables matching the specified environment in the new deployment.',
+    },
     ...EasNonInteractiveAndJsonFlags,
-    ...EASEnvironmentFlag,
   };
 
   static override contextDefinition = {
@@ -93,18 +95,14 @@ export default class WorkerDeploy extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    // NOTE(cedric): `Log.warn` uses `console.log`, which is incorrect when running with `--json`
-    // eslint-disable-next-line no-console
-    console.warn(
-      chalk.yellow('EAS Worker Deployments are in beta and subject to breaking changes.')
-    );
-
     const { flags: rawFlags } = await this.parse(WorkerDeploy);
     const flags = this.sanitizeFlags(rawFlags);
 
     if (flags.json) {
       enableJsonOutput();
     }
+
+    Log.warn('EAS Worker Deployments are in beta and subject to breaking changes.');
 
     const {
       getDynamicPrivateProjectConfigAsync,

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -83,7 +83,7 @@ export default class WorkerDeploy extends EasCommand {
     }),
     environment: {
       ...EASEnvironmentFlag.environment,
-      description: 'Use EAS secret variables matching the specified environment in the new deployment.',
+      description: 'Deploy with EAS Environment Variables matching the specified environment.',
     },
     ...EasNonInteractiveAndJsonFlags,
   };


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The default "Environment variable's environment" explanation isn't enough to describe what it will do for new users. This changes that.

# How

- Enhanced `eas deploy --help`'s `--environment` description

# Test Plan

- `$ eas deploy --help`