### PR TITLE
Change package.json update message to allow faster copy and paste

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -185,7 +185,7 @@
     },
     "warn-if-update-available": {
       "timeoutInDays": 0.5,
-      "message": "<%= chalk('★') %> <%= chalk.bold(config.name + '@' + latest) %> <%= chalk.bold('is now available.') %>\n<%= chalk.dim('To upgrade, run ') %><%= chalk.dim(chalk.bold('npm install -g eas-cli')) %><%= chalk.dim('.') %>\n<%= chalk.dim('Proceeding with outdated version.') %>\n"
+      "message": "<%= chalk('★') %> <%= chalk.bold(config.name + '@' + latest) %> <%= chalk.bold('is now available.') %>\n<%= chalk.dim('To upgrade, run:') %>\n<%= chalk.dim(chalk.bold('npm install -g eas-cli')) %>\n<%= chalk.dim('Proceeding with outdated version.') %>\n"
     },
     "update": {
       "node": {


### PR DESCRIPTION
# Why

By default, the update notice prints:

```
★ eas-cli@12.6.2 is now available.
To upgrade, run npm install -g eas-cli.
Proceeding with outdated version.
```

This is slightly hard to copy and paste, and has a trailing period that needs to be removed.

This puts it on a new line without the period

```
★ eas-cli@12.6.2 is now available.
To upgrade, run:
npm install -g eas-cli
Proceeding with outdated version.
```

This means you can just triple click, copy, and paste and then it'll run. 
