### PR TITLE
ENG-14518 Add keystoreName field to build profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add `eas deploy --dry-run` flag to output tarball. ([#2761](https://github.com/expo/eas-cli/pull/2761) by [@kitten](https://github.com/kitten))
+- Allow specifying credentials for android builds. ([#2775](https://github.com/expo/eas-cli/pull/2775) by [@khamilowicz](https://github.com/khamilowicz))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -151,6 +151,7 @@ async function ensureAndroidCredentialsAsync(
     ctx.android.gradleContext
   );
   const provider = new AndroidCredentialsProvider(ctx.credentialsCtx, {
+    name: ctx.buildProfile.keystoreName,
     app: {
       account: nullthrows(
         ctx.user.accounts.find(a => a.name === ctx.accountName),

--- a/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/android/AndroidCredentialsProvider.ts
@@ -15,6 +15,7 @@ export interface AndroidCredentials {
 
 interface Options {
   app: AppLookupParams;
+  name?: string;
 }
 
 export default class AndroidCredentialsProvider {
@@ -37,7 +38,7 @@ export default class AndroidCredentialsProvider {
   }
 
   private async getRemoteAsync(): Promise<AndroidCredentials> {
-    const setupBuildCredentialsAction = new SetUpBuildCredentials({ app: this.options.app });
+    const setupBuildCredentialsAction = new SetUpBuildCredentials(this.options);
     const buildCredentials = await setupBuildCredentialsAction.runAsync(this.ctx);
     return this.toAndroidCredentials(buildCredentials);
   }

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -129,6 +129,33 @@ test('valid eas.json with specified environment', async () => {
   });
 });
 
+test('valid eas.json with specified keystoreName', async () => {
+  const keystoreName = 'this-is-a-keystore-name';
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      development: {
+        android: {
+          credentialsSource: 'remote',
+          keystoreName,
+        },
+      },
+    },
+  });
+
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
+  const androidProfile = await EasJsonUtils.getBuildProfileAsync(
+    accessor,
+    Platform.ANDROID,
+    'development'
+  );
+
+  expect(androidProfile).toEqual(
+    expect.objectContaining({
+      keystoreName,
+    })
+  );
+});
+
 test('valid eas.json with top level withoutCredentials property', async () => {
   await fs.writeJson('/project/eas.json', {
     build: {

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -101,6 +101,14 @@ const AndroidBuildProfileSchema = PlatformBuildProfileSchema.concat(
       Joi.boolean(),
       Joi.string().valid('version', 'versionCode')
     ),
+
+    keystoreName: Joi.when('credentialsSource', {
+      is: 'remote',
+      then: Joi.string(),
+      otherwise: Joi.forbidden().messages({
+        'any.unknown': 'keystoreName is not allowed when credentialsSource is not remote',
+      }),
+    }),
   })
 );
 

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -93,6 +93,8 @@ export interface AndroidBuildProfile extends PlatformBuildProfile {
 
   // versions
   autoIncrement?: AndroidVersionAutoIncrement;
+
+  keystoreName?: string;
 }
 
 export interface IosBuildProfile extends PlatformBuildProfile {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

[ENG-14518: Add `keystoreName` field to build profile to allow selecting/creating named keystore to use for a build](https://linear.app/expo/issue/ENG-14518/add-keystorename-field-to-build-profile-to-allow-selectingcreating)

Allow specifying keystore name of credentials to be used with a build.

# How

* Added `keystoreName` to eas.json schema
* Pass `name` option to `AndroidCredentialsProvider`

# Test Plan

Added test, tested manually.

1. Create a new android credentials with `eas credentials`
2. Specify `keystoreName` in build profile in `eas.json`
3. Ensure that it works only for android builds
4. Ensure it works only for `remote` `credentialsSource`
5. Ensure that the correct credentials are used

<img width="326" alt="image" src="https://github.com/user-attachments/assets/1245c459-5fa1-4253-b5fc-bdf7a68b814a" />

<img width="628" alt="image" src="https://github.com/user-attachments/assets/5bca4cf7-c895-462c-b527-ef37ce659aca" />

