### PR TITLE
[eas-cli] Default update message to `undefined` in no-VCS client

### DIFF
--- a/packages/eas-cli/src/vcs/clients/noVcs.ts
+++ b/packages/eas-cli/src/vcs/clients/noVcs.ts
@@ -18,6 +18,6 @@ export default class NoVcsClient extends Client {
   }
 
   public override canGetLastCommitMessage(): boolean {
-    return true;
+    return false;
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://staging.expo.dev/accounts/sjchmiela/projects/staging-app/workflows/01932b13-21af-780b-b531-1ed07e3d8228

`eas update --auto` fails in GCS update job because this flag is set to true.

# How

The comment says it can be `false`, so changed it to `false`.

https://github.com/expo/eas-cli/pull/2148/files#diff-a594e233350755033d45aa7b21b78781e4b36322e9312f60e71e7edc79c33a7f

# Test Plan

Update message should be changed to `undefined`.