### PR TITLE
fix(eas-cli): update EAS Metadata with new props for App Store 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Upgrade EAS Metadata with new properties from App Store. ([#2671](https://github.com/expo/eas-cli/pull/2671) by [@byCedric](https://github.com/byCedric))
+
 ## [13.0.0](https://github.com/expo/eas-cli/releases/tag/v13.0.0) - 2024-11-05
 
 ### 🛠 Breaking changes

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "2.0.3",
+    "@expo/apple-utils": "2.1.0",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "9.0.4",
     "@expo/config-plugins": "8.0.10",

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -1,6 +1,20 @@
 {
   "$schema": "http://json-schema.org/draft-06/schema",
   "type": "object",
+  "properties": {
+    "configVersion": {
+      "enum": [0],
+      "description": "The EAS metadata store configuration version"
+    },
+    "apple": {
+      "$ref": "#/definitions/AppleConfig"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "configVersion",
+    "apple"
+  ],
   "definitions": {
     "apple": {
       "AppleKidsAge": {
@@ -323,7 +337,8 @@
           "gambling",
           "unrestrictedWebAccess",
           "kidsAgeBand",
-          "seventeenPlus"
+          "ageRatingOverride",
+          "koreaAgeRatingOverride"
         ],
         "defaultSnippets": [
           {
@@ -442,8 +457,23 @@
           },
           "seventeenPlus": {
             "type": "boolean",
-            "description": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 17, you can manually set the age rating to 17+.\n@see https://help.apple.com/app-store-connect/#/dev599d50efb",
-            "markdownDescription": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 17, you can manually set the age rating to 17+.\n\n[Learn more](https://help.apple.com/app-store-connect/#/dev599d50efb)"
+            "deprecated": true,
+            "description": "This property is deprecated, use `ageRatingOverride` instead.",
+            "markdownDescription": "This property is deprecated, use `ageRatingOverride` instead."
+          },
+          "ageRatingOverride": {
+            "$ref": "#/definitions/apple/AppleAgeRatingOverride",
+            "description": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 17, you can manually set the age rating to 17+.\n\nIf your app will be distributed through alternative app marketplaces or websites in the European Union and you believe your app is [Unrated](https://developer.apple.com/help/app-store-connect/reference/age-ratings), set this to `UNRATED`.\n\n@see https://help.apple.com/app-store-connect/#/dev599d50efb",
+            "markdownDescription": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 17, you can manually set the age rating to 17+.\n\nIf your app will be distributed through alternative app marketplaces or websites in the European Union and you believe your app is [Unrated](https://developer.apple.com/help/app-store-connect/reference/age-ratings), set this to `UNRATED`.\n\n[Learn more](https://help.apple.com/app-store-connect/#/dev599d50efb)"
+          },
+          "koreaAgeRatingOverride": {
+            "$ref": "#/definitions/apple/AppleKoreaAgeRatingOverride",
+            "description": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 15 or 19, you can manually set the age rating to 15+ or 19+.\n\nIf your app will be distributed through alternative app marketplaces or websites in the European Union and you believe your app is [Unrated](https://developer.apple.com/help/app-store-connect/reference/age-ratings), set this to `UNRATED`.\n\n@see https://help.apple.com/app-store-connect/#/dev599d50efb",
+            "markdownDescription": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 15 or 19, you can manually set the age rating to 15+ or 19+.\n\nIf your app will be distributed through alternative app marketplaces or websites in the European Union and you believe your app is [Unrated](https://developer.apple.com/help/app-store-connect/reference/age-ratings), set this to `UNRATED`.\n\n[Learn more](https://help.apple.com/app-store-connect/#/dev599d50efb)"
+          },
+          "lootBox": {
+            "type": "boolean",
+            "description": "Does your app contain purchasable loot boxes? These virtual containers provide players with in-game items, including functional cards or cosmetic modifications, based on random chance."
           }
         }
       },
@@ -565,6 +595,20 @@
             "maxLength": 4000
           }
         }
+      },
+      "AppleAgeRatingOverride": {
+        "enum": [
+          "NONE",
+          "SEVENTEEN_PLUS",
+          "UNRATED"
+        ]
+      },
+      "AppleKoreaAgeRatingOverride": {
+        "enum": [
+          "NONE",
+          "FIFTEEN_PLUS",
+          "NINETEEN_PLUS"
+        ]
       }
     },
     "AppleConfig": {
@@ -775,19 +819,5 @@
         }
       }
     }
-  },
-  "properties": {
-    "configVersion": {
-      "enum": [0],
-      "description": "The EAS metadata store configuration version"
-    },
-    "apple": {
-      "$ref": "#/definitions/AppleConfig"
-    }
-  },
-  "additionalProperties": false,
-  "required": [
-    "configVersion",
-    "apple"
-  ]
+  }
 }

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -360,7 +360,9 @@
               "gambling": false,
               "unrestrictedWebAccess": false,
               "kidsAgeBand": null,
-              "seventeenPlus": false
+              "ageRatingOverride": "NONE",
+              "koreaAgeRatingOverride": "NONE",
+              "lootBox": false
             }
           },
           {
@@ -382,7 +384,9 @@
               "unrestrictedWebAccess": false,
               "gambling": false,
               "kidsAgeBand": null,
-              "seventeenPlus": false
+              "ageRatingOverride": "${13|NONE,SEVENTEEN_PLUS,UNRATED|}",
+              "koreaAgeRatingOverride": "${14|NONE,FIFTEEN_PLUS,NINETEEN_PLUS|}",
+              "lootBox": false
             }
           }
         ],
