### PR TITLE
refactor(eas-cli): simplify the output of `eas deploy --json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- Simplify the output of `eas deploy --json`.
+- Simplify the output of `eas deploy --json`. ([#2596](https://github.com/expo/eas-cli/pull/2596) by [@byCedric](https://github.com/byCedric))
 
 ## [12.5.0](https://github.com/expo/eas-cli/releases/tag/v12.5.0) - 2024-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Simplify the output of `eas deploy --json`.
+
 ## [12.5.0](https://github.com/expo/eas-cli/releases/tag/v12.5.0) - 2024-09-23
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -311,7 +311,7 @@ export default class WorkerDeploy extends EasCommand {
             deploymentIdentifier: deployResult.id,
             url: getDeploymentUrlFromFullName(deployResult.fullName),
           },
-          aliases: [deploymentAlias].filter(Boolean) as WorkerDeploymentAliasFragment[],
+          alias: deploymentAlias,
           production: deploymentProdAlias,
         })
       );
@@ -328,7 +328,7 @@ export default class WorkerDeploy extends EasCommand {
           deploymentIdentifier: deployResult.id,
           url: getDeploymentUrlFromFullName(deployResult.fullName),
         },
-        aliases: [deploymentAlias].filter(Boolean) as WorkerDeploymentAliasFragment[],
+        alias: deploymentAlias,
         production: deploymentProdAlias,
       })
     );

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -6,10 +6,7 @@ import * as path from 'node:path';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { EASEnvironmentFlag, EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import {
-  EnvironmentVariableEnvironment,
-  WorkerDeploymentAliasFragment,
-} from '../../graphql/generated';
+import { EnvironmentVariableEnvironment } from '../../graphql/generated';
 import Log from '../../log';
 import { ora } from '../../ora';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -311,7 +308,7 @@ export default class WorkerDeploy extends EasCommand {
             deploymentIdentifier: deployResult.id,
             url: getDeploymentUrlFromFullName(deployResult.fullName),
           },
-          alias: deploymentAlias,
+          aliases: [deploymentAlias],
           production: deploymentProdAlias,
         })
       );
@@ -328,7 +325,7 @@ export default class WorkerDeploy extends EasCommand {
           deploymentIdentifier: deployResult.id,
           url: getDeploymentUrlFromFullName(deployResult.fullName),
         },
-        alias: deploymentAlias,
+        aliases: [deploymentAlias],
         production: deploymentProdAlias,
       })
     );

--- a/packages/eas-cli/src/worker/utils/logs.ts
+++ b/packages/eas-cli/src/worker/utils/logs.ts
@@ -22,7 +22,7 @@ type WorkerDeploymentData = {
   /** The actual deployment information */
   deployment: Pick<WorkerDeploymentFragment, 'deploymentIdentifier' | 'url'>;
   /** All modified aliases of the deployment, if any */
-  aliases?: WorkerDeploymentAliasFragment[];
+  alias?: WorkerDeploymentAliasFragment | null;
   /** The production promoting alias of the deployment, if any */
   production?: WorkerDeploymentAliasFragment | null;
 };
@@ -33,8 +33,8 @@ export function formatWorkerDeploymentTable(data: WorkerDeploymentData): string 
     { label: 'Deployment URL', value: data.deployment.url },
   ];
 
-  if (data.aliases?.length) {
-    fields.push({ label: 'Alias URL', value: data.aliases[0].url });
+  if (data.alias) {
+    fields.push({ label: 'Alias URL', value: data.alias.url });
   }
   if (data.production) {
     fields.push({ label: 'Production URL', value: data.production.url });
@@ -49,34 +49,22 @@ export function formatWorkerDeploymentTable(data: WorkerDeploymentData): string 
 type WorkerDeploymentOutput = {
   /** The absolute URL to the dashboard on `expo.dev` */
   dashboardUrl: string;
-  /** The deployment information */
-  deployment: {
-    identifier: string;
-    url: string;
-    aliases?: { id: string; name: string; url: string }[];
-    production?: { id: string; url: string };
-  };
+  /** The deployment identifier */
+  identifier: string;
+  /** The deployment URL */
+  url: string;
+  /** A custom alias, if assigned */
+  alias?: { id: string; url: string };
+  /** The production alias, if assigned */
+  production?: { id: string; url: string };
 };
 
 export function formatWorkerDeploymentJson(data: WorkerDeploymentData): WorkerDeploymentOutput {
   return {
     dashboardUrl: getDashboardUrl(data.projectId),
-    deployment: {
-      identifier: data.deployment.deploymentIdentifier,
-      url: data.deployment.url,
-      aliases: !data.aliases?.length
-        ? undefined
-        : data.aliases.map(alias => ({
-            id: alias.id,
-            name: alias.aliasName,
-            url: alias.url,
-          })),
-      production: !data.production
-        ? undefined
-        : {
-            id: data.production.id,
-            url: data.production.url,
-          },
-    },
+    identifier: data.deployment.deploymentIdentifier,
+    url: data.deployment.url,
+    alias: data.alias || undefined,
+    production: data.production || undefined,
   };
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The initial version was a bit conservative, nesting objects to not mix `dashboardUrl` with deployments. This change flattens the `deployment` object into the root object when running with `--json`.

# How

- Flattened the `deployment` object into the root object when running `eas deploy --json`

# Test Plan

![image](https://github.com/user-attachments/assets/958a521a-95c9-416b-9037-4e7428cde862)
