### PR TITLE
[eas-cli] fix warning for gitignored google services file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Fix outdated gitignored Google services file warning. ([#2730](https://github.com/expo/eas-cli/pull/2730) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [13.4.2](https://github.com/expo/eas-cli/releases/tag/v13.4.2) - 2024-11-25
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/validate.ts
+++ b/packages/eas-cli/src/build/validate.ts
@@ -27,23 +27,27 @@ export async function checkGoogleServicesFileAsync<T extends Platform>(
   if (!googleServicesFilePath) {
     return;
   }
+  const googleServicesEnvVar =
+    ctx.platform === Platform.ANDROID
+      ? ctx.env.GOOGLE_SERVICES_JSON
+      : ctx.env.GOOGLE_SERVICES_INFO_PLIST;
   const rootDir = path.normalize(await ctx.vcsClient.getRootPathAsync());
   const absGoogleServicesFilePath = path.resolve(ctx.projectDir, googleServicesFilePath);
   if (
     (await fs.pathExists(absGoogleServicesFilePath)) &&
     (!isInsideDirectory(absGoogleServicesFilePath, rootDir) ||
-      (await ctx.vcsClient.isFileIgnoredAsync(path.relative(rootDir, absGoogleServicesFilePath))))
+      (await ctx.vcsClient.isFileIgnoredAsync(
+        path.relative(rootDir, absGoogleServicesFilePath)
+      ))) &&
+    !googleServicesEnvVar
   ) {
     Log.warn(
       `File specified via "${ctx.platform}.googleServicesFile" field in your app.json is not checked in to your repository and won't be uploaded to the builder.`
     );
     Log.warn(
-      `Use EAS Secret to pass all values that you don't want to include in your version control. ${learnMore(
-        'https://docs.expo.dev/build-reference/variables/#using-secrets-in-environment-variables'
+      `Use EAS file environment variables with secret or sensitive visibility to pass all values that you don't want to include in your version control to build process. ${learnMore(
+        'https://docs.expo.dev/eas/environment-variables/#file-environment-variables'
       )}`
-    );
-    Log.warn(
-      `If you are using that file for compatibility with the classic build service (expo build) you can silence this warning by setting your build profile's env.GOOGLE_SERVICES_FILE in eas.json to any non-empty string.`
     );
     Log.newLine();
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://discord.com/channels/695411232856997968/1309202098591633458/1311040361040183429

# How

Make warning up to date after recent env vars changes
