### PR TITLE
Fix in env:link command: fail in non-interactive mode if variable name is ambigous

### DIFF
--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -353,7 +353,7 @@ export default class EnvironmentVariableCreate extends EasCommand {
   private validateFlags(flags: CreateFlags & { type?: string }): CreateFlags {
     if (flags.scope !== EnvironmentVariableScope.Shared && flags.link) {
       throw new Error(
-        `Unexpected argument: --link can only be used when creating  shared variables`
+        `Unexpected argument: --link can only be used when creating shared variables`
       );
     }
 

--- a/packages/eas-cli/src/commands/env/link.ts
+++ b/packages/eas-cli/src/commands/env/link.ts
@@ -64,6 +64,11 @@ export default class EnvironmentVariableLink extends EasCommand {
     let selectedVariable = variables[0];
 
     if (variables.length > 1) {
+      if (nonInteractive) {
+        throw new Error(
+          'Multiple variables found, run command with --variable-name and --variable-environment arguments.'
+        );
+      }
       selectedVariable = await selectAsync(
         'Select shared variable',
         variables.map(variable => ({


### PR DESCRIPTION
# Why

`env:link` prompts user to select a variable interactively even in non-interactive mode.