### PR TITLE
[eas-cli] Honor `EAS_NO_VCS` in `build:internal`

### DIFF
--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -7,6 +7,7 @@ import EasCommand from '../../commandUtils/EasCommand';
 import { RequestedPlatform } from '../../platform';
 import { enableJsonOutput } from '../../utils/json';
 import GitNoCommitClient from '../../vcs/clients/gitNoCommit';
+import NoVcsClient from '../../vcs/clients/noVcs';
 
 /**
  * This command will be run on the EAS Build workers, when building
@@ -63,7 +64,7 @@ export default class BuildInternal extends EasCommand {
       vcsClient,
     } = await this.getContextAsync(BuildInternal, {
       nonInteractive: true,
-      vcsClientOverride: new GitNoCommitClient(),
+      vcsClientOverride: process.env.EAS_NO_VCS ? new NoVcsClient() : new GitNoCommitClient(),
       withServerSideEnvironment: null,
     });
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We need to use `build:internal` to resolve build configuration in GCS workflow jobs which have no Git repository.

# How

I'm going to be adding `EAS_NO_VCS=1` to GCS workflow jobs. This should prevent `build:internal` from requiring Git repository.

# Test Plan

I have verified `EAS_BUILD_ID=d7fb9f5c-dce0-40e2-b459-cbc05ba1ed77 EAS_NO_VCS=1 easd build:internal -p android` prints the JSON output on my computer.