### PR TITLE
refactor(eas-cli): support assigning dev domain in non interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Support assigning dev domain names in non interactive mode.
+
 ### 🧹 Chores
 
 ## [12.5.0](https://github.com/expo/eas-cli/releases/tag/v12.5.0) - 2024-09-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Support assigning dev domain names in non interactive mode.
+- Support assigning dev domain names in non interactive mode. ([#2595](https://github.com/expo/eas-cli/pull/2595) by [@byCedric](https://github.com/byCedric))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3579,6 +3579,12 @@ export type DeleteWebhookResult = {
   id: Scalars['ID']['output'];
 };
 
+export type DeleteWorkerDeploymentResult = {
+  __typename?: 'DeleteWorkerDeploymentResult';
+  deploymentIdentifier: Scalars['WorkerDeploymentIdentifier']['output'];
+  id: Scalars['ID']['output'];
+};
+
 export type DeployServerlessFunctionResult = {
   __typename?: 'DeployServerlessFunctionResult';
   url: Scalars['String']['output'];
@@ -3724,6 +3730,7 @@ export type DeploymentsMutation = {
   /** Create a signed deployment URL */
   createSignedDeploymentUrl: DeploymentSignedUrlResult;
   deleteAlias: DeleteAliasResult;
+  deleteWorkerDeployment: DeleteWorkerDeploymentResult;
 };
 
 
@@ -3743,6 +3750,11 @@ export type DeploymentsMutationCreateSignedDeploymentUrlArgs = {
 export type DeploymentsMutationDeleteAliasArgs = {
   aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
   appId: Scalars['ID']['input'];
+};
+
+
+export type DeploymentsMutationDeleteWorkerDeploymentArgs = {
+  workerDeploymentId: Scalars['ID']['input'];
 };
 
 export type DiscordUser = {

--- a/packages/eas-cli/src/worker/deployment.ts
+++ b/packages/eas-cli/src/worker/deployment.ts
@@ -140,7 +140,7 @@ export async function assignDevDomainNameAsync({
   graphqlClient: ExpoGraphqlClient;
   appId: string;
   nonInteractive?: boolean;
-}) {
+}): ReturnType<typeof DeploymentsMutation.assignDevDomainNameAsync> {
   let devDomainName = await DeploymentsQuery.getSuggestedDevDomainByAppIdAsync(graphqlClient, {
     appId,
   });

--- a/packages/eas-cli/src/worker/deployment.ts
+++ b/packages/eas-cli/src/worker/deployment.ts
@@ -40,7 +40,11 @@ export async function getSignedDeploymentUrlAsync(
     // Ensure the callback is invoked, containing cleanup logic for possible spinners
     options.onSetupDevDomain?.();
     // Assign the dev domain name by prompting the user
-    await assignDevDomainNameAsync({ graphqlClient, appId: options.appId, nonInteractive: options.nonInteractive });
+    await assignDevDomainNameAsync({
+      graphqlClient,
+      appId: options.appId,
+      nonInteractive: options.nonInteractive,
+    });
     // Retry creating the signed URL
     return await getSignedDeploymentUrlAsync(graphqlClient, options);
   }
@@ -137,10 +141,9 @@ export async function assignDevDomainNameAsync({
   appId: string;
   nonInteractive?: boolean;
 }) {
-  let devDomainName = await DeploymentsQuery.getSuggestedDevDomainByAppIdAsync(
-    graphqlClient,
-    { appId }
-  );
+  let devDomainName = await DeploymentsQuery.getSuggestedDevDomainByAppIdAsync(graphqlClient, {
+    appId,
+  });
 
   if (!nonInteractive) {
     devDomainName = await promptDevDomainNameAsync(devDomainName);
@@ -162,7 +165,7 @@ export async function assignDevDomainNameAsync({
     }
 
     if (!nonInteractive) {
-      Log.error(`The preview URL "${name}" is already taken, choose a different URL.`);
+      Log.error(`The preview URL "${devDomainName}" is already taken, choose a different URL.`);
     }
 
     return await assignDevDomainNameAsync({ graphqlClient, appId, nonInteractive });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When running `eas worker --non-interactive`, it aborts on the first deployment due to a missing dev domain name. This changes that by automatically assigning the suggested dev domain when running in non interactive mode.

# How

- Split out prompting dev domain from assigning dev domain
- Automatically assign the suggested dev domain when running in non interactive mode

# Test Plan

Test the auto-assignment of the dev domain

- `$ export EXPO_STAGING=1`
- `$ bun create expo ./test-auto-assign`
- `$ cd ./test-auto-assign`
- `$ bun expo export --platform web`
- `$ easd init`
- `$ easd deploy --non-interactive`

<details><summary>Example</summary>

![image](https://github.com/user-attachments/assets/0e47a349-bdf9-4e68-8c70-bfebf65298ae)

</details>

Test the manual assignment of the dev domain

- `$ export EXPO_STAGING=1`
- `$ bun create expo ./test-manual-assign`
- `$ cd ./test-manual-assign`
- `$ bun expo export --platform web`
- `$ easd init`
- `$ easd deploy`

<details><summary>Example</summary>

![image](https://github.com/user-attachments/assets/659569d4-2c4e-42f4-9754-a733cbd481cc)

</details>