### PR TITLE
[eas-cli] Add interactivity to eas update:edit command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add `eas channel:pause` and `eas channel:resume` commands to pause/resume update delivery to builds using specific update channels and display paused status in channel details output. ([#2614](https://github.com/expo/eas-cli/pull/2614) by [@fiberjw](https://github.com/fiberjw))
+- Add interactivity to eas update:edit command. ([#2638](https://github.com/expo/eas-cli/pull/2638) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/update/edit.ts
+++ b/packages/eas-cli/src/commands/update/edit.ts
@@ -2,12 +2,14 @@ import { Flags } from '@oclif/core';
 import assert from 'assert';
 import chalk from 'chalk';
 
+import { selectBranchOnAppAsync } from '../../branch/queries';
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import Log from '../../log';
 import { promptAsync } from '../../prompts';
+import { selectUpdateGroupOnBranchAsync } from '../../update/queries';
 import {
   formatUpdateGroup,
   getUpdateGroupDescriptions,
@@ -17,12 +19,10 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class UpdateEdit extends EasCommand {
   static override description = 'edit all the updates in an update group';
-  static override hidden = true;
 
   static override args = [
     {
       name: 'groupId',
-      required: true,
       description: 'The ID of an update group to edit.',
     },
   ];
@@ -34,29 +34,72 @@ export default class UpdateEdit extends EasCommand {
       min: 0,
       max: 100,
     }),
+    branch: Flags.string({
+      description: 'Branch for which to list updates to select from',
+    }),
     ...EasNonInteractiveAndJsonFlags,
   };
 
   static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
     ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
     const {
-      args: { groupId },
+      args: { groupId: maybeGroupId },
       flags: {
         'rollout-percentage': rolloutPercentage,
         json: jsonFlag,
         'non-interactive': nonInteractive,
+        branch: branchFlag,
       },
     } = await this.parse(UpdateEdit);
 
     const {
+      privateProjectConfig: { projectId },
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(UpdateEdit, { nonInteractive });
 
     if (jsonFlag) {
       enableJsonOutput();
+    }
+
+    let groupId: string | undefined = maybeGroupId;
+    if (!groupId) {
+      let branch = branchFlag;
+      if (!branch) {
+        const validationMessage = 'Branch name may not be empty.';
+        if (nonInteractive) {
+          throw new Error(validationMessage);
+        }
+
+        const selectedBranch = await selectBranchOnAppAsync(graphqlClient, {
+          projectId,
+          promptTitle: 'On which branch would you like search for an update to edit?',
+          displayTextForListItem: updateBranch => ({
+            title: updateBranch.name,
+          }),
+          paginatedQueryOptions: {
+            json: jsonFlag,
+            nonInteractive,
+            offset: 0,
+          },
+        });
+
+        branch = selectedBranch.name;
+      }
+
+      const selectedUpdateGroup = await selectUpdateGroupOnBranchAsync(graphqlClient, {
+        projectId,
+        branchName: branch,
+        paginatedQueryOptions: {
+          json: jsonFlag,
+          nonInteractive,
+          offset: 0,
+        },
+      });
+      groupId = selectedUpdateGroup[0].group;
     }
 
     const proposedUpdatesToEdit = (


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When writing the docs for update-based rollouts, I noticed that a) this command was still hidden, and b) it didn't have the best UX for interactive mode (https://github.com/expo/eas-cli/pull/2503 didn't add it)

# How

a) unhide the command
b) Make group arg optional, add optional branch flag, and lead user through interactive process to choose an update group to edit if not supplied as an arg

Note that this doesn't filter update groups to those that are editable since it isn't currently possible to query. We can update this in the future if we want, but usability of the feature probably won't suffer much without it since it's likely the latest update group will always be the one chosen to be edited.

# Test Plan

`neas update:edit`
`neas update:edit --branch main`