### PR TITLE
[eas-cli] Silence all non-command output in non-interactive mode of eas env:exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Load `.env` variables even when `--environment` is specified for `deploy` command. Conflicts will be highlighted by a warning message. ([#2783](https://github.com/expo/eas-cli/pull/2783) by [@kitten](https://github.com/kitten))
+- Silence all non-command output in non-interactive mode of eas env:exec. ([#2800](https://github.com/expo/eas-cli/pull/2800) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When using this programmatically to run a command, `env:exec` shouldn't modify the stdout of the sub-command. This makes it possible to run a JSON command, for example.

Concretely, this came up in https://github.com/expo/expo-github-action/pull/316/files#diff-9a4c8863ad4d04f246a265d420c404b948ffcd8902e7de5312c9205cd034fa2eR226 where we are trying to run `npx expo-updates fingerprint:generate` which outputs JSON.

# How

One solution (this solution) is to slightly overload the `non-interactive` flag to also silence all non-command output. Alternatively we could add a separate flag.

I chose to overload the existing flag since I couldn't think of a reason that a non-interactive scenario would want the `Log.log` calls. That being said, I'm open to adding a separate flag like `--raw` or `--passthrough` or something else if overloading the flag is not desired.

# Test Plan

Before:
```
$ neas env:exec preview "npx expo config --json --type public" --non-interactive
No environment variables with visibility "Plain text" and "Sensitive" found for the "preview" environment on EAS servers.

Running command: npx expo config --json --type public
[stdout] {"name":"pkfsa...
```

After:
```
$ neas env:exec preview "npx expo config --json --type public" --non-interactive
{"name":"pkfsa...
```

Other tests:

Does not print hello since subcommand had nonzero exit status:
```
$ neas env:exec preview "npx expo config --json --type publicd" --non-interactive && echo "hello"
```
Ensure output (no output) matches:
```
npx expo config --json --type publicd && echo "hello"
```

Prints hello after config (correct success exit status):
```
$ neas env:exec preview "npx expo config --json --type public" --non-interactive && echo "hello"
{"name":"pkfsa...
hello
```
Ensure output (no output) matches:
```
npx expo config --json --type public && echo "hello"
```
