### PR TITLE
Bump eas-cli-local-build-plugin to latest version to support new bun lock file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Make automatic env resolution message shorter. ([#2806](https://github.com/expo/eas-cli/pull/2806) by [@szdziedzic](https://github.com/szdziedzic))
 - Make "No remote versions are configured" message green instead of yellow. ([#2805](https://github.com/expo/eas-cli/pull/2805) by [@szdziedzic](https://github.com/szdziedzic))
 - Upload local fingerprint on `eas fingerprint:compare`. ([#2808](https://github.com/expo/eas-cli/pull/2808) by [@quinlanj](https://github.com/quinlanj))
+- Upgrade `eas-cli-local-build-plugin` to `1.0.163` to support Bun's new text-based lock file in local builds. ([#2817](https://github.com/expo/eas-cli/pull/2817) by [@shiroyasha9](https://github.com/shiroyasha9))
 
 ## [14.4.0](https://github.com/expo/eas-cli/releases/tag/v14.4.0) - 2025-01-09
 

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -7,7 +7,7 @@ import Log from '../log';
 import { ora } from '../ora';
 
 const PLUGIN_PACKAGE_NAME = 'eas-cli-local-build-plugin';
-const PLUGIN_PACKAGE_VERSION = '1.0.152';
+const PLUGIN_PACKAGE_VERSION = '1.0.163';
 
 export enum LocalBuildMode {
   /**


### PR DESCRIPTION
### Why 

As mentioned in my original issue (https://github.com/expo/eas-cli/issues/2782#issuecomment-2591174852), Bun introduced a new text based `bun.lock` file with their Bun v1.1.39+. 

This new lock file was supported by EAS in the cloud builds as seen in PRs https://github.com/expo/eas-cli/pull/2801 abd https://github.com/expo/eas-build/pull/482, and indeed upon verification works perfectly fine in cloud builds (https://expo.dev/accounts/mubin-memorang/projects/new-bun-lock/builds/a8f5d20f-20b8-4b20-9430-cbf48ba88103)

This however was not working with the `--local` flag. 

Upon inspection, the `eas-cli-local-build-plugin` is not updated to the latest version that reflects this new lockfile related changes. 

## After bumping the package 

### Gets recognized as a valid bun project 

![image](https://github.com/user-attachments/assets/ec6a14a7-bce2-4b6c-95b0-d7d317ea0610)

### Builds gets successful

![image](https://github.com/user-attachments/assets/fbe474e3-c541-4cb0-bc85-f541560a2b4d)


