### PR TITLE
fix SMS TFA for Apple authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Bump `@expo/apple-utils` to fix sending two-factor authentication codes via SMS. ([#2750](https://github.com/expo/eas-cli/pull/2750) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🧹 Chores
 
 - Change update message to allow faster copy and paste. ([#2661](https://github.com/expo/eas-cli/pull/2661) by [@jonluca](https://github.com/jonluca))

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "2.1.1",
+    "@expo/apple-utils": "2.1.2",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "10.0.6",
     "@expo/config-plugins": "9.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.1.tgz#28a19049d9232f516eee3b5563b002505195b123"
-  integrity sha512-upV16KyjrqSsUK2bxvyTeRyzqcMUyens+yx1TPo2SrtwglHpk/IpUwrNJ0XKNS/JqqrNwgTqcVSrEFNHGTCGhQ==
+"@expo/apple-utils@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.2.tgz#42db84e4fb6f49a08cd9397aeae558bf7b5fc97d"
+  integrity sha512-Z7zGwKBGvZLB00ARz5Z+ny98ikAKwtkYvzoHkSrV6S9pROdbROM2WmhyaZMkq76sjpVTaUAehngQQ/e1YBPHlg==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Apple changed their auth servers for the SMS endpoint to seemingly geotag sms requests to American devices. This caused the error "Verification codes can’t be sent to this phone number at this time. Please try again later." to be thrown when requesting two-factor authentication with an SMS device.

This PR, in addition to a few others, aims to align the API such that SMS codes can successfully be sent to American phone numbers. I can only verify 4 times every hour, so this may only partially fix the issue.

# Test Plan

`eas build -p ios` -> login -> Pick `sms` for the 2fa.