### PR TITLE
[eas-cli] create fingerprint on each update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Calculate fingerprint on each update. ([#2687](https://github.com/expo/eas-cli/pull/2687) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -671,7 +671,7 @@ async function computeAndMaybeUploadRuntimeAndFingerprintMetadataAsync<T extends
 }> {
   const runtimeAndFingerprintMetadata =
     await computeAndMaybeUploadFingerprintFromExpoUpdatesAsync(ctx);
-  if (!runtimeAndFingerprintMetadata?.fingerprint) {
+  if (!runtimeAndFingerprintMetadata?.fingerprintHash) {
     const fingerprint = await computeAndMaybeUploadFingerprintWithoutExpoUpdatesAsync(ctx);
     return {
       ...runtimeAndFingerprintMetadata,
@@ -690,10 +690,7 @@ async function computeAndMaybeUploadFingerprintFromExpoUpdatesAsync<T extends Pl
 ): Promise<{
   runtimeVersion?: string;
   fingerprintSource?: FingerprintSource;
-  fingerprint?: {
-    fingerprintSources: object[];
-    isDebugFingerprintSource: boolean;
-  };
+  fingerprintHash?: string;
 }> {
   const resolvedRuntimeVersion = await resolveRuntimeVersionAsync({
     exp: ctx.exp,
@@ -727,7 +724,7 @@ async function computeAndMaybeUploadFingerprintFromExpoUpdatesAsync<T extends Pl
   return {
     runtimeVersion: uploadedFingerprint.hash,
     fingerprintSource: uploadedFingerprint.fingerprintSource,
-    fingerprint: resolvedRuntimeVersion.fingerprint,
+    fingerprintHash: resolvedRuntimeVersion.fingerprintHash ?? undefined,
   };
 }
 
@@ -740,7 +737,7 @@ async function computeAndMaybeUploadFingerprintWithoutExpoUpdatesAsync<T extends
 }> {
   const fingerprint = await createFingerprintAsync(ctx.projectDir, {
     workflow: ctx.workflow,
-    platform: ctx.platform,
+    platforms: [ctx.platform],
     env: ctx.env,
   });
   if (!fingerprint) {

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -50,7 +50,7 @@ import { truthy } from '../utils/expodash/filter';
 import groupBy from '../utils/expodash/groupBy';
 import mapMapAsync from '../utils/expodash/mapMapAsync';
 import uniqBy from '../utils/expodash/uniqBy';
-import { createFingerprintsByKeyAsync } from '../utils/fingerprintCli';
+import { FingerprintOptions, createFingerprintsByKeyAsync } from '../utils/fingerprintCli';
 import { Client } from '../vcs/vcs';
 
 // update publish does not currently support web
@@ -908,12 +908,12 @@ export async function maybeCalculateFingerprintForRuntimeVersionInfoObjectsWitho
     runtimeToPlatformsAndFingerprintInfoAndFingerprintSourceMapping.filter(
       infoGroup => !infoGroup.fingerprintHash
     );
-  const fingerprintOptionsByRuntimeAndPlatform = new Map();
+  const fingerprintOptionsByRuntimeAndPlatform = new Map<string, FingerprintOptions>();
   for (const infoGroup of runtimesToComputeFingerprintsFor) {
     for (const platform of infoGroup.platforms) {
       const runtimeAndPlatform = `${infoGroup.runtimeVersion}-${platform}`;
       const options = {
-        platform,
+        platforms: [platform],
         workflow: workflowsByPlatform[platform],
         projectDir,
         env,

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig, Platform as ExpoConfigPlatform } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
-import { Env, Workflow } from '@expo/eas-build-job';
+import { Env, FingerprintSource, Platform, Workflow } from '@expo/eas-build-job';
 import JsonFile from '@expo/json-file';
 import assert from 'assert';
 import chalk from 'chalk';
@@ -12,6 +12,7 @@ import nullthrows from 'nullthrows';
 import path from 'path';
 import promiseLimit from 'promise-limit';
 
+import { maybeUploadFingerprintAsync } from './maybeUploadFingerprintAsync';
 import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from './projectUtils';
 import { resolveRuntimeVersionUsingCLIAsync } from './resolveRuntimeVersionAsync';
 import { selectBranchOnAppAsync } from '../branch/queries';
@@ -47,7 +48,9 @@ import { ExpoUpdatesCLIModuleNotFoundError } from '../utils/expoUpdatesCli';
 import chunk from '../utils/expodash/chunk';
 import { truthy } from '../utils/expodash/filter';
 import groupBy from '../utils/expodash/groupBy';
+import mapMapAsync from '../utils/expodash/mapMapAsync';
 import uniqBy from '../utils/expodash/uniqBy';
+import { createFingerprintsByKeyAsync } from '../utils/fingerprintCli';
 import { Client } from '../vcs/vcs';
 
 // update publish does not currently support web
@@ -728,6 +731,16 @@ export type RuntimeVersionInfo = {
     fingerprintSources: object[];
     isDebugFingerprintSource: boolean;
   } | null;
+  fingerprintHash: string | null;
+};
+
+type FingerprintInfoGroup = {
+  [key in UpdatePublishPlatform]?: FingerprintInfo;
+};
+
+type FingerprintInfo = {
+  fingerprintHash: string;
+  fingerprintSource: FingerprintSource;
 };
 
 export async function getRuntimeVersionInfoObjectsAsync({
@@ -782,6 +795,7 @@ async function getRuntimeVersionInfoForPlatformAsync({
     fingerprintSources: object[];
     isDebugFingerprintSource: boolean;
   } | null;
+  fingerprintHash: string | null;
 }> {
   if (await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir)) {
     try {
@@ -833,6 +847,7 @@ async function getRuntimeVersionInfoForPlatformAsync({
   return {
     runtimeVersion: resolvedRuntimeVersion,
     fingerprint: null,
+    fingerprintHash: null,
   };
 }
 
@@ -858,9 +873,119 @@ export function getRuntimeToPlatformsAndFingerprintInfoMappingFromRuntimeVersion
           runtimeVersionInfoObjects.map(
             runtimeVersionInfoObject => runtimeVersionInfoObject.runtimeVersionInfo.fingerprint
           )[0] ?? null,
+        fingerprintHash:
+          runtimeVersionInfoObjects.map(
+            runtimeVersionInfoObject => runtimeVersionInfoObject.runtimeVersionInfo.fingerprintHash
+          )[0] ?? null,
       };
     }
   );
+}
+
+export async function maybeCalculateFingerprintForRuntimeVersionInfoObjectsWithoutExpoUpdatesAsync({
+  projectDir,
+  graphqlClient,
+  runtimeToPlatformsAndFingerprintInfoAndFingerprintSourceMapping,
+  workflowsByPlatform,
+  env,
+}: {
+  projectDir: string;
+  graphqlClient: ExpoGraphqlClient;
+  runtimeToPlatformsAndFingerprintInfoAndFingerprintSourceMapping: (RuntimeVersionInfo & {
+    platforms: UpdatePublishPlatform[];
+    fingerprintSource: FingerprintSource | null;
+  })[];
+  workflowsByPlatform: Record<Platform, Workflow>;
+  env: Env | undefined;
+}): Promise<
+  (RuntimeVersionInfo & {
+    platforms: UpdatePublishPlatform[];
+    fingerprintSource: FingerprintSource | null;
+    fingerprintInfoGroup: FingerprintInfoGroup;
+  })[]
+> {
+  const runtimesToComputeFingerprintsFor =
+    runtimeToPlatformsAndFingerprintInfoAndFingerprintSourceMapping.filter(
+      infoGroup => !infoGroup.fingerprintHash
+    );
+  const fingerprintOptionsByRuntimeAndPlatform = new Map();
+  for (const infoGroup of runtimesToComputeFingerprintsFor) {
+    for (const platform of infoGroup.platforms) {
+      const runtimeAndPlatform = `${infoGroup.runtimeVersion}-${platform}`;
+      const options = {
+        platform,
+        workflow: workflowsByPlatform[platform],
+        projectDir,
+        env,
+      };
+      fingerprintOptionsByRuntimeAndPlatform.set(runtimeAndPlatform, options);
+    }
+  }
+  const fingerprintsByRuntimeAndPlatform = await createFingerprintsByKeyAsync(
+    projectDir,
+    fingerprintOptionsByRuntimeAndPlatform
+  );
+  const uploadedFingerprintsByRuntimeAndPlatform = await mapMapAsync(
+    fingerprintsByRuntimeAndPlatform,
+    async fingerprint => {
+      return {
+        ...fingerprint,
+        uploadedSource: (
+          await maybeUploadFingerprintAsync({
+            hash: fingerprint.hash,
+            fingerprint: {
+              fingerprintSources: fingerprint.sources,
+              isDebugFingerprintSource: fingerprint.isDebugSource,
+            },
+            graphqlClient,
+          })
+        ).fingerprintSource,
+      };
+    }
+  );
+  const runtimesWithComputedFingerprint = runtimesToComputeFingerprintsFor.map(runtimeInfo => {
+    const fingerprintInfoGroup: FingerprintInfoGroup = {};
+    for (const platform of runtimeInfo.platforms) {
+      const runtimeAndPlatform = `${runtimeInfo.runtimeVersion}-${platform}`;
+      const fingerprint = uploadedFingerprintsByRuntimeAndPlatform.get(runtimeAndPlatform);
+      if (fingerprint && fingerprint.uploadedSource) {
+        fingerprintInfoGroup[platform] = {
+          fingerprintHash: fingerprint.hash,
+          fingerprintSource: fingerprint.uploadedSource,
+        };
+      }
+    }
+    return {
+      ...runtimeInfo,
+      fingerprintInfoGroup,
+    };
+  });
+
+  // These are runtimes whose fingerprint has already been computed and uploaded with EAS Update fingerprint runtime policy
+  const runtimesWithPreviouslyComputedFingerprints =
+    runtimeToPlatformsAndFingerprintInfoAndFingerprintSourceMapping
+      .filter(
+        (
+          infoGroup
+        ): infoGroup is RuntimeVersionInfo & {
+          platforms: UpdatePublishPlatform[];
+          fingerprintSource: FingerprintSource;
+          fingerprintHash: string;
+        } => !!infoGroup.fingerprintHash && !!infoGroup.fingerprintSource
+      )
+      .map(infoGroup => {
+        const platform = infoGroup.platforms[0];
+        return {
+          ...infoGroup,
+          fingerprintInfoGroup: {
+            [platform]: {
+              fingerprintHash: infoGroup.fingerprintHash,
+              fingerprintSource: infoGroup.fingerprintSource,
+            },
+          },
+        };
+      });
+  return [...runtimesWithComputedFingerprint, ...runtimesWithPreviouslyComputedFingerprints];
 }
 
 export const platformDisplayNames: Record<UpdatePublishPlatform, string> = {
@@ -871,21 +996,6 @@ export const platformDisplayNames: Record<UpdatePublishPlatform, string> = {
 export const updatePublishPlatformToAppPlatform: Record<UpdatePublishPlatform, AppPlatform> = {
   android: AppPlatform.Android,
   ios: AppPlatform.Ios,
-};
-
-const mapMapAsync = async function <K, V, M>(
-  map: ReadonlyMap<K, V>,
-  mapper: (value: V, key: K) => Promise<M>
-): Promise<Map<K, M>> {
-  const resultingMap: Map<K, M> = new Map();
-  await Promise.all(
-    Array.from(map.keys()).map(async k => {
-      const initialValue = map.get(k) as V;
-      const result = await mapper(initialValue, k);
-      resultingMap.set(k, result);
-    })
-  );
-  return resultingMap;
 };
 
 export async function getRuntimeToUpdateRolloutInfoGroupMappingAsync(

--- a/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
+++ b/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
@@ -27,6 +27,7 @@ export async function resolveRuntimeVersionUsingCLIAsync({
     fingerprintSources: object[];
     isDebugFingerprintSource: boolean;
   } | null;
+  fingerprintHash: string | null;
 }> {
   Log.debug('Using expo-updates runtimeversion:resolve CLI for runtime version resolution');
 
@@ -52,6 +53,9 @@ export async function resolveRuntimeVersionUsingCLIAsync({
           isDebugFingerprintSource: useDebugFingerprintSource,
         }
       : null,
+    fingerprintHash: runtimeVersionResult.fingerprintSources
+      ? runtimeVersionResult.runtimeVersion
+      : null,
   };
 }
 
@@ -75,6 +79,7 @@ export async function resolveRuntimeVersionAsync({
     fingerprintSources: object[];
     isDebugFingerprintSource: boolean;
   } | null;
+  fingerprintHash: string | null;
 } | null> {
   if (!(await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir))) {
     // fall back to the previous behavior (using the @expo/config-plugins eas-cli dependency rather
@@ -82,6 +87,7 @@ export async function resolveRuntimeVersionAsync({
     return {
       runtimeVersion: await Updates.getRuntimeVersionNullableAsync(projectDir, exp, platform),
       fingerprint: null,
+      fingerprintHash: null,
     };
   }
 

--- a/packages/eas-cli/src/utils/expodash/mapMapAsync.ts
+++ b/packages/eas-cli/src/utils/expodash/mapMapAsync.ts
@@ -1,0 +1,14 @@
+export default async function mapMapAsync<K, V, M>(
+  map: ReadonlyMap<K, V>,
+  mapper: (value: V, key: K) => Promise<M>
+): Promise<Map<K, M>> {
+  const resultingMap: Map<K, M> = new Map();
+  await Promise.all(
+    Array.from(map.keys()).map(async k => {
+      const initialValue = map.get(k) as V;
+      const result = await mapper(initialValue, k);
+      resultingMap.set(k, result);
+    })
+  );
+  return resultingMap;
+}

--- a/packages/eas-cli/src/utils/fingerprintCli.ts
+++ b/packages/eas-cli/src/utils/fingerprintCli.ts
@@ -1,6 +1,7 @@
 import { Env, Workflow } from '@expo/eas-build-job';
 import { silent as silentResolveFrom } from 'resolve-from';
 
+import mapMapAsync from './expodash/mapMapAsync';
 import Log from '../log';
 import { ora } from '../ora';
 
@@ -8,7 +9,7 @@ export async function createFingerprintAsync(
   projectDir: string,
   options: {
     workflow: Workflow;
-    platform: string;
+    platforms: string[];
     debug?: boolean;
     env: Env | undefined;
     cwd?: string;
@@ -36,22 +37,109 @@ export async function createFingerprintAsync(
 
   const spinner = ora(`Computing project fingerprint`).start();
   try {
-    const Fingerprint = require(fingerprintPath);
-    const fingerprintOptions: Record<string, any> = {};
-    if (options.platform) {
-      fingerprintOptions.platforms = [options.platform];
-    }
-    if (options.workflow === Workflow.MANAGED) {
-      fingerprintOptions.ignorePaths = ['android/**/*', 'ios/**/*'];
-    }
-    if (options.debug) {
-      fingerprintOptions.debug = true;
-    }
-    const fingerprint = await Fingerprint.createFingerprintAsync(projectDir, fingerprintOptions);
+    const fingerprint = await createFingerprintWithoutLoggingAsync(
+      projectDir,
+      fingerprintPath,
+      options
+    );
     spinner.succeed(`Computed project fingerprint`);
     return fingerprint;
   } catch (e) {
     spinner.fail(`Failed to compute project fingerprint`);
+    Log.log('⏩ To skip this step, set the environment variable: EAS_SKIP_AUTO_FINGERPRINT=1');
+    throw e;
+  } finally {
+    // Clear the timeout if the operation finishes before the time limit
+    clearTimeout(timeoutId);
+    spinner.stop();
+  }
+}
+
+async function createFingerprintWithoutLoggingAsync(
+  projectDir: string,
+  fingerprintPath: string,
+  options: {
+    workflow: Workflow;
+    platforms: string[];
+    debug?: boolean;
+    env: Env | undefined;
+    cwd?: string;
+  }
+): Promise<{
+  hash: string;
+  sources: object[];
+  isDebugSource: boolean;
+}> {
+  const Fingerprint = require(fingerprintPath);
+  const fingerprintOptions: Record<string, any> = {};
+  if (options.platforms) {
+    fingerprintOptions.platforms = [...options.platforms];
+  }
+  if (options.workflow === Workflow.MANAGED) {
+    fingerprintOptions.ignorePaths = ['android/**/*', 'ios/**/*'];
+  }
+  if (options.debug) {
+    fingerprintOptions.debug = true;
+  }
+  // eslint-disable-next-line @typescript-eslint/return-await
+  return await Fingerprint.createFingerprintAsync(projectDir, fingerprintOptions);
+}
+
+/**
+ * Computes project fingerprints based on provided options and returns a map of fingerprint data keyed by a string.
+ *
+ * @param projectDir - The root directory of the project.
+ * @param fingerprintOptionsByKey - A map where each key is associated with options for generating the fingerprint.
+ *   - **Key**: A unique identifier (`string`) for the fingerprint options.
+ *   - **Value**: An object containing options for generating a fingerprint.
+ *
+ * @returns A promise that resolves to a map where each key corresponds to the input keys, and each value is an object containing fingerprint data.
+ *
+ * @throws Will throw an error if fingerprint computation fails.
+ */
+export async function createFingerprintsByKeyAsync(
+  projectDir: string,
+  fingerprintOptionsByKey: Map<
+    string,
+    { workflow: Workflow; platforms: string[]; debug?: boolean; env: Env | undefined }
+  >
+): Promise<
+  Map<
+    string,
+    {
+      hash: string;
+      sources: object[];
+      isDebugSource: boolean;
+    }
+  >
+> {
+  // @expo/fingerprint is exported in the expo package for SDK 52+
+  const fingerprintPath = silentResolveFrom(projectDir, 'expo/fingerprint');
+  if (!fingerprintPath) {
+    return new Map();
+  }
+
+  if (process.env.EAS_SKIP_AUTO_FINGERPRINT) {
+    Log.log('Skipping project fingerprints');
+    return new Map();
+  }
+
+  const timeoutId = setTimeout(() => {
+    Log.log('⌛️ Computing the project fingerprints is taking longer than expected...');
+    Log.log('⏩ To skip this step, set the environment variable: EAS_SKIP_AUTO_FINGERPRINT=1');
+  }, 5000);
+
+  const spinner = ora(`Computing project fingerprints`).start();
+  try {
+    const fingerprintsByKey = await mapMapAsync(
+      fingerprintOptionsByKey,
+      async options =>
+        await createFingerprintWithoutLoggingAsync(projectDir, fingerprintPath, options)
+    );
+    spinner.succeed(`Computed project fingerprints`);
+    return fingerprintsByKey;
+  } catch (e) {
+    spinner.fail(`Failed to compute project fingerprints`);
     Log.log('⏩ To skip this step, set the environment variable: EAS_SKIP_AUTO_FINGERPRINT=1');
     throw e;
   } finally {

--- a/packages/eas-cli/src/utils/fingerprintCli.ts
+++ b/packages/eas-cli/src/utils/fingerprintCli.ts
@@ -5,15 +5,17 @@ import mapMapAsync from './expodash/mapMapAsync';
 import Log from '../log';
 import { ora } from '../ora';
 
+export type FingerprintOptions = {
+  workflow: Workflow;
+  platforms: string[];
+  debug?: boolean;
+  env: Env | undefined;
+  cwd?: string;
+};
+
 export async function createFingerprintAsync(
   projectDir: string,
-  options: {
-    workflow: Workflow;
-    platforms: string[];
-    debug?: boolean;
-    env: Env | undefined;
-    cwd?: string;
-  }
+  options: FingerprintOptions
 ): Promise<{
   hash: string;
   sources: object[];
@@ -58,13 +60,7 @@ export async function createFingerprintAsync(
 async function createFingerprintWithoutLoggingAsync(
   projectDir: string,
   fingerprintPath: string,
-  options: {
-    workflow: Workflow;
-    platforms: string[];
-    debug?: boolean;
-    env: Env | undefined;
-    cwd?: string;
-  }
+  options: FingerprintOptions
 ): Promise<{
   hash: string;
   sources: object[];
@@ -99,10 +95,7 @@ async function createFingerprintWithoutLoggingAsync(
  */
 export async function createFingerprintsByKeyAsync(
   projectDir: string,
-  fingerprintOptionsByKey: Map<
-    string,
-    { workflow: Workflow; platforms: string[]; debug?: boolean; env: Env | undefined }
-  >
+  fingerprintOptionsByKey: Map<string, FingerprintOptions>
 ): Promise<
   Map<
     string,


### PR DESCRIPTION
# Why

This PR computes a fingerprint for each update. 
- If the update does not use the fingerprint policy, it calculates the fingerprint using the exported cli in the `expo` package for projects SDK 52+. 
- If the update uses the fingerprint policy, it just uses the fingerprint that was previously calculated using `expo-updates`.  

# How

- Modified fingerprint computation to handle platform-specific cases
- Updated the fingerprint data structure to use `fingerprintHash` instead of the full fingerprint object
- Added support for computing fingerprints for projects without expo-updates
- Introduced new types and interfaces for handling fingerprint information groups
- Created utility functions for async map operations and fingerprint calculations
- Updated GraphQL schema to support new fingerprint-related fields

# Test Plan

- [x] on build: verify fingerprints till work 
- [x] on update: verify fingerprint is calculated for new project with SDK 52
- [x] on update: verify no fingerprint is calculated for old project (< SDK 52)
- [x] on update: verify fingerprint is reused for project with fingerprint runtime policy