### PR TITLE
fix(eas-cli): resolve Apple authentication error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Disallow republishing an update that is being rolled-out. ([#2602](https://github.com/expo/eas-cli/pull/2602) by [@wschurman](https://github.com/wschurman))
-- Bump `@expo/apple-utils` to `2.0.1` resolving the Apple authentication error. ([#2641](https://github.com/expo/eas-cli/pull/2641) by [@byCedric](https://github.com/byCedric))
+- Bump `@expo/apple-utils` to `2.0.2` resolving the Apple authentication error. ([#2641](https://github.com/expo/eas-cli/pull/2641) by [@byCedric](https://github.com/byCedric))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Disallow republishing an update that is being rolled-out. ([#2602](https://github.com/expo/eas-cli/pull/2602) by [@wschurman](https://github.com/wschurman))
-- Bump `@expo/apple-utils` to `2.0.1` resolving the Apple authentication error.
+- Bump `@expo/apple-utils` to `2.0.1` resolving the Apple authentication error. ([#2641](https://github.com/expo/eas-cli/pull/2641) by [@byCedric](https://github.com/byCedric))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Disallow republishing an update that is being rolled-out. ([#2602](https://github.com/expo/eas-cli/pull/2602) by [@wschurman](https://github.com/wschurman))
+- Bump `@expo/apple-utils` to `2.0.1` resolving the Apple authentication error.
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "1.8.0",
+    "@expo/apple-utils": "2.0.1",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "8.5.4",
     "@expo/config-plugins": "7.8.4",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "2.0.1",
+    "@expo/apple-utils": "2.0.2",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "8.5.4",
     "@expo/config-plugins": "7.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.0.1.tgz#8513b9d21d72d32cce75923077d6865b63711651"
-  integrity sha512-dY2hVVfmqkHyzhPdL2FA1PPp+6S9KVgu0tDyD9NYVMZQ9iyH+IVhcN8MnJLPMGbNVhvLv8BBHlQ1tjUnAPurog==
+"@expo/apple-utils@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.0.2.tgz#1e765aa334485b2cd28d4476bedded0c4d812b71"
+  integrity sha512-KIfzTYgk81YeXCwPVfR2lWdMZBMS2gUt5BXXV1sgDl7BbmjPlRbixL7kaieegwimPmXG2y3+Tth2lqWjuip3oQ==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-1.8.0.tgz#8a359cefbad000be66caa18235ecd4c03406a15d"
-  integrity sha512-JKGfPCCGko7GtLcvCj9VeyrSJGimgWsBJnR4G10kGY9sUQo3ykEgVrUBUaG2HJrCLzbeDUExmsbuZRWqJha77g==
+"@expo/apple-utils@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.0.1.tgz#8513b9d21d72d32cce75923077d6865b63711651"
+  integrity sha512-dY2hVVfmqkHyzhPdL2FA1PPp+6S9KVgu0tDyD9NYVMZQ9iyH+IVhcN8MnJLPMGbNVhvLv8BBHlQ1tjUnAPurog==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This resolves the apple authentication errors currently plaguing Expo and [Fastlane](https://github.com/fastlane/fastlane/issues/26368)

# How

- Upgraded to the latest `@expo/apple-utils`

# Test Plan

Create a new project, login with apple when building for iOS.
