### PR TITLE
[ENG-14328] Pass environment to PublishMutation.publishUpdateGroupAsync

### DIFF
--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -494,6 +494,7 @@ export default class UpdatePublish extends EasCommand {
             gitCommitHash,
             isGitWorkingTreeDirty,
             awaitingCodeSigningInfo: !!codeSigningInfo,
+            environment: environment ?? null,
           };
         }
       );


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

[ENG-14328: store `environment` info on update entity](https://linear.app/expo/issue/ENG-14328/store-environment-info-on-update-entity)

Pass `environment` to `PublishMutation.publishUpdateGroupAsync` to store in the db.

Waits for changes on the `www`. https://github.com/expo/universe/pull/17921
