### PR TITLE
[eas-cli] Fix worker asset upload error not being shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Avoid malforming `app.json` with empty `.expo` object. ([#2573](https://github.com/expo/eas-cli/pull/2573) by [@byCedric](https://github.com/byCedric))
+- Fix typo causing `worker:deploy` asset upload errors not to be shown properly. ([#2579](https://github.com/expo/eas-cli/pull/2579) by [@kitten](https://github.com/kitten))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -165,13 +165,13 @@ export async function* batchUploadAsync(
       }
       yield await Promise.race(queue);
     }
-  } catch (error: any) {
-    if (typeof error !== 'object' || error.name !== 'AbortError') {
-      throw error;
-    }
-  } finally {
+
     if (queue.size > 0) {
       controller.abort();
+    }
+  } catch (error: any) {
+    if (error.name !== 'AbortError') {
+      throw error;
     }
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We accidentally were hiding asset upload errors, which should be shown.

# How

Remove code ignoring upload errors accidentally.

# Test Plan

Manually tested
