### PR TITLE
[ENG-14185][eas-cli] use account-wide vs shared in env commands

### DIFF
--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -64,7 +64,6 @@ export const EASEnvironmentVariableScopeFlag = {
   scope: Flags.enum<EASEnvironmentVariableScopeFlagValue>({
     description: 'Scope for the variable',
     options: ['project', 'account'],
-    parse: upperCaseAsync,
     default: 'project',
   }),
 };

--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core';
 
-import { EnvironmentVariableEnvironment, EnvironmentVariableScope } from '../graphql/generated';
+import { EnvironmentVariableEnvironment } from '../graphql/generated';
 
 // NOTE: not exactly true, but, provided mapToLowercase and upperCaseAsync
 // are used in tandem, it saves on unnecessary typying in commands
@@ -58,12 +58,14 @@ export const EASVariableVisibilityFlag = {
   }),
 };
 
-export const EASVariableScopeFlag = {
-  scope: Flags.enum<EnvironmentVariableScope>({
+export type EASEnvironmentVariableScopeFlagValue = 'project' | 'account';
+
+export const EASEnvironmentVariableScopeFlag = {
+  scope: Flags.enum<EASEnvironmentVariableScopeFlagValue>({
     description: 'Scope for the variable',
-    options: mapToLowercase([EnvironmentVariableScope.Shared, EnvironmentVariableScope.Project]),
+    options: ['project', 'account'],
     parse: upperCaseAsync,
-    default: EnvironmentVariableScope.Project,
+    default: 'project',
   }),
 };
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableCreate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableCreate.test.ts
@@ -171,7 +171,7 @@ describe(EnvironmentVariableCreate, () => {
       });
     });
 
-    it('creates a shared variable', async () => {
+    it('creates an account-wide variable', async () => {
       const command = new EnvironmentVariableCreate(
         [
           '--name',
@@ -181,7 +181,7 @@ describe(EnvironmentVariableCreate, () => {
           '--environment',
           'production',
           '--scope',
-          'shared',
+          'account',
         ],
         mockConfig
       );
@@ -207,7 +207,7 @@ describe(EnvironmentVariableCreate, () => {
       );
     });
 
-    it('throws if a shared variable already exists', async () => {
+    it('throws if an account-wide variable already exists', async () => {
       const command = new EnvironmentVariableCreate(
         [
           '--name',
@@ -217,7 +217,7 @@ describe(EnvironmentVariableCreate, () => {
           '--environment',
           'production',
           '--scope',
-          'shared',
+          'account',
         ],
         mockConfig
       );
@@ -242,7 +242,7 @@ describe(EnvironmentVariableCreate, () => {
       await expect(command.runAsync()).rejects.toThrow();
     });
 
-    it('updates if a shared variable already exists and --force flag is set', async () => {
+    it('updates if an account-wide variable already exists and --force flag is set', async () => {
       const command = new EnvironmentVariableCreate(
         [
           '--name',
@@ -253,7 +253,7 @@ describe(EnvironmentVariableCreate, () => {
           'production',
           '--force',
           '--scope',
-          'shared',
+          'account',
         ],
         mockConfig
       );
@@ -288,7 +288,7 @@ describe(EnvironmentVariableCreate, () => {
       });
     });
 
-    it('creates a shared variable and links it', async () => {
+    it('creates an account-wide variable and links it', async () => {
       const command = new EnvironmentVariableCreate(
         [
           '--name',
@@ -300,7 +300,7 @@ describe(EnvironmentVariableCreate, () => {
           '--environment',
           'development',
           '--scope',
-          'shared',
+          'account',
           '--link',
         ],
         mockConfig

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableLink.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableLink.test.ts
@@ -39,7 +39,7 @@ describe(EnvironmentVariableLink, () => {
     jest.mocked(AppQuery.byIdAsync).mockImplementation(async () => getMockAppFragment());
   });
 
-  it('links a shared variable to the current project in non-interactive mode', async () => {
+  it('links an account-wide variable to the current project in non-interactive mode', async () => {
     const mockVariables = [
       {
         id: variableId,
@@ -75,7 +75,7 @@ describe(EnvironmentVariableLink, () => {
     );
   });
 
-  it('links a shared variable to the current project to a specified environment', async () => {
+  it('links an account-wide variable to the current project to a specified environment', async () => {
     const mockVariables = [
       {
         id: variableId,
@@ -215,7 +215,7 @@ describe(EnvironmentVariableLink, () => {
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue(mockContext);
     await expect(command.runAsync()).rejects.toThrow(
-      "Shared variable NON_EXISTENT_VARIABLE doesn't exist"
+      "Account-wide variable NON_EXISTENT_VARIABLE doesn't exist"
     );
   });
 
@@ -271,7 +271,7 @@ describe(EnvironmentVariableLink, () => {
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue(mockContext);
     await expect(command.runAsync()).rejects.toThrow(
-      "Shared variable NON_EXISTENT_VARIABLE doesn't exist"
+      "Account-wide variable NON_EXISTENT_VARIABLE doesn't exist"
     );
   });
 });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableList.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableList.test.ts
@@ -121,10 +121,10 @@ describe(EnvironmentVariableList, () => {
     expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('TEST_VAR_2'));
   });
 
-  it('lists shared environment variables successfully', async () => {
+  it('lists account-wide environment variables successfully', async () => {
     jest.mocked(EnvironmentVariablesQuery.sharedAsync).mockResolvedValueOnce(mockVariables);
 
-    const command = new EnvironmentVariableList(['--scope', 'shared'], mockConfig);
+    const command = new EnvironmentVariableList(['--scope', 'account'], mockConfig);
 
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
@@ -142,13 +142,13 @@ describe(EnvironmentVariableList, () => {
     expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('TEST_VAR_2'));
   });
 
-  it('lists shared environment variables including sensitive values', async () => {
+  it('lists account-wide environment variables including sensitive values', async () => {
     jest
       .mocked(EnvironmentVariablesQuery.sharedWithSensitiveAsync)
       .mockResolvedValueOnce(mockVariables);
 
     const command = new EnvironmentVariableList(
-      ['--include-sensitive', '--scope', 'shared'],
+      ['--include-sensitive', '--scope', 'account'],
       mockConfig
     );
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableUnlink.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableUnlink.test.ts
@@ -39,7 +39,7 @@ describe(EnvironmentVariableUnlink, () => {
     jest.mocked(AppQuery.byIdAsync).mockImplementation(async () => getMockAppFragment());
   });
 
-  it('unlinks a shared variable from the current project in non-interactive mode', async () => {
+  it('unlinks an account-wide variable from the current project in non-interactive mode', async () => {
     const mockVariables = [
       {
         id: variableId,
@@ -76,7 +76,7 @@ describe(EnvironmentVariableUnlink, () => {
     );
   });
 
-  it('unlinks a shared variable from the current project in a specified environment', async () => {
+  it('unlinks an account-wide variable from the current project in a specified environment', async () => {
     const mockVariables = [
       {
         id: variableId,
@@ -170,7 +170,7 @@ describe(EnvironmentVariableUnlink, () => {
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue(mockContext);
     await expect(command.runAsync()).rejects.toThrow(
-      "Shared variable NON_EXISTENT_VARIABLE doesn't exist"
+      "Account-wide variable NON_EXISTENT_VARIABLE doesn't exist"
     );
   });
 
@@ -226,7 +226,7 @@ describe(EnvironmentVariableUnlink, () => {
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue(mockContext);
     await expect(command.runAsync()).rejects.toThrow(
-      "Shared variable NON_EXISTENT_VARIABLE doesn't exist"
+      "Account-wide variable NON_EXISTENT_VARIABLE doesn't exist"
     );
   });
 });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableUpdate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvironmentVariableUpdate.test.ts
@@ -81,7 +81,7 @@ describe(EnvironmentVariableUpdate, () => {
     );
   });
 
-  it('updates a shared variable by selected name in non-interactive mode', async () => {
+  it('updates an account-wide variable by selected name in non-interactive mode', async () => {
     const mockVariables = [
       {
         id: variableId,
@@ -107,7 +107,7 @@ describe(EnvironmentVariableUpdate, () => {
         '--environment',
         'production',
         '--scope',
-        'shared',
+        'account',
       ],
       mockConfig
     );

--- a/packages/eas-cli/src/commands/env/link.ts
+++ b/packages/eas-cli/src/commands/env/link.ts
@@ -24,8 +24,9 @@ type LinkFlags = {
 };
 
 export default class EnvironmentVariableLink extends EasCommand {
-  static override description = 'link a shared environment variable to the current project';
+  static override description = 'link an account-wide environment variable to the current project';
 
+  // for now we only roll out global account-wide env variables so this should stay hidden
   static override hidden = true;
 
   static override flags = {
@@ -87,7 +88,7 @@ export default class EnvironmentVariableLink extends EasCommand {
         );
       }
       selectedVariable = await selectAsync(
-        'Select shared variable',
+        'Select account-wide variable',
         variables.map(variable => ({
           title: formatVariableName(variable),
           value: variable,
@@ -172,7 +173,7 @@ export default class EnvironmentVariableLink extends EasCommand {
       }
     }
   }
-  private validateInputs(flags: LinkFlags, { environment }: Record<string, string>): LinkFlags {
+  private validateInputs(flags: LinkFlags, { environment }: { environment?: string }): LinkFlags {
     environment = environment?.toUpperCase();
 
     if (environment && !isEnvironment(environment)) {
@@ -196,9 +197,7 @@ export default class EnvironmentVariableLink extends EasCommand {
     }
 
     return {
-      'variable-name': flags['variable-name'],
-      'variable-environment': flags['variable-environment'],
-      'non-interactive': flags['non-interactive'],
+      ...flags,
       environment: environments,
     };
   }

--- a/packages/eas-cli/src/commands/env/link.ts
+++ b/packages/eas-cli/src/commands/env/link.ts
@@ -97,7 +97,7 @@ export default class EnvironmentVariableLink extends EasCommand {
     }
 
     if (!selectedVariable) {
-      throw new Error(`Shared variable ${name} doesn't exist`);
+      throw new Error(`Account-wide variable ${name} doesn't exist`);
     }
 
     let explicitSelect = false;

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -106,12 +106,12 @@ export default class EnvironmentVariablePush extends EasCommand {
         const existingDifferentSharedVariablesNames = existingDifferentSharedVariables.map(
           variable => variable.name
         );
-        Log.error('Shared variables cannot be overwritten by eas env:push command.');
+        Log.error('Account-wide variables cannot be overwritten by eas env:push command.');
         Log.error('Remove them from the env file or unlink them from the project to continue:');
         existingDifferentSharedVariablesNames.forEach(name => {
           Log.error(`- ${name}`);
         });
-        throw new Error('Shared variables cannot be overwritten by eas env:push command');
+        throw new Error('Account-wide variables cannot be overwritten by eas env:push command');
       }
 
       if (existingDifferentVariables.length > 0) {

--- a/packages/eas-cli/src/commands/env/unlink.ts
+++ b/packages/eas-cli/src/commands/env/unlink.ts
@@ -19,8 +19,10 @@ type UnlinkFlags = {
 };
 
 export default class EnvironmentVariableUnlink extends EasCommand {
-  static override description = 'unlink a shared environment variable to the current project';
+  static override description =
+    'unlink an account-wide environment variable from the current project';
 
+  // for now we only roll out global account-wide env variables so this should stay hidden
   static override hidden = true;
 
   static override flags = {
@@ -74,7 +76,7 @@ export default class EnvironmentVariableUnlink extends EasCommand {
         throw new Error("Multiple variables found, please select one using '--variable-name'");
       }
       selectedVariable = await selectAsync(
-        'Select shared variable',
+        'Select account-wide variable',
         variables.map(variable => ({
           title: formatVariableName(variable),
           value: variable,
@@ -83,7 +85,7 @@ export default class EnvironmentVariableUnlink extends EasCommand {
     }
 
     if (!selectedVariable) {
-      throw new Error(`Shared variable ${name} doesn't exist`);
+      throw new Error(`Account-wide variable ${name} doesn't exist`);
     }
 
     let explicitSelect = false;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Stick to account-wide everywhere for now

# How

Rename shared to account-wide, fix some bugs and type issues

# Test Plan

Tests
