### PR TITLE
[eas-cli] improve logs announcing loading of env variables

### DIFF
--- a/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
+++ b/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
@@ -133,6 +133,8 @@ async function resolveEnvVarsAsync({
       }
     }
 
+    Log.newLine();
+
     return { ...serverEnvVars, ...buildProfile.env };
   } catch (e) {
     Log.error(`Failed to pull env variables for environment ${environment} from EAS servers`);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Improve logs announcing loading env vars.

https://exponent-internal.slack.com/archives/C06FK950085/p1729215938823339?thread_ts=1729186741.835629&cid=C06FK950085

# How

Improve logs

# Test Plan

Test manually.