### PR TITLE
fix(eas-cli): check if export is available before validating project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Avoid merging `expo.extra` plugin-generated data with `expo.extra.eas.projectId` in `eas init`. ([#2554](https://github.com/expo/eas-cli/pull/2554) by [@byCedric](https://github.com/byCedric)))
 - Restore "export not found" error and hide recent export timestamps. ([#2566](https://github.com/expo/eas-cli/pull/2566) by [@byCedric](https://github.com/byCedric)))
-- Check if export is available before validating project ID in `eas worker`.
+- Check if export is available before validating project ID in `eas worker`. ([#2569](https://github.com/expo/eas-cli/pull/2569) by [@byCedric](https://github.com/byCedric)))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Avoid merging `expo.extra` plugin-generated data with `expo.extra.eas.projectId` in `eas init`. ([#2554](https://github.com/expo/eas-cli/pull/2554) by [@byCedric](https://github.com/byCedric)))
 - Restore "export not found" error and hide recent export timestamps. ([#2566](https://github.com/expo/eas-cli/pull/2566) by [@byCedric](https://github.com/byCedric)))
+- Check if export is available before validating project ID in `eas worker`.
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -110,10 +110,8 @@ export default class WorkerDeploy extends EasCommand {
       projectDir,
     } = await this.getContextAsync(WorkerDeploy, flags);
 
-    const [{ projectId }, projectDist] = await Promise.all([
-      getDynamicPrivateProjectConfigAsync(),
-      resolveExportedProjectAsync(flags, projectDir),
-    ]);
+    const projectDist = await resolveExportedProjectAsync(flags, projectDir);
+    const { projectId } = await getDynamicPrivateProjectConfigAsync();
 
     logExportedProjectInfo(projectDist);
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I parallized these two actions to make the command as fast as possible. Unfortunately, this has the side effect of conflating a prompt with a command error (as seen in the screenshot below).

![image](https://github.com/user-attachments/assets/78d2f09c-46ed-4f6d-b842-96c55b1e6af4)

This reverts the parallized action back into two stages, where they can't be mixed up.

# How

- First validate if a (valid) export is available
- Then validate if the project is set up properly

# Test Plan

- `$ bun create expo ./test`
- `$ cd ./test`
- `$ eas deploy`
  - Should not trigger the prompt in the screenshot, only the error