### PR TITLE
[eas-cli] Disallow republishing an update that is being rolled-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Disallow republishing an update that is being rolled-out. ([#2602](https://github.com/expo/eas-cli/pull/2602) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 - Implement new `worker` deploy API flow. ([#2601](https://github.com/expo/eas-cli/pull/2601) by [@kitten](https://github.com/kitten)))

--- a/packages/eas-cli/src/update/republish.ts
+++ b/packages/eas-cli/src/update/republish.ts
@@ -69,6 +69,11 @@ export async function republishAsync({
     'All updates must either be roll back to embedded updates or not'
   );
 
+  assert(
+    !updatesToPublish.some(u => !!u.rolloutControlUpdate),
+    'Cannot republish an update that is being rolled-out. Either complete the update rollout and then republish or publish a new rollout update.'
+  );
+
   const { runtimeVersion } = arbitraryUpdate;
 
   // If codesigning was created for the original update, we need to add it to the republish.


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

What it means to republish an update that is being rolled-out is undefined behavior. Rather than try to guess at the user's intent, just throw an error in this case and give guidance about other options to help them clarify intent.

Note that this doesn't hide the groups during interactive chooser, since that'd be even more confusing IMO.

Closes ENG-13613.

# How

Throw error when any update being republished is a rollout update.

# Test Plan

```
$ neas update:republish --branch main
✔ Load more update groups? › [Aug 19 16:23 by wschurman, runtimeVersion: 1.0.0] wat2
✔ The republished update group will appear only on: all
✔ Provide an update message. … dsadsasd
Cannot republish an update that is being rolled-out. Either complete the update rollout and then republish or publish a new rollout update.
    Error: update:republish command failed.
```