### PR TITLE
refactor(eas-cli): Implement updated deployment upload flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Implement new `worker` deploy API flow. ([#2601](https://github.com/expo/eas-cli/pull/2601) by [@kitten](https://github.com/kitten)))
+
 ## [12.5.1](https://github.com/expo/eas-cli/releases/tag/v12.5.1) - 2024-09-27
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -17,7 +17,12 @@ import {
   assignWorkerDeploymentProductionAsync,
   getSignedDeploymentUrlAsync,
 } from '../../worker/deployment';
-import { UploadParams, batchUploadAsync, uploadAsync, callUploadApiAsync } from '../../worker/upload';
+import {
+  UploadParams,
+  batchUploadAsync,
+  callUploadApiAsync,
+  uploadAsync,
+} from '../../worker/upload';
 import {
   formatWorkerDeploymentJson,
   formatWorkerDeploymentTable,
@@ -147,7 +152,10 @@ export default class WorkerDeploy extends EasCommand {
       }
     }
 
-    async function uploadTarballAsync(tarPath: string, uploadUrl: string): Promise<DeployInProgressParams> {
+    async function uploadTarballAsync(
+      tarPath: string,
+      uploadUrl: string
+    ): Promise<DeployInProgressParams> {
       const { response } = await uploadAsync({
         url: uploadUrl,
         filePath: tarPath,

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -50,6 +50,13 @@ interface RawDeployFlags {
   'export-dir': string;
 }
 
+interface DeployInProgressParams {
+  id: string;
+  fullName: string;
+  baseURL: string;
+  token: string;
+}
+
 export default class WorkerDeploy extends EasCommand {
   static override description = 'Deploy your Expo web build';
   static override aliases = ['deploy'];
@@ -126,7 +133,7 @@ export default class WorkerDeploy extends EasCommand {
       }
     }
 
-    async function uploadTarballAsync(tarPath: string, uploadUrl: string): Promise<any> {
+    async function uploadTarballAsync(tarPath: string, uploadUrl: string): Promise<DeployInProgressParams> {
       const { response } = await uploadAsync({
         url: uploadUrl,
         filePath: tarPath,
@@ -150,19 +157,23 @@ export default class WorkerDeploy extends EasCommand {
         if (!json.success || !json.result || typeof json.result !== 'object') {
           throw new Error(json.message ? `Upload failed: ${json.message}` : 'Upload failed!');
         }
-        return json.result;
+        const { id, fullName, token } = json.result;
+        if (typeof token !== 'string') {
+          throw new Error('Upload failed: API failed to return a deployment token');
+        } else if (typeof id !== 'string') {
+          throw new Error('Upload failed: API failed to return a deployment identifier');
+        } else if (typeof fullName !== 'string') {
+          throw new Error('Upload failed: API failed to return a script name');
+        }
+        const baseURL = new URL('/', uploadUrl).toString();
+        return { id, fullName, baseURL, token };
       }
     }
 
     async function uploadAssetsAsync(
       assetMap: WorkerAssets.AssetMap,
-      uploads: Record<string, string>
+      deployParams: DeployInProgressParams
     ): Promise<void> {
-      if (typeof uploads !== 'object' || !uploads) {
-        return;
-      }
-
-      // TODO(@kitten): Batch and upload multiple files in parallel
       const uploadParams: UploadParams[] = [];
       const assetPath = projectDist.type === 'server' ? projectDist.clientPath : projectDist.path;
       if (!assetPath) {
@@ -170,10 +181,9 @@ export default class WorkerDeploy extends EasCommand {
       }
 
       for await (const asset of WorkerAssets.listAssetMapFilesAsync(assetPath, assetMap)) {
-        const uploadURL = uploads[asset.normalizedPath];
-        if (uploadURL) {
-          uploadParams.push({ url: uploadURL, filePath: asset.path });
-        }
+        const uploadURL = new URL(`/asset/${asset.sha512}`, deployParams.baseURL);
+        uploadURL.searchParams.set('token', deployParams.token);
+        uploadParams.push({ url: uploadURL.toString(), filePath: asset.path });
       }
 
       const progress = {
@@ -214,7 +224,7 @@ export default class WorkerDeploy extends EasCommand {
 
     let assetMap: WorkerAssets.AssetMap;
     let tarPath: string;
-    let deployResult: any;
+    let deployResult: DeployInProgressParams;
     let progress = ora('Preparing project').start();
 
     try {
@@ -253,7 +263,7 @@ export default class WorkerDeploy extends EasCommand {
       throw error;
     }
 
-    await uploadAssetsAsync(assetMap, deployResult.uploads);
+    await uploadAssetsAsync(assetMap, deployResult);
 
     let deploymentAlias: null | Awaited<ReturnType<typeof assignWorkerDeploymentAliasAsync>> = null;
     if (flags.aliasName) {

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -129,8 +129,8 @@ export async function createManifestAsync(
 
 interface WorkerFileEntry {
   normalizedPath: string;
+  sha512: string;
   path: string;
-  data: Buffer | string;
 }
 
 /** Reads worker files while normalizing sourcemaps and providing normalized paths */
@@ -151,11 +151,10 @@ async function* listAssetMapFilesAsync(
 ): AsyncGenerator<WorkerFileEntry> {
   for (const normalizedPath in assetMap) {
     const filePath = path.resolve(assetPath, normalizedPath.split('/').join(path.sep));
-    const data = await fs.promises.readFile(filePath);
     yield {
       normalizedPath,
       path: filePath,
-      data,
+      sha512: assetMap[normalizedPath],
     };
   }
 }

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -129,8 +129,8 @@ export async function createManifestAsync(
 
 interface WorkerFileEntry {
   normalizedPath: string;
-  sha512: string;
   path: string;
+  data: Buffer | string;
 }
 
 /** Reads worker files while normalizing sourcemaps and providing normalized paths */
@@ -144,11 +144,17 @@ async function* listWorkerFilesAsync(workerPath: string): AsyncGenerator<WorkerF
   }
 }
 
+interface AssetFileEntry {
+  normalizedPath: string;
+  sha512: string;
+  path: string;
+}
+
 /** Reads files of an asset maps and enumerates normalized paths and data */
 async function* listAssetMapFilesAsync(
   assetPath: string,
   assetMap: AssetMap
-): AsyncGenerator<WorkerFileEntry> {
+): AsyncGenerator<AssetFileEntry> {
   for (const normalizedPath in assetMap) {
     const filePath = path.resolve(assetPath, normalizedPath.split('/').join(path.sep));
     yield {

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -140,27 +140,25 @@ export async function uploadAsync(params: UploadParams): Promise<UploadResult> {
 }
 
 export async function callUploadApiAsync(url: string | URL, init?: RequestInit): Promise<unknown> {
-  return await promiseRetry(
-    async retry => {
-      let response: Response;
-      try {
-        response = await fetch(url, {
-          ...init,
-          agent: getAgent(),
-        });
-      } catch (error) {
-        return retry(error);
-      }
-      if (response.status >= 500 && response.status <= 599) {
-        retry(new Error(`Deployment failed: ${response.statusText}`));
-      }
-      try {
-        return await response.json();
-      } catch (error) {
-        retry(error);
-      }
+  return await promiseRetry(async retry => {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        ...init,
+        agent: getAgent(),
+      });
+    } catch (error) {
+      return retry(error);
     }
-  );
+    if (response.status >= 500 && response.status <= 599) {
+      retry(new Error(`Deployment failed: ${response.statusText}`));
+    }
+    try {
+      return await response.json();
+    } catch (error) {
+      retry(error);
+    }
+  });
 }
 
 export interface UploadPending {

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -139,6 +139,30 @@ export async function uploadAsync(params: UploadParams): Promise<UploadResult> {
   );
 }
 
+export async function callUploadApiAsync(url: string | URL, init?: RequestInit): Promise<unknown> {
+  return await promiseRetry(
+    async retry => {
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          ...init,
+          agent: getAgent(),
+        });
+      } catch (error) {
+        return retry(error);
+      }
+      if (response.status >= 500 && response.status <= 599) {
+        retry(new Error(`Deployment failed: ${response.statusText}`));
+      }
+      try {
+        return await response.json();
+      } catch (error) {
+        retry(error);
+      }
+    }
+  );
+}
+
 export interface UploadPending {
   params: UploadParams;
 }


### PR DESCRIPTION
Depends on: https://github.com/expo/expo-easy-poc/pull/52

# Why

Previously, there was no concept of "finalizing" a deployment, which meant:
- the last asset upload implicitly "finalizes" the deployment and marks it as failed or complete
- if any asset upload failed, the deployment wouldn't delete itself, since it doesn't know whether the CLI will retry
- we accepted a full map object of upload URLs rather than reusing tokens, since the API didn't check if an asset or deployment were known

# How

- Validate new result payload from `/deploy` endpoint
- Construct upload URLs to `/asset/:hash?token=`
- Add call to `/deploy/finalize?token=` after uploading assets

# Test Plan

- Manually tested against staging deployment