### PR TITLE
refactor(eas-cli): allow Expo Router server deployments without client directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Simplify the output of `eas deploy --json`. ([#2596](https://github.com/expo/eas-cli/pull/2596) by [@byCedric](https://github.com/byCedric))
+- Support deploying Expo Router server exports without client directory. ([#2597](https://github.com/expo/eas-cli/pull/2597) by [@byCedric](https://github.com/byCedric))
 
 ## [12.5.0](https://github.com/expo/eas-cli/releases/tag/v12.5.0) - 2024-09-23
 

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -82,12 +82,14 @@ export type AssetMap = Record<string, string>;
 
 /** Creates an asset map of a given target path */
 async function createAssetMapAsync(
-  assetPath: string,
+  assetPath?: string,
   options?: AssetMapOptions
 ): Promise<AssetMap> {
   const map: AssetMap = Object.create(null);
-  for await (const file of listFilesRecursively(assetPath)) {
-    map[file.normalizedPath] = await computeSha512HashAsync(file.path, options?.hashOptions);
+  if (assetPath) {
+    for await (const file of listFilesRecursively(assetPath)) {
+      map[file.normalizedPath] = await computeSha512HashAsync(file.path, options?.hashOptions);
+    }
   }
   return map;
 }


### PR DESCRIPTION
# Why

Previously, we checked on the existence of both `/dist/client` and `/dist/server` to enable a deployment for API routes. With upcoming changes in Expo Router, we'd need to support a "server only" deployment. This means, we can't check `/dist/client` as it might not exist.

# How

- Check on `/dist/server/_expo/routes.json` to enable server deployments
- Make `/dist/client` optional during upload

# Test Plan

- `$ bun create expo ./test-server-only`
- `$ cd ./test-server-only`
- Create an API route, e.g. `app/test+api.ts` with:
  ```ts
  export function GET() {
    return Response.json({ ok: true });
  }
  ```
- Change the output type to `server` in `app.json`'s `web.output = server`.
- `$ rm -rf ./dist/client`
- `$ easd deploy`
