### PR TITLE
Display message when env:list returns an empty result

### DIFF
--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -125,6 +125,11 @@ export default class EnvironmentValueList extends EasCommand {
         Log.log(chalk.bold(`Environment: ${environment}`));
       }
 
+      if (variables.length === 0) {
+        Log.log('No variables found for this environment.');
+        return;
+      }
+
       if (format === 'short') {
         for (const variable of variables) {
           Log.log(`${chalk.bold(variable.name)}=${formatVariableValue(variable)}`);


### PR DESCRIPTION
# Why

[ENG-13847: Show `no env vars found for this environment` if 0 env vars exist for given environment in `eas env:list`](https://linear.app/expo/issue/ENG-13847/show-no-env-vars-found-for-this-environment-if-0-env-vars-exist-for)

<img width="455" alt="image" src="https://github.com/user-attachments/assets/d4286fcb-0adf-4806-a876-4cbbcf3d6157">