### PR TITLE
Environment Variables: Rename `encrypted` to `secret`

### DIFF
--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -52,9 +52,9 @@ export const EASVariableFormatFlag = {
 };
 
 export const EASVariableVisibilityFlag = {
-  visibility: Flags.enum<'plaintext' | 'sensitive' | 'encrypted'>({
+  visibility: Flags.enum<'plaintext' | 'sensitive' | 'secret'>({
     description: 'Visibility of the variable',
-    options: ['plaintext', 'sensitive', 'encrypted'],
+    options: ['plaintext', 'sensitive', 'secret'],
   }),
 };
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableCreate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableCreate.test.ts
@@ -83,7 +83,7 @@ describe(EnvironmentVariableCreate, () => {
           '--environment',
           'production',
           '--visibility',
-          'encrypted',
+          'secret',
         ],
         mockConfig
       );
@@ -119,7 +119,7 @@ describe(EnvironmentVariableCreate, () => {
           '--environment',
           'production',
           '--visibility',
-          'encrypted',
+          'secret',
         ],
         mockConfig
       );

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -40,7 +40,7 @@ type CreateFlags = {
   link?: boolean;
   force?: boolean;
   type?: 'string' | 'file';
-  visibility?: 'plaintext' | 'sensitive' | 'encrypted';
+  visibility?: 'plaintext' | 'sensitive' | 'secret';
   scope?: EnvironmentVariableScope;
   environment?: EnvironmentVariableEnvironment[];
   'non-interactive': boolean;

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -142,7 +142,7 @@ export default class EnvironmentVariablePull extends EasCommand {
     if (skippedSecretVariables.length > 0) {
       Log.addNewLineIfNone();
       Log.warn(
-        `The following variables have the encrypted visibility and can not be read outside of EAS servers. Set their values manually in .env.local: ${skippedSecretVariables.join(
+        `The following variables have the secret visibility and can not be read outside of EAS servers. Set their values manually in .env.local: ${skippedSecretVariables.join(
           '\n'
         )}`
       );

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -42,7 +42,7 @@ type UpdateFlags = {
   value?: string;
   scope?: EnvironmentVariableScope;
   environment?: EnvironmentVariableEnvironment[];
-  visibility?: 'plaintext' | 'sensitive' | 'encrypted';
+  visibility?: 'plaintext' | 'sensitive' | 'secret';
   type?: 'string' | 'file';
   'variable-name'?: string;
   'variable-environment'?: EnvironmentVariableEnvironment;

--- a/packages/eas-cli/src/utils/prompts.ts
+++ b/packages/eas-cli/src/utils/prompts.ts
@@ -32,14 +32,14 @@ export async function promptVariableTypeAsync(
 }
 
 export function parseVisibility(
-  stringVisibility: 'plaintext' | 'sensitive' | 'encrypted'
+  stringVisibility: 'plaintext' | 'sensitive' | 'secret'
 ): EnvironmentVariableVisibility {
   switch (stringVisibility) {
     case 'plaintext':
       return EnvironmentVariableVisibility.Public;
     case 'sensitive':
       return EnvironmentVariableVisibility.Sensitive;
-    case 'encrypted':
+    case 'secret':
       return EnvironmentVariableVisibility.Secret;
     default:
       throw new Error(`Invalid visibility: ${stringVisibility}`);


### PR DESCRIPTION
# Why

`Encrypted` variables were renamed to `secret`, but it was omitted in a couple places.

# Test Plan

Updated tests, tested manually
