### PR TITLE
Move environment from metadata to job object

### DIFF
--- a/packages/eas-cli/src/build/android/graphql.ts
+++ b/packages/eas-cli/src/build/android/graphql.ts
@@ -8,6 +8,7 @@ import {
   transformProjectArchive,
   transformWorkflow,
 } from '../graphql';
+import { buildProfileEnvironmentToEnvironment } from '../utils/environment';
 
 export function transformJob(job: Android.Job): AndroidJobInput {
   return {
@@ -29,6 +30,7 @@ export function transformJob(job: Android.Job): AndroidJobInput {
     experimental: job.experimental,
     mode: transformBuildMode(job.mode),
     customBuildConfig: job.customBuildConfig,
+    environment: buildProfileEnvironmentToEnvironment(job.environment),
     loggerLevel: job.loggerLevel
       ? loggerLevelToGraphQLWorkerLoggerLevel[job.loggerLevel]
       : undefined,

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -92,6 +92,7 @@ export async function prepareJobAsync(
     gradleCommand: buildProfile.gradleCommand,
     applicationArchivePath: buildProfile.applicationArchivePath ?? buildProfile.artifactPath,
     buildArtifactPaths: buildProfile.buildArtifactPaths,
+    environment: ctx.buildProfile.environment,
     buildType,
     username,
     ...(ctx.android.versionCodeOverride && {

--- a/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
+++ b/packages/eas-cli/src/build/evaluateConfigWithEnvVarsAsync.ts
@@ -1,16 +1,11 @@
 import { Env } from '@expo/eas-build-job';
 import { BuildProfile } from '@expo/eas-json';
 
+import { isEnvironment } from './utils/environment';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { EnvironmentVariableEnvironment } from '../graphql/generated';
 import { EnvironmentVariablesQuery } from '../graphql/queries/EnvironmentVariablesQuery';
 import Log, { learnMore } from '../log';
-
-function isEnvironment(env: string): env is EnvironmentVariableEnvironment {
-  return Object.values(EnvironmentVariableEnvironment).includes(
-    env as EnvironmentVariableEnvironment
-  );
-}
 
 export async function evaluateConfigWithEnvVarsAsync<Config extends { projectId: string }, Opts>({
   buildProfile,

--- a/packages/eas-cli/src/build/ios/graphql.ts
+++ b/packages/eas-cli/src/build/ios/graphql.ts
@@ -9,6 +9,7 @@ import {
   transformProjectArchive,
   transformWorkflow,
 } from '../graphql';
+import { buildProfileEnvironmentToEnvironment } from '../utils/environment';
 
 export function transformJob(job: Ios.Job): IosJobInput {
   return {
@@ -31,6 +32,7 @@ export function transformJob(job: Ios.Job): IosJobInput {
     experimental: job.experimental,
     mode: transformBuildMode(job.mode),
     customBuildConfig: job.customBuildConfig,
+    environment: buildProfileEnvironmentToEnvironment(job.environment),
     loggerLevel: job.loggerLevel
       ? loggerLevelToGraphQLWorkerLoggerLevel[job.loggerLevel]
       : undefined,

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -88,6 +88,7 @@ export async function prepareJobAsync(
     buildConfiguration: buildProfile.buildConfiguration,
     applicationArchivePath: buildProfile.applicationArchivePath ?? buildProfile.artifactPath,
     buildArtifactPaths: buildProfile.buildArtifactPaths,
+    environment: ctx.buildProfile.environment,
     username,
     ...(ctx.ios.buildNumberOverride && {
       version: {

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -62,7 +62,6 @@ export async function collectMetadataAsync<T extends Platform>(
     requiredPackageManager: ctx.requiredPackageManager ?? undefined,
     selectedImage: ctx.buildProfile.image,
     customNodeVersion: ctx.buildProfile.node,
-    environment: ctx.buildProfile.environment,
     simulator: 'simulator' in ctx.buildProfile && ctx.buildProfile.simulator,
   };
   return sanitizeMetadata(metadata);

--- a/packages/eas-cli/src/build/utils/environment.ts
+++ b/packages/eas-cli/src/build/utils/environment.ts
@@ -1,0 +1,26 @@
+import { BuildProfile } from '@expo/eas-json';
+
+import { EnvironmentVariableEnvironment } from '../../graphql/generated';
+
+type Environment = NonNullable<BuildProfile['environment']>;
+
+const BuildProfileEnvironmentToEnvironment: Record<Environment, EnvironmentVariableEnvironment> = {
+  production: EnvironmentVariableEnvironment.Production,
+  preview: EnvironmentVariableEnvironment.Preview,
+  development: EnvironmentVariableEnvironment.Development,
+};
+
+export function isEnvironment(env: string): env is EnvironmentVariableEnvironment {
+  return Object.values(EnvironmentVariableEnvironment).includes(
+    env as EnvironmentVariableEnvironment
+  );
+}
+
+export function buildProfileEnvironmentToEnvironment(
+  environment: BuildProfile['environment']
+): EnvironmentVariableEnvironment | null {
+  if (!environment) {
+    return null;
+  }
+  return BuildProfileEnvironmentToEnvironment[environment];
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1090,6 +1090,7 @@ export type AndroidJobInput = {
   cache?: InputMaybe<BuildCacheInput>;
   customBuildConfig?: InputMaybe<CustomBuildConfigInput>;
   developmentClient?: InputMaybe<Scalars['Boolean']['input']>;
+  environment?: InputMaybe<EnvironmentVariableEnvironment>;
   experimental?: InputMaybe<Scalars['JSONObject']['input']>;
   gradleCommand?: InputMaybe<Scalars['String']['input']>;
   loggerLevel?: InputMaybe<WorkerLoggerLevel>;
@@ -1601,6 +1602,7 @@ export type AppUpdatesArgs = {
 export type AppUpdatesPaginatedArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<UpdateFilterInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -2902,7 +2904,7 @@ export type BuildArtifacts = {
   applicationArchiveUrl?: Maybe<Scalars['String']['output']>;
   buildArtifactsUrl?: Maybe<Scalars['String']['output']>;
   buildUrl?: Maybe<Scalars['String']['output']>;
-  /** @deprecated Use 'runtime.fingerprintDebugInfoUrl' instead. */
+  /** @deprecated Use 'runtime.fingerprint.debugInfoUrl' instead. */
   fingerprintUrl?: Maybe<Scalars['String']['output']>;
   xcodeBuildLogsUrl?: Maybe<Scalars['String']['output']>;
 };
@@ -2933,6 +2935,7 @@ export type BuildFilter = {
   appVersion?: InputMaybe<Scalars['String']['input']>;
   buildProfile?: InputMaybe<Scalars['String']['input']>;
   channel?: InputMaybe<Scalars['String']['input']>;
+  developmentClient?: InputMaybe<Scalars['Boolean']['input']>;
   distribution?: InputMaybe<DistributionType>;
   fingerprintHash?: InputMaybe<Scalars['String']['input']>;
   gitCommitHash?: InputMaybe<Scalars['String']['input']>;
@@ -4384,6 +4387,7 @@ export enum GitHubAppEnvironment {
 
 export type GitHubAppInstallation = {
   __typename?: 'GitHubAppInstallation';
+  /** The Expo account that owns the installation entity. */
   account: Account;
   actor?: Maybe<Actor>;
   id: Scalars['ID']['output'];
@@ -4403,10 +4407,17 @@ export type GitHubAppInstallationAccessibleRepository = {
   url: Scalars['String']['output'];
 };
 
+export enum GitHubAppInstallationAccountType {
+  Organization = 'ORGANIZATION',
+  User = 'USER'
+}
+
 export type GitHubAppInstallationMetadata = {
   __typename?: 'GitHubAppInstallationMetadata';
   githubAccountAvatarUrl?: Maybe<Scalars['String']['output']>;
+  /** The login of the GitHub account that owns the installation. Not the display name. */
   githubAccountName?: Maybe<Scalars['String']['output']>;
+  githubAccountType?: Maybe<GitHubAppInstallationAccountType>;
   installationStatus: GitHubAppInstallationStatus;
 };
 
@@ -5050,6 +5061,7 @@ export type IosJobInput = {
   developmentClient?: InputMaybe<Scalars['Boolean']['input']>;
   /** @deprecated */
   distribution?: InputMaybe<DistributionType>;
+  environment?: InputMaybe<EnvironmentVariableEnvironment>;
   experimental?: InputMaybe<Scalars['JSONObject']['input']>;
   loggerLevel?: InputMaybe<WorkerLoggerLevel>;
   mode?: InputMaybe<BuildMode>;
@@ -5744,7 +5756,6 @@ export type PublishUpdateGroupInput = {
   message?: InputMaybe<Scalars['String']['input']>;
   rollBackToEmbeddedInfoGroup?: InputMaybe<UpdateRollBackToEmbeddedGroup>;
   rolloutInfoGroup?: InputMaybe<UpdateRolloutInfoGroup>;
-  runtimeFingerprintSource?: InputMaybe<FingerprintSourceInput>;
   runtimeVersion: Scalars['String']['input'];
   turtleJobRunId?: InputMaybe<Scalars['String']['input']>;
   updateInfoGroup?: InputMaybe<UpdateInfoGroup>;
@@ -6182,7 +6193,7 @@ export type Runtime = {
   builds: AppBuildsConnection;
   createdAt: Scalars['DateTime']['output'];
   deployments: DeploymentsConnection;
-  fingerprintDebugInfoUrl?: Maybe<Scalars['String']['output']>;
+  fingerprint?: Maybe<Fingerprint>;
   firstBuildCreatedAt?: Maybe<Scalars['DateTime']['output']>;
   id: Scalars['ID']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -6982,6 +6993,12 @@ export type UpdateEnvironmentVariableInput = {
   type?: InputMaybe<EnvironmentSecretType>;
   value?: InputMaybe<Scalars['String']['input']>;
   visibility?: InputMaybe<EnvironmentVariableVisibility>;
+};
+
+export type UpdateFilterInput = {
+  fingerprintHash?: InputMaybe<Scalars['String']['input']>;
+  hasFingerprint?: InputMaybe<Scalars['Boolean']['input']>;
+  runtimeVersion?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateGitHubBuildTriggerInput = {
@@ -8499,6 +8516,7 @@ export type WorkflowRunMutationCreateWorkflowRunArgs = {
 
 
 export type WorkflowRunMutationRetryWorkflowRunArgs = {
+  fromFailedJobs?: InputMaybe<Scalars['Boolean']['input']>;
   workflowRunId: Scalars['ID']['input'];
 };
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

[ENG-14307: move environment to job object from metadata](https://linear.app/expo/issue/ENG-14307/move-environment-to-job-object-from-metadata)

`Environment` should be considering  a first class citizen in job object instead of being stored in the metadata.

# How

* Pass `environment` in `job` object
* remove `environment` from `metadata`.

# Test Plan

1. Start a build specifying `environment` in `eas.json`.
2. Build should use the specified environment (check on website in `Build details`)
