### PR TITLE
[eas-cli] Let iOS bundle identifier override always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Log command execution to assist in debugging local builds. ([#2526](https://github.com/expo/eas-cli/pull/2526) by [@trajano](https://github.com/trajano))
 - Allow submitting builds in progress ([#2543](https://github.com/expo/eas-cli/pull/2543) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+- Use `EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID` and `EAS_DANGEROUS_OVERRIDE_IOS_BUNDLE_IDENTIFIER` environment variables as overrides of the Android application ID and iOS bundle identifier in managed workflow too. ([#2576](https://github.com/expo/eas-cli/pull/2576) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -65,9 +65,6 @@ export async function getApplicationIdFromBareAsync(
   projectDir: string,
   gradleContext?: GradleBuildContext
 ): Promise<string> {
-  if (env.overrideAndroidApplicationId) {
-    return env.overrideAndroidApplicationId;
-  }
   const errorMessage = 'Could not read applicationId from Android project.';
 
   if (gradleContext) {
@@ -109,6 +106,10 @@ export async function getApplicationIdAsync(
   vcsClient: Client,
   gradleContext?: GradleBuildContext
 ): Promise<string> {
+  if (env.overrideAndroidApplicationId) {
+    return env.overrideAndroidApplicationId;
+  }
+
   const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
   if (workflow === Workflow.GENERIC) {
     warnIfAndroidPackageDefinedInAppConfigForBareWorkflowProject(projectDir, exp);

--- a/packages/eas-cli/src/project/ios/bundleIdentifier.ts
+++ b/packages/eas-cli/src/project/ios/bundleIdentifier.ts
@@ -59,13 +59,14 @@ export async function getBundleIdentifierAsync(
   vcsClient: Client,
   xcodeContext?: { targetName?: string; buildConfiguration?: string }
 ): Promise<string> {
+  if (env.overrideIosBundleIdentifier) {
+    return env.overrideIosBundleIdentifier;
+  }
+
   const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+
   if (workflow === Workflow.GENERIC) {
     warnIfBundleIdentifierDefinedInAppConfigForBareWorkflowProject(projectDir, exp);
-
-    if (env.overrideIosBundleIdentifier) {
-      return env.overrideIosBundleIdentifier;
-    }
 
     const xcodeProject = IOSConfig.XcodeUtils.getPbxproj(projectDir);
     const isMultiScheme = IOSConfig.BuildScheme.getSchemesFromXcodeproj(projectDir).length > 1;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

In a submit job we're going to have an IPA/APK to submit. We don't want to resolve any bundle identifiers from the project, we can use one from that IPA/APK.

# How

Let the override env variable override bundle identifier resolution if the workflow is managed too.

# Test Plan

I used it to submit an IPA with workflows.