### PR TITLE
[eas-cli] add simplified projectId-focused context

### DIFF
--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -16,6 +16,7 @@ import MaybeLoggedInContextField from './context/MaybeLoggedInContextField';
 import { OptionalPrivateProjectConfigContextField } from './context/OptionalPrivateProjectConfigContextField';
 import { PrivateProjectConfigContextField } from './context/PrivateProjectConfigContextField';
 import ProjectDirContextField from './context/ProjectDirContextField';
+import { ProjectIdContextField } from './context/ProjectIdContextField';
 import { ServerSideEnvironmentVariablesContextField } from './context/ServerSideEnvironmentVariablesContextField';
 import SessionManagementContextField from './context/SessionManagementContextField';
 import VcsClientContextField from './context/VcsClientContextField';
@@ -139,6 +140,12 @@ export default abstract class EasCommand extends Command {
     ServerSideEnvironmentVariables: {
       // eslint-disable-next-line async-protect/async-suffix
       getServerSideEnvironmentVariablesAsync: new ServerSideEnvironmentVariablesContextField(),
+    },
+    /**
+     * Require the project to be identified and registered on server. Returns the project ID evaluated from the app config.
+     */
+    ProjectId: {
+      projectId: new ProjectIdContextField(),
     },
   };
 

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -188,6 +188,7 @@ export default abstract class EasCommand extends Command {
       // to resolve dynamic config (if dynamic config context is used) and enable getServerSideEnvironmentVariablesAsync function (if server side environment variables context is used)
       withServerSideEnvironment,
     }: C extends
+      | GetContextType<typeof EasCommand.ContextOptions.ProjectConfig>
       | GetContextType<typeof EasCommand.ContextOptions.DynamicProjectConfig>
       | GetContextType<typeof EasCommand.ContextOptions.OptionalProjectConfig>
       | GetContextType<typeof EasCommand.ContextOptions.ServerSideEnvironmentVariables>

--- a/packages/eas-cli/src/commandUtils/context/ProjectIdContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/ProjectIdContextField.ts
@@ -1,0 +1,15 @@
+import ContextField, { ContextOptions } from './ContextField';
+import { findProjectDirAndVerifyProjectSetupAsync } from './contextUtils/findProjectDirAndVerifyProjectSetupAsync';
+import { getProjectIdAsync } from './contextUtils/getProjectIdAsync';
+import { getPrivateExpoConfig } from '../../project/expoConfig';
+
+export class ProjectIdContextField extends ContextField<string> {
+  async getValueAsync({ nonInteractive, sessionManager }: ContextOptions): Promise<string> {
+    const projectDir = await findProjectDirAndVerifyProjectSetupAsync();
+    const expBefore = getPrivateExpoConfig(projectDir);
+    const projectId = await getProjectIdAsync(sessionManager, expBefore, {
+      nonInteractive,
+    });
+    return projectId;
+  }
+}

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -25,7 +25,7 @@ export default class BranchCreate extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
     ...this.ContextOptions.Vcs,
   };
@@ -36,7 +36,7 @@ export default class BranchCreate extends EasCommand {
       flags: { json: jsonFlag, 'non-interactive': nonInteractive },
     } = await this.parse(BranchCreate);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
       vcsClient,
     } = await this.getContextAsync(BranchCreate, {

--- a/packages/eas-cli/src/commands/branch/delete.ts
+++ b/packages/eas-cli/src/commands/branch/delete.ts
@@ -79,7 +79,7 @@ export default class BranchDelete extends EasCommand {
   static override description = 'delete a branch';
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -108,7 +108,7 @@ export default class BranchDelete extends EasCommand {
     }
 
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BranchDelete, { nonInteractive });
     const projectDisplayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);

--- a/packages/eas-cli/src/commands/branch/list.ts
+++ b/packages/eas-cli/src/commands/branch/list.ts
@@ -13,14 +13,14 @@ export default class BranchList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BranchList);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BranchList, {
       nonInteractive: flags['non-interactive'],

--- a/packages/eas-cli/src/commands/branch/rename.ts
+++ b/packages/eas-cli/src/commands/branch/rename.ts
@@ -63,7 +63,7 @@ export default class BranchRename extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -72,7 +72,7 @@ export default class BranchRename extends EasCommand {
       flags: { json: jsonFlag, from: currentName, to: newName, 'non-interactive': nonInteractive },
     } = await this.parse(BranchRename);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BranchRename, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/branch/view.ts
+++ b/packages/eas-cli/src/commands/branch/view.ts
@@ -27,7 +27,7 @@ export default class BranchView extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -38,7 +38,7 @@ export default class BranchView extends EasCommand {
     } = await this.parse(BranchView);
     const { 'non-interactive': nonInteractive } = flags;
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BranchView, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/build/cancel.ts
+++ b/packages/eas-cli/src/commands/build/cancel.ts
@@ -110,7 +110,7 @@ export default class BuildCancel extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
     ...this.ContextOptions.Vcs,
   };
