### PR TITLE
[eas-cli] add support for broadcast push notifications option for push notifications capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add support for enabeling broadcast Push Notifications capability option, by setting `ios.usesBroadcastPushNotifications` to `true` in app config. ([#2748](https://github.com/expo/eas-cli/pull/2748) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "2.1.3",
+    "@expo/apple-utils": "2.1.4",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "10.0.6",
     "@expo/config-plugins": "9.0.12",

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -32,6 +32,7 @@ export class CredentialsContext {
   public readonly analytics: Analytics;
   public readonly vcsClient: Client;
   public readonly easJsonCliConfig?: EasJson['cli'];
+  public readonly usesBroadcastPushNotifications: boolean;
 
   private shouldAskAuthenticateAppStore: boolean = true;
 
@@ -61,6 +62,8 @@ export class CredentialsContext {
     this.nonInteractive = options.nonInteractive ?? false;
     this.projectInfo = options.projectInfo;
     this.freezeCredentials = options.freezeCredentials ?? false;
+    this.usesBroadcastPushNotifications =
+      options.projectInfo?.exp.ios?.usesBroadcastPushNotifications ?? false;
   }
 
   get hasProjectContext(): boolean {

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpTargetBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpTargetBuildCredentials.ts
@@ -35,7 +35,7 @@ export class SetUpTargetBuildCredentials {
           bundleIdentifier: app.bundleIdentifier,
           projectName: app.projectName,
         },
-        { entitlements }
+        { entitlements, usesBroadcastPushNotifications: ctx.usesBroadcastPushNotifications }
       );
     }
     try {

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts
@@ -45,7 +45,9 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       id: 'XXX',
     } as any;
 
-    await syncCapabilitiesForEntitlementsAsync(bundleId, entitlements);
+    await syncCapabilitiesForEntitlementsAsync(bundleId, entitlements, {
+      usesBroadcastPushNotifications: false,
+    });
 
     expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
       {
@@ -62,63 +64,70 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       id: 'XXX',
     } as any;
 
-    const results = await syncCapabilitiesForEntitlementsAsync(bundleId, {
-      'com.apple.developer.healthkit': true,
-      //   'com.apple.developer.healthkit.access': [],
-      'com.apple.developer.in-app-payments': ['merchant.com.example.development'],
-      'com.apple.developer.icloud-container-identifiers': [],
-      'com.apple.developer.ClassKit-environment': 'development',
-      'com.apple.developer.default-data-protection':
-        'NSFileProtectionCompleteUntilFirstUserAuthentication',
-      'com.apple.developer.networking.networkextension': ['dns-proxy'],
-      'com.apple.developer.networking.vpn.api': ['allow-vpn'],
-      'com.apple.developer.networking.HotspotConfiguration': true,
-      'com.apple.developer.kernel.extended-virtual-addressing': true,
-      'com.apple.developer.homekit': true,
-      'com.apple.developer.networking.multipath': true,
-      'com.apple.external-accessory.wireless-configuration': true,
-      'inter-app-audio': true,
-      'com.apple.developer.pass-type-identifiers': ['$(TeamIdentifierPrefix)*'],
-      'com.apple.developer.user-fonts': ['app-usage'],
-      'com.apple.developer.devicecheck.appattest-environment': 'development',
-      'com.apple.developer.nfc.readersession.formats': ['NDEF', 'TAG'],
-      'com.apple.developer.applesignin': ['Default'],
-      'com.apple.developer.siri': true,
-      'com.apple.developer.networking.wifi-info': true,
-      'com.apple.developer.usernotifications.communication': true,
-      'com.apple.developer.usernotifications.time-sensitive': true,
-      'com.apple.developer.group-session': true,
-      'com.apple.developer.family-controls': true,
-      'com.apple.developer.authentication-services.autofill-credential-provider': true,
-      //   'com.apple.developer.game-center': true,
-      'com.apple.security.application-groups': [
-        'group.CY-A5149AC2-49FC-11E7-B3F3-0335A16FFB8D.com.cydia.Extender',
-      ],
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {
+        'com.apple.developer.healthkit': true,
+        //   'com.apple.developer.healthkit.access': [],
+        'com.apple.developer.in-app-payments': ['merchant.com.example.development'],
+        'com.apple.developer.icloud-container-identifiers': [],
+        'com.apple.developer.ClassKit-environment': 'development',
+        'com.apple.developer.default-data-protection':
+          'NSFileProtectionCompleteUntilFirstUserAuthentication',
+        'com.apple.developer.networking.networkextension': ['dns-proxy'],
+        'com.apple.developer.networking.vpn.api': ['allow-vpn'],
+        'com.apple.developer.networking.HotspotConfiguration': true,
+        'com.apple.developer.kernel.extended-virtual-addressing': true,
+        'com.apple.developer.homekit': true,
+        'com.apple.developer.networking.multipath': true,
+        'com.apple.external-accessory.wireless-configuration': true,
+        'inter-app-audio': true,
+        'com.apple.developer.pass-type-identifiers': ['$(TeamIdentifierPrefix)*'],
+        'com.apple.developer.user-fonts': ['app-usage'],
+        'com.apple.developer.devicecheck.appattest-environment': 'development',
+        'com.apple.developer.nfc.readersession.formats': ['NDEF', 'TAG'],
+        'com.apple.developer.applesignin': ['Default'],
+        'com.apple.developer.siri': true,
+        'com.apple.developer.networking.wifi-info': true,
+        'com.apple.developer.usernotifications.communication': true,
+        'com.apple.developer.usernotifications.time-sensitive': true,
+        'com.apple.developer.group-session': true,
+        'com.apple.developer.family-controls': true,
+        'com.apple.developer.authentication-services.autofill-credential-provider': true,
+        //   'com.apple.developer.game-center': true,
+        'com.apple.security.application-groups': [
+          'group.CY-A5149AC2-49FC-11E7-B3F3-0335A16FFB8D.com.cydia.Extender',
+        ],
 
-      'com.apple.developer.fileprovider.testing-mode': true,
-      'com.apple.developer.healthkit.recalibrate-estimates': true,
-      'com.apple.developer.maps': true,
-      'com.apple.developer.user-management': true,
-      'com.apple.developer.networking.custom-protocol': true,
-      'com.apple.developer.system-extension.install': true,
-      'com.apple.developer.push-to-talk': true,
-      'com.apple.developer.driverkit.transport.usb': true,
-      'com.apple.developer.kernel.increased-memory-limit': true,
-      'com.apple.developer.driverkit.communicates-with-drivers': true,
-      'com.apple.developer.media-device-discovery-extension': true,
-      'com.apple.developer.driverkit.allow-third-party-userclients': true,
-      'com.apple.developer.weatherkit': true,
-      'com.apple.developer.on-demand-install-capable': true,
-      'com.apple.developer.driverkit.family.scsicontroller': true,
-      'com.apple.developer.driverkit.family.serial': true,
-      'com.apple.developer.driverkit.family.networking': true,
-      'com.apple.developer.driverkit.family.hid.eventservice': true,
-      'com.apple.developer.driverkit.family.hid.device': true,
-      'com.apple.developer.driverkit': true,
-      'com.apple.developer.driverkit.transport.hid': true,
-      'com.apple.developer.driverkit.family.audio': true,
-      'com.apple.developer.shared-with-you': true,
-    });
+        'com.apple.developer.fileprovider.testing-mode': true,
+        'com.apple.developer.healthkit.recalibrate-estimates': true,
+        'com.apple.developer.maps': true,
+        'com.apple.developer.user-management': true,
+        'com.apple.developer.networking.custom-protocol': true,
+        'com.apple.developer.system-extension.install': true,
+        'com.apple.developer.push-to-talk': true,
+        'com.apple.developer.driverkit.transport.usb': true,
+        'com.apple.developer.kernel.increased-memory-limit': true,
+        'com.apple.developer.driverkit.communicates-with-drivers': true,
+        'com.apple.developer.media-device-discovery-extension': true,
+        'com.apple.developer.driverkit.allow-third-party-userclients': true,
+        'com.apple.developer.weatherkit': true,
+        'com.apple.developer.on-demand-install-capable': true,
+        'com.apple.developer.driverkit.family.scsicontroller': true,
+        'com.apple.developer.driverkit.family.serial': true,
+        'com.apple.developer.driverkit.family.networking': true,
+        'com.apple.developer.driverkit.family.hid.eventservice': true,
+        'com.apple.developer.driverkit.family.hid.device': true,
+        'com.apple.developer.driverkit': true,
+        'com.apple.developer.driverkit.transport.hid': true,
+        'com.apple.developer.driverkit.family.audio': true,
+        'com.apple.developer.shared-with-you': true,
+        'aps-environment': 'production',
+      },
+      {
+        usesBroadcastPushNotifications: false,
+      }
+    );
 
     expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
       { capabilityType: 'HEALTHKIT', option: 'ON' },
@@ -251,6 +260,10 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
         capabilityType: 'SHARED_WITH_YOU',
         option: 'ON',
       },
