### PR TITLE
[ENG-14249][eas-cli] deprecate eas secret commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Deprecate `eas secret` commands. ([#2705](https://github.com/expo/eas-cli/pull/2705) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [13.3.0](https://github.com/expo/eas-cli/releases/tag/v13.3.0) - 2024-11-18
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commands/secret/create.ts
+++ b/packages/eas-cli/src/commands/secret/create.ts
@@ -25,6 +25,7 @@ import { promptAsync, selectAsync } from '../../prompts';
 export default class EnvironmentSecretCreate extends EasCommand {
   static override description =
     'create an environment secret on the current project or owner account';
+  static override hidden = true;
 
   static override flags = {
     scope: Flags.enum({
@@ -55,6 +56,9 @@ export default class EnvironmentSecretCreate extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
+    Log.warn('This command is deprecated. Use eas env:create instead.');
+    Log.newLine();
+
     let {
       flags: {
         name,

--- a/packages/eas-cli/src/commands/secret/delete.ts
+++ b/packages/eas-cli/src/commands/secret/delete.ts
@@ -13,6 +13,7 @@ import { promptAsync, toggleConfirmAsync } from '../../prompts';
 
 export default class EnvironmentSecretDelete extends EasCommand {
   static override description = 'delete an environment secret by ID';
+  static override hidden = true;
 
   static override flags = {
     id: Flags.string({
@@ -27,6 +28,9 @@ export default class EnvironmentSecretDelete extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
+    Log.warn('This command is deprecated. Use eas env:delete instead.');
+    Log.newLine();
+
     let {
       flags: { id, 'non-interactive': nonInteractive },
     } = await this.parse(EnvironmentSecretDelete);

--- a/packages/eas-cli/src/commands/secret/list.ts
+++ b/packages/eas-cli/src/commands/secret/list.ts
@@ -11,6 +11,7 @@ import formatFields from '../../utils/formatFields';
 
 export default class EnvironmentSecretList extends EasCommand {
   static override description = 'list environment secrets available for your current app';
+  static override hidden = true;
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectId,
@@ -18,6 +19,9 @@ export default class EnvironmentSecretList extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
+    Log.warn('This command is deprecated. Use eas env:list instead.');
+    Log.newLine();
+
     const {
       projectId,
       loggedIn: { graphqlClient },

--- a/packages/eas-cli/src/commands/secret/push.ts
+++ b/packages/eas-cli/src/commands/secret/push.ts
@@ -24,6 +24,7 @@ import intersection from '../../utils/expodash/intersection';
 
 export default class EnvironmentSecretPush extends EasCommand {
   static override description = 'read environment secrets from env file and store on the server';
+  static override hidden = true;
 
   static override flags = {
     scope: Flags.enum({
@@ -47,6 +48,9 @@ export default class EnvironmentSecretPush extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
+    Log.warn('This command is deprecated. Use eas env:push instead.');
+    Log.newLine();
+
     const {
       flags: { scope, force, 'env-file': maybeEnvFilePath, 'non-interactive': nonInteractive },
     } = await this.parse(EnvironmentSecretPush);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Deprecate old secret commands

# How

Mark as hidden + print warn when used

# Test Plan

Tests
