### PR TITLE
All account-wide envvars should be global (for now)

### DIFF
--- a/packages/eas-cli/src/commands/env/__tests__/EnvCreate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvCreate.test.ts
@@ -199,6 +199,7 @@ describe(EnvCreate, () => {
         {
           name: 'VarName',
           value: 'VarValue',
+          isGlobal: true,
           environments: [EnvironmentVariableEnvironment.Production],
           visibility: EnvironmentVariableVisibility.Public,
           type: EnvironmentSecretType.String,
@@ -324,6 +325,7 @@ describe(EnvCreate, () => {
             EnvironmentVariableEnvironment.Development,
           ],
           visibility: EnvironmentVariableVisibility.Public,
+          isGlobal: true,
           type: EnvironmentSecretType.String,
         },
         testAccountId

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -252,6 +252,7 @@ export default class EnvCreate extends EasCommand {
                 value,
                 visibility,
                 environments,
+                isGlobal: true, // TODO: every account-wide variable is global for now so it's not user facing
                 type: type ?? EnvironmentSecretType.String,
               },
               ownerAccount.id
@@ -416,12 +417,6 @@ export default class EnvCreate extends EasCommand {
     if (flags.scope !== 'account' && flags.link) {
       throw new Error(
         `Unexpected argument: --link can only be used when creating account-wide variables`
-      );
-    }
-
-    if (flags.scope === 'account' && flags.environment && !flags.link && flags['non-interactive']) {
-      throw new Error(
-        'Unexpected argument: --environment in non-interactive mode can only be used with --link flag.'
       );
     }
 

--- a/packages/eas-cli/src/graphql/mutations/EnvironmentVariableMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/EnvironmentVariableMutation.ts
@@ -24,6 +24,7 @@ type CreateVariableArgs = {
   visibility: EnvironmentVariableVisibility;
   environments: EnvironmentVariableEnvironment[];
   type: EnvironmentSecretType;
+  isGlobal?: boolean;
   fileName?: string;
 };
 


### PR DESCRIPTION
# Why

[ENG-14274: Remove linking from eas-cli](https://linear.app/expo/issue/ENG-14274/remove-linking-from-eas-cli)

Initial release will not include linking account-wide variables to specific projects - they all should be global.
Without explicitly setting `isGlobal` flag, account-wide envvars would be created as non-global, without possibility to link it to anything.

# How

* Added `isGlobal` = true to requests
* Also, removed unnecessary check in non-interactive mode - user should be able to create an account-wide variable with environments without linking it to the current project.

# Test Plan

Updated tests