+      {
+        capabilityType: 'PUSH_NOTIFICATIONS',
+        option: 'ON',
+      },
     ]);
 
     expect(results.enabled).toMatchInlineSnapshot(`
@@ -304,6 +317,7 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
         "DriverKit Transport HID (development)",
         "DriverKit Family Audio (development)",
         "Shared with You",
+        "Push Notifications",
       ]
     `);
     expect(results.disabled).toStrictEqual([]);
@@ -318,9 +332,15 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       id: 'XXX',
     } as any;
 
-    const results = await syncCapabilitiesForEntitlementsAsync(bundleId, {
-      'com.apple.developer.healthkit': true,
-    });
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {
+        'com.apple.developer.healthkit': true,
+      },
+      {
+        usesBroadcastPushNotifications: false,
+      }
+    );
 
     expect(bundleId.updateBundleIdCapabilityAsync).not.toBeCalled();
 
@@ -344,9 +364,15 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
     } as any;
 
     await expect(
-      syncCapabilitiesForEntitlementsAsync(bundleId, {
-        'com.apple.developer.healthkit': true,
-      })
+      syncCapabilitiesForEntitlementsAsync(
+        bundleId,
+        {
+          'com.apple.developer.healthkit': true,
+        },
+        {
+          usesBroadcastPushNotifications: false,
+        }
+      )
     ).rejects.toThrowError(
       `https://developer-mdn.apple.com/account/resources/identifiers/bundleId/edit/XXX333`
     );
