### PR TITLE
Allow prompting for multiple environments

### DIFF
--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -26,15 +26,24 @@ export const EasNonInteractiveAndJsonFlags = {
   }),
 };
 
+const EasEnvironmentFlagParameters = {
+  description: "Environment variable's environment",
+  parse: upperCaseAsync,
+  options: mapToLowercase([
+    EnvironmentVariableEnvironment.Development,
+    EnvironmentVariableEnvironment.Preview,
+    EnvironmentVariableEnvironment.Production,
+  ]),
+};
+
 export const EASEnvironmentFlag = {
+  environment: Flags.enum<EnvironmentVariableEnvironment>(EasEnvironmentFlagParameters),
+};
+
+export const EASMultiEnvironmentFlag = {
   environment: Flags.enum<EnvironmentVariableEnvironment>({
-    description: "Environment variable's environment",
-    parse: upperCaseAsync,
-    options: mapToLowercase([
-      EnvironmentVariableEnvironment.Development,
-      EnvironmentVariableEnvironment.Preview,
-      EnvironmentVariableEnvironment.Production,
-    ]),
+    ...EasEnvironmentFlagParameters,
+    multiple: true,
   }),
 };
 

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -112,7 +112,7 @@ export default class EnvironmentVariableCreate extends EasCommand {
     }
 
     if (!environment) {
-      environment = await promptVariableEnvironmentAsync(nonInteractive);
+      environment = await promptVariableEnvironmentAsync({ nonInteractive });
     }
 
     const environments = [environment];

--- a/packages/eas-cli/src/commands/env/delete.ts
+++ b/packages/eas-cli/src/commands/env/delete.ts
@@ -52,7 +52,7 @@ export default class EnvironmentVariableDelete extends EasCommand {
 
     if (scope === EnvironmentVariableScope.Project) {
       if (!environment) {
-        environment = await promptVariableEnvironmentAsync(nonInteractive);
+        environment = await promptVariableEnvironmentAsync({ nonInteractive });
       }
     }
 

--- a/packages/eas-cli/src/commands/env/exec.ts
+++ b/packages/eas-cli/src/commands/env/exec.ts
@@ -64,7 +64,8 @@ export default class EnvExec extends EasCommand {
     });
 
     const environment =
-      parsedFlags.environment ?? (await promptVariableEnvironmentAsync(parsedFlags.nonInteractive));
+      parsedFlags.environment ??
+      (await promptVariableEnvironmentAsync({ nonInteractive: parsedFlags.nonInteractive }));
     const environmentVariables = await this.loadEnvironmentVariablesAsync({
       graphqlClient,
       projectId,

--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -70,7 +70,7 @@ export default class EnvironmentVariableGet extends EasCommand {
     }
 
     if (!environment && scope === EnvironmentVariableScope.Project) {
-      environment = await promptVariableEnvironmentAsync(nonInteractive);
+      environment = await promptVariableEnvironmentAsync({ nonInteractive });
     }
     const variable = await getVariableAsync(graphqlClient, scope, projectId, name, environment);
 

--- a/packages/eas-cli/src/commands/env/link.ts
+++ b/packages/eas-cli/src/commands/env/link.ts
@@ -61,7 +61,7 @@ export default class EnvironmentVariableLink extends EasCommand {
     }
 
     if (!environment) {
-      environment = await promptVariableEnvironmentAsync(nonInteractive);
+      environment = await promptVariableEnvironmentAsync({ nonInteractive });
     }
 
     const linkedVariable = await EnvironmentVariableMutation.linkSharedEnvironmentVariableAsync(

--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -50,7 +50,7 @@ export default class EnvironmentValueList extends EasCommand {
     });
 
     if (scope === EnvironmentVariableScope.Project && !environment) {
-      environment = await promptVariableEnvironmentAsync(false);
+      environment = await promptVariableEnvironmentAsync({ nonInteractive: false });
     }
 
     const variables = await this.getVariablesForScopeAsync(graphqlClient, {

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -34,7 +34,7 @@ export default class EnvironmentVariablePull extends EasCommand {
     } = await this.parse(EnvironmentVariablePull);
 
     if (!environment) {
-      environment = await promptVariableEnvironmentAsync(nonInteractive);
+      environment = await promptVariableEnvironmentAsync({ nonInteractive });
     }
     const {
       privateProjectConfig: { projectId },

--- a/packages/eas-cli/src/commands/env/unlink.ts
+++ b/packages/eas-cli/src/commands/env/unlink.ts
@@ -41,7 +41,7 @@ export default class EnvironmentVariableUnlink extends EasCommand {
     });
 
     if (!environment) {
-      environment = await promptVariableEnvironmentAsync(nonInteractive);
+      environment = await promptVariableEnvironmentAsync({ nonInteractive });
     }
 
     const projectDisplayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -81,7 +81,7 @@ export default class EnvironmentVariableUpdate extends EasCommand {
     ]);
 
     if (!environment) {
-      environment = await promptVariableEnvironmentAsync(nonInteractive);
+      environment = await promptVariableEnvironmentAsync({ nonInteractive });
     }
 
     const environments = environment ? [environment] : undefined;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

[ENG-13525: Update EAS-CLI for new EnvVar features](https://linear.app/expo/issue/ENG-13525/update-eas-cli-for-new-envvar-features)

EnvVar will support having multiple environments, CLI should support this.

# How

* Add an optional parameter `multiple` to `promptVariableEnvironmentAsync`
* Update commands using `promptVariableEnvironmentAsync`
* Add a new flag `EASMultiEnvironmentFlag`

# Test Plan

Tested manually, tests will be added in the following PRs
