### PR TITLE
Use lower case environment across all eas env commands

### DIFF
--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -101,7 +101,9 @@ export default class EnvironmentVariableGet extends EasCommand {
 
       const variableInEnvironment = variables.find(v => v.environments?.includes(environment!));
       if (!variableInEnvironment) {
-        throw new Error(`Variable with name "${name}" not found in environment "${environment}"`);
+        throw new Error(
+          `Variable with name "${name}" not found in environment "${environment.toLocaleLowerCase()}"`
+        );
       }
 
       variable = variableInEnvironment;

--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -122,7 +122,7 @@ export default class EnvironmentValueList extends EasCommand {
 
       Log.addNewLineIfNone();
       if (environment) {
-        Log.log(chalk.bold(`Environment: ${environment}`));
+        Log.log(chalk.bold(`Environment: ${environment.toLocaleLowerCase()}`));
       }
 
       if (format === 'short') {

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -63,7 +63,7 @@ export default class EnvironmentVariablePull extends EasCommand {
       }
     }
 
-    const filePrefix = `# Environment: ${environment}\n\n`;
+    const filePrefix = `# Environment: ${environment.toLocaleLowerCase()}\n\n`;
 
     const envFileContent = environmentVariables
       .map((variable: EnvironmentVariableFragment) => {

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -58,6 +58,7 @@ export default class EnvironmentVariablePush extends EasCommand {
     const variableNames = Object.keys(updateVariables);
 
     for (const environment of environments) {
+      const displayedEnvironment = environment.toLocaleLowerCase();
       const existingVariables = await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
         appId: projectId,
         environment,
@@ -99,15 +100,15 @@ export default class EnvironmentVariablePush extends EasCommand {
       }
 
       if (existingDifferentVariables.length > 0) {
-        Log.warn(`Some variables already exist in the ${environment} environment.`);
+        Log.warn(`Some variables already exist in the ${displayedEnvironment} environment.`);
         const variableNames = existingDifferentVariables.map(variable => variable.name);
 
         const confirmationMessage =
           variableNames.length > 1
             ? `The ${variableNames.join(
                 ', '
-              )} environment variables already exist in ${environment} environment. Do you want to override them all?`
-            : `The ${variableNames[0]} environment variable already exists in ${environment} environment. Do you want to override it?`;
+              )} environment variables already exist in ${displayedEnvironment} environment. Do you want to override them all?`
+            : `The ${variableNames[0]} environment variable already exists in ${displayedEnvironment} environment. Do you want to override it?`;
 
         const confirm = await confirmAsync({
           message: confirmationMessage,
@@ -180,8 +181,7 @@ export default class EnvironmentVariablePush extends EasCommand {
       variablesToPush,
       projectId
     );
-
-    Log.log(`Uploaded env file to ${environments.join(', ')}.`);
+    Log.log(`Uploaded env file to ${environments.join(', ').toLocaleLowerCase()}.`);
   }
 
   private async parseEnvFileAsync(

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -136,7 +136,7 @@ export default class EnvironmentVariableUpdate extends EasCommand {
     if (existingVariables.length === 0) {
       throw new Error(
         `Variable with name ${currentName} ${
-          currentEnvironment ? `in environment ${currentEnvironment}` : ''
+          currentEnvironment ? `in environment ${currentEnvironment.toLocaleLowerCase()}` : ''
         } does not exist ${suffix}.`
       );
     } else if (existingVariables.length > 1) {

--- a/packages/eas-cli/src/utils/prompts.ts
+++ b/packages/eas-cli/src/utils/prompts.ts
@@ -81,7 +81,7 @@ export async function promptVariableEnvironmentAsync({
     return await selectAsync(
       'Select environment:',
       (availableEnvironments ?? Object.values(EnvironmentVariableEnvironment)).map(environment => ({
-        title: environment,
+        title: environment.toLocaleLowerCase(),
         value: environment,
       }))
     );
@@ -91,7 +91,7 @@ export async function promptVariableEnvironmentAsync({
     name: 'environments',
     type: 'multiselect',
     choices: Object.values(EnvironmentVariableEnvironment).map(environment => ({
-      title: environment,
+      title: environment.toLocaleLowerCase(),
       value: environment,
       selected: selectedEnvironments?.includes(environment),
     })),


### PR DESCRIPTION
# Why

[ENG-13846: Use lower-case environment names across all `eas env:xyz` commands for consistency](https://linear.app/expo/issue/ENG-13846/use-lower-case-environment-names-across-all-eas-envxyz-commands-for)