### PR TITLE
refactor(eas-cli): remove the cursor space when prompting dev domain after input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Share similar table/json output in both `worker` and `worker:alias` command outputs. ([#2563](https://github.com/expo/eas-cli/pull/2563) by [@byCedric](https://github.com/byCedric)))
 - Polish the project URL prompt when setting up new projects. ([#2564](https://github.com/expo/eas-cli/pull/2564) by [@byCedric](https://github.com/byCedric)))
 - Always assume `static` exports in `eas deploy` and add modified time. ([#2565](https://github.com/expo/eas-cli/pull/2565) by [@byCedric](https://github.com/byCedric)))
+- Remove the cursor space after selecting project dev domain. ([#2568](https://github.com/expo/eas-cli/pull/2568) by [@byCedric](https://github.com/byCedric)))
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/packages/eas-cli/src/worker/deployment.ts
+++ b/packages/eas-cli/src/worker/deployment.ts
@@ -66,6 +66,7 @@ type PromptInstance = {
   placeholder: boolean;
   rendered: string;
   initial: string;
+  done: boolean;
   get value(): string;
   set value(input: string);
 };
@@ -126,7 +127,10 @@ async function chooseDevDomainNameAsync({
     onRender(this: PromptInstance, kleur) {
       this.cursorOffset = -rootDomain.length - 1;
 
-      if (this.placeholder) {
+      if (this.done) {
+        // Remove the space for the cursor when the prompt is done
+        this.rendered = this.value + kleur.dim(`${rootDomain}`);
+      } else if (this.placeholder) {
         this.rendered = kleur.dim(`${this.initial} ${rootDomain}`);
       } else {
         this.rendered = this.value + kleur.dim(` ${rootDomain}`);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This drops the extra space between `<input> .staging.expo.app` after choosing a project URL.

# How

- Dropped cursor space after selecting project URL

# Test Plan

<img width="973" alt="image" src="https://github.com/user-attachments/assets/09f72478-4ffa-42cb-9a19-89b58804ff54">