### PR TITLE
Use the same names for visibility options in eas cli as on

### DIFF
--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -1,10 +1,6 @@
 import { Flags } from '@oclif/core';
 
-import {
-  EnvironmentVariableEnvironment,
-  EnvironmentVariableScope,
-  EnvironmentVariableVisibility,
-} from '../graphql/generated';
+import { EnvironmentVariableEnvironment, EnvironmentVariableScope } from '../graphql/generated';
 
 // NOTE: not exactly true, but, provided mapToLowercase and upperCaseAsync
 // are used in tandem, it saves on unnecessary typying in commands
@@ -56,14 +52,9 @@ export const EASVariableFormatFlag = {
 };
 
 export const EASVariableVisibilityFlag = {
-  visibility: Flags.enum<EnvironmentVariableVisibility>({
+  visibility: Flags.enum({
     description: 'Visibility of the variable',
-    options: mapToLowercase([
-      EnvironmentVariableVisibility.Secret,
-      EnvironmentVariableVisibility.Sensitive,
-      EnvironmentVariableVisibility.Public,
-    ]),
-    parse: upperCaseAsync,
+    options: ['plaintext', 'sensitive', 'encrypted'],
   }),
 };
 

--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -52,7 +52,7 @@ export const EASVariableFormatFlag = {
 };
 
 export const EASVariableVisibilityFlag = {
-  visibility: Flags.enum({
+  visibility: Flags.enum<'plaintext' | 'sensitive' | 'encrypted'>({
     description: 'Visibility of the variable',
     options: ['plaintext', 'sensitive', 'encrypted'],
   }),

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableCreate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableCreate.test.ts
@@ -13,6 +13,7 @@ import { EnvironmentVariableMutation } from '../../../graphql/mutations/Environm
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
 import {
+  parseVisibility,
   promptVariableEnvironmentAsync,
   promptVariableNameAsync,
   promptVariableTypeAsync,
@@ -33,6 +34,10 @@ describe(EnvironmentVariableCreate, () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    jest
+      .mocked(parseVisibility)
+      .mockImplementation(jest.requireActual('../../../utils/prompts').parseVisibility);
+
     jest.mocked(AppQuery.byIdAsync).mockImplementation(async () => getMockAppFragment());
     jest
       .mocked(EnvironmentVariableMutation.createForAppAsync)
@@ -70,7 +75,16 @@ describe(EnvironmentVariableCreate, () => {
   describe('in interactive mode', () => {
     it('creates a project variable', async () => {
       const command = new EnvironmentVariableCreate(
-        ['--name', 'VarName', '--value', 'VarValue', '--environment', 'production'],
+        [
+          '--name',
+          'VarName',
+          '--value',
+          'VarValue',
+          '--environment',
+          'production',
+          '--visibility',
+          'encrypted',
+        ],
         mockConfig
       );
 
@@ -88,7 +102,7 @@ describe(EnvironmentVariableCreate, () => {
           name: 'VarName',
           value: 'VarValue',
           environments: [EnvironmentVariableEnvironment.Production],
-          visibility: EnvironmentVariableVisibility.Public,
+          visibility: EnvironmentVariableVisibility.Secret,
           type: EnvironmentSecretType.String,
         },
         testProjectId
@@ -97,7 +111,16 @@ describe(EnvironmentVariableCreate, () => {
 
     it('updates an existing variable in the same environment', async () => {
       const command = new EnvironmentVariableCreate(
-        ['--name', 'VarName', '--value', 'VarValue', '--environment', 'production'],
+        [
+          '--name',
+          'VarName',
+          '--value',
+          'VarValue',
+          '--environment',
+          'production',
+          '--visibility',
+          'encrypted',
+        ],
         mockConfig
       );
 
@@ -144,7 +167,7 @@ describe(EnvironmentVariableCreate, () => {
         name: 'VarName',
         value: 'VarValue',
         environments: [EnvironmentVariableEnvironment.Production],
-        visibility: EnvironmentVariableVisibility.Public,
+        visibility: EnvironmentVariableVisibility.Secret,
       });
     });
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableUpdate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableUpdate.test.ts
@@ -5,6 +5,7 @@ import { getMockAppFragment } from '../../../__tests__/commands/utils';
 import {
   EnvironmentVariableEnvironment,
   EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
 } from '../../../graphql/generated';
 import { EnvironmentVariableMutation } from '../../../graphql/mutations/EnvironmentVariableMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
@@ -59,6 +60,8 @@ describe(EnvironmentVariableUpdate, () => {
         'NEW_VARIABLE',
         '--environment',
         'production',
+        '--visibility',
+        'plaintext',
       ],
       mockConfig
     );
@@ -71,6 +74,7 @@ describe(EnvironmentVariableUpdate, () => {
       name: 'NEW_VARIABLE',
       value: 'new-value',
       environments: [EnvironmentVariableEnvironment.Production],
+      visibility: EnvironmentVariableVisibility.Public,
     });
     expect(Log.withTick).toHaveBeenCalledWith(
       `Updated variable ${chalk.bold('TEST_VARIABLE')} on project @testuser/testpp.`

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -42,7 +42,7 @@ type UpdateFlags = {
   value?: string;
   scope?: EnvironmentVariableScope;
   environment?: EnvironmentVariableEnvironment[];
-  visibility?: string;
+  visibility?: 'plaintext' | 'sensitive' | 'encrypted';
   type?: 'string' | 'file';
   'variable-name'?: string;
   'variable-environment'?: EnvironmentVariableEnvironment;

--- a/packages/eas-cli/src/utils/prompts.ts
+++ b/packages/eas-cli/src/utils/prompts.ts
@@ -31,7 +31,9 @@ export async function promptVariableTypeAsync(
   });
 }
 
-export function parseVisibility(stringVisibility: string): EnvironmentVariableVisibility {
+export function parseVisibility(
+  stringVisibility: 'plaintext' | 'sensitive' | 'encrypted'
+): EnvironmentVariableVisibility {
   switch (stringVisibility) {
     case 'plaintext':
       return EnvironmentVariableVisibility.Public;

--- a/packages/eas-cli/src/utils/prompts.ts
+++ b/packages/eas-cli/src/utils/prompts.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 
-import capitalize from './expodash/capitalize';
 import {
   EnvironmentSecretType,
   EnvironmentVariableEnvironment,
@@ -32,6 +31,19 @@ export async function promptVariableTypeAsync(
   });
 }
 
+export function parseVisibility(stringVisibility: string): EnvironmentVariableVisibility {
+  switch (stringVisibility) {
+    case 'plaintext':
+      return EnvironmentVariableVisibility.Public;
+    case 'sensitive':
+      return EnvironmentVariableVisibility.Sensitive;
+    case 'encrypted':
+      return EnvironmentVariableVisibility.Secret;
+    default:
+      throw new Error(`Invalid visibility: ${stringVisibility}`);
+  }
+}
+
 export async function promptVariableVisibilityAsync(
   nonInteractive: boolean,
   selectedVisibility?: EnvironmentVariableVisibility | null
@@ -41,14 +53,23 @@ export async function promptVariableVisibilityAsync(
       'The `--visibility` flag must be set when running in `--non-interactive` mode.'
     );
   }
-  return await selectAsync(
-    'Select visibility:',
-    Object.values(EnvironmentVariableVisibility).map(visibility => ({
-      title: capitalize(visibility),
-      value: visibility,
-      selected: visibility === selectedVisibility,
-    }))
-  );
+  return await selectAsync('Select visibility:', [
+    {
+      title: 'Plain text',
+      value: EnvironmentVariableVisibility.Public,
+      selected: selectedVisibility === EnvironmentVariableVisibility.Public,
+    },
+    {
+      title: 'Sensitive',
+      value: EnvironmentVariableVisibility.Sensitive,
+      selected: selectedVisibility === EnvironmentVariableVisibility.Sensitive,
+    },
+    {
+      title: 'Encrypted',
+      value: EnvironmentVariableVisibility.Secret,
+      selected: selectedVisibility === EnvironmentVariableVisibility.Secret,
+    },
+  ]);
 }
 
 type EnvironmentPromptArgs = {


### PR DESCRIPTION
# Why

[ENG-13849: When no `--visibility` input is provided `eas env:create` should ask about it by default](https://linear.app/expo/issue/ENG-13849/when-no-visibility-input-is-provided-eas-envcreate-should-ask-about-it)

[ENG-13850: Use the same names for visibility options in EAS CLI as on website](https://linear.app/expo/issue/ENG-13850/use-the-same-names-for-visibility-options-in-eas-cli-as-on-website)

`eas env:*` commands were using obsolete names for visibility options: `public` and `secret`, instead of `plaintext` and `encrypted`. It should be updated.
Also, user is prompted for the variable visibility if not provided.

# Test Plan

Updated tests