@@ -361,9 +387,15 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       id: 'XXX',
     } as any;
 
-    const results = await syncCapabilitiesForEntitlementsAsync(bundleId, {
-      'com.apple.developer.healthkit': true,
-    });
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {
+        'com.apple.developer.healthkit': true,
+      },
+      {
+        usesBroadcastPushNotifications: false,
+      }
+    );
 
     expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
       { capabilityType: 'HEALTHKIT', option: 'ON' },
@@ -382,9 +414,15 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       id: 'XXX',
     } as any;
 
-    const results = await syncCapabilitiesForEntitlementsAsync(bundleId, {
-      'com.apple.developer.healthkit': true,
-    });
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {
+        'com.apple.developer.healthkit': true,
+      },
+      {
+        usesBroadcastPushNotifications: false,
+      }
+    );
 
     expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
       { capabilityType: 'HEALTHKIT', option: 'ON' },
@@ -406,7 +444,13 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       id: 'XXX',
     } as any;
 
-    const results = await syncCapabilitiesForEntitlementsAsync(bundleId, {});
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {},
+      {
+        usesBroadcastPushNotifications: false,
+      }
+    );
 
     expect(bundleId.updateBundleIdCapabilityAsync).not.toBeCalled();
 
@@ -423,9 +467,15 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       id: 'XXX',
     } as any;
 
