### PR TITLE
[eas-cli] add pause/resume commands for Update Channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- Add `eas channel:pause` and `eas channel:resume` commands to pause and resume update delivery to
-  builds using specific update channels. ([#2614](https://github.com/expo/eas-cli/pull/2614) by
-  [@fiberjw](https://github.com/fiberjw))
-- Update channel details output to show paused status. ([#2614](https://github.com/expo/eas-cli/pull/2614) by
-  [@fiberjw](https://github.com/fiberjw))
+- Add `eas channel:pause` and `eas channel:resume` commands to pause/resume update delivery to builds using specific update channels and display paused status in channel details output. ([#2614](https://github.com/expo/eas-cli/pull/2614) by [@fiberjw](https://github.com/fiberjw))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `eas channel:pause` and `eas channel:resume` commands to pause and resume update delivery to
+  builds using specific update channels. ([#2614](https://github.com/expo/eas-cli/pull/2614) by
+  [@fiberjw](https://github.com/fiberjw))
+- Update channel details output to show paused status. ([#2614](https://github.com/expo/eas-cli/pull/2614) by
+  [@fiberjw](https://github.com/fiberjw))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -4588,6 +4588,11 @@
             "kind": "OBJECT",
             "name": "Update",
             "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "WorkerDeployment",
+            "ofType": null
           }
         ]
       },
@@ -4613,6 +4618,12 @@
           },
           {
             "name": "UPDATE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "WORKER",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -10705,6 +10716,30 @@
               "kind": "OBJECT",
               "name": "WorkerDeploymentRequests",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflows",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Workflow",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -16861,11 +16896,11 @@
         "description": null,
         "fields": [
           {
-            "name": "byAccountId",
-            "description": "Query Audit Logs by account ID",
+            "name": "byId",
+            "description": "Audit logs for account",
             "args": [
               {
-                "name": "accountId",
+                "name": "auditLogId",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -16879,95 +16914,15 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "targetEntityMutationType",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "TargetEntityMutationType",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "targetEntityTypeName",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "EntityTypeName",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
               }
             ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "AuditLog",
-                    "ofType": null
-                  }
-                }
+                "kind": "OBJECT",
+                "name": "AuditLog",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -26307,6 +26262,18 @@
           },
           {
             "name": "UserPermission",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "Workflow",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "WorkflowRevision",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -37790,6 +37757,115 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestsOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "RequestsOrderByDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "RequestsOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "RequestsOrderByDirection",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "RequestsOrderByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASSETS_SUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CACHE_HIT_RATIO",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CACHE_PASS_RATIO",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CRASHES_SUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DURATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REQUESTS_SUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "RescindUserInvitationResult",
         "description": null,
@@ -40150,6 +40226,38 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "WorkerDeploymentQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowRevisions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowRevisionQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflows",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowQuery",
                 "ofType": null
               }
             },
@@ -49716,83 +49824,11 @@
         "description": null,
         "fields": [
           {
-            "name": "byUserId",
-            "description": "Query User Audit Logs by user ID",
+            "name": "byId",
+            "description": "Audit logs for user",
             "args": [
               {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "targetEntityMutationType",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "TargetEntityMutationType",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "targetEntityTypeName",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "UserEntityTypeName",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "userId",
+                "name": "auditLogId",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -49812,17 +49848,9 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "UserAuditLog",
-                    "ofType": null
-                  }
-                }
+                "kind": "OBJECT",
+                "name": "UserAuditLog",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -49830,7 +49858,7 @@
           },
           {
             "name": "byUserIdPaginated",
-            "description": "Audit logs for user",
+            "description": null,
             "args": [
               {
                 "name": "after",
@@ -51985,6 +52013,34 @@
         "description": null,
         "fields": [
           {
+            "name": "activityTimestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "actor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "aliases",
             "description": null,
             "args": [],
@@ -52253,7 +52309,13 @@
           }
         ],
         "inputFields": null,
-        "interfaces": [],
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ActivityTimelineProjectActivity",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -53895,7 +53957,32 @@
           {
             "name": "byBrowser",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestsOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -53919,7 +54006,32 @@
           {
             "name": "byCacheStatus",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestsOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -53943,7 +54055,32 @@
           {
             "name": "byContinent",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestsOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -53965,9 +54102,83 @@
             "deprecationReason": null
           },
           {
+            "name": "byCountry",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestsOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestsCountryEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "byMethod",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestsOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -53991,7 +54202,32 @@
           {
             "name": "byOS",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestsOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -54013,9 +54249,83 @@
             "deprecationReason": null
           },
           {
+            "name": "byResponseType",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestsOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestsResponseTypeEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "byStatusType",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestsOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -54840,6 +55150,45 @@
       },
       {
         "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestsCountryEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "country",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestsAggregationNode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "WorkerDeploymentRequestsMethodEdge",
         "description": null,
         "fields": [
@@ -54910,6 +55259,49 @@
               "kind": "ENUM",
               "name": "UserAgentOS",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerDeploymentRequestsResponseTypeEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkerDeploymentRequestsAggregationNode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "responseType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ResponseType",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -55037,6 +55429,30 @@
             "deprecationReason": null
           },
           {
+            "name": "byCountry",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestsCountryEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "byMethod",
             "description": null,
             "args": [],
@@ -55076,6 +55492,30 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "WorkerDeploymentRequestsOperatingSystemEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "byResponseType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerDeploymentRequestsResponseTypeEdge",
                     "ofType": null
                   }
                 }
@@ -55242,6 +55682,133 @@
       },
       {
         "kind": "OBJECT",
+        "name": "Workflow",
+        "description": null,
+        "fields": [
+          {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revisions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowRevision",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "WorkflowJobMutation",
         "description": null,
         "fields": [
@@ -55272,6 +55839,201 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowQuery",
+        "description": "Look up Workflow by ID",
+        "fields": [
+          {
+            "name": "byId",
+            "description": null,
+            "args": [
+              {
+                "name": "workflowId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Workflow",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowRevision",
+        "description": null,
+        "fields": [
+          {
+            "name": "blobSha",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "commitSha",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflow",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Workflow",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "yamlConfig",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowRevisionQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byId",
+            "description": null,
+            "args": [
+              {
+                "name": "workflowRevisionId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowRevision",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/src/channel/__tests__/fixtures.ts
+++ b/packages/eas-cli/src/channel/__tests__/fixtures.ts
@@ -128,6 +128,7 @@ export const testChannelObject: UpdateChannelObject = {
   branchMapping:
     '{"data":[{"branchId":"754bf17f-efc0-46ab-8a59-a03f20e53e9b","branchMappingLogic":{"operand":0.15,"clientKey":"rolloutToken","branchMappingOperator":"hash_lt"}},{"branchId":"6941a8dd-5c0a-48bc-8876-f49c88ed419f","branchMappingLogic":"true"}],"version":0}',
   updateBranches: [testUpdateBranch1, testUpdateBranch2],
+  isPaused: false,
   __typename: 'UpdateChannel',
 };
 

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -110,7 +110,11 @@ export async function listAndRenderBranchesAndUpdatesOnChannelAsync(
   }
 ): Promise<void> {
   const channel = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, { appId, channelName });
-  renderChannelHeaderContent({ channelName: channel.name, channelId: channel.id });
+  renderChannelHeaderContent({
+    channelName: channel.name,
+    channelId: channel.id,
+    isPaused: channel.isPaused,
+  });
 
   if (paginatedQueryOptions.nonInteractive) {
     const branches = await queryBranchesAndUpdateGroupsOnChannelAsync(graphqlClient, {
@@ -167,7 +171,11 @@ function renderPageOfChannels(
     printJsonOnlyOutput({ currentPage });
   } else {
     for (const channel of currentPage) {
-      renderChannelHeaderContent({ channelName: channel.name, channelId: channel.id });
+      renderChannelHeaderContent({
+        channelName: channel.name,
+        channelId: channel.id,
+        isPaused: channel.isPaused,
+      });
       Log.addNewLineIfNone();
       logChannelDetails(channel);
 
@@ -196,9 +204,11 @@ function renderPageOfBranchesOnChannel(
 function renderChannelHeaderContent({
   channelName,
   channelId,
+  isPaused,
 }: {
   channelName: string;
   channelId: string;
+  isPaused: boolean;
 }): void {
   Log.addNewLineIfNone();
   Log.log(chalk.bold('Channel:'));
@@ -206,6 +216,7 @@ function renderChannelHeaderContent({
     formatFields([
       { label: 'Name', value: channelName },
       { label: 'ID', value: channelId },
+      { label: 'Status', value: isPaused ? 'Paused' : 'Active' },
     ])
   );
   Log.addNewLineIfNone();

--- a/packages/eas-cli/src/commands/channel/pause.ts
+++ b/packages/eas-cli/src/commands/channel/pause.ts
@@ -1,0 +1,113 @@
+import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { selectChannelOnAppAsync } from '../../channel/queries';
+import EasCommand from '../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { withErrorHandlingAsync } from '../../graphql/client';
+import {
+  PauseUpdateChannelMutation,
+  PauseUpdateChannelMutationVariables,
+  UpdateChannelBasicInfoFragment,
+} from '../../graphql/generated';
+import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import { UpdateChannelBasicInfoFragmentNode } from '../../graphql/types/UpdateChannelBasicInfo';
+import Log from '../../log';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+export async function pauseUpdateChannelAsync(
+  graphqlClient: ExpoGraphqlClient,
+  { channelId }: PauseUpdateChannelMutationVariables
+): Promise<UpdateChannelBasicInfoFragment> {
+  const data = await withErrorHandlingAsync(
+    graphqlClient
+      .mutation<PauseUpdateChannelMutation, PauseUpdateChannelMutationVariables>(
+        gql`
+          mutation PauseUpdateChannel($channelId: ID!) {
+            updateChannel {
+              pauseUpdateChannel(channelId: $channelId) {
+                id
+                ...UpdateChannelBasicInfoFragment
+              }
+            }
+          }
+          ${print(UpdateChannelBasicInfoFragmentNode)}
+        `,
+        { channelId }
+      )
+      .toPromise()
+  );
+  const channel = data.updateChannel.pauseUpdateChannel;
+  if (!channel) {
+    throw new Error(`Could not find a channel with id: ${channelId}`);
+  }
+  return channel;
+}
+
+export default class ChannelPause extends EasCommand {
+  static override description = 'pause a channel to stop it from sending updates';
+
+  static override args = [
+    {
+      name: 'name',
+      required: false,
+      description: 'Name of the channel to edit',
+    },
+  ];
+
+  static override flags = {
+    branch: Flags.string({
+      description: 'Name of the branch to point to',
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args,
+      flags: { json, 'non-interactive': nonInteractive },
+    } = await this.parse(ChannelPause);
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(ChannelPause, {
+      nonInteractive,
+    });
+    if (json) {
+      enableJsonOutput();
+    }
+
+    const existingChannel = args.name
+      ? await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+          appId: projectId,
+          channelName: args.name,
+        })
+      : await selectChannelOnAppAsync(graphqlClient, {
+          projectId,
+          selectionPromptTitle: 'Select a channel to edit',
+          paginatedQueryOptions: { json, nonInteractive, offset: 0 },
+        });
+
+    const channel = await pauseUpdateChannelAsync(graphqlClient, {
+      channelId: existingChannel.id,
+    });
+
+    if (json) {
+      printJsonOnlyOutput(channel);
+    } else {
+      Log.withTick(chalk`Channel {bold ${channel.name}} is now paused.\n`);
+      Log.addNewLineIfNone();
+      Log.log(
+        chalk`Users with builds on channel {bold ${channel.name}} will no longer receive updates.`
+      );
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/channel/resume.ts
+++ b/packages/eas-cli/src/commands/channel/resume.ts
@@ -1,0 +1,111 @@
+import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { selectChannelOnAppAsync } from '../../channel/queries';
+import EasCommand from '../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { withErrorHandlingAsync } from '../../graphql/client';
+import {
+  PauseUpdateChannelMutation,
+  PauseUpdateChannelMutationVariables,
+  UpdateChannelBasicInfoFragment,
+} from '../../graphql/generated';
+import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import { UpdateChannelBasicInfoFragmentNode } from '../../graphql/types/UpdateChannelBasicInfo';
+import Log from '../../log';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+export async function resumeUpdateChannelAsync(
+  graphqlClient: ExpoGraphqlClient,
+  { channelId }: PauseUpdateChannelMutationVariables
+): Promise<UpdateChannelBasicInfoFragment> {
+  const data = await withErrorHandlingAsync(
+    graphqlClient
+      .mutation<PauseUpdateChannelMutation, PauseUpdateChannelMutationVariables>(
+        gql`
+          mutation ResumeUpdateChannel($channelId: ID!) {
+            updateChannel {
+              resumeUpdateChannel(channelId: $channelId) {
+                id
+                ...UpdateChannelBasicInfoFragment
+              }
+            }
+          }
+          ${print(UpdateChannelBasicInfoFragmentNode)}
+        `,
+        { channelId }
+      )
+      .toPromise()
+  );
+  const channel = data.updateChannel.pauseUpdateChannel;
+  if (!channel) {
+    throw new Error(`Could not find a channel with id: ${channelId}`);
+  }
+  return channel;
+}
+
+export default class ChannelResume extends EasCommand {
+  static override description = 'resume a channel to start sending updates';
+
+  static override args = [
+    {
+      name: 'name',
+      required: false,
+      description: 'Name of the channel to edit',
+    },
+  ];
+
+  static override flags = {
+    branch: Flags.string({
+      description: 'Name of the branch to point to',
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args,
+      flags: { json, 'non-interactive': nonInteractive },
+    } = await this.parse(ChannelResume);
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(ChannelResume, {
+      nonInteractive,
+    });
+    if (json) {
+      enableJsonOutput();
+    }
+
+    const existingChannel = args.name
+      ? await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+          appId: projectId,
+          channelName: args.name,
+        })
+      : await selectChannelOnAppAsync(graphqlClient, {
+          projectId,
+          selectionPromptTitle: 'Select a channel to edit',
+          paginatedQueryOptions: { json, nonInteractive, offset: 0 },
+        });
+
+    const channel = await resumeUpdateChannelAsync(graphqlClient, {
+      channelId: existingChannel.id,
+    });
+
+    if (json) {
+      printJsonOnlyOutput(channel);
+    } else {
+      Log.withTick(chalk`Channel {bold ${channel.name}} is now resumed.\n`);
+      Log.addNewLineIfNone();
+      Log.log(chalk`Users with builds on channel {bold ${channel.name}} will now receive updates.`);
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/channel/resume.ts
+++ b/packages/eas-cli/src/commands/channel/resume.ts
@@ -9,8 +9,8 @@ import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/creat
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { withErrorHandlingAsync } from '../../graphql/client';
 import {
-  PauseUpdateChannelMutation,
-  PauseUpdateChannelMutationVariables,
+  ResumeUpdateChannelMutation,
+  ResumeUpdateChannelMutationVariables,
   UpdateChannelBasicInfoFragment,
 } from '../../graphql/generated';
 import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
@@ -20,11 +20,11 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export async function resumeUpdateChannelAsync(
   graphqlClient: ExpoGraphqlClient,
-  { channelId }: PauseUpdateChannelMutationVariables
+  { channelId }: ResumeUpdateChannelMutationVariables
 ): Promise<UpdateChannelBasicInfoFragment> {
   const data = await withErrorHandlingAsync(
     graphqlClient
-      .mutation<PauseUpdateChannelMutation, PauseUpdateChannelMutationVariables>(
+      .mutation<ResumeUpdateChannelMutation, ResumeUpdateChannelMutationVariables>(
         gql`
           mutation ResumeUpdateChannel($channelId: ID!) {
             updateChannel {
@@ -40,7 +40,7 @@ export async function resumeUpdateChannelAsync(
       )
       .toPromise()
   );
-  const channel = data.updateChannel.pauseUpdateChannel;
+  const channel = data.updateChannel.resumeUpdateChannel;
   if (!channel) {
     throw new Error(`Could not find a channel with id: ${channelId}`);
   }
@@ -103,7 +103,7 @@ export default class ChannelResume extends EasCommand {
     if (json) {
       printJsonOnlyOutput(channel);
     } else {
-      Log.withTick(chalk`Channel {bold ${channel.name}} is now resumed.\n`);
+      Log.withTick(chalk`Channel {bold ${channel.name}} is now active.\n`);
       Log.addNewLineIfNone();
       Log.log(chalk`Users with builds on channel {bold ${channel.name}} will now receive updates.`);
     }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -762,7 +762,8 @@ export type ActivityTimelineProjectActivity = {
 export enum ActivityTimelineProjectActivityType {
   Build = 'BUILD',
   Submission = 'SUBMISSION',
-  Update = 'UPDATE'
+  Update = 'UPDATE',
+  Worker = 'WORKER'
 }
 
 /** A regular user, SSO user, or robot that can authenticate with Expo services and be a member of accounts. */
@@ -1373,6 +1374,7 @@ export type App = Project & {
   workerDeploymentsCrashes?: Maybe<WorkerDeploymentCrashes>;
   workerDeploymentsRequest: WorkerDeploymentRequestEdge;
   workerDeploymentsRequests?: Maybe<WorkerDeploymentRequests>;
+  workflows: Array<Workflow>;
 };
 
 
@@ -2531,17 +2533,13 @@ export type AuditLogMutationExportAuditLogsArgs = {
 
 export type AuditLogQuery = {
   __typename?: 'AuditLogQuery';
-  /** Query Audit Logs by account ID */
-  byAccountId: Array<AuditLog>;
+  /** Audit logs for account */
+  byId: AuditLog;
 };
 
 
-export type AuditLogQueryByAccountIdArgs = {
-  accountId: Scalars['ID']['input'];
-  limit: Scalars['Int']['input'];
-  offset: Scalars['Int']['input'];
-  targetEntityMutationType?: InputMaybe<Array<TargetEntityMutationType>>;
-  targetEntityTypeName?: InputMaybe<Array<EntityTypeName>>;
+export type AuditLogQueryByIdArgs = {
+  auditLogId: Scalars['ID']['input'];
 };
 
 export enum AuditLogsExportFormat {
@@ -3881,7 +3879,9 @@ export enum EntityTypeName {
   GoogleServiceAccountKey = 'GoogleServiceAccountKey',
   IosAppCredentials = 'IosAppCredentials',
   UserInvitation = 'UserInvitation',
-  UserPermission = 'UserPermission'
+  UserPermission = 'UserPermission',
+  Workflow = 'Workflow',
+  WorkflowRevision = 'WorkflowRevision'
 }
 
 export type EnvironmentSecret = {
@@ -5463,6 +5463,25 @@ export type RequestsFilters = {
   statusType?: InputMaybe<Array<ResponseStatusType>>;
 };
 
+export type RequestsOrderBy = {
+  direction?: InputMaybe<RequestsOrderByDirection>;
+  field: RequestsOrderByField;
+};
+
+export enum RequestsOrderByDirection {
+  Asc = 'ASC',
+  Desc = 'DESC'
+}
+
+export enum RequestsOrderByField {
+  AssetsSum = 'ASSETS_SUM',
+  CacheHitRatio = 'CACHE_HIT_RATIO',
+  CachePassRatio = 'CACHE_PASS_RATIO',
+  CrashesSum = 'CRASHES_SUM',
+  Duration = 'DURATION',
+  RequestsSum = 'REQUESTS_SUM'
+}
+
 export type RescindUserInvitationResult = {
   __typename?: 'RescindUserInvitationResult';
   id: Scalars['ID']['output'];
@@ -5799,6 +5818,8 @@ export type RootQuery = {
   /** Top-level query object for querying Webhooks. */
   webhook: WebhookQuery;
   workerDeployment: WorkerDeploymentQuery;
+  workflowRevisions: WorkflowRevisionQuery;
+  workflows: WorkflowQuery;
 };
 
 
@@ -7175,19 +7196,14 @@ export type UserAuditLogMutationExportUserAuditLogsArgs = {
 
 export type UserAuditLogQuery = {
   __typename?: 'UserAuditLogQuery';
-  /** Query User Audit Logs by user ID */
-  byUserId: Array<UserAuditLog>;
   /** Audit logs for user */
+  byId: UserAuditLog;
   byUserIdPaginated: UserAuditLogConnection;
 };
 
 
-export type UserAuditLogQueryByUserIdArgs = {
-  limit: Scalars['Int']['input'];
-  offset: Scalars['Int']['input'];
-  targetEntityMutationType?: InputMaybe<Array<TargetEntityMutationType>>;
-  targetEntityTypeName?: InputMaybe<Array<UserEntityTypeName>>;
-  userId: Scalars['ID']['input'];
+export type UserAuditLogQueryByIdArgs = {
+  auditLogId: Scalars['ID']['input'];
 };
 
 
@@ -7517,8 +7533,10 @@ export type WorkerCustomDomain = {
   verificationRecord?: Maybe<CustomDomainDnsRecord>;
 };
 
-export type WorkerDeployment = {
+export type WorkerDeployment = ActivityTimelineProjectActivity & {
   __typename?: 'WorkerDeployment';
+  activityTimestamp: Scalars['DateTime']['output'];
+  actor?: Maybe<Actor>;
   aliases?: Maybe<Array<WorkerDeploymentAlias>>;
   crashes?: Maybe<WorkerDeploymentCrashes>;
   createdAt: Scalars['DateTime']['output'];
@@ -7719,14 +7737,64 @@ export type WorkerDeploymentRequests = {
   byBrowser: Array<WorkerDeploymentRequestsBrowserEdge>;
   byCacheStatus: Array<WorkerDeploymentRequestsCacheStatusEdge>;
   byContinent: Array<WorkerDeploymentRequestsContinentEdge>;
+  byCountry: Array<WorkerDeploymentRequestsCountryEdge>;
   byMethod: Array<WorkerDeploymentRequestsMethodEdge>;
   byOS: Array<WorkerDeploymentRequestsOperatingSystemEdge>;
+  byResponseType: Array<WorkerDeploymentRequestsResponseTypeEdge>;
   byStatusType: Array<WorkerDeploymentRequestsStatusTypeEdge>;
   interval: Scalars['Int']['output'];
   minRowsWithoutLimit: Scalars['Int']['output'];
   nodes: Array<WorkerDeploymentRequestNode>;
   summary: WorkerDeploymentRequestsAggregationNode;
   timeseries: Array<WorkerDeploymentRequestsTimeseriesEdge>;
+};
+
+
+export type WorkerDeploymentRequestsByBrowserArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RequestsOrderBy>;
+};
+
+
+export type WorkerDeploymentRequestsByCacheStatusArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RequestsOrderBy>;
+};
+
+
+export type WorkerDeploymentRequestsByContinentArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RequestsOrderBy>;
+};
+
+
+export type WorkerDeploymentRequestsByCountryArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RequestsOrderBy>;
+};
+
+
+export type WorkerDeploymentRequestsByMethodArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RequestsOrderBy>;
+};
+
+
+export type WorkerDeploymentRequestsByOsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RequestsOrderBy>;
+};
+
+
+export type WorkerDeploymentRequestsByResponseTypeArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RequestsOrderBy>;
+};
+
+
+export type WorkerDeploymentRequestsByStatusTypeArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RequestsOrderBy>;
 };
 
 export type WorkerDeploymentRequestsAggregationNode = {
@@ -7788,6 +7856,12 @@ export type WorkerDeploymentRequestsContinentEdge = {
   node: WorkerDeploymentRequestsAggregationNode;
 };
 
+export type WorkerDeploymentRequestsCountryEdge = {
+  __typename?: 'WorkerDeploymentRequestsCountryEdge';
+  country?: Maybe<Scalars['String']['output']>;
+  node: WorkerDeploymentRequestsAggregationNode;
+};
+
 export type WorkerDeploymentRequestsMethodEdge = {
   __typename?: 'WorkerDeploymentRequestsMethodEdge';
   method: Scalars['String']['output'];
@@ -7798,6 +7872,12 @@ export type WorkerDeploymentRequestsOperatingSystemEdge = {
   __typename?: 'WorkerDeploymentRequestsOperatingSystemEdge';
   node: WorkerDeploymentRequestsAggregationNode;
   os?: Maybe<UserAgentOs>;
+};
+
+export type WorkerDeploymentRequestsResponseTypeEdge = {
+  __typename?: 'WorkerDeploymentRequestsResponseTypeEdge';
+  node: WorkerDeploymentRequestsAggregationNode;
+  responseType: ResponseType;
 };
 
 export type WorkerDeploymentRequestsStatusTypeEdge = {
@@ -7811,8 +7891,10 @@ export type WorkerDeploymentRequestsTimeseriesEdge = {
   byBrowser: Array<WorkerDeploymentRequestsBrowserEdge>;
   byCacheStatus: Array<WorkerDeploymentRequestsCacheStatusEdge>;
   byContinent: Array<WorkerDeploymentRequestsContinentEdge>;
+  byCountry: Array<WorkerDeploymentRequestsCountryEdge>;
   byMethod: Array<WorkerDeploymentRequestsMethodEdge>;
   byOS: Array<WorkerDeploymentRequestsOperatingSystemEdge>;
+  byResponseType: Array<WorkerDeploymentRequestsResponseTypeEdge>;
   byStatusType: Array<WorkerDeploymentRequestsStatusTypeEdge>;
   node?: Maybe<WorkerDeploymentRequestsAggregationNode>;
   timestamp: Scalars['DateTime']['output'];
@@ -7833,6 +7915,17 @@ export enum WorkerLoggerLevel {
   Warn = 'WARN'
 }
 
+export type Workflow = {
+  __typename?: 'Workflow';
+  app: App;
+  createdAt: Scalars['DateTime']['output'];
+  fileName: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+  revisions: Array<WorkflowRevision>;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
 export type WorkflowJobMutation = {
   __typename?: 'WorkflowJobMutation';
   approveWorkflowJob: Scalars['ID']['output'];
@@ -7841,6 +7934,38 @@ export type WorkflowJobMutation = {
 
 export type WorkflowJobMutationApproveWorkflowJobArgs = {
   workflowJobId: Scalars['ID']['input'];
+};
+
+/** Look up Workflow by ID */
+export type WorkflowQuery = {
+  __typename?: 'WorkflowQuery';
+  byId: Workflow;
+};
+
+
+/** Look up Workflow by ID */
+export type WorkflowQueryByIdArgs = {
+  workflowId: Scalars['ID']['input'];
+};
+
+export type WorkflowRevision = {
+  __typename?: 'WorkflowRevision';
+  blobSha: Scalars['String']['output'];
+  commitSha: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['ID']['output'];
+  workflow: Workflow;
+  yamlConfig: Scalars['String']['output'];
+};
+
+export type WorkflowRevisionQuery = {
+  __typename?: 'WorkflowRevisionQuery';
+  byId: WorkflowRevision;
+};
+
+
+export type WorkflowRevisionQueryByIdArgs = {
+  workflowRevisionId: Scalars['ID']['input'];
 };
 
 export type DeleteAndroidAppBuildCredentialsResult = {
@@ -7930,6 +8055,20 @@ export type UpdateChannelBranchMappingMutationVariables = Exact<{
 
 
 export type UpdateChannelBranchMappingMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', editUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
+
+export type PauseUpdateChannelMutationVariables = Exact<{
+  channelId: Scalars['ID']['input'];
+}>;
+
+
+export type PauseUpdateChannelMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', pauseUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
+
+export type ResumeUpdateChannelMutationVariables = Exact<{
+  channelId: Scalars['ID']['input'];
+}>;
+
+
+export type ResumeUpdateChannelMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', resumeUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
 
 export type AppInfoQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -8686,7 +8825,7 @@ export type ViewUpdateChannelOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, updatedAt: any, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }>> }> } | null } } };
+export type ViewUpdateChannelOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, isPaused: boolean, name: string, updatedAt: any, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }>> }> } | null } } };
 
 export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -8695,7 +8834,7 @@ export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, name: string, updatedAt: any, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }>> }> }> } } };
+export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, isPaused: boolean, name: string, updatedAt: any, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null }>> }> }> } } };
 
 export type ViewUpdateChannelsPaginatedOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
@@ -59,6 +59,7 @@ export const ChannelQuery = {
                   id
                   updateChannelByName(name: $channelName) {
                     id
+                    isPaused
                     name
                     updatedAt
                     createdAt
@@ -104,6 +105,7 @@ export const ChannelQuery = {
                   id
                   updateChannels(offset: $offset, limit: $limit) {
                     id
+                    isPaused
                     name
                     updatedAt
                     createdAt


### PR DESCRIPTION
# Why

We want to allow developers to prevent updates from being served to certain builds by "pausing" update channels.

# How

- I added two new CLI commands to toggle the channel pausing state
- I added the pause status to the channel details output in the `view` and `list` commands

# Test Plan

Build the CLI locally under the `neas` alias, and run `neas channel:pause development && neas channel:view development && neas channel:resume development && neas channel:view development`:

<img width="1364" alt="Screenshot 2024-10-17 at 05 33 36" src="https://github.com/user-attachments/assets/fd557e57-bbf7-463c-8cec-1febcb2fdde8">

