### PR TITLE
Allow to skip disabeling capabilities using EXPO_SKIP_DISABLE_CAPABILITIES env variable

### DIFF
--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -94,11 +94,10 @@ export async function syncCapabilitiesForEntitlementsAsync(
     entitlements
   );
 
-  const { disabledCapabilityNames, request: modifiedRequest } = getCapabilitiesToDisable(
-    bundleId,
-    remainingCapabilities,
-    request
-  );
+  const { disabledCapabilityNames, request: modifiedRequest } = process.env
+    .EXPO_SKIP_DISABLE_CAPABILITIES
+    ? { disabledCapabilityNames: [], request }
+    : getCapabilitiesToDisable(bundleId, remainingCapabilities, request);
 
   if (modifiedRequest.length) {
     Log.debug(`Patch Request:`, inspect(modifiedRequest, { depth: null, colors: true }));


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

In some cases disabling old capabilities is unwanted, but you still may want to enable new ones. 

# How

If `EXPO_SKIP_DISABLE_CAPABILITIES` env var is set skip disabling capabilities

# Test Plan

Tests

Test manually