-    const results = await syncCapabilitiesForEntitlementsAsync(bundleId, {
-      'com.apple.developer.healthkit': true,
-    });
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {
+        'com.apple.developer.healthkit': true,
+      },
+      {
+        usesBroadcastPushNotifications: false,
+      }
+    );
 
     expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
       { capabilityType: 'HEALTHKIT', option: 'ON' },
@@ -433,5 +483,165 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
 
     expect(results.enabled).toStrictEqual(['HealthKit']);
     expect(results.disabled).toStrictEqual([]);
+  });
+
+  it('enables push notifications capability with broadcast option when the capability is disabled and usesBroadcastPushNotifications is true', async () => {
+    const bundleId = {
+      getBundleIdCapabilitiesAsync: jest.fn(() => []),
+      updateBundleIdCapabilityAsync: jest.fn(),
+      id: 'XXX',
+    } as any;
+
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {
+        'aps-environment': 'production',
+      },
+      {
+        usesBroadcastPushNotifications: true,
+      }
+    );
+
+    expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
+      { capabilityType: 'PUSH_NOTIFICATIONS', option: 'PUSH_NOTIFICATION_FEATURE_BROADCAST' },
+    ]);
+
+    expect(results.enabled).toStrictEqual(['Push Notifications']);
+    expect(results.disabled).toStrictEqual([]);
+  });
+
+  it('updates push notifications capability with broadcast option when the capability is enabled without settings and usesBroadcastPushNotifications is true', async () => {
+    const bundleId = {
+      getBundleIdCapabilitiesAsync: jest.fn(() => [
+        new BundleIdCapability({}, 'XXX_PUSH_NOTIFICATIONS', { settings: null }),
+      ]),
+      updateBundleIdCapabilityAsync: jest.fn(),
+      id: 'XXX',
+    } as any;
+
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {
+        'aps-environment': 'production',
+      },
+      {
+        usesBroadcastPushNotifications: true,
+      }
+    );
+
+    expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
+      { capabilityType: 'PUSH_NOTIFICATIONS', option: 'PUSH_NOTIFICATION_FEATURE_BROADCAST' },
+    ]);
+
+    expect(results.enabled).toStrictEqual(['Push Notifications']);
+    expect(results.disabled).toStrictEqual([]);
+  });
+
+  it('disables push notifications capability', async () => {
+    const bundleId = {
+      getBundleIdCapabilitiesAsync: jest.fn(() => [
+        new BundleIdCapability({}, 'XXX_PUSH_NOTIFICATIONS', { settings: null }),
+      ]),
+      updateBundleIdCapabilityAsync: jest.fn(),
+      id: 'XXX',
+    } as any;
+
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {},
+      {
+        usesBroadcastPushNotifications: true,
+      }
+    );
+
+    expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
+      { capabilityType: 'PUSH_NOTIFICATIONS', option: 'OFF' },
+    ]);
+
+    expect(results.disabled).toStrictEqual(['Push Notifications']);
+    expect(results.enabled).toStrictEqual([]);
+  });
+
+  it('does nothing when push notifications capability is enabled with broadcast options and usesBroadcastPushNotifications is true', async () => {
+    const bundleId = {
+      getBundleIdCapabilitiesAsync: jest.fn(() => [
+        new BundleIdCapability({}, 'XXX_PUSH_NOTIFICATIONS', {
+          settings: [],
+        }),
+      ]),
+      updateBundleIdCapabilityAsync: jest.fn(),
+      id: 'XXX',
+    } as any;
+
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {
+        'aps-environment': 'production',
+      },
+      {
+        usesBroadcastPushNotifications: true,
+      }
+    );
+
+    expect(bundleId.updateBundleIdCapabilityAsync).not.toBeCalled();
+
+    expect(results.disabled).toStrictEqual([]);
+    expect(results.enabled).toStrictEqual([]);
+  });
+
+  it('does nothing when push notifications capability is enabled without broadcast options and usesBroadcastPushNotifications is false', async () => {
+    const bundleId = {
+      getBundleIdCapabilitiesAsync: jest.fn(() => [
+        new BundleIdCapability({}, 'XXX_PUSH_NOTIFICATIONS', {
+          settings: null,
+        }),
+      ]),
+      updateBundleIdCapabilityAsync: jest.fn(),
+      id: 'XXX',
+    } as any;
+
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {
+        'aps-environment': 'production',
+      },
+      {
+        usesBroadcastPushNotifications: false,
+      }
+    );
+
+    expect(bundleId.updateBundleIdCapabilityAsync).not.toBeCalled();
+
+    expect(results.disabled).toStrictEqual([]);
+    expect(results.enabled).toStrictEqual([]);
+  });
+
+  it('updates push notifications capability without broadcast options when it is enabled and usesBroadcastPushNotifications is false', async () => {
+    const bundleId = {
+      getBundleIdCapabilitiesAsync: jest.fn(() => [
+        new BundleIdCapability({}, 'XXX_PUSH_NOTIFICATIONS', {
+          settings: [],
+        }),
+      ]),
+      updateBundleIdCapabilityAsync: jest.fn(),
+      id: 'XXX',
+    } as any;
+
+    const results = await syncCapabilitiesForEntitlementsAsync(
+      bundleId,
+      {
+        'aps-environment': 'production',
+      },
+      {
+        usesBroadcastPushNotifications: false,
+      }
+    );
+
+    expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
+      { capabilityType: 'PUSH_NOTIFICATIONS', option: 'ON' },
+    ]);
+
+    expect(results.disabled).toStrictEqual([]);
+    expect(results.enabled).toStrictEqual(['Push Notifications']);
   });
 });

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -6,6 +6,7 @@ import {
   CapabilityType,
   CapabilityTypeDataProtectionOption,
   CapabilityTypeOption,
+  CapabilityTypePushNotificationsOption,
   CloudContainer,
   MerchantId,
 } from '@expo/apple-utils';
