### PR TITLE
feat(eas-cli): Add `--dry-run` flag to `deploy` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `eas deploy --dry-run` flag to output tarball. ([#2761](https://github.com/expo/eas-cli/pull/2761) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 - Remove random branch name generation for --auto branch name non-vcs fallback. ([#2747](https://github.com/expo/eas-cli/pull/2747) by [@wschurman](https://github.com/wschurman))

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -275,10 +275,12 @@ export default class WorkerDeploy extends EasCommand {
       );
 
       if (flags.dryRun) {
-        const dryRunPath = 'deploy.tar.gz';
-        await fs.promises.copyFile(tarPath, dryRunPath);
+        const DRY_RUN_OUTPUT_PATH = 'deploy.tar.gz';
+        await fs.promises.copyFile(tarPath, DRY_RUN_OUTPUT_PATH);
         progress.succeed('Saved deploy.tar.gz tarball');
-        if (flags.json) printJsonOnlyOutput({ tarPath: dryRunPath });
+        if (flags.json) {
+          printJsonOnlyOutput({ tarPath: DRY_RUN_OUTPUT_PATH });
+        }
         return;
       }
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -43,6 +43,7 @@ interface DeployFlags {
   environment?: EnvironmentVariableEnvironment;
   deploymentIdentifier?: string;
   exportDir: string;
+  dryRun: boolean;
 }
 
 interface RawDeployFlags {
@@ -53,6 +54,7 @@ interface RawDeployFlags {
   alias?: string;
   id?: string;
   'export-dir': string;
+  'dry-run': boolean;
 }
 
 interface DeployInProgressParams {
@@ -89,6 +91,10 @@ export default class WorkerDeploy extends EasCommand {
       description: 'Directory where the Expo project was exported.',
       helpValue: 'dir',
       default: 'dist',
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Outputs a tarball of the new deployment instead of uploading it.',
+      default: false,
     }),
     environment: {
       ...EASEnvironmentFlag.environment,
@@ -268,6 +274,14 @@ export default class WorkerDeploy extends EasCommand {
         })
       );
 
+      if (flags.dryRun) {
+        const dryRunPath = 'deploy.tar.gz';
+        await fs.promises.copyFile(tarPath, dryRunPath);
+        progress.succeed('Saved deploy.tar.gz tarball');
+        if (flags.json) printJsonOnlyOutput({ tarPath: dryRunPath });
+        return;
+      }
+
       const uploadUrl = await getSignedDeploymentUrlAsync(graphqlClient, {
         appId: projectId,
         deploymentIdentifier: flags.deploymentIdentifier,
@@ -382,6 +396,7 @@ export default class WorkerDeploy extends EasCommand {
       aliasName: flags.alias?.trim().toLowerCase(),
       deploymentIdentifier: flags.id?.trim(),
       exportDir: flags['export-dir'],
+      dryRun: flags['dry-run'],
     };
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This outputs a tarball to `deploy.tar.gz` if the `--dry-run` flag is passed, skipping all other work.

# How

- Added flag
- Add early abort with `fs.promises.copyFile` run

# Test Plan

