### PR TITLE
[eas-cli] Enhance `eas env:exec` command by enabling shell execution for commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Enable shell execution for env:exec commands. ([#2788](https://github.com/expo/eas-cli/pull/2788) by [@tharakadesilva](https://github.com/tharakadesilva))
+
 ### 🧹 Chores
 
 - Make automatic env resolution message shorter. ([#2806](https://github.com/expo/eas-cli/pull/2806) by [@szdziedzic](https://github.com/szdziedzic))

--- a/packages/eas-cli/src/commands/env/exec.ts
+++ b/packages/eas-cli/src/commands/env/exec.ts
@@ -107,10 +107,17 @@ export default class EnvExec extends EasCommand {
       throw new Error("Invalid environment. Use one of 'production', 'preview', or 'development'.");
     }
 
+    const firstChar = bash_command[0];
+    const lastChar = bash_command[bash_command.length - 1];
+    const cleanCommand =
+      (firstChar === '"' && lastChar === '"') || (firstChar === "'" && lastChar === "'")
+        ? bash_command.slice(1, -1)
+        : bash_command;
+
     return {
       nonInteractive: rawFlags['non-interactive'],
       environment,
-      command: bash_command,
+      command: cleanCommand,
     };
   }
 
@@ -149,7 +156,8 @@ export default class EnvExec extends EasCommand {
     environmentVariables: Record<string, string>;
   }): Promise<void> {
     Log.log(`Running command: ${chalk.bold(command)}`);
-    const spawnPromise = spawnAsync('bash', ['-c', command], {
+    const spawnPromise = spawnAsync(command, [], {
+      shell: true,
       stdio: ['inherit', 'pipe', 'pipe'],
       env: {
         ...process.env,

--- a/packages/eas-cli/src/commands/env/exec.ts
+++ b/packages/eas-cli/src/commands/env/exec.ts
@@ -121,22 +121,6 @@ export default class EnvExec extends EasCommand {
     };
   }
 
-  private async runCommandNonInteractiveWithEnvVarsAsync({
-    command,
-    environmentVariables,
-  }: {
-    command: string;
-    environmentVariables: Record<string, string>;
-  }): Promise<void> {
-    await spawnAsync('bash', ['-c', command], {
-      stdio: 'inherit',
-      env: {
-        ...process.env,
-        ...environmentVariables,
-      },
-    });
-  }
-
   // eslint-disable-next-line async-protect/async-suffix
   protected override async catch(err: Error): Promise<any> {
     // when in non-interactive, make the behavior of this command a pure passthrough, outputting only the subprocess' stdout and stderr and exiting with the
@@ -146,6 +130,23 @@ export default class EnvExec extends EasCommand {
     } else {
       await super.catch(err);
     }
+  }
+
+  private async runCommandNonInteractiveWithEnvVarsAsync({
+    command,
+    environmentVariables,
+  }: {
+    command: string;
+    environmentVariables: Record<string, string>;
+  }): Promise<void> {
+    await spawnAsync(command, [], {
+      shell: true,
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        ...environmentVariables,
+      },
+    });
   }
 
   private async runCommandWithEnvVarsAsync({


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Rebase and update of https://github.com/expo/eas-cli/pull/2788. (couldn't push to remote to update that PR, would be good to get this in soon).

# How

Cherry-pick, rebase, apply requested changes.

# Test Plan


Same as https://github.com/expo/eas-cli/pull/2788.

Manual test:
```
$ neas env:exec preview "npx expo config --json --type publicd" --non-interactive && echo "hello"

$ neas env:exec preview "npx expo config --json --type public" --non-interactive && echo "hello"
{"name":"pkfsapjfasafj...hello
```