@@ -19,7 +20,10 @@ export const EXPO_NO_CAPABILITY_SYNC = getenv.boolish('EXPO_NO_CAPABILITY_SYNC',
 
 type GetOptionsMethod<T extends CapabilityType = any> = (
   entitlement: JSONValue,
-  entitlementsJson: JSONObject
+  entitlementsJson: JSONObject,
+  additionalOptions: {
+    usesBroadcastPushNotifications?: boolean;
+  }
 ) => CapabilityOptionMap[T];
 
 const validateBooleanOptions = (options: any): boolean => {
@@ -78,7 +82,10 @@ const getDefinedOptions: GetOptionsMethod = entitlement => {
  */
 export async function syncCapabilitiesForEntitlementsAsync(
   bundleId: BundleId,
-  entitlements: JSONObject = {}
+  entitlements: JSONObject = {},
+  additionalOptions: {
+    usesBroadcastPushNotifications: boolean;
+  }
 ): Promise<{ enabled: string[]; disabled: string[] }> {
   if (EXPO_NO_CAPABILITY_SYNC) {
     return { enabled: [], disabled: [] };
@@ -91,7 +98,8 @@ export async function syncCapabilitiesForEntitlementsAsync(
 
   const { enabledCapabilityNames, request, remainingCapabilities } = getCapabilitiesToEnable(
     currentCapabilities,
-    entitlements
+    entitlements,
+    additionalOptions
   );
 
   const { disabledCapabilityNames, request: modifiedRequest } = getCapabilitiesToDisable(
@@ -127,7 +135,10 @@ interface CapabilitiesRequest {
 
 function getCapabilitiesToEnable(
   currentCapabilities: BundleIdCapability[],
-  entitlements: JSONObject
+  entitlements: JSONObject,
+  additionalOptions: {
+    usesBroadcastPushNotifications: boolean;
+  }
 ): {
   enabledCapabilityNames: string[];
   request: CapabilitiesRequest[];
@@ -156,7 +167,23 @@ function getCapabilitiesToEnable(
     // Only skip if the existing capability is a simple boolean value,
     // if it has more complex settings then we should always update it.
     // If the `existing.attributes.settings` object is defined, then we can determine that it has extra configuration.
-    if (existing && existing?.attributes.settings == null) {
+    // For push notifications, we should always update the capabaility if
+    // - settings are not defined in the existing capability, but usesBroadcastPushNotifications is enabled (we want to add settings for this capability)
+    // - settings are defined in the existing capability, but usesBroadcastPushNotifications is disabled (we want to remove settings for this capability)
+    const isPushNotificationsCapability =
+      staticCapabilityInfo.capability === CapabilityType.PUSH_NOTIFICATIONS;
+    const noSettingsAttributes = existing?.attributes.settings == null;
+    const hasBroadcastPushNotificationsDisabledBothLocalAndRemote =
+      !additionalOptions.usesBroadcastPushNotifications && noSettingsAttributes;
+    const hasBroadcastPushNotificationsEnabledBothLocalAndRemote =
+      additionalOptions.usesBroadcastPushNotifications && !noSettingsAttributes;
+    if (
+      existing &&
+      ((noSettingsAttributes && !isPushNotificationsCapability) ||
+        (isPushNotificationsCapability &&
+          (hasBroadcastPushNotificationsDisabledBothLocalAndRemote ||
+            hasBroadcastPushNotificationsEnabledBothLocalAndRemote)))
+    ) {
       // Remove the item from the list of capabilities so we don't disable it.
       remainingCapabilities.splice(existingIndex, 1);
       if (Log.isDebug) {
@@ -173,7 +200,7 @@ function getCapabilitiesToEnable(
 
     enabledCapabilityNames.push(staticCapabilityInfo.name);
 
-    const option = staticCapabilityInfo.getOptions(value, entitlements);
+    const option = staticCapabilityInfo.getOptions(value, entitlements, additionalOptions);
 
     request.push({
       capabilityType: staticCapabilityInfo.capability,
@@ -488,7 +515,15 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     entitlement: 'aps-environment',
     capability: CapabilityType.PUSH_NOTIFICATIONS,
     validateOptions: validateDevProdString,
-    getOptions: getDefinedOptions,
+    getOptions(entitlement, _entitlementsJson, { usesBroadcastPushNotifications }) {
+      Log.log('usesBroadcastPushNotifications', usesBroadcastPushNotifications);
+      const option = entitlement ? CapabilityTypeOption.ON : CapabilityTypeOption.OFF;
+      if (option === CapabilityTypeOption.ON && usesBroadcastPushNotifications) {
+        Log.log('Using broadcast push notifications');
+        return CapabilityTypePushNotificationsOption.PUSH_NOTIFICATION_FEATURE_BROADCAST;
+      }
+      return option;
+    },
   },
   {
     name: 'Wallet',

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -516,10 +516,8 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     capability: CapabilityType.PUSH_NOTIFICATIONS,
     validateOptions: validateDevProdString,
     getOptions(entitlement, _entitlementsJson, { usesBroadcastPushNotifications }) {
-      Log.log('usesBroadcastPushNotifications', usesBroadcastPushNotifications);
       const option = entitlement ? CapabilityTypeOption.ON : CapabilityTypeOption.OFF;
       if (option === CapabilityTypeOption.ON && usesBroadcastPushNotifications) {
-        Log.log('Using broadcast push notifications');
         return CapabilityTypePushNotificationsOption.PUSH_NOTIFICATION_FEATURE_BROADCAST;
       }
       return option;

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -12,6 +12,7 @@ import { ora } from '../../../ora';
 
 export interface IosCapabilitiesOptions {
   entitlements: JSONObject;
+  usesBroadcastPushNotifications: boolean;
 }
 
 export interface AppLookupParams {
@@ -93,7 +94,7 @@ export async function ensureBundleIdExistsWithNameAsync(
 
 export async function syncCapabilitiesAsync(
   bundleId: BundleId,
-  { entitlements }: IosCapabilitiesOptions
+  { entitlements, ...rest }: IosCapabilitiesOptions
 ): Promise<void> {
   const spinner = ora(`Syncing capabilities`).start();
 
@@ -105,7 +106,8 @@ export async function syncCapabilitiesAsync(
   try {
     const { enabled, disabled } = await syncCapabilitiesForEntitlementsAsync(
       bundleId,
-      entitlements
+      entitlements,
+      rest
     );
     const results =
       [buildMessage('Enabled', enabled), buildMessage('Disabled', disabled)]
@@ -119,7 +121,7 @@ export async function syncCapabilitiesAsync(
   }
 
   // Always run this after syncing the capabilities...
-  await syncCapabilityIdentifiersAsync(bundleId, { entitlements });
+  await syncCapabilityIdentifiersAsync(bundleId, { entitlements, ...rest });
 }
 
 const buildMessage = (title: string, items: string[]): string =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.3.tgz#171c257c0b07068f3ed47678cc1838d0119f1d1e"
-  integrity sha512-lra+cuWQblMvfzAQCMCwUqH7Gl9q1XjXh/jNuCLRZkaFNVyFiy/2M5+Oq+Lje2WKKUC3/CPH4FIxB9TGivSIAA==
+"@expo/apple-utils@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.4.tgz#387a8d1e5c5cd064416f0b9ebea12006e4291922"
+  integrity sha512-VFbfuljSDvjrgDYngs7tE1xNYpJOHpqOSdTFHF4d1Bl5jGcDE3KAfs0YzRVpVoEJ9blQAetInnk5R4YmUWyl8Q==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"
@@ -10783,10 +10783,10 @@ nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
 
-nanoid@3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
-  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+nanoid@3.3.8:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
+  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Companion to https://github.com/expo/expo/pull/32623 and https://github.com/expo/third-party/pull/113

https://exponent-internal.slack.com/archives/C02123T524U/p1728981742266059

We want to handle new broadcast push notifications option for push notifications capability

![Screenshot 2024-12-09 at 13.39.53.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9YRXgAETSTRMfjZ0IP35/a5d7010e-b1a8-41af-99b3-a7680f350f45.png)

It's a bit atypical because there's no way to enable it by using entitlement (this is how it works for the rest of the capabilities using options). I talked about it with @brentvatne and we decided to add a new field to the app config to manage this option `ios.usesBroadcastPushNotifications`.

# How

If `usesBroadcastPushNotifications` is `true` and push notification entitlement is set use the correct option for the push notification capability in Apple's API.

Make sure that we update the capability at the correct times:
- when the entitlement is present but the capability is disabled - enable it (with to without a new option, depending on whether it is set)
- when the entitlement is missing but the capability is enabled (with or without broadcast) - disable it
- when the entitlement is present, the capability is enabled, no options are set on the remote side, and `usesBroadcastPushNotifications` is true locally - add a new option for capability
- when the entitlement is present, the capability is enabled, the broadcast option is set on the remote side, and `usesBroadcastPushNotifications` is false - remove the option
-  when the entitlement is present, the capability is enabled, and broadcast is defined both locally and remotely - do nothing
- when the entitlement is present, the capability is enabled, broadcast is not used both locally and remotely - do nothing

https://github.com/expo/third-party/pull/113 is a part of this change and needs to be merged first + new version of a package needs to be published - for local testing I used linked version

# Test Plan

Test each of these cases manually in EAS CLI on the test project and confirm that the correct capabilities are turned on using Apple's developer portal
