### PR TITLE
[eas-cli] Add environment flag to deploy script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Remove random branch name generation for --auto branch name non-vcs fallback. ([#2747](https://github.com/expo/eas-cli/pull/2747) by [@wschurman](https://github.com/wschurman))
 - Upgrade @expo/multipart-body-parser. ([#2751](https://github.com/expo/eas-cli/pull/2751) by [@wschurman](https://github.com/wschurman))
+- Pass env var flag to worker deployments. ([#2763](https://github.com/expo/eas-cli/pull/2763) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -47,7 +47,7 @@ interface DeployFlags {
 
 interface RawDeployFlags {
   'non-interactive': boolean;
-  environment?: string;
+  environment?: EnvironmentVariableEnvironment;
   json: boolean;
   prod: boolean;
   alias?: string;
@@ -90,10 +90,7 @@ export default class WorkerDeploy extends EasCommand {
       helpValue: 'dir',
       default: 'dist',
     }),
-    environment: {
-      ...EASEnvironmentFlag.environment,
-      description: 'Deploy with EAS Environment Variables matching the specified environment.',
-    },
+    ...EASEnvironmentFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
 
@@ -382,6 +379,7 @@ export default class WorkerDeploy extends EasCommand {
       aliasName: flags.alias?.trim().toLowerCase(),
       deploymentIdentifier: flags.id?.trim(),
       exportDir: flags['export-dir'],
+      environment: flags['environment'],
     };
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The `--environment` flag was getting sanitised out of the flags so it was always `undefined`.

# How

Added the `environment` flag to `sanitizeFlags`.
Also switched to using the shared `EASEnvironmentFlag` which does additional validation and transforms the flag to uppercase.

# Test Plan

Tested locally that `easd deploy --environment production` includes env vars in api routes.
