### PR TITLE
[eas-cli] Enhance `eas env:exec` command by enabling shell execution for commands

### DIFF
--- a/packages/eas-cli/src/commands/env/exec.ts
+++ b/packages/eas-cli/src/commands/env/exec.ts
@@ -107,10 +107,17 @@ export default class EnvExec extends EasCommand {
       throw new Error("Invalid environment. Use one of 'production', 'preview', or 'development'.");
     }
 
+    const firstChar = bash_command[0];
+    const lastChar = bash_command[bash_command.length - 1];
+    const cleanCommand =
+      (firstChar === '"' && lastChar === '"') || (firstChar === "'" && lastChar === "'")
+        ? bash_command.slice(1, -1)
+        : bash_command;
+
     return {
       nonInteractive: rawFlags['non-interactive'],
       environment,
-      command: bash_command,
+      command: cleanCommand,
     };
   }
 
@@ -149,7 +156,8 @@ export default class EnvExec extends EasCommand {
     environmentVariables: Record<string, string>;
   }): Promise<void> {
     Log.log(`Running command: ${chalk.bold(command)}`);
-    const spawnPromise = spawnAsync('bash', ['-c', command], {
+    const spawnPromise = spawnAsync(command, [], {
+      shell: true,
       stdio: ['inherit', 'pipe', 'pipe'],
       env: {
         ...process.env,


### PR DESCRIPTION
# Why

## Initial Problem: Command Not Found in CI

The impetus for these changes originated from feedback on [this pull request](https://github.com/expo/expo-github-action/pull/316). The initial problem, highlighted [here](https://github.com/expo/expo-github-action/pull/316#issuecomment-2543879065), was that commands passed to the `env:exec` functionality were failing to execute within the GitHub Actions environment. Specifically, the error message indicated that `npx expo config --json --type public` could not be found.

```
[stderr] bash: line 1: npx expo config --json --type public: command not found
❌ "npx expo config --json --type public" failed
bash -c "npx expo config --json --type public" exited with non-zero code: 127
    Error: env:exec command failed.
```

This error suggested that the command was not being executed within a context where `npx` was accessible.

## Second Problem: Local Terminal Failures

After resolving the initial "command not found" error in CI, a [new problem](https://github.com/expo/expo-github-action/pull/316#issuecomment-2552366932) surfaced. The command, which now worked in the CI environment, began to fail when executed directly from a local terminal. This was unexpected, as local terminals typically have access to `npx`.

```
$ neas env:exec preview "npx expo config --json --type public"
No environment variables with visibility "Plain text" and "Sensitive" found for the "preview" environment on EAS servers.

Running command: npx expo config --json --type public
[stdout] Entering npm script environment at location:
[stdout] /Users/wschurman/temp/pkfsapjfasafjpfajaf
[stdout] Type 'exit' or ^D when finished
```

The error was due to a bash session starting without executing the code.

## Third Problem: Unstripped Quotes in CI

The third issue arose when inspecting the output in the CI environment after the previous fixes. It became apparent that the command being executed was still enclosed in quotes (was trying to execute a string).

**Local Output (Correct):**

```
expo/eas-cli/packages/eas-cli/bin/run env:exec preview "npx expo config --json --type public" 
Environment variables with visibility "Plain text" and "Sensitive" loaded from the "preview" environment on EAS: BUILD_VAR, EXPO_PUBLIC_UPDATE_VAR.

Running command: npx expo config --json --type public
```

**Remote Output (Incorrect):**

```
eas env:exec preview "npx expo config --json --type public"
Environment variables with visibility "Plain text" and "Sensitive" loaded from the "preview" environment on EAS: BUILD_VAR, EXPO_PUBLIC_UPDATE_VAR.
Running command: "npx expo config --json --type public"
```

The key difference was the `Running command:` line. In CI, the command was being executed as a quoted string ( `"npx expo config --json --type public"`), rather than a direct command ( `npx expo config --json --type public`), indicating that the quotes were not being parsed correctly by oclif. I am still not sure why.

# How

This section details the solutions implemented to address the identified problems.

## Solution to "Command Not Found"

To address the initial "command not found" error in the CI environment, we implemented the suggestion found in [this Stack Overflow answer](https://stackoverflow.com/a/44987029). This solution involves adding `shell: true` to the `spawn` command.

> While calling spawn itself, there is no npm command under spawn. Thus you got that error message. Instead of using spawn itself, while adding shell: true, spawn will use shell of your system to run that command. Since your system has npm, it works.

By setting `shell: true`, the command is executed via the system shell, which has the necessary context to locate and execute `npx`.

## Solution for Local Terminal Failures

The second issue, the local terminal failures, was resolved by opting to execute the command without using `bash -c`. We instead adopted the approach recommended by [this Stack Overflow answer](https://stackoverflow.com/a/45134890), which advocates for a more direct approach. This avoids the need to shell out to `bash -c` and reduces the chances of issues with command parsing, especially when dealing with arguments containing spaces or quotes.

## Solution for Unstripped Quotes

Finally, to address the issue of unstripped quotes in the CI environment, a basic sanitization method was added. This method is designed to remove quotes from the command string prior to execution, ensuring that the command is executed correctly as intended. It's important to note that this sanitization is intended to be a preliminary fix and may require further refinement for broader applicability.

# Test Plan

This section outlines the steps taken to verify the correctness of the changes.

## Verification Steps

*   **GitHub CI Testing:** The primary goal was to ensure the command now executes successfully within the GitHub CI environment, which was accomplished.
*   **Local Command Testing:** The following commands were executed locally to ensure the changes did not break existing functionality and worked as expected.

    ```bash
    expo/eas-cli/packages/eas-cli/bin/run env:exec preview "npx expo config --json --type public"
    Environment variables with visibility "Plain text" and "Sensitive" loaded from the "preview" environment on EAS: BUILD_VAR, EXPO_PUBLIC_UPDATE_VAR.

    Running command: npx expo config --json --type public
    [stdout] {"name":"Your Projects name" ... }
    ```

    This test confirms the primary command and ensures it now works locally with environment variables

    ```bash
    expo/eas-cli/packages/eas-cli/bin/run env:exec preview "echo 'hello
    world'"
    Environment variables with visibility "Plain text" and "Sensitive" loaded from the "preview" environment on EAS: BUILD_VAR, EXPO_PUBLIC_UPDATE_VAR.

    Running command: echo 'hello
    world'
    [stdout] hello
    [stdout] world
    ```

    This test confirms that commands with inner single quotes now works

These tests were conducted to ensure the fixes addressed the issues and did not introduce new problems.