### PR TITLE
[ENG-14644][eas-cli] make "No remote versions are configured" message green instead of yellow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Make automatic env resolution message shorter. ([#2806](https://github.com/expo/eas-cli/pull/2806) by [@szdziedzic](https://github.com/szdziedzic))
+- Make "No remote versions are configured" message green instead of yellow. ([#2805](https://github.com/expo/eas-cli/pull/2805) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [14.4.0](https://github.com/expo/eas-cli/releases/tag/v14.4.0) - 2025-01-09
 

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -208,8 +208,10 @@ export async function resolveRemoteVersionCodeAsync(
     currentBuildVersion = remoteVersions.buildVersion;
   } else {
     if (localVersions.appBuildVersion) {
-      Log.warn(
-        'No remote versions are configured for this project, versionCode will be initialized based on the value from the local project.'
+      Log.log(
+        chalk.green(
+          'No remote versions are configured for this project, versionCode will be initialized based on the value from the local project.'
+        )
       );
       currentBuildVersion = localVersions.appBuildVersion;
     } else {

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -334,8 +334,10 @@ export async function resolveRemoteBuildNumberAsync(
     currentBuildVersion = remoteVersions.buildVersion;
   } else {
     if (localBuildNumber) {
-      Log.warn(
-        'No remote versions are configured for this project, buildNumber will be initialized based on the value from the local project.'
+      Log.log(
+        chalk.green(
+          'No remote versions are configured for this project, buildNumber will be initialized based on the value from the local project.'
+        )
       );
       currentBuildVersion = localBuildNumber;
     } else {


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-14644/make-no-remote-versions-are-configured-message-green-instead-of-yellow

# How

make "No remote versions are configured" message green instead of yellow

# Test Plan

Tests
