### PR TITLE
[eas-cli] bump @expo/apple-utils to add fyi link for apple 2fa sms failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add link to FYI page mentioning the workaround for Apple SMS 2FA issue. ([#2752](https://github.com/expo/eas-cli/pull/2752) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [14.0.3](https://github.com/expo/eas-cli/releases/tag/v14.0.3) - 2024-12-09
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "2.1.2",
+    "@expo/apple-utils": "2.1.3",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "10.0.6",
     "@expo/config-plugins": "9.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.2.tgz#42db84e4fb6f49a08cd9397aeae558bf7b5fc97d"
-  integrity sha512-Z7zGwKBGvZLB00ARz5Z+ny98ikAKwtkYvzoHkSrV6S9pROdbROM2WmhyaZMkq76sjpVTaUAehngQQ/e1YBPHlg==
+"@expo/apple-utils@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.3.tgz#171c257c0b07068f3ed47678cc1838d0119f1d1e"
+  integrity sha512-lra+cuWQblMvfzAQCMCwUqH7Gl9q1XjXh/jNuCLRZkaFNVyFiy/2M5+Oq+Lje2WKKUC3/CPH4FIxB9TGivSIAA==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://github.com/expo/third-party/pull/115 

https://exponent-internal.slack.com/archives/C017N0N99RA/p1733768696103679

bump apple utils to link to FYI page mentioning workaround for Apple 2fa SMS issues

# How

bump apple-utils

# Test Plan

tests