### PR TITLE
[eas-cli] Combine `.env` and EAS environment variables for `deploy` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Load `.env` variables even when `--environment` is specified for `deploy` command. Conflicts will be highlighted by a warning message. ([#2783](https://github.com/expo/eas-cli/pull/2783) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -14,7 +14,7 @@
     "@expo/config-plugins": "9.0.12",
     "@expo/eas-build-job": "1.0.156",
     "@expo/eas-json": "14.3.1",
-    "@expo/env": "^0.4.0",
+    "@expo/env": "^1.0.0",
     "@expo/json-file": "8.3.3",
     "@expo/logger": "1.0.117",
     "@expo/multipart-body-parser": "2.0.0",

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -263,9 +263,9 @@ export default class WorkerDeploy extends EasCommand {
       );
       if (manifestResult.conflictingVariableNames?.length) {
         Log.warn(
-          '> The following environment variables were loaded both from local .env files as well as EAS environment variables, '
-            + ' and will be set to the EAS environment variable values instead: '
-            + manifestResult.conflictingVariableNames.join(' '),
+          '> The following environment variables were loaded both from local .env files as well as EAS environment variables, ' +
+            ' and will be set to the EAS environment variable values instead: ' +
+            manifestResult.conflictingVariableNames.join(' ')
         );
       }
       assetMap = await WorkerAssets.createAssetMapAsync(

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -263,8 +263,8 @@ export default class WorkerDeploy extends EasCommand {
       );
       if (manifestResult.conflictingVariableNames?.length) {
         Log.warn(
-          '> The following environment variables were loaded both from local .env files as well as EAS environment variables, ' +
-            ' and will be set to the EAS environment variable values instead: ' +
+          '> The following environment variables were present in local .env files as well as EAS environment variables. ' +
+            'In case of conflict, the EAS environment variable values will be used: ' +
             manifestResult.conflictingVariableNames.join(' ')
         );
       }

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -253,7 +253,7 @@ export default class WorkerDeploy extends EasCommand {
     let progress = ora('Preparing project').start();
 
     try {
-      const manifest = await WorkerAssets.createManifestAsync(
+      const manifestResult = await WorkerAssets.createManifestAsync(
         {
           environment: flags.environment,
           projectDir,
@@ -261,13 +261,20 @@ export default class WorkerDeploy extends EasCommand {
         },
         graphqlClient
       );
+      if (manifestResult.conflictingVariableNames?.length) {
+        Log.warn(
+          '> The following environment variables were loaded both from local .env files as well as EAS environment variables, '
+            + ' and will be set to the EAS environment variable values instead: '
+            + manifestResult.conflictingVariableNames.join(' '),
+        );
+      }
       assetMap = await WorkerAssets.createAssetMapAsync(
         projectDist.type === 'server' ? projectDist.clientPath : projectDist.path
       );
       tarPath = await WorkerAssets.packFilesIterableAsync(
         emitWorkerTarballAsync({
           assetMap,
-          manifest,
+          manifest: manifestResult.manifest,
         })
       );
 

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -1,4 +1,4 @@
-import { get as getEnv } from '@expo/env';
+import { parseProjectEnv } from '@expo/env';
 import { Gzip, GzipOptions } from 'minizlib';
 import { HashOptions, createHash, randomBytes } from 'node:crypto';
 import fs, { createWriteStream } from 'node:fs';
@@ -114,10 +114,8 @@ export async function createManifestAsync(
   params: CreateManifestParams,
   graphqlClient: ExpoGraphqlClient
 ): Promise<CreateManifestResult> {
-  // NOTE: This is required for the .env resolution
-  process.env.NODE_ENV = 'production';
   // Resolve .env file variables
-  const env: Record<string, string | undefined> = getEnv(params.projectDir).env;
+  const { env } = parseProjectEnv(params.projectDir, { mode: 'production' });
   // Maybe load EAS Environment Variables (based on `--environment` arg)
   let conflictingVariableNames: string[] | undefined;
   if (params.environment) {

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -98,6 +98,11 @@ export interface Manifest {
   env: Record<string, string | undefined>;
 }
 
+export interface CreateManifestResult {
+  conflictingVariableNames: string[] | undefined;
+  manifest: Manifest;
+}
+
 interface CreateManifestParams {
   projectId: string;
   projectDir: string;
@@ -108,23 +113,31 @@ interface CreateManifestParams {
 export async function createManifestAsync(
   params: CreateManifestParams,
   graphqlClient: ExpoGraphqlClient
-): Promise<Manifest> {
-  let env: Record<string, string | undefined>;
+): Promise<CreateManifestResult> {
+  // NOTE: This is required for the .env resolution
+  process.env.NODE_ENV = 'production';
+  // Resolve .env file variables
+  const env: Record<string, string | undefined> = getEnv(params.projectDir).env;
+  // Maybe load EAS Environment Variables (based on `--environment` arg)
+  let conflictingVariableNames: string[] | undefined;
   if (params.environment) {
-    env = Object.fromEntries(
-      (
-        await EnvironmentVariablesQuery.byAppIdWithSensitiveAsync(graphqlClient, {
-          appId: params.projectId,
-          environment: params.environment,
-        })
-      ).map(variable => [variable.name, variable.value ?? undefined])
-    );
-  } else {
-    // NOTE: This is required for the .env resolution
-    process.env.NODE_ENV = 'production';
-    env = getEnv(params.projectDir).env;
+    const loadedVariables = await EnvironmentVariablesQuery.byAppIdWithSensitiveAsync(graphqlClient, {
+      appId: params.projectId,
+      environment: params.environment,
+    });
+    // Load EAS Env vars into `env` object, keeping track of conflicts
+    conflictingVariableNames = [];
+    for (const variable of loadedVariables) {
+      if (variable.value != null) {
+        if (env[variable.name] != null) {
+          conflictingVariableNames.push(variable.name);
+        }
+        env[variable.name] = variable.value;
+      }
+    }
   }
-  return { env };
+  const manifest: Manifest = { env };
+  return { conflictingVariableNames, manifest };
 }
 
 interface WorkerFileEntry {

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -121,10 +121,13 @@ export async function createManifestAsync(
   // Maybe load EAS Environment Variables (based on `--environment` arg)
   let conflictingVariableNames: string[] | undefined;
   if (params.environment) {
-    const loadedVariables = await EnvironmentVariablesQuery.byAppIdWithSensitiveAsync(graphqlClient, {
-      appId: params.projectId,
-      environment: params.environment,
-    });
+    const loadedVariables = await EnvironmentVariablesQuery.byAppIdWithSensitiveAsync(
+      graphqlClient,
+      {
+        appId: params.projectId,
+        environment: params.environment,
+      }
+    );
     // Load EAS Env vars into `env` object, keeping track of conflicts
     conflictingVariableNames = [];
     for (const variable of loadedVariables) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,10 +1475,10 @@
     semver "^7.6.2"
     zod "^3.23.8"
 
-"@expo/env@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@expo/env/-/env-0.4.0.tgz#1ff3a15084566d12ca92cb67e5b0a9796a9f0aa7"
-  integrity sha512-g2JYFqck3xKIwJyK+8LxZ2ENZPWtRgjFWpeht9abnKgzXVXBeSNECFBkg+WQjQocSIdxXhEWM6hz4ZAe7Tc4ng==
+"@expo/env@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/env/-/env-1.0.0.tgz#8e22894fae04ba6dc41fe0f1351a4973d410273a"
+  integrity sha512-43R5rxlaLJQOWunyfnQEpgHJCsSLCUWDoU/wJNABEYkHdt1Sjrlf+ieH3MG1f/RZYE+1Wss3sYiO9oPps1aMNg==
   dependencies:
     chalk "^4.0.0"
     debug "^4.3.4"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This allows `--environment` to be combined with local `.env` files, outputting a warning when any variables conflict since EAS environment variables will take precedence.

# How

- Update `createManifestAsync` to return `manifest` and conflicting variable names
- Always call `getEnv` and merge variables into the `env` object
- Output names when conflicts occurred

# Test Plan

- Tested locally
