### PR TITLE
[eas-cli] improve fingerprint UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add EAS_SKIP_AUTO_FINGERPRINT to skip fingerprint computation on build ([#2675](https://github.com/expo/eas-cli/pull/2675) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/utils/fingerprintCli.ts
+++ b/packages/eas-cli/src/utils/fingerprintCli.ts
@@ -18,6 +18,12 @@ export async function createFingerprintAsync(
   sources: object[];
   isDebugSource: boolean;
 } | null> {
+  // @expo/fingerprint is exported in the expo package for SDK 52+
+  const fingerprintPath = silentResolveFrom(projectDir, 'expo/fingerprint');
+  if (!fingerprintPath) {
+    return null;
+  }
+
   if (process.env.EAS_SKIP_AUTO_FINGERPRINT) {
     Log.log('Skipping project fingerprint');
     return null;
@@ -30,11 +36,6 @@ export async function createFingerprintAsync(
 
   const spinner = ora(`Computing project fingerprint`).start();
   try {
-    // @expo/fingerprint is exported in the expo package for SDK 52+
-    const fingerprintPath = silentResolveFrom(projectDir, 'expo/fingerprint');
-    if (!fingerprintPath) {
-      return null;
-    }
     const Fingerprint = require(fingerprintPath);
     const fingerprintOptions: Record<string, any> = {};
     if (options.platform) {
@@ -46,7 +47,6 @@ export async function createFingerprintAsync(
     if (options.debug) {
       fingerprintOptions.debug = true;
     }
-    // eslint-disable-next-line @typescript-eslint/return-await
     const fingerprint = await Fingerprint.createFingerprintAsync(projectDir, fingerprintOptions);
     spinner.succeed(`Computed project fingerprint`);
     return fingerprint;
@@ -57,5 +57,6 @@ export async function createFingerprintAsync(
   } finally {
     // Clear the timeout if the operation finishes before the time limit
     clearTimeout(timeoutId);
+    spinner.stop();
   }
 }

--- a/packages/eas-cli/src/utils/fingerprintCli.ts
+++ b/packages/eas-cli/src/utils/fingerprintCli.ts
@@ -30,7 +30,7 @@ export async function createFingerprintAsync(
   }
 
   const timeoutId = setTimeout(() => {
-    Log.log('⌛️ Computing project fingerprint taking longer than expected...');
+    Log.log('⌛️ Computing the project fingerprint is taking longer than expected...');
     Log.log('⏩ To skip this step, set the environment variable: EAS_SKIP_AUTO_FINGERPRINT=1');
   }, 5000);
 

--- a/packages/eas-cli/src/utils/fingerprintCli.ts
+++ b/packages/eas-cli/src/utils/fingerprintCli.ts
@@ -18,6 +18,11 @@ export async function createFingerprintAsync(
   sources: object[];
   isDebugSource: boolean;
 } | null> {
+  if (process.env.EAS_SKIP_AUTO_FINGERPRINT) {
+    Log.log('Skipping project fingerprint');
+    return null;
+  }
+
   const timeoutId = setTimeout(() => {
     Log.log('⌛️ Computing project fingerprint taking longer than expected...');
     Log.log('⏩ To skip this step, set the environment variable: EAS_SKIP_AUTO_FINGERPRINT=1');


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This PR does the following:
- Add logs to notify user fingerprint is getting computed
- Lets user know they can skip fingerprint computation if it's taking longer than 5 seconds
- Skips fingerprint computation if `EAS_SKIP_AUTO_FINGERPRINT` is set, as per https://www.notion.so/expo/Soft-fingerprinting-116e5b5735248071951cddcab32ae43d?pvs=4#116e5b57352480e89189eb7feb88dacd

# How
```
Compressing project files and uploading to EAS Build. Learn more: https://expo.fyi/eas-build-archive
✔ Uploaded to EAS 
⌛️ Computing project fingerprint taking longer than expected...
⏩ To skip this step, set the environment variable: EAS_SKIP_AUTO_FINGERPRINT=1
✔ Computed project fingerprint
```

# Test Plan

- [x] Tested a fingerprint computation that 'takes too long' (await 5 second promise)
- [x] Tested a fast fingerprint computation
- [x] Tested `eas build` with and without `EAS_SKIP_AUTO_FINGERPRINT=1`
