### PR TITLE
[eas-cli] Add `configInput` to `submit:internal` output

### DIFF
--- a/packages/eas-cli/src/commands/submit/internal.ts
+++ b/packages/eas-cli/src/commands/submit/internal.ts
@@ -92,6 +92,7 @@ export default class SubmitInternal extends EasCommand {
     });
 
     let config;
+    let configInput;
 
     if (ctx.platform === Platform.IOS) {
       const command = new IosSubmitCommand(ctx as SubmissionContext<Platform.IOS>);
@@ -104,7 +105,7 @@ export default class SubmitInternal extends EasCommand {
         graphqlClient,
       });
 
-      const configInput: z.input<typeof SubmissionConfig.Ios.SchemaZ> = {
+      const schemaInput: z.input<typeof SubmissionConfig.Ios.SchemaZ> = {
         ascAppIdentifier: iosConfig.ascAppIdentifier,
         isVerboseFastlaneEnabled: iosConfig.isVerboseFastlaneEnabled ?? undefined,
         ...(ascApiKeyJson
@@ -115,7 +116,8 @@ export default class SubmitInternal extends EasCommand {
             }),
       };
 
-      config = SubmissionConfig.Ios.SchemaZ.parse(configInput);
+      config = SubmissionConfig.Ios.SchemaZ.parse(schemaInput);
+      configInput = iosConfig;
     } else if (ctx.platform === Platform.ANDROID) {
       const command = new AndroidSubmitCommand(ctx as SubmissionContext<Platform.ANDROID>);
       const submitter = await command.runAsync();
@@ -134,7 +136,7 @@ export default class SubmitInternal extends EasCommand {
       );
       const track = graphQlTrackToConfigTrack[androidConfig.track];
 
-      const configInput: z.input<typeof SubmissionConfig.Android.SchemaZ> = {
+      const schemaInput: z.input<typeof SubmissionConfig.Android.SchemaZ> = {
         changesNotSentForReview,
         googleServiceAccountKeyJson,
         track,
@@ -146,12 +148,13 @@ export default class SubmitInternal extends EasCommand {
           : { releaseStatus }),
       };
 
-      config = SubmissionConfig.Android.SchemaZ.parse(configInput);
+      config = SubmissionConfig.Android.SchemaZ.parse(schemaInput);
+      configInput = androidConfig;
     } else {
       throw new Error(`Unsupported platform: ${ctx.platform}`);
     }
 
-    printJsonOnlyOutput({ config });
+    printJsonOnlyOutput({ config, configInput });
   }
 }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When creating a Submission Entity I want to also provide the submission config. https://linear.app/expo/issue/ENG-13612/create-submission-entity-upon-successful-workflow-submission

# How

Added `configInput` next to `config`. Backwards compatible.

# Test Plan

`EXPO_LOCAL=1 /Users/sjchmiela/Developer/eas-cli/bin/run submit:internal --platform ios --id eebf0c9b-8f7a-41c0-9633-cb1576e17e23`:

<img width="340" alt="Zrzut ekranu 2024-10-9 o 11 39 40" src="https://github.com/user-attachments/assets/52d406f9-9dc7-478c-87db-0571d3c2d2f1">

