### PR TITLE
refactor(eas-cli): reword dev domain prompt to use "preview URL"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Always assume `static` exports in `eas deploy` and add modified time. ([#2565](https://github.com/expo/eas-cli/pull/2565) by [@byCedric](https://github.com/byCedric)))
 - Update the `eas worker --help` `--environment` description. ([#2567](https://github.com/expo/eas-cli/pull/2567) by [@byCedric](https://github.com/byCedric)))
 - Remove the cursor space after selecting project dev domain. ([#2568](https://github.com/expo/eas-cli/pull/2568) by [@byCedric](https://github.com/byCedric)))
-- Reword the dev domain prompt to mention "preview URL".
+- Reword the dev domain prompt to mention "preview URL". ([#2572](https://github.com/expo/eas-cli/pull/2572) by [@byCedric](https://github.com/byCedric)))
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Always assume `static` exports in `eas deploy` and add modified time. ([#2565](https://github.com/expo/eas-cli/pull/2565) by [@byCedric](https://github.com/byCedric)))
 - Update the `eas worker --help` `--environment` description. ([#2567](https://github.com/expo/eas-cli/pull/2567) by [@byCedric](https://github.com/byCedric)))
 - Remove the cursor space after selecting project dev domain. ([#2568](https://github.com/expo/eas-cli/pull/2568) by [@byCedric](https://github.com/byCedric)))
+- Reword the dev domain prompt to mention "preview URL".
 
 ## [12.3.0](https://github.com/expo/eas-cli/releases/tag/v12.3.0) - 2024-09-09
 

--- a/packages/eas-cli/src/worker/deployment.ts
+++ b/packages/eas-cli/src/worker/deployment.ts
@@ -104,17 +104,17 @@ async function chooseDevDomainNameAsync({
   const { name } = await promptAsync({
     type: 'text',
     name: 'name',
-    message: 'Choose a URL for your project:',
+    message: 'Choose a preview URL for your project:',
     initial,
     validate: (value: string) => {
       if (!value) {
-        return 'You have to choose a URL for your project';
+        return 'You have to choose a preview URL for your project';
       }
       if (value.length < 3) {
-        return 'Project URLs must be at least 3 characters long';
+        return 'Preview URLs must be at least 3 characters long';
       }
       if (value.endsWith('-')) {
-        return 'Project URLs cannot end with a hyphen (-)';
+        return 'Preview URLs cannot end with a hyphen (-)';
       }
       return true;
     },
@@ -139,7 +139,7 @@ async function chooseDevDomainNameAsync({
   });
 
   if (!name) {
-    throw new Error('No project URL provided, aborting deployment.');
+    throw new Error('No preview URL provided, aborting deployment.');
   }
 
   try {
@@ -149,7 +149,7 @@ async function chooseDevDomainNameAsync({
     });
 
     if (!success) {
-      throw new Error('Failed to assign project URL');
+      throw new Error('Failed to assign preview URL');
     }
   } catch (error: any) {
     const isChosenNameTaken = (error as GraphqlError)?.graphQLErrors?.some(e =>
@@ -157,7 +157,7 @@ async function chooseDevDomainNameAsync({
     );
 
     if (isChosenNameTaken) {
-      Log.error(`The project URL "${name}" is already taken, choose a different name.`);
+      Log.error(`The preview URL "${name}" is already taken, choose a different URL.`);
       await chooseDevDomainNameAsync({ graphqlClient, appId, initial });
     }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

As discussed in Slack, to align the CLI prompts with the website/dashboard information.

# How

- Reworded the prompts and error messages to mention "preview URL"

# Test Plan

- `$ bun create expo ./test-prompt`
- `$ cd ./test-prompt`
- `$ eas worker`