### PR TITLE
@bycedric/eas cli/avoid corrupting appjson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Avoid malforming `app.json` with empty `.expo` object.
+
 ### 🧹 Chores
 
 ## [12.4.1](https://github.com/expo/eas-cli/releases/tag/v12.4.1) - 2024-09-14

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -1,9 +1,7 @@
 import { ExpoConfig, getConfig, getConfigFilePaths, modifyConfigAsync } from '@expo/config';
 import { Env } from '@expo/eas-build-job';
-import JsonFile from '@expo/json-file';
 import fs from 'fs-extra';
 import Joi from 'joi';
-import nullthrows from 'nullthrows';
 import path from 'path';
 
 export type PublicExpoConfig = Omit<
@@ -31,7 +29,6 @@ export async function createOrModifyExpoConfigAsync(
   readOptions?: { skipSDKVersionRequirement?: boolean }
 ): ReturnType<typeof modifyConfigAsync> {
   ensureExpoConfigExists(projectDir);
-  await ensureStaticExpoConfigIsValidAsync(projectDir);
 
   if (readOptions) {
     return await modifyConfigAsync(projectDir, exp, readOptions);
@@ -92,20 +89,6 @@ export function ensureExpoConfigExists(projectDir: string): void {
   if (!paths?.staticConfigPath && !paths?.dynamicConfigPath) {
     // eslint-disable-next-line node/no-sync
     fs.writeFileSync(path.join(projectDir, 'app.json'), JSON.stringify({ expo: {} }, null, 2));
-  }
-}
-
-async function ensureStaticExpoConfigIsValidAsync(projectDir: string): Promise<void> {
-  if (isUsingStaticExpoConfig(projectDir)) {
-    const staticConfigPath = nullthrows(getConfigFilePaths(projectDir).staticConfigPath);
-    const staticConfig = await JsonFile.readAsync(staticConfigPath);
-
-    // Add the "expo" key if it doesn't exist on app.json yet, such as in
-    // projects initialized with RNC CLI
-    if (!staticConfig?.expo) {
-      staticConfig.expo = {};
-      await JsonFile.writeAsync(staticConfigPath, staticConfig);
-    }
   }
 }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`app.json` may contain either a root level `.expo` object with all config options or no `.expo` property at all. `@expo/config` reads them both as valid Expo config files.

This removes the unnecessary `.expo` change, allowing `app.json` files without `.expo` property.

# How

- Removed `ensureStaticExpoConfigIsValidAsync` as this malforms projects using no `.expo` property

# Test Plan

- `$ bun create expo ./test`
- Change `app.json` to drop the root `.expo` property (use `.expo` as root)
- `$ cd ./test`
- `$ eas deploy` + setup project ID
- `$ eas deploy`
- Subsequent run should be possible without EAS malforming the `app.json` file.