@@ -128,7 +128,7 @@ export default class BuildCancel extends EasCommand {
     }
 
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildCancel, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/build/configure.ts
+++ b/packages/eas-cli/src/commands/build/configure.ts
@@ -38,6 +38,7 @@ export default class BuildConfigure extends EasCommand {
       vcsClient,
     } = await this.getContextAsync(BuildConfigure, {
       nonInteractive: false,
+      withServerSideEnvironment: null,
     });
 
     Log.log(

--- a/packages/eas-cli/src/commands/build/delete.ts
+++ b/packages/eas-cli/src/commands/build/delete.ts
@@ -94,7 +94,7 @@ export default class BuildDelete extends EasCommand {
     }),
   };
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
     ...this.ContextOptions.Vcs,
   };
@@ -112,7 +112,7 @@ export default class BuildDelete extends EasCommand {
     }
 
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildDelete, { nonInteractive });
     const displayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -72,7 +72,7 @@ export default class BuildList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
     ...this.ContextOptions.Vcs,
   };
@@ -99,7 +99,7 @@ export default class BuildList extends EasCommand {
       process.exit(1);
     }
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildList, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -79,8 +79,7 @@ export default class Run extends EasCommand {
 
   static override contextDefinition = {
     ...this.ContextOptions.LoggedIn,
-    ...this.ContextOptions.ProjectConfig,
-    ...this.ContextOptions.ProjectDir,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.Vcs,
   };
 
@@ -90,7 +89,7 @@ export default class Run extends EasCommand {
     const queryOptions = getPaginatedQueryOptions(flags);
     const {
       loggedIn: { graphqlClient },
-      privateProjectConfig: { projectId },
+      projectId,
     } = await this.getContextAsync(Run, {
       nonInteractive: false,
     });

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -18,7 +18,7 @@ export default class BuildView extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
     ...this.ContextOptions.Vcs,
   };
@@ -29,7 +29,7 @@ export default class BuildView extends EasCommand {
       flags,
     } = await this.parse(BuildView);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildView, {
       nonInteractive: true,

--- a/packages/eas-cli/src/commands/channel/create.ts
+++ b/packages/eas-cli/src/commands/channel/create.ts
@@ -23,7 +23,7 @@ export default class ChannelCreate extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -33,7 +33,7 @@ export default class ChannelCreate extends EasCommand {
       flags: { json: jsonFlag, 'non-interactive': nonInteractive },
     } = await this.parse(ChannelCreate);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelCreate, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/channel/delete.ts
+++ b/packages/eas-cli/src/commands/channel/delete.ts
@@ -31,7 +31,7 @@ export default class ChannelDelete extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -41,7 +41,7 @@ export default class ChannelDelete extends EasCommand {
       flags: { json: jsonFlag, 'non-interactive': nonInteractive },
     } = await this.parse(ChannelDelete);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelDelete, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -74,7 +74,7 @@ export default class ChannelEdit extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -84,7 +84,7 @@ export default class ChannelEdit extends EasCommand {
       flags: { branch: branchFlag, json, 'non-interactive': nonInteractive },
     } = await this.parse(ChannelEdit);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelEdit, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/channel/list.ts
+++ b/packages/eas-cli/src/commands/channel/list.ts
@@ -18,7 +18,7 @@ export default class ChannelList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -27,7 +27,7 @@ export default class ChannelList extends EasCommand {
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     const { json: jsonFlag, 'non-interactive': nonInteractive } = flags;
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelList, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/channel/pause.ts
+++ b/packages/eas-cli/src/commands/channel/pause.ts
@@ -66,7 +66,7 @@ export default class ChannelPause extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -76,7 +76,7 @@ export default class ChannelPause extends EasCommand {
       flags: { json, 'non-interactive': nonInteractive },
     } = await this.parse(ChannelPause);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelPause, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/channel/resume.ts
+++ b/packages/eas-cli/src/commands/channel/resume.ts
@@ -66,7 +66,7 @@ export default class ChannelResume extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -76,7 +76,7 @@ export default class ChannelResume extends EasCommand {
       flags: { json, 'non-interactive': nonInteractive },
     } = await this.parse(ChannelResume);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelResume, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -138,6 +138,7 @@ export default class ChannelRollout extends EasCommand {
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelRollout, {
       nonInteractive: argsAndFlags.nonInteractive,
+      withServerSideEnvironment: null,
     });
     if (argsAndFlags.json) {
       enableJsonOutput();

--- a/packages/eas-cli/src/commands/channel/view.ts
+++ b/packages/eas-cli/src/commands/channel/view.ts
@@ -26,7 +26,7 @@ export default class ChannelView extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -38,7 +38,7 @@ export default class ChannelView extends EasCommand {
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     const { json: jsonFlag, 'non-interactive': nonInteractive } = flags;
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelView, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/device/delete.ts
+++ b/packages/eas-cli/src/commands/device/delete.ts
@@ -34,7 +34,7 @@ export default class DeviceDelete extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -43,7 +43,7 @@ export default class DeviceDelete extends EasCommand {
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     let { 'apple-team-id': appleTeamIdentifier, udid } = flags;
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(DeviceDelete, {
       nonInteractive: paginatedQueryOptions.nonInteractive,

--- a/packages/eas-cli/src/commands/device/list.ts
+++ b/packages/eas-cli/src/commands/device/list.ts
@@ -21,7 +21,7 @@ export default class BuildList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -29,7 +29,7 @@ export default class BuildList extends EasCommand {
     const { flags } = await this.parse(BuildList);
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildList, {
       nonInteractive: paginatedQueryOptions.nonInteractive,

--- a/packages/eas-cli/src/commands/device/rename.ts
+++ b/packages/eas-cli/src/commands/device/rename.ts
@@ -35,7 +35,7 @@ export default class DeviceRename extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -44,7 +44,7 @@ export default class DeviceRename extends EasCommand {
     const paginatedQueryOptions = getPaginatedQueryOptions(flags);
     let { 'apple-team-id': appleTeamIdentifier, udid, name } = flags;
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(DeviceRename, {
       nonInteractive: paginatedQueryOptions.nonInteractive,

--- a/packages/eas-cli/src/commands/device/view.ts
+++ b/packages/eas-cli/src/commands/device/view.ts
@@ -11,7 +11,7 @@ export default class DeviceView extends EasCommand {
   static override args = [{ name: 'UDID' }];
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -32,7 +32,7 @@ If you are not sure what is the UDID of the device you are looking for, run:
       throw new Error('Device UDID is missing');
     }
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(DeviceView, {
       nonInteractive: true,

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableCreate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableCreate.test.ts
@@ -91,7 +91,7 @@ describe(EnvironmentVariableCreate, () => {
       // @ts-expect-error
       jest.spyOn(command, 'getContextAsync').mockReturnValue({
         loggedIn: { graphqlClient },
-        privateProjectConfig: { projectId: testProjectId },
+        projectId: testProjectId,
       });
 
       await command.runAsync();
@@ -127,7 +127,7 @@ describe(EnvironmentVariableCreate, () => {
       // @ts-expect-error
       jest.spyOn(command, 'getContextAsync').mockReturnValue({
         loggedIn: { graphqlClient },
-        privateProjectConfig: { projectId: testProjectId },
+        projectId: testProjectId,
       });
 
       const otherVariableId = 'otherId';
@@ -309,7 +309,7 @@ describe(EnvironmentVariableCreate, () => {
       // @ts-expect-error
       jest.spyOn(command, 'getContextAsync').mockReturnValue({
         loggedIn: { graphqlClient },
-        privateProjectConfig: { projectId: testProjectId },
+        projectId: testProjectId,
       });
 
       await command.runAsync();
@@ -359,7 +359,7 @@ describe(EnvironmentVariableCreate, () => {
       // @ts-expect-error
       jest.spyOn(command, 'getContextAsync').mockReturnValue({
         loggedIn: { graphqlClient },
-        privateProjectConfig: { projectId: testProjectId },
+        projectId: testProjectId,
       });
 
       await command.runAsync();

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableGet.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableGet.test.ts
@@ -47,7 +47,7 @@ describe(EnvironmentVariableGet, () => {
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
       loggedIn: { graphqlClient },
-      privateProjectConfig: { projectId: testProjectId },
+      projectId: testProjectId,
     });
 
     await command.runAsync();

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableLink.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableLink.test.ts
@@ -25,7 +25,7 @@ describe(EnvironmentVariableLink, () => {
   const graphqlClient = {};
   const mockConfig = {} as unknown as Config;
   const mockContext = {
-    privateProjectConfig: { projectId },
+    projectId,
     loggedIn: { graphqlClient },
   };
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableList.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableList.test.ts
@@ -61,7 +61,7 @@ describe(EnvironmentVariableList, () => {
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
       loggedIn: { graphqlClient },
-      privateProjectConfig: { projectId: testProjectId },
+      projectId: testProjectId,
     });
     await command.runAsync();
 
@@ -82,7 +82,7 @@ describe(EnvironmentVariableList, () => {
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
       loggedIn: { graphqlClient },
-      privateProjectConfig: { projectId: testProjectId },
+      projectId: testProjectId,
     });
     await command.runAsync();
 
@@ -105,7 +105,7 @@ describe(EnvironmentVariableList, () => {
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
       loggedIn: { graphqlClient },
-      privateProjectConfig: { projectId: testProjectId },
+      projectId: testProjectId,
     });
     await command.runAsync();
 
@@ -129,7 +129,7 @@ describe(EnvironmentVariableList, () => {
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
       loggedIn: { graphqlClient },
-      privateProjectConfig: { projectId: testProjectId },
+      projectId: testProjectId,
     });
     await command.runAsync();
 
@@ -155,7 +155,7 @@ describe(EnvironmentVariableList, () => {
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
       loggedIn: { graphqlClient },
-      privateProjectConfig: { projectId: testProjectId },
+      projectId: testProjectId,
     });
     await command.runAsync();
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableUnlink.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableUnlink.test.ts
@@ -25,7 +25,7 @@ describe(EnvironmentVariableUnlink, () => {
   const graphqlClient = {};
   const mockConfig = {} as unknown as Config;
   const mockContext = {
-    privateProjectConfig: { projectId },
+    projectId,
     loggedIn: { graphqlClient },
   };
 

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -77,7 +77,7 @@ export default class EnvironmentVariableCreate extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.Analytics,
     ...this.ContextOptions.LoggedIn,
   };
@@ -101,7 +101,7 @@ export default class EnvironmentVariableCreate extends EasCommand {
     } = await this.promptForMissingFlagsAsync(validatedFlags);
 
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentVariableCreate, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/env/delete.ts
+++ b/packages/eas-cli/src/commands/env/delete.ts
@@ -40,7 +40,7 @@ export default class EnvironmentVariableDelete extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -53,7 +53,7 @@ export default class EnvironmentVariableDelete extends EasCommand {
       scope,
     } = this.validateFlags(flags);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentVariableDelete, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/env/exec.ts
+++ b/packages/eas-cli/src/commands/env/exec.ts
@@ -31,7 +31,7 @@ export default class EnvExec extends EasCommand {
   static override hidden = true;
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -57,7 +57,7 @@ export default class EnvExec extends EasCommand {
     const parsedFlags = this.sanitizeFlags(flags);
 
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvExec, {
       nonInteractive: parsedFlags.nonInteractive,

--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -34,7 +34,7 @@ export default class EnvironmentVariableGet extends EasCommand {
   static override hidden = true;
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -63,7 +63,7 @@ export default class EnvironmentVariableGet extends EasCommand {
     } = this.validateFlags(flags);
 
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentVariableGet, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/env/link.ts
+++ b/packages/eas-cli/src/commands/env/link.ts
@@ -34,7 +34,7 @@ export default class EnvironmentVariableLink extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -48,7 +48,7 @@ export default class EnvironmentVariableLink extends EasCommand {
       },
     } = await this.parse(EnvironmentVariableLink);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentVariableLink, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -71,7 +71,7 @@ export default class EnvironmentValueList extends EasCommand {
   static override hidden = true;
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -101,7 +101,7 @@ export default class EnvironmentValueList extends EasCommand {
       },
     } = await this.parse(EnvironmentValueList);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentValueList, {
       nonInteractive: true,

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -23,9 +23,9 @@ export default class EnvironmentVariablePull extends EasCommand {
   static override hidden = true;
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
-    ...this.ContextOptions.ProjectDir,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
+    ...this.ContextOptions.ProjectDir,
   };
 
   static override flags = {
@@ -46,7 +46,7 @@ export default class EnvironmentVariablePull extends EasCommand {
       environment = await promptVariableEnvironmentAsync({ nonInteractive });
     }
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
       projectDir,
     } = await this.getContextAsync(EnvironmentVariablePull, {

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -26,7 +26,7 @@ export default class EnvironmentVariablePush extends EasCommand {
   static override hidden = true;
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -44,7 +44,7 @@ export default class EnvironmentVariablePush extends EasCommand {
     } = await this.parse(EnvironmentVariablePush);
 
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentVariablePush, {
       nonInteractive: false,

--- a/packages/eas-cli/src/commands/env/unlink.ts
+++ b/packages/eas-cli/src/commands/env/unlink.ts
@@ -26,7 +26,7 @@ export default class EnvironmentVariableUnlink extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -39,7 +39,7 @@ export default class EnvironmentVariableUnlink extends EasCommand {
       },
     } = await this.parse(EnvironmentVariableUnlink);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentVariableUnlink, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -80,7 +80,7 @@ export default class EnvironmentVariableUpdate extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.Analytics,
     ...this.ContextOptions.LoggedIn,
   };
@@ -100,7 +100,7 @@ export default class EnvironmentVariableUpdate extends EasCommand {
     } = this.validateFlags(flags);
 
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentVariableUpdate, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -41,6 +41,7 @@ export default class MetadataPull extends EasCommand {
       vcsClient,
     } = await this.getContextAsync(MetadataPull, {
       nonInteractive: false,
+      withServerSideEnvironment: null,
     });
 
     // this command is interactive (all nonInteractive flags passed to utility functions are false)

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -39,6 +39,7 @@ export default class MetadataPush extends EasCommand {
       vcsClient,
     } = await this.getContextAsync(MetadataPush, {
       nonInteractive: false,
+      withServerSideEnvironment: null,
     });
 
     // this command is interactive (all nonInteractive flags passed to utility functions are false)

--- a/packages/eas-cli/src/commands/open.ts
+++ b/packages/eas-cli/src/commands/open.ts
@@ -20,6 +20,7 @@ export default class Open extends EasCommand {
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(Open, {
       nonInteractive: false,
+      withServerSideEnvironment: null,
     });
 
     const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);

--- a/packages/eas-cli/src/commands/project/info.ts
+++ b/packages/eas-cli/src/commands/project/info.ts
@@ -37,13 +37,13 @@ export default class ProjectInfo extends EasCommand {
   static override description = 'information about the current project';
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ProjectInfo, {
       nonInteractive: true,

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -50,7 +50,7 @@ export default class EnvironmentSecretCreate extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -66,7 +66,7 @@ export default class EnvironmentSecretCreate extends EasCommand {
       },
     } = await this.parse(EnvironmentSecretCreate);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentSecretCreate, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -22,7 +22,7 @@ export default class EnvironmentSecretDelete extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -31,7 +31,7 @@ export default class EnvironmentSecretDelete extends EasCommand {
       flags: { id, 'non-interactive': nonInteractive },
     } = await this.parse(EnvironmentSecretDelete);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentSecretDelete, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -13,13 +13,13 @@ export default class EnvironmentSecretList extends EasCommand {
   static override description = 'list environment secrets available for your current app';
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentSecretList, {
       nonInteractive: true,

--- a/packages/eas-cli/src/commands/secret/push.ts
+++ b/packages/eas-cli/src/commands/secret/push.ts
@@ -42,7 +42,7 @@ export default class EnvironmentSecretPush extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -51,7 +51,7 @@ export default class EnvironmentSecretPush extends EasCommand {
       flags: { scope, force, 'env-file': maybeEnvFilePath, 'non-interactive': nonInteractive },
     } = await this.parse(EnvironmentSecretPush);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvironmentSecretPush, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -112,6 +112,7 @@ export default class Submit extends EasCommand {
       vcsClient,
     } = await this.getContextAsync(Submit, {
       nonInteractive: false,
+      withServerSideEnvironment: null,
     });
 
     const flags = this.sanitizeFlags(rawFlags);

--- a/packages/eas-cli/src/commands/submit/internal.ts
+++ b/packages/eas-cli/src/commands/submit/internal.ts
@@ -65,6 +65,7 @@ export default class SubmitInternal extends EasCommand {
     } = await this.getContextAsync(SubmitInternal, {
       nonInteractive: true,
       vcsClientOverride: new GitNoCommitClient(),
+      withServerSideEnvironment: null,
     });
 
     const submissionProfile = await EasJsonUtils.getSubmitProfileAsync(

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -38,6 +38,7 @@ export default class UpdateConfigure extends EasCommand {
       vcsClient,
     } = await this.getContextAsync(UpdateConfigure, {
       nonInteractive: flags['non-interactive'],
+      withServerSideEnvironment: null,
     });
 
     Log.log(

--- a/packages/eas-cli/src/commands/update/edit.ts
+++ b/packages/eas-cli/src/commands/update/edit.ts
@@ -41,7 +41,7 @@ export default class UpdateEdit extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -57,7 +57,7 @@ export default class UpdateEdit extends EasCommand {
     } = await this.parse(UpdateEdit);
 
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(UpdateEdit, { nonInteractive });
 

--- a/packages/eas-cli/src/commands/update/list.ts
+++ b/packages/eas-cli/src/commands/update/list.ts
@@ -33,7 +33,7 @@ export default class UpdateList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -41,7 +41,7 @@ export default class UpdateList extends EasCommand {
     const { flags } = await this.parse(UpdateList);
     const { branch: branchFlag, all, json: jsonFlag, 'non-interactive': nonInteractive } = flags;
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(UpdateList, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/update/republish.ts
+++ b/packages/eas-cli/src/commands/update/republish.ts
@@ -103,6 +103,7 @@ export default class UpdateRepublish extends EasCommand {
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(UpdateRepublish, {
       nonInteractive: flags.nonInteractive,
+      withServerSideEnvironment: null,
     });
 
     if (flags.json) {

--- a/packages/eas-cli/src/commands/webhook/create.ts
+++ b/packages/eas-cli/src/commands/webhook/create.ts
@@ -26,14 +26,14 @@ export default class WebhookCreate extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(WebhookCreate);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(WebhookCreate, {
       nonInteractive: flags['non-interactive'],

--- a/packages/eas-cli/src/commands/webhook/delete.ts
+++ b/packages/eas-cli/src/commands/webhook/delete.ts
@@ -29,7 +29,7 @@ export default class WebhookDelete extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -39,7 +39,7 @@ export default class WebhookDelete extends EasCommand {
       flags: { 'non-interactive': nonInteractive },
     } = await this.parse(WebhookDelete);
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(WebhookDelete, {
       nonInteractive,

--- a/packages/eas-cli/src/commands/webhook/list.ts
+++ b/packages/eas-cli/src/commands/webhook/list.ts
@@ -23,7 +23,7 @@ export default class WebhookList extends EasCommand {
   };
 
   static override contextDefinition = {
-    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -36,7 +36,7 @@ export default class WebhookList extends EasCommand {
     }
 
     const {
-      privateProjectConfig: { projectId },
+      projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(WebhookList, {
       nonInteractive: true,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

As suggested in the base PR we need a simple context focused on only getting the project ID, without specifying the server-side environment and resolving Expo config with it.

# How

Add such context. Make the `withServerSideEnvironment` argument required for standard project config context.

# Test Plan

Tests, test manually