### PR TITLE
[eas-cli] use full command in error describtion when npx expo config --type introspect command fails

### DIFF
--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -47,7 +47,7 @@ export async function getManagedApplicationTargetEntitlementsAsync(
     } catch (err: any) {
       if (!wasExpoConfigPluginsWarnPrinted) {
         Log.warn(
-          `Failed to read the app config from the project using "npx expo config" command: ${err.message}.`
+          `Failed to read the app config from the project using "npx expo config --type introspect" command: ${err.message}.`
         );
         Log.warn('Falling back to the version of "@expo/config" shipped with the EAS CLI.');
         wasExpoConfigPluginsWarnPrinted = true;


### PR DESCRIPTION
# Why

The error message when reading app config was not accurately reflecting the command being used, which could lead to confusion when troubleshooting configuration issues.

# How

Updated the error message in `entitlements.ts` to include the correct command flag `--type introspect` when displaying the failure message for reading app config.