### PR TITLE
Support pushing existing secret and sensitive variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Show `eas deploy` upload error messages. ([#2771](https://github.com/expo/eas-cli/pull/2771) by [@kadikraman](https://github.com/kadikraman))
 - Prevent EAS CLI dependencies check from running repeatedly. ([#2781](https://github.com/expo/eas-cli/pull/2781) by [@kitten](https://github.com/kitten))
 - Prevent optimistic request body parsing for `eas deploy`. ([#2784](https://github.com/expo/eas-cli/pull/2784) by [@kadikraman](https://github.com/kadikraman))
+- Support pushing existing secret and sensitive environment variables. ([#2765](https://github.com/expo/eas-cli/pull/2765) by [@khamilowicz](https://github.com/khamilowicz))
 
 ### 🧹 Chores
 


### PR DESCRIPTION
# Why

[ENG-14486: Support updating secret variables with `eas env:push`](https://linear.app/expo/issue/ENG-14486/support-updating-secret-vars-with-eas-envpush)

https://github.com/expo/eas-cli/issues/2753

Currently, we don't support adding secrets using the `eas env:push` command. However, this behavior conflicts with the legacy `eas secrets:push` command, forcing some users to either convert their secrets to public variables or prefix them with `EXPO_SENSITIVE`. This pull request addresses this issue by enabling users to update existing secret or sensitive variables without any additional work.

Additionally, the `--force` option has been added to skip prompts.

Also, an unintended behavior has been fixed: pushing variables would overwrite the existing `environments` field of eas variables instead of appending to it. If a user has defined a variable in multiple environments and then pushes it to just one, the variable will only be linked to that specific environment.

# How

* A boolean `force` flag has been added.
* If a variable from the `.env` file is already present in `eas`, its `visibility` and `environments` are preserved.

# Test Plan

Tested manually