### PR TITLE
[eas-cli] parse request body for error only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Show `eas deploy` upload error messages. ([#2771](https://github.com/expo/eas-cli/pull/2771) by [@kadikraman](https://github.com/kadikraman))
 - Prevent EAS CLI dependencies check from running repeatedly. ([#2781](https://github.com/expo/eas-cli/pull/2781) by [@kitten](https://github.com/kitten))
+- Prevent optimistic request body parsing for `eas deploy`. ([#2784](https://github.com/expo/eas-cli/pull/2784) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -109,10 +109,10 @@ export async function uploadAsync(params: UploadParams): Promise<UploadResult> {
         return retry(error);
       }
 
-      const getErrorMessage = async () => {
+      const getErrorMessageAsync = async (): Promise<string> => {
         const body = await response.json().catch(() => null);
         return body?.error ?? `Upload of "${filePath}" failed: ${response.statusText}`;
-      }
+      };
 
       if (
         response.status === 408 ||
@@ -120,12 +120,12 @@ export async function uploadAsync(params: UploadParams): Promise<UploadResult> {
         response.status === 429 ||
         (response.status >= 500 && response.status <= 599)
       ) {
-        return retry(new Error(await getErrorMessage()));
+        return retry(new Error(await getErrorMessageAsync()));
       } else if (response.status === 413) {
         const message = `Upload of "${filePath}" failed: File size exceeded the upload limit`;
         throw new Error(message);
       } else if (!response.ok) {
-        throw new Error(await getErrorMessage());
+        throw new Error(await getErrorMessageAsync());
       }
 
       return {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Fixes a regression I introduced in https://github.com/expo/eas-cli/pull/2771/files
_Successful_ deployments error because the body is already parsed.

# How

Only parse the request body when to show the error message when needed.

# Test Plan

Ensure `eas deploy` works without errors.
