### PR TITLE
[ENG-14204][eas-cli] UX improvements for env:list command

### DIFF
--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -25,11 +25,9 @@ export const EasNonInteractiveAndJsonFlags = {
 export const EasEnvironmentFlagParameters = {
   description: "Environment variable's environment",
   parse: upperCaseAsync,
-  options: mapToLowercase([
-    EnvironmentVariableEnvironment.Development,
-    EnvironmentVariableEnvironment.Preview,
-    EnvironmentVariableEnvironment.Production,
-  ]),
+  options: mapToLowercase(Object.values(EnvironmentVariableEnvironment)),
+  required: false,
+  hidden: true,
 };
 
 export const EASEnvironmentFlag = {

--- a/packages/eas-cli/src/commands/env/__tests__/EnvList.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvList.test.ts
@@ -53,31 +53,13 @@ describe(EnvironmentVariableList, () => {
     jest.mocked(AppQuery.byIdAsync).mockImplementation(async () => getMockAppFragment());
   });
 
-  it('lists project environment variables successfully', async () => {
-    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValueOnce(mockVariables);
-
-    const command = new EnvironmentVariableList([], mockConfig);
-
-    // @ts-expect-error
-    jest.spyOn(command, 'getContextAsync').mockReturnValue({
-      loggedIn: { graphqlClient },
-      projectId: testProjectId,
-    });
-    await command.runAsync();
-
-    expect(EnvironmentVariablesQuery.byAppIdAsync).toHaveBeenCalledWith(graphqlClient, {
-      appId: testProjectId,
-      environment: undefined,
-      includeFileContent: false,
-    });
-    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('TEST_VAR_1'));
-    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('TEST_VAR_2'));
-  });
-
   it('lists project environment variables in specified environments', async () => {
     jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValueOnce(mockVariables);
 
-    const command = new EnvironmentVariableList(['--environment', 'production'], mockConfig);
+    const command = new EnvironmentVariableList(
+      ['--environment', 'production', '--non-interactive'],
+      mockConfig
+    );
 
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
@@ -100,7 +82,10 @@ describe(EnvironmentVariableList, () => {
       .mocked(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync)
       .mockResolvedValueOnce(mockVariables);
 
-    const command = new EnvironmentVariableList(['--include-sensitive'], mockConfig);
+    const command = new EnvironmentVariableList(
+      ['--include-sensitive', '--environment', 'production', '--non-interactive'],
+      mockConfig
+    );
 
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
@@ -113,7 +98,7 @@ describe(EnvironmentVariableList, () => {
       graphqlClient,
       {
         appId: testProjectId,
-        environment: undefined,
+        environment: EnvironmentVariableEnvironment.Production,
         includeFileContent: false,
       }
     );
@@ -124,7 +109,10 @@ describe(EnvironmentVariableList, () => {
   it('lists shared environment variables successfully', async () => {
     jest.mocked(EnvironmentVariablesQuery.sharedAsync).mockResolvedValueOnce(mockVariables);
 
-    const command = new EnvironmentVariableList(['--scope', 'shared'], mockConfig);
+    const command = new EnvironmentVariableList(
+      ['--scope', 'shared', '--non-interactive', '--environment', 'production'],
+      mockConfig
+    );
 
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
@@ -135,7 +123,7 @@ describe(EnvironmentVariableList, () => {
 
     expect(EnvironmentVariablesQuery.sharedAsync).toHaveBeenCalledWith(graphqlClient, {
       appId: testProjectId,
-      environment: undefined,
+      environment: EnvironmentVariableEnvironment.Production,
       includeFileContent: false,
     });
     expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('TEST_VAR_1'));
@@ -148,7 +136,14 @@ describe(EnvironmentVariableList, () => {
       .mockResolvedValueOnce(mockVariables);
 
     const command = new EnvironmentVariableList(
-      ['--include-sensitive', '--scope', 'shared'],
+      [
+        '--include-sensitive',
+        '--scope',
+        'shared',
+        '--non-interactive',
+        '--environment',
+        'production',
+      ],
       mockConfig
     );
 
@@ -161,7 +156,7 @@ describe(EnvironmentVariableList, () => {
 
     expect(EnvironmentVariablesQuery.sharedWithSensitiveAsync).toHaveBeenCalledWith(graphqlClient, {
       appId: testProjectId,
-      environment: undefined,
+      environment: EnvironmentVariableEnvironment.Production,
       includeFileContent: false,
     });
     expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('TEST_VAR_1'));

--- a/packages/eas-cli/src/utils/variableUtils.ts
+++ b/packages/eas-cli/src/utils/variableUtils.ts
@@ -38,15 +38,15 @@ export function formatVariableValue(variable: EnvironmentVariableWithFileContent
   }
 
   if (variable.visibility === EnvironmentVariableVisibility.Sensitive) {
-    return '***** (This is a sensitive env variable. To access it, run command with --include-sensitive flag. Learn more.)';
+    return '*****(Sensitive)';
   }
 
   if (variable.visibility === EnvironmentVariableVisibility.Secret) {
-    return "***** (This is a secret env variable that can only be accessed on EAS builder and can't be read in any UI. Learn more.)";
+    return '*****(Secret)';
   }
 
   if (variable.type === EnvironmentSecretType.FileBase64) {
-    return '***** (This is a file env variable. To access it, run command with --include-file-content flag. Learn more.)';
+    return '(File type variable)';
   }
 
   return '*****';
@@ -62,20 +62,33 @@ export async function performForEnvironmentsAsync(
 
 export function formatVariable(variable: EnvironmentVariableWithFileContent): string {
   return formatFields([
-    { label: 'ID', value: variable.id },
     { label: 'Name', value: variable.name },
     { label: 'Value', value: formatVariableValue(variable) },
-    { label: 'Scope', value: variable.scope },
-    { label: 'Visibility', value: variable.visibility ?? '' },
     {
-      label: 'Environments',
-      value: variable.environments ? variable.environments.join(', ') : '-',
+      label: 'Scope',
+      value: variable.scope === EnvironmentVariableScope.Project ? 'Project' : 'Account',
     },
     {
-      label: 'type',
-      value: variable.type === EnvironmentSecretType.FileBase64 ? 'file' : 'string',
+      label: 'Visibility',
+      value: variable.visibility ? visibilityToVisibilityName[variable.visibility] : '',
+    },
+    {
+      label: 'Environments',
+      value: variable.environments
+        ? variable.environments.map(env => env.toLowerCase()).join(', ')
+        : '-',
+    },
+    {
+      label: 'Type',
+      value: variable.type === EnvironmentSecretType.FileBase64 ? 'File' : 'String',
     },
     { label: 'Created at', value: dateFormat(variable.createdAt, 'mmm dd HH:MM:ss') },
     { label: 'Updated at', value: dateFormat(variable.updatedAt, 'mmm dd HH:MM:ss') },
   ]);
 }
+
+const visibilityToVisibilityName: Record<EnvironmentVariableVisibility, string> = {
+  [EnvironmentVariableVisibility.Public]: 'Plain text',
+  [EnvironmentVariableVisibility.Sensitive]: 'Sensitive',
+  [EnvironmentVariableVisibility.Secret]: 'Secret',
+};


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Currently using the `env:list` command is confusing and annoying with this multi-select for environments and too noisy when an env var is secret or sensitive

# How

Make it less noisy.

Just use select for environment vs multi-select.

# Test Plan

Tested it manually
