### PR TITLE
[ENG-13252][eas-cli] resolve default environment automatically based on build configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This is the log of notable changes to EAS CLI and related packages.
 - Calculate fingerprint on each update. ([#2687](https://github.com/expo/eas-cli/pull/2687) by [@quinlanj](https://github.com/quinlanj))
 - Calculate fingerprint on each update republish. ([#2708](https://github.com/expo/eas-cli/pull/2708) by [@quinlanj](https://github.com/quinlanj))
 - Add `eas env` commands. ([#2711](https://github.com/expo/eas-cli/pull/2711) by [@szdziedzic](https://github.com/szdziedzic))
+- Add `--environment` flag to `eas update` command. ([#2711](https://github.com/expo/eas-cli/pull/2711) by [@szdziedzic](https://github.com/szdziedzic))
+- Load readable environment variables from EAS servers on every build. ([#2644](https://github.com/expo/eas-cli/pull/2644) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
+++ b/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
@@ -55,10 +55,9 @@ async function resolveEnvVarsAsync({
 }): Promise<Env> {
   const environment =
     buildProfile.environment?.toUpperCase() ??
-    process.env.EAS_CURRENT_ENVIRONMENT ??
     resolveSuggestedEnvironmentForBuildProfileConfiguration(buildProfile);
 
-  if (!environment || !isEnvironment(environment)) {
+  if (!isEnvironment(environment)) {
     Log.log(
       `Loaded "env" configuration for the "${buildProfileName}" profile: ${
         buildProfile.env && Object.keys(buildProfile.env).length > 0
@@ -137,7 +136,7 @@ function resolveSuggestedEnvironmentForBuildProfileConfiguration(
   buildProfile: BuildProfile
 ): EnvironmentVariableEnvironment {
   const setEnvironmentMessage =
-    'Set the environment using the "environment" field in the build profile configuration if you want to use a specific environment.';
+    'Set the "environment" field in the build profile if you want to specify the environment manually.';
   if (buildProfile.distribution === 'store') {
     Log.log(
       `We detected that you are building for the "store" distribution. Resolving the environment for environment variables used during the build to "production". ${setEnvironmentMessage}`


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C06FK950085/p1729212611408479?thread_ts=1729186741.835629&cid=C06FK950085

# How

Resolve the default (if not set in the build profile) `environment` to use for a build based on its configuration.

Store build -> `production`
Dev client -> `development`
Other (`internal`) -> `preview`

# Test Plan

Test manually
