### PR TITLE
[eas-cli] show deployment errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Show `eas deploy` upload error messages. ([#2771](https://github.com/expo/eas-cli/pull/2771) by [@kadikraman](https://github.com/kadikraman))
+
 ### 🧹 Chores
 
 ## [14.2.0](https://github.com/expo/eas-cli/releases/tag/v14.2.0) - 2024-12-13
@@ -24,7 +26,6 @@ This is the log of notable changes to EAS CLI and related packages.
 - Upgrade @expo/multipart-body-parser. ([#2751](https://github.com/expo/eas-cli/pull/2751) by [@wschurman](https://github.com/wschurman))
 - Pass env var flag to worker deployments. ([#2763](https://github.com/expo/eas-cli/pull/2763) by [@kadikraman](https://github.com/kadikraman))
 - Fix request for switching providers when doing Apple auth. ([#2769](https://github.com/expo/eas-cli/pull/2769) by [@szdziedzic](https://github.com/szdziedzic))
-- Show upload error message.
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Remove random branch name generation for --auto branch name non-vcs fallback. ([#2747](https://github.com/expo/eas-cli/pull/2747) by [@wschurman](https://github.com/wschurman))
 - Upgrade @expo/multipart-body-parser. ([#2751](https://github.com/expo/eas-cli/pull/2751) by [@wschurman](https://github.com/wschurman))
 - Pass env var flag to worker deployments. ([#2763](https://github.com/expo/eas-cli/pull/2763) by [@kadikraman](https://github.com/kadikraman))
+- Show upload error message.
 
 ### 🧹 Chores
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The error messages from `403` upload error were not being shown in the terminal.

# How

Extract the error message from `403` errors and show to the user when applicable.

# Test Plan

Tested locally by uploading a build with 100+ assets.

<details>
<summary>
Before / After
</summary>

### Before
<img width="1135" alt="Screenshot 2024-12-13 at 11 47 08" src="https://github.com/user-attachments/assets/6be8e481-bdbf-4b8f-ab27-74b64441871e" />


### After
<img width="1275" alt="Screenshot 2024-12-13 at 15 37 55" src="https://github.com/user-attachments/assets/c07f5d72-d1dc-4859-88c4-ef01a030f0ac" />
</details>



