### PR TITLE
[eas-cli][eas-update] Change behavior of roll-back-to-embedded to not use current project state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Change behavior of roll-back-to-embedded to not use current project state. ([#2722](https://github.com/expo/eas-cli/pull/2722) by [@wschurman](https://github.com/wschurman))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -9438,7 +9438,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use 'privacySetting' instead."
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "privacySetting",
@@ -9453,8 +9453,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "published",
@@ -11445,22 +11445,6 @@
               "kind": "INPUT_OBJECT",
               "name": "AppInfoInput",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "privacy",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "AppPrivacy",
-                "ofType": null
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -13688,22 +13672,6 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "privacy",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "AppPrivacy",
-                "ofType": null
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -18071,6 +18039,18 @@
             "deprecationReason": null
           },
           {
+            "name": "fingerprint",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Fingerprint",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "gitCommitHash",
             "description": null,
             "args": [],
@@ -18441,6 +18421,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resolvedEnvironment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "EnvironmentVariableEnvironment",
               "ofType": null
             },
             "isDeprecated": false,

--- a/packages/eas-cli/src/commands/update/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/index.test.ts
@@ -88,7 +88,10 @@ describe(UpdatePublish.name, () => {
     const { platforms, runtimeVersion } = mockTestExport();
 
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
-      branchId: 'branch123',
+      branch: {
+        id: 'branch123',
+        name: 'wat',
+      },
       createdBranch: false,
     });
 
@@ -111,7 +114,10 @@ describe(UpdatePublish.name, () => {
       .mocked(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync)
       .mockResolvedValue({ branchId: 'branch123', branchName: 'branchFromChannel' });
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
-      branchId: 'branch123',
+      branch: {
+        id: 'branch123',
+        name: 'wat',
+      },
       createdBranch: false,
     });
 
@@ -146,7 +152,10 @@ describe(UpdatePublish.name, () => {
 
     // Mock an existing branch, so we don't create a new one
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
-      branchId: 'branch123',
+      branch: {
+        id: 'branch123',
+        name: 'wat',
+      },
       createdBranch: false,
     });
 

--- a/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/roll-back-to-embedded.test.ts
@@ -1,5 +1,4 @@
 import { AppJSONConfig, ExpoConfig, PackageJSONConfig, getConfig } from '@expo/config';
-import { Updates } from '@expo/config-plugins';
 import { vol } from 'memfs';
 import nullthrows from 'nullthrows';
 import path from 'path';
@@ -82,16 +81,23 @@ describe(UpdateRollBackToEmbedded.name, () => {
     );
   });
 
