### PR TITLE
[eas-cli] Add destination branch arguments to update:republish command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Log command execution to assist in debugging local builds. ([#2526](https://github.com/expo/eas-cli/pull/2526) by [@trajano](https://github.com/trajano))
 - Allow submitting builds in progress ([#2543](https://github.com/expo/eas-cli/pull/2543) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 - Use `EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID` and `EAS_DANGEROUS_OVERRIDE_IOS_BUNDLE_IDENTIFIER` environment variables as overrides of the Android application ID and iOS bundle identifier in managed workflow too. ([#2576](https://github.com/expo/eas-cli/pull/2576) by [@sjchmiela](https://github.com/sjchmiela))
+- Add destination branch arguments to update:republish command. ([#2575](https://github.com/expo/eas-cli/pull/2575) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -21,7 +21,7 @@ import { UpdateFragment } from '../../../graphql/generated';
 import { PublishMutation } from '../../../graphql/mutations/PublishMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { collectAssetsAsync, uploadAssetsAsync } from '../../../project/publish';
-import { getBranchNameFromChannelNameAsync } from '../../../update/getBranchNameFromChannelNameAsync';
+import { getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync } from '../../../update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync';
 import { resolveVcsClient } from '../../../vcs';
 
 const projectRoot = '/test-project';
@@ -47,7 +47,7 @@ jest.mock('@expo/config-plugins');
 jest.mock('../../../branch/queries');
 jest.mock('../../../commandUtils/context/contextUtils/getProjectIdAsync');
 jest.mock('../../../update/configure');
-jest.mock('../../../update/getBranchNameFromChannelNameAsync');
+jest.mock('../../../update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync');
 jest.mock('../../../graphql/mutations/PublishMutation');
 jest.mock('../../../graphql/queries/AppQuery');
 jest.mock('../../../graphql/queries/UpdateQuery');
@@ -106,7 +106,9 @@ describe(UpdatePublish.name, () => {
     const { projectId } = mockTestProject();
     const { platforms, runtimeVersion } = mockTestExport();
 
-    jest.mocked(getBranchNameFromChannelNameAsync).mockResolvedValue('branchFromChannel');
+    jest
+      .mocked(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync)
+      .mockResolvedValue({ branchId: 'branch123', branchName: 'branchFromChannel' });
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
       branchId: 'branch123',
       createdBranch: false,

--- a/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
@@ -11,8 +11,9 @@ import { jester } from '../../../credentials/__tests__/fixtures-constants';
 import { UpdateFragment } from '../../../graphql/generated';
 import { PublishMutation } from '../../../graphql/mutations/PublishMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
+import { BranchQuery } from '../../../graphql/queries/BranchQuery';
 import { UpdateQuery } from '../../../graphql/queries/UpdateQuery';
-import { getBranchNameFromChannelNameAsync } from '../../../update/getBranchNameFromChannelNameAsync';
+import { getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync } from '../../../update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync';
 import { selectUpdateGroupOnBranchAsync } from '../../../update/queries';
 import {
   getCodeSigningInfoAsync,
@@ -44,7 +45,8 @@ jest.mock('../../../commandUtils/context/contextUtils/getProjectIdAsync');
 jest.mock('../../../graphql/mutations/PublishMutation');
 jest.mock('../../../graphql/queries/AppQuery');
 jest.mock('../../../graphql/queries/UpdateQuery');
-jest.mock('../../../update/getBranchNameFromChannelNameAsync');
+jest.mock('../../../graphql/queries/BranchQuery');
+jest.mock('../../../update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync');
 jest.mock('../../../update/queries');
 jest.mock('../../../ora', () => ({
   ora: () => ({
@@ -57,6 +59,7 @@ jest.mock('../../../fetch');
 describe(UpdateRepublish.name, () => {
   afterEach(() => {
     vol.reset();
+    jest.resetAllMocks();
   });
 
   it('errors when providing both --group and --branch', async () => {
@@ -86,6 +89,16 @@ describe(UpdateRepublish.name, () => {
 
     await expect(new UpdateRepublish(flags, commandOptions).run()).rejects.toThrow(
       /--channel=main cannot also be provided when using --group/
+    );
+  });
+
+  it('errors when providing both --destination-channel and --destination-branch', async () => {
+    const flags = ['--group=1234', '--destination-channel=test', '--destination-branch=wat'];
+
+    mockTestProject();
+
+    await expect(new UpdateRepublish(flags, commandOptions).run()).rejects.toThrow(
+      /--destination-branch=wat cannot also be provided when using --destination-channel/
     );
   });
 
@@ -271,7 +284,9 @@ describe(UpdateRepublish.name, () => {
 
     mockTestProject();
     // Mock resolving the channel to branch name, only valid for a single branch connected
-    jest.mocked(getBranchNameFromChannelNameAsync).mockResolvedValue('branchFromChannel');
+    jest
+      .mocked(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync)
+      .mockResolvedValue({ branchId: updateStub.branch.id, branchName: 'branchFromChannel' });
     // Mock the prompt to ask the user which update to republish, from branch
     jest.mocked(selectUpdateGroupOnBranchAsync).mockResolvedValue([updateStub]);
     // Mock mutations to store the new update
@@ -296,6 +311,94 @@ describe(UpdateRepublish.name, () => {
       expect.arrayContaining([
         expect.objectContaining({
           branchId: updateStub.branch.id,
+          runtimeVersion: updateStub.runtimeVersion,
+          updateInfoGroup: expect.objectContaining({
+            ios: expect.any(Object),
+          }),
+          gitCommitHash: updateStub.gitCommitHash,
+          awaitingCodeSigningInfo: false,
+        }),
+      ])
+    );
+  });
+
+  it('republishes to a different branch when --destination-branch is supplied', async () => {
+    const flags = ['--branch=branch123', '--message=test-republish', '--destination-branch=other'];
+
+    mockTestProject();
+    // Mock the prompt to ask the user which update to republish, from branch
+    jest.mocked(selectUpdateGroupOnBranchAsync).mockResolvedValue([updateStub]);
+    // Mock mutations to store the new update
+    jest.mocked(PublishMutation.publishUpdateGroupAsync).mockResolvedValue([
+      {
+        ...updateStub,
+        branch: { id: 'other-id', name: 'other' },
+        id: 'update-new',
+        platform: 'ios',
+        manifestPermalink: 'https://expo.dev/@test/test-project/manifest',
+      },
+    ]);
+    jest.mocked(BranchQuery.getBranchByNameAsync).mockResolvedValue({
+      id: 'other-id',
+      name: 'other',
+    });
+
+    await new UpdateRepublish(flags, commandOptions).run();
+
+    expect(selectUpdateGroupOnBranchAsync).toHaveBeenCalledWith(
+      expect.any(Object), // graphql client
+      expect.objectContaining({ branchName: 'branch123' })
+    );
+
+    expect(PublishMutation.publishUpdateGroupAsync).toHaveBeenCalledWith(
+      expect.any(Object), // graphql client
+      expect.arrayContaining([
+        expect.objectContaining({
+          branchId: 'other-id',
+          runtimeVersion: updateStub.runtimeVersion,
+          updateInfoGroup: expect.objectContaining({
+            ios: expect.any(Object),
+          }),
+          gitCommitHash: updateStub.gitCommitHash,
+          awaitingCodeSigningInfo: false,
+        }),
+      ])
+    );
+  });
+
+  it('republishes to a different branch when --destination-channel is supplied', async () => {
+    const flags = ['--branch=branch123', '--message=test-republish', '--destination-channel=blah'];
+
+    mockTestProject();
+    // Mock the prompt to ask the user which update to republish, from branch
+    jest.mocked(selectUpdateGroupOnBranchAsync).mockResolvedValue([updateStub]);
+    // Mock mutations to store the new update
+    jest.mocked(PublishMutation.publishUpdateGroupAsync).mockResolvedValue([
+      {
+        ...updateStub,
+        branch: { id: 'other-id', name: 'other' },
+        id: 'update-new',
+        platform: 'ios',
+        manifestPermalink: 'https://expo.dev/@test/test-project/manifest',
+      },
+    ]);
+
+    jest
+      .mocked(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync)
+      .mockResolvedValue({ branchId: 'blah-id', branchName: 'blah' });
+
+    await new UpdateRepublish(flags, commandOptions).run();
+
+    expect(selectUpdateGroupOnBranchAsync).toHaveBeenCalledWith(
+      expect.any(Object), // graphql client
+      expect.objectContaining({ branchName: 'branch123' })
+    );
+
+    expect(PublishMutation.publishUpdateGroupAsync).toHaveBeenCalledWith(
+      expect.any(Object), // graphql client
+      expect.arrayContaining([
+        expect.objectContaining({
+          branchId: 'blah-id',
           runtimeVersion: updateStub.runtimeVersion,
           updateInfoGroup: expect.objectContaining({
             ios: expect.any(Object),

--- a/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
@@ -19,7 +19,7 @@ import { jester } from '../../../credentials/__tests__/fixtures-constants';
 import { UpdateFragment } from '../../../graphql/generated';
 import { PublishMutation } from '../../../graphql/mutations/PublishMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
-import { getBranchNameFromChannelNameAsync } from '../../../update/getBranchNameFromChannelNameAsync';
+import { getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync } from '../../../update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync';
 import { resolveVcsClient } from '../../../vcs';
 import UpdateRollBackToEmbedded from '../roll-back-to-embedded';
 
@@ -50,7 +50,7 @@ jest.mock('../../../project/projectUtils', () => ({
   enforceRollBackToEmbeddedUpdateSupportAsync: jest.fn(),
 }));
 jest.mock('../../../update/configure');
-jest.mock('../../../update/getBranchNameFromChannelNameAsync');
+jest.mock('../../../update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync');
 jest.mock('../../../graphql/mutations/PublishMutation');
 jest.mock('../../../graphql/queries/AppQuery');
 jest.mock('../../../graphql/queries/UpdateQuery');
@@ -112,7 +112,9 @@ describe(UpdateRollBackToEmbedded.name, () => {
     const runtimeVersion = 'exposdk:47.0.0';
     jest.mocked(Updates.getRuntimeVersionAsync).mockResolvedValue(runtimeVersion);
 
-    jest.mocked(getBranchNameFromChannelNameAsync).mockResolvedValue('branchFromChannel');
+    jest
+      .mocked(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync)
+      .mockResolvedValue({ branchId: updateStub.branch.id, branchName: 'branchFromChannel' });
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
       branchId: 'branch123',
       createdBranch: false,

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -31,7 +31,7 @@ import { PublishQuery } from '../graphql/queries/PublishQuery';
 import Log, { learnMore } from '../log';
 import { RequestedPlatform, requestedPlatformDisplayNames } from '../platform';
 import { promptAsync } from '../prompts';
-import { getBranchNameFromChannelNameAsync } from '../update/getBranchNameFromChannelNameAsync';
+import { getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync } from '../update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync';
 import {
   UpdateJsonInfo,
   formatUpdateMessage,
@@ -598,7 +598,12 @@ export async function getBranchNameForCommandAsync({
   }
 
   if (channelNameArg) {
-    return await getBranchNameFromChannelNameAsync(graphqlClient, projectId, channelNameArg);
+    const { branchName } = await getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
+      graphqlClient,
+      projectId,
+      channelNameArg
+    );
+    return branchName;
   }
 
   if (branchNameArg) {

--- a/packages/eas-cli/src/update/__tests__/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync-test.ts
@@ -10,12 +10,12 @@ import {
   UpdateInsights,
 } from '../../graphql/generated';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
-import { getBranchNameFromChannelNameAsync } from '../getBranchNameFromChannelNameAsync';
+import { getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync } from '../getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync';
 
 jest.mock('../../graphql/queries/ChannelQuery');
 jest.mock('../../graphql/queries/BranchQuery');
 
-describe(getBranchNameFromChannelNameAsync, () => {
+describe(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync, () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
@@ -30,13 +30,14 @@ describe(getBranchNameFromChannelNameAsync, () => {
         }) as any
     );
 
-    const result = await getBranchNameFromChannelNameAsync(
+    const result = await getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
       graphqlClient,
       'test-project-id',
       'channel-name'
     );
 
-    expect(result).toBe('test-branch-name');
+    expect(result.branchId).toBeTruthy();
+    expect(result.branchName).toBe('test-branch-name');
   });
 
   test('errors when no branch is connected to channel', async () => {
@@ -49,7 +50,11 @@ describe(getBranchNameFromChannelNameAsync, () => {
     );
 
     await expect(
-      getBranchNameFromChannelNameAsync(graphqlClient, 'test-project-id', 'test-channel-name')
+      getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
+        graphqlClient,
+        'test-project-id',
+        'test-channel-name'
+      )
     ).rejects.toThrow(
       "Channel has no branches associated with it. Run 'eas channel:edit' to map a branch"
     );
@@ -66,7 +71,11 @@ describe(getBranchNameFromChannelNameAsync, () => {
     );
 
     await expect(
-      getBranchNameFromChannelNameAsync(graphqlClient, 'test-project-id', 'test-channel-name')
+      getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
+        graphqlClient,
+        'test-project-id',
+        'test-channel-name'
+      )
     ).rejects.toThrow(
       "Channel has multiple branches associated with it. Instead, use '--branch' instead of '--channel'"
     );
@@ -82,13 +91,13 @@ describe(getBranchNameFromChannelNameAsync, () => {
         }) as any
     );
 
-    const result = await getBranchNameFromChannelNameAsync(
+    const result = await getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
       graphqlClient,
       'test-project-id',
       'test-channel-name'
     );
 
-    expect(result).toBe('test-branch-name');
+    expect(result.branchName).toBe('test-branch-name');
   });
 });
 

--- a/packages/eas-cli/src/update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync.ts
+++ b/packages/eas-cli/src/update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync.ts
@@ -4,12 +4,12 @@ import { createChannelOnAppAsync } from '../channel/queries';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { ChannelQuery } from '../graphql/queries/ChannelQuery';
 
-export async function getBranchNameFromChannelNameAsync(
+export async function getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
   graphqlClient: ExpoGraphqlClient,
   projectId: string,
   channelName: string
-): Promise<string> {
-  let branchName;
+): Promise<{ branchName: string; branchId: string }> {
+  let branchInfo: { branchName: string; branchId: string };
 
   try {
     const channel = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
@@ -18,7 +18,8 @@ export async function getBranchNameFromChannelNameAsync(
     });
 
     if (channel.updateBranches.length === 1) {
-      branchName = channel.updateBranches[0].name;
+      const branch = channel.updateBranches[0];
+      branchInfo = { branchId: branch.id, branchName: branch.name };
     } else if (channel.updateBranches.length === 0) {
       throw new Error(
         "Channel has no branches associated with it. Run 'eas channel:edit' to map a branch"
@@ -51,8 +52,8 @@ export async function getBranchNameFromChannelNameAsync(
       );
     }
 
-    branchName = channelName;
+    branchInfo = { branchId, branchName: channelName };
   }
 
-  return branchName;
+  return branchInfo;
 }

--- a/packages/eas-cli/src/update/republish.ts
+++ b/packages/eas-cli/src/update/republish.ts
@@ -58,7 +58,10 @@ export async function republishAsync({
     update.branchId === arbitraryUpdate.branchId &&
     update.branchName === arbitraryUpdate.branchName &&
     update.runtimeVersion === arbitraryUpdate.runtimeVersion;
-  assert(updatesToPublish.every(isSameGroup), 'All updates must belong to the same update group');
+  assert(
+    updatesToPublish.every(isSameGroup),
+    'All updates being republished must belong to the same update group'
+  );
 
   assert(
     updatesToPublish.every(u => u.isRollBackToEmbedded) ||
@@ -90,7 +93,9 @@ export async function republishAsync({
       }
     }
 
-    Log.withTick(`The republished update group will be signed`);
+    Log.withTick(
+      `The republished update group will be signed with the same code signing key and algorithm as the original update`
+    );
   }
 
   const publishIndicator = ora('Republishing...').start();


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This adds the ability to republish an update group from one branch to another. This will help make the update promotion workflows more seamless. The update group must have the same code signing key.

# How

Add command.

# Test Plan

```
$ eas branch:list

Branches:

Branch           hello
Platforms        android, ios
Runtime Version  1.0.0
Message          "Initial commit

Generated by create-expo-app 3.0.0." (12 seconds ago by wschurman)
Group ID         62414475-44c3-43c6-b2bd-ed9f864789f9

———

Branch           production
Platforms        N/A
Runtime Version  N/A
Message          N/A
Group ID         N/A

———

Branch           main
Platforms        android, ios
Runtime Version  1.0.0
Message          "Initial commit
```
```
$ neas update:republish --branch hello --destination-branch production
✔ Load more update groups? › [Sep 22 13:31 by wschurman, runtimeVersion: 1.0.0] Initial commit

Generated by create-expo-app 3.0.0.
✔ The republished update group will appear only on: all
✔ Provide an update message. … Republish "Initial commit

Generated by create-expo-app 3.0.0." - group: 62414475-44c3-43c6-b2bd-ed9f864789f9
✔ Republished update group

Branch             production
Runtime version    1.0.0
Platform           android, ios
Update group ID    d03851a5-0159-4d60-b26c-7c6049afdaff
Android update ID  efd30776-55eb-46ab-b165-8fed7ee9ce89
iOS update ID      7d5b1d94-2e6a-4663-8331-0fb19a61739d
Message            Republish "Initial commit

Generated by create-expo-app 3.0.0." - group: 62414475-44c3-43c6-b2bd-ed9f864789f9
EAS Dashboard      https://staging.expo.dev/accounts/real-org-will/projects/lkjfaskljafsjklfsakljafklj/updates/d03851a5-0159-4d60-b26c-7c6049afdaff
```
```
$ eas branch:list

Branches:

Branch           production
Platforms        android, ios
Runtime Version  1.0.0
Message          "Republish "Initial commit

Generated by create-expo-app 3.0.0." - group: 62414475-44c3-43c6-b2bd-ed9f864789f9" (just now by wschurman)
Group ID         d03851a5-0159-4d60-b26c-7c6049afdaff

———

Branch           hello
Platforms        android, ios
Runtime Version  1.0.0
Message          "Initial commit

Generated by create-expo-app 3.0.0." (2 minutes ago by wschurman)
Group ID         62414475-44c3-43c6-b2bd-ed9f864789f9

———

Branch           main
Platforms        android, ios
Runtime Version  1.0.0
Message          "Initial commit

Generated by create-expo-app 3.0.0." (1 month ago by wschurman)
Group ID         3251aa8d-46db-4148-92ee-4a3a1ec12c64