### PR TITLE
[eas-cli] Unhide workflow commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Added `eas workflow` commands.
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -182,6 +182,9 @@
       },
       "webhook": {
         "description": "manage webhooks"
+      },
+      "workflow": {
+        "description": "manage workflows"
       }
     },
     "warn-if-update-available": {

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -16,10 +16,6 @@ import { WorkflowFile } from '../../utils/workflowFile';
 export default class WorkflowRun extends EasCommand {
   static override description = 'Run an EAS workflow';
 
-  // TODO(@sjchmiela): Keep command hidden until workflows are live
-  static override hidden = true;
-  static override state = 'beta';
-
   static override args = [{ name: 'file', description: 'Path to the workflow file to run' }];
 
   static override flags = {
@@ -35,8 +31,6 @@ export default class WorkflowRun extends EasCommand {
 
   async runAsync(): Promise<void> {
     const { flags, args } = await this.parse(WorkflowRun);
-
-    Log.warn('Workflows are in beta and subject to breaking changes.');
 
     const {
       getDynamicPrivateProjectConfigAsync,

--- a/packages/eas-cli/src/commands/workflow/validate.ts
+++ b/packages/eas-cli/src/commands/workflow/validate.ts
@@ -11,7 +11,6 @@ import { WorkflowFile } from '../../utils/workflowFile';
 
 export class WorkflowValidate extends EasCommand {
   static override description = 'validate a workflow configuration yaml file';
-  static override hidden = true;
 
   static override args = [
     {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Going to release soon.

# How

Removed `hidden = true` overrides.

# Test Plan

`easd --help` printed out information about workflow commands.

```
~/Developer/test-local (main [$!]) easd --help
EAS command line tool

VERSION
  eas-cli/13.1.1 darwin-arm64 node-v22.4.0

USAGE
  $ eas [COMMAND]

TOPICS
...
  workflow     manage workflows
```

```
~/Developer/test-local (main [$!]) easd workflow --help                       
manage workflows

USAGE
  $ eas workflow:COMMAND

COMMANDS
  workflow:run       Run an EAS workflow
  workflow:validate  validate a workflow configuration yaml file
```