-  it('creates a roll back to embedded with --non-interactive, --branch, and --message', async () => {
-    const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
+  it('creates a roll back to embedded with --non-interactive, --branch, --message, and --runtime-version', async () => {
+    const flags = [
+      '--non-interactive',
+      '--branch=branch123',
+      '--message=abc',
+      '--runtime-version=exposdk:47.0.0',
+    ];
 
     mockTestProject();
     const platforms = ['android', 'ios'];
     const runtimeVersion = 'exposdk:47.0.0';
-    jest.mocked(Updates.getRuntimeVersionAsync).mockResolvedValue(runtimeVersion);
 
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
-      branchId: 'branch123',
+      branch: {
+        id: 'branch123',
+        name: 'wat',
+      },
       createdBranch: false,
     });
 
@@ -104,19 +110,26 @@ describe(UpdateRollBackToEmbedded.name, () => {
     expect(PublishMutation.publishUpdateGroupAsync).toHaveBeenCalled();
   });
 
-  it('creates a roll back to embedded with --non-interactive, --channel, and --message', async () => {
-    const flags = ['--non-interactive', '--channel=channel123', '--message=abc'];
+  it('creates a roll back to embedded with --non-interactive, --channel, --message, and --runtime-version', async () => {
+    const flags = [
+      '--non-interactive',
+      '--channel=channel123',
+      '--message=abc',
+      '--runtime-version=exposdk:47.0.0',
+    ];
 
     const { projectId } = mockTestProject();
     const platforms = ['android', 'ios'];
     const runtimeVersion = 'exposdk:47.0.0';
-    jest.mocked(Updates.getRuntimeVersionAsync).mockResolvedValue(runtimeVersion);
 
     jest
       .mocked(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync)
       .mockResolvedValue({ branchId: updateStub.branch.id, branchName: 'branchFromChannel' });
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
-      branchId: 'branch123',
+      branch: {
+        id: 'branch123',
+        name: 'wat',
+      },
       createdBranch: false,
     });
 
@@ -142,18 +155,25 @@ describe(UpdateRollBackToEmbedded.name, () => {
   });
 
   it('creates a roll back to embedded with the public expo config', async () => {
-    const flags = ['--non-interactive', '--branch=branch123', '--message=abc'];
+    const flags = [
+      '--non-interactive',
+      '--branch=branch123',
+      '--message=abc',
+      '--runtime-version=exposdk:47.0.0',
+    ];
 
     // Add configuration to the project that should not be included in the update
     mockTestProject();
 
     const platforms = ['ios'];
     const runtimeVersion = 'exposdk:47.0.0';
-    jest.mocked(Updates.getRuntimeVersionAsync).mockResolvedValue(runtimeVersion);
 
     // Mock an existing branch, so we don't create a new one
     jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
-      branchId: 'branch123',
+      branch: {
+        id: 'branch123',
+        name: 'wat',
+      },
       createdBranch: false,
     });
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -400,7 +400,7 @@ export default class UpdatePublish extends EasCommand {
         runtimeVersionInfoObjects
       );
 
-    const { branchId } = await ensureBranchExistsAsync(graphqlClient, {
+    const { branch } = await ensureBranchExistsAsync(graphqlClient, {
       appId: projectId,
       branchName,
     });
@@ -482,7 +482,7 @@ export default class UpdatePublish extends EasCommand {
           );
 
           return {
-            branchId,
+            branchId: branch.id,
             updateInfoGroup: localUpdateInfoGroup,
             rolloutInfoGroup: localRolloutInfoGroup,
             runtimeFingerprintSource: fingerprintSource

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1310,8 +1310,9 @@ export type App = Project & {
    * @deprecated Classic updates have been deprecated.
    */
   playStoreUrl?: Maybe<Scalars['String']['output']>;
-  /** @deprecated Use 'privacySetting' instead. */
+  /** @deprecated No longer supported */
   privacy: Scalars['String']['output'];
+  /** @deprecated No longer supported */
   privacySetting: AppPrivacy;
   /**
    * Whether there have been any classic update publishes
@@ -1746,7 +1747,6 @@ export type AppInfoInput = {
 export type AppInput = {
   accountId: Scalars['ID']['input'];
   appInfo?: InputMaybe<AppInfoInput>;
-  privacy: AppPrivacy;
   projectName: Scalars['String']['input'];
 };
 
@@ -2098,7 +2098,6 @@ export type AppWithGithubRepositoryInput = {
   accountId: Scalars['ID']['input'];
   appInfo?: InputMaybe<AppInfoInput>;
   installationIdentifier?: InputMaybe<Scalars['String']['input']>;
-  privacy: AppPrivacy;
   projectName: Scalars['String']['input'];
 };
 
@@ -2690,6 +2689,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   error?: Maybe<BuildError>;
   estimatedWaitTimeLeftSeconds?: Maybe<Scalars['Int']['output']>;
   expirationDate?: Maybe<Scalars['DateTime']['output']>;
+  fingerprint?: Maybe<Fingerprint>;
   gitCommitHash?: Maybe<Scalars['String']['output']>;
   gitCommitMessage?: Maybe<Scalars['String']['output']>;
   gitRef?: Maybe<Scalars['String']['output']>;
@@ -2723,6 +2723,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   reactNativeVersion?: Maybe<Scalars['String']['output']>;
   releaseChannel?: Maybe<Scalars['String']['output']>;
   requiredPackageManager?: Maybe<Scalars['String']['output']>;
+  resolvedEnvironment?: Maybe<EnvironmentVariableEnvironment>;
   /**
    * The builder resource class requested by the developer
    * @deprecated Use resourceClassDisplayName instead

--- a/packages/eas-cli/src/rollout/actions/CreateRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/CreateRollout.ts
@@ -149,7 +149,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     return newChannelInfo;
   }
 
-  async confirmCreationAsync(ctx: EASUpdateContext): Promise<boolean> {
+  private async confirmCreationAsync(ctx: EASUpdateContext): Promise<boolean> {
     const { nonInteractive } = ctx;
     if (nonInteractive) {
       return true;
@@ -159,7 +159,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     });
   }
 
-  async getChannelObjectAsync(
+  private async getChannelObjectAsync(
     ctx: EASUpdateContext,
     runtimeVersion: string
   ): Promise<UpdateChannelObject> {
@@ -172,7 +172,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     });
   }
 
-  async getLatestUpdateGroupOnBranchAsync(
+  private async getLatestUpdateGroupOnBranchAsync(
     ctx: EASUpdateContext,
     branchInfo: UpdateBranchBasicInfoFragment,
     runtimeVersion: string
@@ -195,7 +195,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     return updateGroups[0] ?? null;
   }
 
-  async selectRuntimeVersionAsync(
+  private async selectRuntimeVersionAsync(
     ctx: EASUpdateContext,
     branchToRollout: UpdateBranchBasicInfoFragment,
     defaultBranchId: string
@@ -223,7 +223,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     );
   }
 
-  async selectRuntimeVersionFromAlternativeSourceAsync(
+  private async selectRuntimeVersionFromAlternativeSourceAsync(
     ctx: EASUpdateContext,
     branchToRollout: UpdateBranchBasicInfoFragment,
     defaultBranch: UpdateBranchBasicInfoFragment
@@ -271,7 +271,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     );
   }
 
-  async selectRuntimeVersionFromProjectConfigAsync(ctx: EASUpdateContext): Promise<string> {
+  private async selectRuntimeVersionFromProjectConfigAsync(ctx: EASUpdateContext): Promise<string> {
     const platforms: ('ios' | 'android')[] = ['ios', 'android'];
     const workflows = await resolveWorkflowPerPlatformAsync(ctx.app.projectDir, ctx.vcsClient);
     const runtimes = (
@@ -313,7 +313,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     return selectedRuntime;
   }
 
-  async selectBranchAsync(
+  private async selectBranchAsync(
     ctx: EASUpdateContext,
     defaultBranchId: string
   ): Promise<UpdateBranchBasicInfoFragment> {
@@ -333,7 +333,7 @@ export class CreateRollout implements EASUpdateAction<UpdateChannelBasicInfoFrag
     return branchInfo;
   }
 
-  async resolveBranchNameAsync(
+  private async resolveBranchNameAsync(
     ctx: EASUpdateContext,
     branchName: string
   ): Promise<UpdateBranchBasicInfoFragment> {

--- a/packages/eas-cli/src/rollout/actions/EditRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/EditRollout.ts
@@ -86,7 +86,7 @@ export class EditRollout implements EASUpdateAction<UpdateChannelBasicInfoFragme
     return newChannelInfo;
   }
 
-  async confirmEditAsync(ctx: EASUpdateContext): Promise<boolean> {
+  private async confirmEditAsync(ctx: EASUpdateContext): Promise<boolean> {
     const { nonInteractive } = ctx;
     if (nonInteractive) {
       return true;
@@ -96,7 +96,7 @@ export class EditRollout implements EASUpdateAction<UpdateChannelBasicInfoFragme
     });
   }
 
-  async getChannelObjectAsync(ctx: EASUpdateContext): Promise<UpdateChannelObject> {
+  private async getChannelObjectAsync(ctx: EASUpdateContext): Promise<UpdateChannelObject> {
     const { graphqlClient, app } = ctx;
     const { projectId } = app;
     if (!isRollout(this.channelInfo)) {

--- a/packages/eas-cli/src/rollout/actions/EndRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/EndRollout.ts
@@ -87,7 +87,7 @@ export class EndRollout implements EASUpdateAction<UpdateChannelBasicInfoFragmen
     return await this.performOutcomeAsync(ctx, rollout, outcome);
   }
 
-  async getChannelObjectAsync(ctx: EASUpdateContext): Promise<UpdateChannelObject> {
+  private async getChannelObjectAsync(ctx: EASUpdateContext): Promise<UpdateChannelObject> {
     const { graphqlClient, app } = ctx;
     const { projectId } = app;
     if (!isRollout(this.channelInfo)) {
@@ -107,7 +107,7 @@ export class EndRollout implements EASUpdateAction<UpdateChannelBasicInfoFragmen
     });
   }
 
-  async selectOutcomeAsync(rollout: Rollout<UpdateBranchObject>): Promise<EndOutcome> {
+  private async selectOutcomeAsync(rollout: Rollout<UpdateBranchObject>): Promise<EndOutcome> {
     const { rolledOutBranch, percentRolledOut, defaultBranch } = rollout;
     const rolledOutUpdateGroup = rolledOutBranch.updateGroups[0];
     const defaultUpdateGroup = defaultBranch.updateGroups[0];
@@ -144,7 +144,7 @@ export class EndRollout implements EASUpdateAction<UpdateChannelBasicInfoFragmen
     return selectedOutcome;
   }
 
-  async performOutcomeAsync(
+  private async performOutcomeAsync(
     ctx: EASUpdateContext,
     rollout: Rollout<UpdateBranchObject>,
     outcome: EndOutcome
@@ -185,7 +185,7 @@ export class EndRollout implements EASUpdateAction<UpdateChannelBasicInfoFragmen
     return newChannelInfo;
   }
 
-  async confirmOutcomeAsync(
+  private async confirmOutcomeAsync(
     ctx: EASUpdateContext,
     selectedOutcome: EndOutcome,
     rollout: Rollout<UpdateBranchObject>

--- a/packages/eas-cli/src/rollout/actions/ManageRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/ManageRollout.ts
@@ -61,7 +61,7 @@ export class ManageRollout implements EASUpdateAction<EASUpdateAction> {
     }
   }
 
-  async selectActionAsync(): Promise<ManageRolloutActions> {
+  private async selectActionAsync(): Promise<ManageRolloutActions> {
     const manageOptions = [ManageRolloutActions.EDIT, ManageRolloutActions.END];
     if (this.options.callingAction) {
       manageOptions.push(ManageRolloutActions.GO_BACK);
@@ -78,7 +78,7 @@ export class ManageRollout implements EASUpdateAction<EASUpdateAction> {
     return selectedManageOption;
   }
 
-  async getChannelObjectAsync(ctx: EASUpdateContext): Promise<UpdateChannelObject> {
+  private async getChannelObjectAsync(ctx: EASUpdateContext): Promise<UpdateChannelObject> {
     const { graphqlClient, app } = ctx;
     const { projectId } = app;
     if (!isRollout(this.channelInfo)) {

--- a/packages/eas-cli/src/rollout/actions/NonInteractiveRollout.ts
+++ b/packages/eas-cli/src/rollout/actions/NonInteractiveRollout.ts
@@ -91,7 +91,7 @@ export class NonInteractiveRollout implements EASUpdateAction<void> {
     }
   }
 
-  async runActionAsync(
+  private async runActionAsync(
     ctx: EASUpdateContext,
     action: RolloutActions,
     channelObject: UpdateChannelObject
@@ -108,7 +108,7 @@ export class NonInteractiveRollout implements EASUpdateAction<void> {
     }
   }
 
-  viewRollout(channelObject: UpdateChannelObject): UpdateChannelObject {
+  private viewRollout(channelObject: UpdateChannelObject): UpdateChannelObject {
     if (!this.options.json) {
       printRollout(channelObject);
       Log.warn('For formatted output, add the --json flag to your command.');
@@ -116,7 +116,7 @@ export class NonInteractiveRollout implements EASUpdateAction<void> {
     return channelObject;
   }
 
-  async getJsonAsync({
+  private async getJsonAsync({
     originalChannelObject,
     updatedChannelObject,
   }: {
@@ -134,7 +134,9 @@ export class NonInteractiveRollout implements EASUpdateAction<void> {
     };
   }
 
-  async getRolloutJsonAsync(channelObject: UpdateChannelObject): Promise<JSONRolloutOutput> {
+  private async getRolloutJsonAsync(
+    channelObject: UpdateChannelObject
+  ): Promise<JSONRolloutOutput> {
     const rollout = getRollout(channelObject);
     return {
       defaultBranch: rollout.defaultBranch,
@@ -145,7 +147,7 @@ export class NonInteractiveRollout implements EASUpdateAction<void> {
     };
   }
 
-  getRuntimeVersion(channelInfo: UpdateChannelBasicInfoFragment): string | undefined {
+  private getRuntimeVersion(channelInfo: UpdateChannelBasicInfoFragment): string | undefined {
     if (isRollout(channelInfo)) {
       const updatedRolloutInfo = getRolloutInfo(channelInfo);
       if (isConstrainedRolloutInfo(updatedRolloutInfo)) {
@@ -155,7 +157,7 @@ export class NonInteractiveRollout implements EASUpdateAction<void> {
     return undefined;
   }
 
-  async getChannelObjectAsync(
+  private async getChannelObjectAsync(
     ctx: EASUpdateContext,
     { channelName, runtimeVersion }: { channelName: string; runtimeVersion?: string }
   ): Promise<UpdateChannelObject> {

--- a/packages/eas-cli/src/rollout/actions/RolloutMainMenu.ts
+++ b/packages/eas-cli/src/rollout/actions/RolloutMainMenu.ts
@@ -54,7 +54,7 @@ export class RolloutMainMenu implements EASUpdateAction<void> {
     await this.runActionAsync(ctx, menuOption);
   }
 
-  async runActionAsync(ctx: EASUpdateContext, menuAction: MainMenuActions): Promise<null> {
+  private async runActionAsync(ctx: EASUpdateContext, menuAction: MainMenuActions): Promise<null> {
     const { channelName } = this.options;
     switch (menuAction) {
       case MainMenuActions.CREATE_NEW: {
@@ -87,13 +87,15 @@ export class RolloutMainMenu implements EASUpdateAction<void> {
     }
   }
 
-  async selectRolloutAsync(ctx: EASUpdateContext): Promise<UpdateChannelBasicInfoFragment | null> {
+  private async selectRolloutAsync(
+    ctx: EASUpdateContext
+  ): Promise<UpdateChannelBasicInfoFragment | null> {
     const selectRollout = new SelectRollout();
     const channelInfo = await selectRollout.runAsync(ctx);
     return channelInfo;
   }
 
-  async selectChannelToRolloutAsync(
+  private async selectChannelToRolloutAsync(
     ctx: EASUpdateContext
   ): Promise<UpdateChannelBasicInfoFragment> {
     let hasSomeChannel = false;
@@ -113,7 +115,7 @@ export class RolloutMainMenu implements EASUpdateAction<void> {
     return channelInfo;
   }
 
-  async resolveChannelNameAsync(
+  private async resolveChannelNameAsync(
     ctx: EASUpdateContext,
     channelName: string
   ): Promise<UpdateChannelBasicInfoFragment> {
@@ -124,7 +126,7 @@ export class RolloutMainMenu implements EASUpdateAction<void> {
     });
   }
 
-  toMainMenuAction(action: RolloutActions): MainMenuActions {
+  private toMainMenuAction(action: RolloutActions): MainMenuActions {
     if (action === MainMenuActions.CREATE_NEW) {
       return MainMenuActions.CREATE_NEW;
     } else if (
@@ -138,7 +140,7 @@ export class RolloutMainMenu implements EASUpdateAction<void> {
     }
   }
 
-  async promptMenuActionAsync(): Promise<MainMenuActions> {
+  private async promptMenuActionAsync(): Promise<MainMenuActions> {
     const menuOptions = [MainMenuActions.CREATE_NEW, MainMenuActions.MANAGE_EXISTING];
     const { menuOption: selectedMenuOption } = await promptAsync({
       type: 'select',

--- a/packages/eas-cli/src/rollout/actions/SelectRuntime.ts
+++ b/packages/eas-cli/src/rollout/actions/SelectRuntime.ts
@@ -27,7 +27,7 @@ export class SelectRuntime implements EASUpdateAction<string | null> {
       : `runtime`;
   }
 
-  warnNoRuntime(): void {
+  private warnNoRuntime(): void {
     if (this.options.anotherBranchToIntersectRuntimesBy) {
       const intersectBranchName = this.options.anotherBranchToIntersectRuntimesBy.name;
       Log.warn(
@@ -42,7 +42,7 @@ export class SelectRuntime implements EASUpdateAction<string | null> {
     }
   }
 
-  formatCantFindRuntime(): string {
+  private formatCantFindRuntime(): string {
     return `🕵️ Not finding the update you were looking for? ${learnMore(
       'https://expo.fyi/eas-update-rollouts'
     )}`;
@@ -104,7 +104,7 @@ export class SelectRuntime implements EASUpdateAction<string | null> {
     return selectedRuntime.version;
   }
 
-  async getNewestRuntimeAsync(
+  private async getNewestRuntimeAsync(
     graphqlClient: ExpoGraphqlClient,
     {
       appId,
@@ -126,7 +126,7 @@ export class SelectRuntime implements EASUpdateAction<string | null> {
     });
   }
 
-  async displayLatestUpdateGroupAsync({
+  private async displayLatestUpdateGroupAsync({
     graphqlClient,
     appId,
     branchName,
@@ -153,7 +153,7 @@ export class SelectRuntime implements EASUpdateAction<string | null> {
     return formatRuntimeWithUpdateGroup(updateGroups[0], runtime, branchName);
   }
 
-  async selectRuntimesAsync(
+  private async selectRuntimesAsync(
     graphqlClient: ExpoGraphqlClient,
     {
       appId,

--- a/packages/eas-cli/src/update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync.ts
+++ b/packages/eas-cli/src/update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync.ts
@@ -34,7 +34,7 @@ export async function getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
       throw error;
     }
 
-    const { branchId } = await ensureBranchExistsAsync(graphqlClient, {
+    const { branch } = await ensureBranchExistsAsync(graphqlClient, {
       appId: projectId,
       branchName: channelName,
     });
@@ -43,7 +43,7 @@ export async function getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
     } = await createChannelOnAppAsync(graphqlClient, {
       appId: projectId,
       channelName,
-      branchId,
+      branchId: branch.id,
     });
 
     if (!newChannel) {
@@ -52,7 +52,7 @@ export async function getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
       );
     }
 
-    branchInfo = { branchId, branchName: channelName };
+    branchInfo = { branchId: branch.id, branchName: channelName };
   }
 
   return branchInfo;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

After discussion with @quinlanj  about whether fingerprints should be taken during roll-back-to-embedded publish, we realized that this command actually probably shouldn't rely on the current state of the project in the current working directory for anything (except code signing, but that's an edge case).

The reason for this is that one shouldn't have to check out a release branch to publish the roll-back-to-embedded directive since fingerprint might differ if branch is stale and deps change under the hood, thus making it impossible to issue the directive for the desired binary (rtv).

Closes ENG-14282.

# How

Make this behave more like a rollout or roll-back-to-embedded on the website: ask for all info rather than gathering it from the current working directory.

# Test Plan

Run test.

Manual test:

```
$ neas update:roll-back-to-embedded
★ eas-cli@13.4.2 is now available.
To upgrade, run npm install -g eas-cli.
Proceeding with outdated version.

✔ Which branch would you like to use? › main - current update: "Republish "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce non enim nulla. Praesent turpis massa, imperdiet et imperdiet quis, semper id nisl. Pellentesque ut ex consectetur, maximus nisl vel, vehicula ipsum. Vestibulum facilisis arcu nec rhoncus lacinia. Proin dignissim libero vitae porttitor lacinia. Duis quis risus id dui accumsan interdum sollicitudin id odio. Nam tincidunt malesuada interdum. Aliquam ac auctor odio. Nam sit amet rhoncus lorem. Donec venenatis ipsum nibh, a pellentesqu..." (2 weeks ago by wschurman)
✔ Provide an update message: … Initial commit

Generated by create-expo-app 3.0.0.
✔ Select a target runtime › 1.0.0
✔ Published!

Branch             main
Runtime version    1.0.0
Platform           android, ios
Update group ID    302acb22-656c-4b0e-9706-6f08d21cebd8
Android update ID  34ea2160-3fd9-4663-92bb-f2128197fd69
iOS update ID      98aa58e7-40e0-42d7-925d-2d284800932f
Message            Initial commit
```