@@ -458,8 +462,9 @@
           "seventeenPlus": {
             "type": "boolean",
             "deprecated": true,
-            "description": "This property is deprecated, use `ageRatingOverride` instead.",
-            "markdownDescription": "This property is deprecated, use `ageRatingOverride` instead."
+            "deprecationMessage": "This property is deprecated, use `ageRatingOverride` instead.",
+            "description": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 17, you can manually set the age rating to 17+.\n@see https://help.apple.com/app-store-connect/#/dev599d50efb",
+            "markdownDescription": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 17, you can manually set the age rating to 17+.\n\n[Learn more](https://help.apple.com/app-store-connect/#/dev599d50efb)"
           },
           "ageRatingOverride": {
             "$ref": "#/definitions/apple/AppleAgeRatingOverride",

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/ageRatingDeclaration.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/ageRatingDeclaration.ts
@@ -1,10 +1,12 @@
-import { AgeRatingDeclaration, KidsAge, Rating } from '@expo/apple-utils';
+import { AgeRatingDeclaration, KidsAgeBand, KoreaRatingOverride, Rating, RatingOverride } from '@expo/apple-utils';
 
 import { AttributesOf } from '../../../../utils/asc';
 
-// @ts-expect-error: Deprecated property `gamblingAndContests` needs to be deleted from the types
+// Note, both `seventeenPlus` and `gamlingAndContests` are deprecated
+type AgeRatingDeclarationProps = Omit<AttributesOf<AgeRatingDeclaration>, 'seventeenPlus' | 'gamblingAndContests'>;
+
 // These attributes is what we get from the API when no questions are answered
-export const emptyAdvisory: AttributesOf<AgeRatingDeclaration> = {
+export const emptyAdvisory: AgeRatingDeclarationProps = {
   alcoholTobaccoOrDrugUseOrReferences: null,
   contests: null,
   gamblingSimulated: null,
@@ -20,11 +22,12 @@ export const emptyAdvisory: AttributesOf<AgeRatingDeclaration> = {
   gambling: false,
   unrestrictedWebAccess: false,
   kidsAgeBand: null,
-  seventeenPlus: false,
+  ageRatingOverride: null,
+  koreaAgeRatingOverride: null,
+  lootBox: null,
 };
 
-// @ts-expect-error: Deprecated property `gamblingAndContests` needs to be deleted from the types
-export const leastRestrictiveAdvisory: AttributesOf<AgeRatingDeclaration> = {
+export const leastRestrictiveAdvisory: AgeRatingDeclarationProps = {
   alcoholTobaccoOrDrugUseOrReferences: Rating.NONE,
   contests: Rating.NONE,
   gamblingSimulated: Rating.NONE,
@@ -40,11 +43,12 @@ export const leastRestrictiveAdvisory: AttributesOf<AgeRatingDeclaration> = {
   gambling: false,
   unrestrictedWebAccess: false,
   kidsAgeBand: null,
-  seventeenPlus: false,
+  ageRatingOverride: RatingOverride.NONE,
+  koreaAgeRatingOverride: KoreaRatingOverride.NONE,
+  lootBox: false,
 };
 
-// @ts-expect-error: Deprecated property `gamblingAndContests` needs to be deleted from the types
-export const mostRestrictiveAdvisory: AttributesOf<AgeRatingDeclaration> = {
+export const mostRestrictiveAdvisory: AgeRatingDeclarationProps = {
   alcoholTobaccoOrDrugUseOrReferences: Rating.FREQUENT_OR_INTENSE,
   contests: Rating.FREQUENT_OR_INTENSE,
   gamblingSimulated: Rating.FREQUENT_OR_INTENSE,
@@ -60,11 +64,12 @@ export const mostRestrictiveAdvisory: AttributesOf<AgeRatingDeclaration> = {
   gambling: true,
   unrestrictedWebAccess: true,
   kidsAgeBand: null,
-  seventeenPlus: true,
+  ageRatingOverride: RatingOverride.SEVENTEEN_PLUS,
+  koreaAgeRatingOverride: KoreaRatingOverride.NINETEEN_PLUS,
+  lootBox: true,
 };
 
-// @ts-expect-error: Deprecated property `gamblingAndContests` needs to be deleted from the types
-export const kidsSixToEightAdvisory: AttributesOf<AgeRatingDeclaration> = {
+export const kidsSixToEightAdvisory: AgeRatingDeclarationProps = {
   alcoholTobaccoOrDrugUseOrReferences: Rating.NONE,
   contests: Rating.NONE,
   gamblingSimulated: Rating.NONE,
@@ -79,6 +84,8 @@ export const kidsSixToEightAdvisory: AttributesOf<AgeRatingDeclaration> = {
   violenceRealisticProlongedGraphicOrSadistic: Rating.NONE,
   gambling: false,
   unrestrictedWebAccess: false,
-  kidsAgeBand: KidsAge.SIX_TO_EIGHT,
-  seventeenPlus: false,
+  kidsAgeBand: KidsAgeBand.SIX_TO_EIGHT,
+  ageRatingOverride: RatingOverride.NONE,
+  koreaAgeRatingOverride: KoreaRatingOverride.NONE,
+  lootBox: false,
 };

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/ageRatingDeclaration.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/ageRatingDeclaration.ts
@@ -1,9 +1,18 @@
-import { AgeRatingDeclaration, KidsAgeBand, KoreaRatingOverride, Rating, RatingOverride } from '@expo/apple-utils';
+import {
+  AgeRatingDeclaration,
+  KidsAgeBand,
+  KoreaRatingOverride,
+  Rating,
+  RatingOverride,
+} from '@expo/apple-utils';
 
 import { AttributesOf } from '../../../../utils/asc';
 
 // Note, both `seventeenPlus` and `gamlingAndContests` are deprecated
-type AgeRatingDeclarationProps = Omit<AttributesOf<AgeRatingDeclaration>, 'seventeenPlus' | 'gamblingAndContests'>;
+type AgeRatingDeclarationProps = Omit<
+  AttributesOf<AgeRatingDeclaration>,
+  'seventeenPlus' | 'gamblingAndContests'
+>;
 
 // These attributes is what we get from the API when no questions are answered
 export const emptyAdvisory: AgeRatingDeclarationProps = {

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreVersion.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreVersion.ts
@@ -1,4 +1,11 @@
-import { AppStoreState, AppStoreVersion, AppVersionState, Platform, ReleaseType, ReviewType } from '@expo/apple-utils';
+import {
+  AppStoreState,
+  AppStoreVersion,
+  AppVersionState,
+  Platform,
+  ReleaseType,
+  ReviewType,
+} from '@expo/apple-utils';
 
 import { AttributesOf } from '../../../../utils/asc';
 

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreVersion.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/appStoreVersion.ts
@@ -1,4 +1,4 @@
-import { AppStoreState, AppStoreVersion, Platform, ReleaseType } from '@expo/apple-utils';
+import { AppStoreState, AppStoreVersion, AppVersionState, Platform, ReleaseType, ReviewType } from '@expo/apple-utils';
 
 import { AttributesOf } from '../../../../utils/asc';
 
@@ -6,43 +6,43 @@ export const manualRelease: AttributesOf<AppStoreVersion> = {
   platform: Platform.IOS,
   versionString: '1.0.0',
   appStoreState: AppStoreState.WAITING_FOR_REVIEW,
+  appVersionState: AppVersionState.WAITING_FOR_REVIEW,
   storeIcon: null,
   watchStoreIcon: null,
   copyright: '2022 - ACME',
   releaseType: ReleaseType.MANUAL,
   earliestReleaseDate: null,
-  usesIdfa: null,
-  isWatchOnly: false,
   downloadable: false,
   createdDate: '2022-05-23T00:00:00.000Z',
+  reviewType: ReviewType.APP_STORE,
 };
 
 export const automaticRelease: AttributesOf<AppStoreVersion> = {
   platform: Platform.IOS,
   versionString: '2.0.0',
   appStoreState: AppStoreState.WAITING_FOR_REVIEW,
+  appVersionState: AppVersionState.WAITING_FOR_REVIEW,
   storeIcon: null,
   watchStoreIcon: null,
   copyright: '2022 - ACME',
   releaseType: ReleaseType.AFTER_APPROVAL,
   earliestReleaseDate: null,
-  usesIdfa: null,
-  isWatchOnly: false,
   downloadable: false,
   createdDate: '2022-05-23T00:00:00.000Z',
+  reviewType: ReviewType.APP_STORE,
 };
 
 export const scheduledRelease: AttributesOf<AppStoreVersion> = {
   platform: Platform.IOS,
   versionString: '3.0.0',
   appStoreState: AppStoreState.READY_FOR_SALE,
+  appVersionState: AppVersionState.ACCEPTED,
   storeIcon: null,
   watchStoreIcon: null,
   copyright: '2022 - ACME',
   releaseType: ReleaseType.SCHEDULED,
   earliestReleaseDate: '2022-05-29T00:00:00.000Z',
-  usesIdfa: null,
-  isWatchOnly: false,
   downloadable: false,
   createdDate: '2022-05-23T00:00:00.000Z',
+  reviewType: ReviewType.APP_STORE,
 };

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -6,8 +6,10 @@ import {
   AppStoreVersionLocalization,
   AppStoreVersionPhasedRelease,
   CategoryIds,
+  KoreaRatingOverride,
   PhasedReleaseState,
   Rating,
+  RatingOverride,
   ReleaseType,
 } from '@expo/apple-utils';
 
@@ -35,24 +37,26 @@ export class AppleConfigReader {
     }
 
     return {
+      ageRatingOverride: attributes.ageRatingOverride ?? RatingOverride.NONE,
       alcoholTobaccoOrDrugUseOrReferences:
         attributes.alcoholTobaccoOrDrugUseOrReferences ?? Rating.NONE,
       contests: attributes.contests ?? Rating.NONE,
+      gambling: attributes.gambling ?? false,
       gamblingSimulated: attributes.gamblingSimulated ?? Rating.NONE,
       horrorOrFearThemes: attributes.horrorOrFearThemes ?? Rating.NONE,
+      kidsAgeBand: attributes.kidsAgeBand ?? null,
+      koreaAgeRatingOverride: attributes.koreaAgeRatingOverride ?? KoreaRatingOverride.NONE,
+      lootBox: attributes.lootBox ?? false,
       matureOrSuggestiveThemes: attributes.matureOrSuggestiveThemes ?? Rating.NONE,
       medicalOrTreatmentInformation: attributes.medicalOrTreatmentInformation ?? Rating.NONE,
       profanityOrCrudeHumor: attributes.profanityOrCrudeHumor ?? Rating.NONE,
       sexualContentGraphicAndNudity: attributes.sexualContentGraphicAndNudity ?? Rating.NONE,
       sexualContentOrNudity: attributes.sexualContentOrNudity ?? Rating.NONE,
+      unrestrictedWebAccess: attributes.unrestrictedWebAccess ?? false,
       violenceCartoonOrFantasy: attributes.violenceCartoonOrFantasy ?? Rating.NONE,
       violenceRealistic: attributes.violenceRealistic ?? Rating.NONE,
       violenceRealisticProlongedGraphicOrSadistic:
         attributes.violenceRealisticProlongedGraphicOrSadistic ?? Rating.NONE,
-      gambling: attributes.gambling ?? false,
-      unrestrictedWebAccess: attributes.unrestrictedWebAccess ?? false,
-      kidsAgeBand: attributes.kidsAgeBand ?? null,
-      seventeenPlus: attributes.seventeenPlus ?? false,
     };
   }
 

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -30,7 +30,8 @@ export class AppleConfigWriter {
     };
   }
 
-  public setAgeRating(attributes: AttributesOf<AgeRatingDeclaration>): void {
+  // Note, both `seventeenPlus` and `gamlingAndContests` are deprecated
+  public setAgeRating(attributes: Omit<AttributesOf<AgeRatingDeclaration>, 'seventeenPlus' | 'gamblingAndContests'>): void {
     this.schema.advisory = {
       ageRatingOverride: attributes.ageRatingOverride ?? RatingOverride.NONE,
       alcoholTobaccoOrDrugUseOrReferences:

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -31,7 +31,9 @@ export class AppleConfigWriter {
   }
 
   // Note, both `seventeenPlus` and `gamlingAndContests` are deprecated
-  public setAgeRating(attributes: Omit<AttributesOf<AgeRatingDeclaration>, 'seventeenPlus' | 'gamblingAndContests'>): void {
+  public setAgeRating(
+    attributes: Omit<AttributesOf<AgeRatingDeclaration>, 'seventeenPlus' | 'gamblingAndContests'>
+  ): void {
     this.schema.advisory = {
       ageRatingOverride: attributes.ageRatingOverride ?? RatingOverride.NONE,
       alcoholTobaccoOrDrugUseOrReferences:

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -6,7 +6,9 @@ import {
   AppStoreVersion,
   AppStoreVersionLocalization,
   AppStoreVersionPhasedRelease,
+  KoreaRatingOverride,
   Rating,
+  RatingOverride,
   ReleaseType,
 } from '@expo/apple-utils';
 
@@ -23,31 +25,33 @@ export class AppleConfigWriter {
   /** Get the schema result to write it to the config file */
   public toSchema(): { configVersion: number; apple: Partial<AppleMetadata> } {
     return {
-      configVersion: 0,
+      configVersion: 1,
       apple: this.schema,
     };
   }
 
   public setAgeRating(attributes: AttributesOf<AgeRatingDeclaration>): void {
     this.schema.advisory = {
+      ageRatingOverride: attributes.ageRatingOverride ?? RatingOverride.NONE,
       alcoholTobaccoOrDrugUseOrReferences:
         attributes.alcoholTobaccoOrDrugUseOrReferences ?? Rating.NONE,
       contests: attributes.contests ?? Rating.NONE,
+      gambling: attributes.gambling ?? false,
       gamblingSimulated: attributes.gamblingSimulated ?? Rating.NONE,
       horrorOrFearThemes: attributes.horrorOrFearThemes ?? Rating.NONE,
+      kidsAgeBand: attributes.kidsAgeBand ?? null,
+      koreaAgeRatingOverride: attributes.koreaAgeRatingOverride ?? KoreaRatingOverride.NONE,
+      lootBox: attributes.lootBox ?? false,
       matureOrSuggestiveThemes: attributes.matureOrSuggestiveThemes ?? Rating.NONE,
       medicalOrTreatmentInformation: attributes.medicalOrTreatmentInformation ?? Rating.NONE,
       profanityOrCrudeHumor: attributes.profanityOrCrudeHumor ?? Rating.NONE,
       sexualContentGraphicAndNudity: attributes.sexualContentGraphicAndNudity ?? Rating.NONE,
       sexualContentOrNudity: attributes.sexualContentOrNudity ?? Rating.NONE,
+      unrestrictedWebAccess: attributes.unrestrictedWebAccess ?? false,
       violenceCartoonOrFantasy: attributes.violenceCartoonOrFantasy ?? Rating.NONE,
       violenceRealistic: attributes.violenceRealistic ?? Rating.NONE,
       violenceRealisticProlongedGraphicOrSadistic:
         attributes.violenceRealisticProlongedGraphicOrSadistic ?? Rating.NONE,
-      gambling: attributes.gambling ?? false,
-      unrestrictedWebAccess: attributes.unrestrictedWebAccess ?? false,
-      kidsAgeBand: attributes.kidsAgeBand ?? null,
-      seventeenPlus: attributes.seventeenPlus ?? false,
     };
   }
 

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -25,7 +25,7 @@ export class AppleConfigWriter {
   /** Get the schema result to write it to the config file */
   public toSchema(): { configVersion: number; apple: Partial<AppleMetadata> } {
     return {
-      configVersion: 1,
+      configVersion: 0,
       apple: this.schema,
     };
   }

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -14,7 +14,10 @@ export interface AppleMetadata {
 }
 
 // The omited properties are deprecated
-export type AppleAdvisory = Omit<Partial<AgeRatingDeclarationProps>, 'seventeenPlus' | 'gamblingAndContests'>;
+export type AppleAdvisory = Omit<
+  Partial<AgeRatingDeclarationProps>,
+  'seventeenPlus' | 'gamblingAndContests'
+>;
 
 /** Apps can define up to two categories, or categories with up to two subcategories */
 export type AppleCategory = (string | string[])[];

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -13,7 +13,8 @@ export interface AppleMetadata {
   review?: AppleReview;
 }
 
-export type AppleAdvisory = Partial<AgeRatingDeclarationProps>;
+// The omited properties are deprecated
+export type AppleAdvisory = Omit<Partial<AgeRatingDeclarationProps>, 'seventeenPlus' | 'gamblingAndContests'>;
 
 /** Apps can define up to two categories, or categories with up to two subcategories */
 export type AppleCategory = (string | string[])[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.0.3.tgz#558f185a44533ee7b33fc9da3a76ebb953ab8777"
-  integrity sha512-RvV6rCvwdYvCv9c/57XHDAUfTq3RM/wQMmurrLLuYADEurwRveltO7SQ/ajpa4SrTpCzQDx2L3WZGXah7Syr6Q==
+"@expo/apple-utils@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.0.tgz#9cabfb9fc9dab5e7835b499804ecd6da289eb3fd"
+  integrity sha512-RzZkPiPtdBuswnTM44LowiScej5M9J/OqTPjWTKSIXhB8veJwb1f5iAE1aqzsceXibOaz0F+4135XahRaPjVvw==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
# Why

This changes a few properties from `apple.advisory.*` object in the store config. It's just an update to keep up with Apple's changes on the App Store.

- `seventeenPlus` - Dropped in favor of `ageRatingOverride`
- `ageRatingOverride` - New property to override the standard age rating
- `koreaAgeRatingOverride` - Same as `ageRatingOverride`, but for South Korea

If you see this, you can upgrade to use this new format:

- `eas metadata:pull`

> Yep, that's it.

Make sure you don't have any local changes, as this command will override your local store config.

# How

- Updated to `@expo/apple-utils@2.1.0`

# Test Plan

Both command should work fine for any listed app.

- `eas metadata:pull`
- `eas metadata:push`
