### PR TITLE
[build] Default build-logger-level to debug when EXPO_DEBUG is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add EAS_SKIP_AUTO_FINGERPRINT to skip fingerprint computation on build ([#2675](https://github.com/expo/eas-cli/pull/2675) by [@quinlanj](https://github.com/quinlanj))
+- Default build-logger-level to debug when EXPO_DEBUG is set. ([#2676](https://github.com/expo/eas-cli/pull/2676) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -381,7 +381,7 @@ async function prepareAndStartBuildAsync({
     vcsClient,
     getDynamicPrivateProjectConfigAsync,
     customBuildConfigMetadata,
-    buildLoggerLevel: flags.buildLoggerLevel,
+    buildLoggerLevel: flags.buildLoggerLevel ?? (Log.isDebug ? LoggerLevel.DEBUG : undefined),
     freezeCredentials: flags.freezeCredentials,
     repack: flags.repack,
     env,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

It's convenient to have this be the default value when trying to debug, so that the whole build can be used to debug. Not set on this, but wanted to see what others thought.

Closes ENG-14060.

# How

Default when `Log.isDebug` is true and flag isn't provided.

# Test Plan

1. `EXPO_DEBUG=1 neas build`, see debug logs in build.
