### PR TITLE
Improve wording in env:pull command

### DIFF
--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -124,9 +124,9 @@ export default class EnvironmentVariablePull extends EasCommand {
     if (skippedSecretVariables.length > 0) {
       Log.addNewLineIfNone();
       Log.warn(
-        `The following variables have the encrypted visibility and were added to .env.local as variables without values: ${skippedSecretVariables.join(
+        `The following variables have the encrypted visibility and can not be read outside of EAS servers. Set their values manually in .env.local: ${skippedSecretVariables.join(
           '\n'
-        )}.`
+        )}`
       );
     }
   }

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -112,22 +112,22 @@ export default class EnvironmentVariablePull extends EasCommand {
 
     await fs.writeFile(targetPath, filePrefix + envFileContentLines.join('\n'));
 
+    Log.log(
+      `Pulled environment variables from ${environment.toLowerCase()} environment to ${targetPath}.`
+    );
+
     if (overridenSecretVariables.length > 0) {
       Log.addNewLineIfNone();
       Log.log(`Reused local values for following secrets: ${overridenSecretVariables.join('\n')}`);
     }
 
     if (skippedSecretVariables.length > 0) {
+      Log.addNewLineIfNone();
       Log.warn(
-        `The eas env:pull command tried to pull environment variables with "secret" visibility. The variables with "secret" visibility are not available for reading, therefore thet were marked as "*****" in the generated .env file. Provide values for these manually in ${targetPath} if needed. Skipped variables: ${skippedSecretVariables.join(
+        `The following variables have the encrypted visibility and were added to .env.local as variables without values: ${skippedSecretVariables.join(
           '\n'
-        )}`
+        )}.`
       );
-      Log.warn();
     }
-
-    Log.log(
-      `Pulled environment variables from ${environment.toLowerCase()} environment to ${targetPath}.`
-    );
   }
 }


### PR DESCRIPTION
# Why

[ENG-13928: Update "secret" with "encrypted" on eas env:pull](https://linear.app/expo/issue/ENG-13928/update-secret-with-encrypted-on-eas-envpull)

The message informing user about encrypted variables omission can be clearer.

<img width="555" alt="image" src="https://github.com/user-attachments/assets/34a85168-de32-4f45-a56f-86003819e8e8">

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
