### PR TITLE
[eas-cli] Create dynamic logged in context field and clean up erroneous SessionManager context field uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Create dynamic logged in context field and clean up erroneous SessionManager context field uses. ([#2648](https://github.com/expo/eas-cli/pull/2648) by [@wschurman](https://github.com/wschurman))
+
 ## [12.6.0](https://github.com/expo/eas-cli/releases/tag/v12.6.0) - 2024-10-21
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -6,6 +6,7 @@ import nullthrows from 'nullthrows';
 
 import AnalyticsContextField from './context/AnalyticsContextField';
 import ContextField from './context/ContextField';
+import DynamicLoggedInContextField from './context/DynamicLoggedInContextField';
 import {
   DynamicPrivateProjectConfigContextField,
   DynamicPublicProjectConfigContextField,
@@ -62,7 +63,15 @@ export default abstract class EasCommand extends Command {
       maybeLoggedIn: new MaybeLoggedInContextField(),
     },
     /**
+     * Specify this context if the logged-in requirement is only necessary in a particular execution of the command.
+     */
+    DynamicLoggedIn: {
+      // eslint-disable-next-line async-protect/async-suffix
+      getDynamicLoggedInAsync: new DynamicLoggedInContextField(),
+    },
+    /**
      * Specify this context requirement if the command needs to mutate the user session.
+     * @deprecated Should not be used outside of session management commands, which currently only includes `login` and `logout`.
      */
     SessionManagment: {
       sessionManager: new SessionManagementContextField(),

--- a/packages/eas-cli/src/commandUtils/context/DynamicLoggedInContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/DynamicLoggedInContextField.ts
@@ -1,0 +1,36 @@
+import ContextField, { ContextOptions } from './ContextField';
+import { ExpoGraphqlClient, createGraphqlClient } from './contextUtils/createGraphqlClient';
+import { LoggedInAuthenticationInfo } from '../../user/SessionManager';
+import { Actor } from '../../user/User';
+import FeatureGateEnvOverrides from '../gating/FeatureGateEnvOverrides';
+import FeatureGating from '../gating/FeatureGating';
+
+export type DynamicLoggedInContextFn = () => Promise<{
+  actor: Actor;
+  featureGating: FeatureGating;
+  graphqlClient: ExpoGraphqlClient;
+  authenticationInfo: LoggedInAuthenticationInfo;
+}>;
+
+export default class DynamicLoggedInContextField extends ContextField<DynamicLoggedInContextFn> {
+  async getValueAsync({
+    nonInteractive,
+    sessionManager,
+  }: ContextOptions): Promise<DynamicLoggedInContextFn> {
+    return async () => {
+      const { actor, authenticationInfo } = await sessionManager.ensureLoggedInAsync({
+        nonInteractive,
+      });
+      const featureGateServerValues: { [key: string]: boolean } = actor?.featureGates ?? {};
+
+      const graphqlClient = createGraphqlClient(authenticationInfo);
+
+      return {
+        actor,
+        featureGating: new FeatureGating(featureGateServerValues, new FeatureGateEnvOverrides()),
+        graphqlClient,
+        authenticationInfo,
+      };
+    };
+  }
+}

--- a/packages/eas-cli/src/commandUtils/context/LoggedInContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/LoggedInContextField.ts
@@ -1,19 +1,22 @@
 import ContextField, { ContextOptions } from './ContextField';
 import { ExpoGraphqlClient, createGraphqlClient } from './contextUtils/createGraphqlClient';
+import { LoggedInAuthenticationInfo } from '../../user/SessionManager';
 import { Actor } from '../../user/User';
 import FeatureGateEnvOverrides from '../gating/FeatureGateEnvOverrides';
 import FeatureGating from '../gating/FeatureGating';
 
-export default class LoggedInContextField extends ContextField<{
+type LoggedInContextType = {
   actor: Actor;
   featureGating: FeatureGating;
   graphqlClient: ExpoGraphqlClient;
-}> {
-  async getValueAsync({ nonInteractive, sessionManager }: ContextOptions): Promise<{
-    actor: Actor;
-    featureGating: FeatureGating;
-    graphqlClient: ExpoGraphqlClient;
-  }> {
+  authenticationInfo: LoggedInAuthenticationInfo;
+};
+
+export default class LoggedInContextField extends ContextField<LoggedInContextType> {
+  async getValueAsync({
+    nonInteractive,
+    sessionManager,
+  }: ContextOptions): Promise<LoggedInContextType> {
     const { actor, authenticationInfo } = await sessionManager.ensureLoggedInAsync({
       nonInteractive,
     });
@@ -25,6 +28,7 @@ export default class LoggedInContextField extends ContextField<{
       actor,
       featureGating: new FeatureGating(featureGateServerValues, new FeatureGateEnvOverrides()),
       graphqlClient,
+      authenticationInfo,
     };
   }
 }

--- a/packages/eas-cli/src/commandUtils/context/MaybeLoggedInContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/MaybeLoggedInContextField.ts
@@ -4,16 +4,18 @@ import { Actor } from '../../user/User';
 import FeatureGateEnvOverrides from '../gating/FeatureGateEnvOverrides';
 import FeatureGating from '../gating/FeatureGating';
 
-export default class MaybeLoggedInContextField extends ContextField<{
+type MaybeLoggedInContextType = {
   actor: Actor | null;
   featureGating: FeatureGating;
   graphqlClient: ExpoGraphqlClient;
-}> {
-  async getValueAsync({ sessionManager }: ContextOptions): Promise<{
-    actor: Actor | null;
-    featureGating: FeatureGating;
-    graphqlClient: ExpoGraphqlClient;
-  }> {
+  authenticationInfo: {
+    accessToken: string | null;
+    sessionSecret: string | null;
+  };
+};
+
+export default class MaybeLoggedInContextField extends ContextField<MaybeLoggedInContextType> {
+  async getValueAsync({ sessionManager }: ContextOptions): Promise<MaybeLoggedInContextType> {
     const authenticationInfo = {
       accessToken: sessionManager.getAccessToken(),
       sessionSecret: sessionManager.getSessionSecret(),
@@ -27,6 +29,7 @@ export default class MaybeLoggedInContextField extends ContextField<{
       actor: actor ?? null,
       featureGating: new FeatureGating(featureGateServerValues, new FeatureGateEnvOverrides()),
       graphqlClient,
+      authenticationInfo,
     };
   }
 }

--- a/packages/eas-cli/src/commands/account/view.ts
+++ b/packages/eas-cli/src/commands/account/view.ts
@@ -12,16 +12,14 @@ export default class AccountView extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.MaybeLoggedIn,
-    ...this.ContextOptions.SessionManagment,
   };
 
   async runAsync(): Promise<void> {
     const {
-      maybeLoggedIn: { actor },
-      sessionManager,
+      maybeLoggedIn: { actor, authenticationInfo },
     } = await this.getContextAsync(AccountView, { nonInteractive: true });
     if (actor) {
-      const loggedInAs = sessionManager.getAccessToken()
+      const loggedInAs = authenticationInfo.accessToken
         ? `${getActorDisplayName(actor)} (authenticated using EXPO_TOKEN)`
         : getActorDisplayName(actor);
       Log.log(chalk.green(loggedInAs));

--- a/packages/eas-cli/src/commands/config.ts
+++ b/packages/eas-cli/src/commands/config.ts
@@ -6,7 +6,6 @@ import chalk from 'chalk';
 
 import { evaluateConfigWithEnvVarsAsync } from '../build/evaluateConfigWithEnvVarsAsync';
 import EasCommand from '../commandUtils/EasCommand';
-import { createGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { EasNonInteractiveAndJsonFlags } from '../commandUtils/flags';
 import { toAppPlatform } from '../graphql/types/AppPlatform';
 import Log from '../log';
@@ -35,7 +34,7 @@ export default class Config extends EasCommand {
   static override contextDefinition = {
     ...this.ContextOptions.DynamicProjectConfig,
     ...this.ContextOptions.ProjectDir,
-    ...this.ContextOptions.SessionManagment,
+    ...this.ContextOptions.DynamicLoggedIn,
   };
 
   async runAsync(): Promise<void> {
@@ -48,7 +47,7 @@ export default class Config extends EasCommand {
       profile: maybeProfile,
       'non-interactive': nonInteractive,
     } = flags;
-    const { getDynamicPublicProjectConfigAsync, projectDir, sessionManager } =
+    const { getDynamicPublicProjectConfigAsync, projectDir, getDynamicLoggedInAsync } =
       await this.getContextAsync(Config, {
         nonInteractive,
       });
@@ -88,10 +87,7 @@ export default class Config extends EasCommand {
         Log.log(JSON.stringify(profile, null, 2));
       }
     } else {
-      const { authenticationInfo } = await sessionManager.ensureLoggedInAsync({
-        nonInteractive,
-      });
-      const graphqlClient = createGraphqlClient(authenticationInfo);
+      const { graphqlClient } = await getDynamicLoggedInAsync();
       const { exp: appConfig } = await evaluateConfigWithEnvVarsAsync({
         buildProfile: profile,
         buildProfileName: profileName,

--- a/packages/eas-cli/src/commands/project/__tests__/init.test.ts
+++ b/packages/eas-cli/src/commands/project/__tests__/init.test.ts
@@ -90,6 +90,7 @@ function mockTestProject(options: {
     actor: jester,
     featureGating: new FeatureGating({}, new FeatureGateEnvOverrides()),
     graphqlClient,
+    authenticationInfo: { accessToken: null, sessionSecret: '1234' },
   });
 }
 

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -254,6 +254,7 @@ function mockTestProject({
     actor: jester,
     featureGating: new FeatureGating({}, new FeatureGateEnvOverrides()),
     graphqlClient,
+    authenticationInfo: { accessToken: null, sessionSecret: '1234' },
   });
   jest
     .spyOn(VcsClientContextField.prototype, 'getValueAsync')

--- a/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/republish.test.ts
@@ -467,6 +467,7 @@ function mockTestProject({
     actor: jester,
     featureGating: new FeatureGating({}, new FeatureGateEnvOverrides()),
     graphqlClient,
+    authenticationInfo: { accessToken: null, sessionSecret: '1234' },
   });
 
   jest.mocked(AppQuery.byIdAsync).mockResolvedValue({

--- a/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
@@ -255,6 +255,7 @@ function mockTestProject({
     actor: jester,
     featureGating: new FeatureGating({}, new FeatureGateEnvOverrides()),
     graphqlClient,
+    authenticationInfo: { accessToken: null, sessionSecret: '1234' },
   });
   jest
     .spyOn(VcsClientContextField.prototype, 'getValueAsync')

--- a/packages/eas-cli/src/user/SessionManager.ts
+++ b/packages/eas-cli/src/user/SessionManager.ts
@@ -41,7 +41,7 @@ type SecondFactorDevice = {
   is_primary: boolean;
 };
 
-type LoggedInAuthenticationInfo =
+export type LoggedInAuthenticationInfo =
   | {
       accessToken: string;
       sessionSecret: null;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Noticed while reviewing another PR that the `config` command was using the session management context, when that context should only be necessary to use in `login` and `logout` commands.

Digging in a bit, it was needed because the command only required being logged in in a certain conditional codepath, but there was no context construct available to support this.

Ref: https://github.com/expo/eas-cli/pull/2517
Ref: https://github.com/expo/eas-cli/pull/2461

Closes ENG-13892.

# How

1. Add a new context field, `DynamicLoggedIn`, which requires log in but only when the context function is called.
2. Change `config` command to use this.
3. Change logged in contexts to also expose the authentication info so that session isn't needed in `account:view` command.

# Test Plan

While both logged in and logged out:

```
neas account:view
neas config
neas config --eas-json-only
```
