### PR TITLE
[eas-cli] Make variable naming more explicit, remove deprecated runtimeFingerprintSource uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Make variable naming more explicit, remove deprecated runtimeFingerprintSource uses. ([#2816](https://github.com/expo/eas-cli/pull/2816) by [@wschurman](https://github.com/wschurman))
+
 ## [14.4.1](https://github.com/expo/eas-cli/releases/tag/v14.4.1) - 2025-01-15
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -709,7 +709,10 @@ async function computeAndMaybeUploadFingerprintFromExpoUpdatesAsync<T extends Pl
    * It's ok for fingerprintSources or runtimeVersion to be empty
    * fingerprintSources only exist if the project is using runtimeVersion.policy: fingerprint
    */
-  if (!resolvedRuntimeVersion.fingerprint || !resolvedRuntimeVersion.runtimeVersion) {
+  if (
+    !resolvedRuntimeVersion.expoUpdatesRuntimeFingerprint ||
+    !resolvedRuntimeVersion.runtimeVersion
+  ) {
     return {
       runtimeVersion: resolvedRuntimeVersion.runtimeVersion ?? undefined,
     };
@@ -717,14 +720,14 @@ async function computeAndMaybeUploadFingerprintFromExpoUpdatesAsync<T extends Pl
 
   const uploadedFingerprint = await maybeUploadFingerprintAsync({
     hash: resolvedRuntimeVersion.runtimeVersion,
-    fingerprint: resolvedRuntimeVersion.fingerprint,
+    fingerprint: resolvedRuntimeVersion.expoUpdatesRuntimeFingerprint,
     graphqlClient: ctx.graphqlClient,
     localBuildMode: ctx.localBuildOptions.localBuildMode,
   });
   return {
     runtimeVersion: uploadedFingerprint.hash,
     fingerprintSource: uploadedFingerprint.fingerprintSource,
-    fingerprintHash: resolvedRuntimeVersion.fingerprintHash ?? undefined,
+    fingerprintHash: resolvedRuntimeVersion.expoUpdatesRuntimeFingerprintHash ?? undefined,
   };
 }
 

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -410,11 +410,11 @@ export default class UpdatePublish extends EasCommand {
         runtimeToPlatformsAndFingerprintInfoMapping.map(async info => {
           return {
             ...info,
-            fingerprintSource: info.fingerprint
+            expoUpdatesRuntimeFingerprintSource: info.expoUpdatesRuntimeFingerprint
               ? (
                   await maybeUploadFingerprintAsync({
                     hash: info.runtimeVersion,
-                    fingerprint: info.fingerprint,
+                    fingerprint: info.expoUpdatesRuntimeFingerprint,
                     graphqlClient,
                   })
                 ).fingerprintSource ?? null
@@ -449,7 +449,7 @@ export default class UpdatePublish extends EasCommand {
     // Sort the updates into different groups based on their platform specific runtime versions
     const updateGroups: PublishUpdateGroupInput[] =
       runtimeToPlatformsAndFingerprintInfoAndFingerprintSourceMapping.map(
-        ({ runtimeVersion, platforms, fingerprintSource, fingerprintInfoGroup }) => {
+        ({ runtimeVersion, platforms, fingerprintInfoGroup }) => {
           const localUpdateInfoGroup = Object.fromEntries(
             platforms.map(platform => [
               platform,
@@ -485,9 +485,6 @@ export default class UpdatePublish extends EasCommand {
             branchId: branch.id,
             updateInfoGroup: localUpdateInfoGroup,
             rolloutInfoGroup: localRolloutInfoGroup,
-            runtimeFingerprintSource: fingerprintSource
-              ? transformFingerprintSource(fingerprintSource)
-              : null,
             fingerprintInfoGroup: transformedFingerprintInfoGroup,
             runtimeVersion,
             message: updateMessage,

--- a/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
+++ b/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts
@@ -208,8 +208,8 @@ export default class UpdateRollBackToEmbedded extends EasCommand {
           platform,
           runtimeVersionInfo: {
             runtimeVersion: selectedRuntime,
-            fingerprint: null,
-            fingerprintHash: null,
+            expoUpdatesRuntimeFingerprint: null,
+            expoUpdatesRuntimeFingerprintHash: null,
           },
         }))
       );

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -733,11 +733,11 @@ export const defaultPublishPlatforms: UpdatePublishPlatform[] = ['android', 'ios
 
 export type RuntimeVersionInfo = {
   runtimeVersion: string;
-  fingerprint: {
+  expoUpdatesRuntimeFingerprint: {
     fingerprintSources: object[];
     isDebugFingerprintSource: boolean;
   } | null;
-  fingerprintHash: string | null;
+  expoUpdatesRuntimeFingerprintHash: string | null;
 };
 
 type FingerprintInfoGroup = {
@@ -797,11 +797,11 @@ async function getRuntimeVersionInfoForPlatformAsync({
   env: Env | undefined;
 }): Promise<{
   runtimeVersion: string;
-  fingerprint: {
+  expoUpdatesRuntimeFingerprint: {
     fingerprintSources: object[];
     isDebugFingerprintSource: boolean;
   } | null;
-  fingerprintHash: string | null;
+  expoUpdatesRuntimeFingerprintHash: string | null;
 }> {
   if (await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir)) {
     try {
@@ -852,8 +852,8 @@ async function getRuntimeVersionInfoForPlatformAsync({
 
   return {
     runtimeVersion: resolvedRuntimeVersion,
-    fingerprint: null,
-    fingerprintHash: null,
+    expoUpdatesRuntimeFingerprint: null,
+    expoUpdatesRuntimeFingerprintHash: null,
   };
 }
 
@@ -875,13 +875,15 @@ export function getRuntimeToPlatformsAndFingerprintInfoMappingFromRuntimeVersion
         platforms: runtimeVersionInfoObjects.map(
           runtimeVersionInfoObject => runtimeVersionInfoObject.platform
         ),
-        fingerprint:
+        expoUpdatesRuntimeFingerprint:
           runtimeVersionInfoObjects.map(
-            runtimeVersionInfoObject => runtimeVersionInfoObject.runtimeVersionInfo.fingerprint
+            runtimeVersionInfoObject =>
+              runtimeVersionInfoObject.runtimeVersionInfo.expoUpdatesRuntimeFingerprint
           )[0] ?? null,
-        fingerprintHash:
+        expoUpdatesRuntimeFingerprintHash:
           runtimeVersionInfoObjects.map(
-            runtimeVersionInfoObject => runtimeVersionInfoObject.runtimeVersionInfo.fingerprintHash
+            runtimeVersionInfoObject =>
+              runtimeVersionInfoObject.runtimeVersionInfo.expoUpdatesRuntimeFingerprintHash
           )[0] ?? null,
       };
     }
@@ -899,20 +901,20 @@ export async function maybeCalculateFingerprintForRuntimeVersionInfoObjectsWitho
   graphqlClient: ExpoGraphqlClient;
   runtimeToPlatformsAndFingerprintInfoAndFingerprintSourceMapping: (RuntimeVersionInfo & {
     platforms: UpdatePublishPlatform[];
-    fingerprintSource: FingerprintSource | null;
+    expoUpdatesRuntimeFingerprintSource: FingerprintSource | null;
   })[];
   workflowsByPlatform: Record<Platform, Workflow>;
   env: Env | undefined;
 }): Promise<
   (RuntimeVersionInfo & {
     platforms: UpdatePublishPlatform[];
-    fingerprintSource: FingerprintSource | null;
+    expoUpdatesRuntimeFingerprintSource: FingerprintSource | null;
     fingerprintInfoGroup: FingerprintInfoGroup;
   })[]
 > {
   const runtimesToComputeFingerprintsFor =
     runtimeToPlatformsAndFingerprintInfoAndFingerprintSourceMapping.filter(
-      infoGroup => !infoGroup.fingerprintHash
+      infoGroup => !infoGroup.expoUpdatesRuntimeFingerprintHash
     );
   const fingerprintOptionsByRuntimeAndPlatform = new Map<string, FingerprintOptions>();
   for (const infoGroup of runtimesToComputeFingerprintsFor) {
@@ -975,9 +977,11 @@ export async function maybeCalculateFingerprintForRuntimeVersionInfoObjectsWitho
           infoGroup
         ): infoGroup is RuntimeVersionInfo & {
           platforms: UpdatePublishPlatform[];
-          fingerprintSource: FingerprintSource;
-          fingerprintHash: string;
-        } => !!infoGroup.fingerprintHash && !!infoGroup.fingerprintSource
+          expoUpdatesRuntimeFingerprintSource: FingerprintSource;
+          expoUpdatesRuntimeFingerprintHash: string;
+        } =>
+          !!infoGroup.expoUpdatesRuntimeFingerprintHash &&
+          !!infoGroup.expoUpdatesRuntimeFingerprintSource
       )
       .map(infoGroup => {
         const platform = infoGroup.platforms[0];
@@ -985,8 +989,8 @@ export async function maybeCalculateFingerprintForRuntimeVersionInfoObjectsWitho
           ...infoGroup,
           fingerprintInfoGroup: {
             [platform]: {
-              fingerprintHash: infoGroup.fingerprintHash,
-              fingerprintSource: infoGroup.fingerprintSource,
+              fingerprintHash: infoGroup.expoUpdatesRuntimeFingerprintHash,
+              fingerprintSource: infoGroup.expoUpdatesRuntimeFingerprintSource,
             },
           },
         };

--- a/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
+++ b/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
@@ -23,11 +23,11 @@ export async function resolveRuntimeVersionUsingCLIAsync({
   cwd?: string;
 }): Promise<{
   runtimeVersion: string | null;
-  fingerprint: {
+  expoUpdatesRuntimeFingerprint: {
     fingerprintSources: object[];
     isDebugFingerprintSource: boolean;
   } | null;
-  fingerprintHash: string | null;
+  expoUpdatesRuntimeFingerprintHash: string | null;
 }> {
   Log.debug('Using expo-updates runtimeversion:resolve CLI for runtime version resolution');
 
@@ -47,13 +47,13 @@ export async function resolveRuntimeVersionUsingCLIAsync({
 
   return {
     runtimeVersion: runtimeVersionResult.runtimeVersion ?? null,
-    fingerprint: runtimeVersionResult.fingerprintSources
+    expoUpdatesRuntimeFingerprint: runtimeVersionResult.fingerprintSources
       ? {
           fingerprintSources: runtimeVersionResult.fingerprintSources,
           isDebugFingerprintSource: useDebugFingerprintSource,
         }
       : null,
-    fingerprintHash: runtimeVersionResult.fingerprintSources
+    expoUpdatesRuntimeFingerprintHash: runtimeVersionResult.fingerprintSources
       ? runtimeVersionResult.runtimeVersion
       : null,
   };
@@ -75,19 +75,19 @@ export async function resolveRuntimeVersionAsync({
   cwd?: string;
 }): Promise<{
   runtimeVersion: string | null;
-  fingerprint: {
+  expoUpdatesRuntimeFingerprint: {
     fingerprintSources: object[];
     isDebugFingerprintSource: boolean;
   } | null;
-  fingerprintHash: string | null;
+  expoUpdatesRuntimeFingerprintHash: string | null;
 } | null> {
   if (!(await isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync(projectDir))) {
     // fall back to the previous behavior (using the @expo/config-plugins eas-cli dependency rather
     // than the versioned @expo/config-plugins dependency in the project)
     return {
       runtimeVersion: await Updates.getRuntimeVersionNullableAsync(projectDir, exp, platform),
-      fingerprint: null,
-      fingerprintHash: null,
+      expoUpdatesRuntimeFingerprint: null,
+      expoUpdatesRuntimeFingerprintHash: null,
     };
   }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This renames some fields of runtime version info to make it clearer where the fingerprint source is coming from.

It also stops uploading `runtimeFingerprintSource` as that is no longer used on the server.

# How

Rename, tsc.

Remove field.

# Test Plan

With both fingerprint runtime version policy and without, run `neas update` to ensure it works. (ensure fingerprint is attached to runtime version  by checking runtime permalink on website and downloading the fingerprint)