### PR TITLE
[ENG-14184][eas-cli] make logs anouncing loading env variables less noisy

### DIFF
--- a/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
+++ b/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
@@ -83,24 +83,13 @@ async function resolveEnvVarsAsync({
 
     if (Object.keys(serverEnvVars).length > 0) {
       Log.log(
-        `Environment variables loaded from the "${environment.toLowerCase()}" environment on EAS servers: ${Object.keys(
+        `Environment variables with visibility "Plain text" and "Sensitive" loaded from the "${environment.toLowerCase()}" environment on EAS servers: ${Object.keys(
           serverEnvVars
         ).join(', ')}.`
       );
     } else {
       Log.log(
-        `No environment variables found for the "${environment.toLowerCase()}" environment on EAS servers.`
-      );
-    }
-
-    const encryptedEnvVars = environmentVariables.filter(({ name, value }) => name && !value);
-    if (encryptedEnvVars.length > 0) {
-      Log.warn(
-        `Some environment variables defined in the "${environment.toLowerCase()}" environment on EAS servers are of "encrypted" type and cannot be read outside of the EAS servers (including EAS CLI): ${encryptedEnvVars
-          .map(({ name }) => name)
-          .join(
-            ', '
-          )}. However, they will be available during the build process happening on the EAS servers. This can lead to potential configuration mismatches between the local development environment and the build environment if the encrypted environment variables are used to resolve the app config.`
+        `No environment variables with visibility "Plain text" and "Sensitive" found for the "${environment.toLowerCase()}" environment on EAS servers.`
       );
     }
 
@@ -109,10 +98,6 @@ async function resolveEnvVarsAsync({
         `Environment variables loaded from the "${buildProfileName}" build profile "env" configuration: ${
           buildProfile.env && Object.keys(buildProfile.env).join(', ')
         }.`
-      );
-    } else {
-      Log.log(
-        `No environment variables specified in the "${buildProfileName}" build profile "env" configuration.`
       );
     }
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/loadServerSideEnvironmentVariablesAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/loadServerSideEnvironmentVariablesAsync.ts
@@ -42,22 +42,13 @@ export async function loadServerSideEnvironmentVariablesAsync({
 
   if (Object.keys(serverEnvVars).length > 0) {
     Log.log(
-      `Environment variables loaded from the "${environment.toLowerCase()}" environment on EAS servers: ${Object.keys(
+      `Environment variables with visibility "Plain text" and "Sensitive" loaded from the "${environment.toLowerCase()}" environment on EAS servers: ${Object.keys(
         serverEnvVars
       ).join(', ')}.`
     );
   } else {
     Log.log(
-      `No readable environment variables found for the "${environment.toLowerCase()}" environment on EAS servers.`
-    );
-  }
-
-  const encryptedEnvVars = environmentVariables.filter(({ name, value }) => name && !value);
-  if (encryptedEnvVars.length > 0) {
-    Log.warn(
-      `Some environment variables defined in the "${environment.toLowerCase()}" environment on EAS servers are of "encrypted" type and cannot be read outside of the EAS servers (including EAS CLI): ${encryptedEnvVars
-        .map(({ name }) => name)
-        .join(', ')}. `
+      `No environment variables with visibility "Plain text" and "Sensitive" found for the "${environment.toLowerCase()}" environment on EAS servers.`
     );
   }
   Log.newLine();


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://linear.app/expo/issue/ENG-14184/make-eas-cli-print-less-spamy-logs-related-to-loading-env-variables

# How

Make logs less noisy as proposed by Brent

# Test Plan

Tests
