### PR TITLE
[eas-cli] Remove random branch name generation for --auto branch name non-vcs fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Remove random branch name generation for --auto branch name non-vcs fallback. ([#2747](https://github.com/expo/eas-cli/pull/2747) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 ## [14.1.0](https://github.com/expo/eas-cli/releases/tag/v14.1.0) - 2024-12-10

--- a/packages/eas-cli/src/branch/utils.ts
+++ b/packages/eas-cli/src/branch/utils.ts
@@ -1,9 +1,7 @@
 import { Client } from '../vcs/vcs';
 
-export async function getDefaultBranchNameAsync(vcsClient: Client): Promise<string> {
-  return (
-    (await vcsClient.getBranchNameAsync()) || `branch-${Math.random().toString(36).substring(2, 4)}`
-  );
+export async function getDefaultBranchNameAsync(vcsClient: Client): Promise<string | null> {
+  return await vcsClient.getBranchNameAsync();
 }
 
 export class BranchNotFoundError extends Error {

--- a/packages/eas-cli/src/commands/branch/create.ts
+++ b/packages/eas-cli/src/commands/branch/create.ts
@@ -58,7 +58,7 @@ export default class BranchCreate extends EasCommand {
         type: 'text',
         name: 'name',
         message: 'Provide a branch name:',
-        initial: await getDefaultBranchNameAsync(vcsClient),
+        initial: (await getDefaultBranchNameAsync(vcsClient)) ?? undefined,
         validate: value => (value ? true : validationMessage),
       }));
     }

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -634,7 +634,13 @@ export async function getBranchNameForCommandAsync({
   }
 
   if (autoFlag) {
-    return await getDefaultBranchNameAsync(vcsClient);
+    const defaultBranchNameFromVcs = await getDefaultBranchNameAsync(vcsClient);
+    if (!defaultBranchNameFromVcs) {
+      throw new Error(
+        'Must supply --branch or --channel for branch name as auto-detection of branch name via --auto is not supported when no VCS is present.'
+      );
+    }
+    return defaultBranchNameFromVcs;
   } else if (nonInteractive) {
     throw new Error('Must supply --channel, --branch or --auto when in non-interactive mode.');
   } else {
@@ -658,7 +664,7 @@ export async function getBranchNameForCommandAsync({
         type: 'text',
         name: 'name',
         message: 'No branches found. Provide a branch name:',
-        initial: await getDefaultBranchNameAsync(vcsClient),
+        initial: (await getDefaultBranchNameAsync(vcsClient)) ?? undefined,
         validate: value => (value ? true : 'Branch name may not be empty.'),
       });
       branchName = name;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C06EFBQK3B7/p1732217583248979

We should never be defaulting to a random branch name for an EAS Update. This would have disastrous consequences for usability and our interfaces, as well as for publishes and channel-branch mappings.

For workflows, this problem is more in the foreground since there's no VCS on the workflow runner.

Closes ENG-14314.

# How

Remove fallback, throw an descriptive error when needed.

# Test Plan

Run `neas update --auto` in a directory that doesn't have vcs (remove .git folder). See other error indicating that VCS is required.

Run `neas branch:create`, see that there's no default suggestion in the prompt.

```
$ neas update --auto
It looks like you haven't initialized the git repository yet.
EAS requires you to use a git repository for your project.
✔ Would you like us to run 'git init' in <dir> for you? … no
A git repository is required for building your project. Initialize it and run this command again.
    Error: update command failed.

$ neas branch:create
✖ Provide a branch name:
```