### PR TITLE
env:pull uses local values of encrypted variables

### DIFF
--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -114,11 +114,7 @@ export default class EnvironmentVariablePull extends EasCommand {
 
     if (overridenSecretVariables.length > 0) {
       Log.addNewLineIfNone();
-      Log.log(
-        `Following encrypted variables were overriden by local values: ${overridenSecretVariables.join(
-          '\n'
-        )}`
-      );
+      Log.log(`Reused local values for following secrets: ${overridenSecretVariables.join('\n')}`);
     }
 
     if (skippedSecretVariables.length > 0) {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

[ENG-13929: eas env:pull overwrites all variables](https://linear.app/expo/issue/ENG-13929/eas-envpull-overwrites-all-variables)

`env:pull` should not overwrite existing values for encrypted variables, but leave them in `.env.local`.

# Test Plan

Tested manually
