### PR TITLE
[eas-cli] support platform version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Added support to read platform version from `app.json`. ([#2778](https://github.com/expo/eas-cli/pull/2778) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 - Show `eas deploy` upload error messages. ([#2771](https://github.com/expo/eas-cli/pull/2771) by [@kadikraman](https://github.com/kadikraman))

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -20,7 +20,11 @@ import { getNextVersionCode } from '../../project/android/versions';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { Client } from '../../vcs/vcs';
 import { updateAppJsonConfigAsync } from '../utils/appJson';
-import { bumpAppVersionAsync, ensureStaticConfigExists } from '../utils/version';
+import {
+  bumpAppVersionAsync,
+  ensureStaticConfigExists,
+  getVersionConfigTarget,
+} from '../utils/version';
 
 export enum BumpStrategy {
   APP_VERSION,
@@ -53,9 +57,11 @@ export async function bumpVersionAsync({
 
   await bumpVersionInAppJsonAsync({ bumpStrategy, projectDir, exp });
   Log.log('Updated versions in app.json');
+  const { versionGetter } = getVersionConfigTarget({ exp, platform: Platform.ANDROID });
+  const version = versionGetter(exp);
   await updateNativeVersionsAsync({
     projectDir,
-    version: exp.version,
+    version,
     versionCode: exp.android?.versionCode,
   });
   Log.log('Synchronized versions with build gradle');
@@ -79,7 +85,7 @@ export async function bumpVersionInAppJsonAsync({
 
   if (bumpStrategy === BumpStrategy.APP_VERSION) {
     const appVersion = AndroidConfig.Version.getVersionName(exp) ?? '1.0.0';
-    await bumpAppVersionAsync({ appVersion, projectDir, exp });
+    await bumpAppVersionAsync({ appVersion, projectDir, exp, platform: Platform.ANDROID });
   } else {
     const versionCode = AndroidConfig.Version.getVersionCode(exp);
     const bumpedVersionCode = getNextVersionCode(versionCode);
@@ -118,9 +124,11 @@ export async function maybeResolveVersionsAsync(
       return {};
     }
   } else {
+    const { versionGetter } = getVersionConfigTarget({ exp, platform: Platform.ANDROID });
+    const appVersion = versionGetter(exp);
     return {
       appBuildVersion: String(AndroidConfig.Version.getVersionCode(exp)),
-      appVersion: exp.version,
+      appVersion,
     };
   }
 }
@@ -202,6 +210,7 @@ export async function resolveRemoteVersionCodeAsync(
     applicationId
   );
 
+  const { versionGetter } = getVersionConfigTarget({ exp, platform: Platform.ANDROID });
   const localVersions = await maybeResolveVersionsAsync(projectDir, exp, buildProfile, vcsClient);
   let currentBuildVersion: string;
   if (remoteVersions?.buildVersion) {
@@ -230,7 +239,7 @@ export async function resolveRemoteVersionCodeAsync(
         appId: projectId,
         platform: AppPlatform.Android,
         applicationIdentifier: applicationId,
-        storeVersion: localVersions.appVersion ?? exp.version ?? '1.0.0',
+        storeVersion: localVersions.appVersion ?? versionGetter(exp) ?? '1.0.0',
         buildVersion: currentBuildVersion,
         runtimeVersion:
           (await Updates.getRuntimeVersionNullableAsync(projectDir, exp, Platform.ANDROID)) ??
@@ -254,7 +263,7 @@ export async function resolveRemoteVersionCodeAsync(
         appId: projectId,
         platform: AppPlatform.Android,
         applicationIdentifier: applicationId,
-        storeVersion: localVersions.appVersion ?? exp.version ?? '1.0.0',
+        storeVersion: localVersions.appVersion ?? versionGetter(exp) ?? '1.0.0',
         buildVersion: String(nextBuildVersion),
         runtimeVersion:
           (await Updates.getRuntimeVersionNullableAsync(projectDir, exp, Platform.ANDROID)) ??

--- a/packages/eas-cli/src/build/utils/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/utils/__tests__/version-test.ts
@@ -1,0 +1,147 @@
+import { bumpAppVersionAsync, getVersionConfigTarget } from '../version';
+import { ExpoConfig } from '@expo/config';
+import { Platform } from '@expo/eas-build-job';
+import { updateAppJsonConfigAsync } from '../appJson';
+
+jest.mock('../appJson', () => ({
+  __esModule: true,
+  updateAppJsonConfigAsync: jest.fn().mockImplementation(
+    async (
+      {
+        exp,
+      }: {
+        projectDir: string;
+        exp: ExpoConfig;
+      },
+      modifyConfig: (config: any) => void
+    ) => {
+      // a mocked implementation that only mutates the config object without writing to disk
+      modifyConfig(exp);
+    }
+  ),
+}));
+
+describe(bumpAppVersionAsync, () => {
+  const name = 'test';
+  const slug = 'test';
+  const projectDir = '/app';
+  const mockUpdateAppJsonConfigAsync = updateAppJsonConfigAsync as jest.MockedFunction<
+    typeof updateAppJsonConfigAsync
+  >;
+
+  it('should bump expo.version for valid semver', async () => {
+    const appVersion = '1.0.0';
+    const exp: ExpoConfig = {
+      name,
+      slug,
+      version: appVersion,
+    };
+
+    await bumpAppVersionAsync({ appVersion, projectDir, exp, platform: Platform.IOS });
+    expect(mockUpdateAppJsonConfigAsync).toHaveBeenCalled();
+    expect(exp.version).toBe('1.0.1');
+  });
+
+  it('should bump expo.android.version if the expo.android.version exists', async () => {
+    const exp: ExpoConfig = {
+      name,
+      slug,
+      version: '0.0.0',
+      android: {
+        // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+        version: '1.0.0',
+      },
+      ios: {
+        // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+        version: '2.0.0',
+      },
+    };
+
+    await bumpAppVersionAsync({ appVersion: '1.0.0', projectDir, exp, platform: Platform.ANDROID });
+    expect(mockUpdateAppJsonConfigAsync).toHaveBeenCalled();
+    expect(exp.version).toBe('0.0.0');
+    // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+    expect(exp.android.version).toBe('1.0.1');
+    // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+    expect(exp.ios.version).toBe('2.0.0');
+  });
+
+  it('should bump expo.ios.version if the expo.ios.version exists', async () => {
+    const exp: ExpoConfig = {
+      name,
+      slug,
+      version: '0.0.0',
+      android: {
+        // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+        version: '1.0.0',
+      },
+      ios: {
+        // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+        version: '2.0.0',
+      },
+    };
+
+    await bumpAppVersionAsync({ appVersion: '2.0.0', projectDir, exp, platform: Platform.IOS });
+    expect(mockUpdateAppJsonConfigAsync).toHaveBeenCalled();
+    expect(exp.version).toBe('0.0.0');
+    // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+    expect(exp.android.version).toBe('1.0.0');
+    // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+    expect(exp.ios.version).toBe('2.0.1');
+  });
+});
+
+describe(getVersionConfigTarget, () => {
+  const exp: ExpoConfig = {
+    name: 'test',
+    slug: 'test',
+    version: '0.0.0',
+    android: {
+      // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+      version: '1.0.0',
+    },
+    ios: {
+      // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+      version: '2.0.0',
+    },
+  };
+
+  it('should return the correct config target for the android platform', () => {
+    const { fieldName, versionGetter, versionUpdater } = getVersionConfigTarget({
+      exp,
+      platform: Platform.ANDROID,
+    });
+    expect(fieldName).toBe('expo.android.version');
+    expect(versionGetter(exp)).toBe('1.0.0');
+    // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+    expect(versionUpdater(exp, '3.3.3').android.version).toBe('3.3.3');
+    expect(versionUpdater(exp, '0.0.0').version).toBe('0.0.0');
+  });
+
+  it('should return the correct config target for the ios platform', () => {
+    const { fieldName, versionGetter, versionUpdater } = getVersionConfigTarget({
+      exp,
+      platform: Platform.IOS,
+    });
+    expect(fieldName).toBe('expo.ios.version');
+    expect(versionGetter(exp)).toBe('2.0.0');
+    // @ts-expect-error: Resolve type errors after upgrading `@expo/config`
+    expect(versionUpdater(exp, '3.3.3').ios.version).toBe('3.3.3');
+    expect(versionUpdater(exp, '0.0.0').version).toBe('0.0.0');
+  });
+
+  it('should return the correct config target for common version', () => {
+    const exp: ExpoConfig = {
+      name: 'test',
+      slug: 'test',
+      version: '0.0.0',
+    };
+    const { fieldName, versionGetter, versionUpdater } = getVersionConfigTarget({
+      exp,
+      platform: Platform.IOS,
+    });
+    expect(fieldName).toBe('expo.version');
+    expect(versionGetter(exp)).toBe('0.0.0');
+    expect(versionUpdater(exp, '3.3.3').version).toBe('3.3.3');
+  });
+});

--- a/packages/eas-cli/src/build/utils/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/utils/__tests__/version-test.ts
@@ -1,7 +1,8 @@
-import { bumpAppVersionAsync, getVersionConfigTarget } from '../version';
 import { ExpoConfig } from '@expo/config';
 import { Platform } from '@expo/eas-build-job';
+
 import { updateAppJsonConfigAsync } from '../appJson';
+import { bumpAppVersionAsync, getVersionConfigTarget } from '../version';
 
 jest.mock('../appJson', () => ({
   __esModule: true,

--- a/packages/eas-cli/src/build/utils/version.ts
+++ b/packages/eas-cli/src/build/utils/version.ts
@@ -1,8 +1,8 @@
 import { ExpoConfig, getConfigFilePaths } from '@expo/config';
+import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 import semver from 'semver';
-import { Platform } from '@expo/eas-build-job';
 
 import { updateAppJsonConfigAsync } from './appJson';
 import Log from '../../log';

--- a/packages/eas-cli/src/commands/build/version/set.ts
+++ b/packages/eas-cli/src/commands/build/version/set.ts
@@ -5,6 +5,7 @@ import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
 import { evaluateConfigWithEnvVarsAsync } from '../../../build/evaluateConfigWithEnvVarsAsync';
+import { getVersionConfigTarget } from '../../../build/utils/version';
 import EasCommand from '../../../commandUtils/EasCommand';
 import { AppVersionMutation } from '../../../graphql/mutations/AppVersionMutation';
 import { AppVersionQuery } from '../../../graphql/queries/AppVersionQuery';
@@ -111,6 +112,7 @@ export default class BuildVersionSetView extends EasCommand {
       : `What version would you like to initialize it with?`;
     Log.log(currentStateMessage);
 
+    const { versionGetter } = getVersionConfigTarget({ exp, platform });
     const { version } = await promptAsync({
       type: platform === Platform.ANDROID ? 'number' : 'text',
       name: 'version',
@@ -124,7 +126,7 @@ export default class BuildVersionSetView extends EasCommand {
       appId: projectId,
       platform: toAppPlatform(platform),
       applicationIdentifier,
-      storeVersion: exp.version ?? '1.0.0',
+      storeVersion: versionGetter(exp) ?? '1.0.0',
       buildVersion: String(version),
       runtimeVersion:
         (await getRuntimeVersionNullableAsync(projectDir, exp, platform)) ?? undefined,


### PR DESCRIPTION
# Why

support platform version from https://github.com/expo/expo/pull/33637 to eas-cli

# How

- introduced `getVersionConfigTarget` to get related version field, value, and updater.
- replace all fixed `exp.version` to use `getVersionConfigTarget`

# Test Plan

add unit test for `getVersionConfigTarget` and `bumpAppVersionAsync`