### PR TITLE
[eas-cli] Fix VCS client used for `submit:internal`

### DIFF
--- a/packages/eas-cli/src/commands/submit/internal.ts
+++ b/packages/eas-cli/src/commands/submit/internal.ts
@@ -19,6 +19,7 @@ import { SubmissionContext, createSubmissionContextAsync } from '../../submit/co
 import IosSubmitCommand from '../../submit/ios/IosSubmitCommand';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import GitNoCommitClient from '../../vcs/clients/gitNoCommit';
+import NoVcsClient from '../../vcs/clients/noVcs';
 
 /**
  * This command will be run on the EAS workers.
@@ -64,7 +65,7 @@ export default class SubmitInternal extends EasCommand {
       vcsClient,
     } = await this.getContextAsync(SubmitInternal, {
       nonInteractive: true,
-      vcsClientOverride: new GitNoCommitClient(),
+      vcsClientOverride: process.env.EAS_NO_VCS ? new NoVcsClient() : new GitNoCommitClient(),
       withServerSideEnvironment: null,
     });
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Counterpart of https://github.com/expo/eas-cli/pull/2677, applied to `submit:internal`.

# How

Copied the solution from `build:internal`.

# Test Plan

None.