### PR TITLE
[eas-cli] add exit option to eas credentials interactive menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Simplify the output of `eas deploy --json`. ([#2596](https://github.com/expo/eas-cli/pull/2596) by [@byCedric](https://github.com/byCedric))
 - Support deploying Expo Router server exports without client directory. ([#2597](https://github.com/expo/eas-cli/pull/2597) by [@byCedric](https://github.com/byCedric))
+- Add exit option to `eas credentials` interactive menu. ([#2570](https://github.com/expo/eas-cli/pull/2570) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [12.5.0](https://github.com/expo/eas-cli/releases/tag/v12.5.0) - 2024-09-23
 

--- a/packages/eas-cli/src/credentials/manager/Actions.ts
+++ b/packages/eas-cli/src/credentials/manager/Actions.ts
@@ -36,6 +36,7 @@ export enum AndroidActionType {
   UpdateCredentialsJson,
   SetUpBuildCredentialsFromCredentialsJson,
   SetUpBuildCredentials,
+  Exit,
 }
 
 export enum IosActionType {
@@ -60,4 +61,5 @@ export enum IosActionType {
   UseExistingAscApiKeyForSubmissions,
   CreateAscApiKeyForSubmissions,
   RemoveAscApiKey,
+  Exit,
 }

--- a/packages/eas-cli/src/credentials/manager/AndroidActions.ts
+++ b/packages/eas-cli/src/credentials/manager/AndroidActions.ts
@@ -26,6 +26,11 @@ export const highLevelActions: ActionInfo[] = [
     title: 'Go back',
     scope: Scope.Manager,
   },
+  {
+    value: AndroidActionType.Exit,
+    title: 'Exit',
+    scope: Scope.Manager,
+  },
 ];
 
 export const credentialsJsonActions: ActionInfo[] = [

--- a/packages/eas-cli/src/credentials/manager/IosActions.ts
+++ b/packages/eas-cli/src/credentials/manager/IosActions.ts
@@ -27,6 +27,11 @@ export const highLevelActions: ActionInfo[] = [
     title: 'Go back',
     scope: Scope.Manager,
   },
+  {
+    value: IosActionType.Exit,
+    title: 'Exit',
+    scope: Scope.Manager,
+  },
 ];
 
 export const credentialsJsonActions: ActionInfo[] = [

--- a/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageAndroid.ts
@@ -145,6 +145,8 @@ export class ManageAndroid {
           } else if (chosenAction === AndroidActionType.GoBackToCaller) {
             await this.callingAction.runAsync(ctx);
             return;
+          } else if (chosenAction === AndroidActionType.Exit) {
+            return;
           }
         }
 

--- a/packages/eas-cli/src/credentials/manager/ManageIos.ts
+++ b/packages/eas-cli/src/credentials/manager/ManageIos.ts
@@ -154,6 +154,8 @@ export class ManageIos {
           } else if (chosenAction === IosActionType.GoBackToCaller) {
             await this.callingAction.runAsync(ctx);
             return;
+          } else if (chosenAction === IosActionType.Exit) {
+            return;
           }
         } else if (actionInfo.scope === Scope.Project) {
           assert(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1726226230206999

Right now the only way to exit the `eas credentials` command is to kill the process by doing ctrl+c. Let's add an `exit` option to the interactive menu.

# How

Add exit option to menu.

# Test Plan

Test manually
