### PR TITLE
Add tests to EnvironmentVariableGet

### DIFF
--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -26,7 +26,7 @@ export const EasNonInteractiveAndJsonFlags = {
   }),
 };
 
-const EasEnvironmentFlagParameters = {
+export const EasEnvironmentFlagParameters = {
   description: "Environment variable's environment",
   parse: upperCaseAsync,
   options: mapToLowercase([

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableGet.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableGet.test.ts
@@ -1,0 +1,109 @@
+import { Config } from '@oclif/core';
+
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../credentials/__tests__/fixtures-constants';
+import {
+  EnvironmentVariableEnvironment,
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+} from '../../../graphql/generated';
+import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
+import Log from '../../../log';
+import { promptVariableEnvironmentAsync, promptVariableNameAsync } from '../../../utils/prompts';
+import EnvironmentVariableGet from '../get';
+
+jest.mock('../../../graphql/mutations/EnvironmentVariableMutation');
+jest.mock('../../../graphql/queries/AppQuery');
+jest.mock('../../../graphql/queries/EnvironmentVariablesQuery');
+jest.mock('../../../utils/prompts');
+
+describe(EnvironmentVariableGet, () => {
+  const graphqlClient = {} as any as ExpoGraphqlClient;
+  const mockConfig = {} as unknown as Config;
+  const mockVariables = [
+    {
+      id: 'var1',
+      name: 'TEST_VAR_1',
+      value: 'value1',
+      environments: [EnvironmentVariableEnvironment.Production],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+    },
+  ];
+
+  it('retrieves environment variables successfully', async () => {
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync)
+      .mockResolvedValueOnce(mockVariables);
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+
+    const command = new EnvironmentVariableGet(['--variable-name', 'TEST_VAR_1'], mockConfig);
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      privateProjectConfig: { projectId: testProjectId },
+    });
+
+    await command.runAsync();
+
+    expect(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      {
+        appId: testProjectId,
+        environment: undefined,
+        filterNames: ['TEST_VAR_1'],
+      }
+    );
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('TEST_VAR_1'));
+  });
+
+  it('handles errors during retrieval', async () => {
+    const errorMessage =
+      "Variable name is required. Run the command with '--variable-name VARIABLE_NAME' flag";
+
+    const command = new EnvironmentVariableGet([], mockConfig);
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      privateProjectConfig: { projectId: testProjectId },
+    });
+
+    await expect(command.runAsync()).rejects.toThrow(errorMessage);
+  });
+
+  it('prompts for variable name and environment if the name is ambigous', async () => {
+    jest
+      .mocked(promptVariableEnvironmentAsync)
+      .mockResolvedValueOnce(EnvironmentVariableEnvironment.Production);
+    jest.mocked(promptVariableNameAsync).mockResolvedValueOnce('TEST_VAR_1');
+
+    const command = new EnvironmentVariableGet([], mockConfig);
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      privateProjectConfig: { projectId: testProjectId },
+    });
+    jest.mocked(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync).mockResolvedValueOnce([
+      ...mockVariables,
+      {
+        id: 'var2',
+        name: 'TEST_VAR_1',
+        value: 'value1',
+        environments: [EnvironmentVariableEnvironment.Development],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scope: EnvironmentVariableScope.Project,
+        visibility: EnvironmentVariableVisibility.Public,
+      },
+    ]);
+    await command.runAsync();
+
+    expect(promptVariableEnvironmentAsync).toHaveBeenCalled();
+    expect(promptVariableNameAsync).toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/graphql/queries/EnvironmentVariablesQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EnvironmentVariablesQuery.ts
@@ -44,6 +44,7 @@ export const EnvironmentVariablesQuery = {
                     id
                     name
                     value
+                    environments
                   }
                 }
               }
@@ -167,6 +168,7 @@ export const EnvironmentVariablesQuery = {
                       id
                       name
                       value
+                      environments
                     }
                   }
                 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

[ENG-13525: Update EAS-CLI for new EnvVar features](https://linear.app/expo/issue/ENG-13525/update-eas-cli-for-new-envvar-features)

Polished the interface:

 - user is prompted for environment only when the name is ambiguous.
- changed `name` parameter to `variable-name`. 

All commands that were using `name` parameter to identify a single variable will use `variable-name` and `variable-environment` instead. This change will enable user to distinguish between `name` and `environment` that is identifying variable that is acted upon, and `name` and `environment` that is a parameter for command.

For example, when the user wants to update variable `TEST` that has environment `production` and change its name and change its environment, they can use:

`eas env:update --variable-name TEST --variable-environment production --name TEST-update --environment production --environment preview`

# Test Plan

Added tests
