### PR TITLE
Support multiple environments in env:push command

### DIFF
--- a/packages/eas-cli/src/graphql/mutations/EnvironmentVariableMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/EnvironmentVariableMutation.ts
@@ -29,7 +29,7 @@ type CreateVariableArgs = {
 export type EnvironmentVariablePushInput = {
   name: string;
   value: string;
-  environment: string;
+  environments: EnvironmentVariableEnvironment[];
   visibility: EnvironmentVariableVisibility;
   overwrite?: boolean;
 };


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`env:push` should support multiple environments, just like other `eas env:*` commands.

# How

* Added `EASMultiEnvironmentFlag`
* Use `environments` input parameter in `createBulkEnvironmentVariablesForApp` mutation to create envvars with multiple envs
* Checking for each environment if variable exists, updating variable when its value doesn't change but environments do.

# Test Plan

Tested manually