### PR TITLE
Ask for file path in env:* commands

### DIFF
--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -331,6 +331,7 @@ export default class EnvironmentVariableCreate extends EasCommand {
       value = await promptVariableValueAsync({
         nonInteractive,
         hidden: newVisibility !== EnvironmentVariableVisibility.Public,
+        filePath: newType === EnvironmentSecretType.FileBase64,
       });
     }
 

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -233,11 +233,6 @@ export default class EnvironmentVariableUpdate extends EasCommand {
         }
       }
 
-      Log.log(
-        selectedVariable.type,
-        EnvironmentSecretType.String === selectedVariable.type,
-        EnvironmentSecretType.FileBase64 === selectedVariable.type
-      );
       if (!type && !value && !nonInteractive) {
         newType = await promptVariableTypeAsync(nonInteractive, selectedVariable.type);
 
@@ -250,6 +245,7 @@ export default class EnvironmentVariableUpdate extends EasCommand {
         value = await promptVariableValueAsync({
           nonInteractive,
           required: false,
+          filePath: (newType ?? selectedVariable.type) === EnvironmentSecretType.FileBase64,
           initial:
             (newType ?? selectedVariable.type) === EnvironmentSecretType.FileBase64
               ? undefined
@@ -263,7 +259,7 @@ export default class EnvironmentVariableUpdate extends EasCommand {
 
       let environmentFilePath: string | undefined;
 
-      if (newType === EnvironmentSecretType.FileBase64 && value) {
+      if ((newType ?? selectedVariable.type) === EnvironmentSecretType.FileBase64 && value) {
         environmentFilePath = path.resolve(value);
         if (!(await fs.pathExists(environmentFilePath))) {
           throw new Error(`File "${value}" does not exist`);

--- a/packages/eas-cli/src/utils/prompts.ts
+++ b/packages/eas-cli/src/utils/prompts.ts
@@ -126,11 +126,13 @@ export async function promptVariableValueAsync({
   nonInteractive,
   required = true,
   hidden = false,
+  filePath = false,
   initial,
 }: {
   nonInteractive: boolean;
   required?: boolean;
   initial?: string | null;
+  filePath?: boolean;
   hidden?: boolean;
 }): Promise<string> {
   if (nonInteractive && required) {
@@ -142,9 +144,9 @@ export async function promptVariableValueAsync({
   }
 
   const { variableValue } = await promptAsync({
-    type: hidden ? 'password' : 'text',
+    type: hidden && !filePath ? 'password' : 'text',
     name: 'variableValue',
-    message: 'Variable value:',
+    message: filePath ? 'File path:' : 'Variable value:',
     initial: initial ?? '',
     validate: variableValue => {
       if (!required) {


### PR DESCRIPTION
# Why

[ENG-13855: When creating `file` type env var in `env:create` ask about file path vs variable value](https://linear.app/expo/issue/ENG-13855/when-creating-file-type-env-var-in-envcreate-ask-about-file-path-vs)
