### PR TITLE
[ENG-14625][eas-cli] add `eas build:dev` command

### DIFF
--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -77,10 +77,14 @@ export async function createBuildProfileAsync({
   projectDir,
   profileName,
   profileContents,
+  vcsClient,
+  nonInteractive,
 }: {
   projectDir: string;
   profileName: string;
   profileContents: Record<string, any>;
+  vcsClient: Client;
+  nonInteractive: boolean;
 }): Promise<void> {
   const spinner = ora(`Adding "${profileName}" build profile to ${chalk.bold('eas.json')}`).start();
   try {
@@ -100,6 +104,17 @@ export async function createBuildProfileAsync({
     spinner.succeed(
       `Successfully added "${profileName}" build profile to ${chalk.bold('eas.json')}.`
     );
+
+    if (await vcsClient.isCommitRequiredAsync()) {
+      Log.newLine();
+      await reviewAndCommitChangesAsync(
+        vcsClient,
+        `Add "${profileName}" build profile to eas.json`,
+        {
+          nonInteractive,
+        }
+      );
+    }
   } catch (error) {
     spinner.fail(
       `We were not able to configure "${profileName}" build profile inside of ${chalk.bold(

--- a/packages/eas-cli/src/build/configure.ts
+++ b/packages/eas-cli/src/build/configure.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 
 import { maybeBailOnRepoStatusAsync, reviewAndCommitChangesAsync } from './utils/repository';
 import Log, { learnMore } from '../log';
+import { ora } from '../ora';
 import { easCliVersion } from '../utils/easCli';
 import { Client } from '../vcs/vcs';
 
@@ -49,6 +50,63 @@ async function configureAsync({
     await reviewAndCommitChangesAsync(vcsClient, 'Configure EAS Build', {
       nonInteractive,
     });
+  }
+}
+
+export async function doesBuildProfileExistAsync({
+  projectDir,
+  profileName,
+}: {
+  projectDir: string;
+  profileName: string;
+}): Promise<boolean> {
+  try {
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
+    const easJson = await easJsonAccessor.readRawJsonAsync();
+    if (!easJson.build?.[profileName]) {
+      return false;
+    }
+    return true;
+  } catch (error) {
+    Log.error(`We were unable to read ${chalk.bold('eas.json')} contents. Error: ${error}.`);
+    throw error;
+  }
+}
+
+export async function createBuildProfileAsync({
+  projectDir,
+  profileName,
+  profileContents,
+}: {
+  projectDir: string;
+  profileName: string;
+  profileContents: Record<string, any>;
+}): Promise<void> {
+  const spinner = ora(`Adding "${profileName}" build profile to ${chalk.bold('eas.json')}`).start();
+  try {
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
+    await easJsonAccessor.readRawJsonAsync();
+
+    easJsonAccessor.patch(easJsonRawObject => {
+      return {
+        ...easJsonRawObject,
+        build: {
+          ...easJsonRawObject.build,
+          [profileName]: profileContents,
+        },
+      };
+    });
+    await easJsonAccessor.writeAsync();
+    spinner.succeed(
+      `Successfully added "${profileName}" build profile to ${chalk.bold('eas.json')}.`
+    );
+  } catch (error) {
+    spinner.fail(
+      `We were not able to configure "${profileName}" build profile inside of ${chalk.bold(
+        'eas.json'
+      )}. Error: ${error}.`
+    );
+    throw error;
   }
 }
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -99,18 +99,29 @@ export interface BuildFlags {
   repack: boolean;
 }
 
-export async function runBuildAndSubmitAsync(
-  graphqlClient: ExpoGraphqlClient,
-  analytics: Analytics,
-  vcsClient: Client,
-  projectDir: string,
-  flags: BuildFlags,
-  actor: Actor,
-  getDynamicPrivateProjectConfigAsync: DynamicConfigContextFn,
-  buildProfilesOverride?: ProfileData<'build'>[],
-  downloadSimBuildAutoConfirm?: boolean,
-  envOverride?: Env
-): Promise<{
+export async function runBuildAndSubmitAsync({
+  graphqlClient,
+  analytics,
+  vcsClient,
+  projectDir,
+  flags,
+  actor,
+  getDynamicPrivateProjectConfigAsync,
+  buildProfilesOverride,
+  downloadSimBuildAutoConfirm,
+  envOverride,
+}: {
+  graphqlClient: ExpoGraphqlClient;
+  analytics: Analytics;
+  vcsClient: Client;
+  projectDir: string;
+  flags: BuildFlags;
+  actor: Actor;
+  getDynamicPrivateProjectConfigAsync: DynamicConfigContextFn;
+  buildProfilesOverride?: ProfileData<'build'>[];
+  downloadSimBuildAutoConfirm?: boolean;
+  envOverride?: Env;
+}): Promise<{
   buildIds: string[];
 }> {
   await vcsClient.ensureRepoExistsAsync();

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -107,7 +107,6 @@ export async function runBuildAndSubmitAsync({
   flags,
   actor,
   getDynamicPrivateProjectConfigAsync,
-  buildProfilesOverride,
   downloadSimBuildAutoConfirm,
   envOverride,
 }: {
@@ -118,7 +117,6 @@ export async function runBuildAndSubmitAsync({
   flags: BuildFlags;
   actor: Actor;
   getDynamicPrivateProjectConfigAsync: DynamicConfigContextFn;
-  buildProfilesOverride?: ProfileData<'build'>[];
   downloadSimBuildAutoConfirm?: boolean;
   envOverride?: Env;
 }): Promise<{
@@ -137,15 +135,13 @@ export async function runBuildAndSubmitAsync({
     (await EasJsonUtils.getCliConfigAsync(easJsonAccessor)) ?? {};
 
   const platforms = toPlatforms(flags.requestedPlatform);
-  const buildProfiles =
-    buildProfilesOverride ??
-    (await getProfilesAsync({
-      type: 'build',
-      easJsonAccessor,
-      platforms,
-      profileName: flags.profile ?? undefined,
-      projectDir,
-    }));
+  const buildProfiles = await getProfilesAsync({
+    type: 'build',
+    easJsonAccessor,
+    platforms,
+    profileName: flags.profile ?? undefined,
+    projectDir,
+  });
 
   for (const buildProfile of buildProfiles) {
     if (buildProfile.profile.image && ['default', 'stable'].includes(buildProfile.profile.image)) {

--- a/packages/eas-cli/src/commands/build/dev.ts
+++ b/packages/eas-cli/src/commands/build/dev.ts
@@ -2,23 +2,23 @@ import { Platform } from '@expo/eas-build-job';
 import { BuildProfile, CredentialsSource } from '@expo/eas-json';
 import { Errors, Flags } from '@oclif/core';
 
-import { runBuildAndSubmitAsync } from '../build/runBuildAndSubmit';
-import EasCommand from '../commandUtils/EasCommand';
+import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
+import EasCommand from '../../commandUtils/EasCommand';
 import {
   BuildStatus,
   DistributionType,
   EnvironmentVariableEnvironment,
-} from '../graphql/generated';
-import { BuildQuery } from '../graphql/queries/BuildQuery';
-import { toAppPlatform } from '../graphql/types/AppPlatform';
-import Log from '../log';
-import { RequestedPlatform } from '../platform';
-import { resolveWorkflowAsync } from '../project/workflow';
-import { runAsync } from '../run/run';
-import { downloadAndMaybeExtractAppAsync } from '../utils/download';
-import { createFingerprintAsync } from '../utils/fingerprintCli';
+} from '../../graphql/generated';
+import { BuildQuery } from '../../graphql/queries/BuildQuery';
+import { toAppPlatform } from '../../graphql/types/AppPlatform';
+import Log from '../../log';
+import { RequestedPlatform } from '../../platform';
+import { resolveWorkflowAsync } from '../../project/workflow';
+import { runAsync } from '../../run/run';
+import { downloadAndMaybeExtractAppAsync } from '../../utils/download';
+import { createFingerprintAsync } from '../../utils/fingerprintCli';
 
-export default class Dev extends EasCommand {
+export default class BuildDev extends EasCommand {
   static override description =
     'run dev client simulator/emulator build with matching fingerprint or create a new one';
 
@@ -41,7 +41,7 @@ export default class Dev extends EasCommand {
   };
 
   protected override async runAsync(): Promise<any> {
-    const { flags } = await this.parse(Dev);
+    const { flags } = await this.parse(BuildDev);
 
     const {
       loggedIn: { actor, graphqlClient },
@@ -51,7 +51,7 @@ export default class Dev extends EasCommand {
       vcsClient,
       getServerSideEnvironmentVariablesAsync,
       projectId,
-    } = await this.getContextAsync(Dev, {
+    } = await this.getContextAsync(BuildDev, {
       nonInteractive: false,
       withServerSideEnvironment: EnvironmentVariableEnvironment.Development,
     });

--- a/packages/eas-cli/src/commands/build/dev.ts
+++ b/packages/eas-cli/src/commands/build/dev.ts
@@ -26,6 +26,8 @@ import { ProfileData, getProfilesAsync } from '../../utils/profiles';
 const DEFAULT_EAS_BUILD_RUN_PROFILE_NAME = 'development-simulator';
 
 export default class BuildDev extends EasCommand {
+  static override hidden: true;
+
   static override description =
     'run dev client simulator/emulator build with matching fingerprint or create a new one';
 

--- a/packages/eas-cli/src/commands/build/dev.ts
+++ b/packages/eas-cli/src/commands/build/dev.ts
@@ -1,32 +1,43 @@
 import { Platform } from '@expo/eas-build-job';
-import { BuildProfile, CredentialsSource } from '@expo/eas-json';
+import { BuildProfile, EasJsonAccessor } from '@expo/eas-json';
 import { Errors, Flags } from '@oclif/core';
 
-import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
-import EasCommand from '../../commandUtils/EasCommand';
 import {
-  BuildStatus,
-  DistributionType,
-  EnvironmentVariableEnvironment,
-} from '../../graphql/generated';
+  createBuildProfileAsync,
+  doesBuildProfileExistAsync,
+  ensureProjectConfiguredAsync,
+} from '../../build/configure';
+import { evaluateConfigWithEnvVarsAsync } from '../../build/evaluateConfigWithEnvVarsAsync';
+import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
+import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
+import EasCommand from '../../commandUtils/EasCommand';
+import { BuildStatus, DistributionType } from '../../graphql/generated';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import { toAppPlatform } from '../../graphql/types/AppPlatform';
 import Log from '../../log';
 import { RequestedPlatform } from '../../platform';
 import { resolveWorkflowAsync } from '../../project/workflow';
+import { confirmAsync, promptAsync } from '../../prompts';
 import { runAsync } from '../../run/run';
 import { downloadAndMaybeExtractAppAsync } from '../../utils/download';
 import { createFingerprintAsync } from '../../utils/fingerprintCli';
+import { ProfileData, getProfilesAsync } from '../../utils/profiles';
+
+const DEFAULT_EAS_BUILD_RUN_PROFILE_NAME = 'development-simulator';
 
 export default class BuildDev extends EasCommand {
   static override description =
     'run dev client simulator/emulator build with matching fingerprint or create a new one';
 
   static override flags = {
-    platform: Flags.enum<RequestedPlatform.Ios | RequestedPlatform.Android>({
+    platform: Flags.enum<Platform.IOS | Platform.ANDROID>({
       char: 'p',
-      options: [RequestedPlatform.Android, RequestedPlatform.Ios],
-      required: true,
+      options: [Platform.IOS, Platform.ANDROID],
+    }),
+    profile: Flags.string({
+      char: 'e',
+      description: `Name of the build profile from eas.json. It must be a profile allowing to create emulator/simulator internal distribution dev client builds. The "${DEFAULT_EAS_BUILD_RUN_PROFILE_NAME}" build profile will be selected by default.`,
+      helpValue: 'PROFILE_NAME',
     }),
   };
 
@@ -36,7 +47,6 @@ export default class BuildDev extends EasCommand {
     ...this.ContextOptions.ProjectDir,
     ...this.ContextOptions.Vcs,
     ...this.ContextOptions.Analytics,
-    ...this.ContextOptions.ServerSideEnvironmentVariables,
     ...this.ContextOptions.ProjectId,
   };
 
@@ -49,22 +59,40 @@ export default class BuildDev extends EasCommand {
       projectDir,
       analytics,
       vcsClient,
-      getServerSideEnvironmentVariablesAsync,
       projectId,
     } = await this.getContextAsync(BuildDev, {
       nonInteractive: false,
-      withServerSideEnvironment: EnvironmentVariableEnvironment.Development,
+      withServerSideEnvironment: null,
     });
 
-    const platform = flags.platform === RequestedPlatform.Android ? Platform.ANDROID : Platform.IOS;
+    const platform = await this.selectPlatformAsync(flags.platform);
     if (process.platform !== 'darwin' && platform === Platform.IOS) {
-      Errors.error('iOS builds are only supported on macOS.', { exit: 1 });
+      Errors.error('Running iOS builds in simulator is only supported on macOS.', { exit: 1 });
     }
 
-    const [env, workflow] = await Promise.all([
-      getServerSideEnvironmentVariablesAsync(),
-      resolveWorkflowAsync(projectDir, platform, vcsClient),
-    ]);
+    await vcsClient.ensureRepoExistsAsync();
+    await ensureRepoIsCleanAsync(vcsClient, flags.nonInteractive);
+    await ensureProjectConfiguredAsync({
+      projectDir,
+      nonInteractive: false,
+      vcsClient,
+    });
+
+    const buildProfile = await this.ensureValidBuildRunProfileExistsAsync({
+      projectDir,
+      platform,
+      selectedBuildProfileName: flags.profile,
+    });
+
+    const workflow = await resolveWorkflowAsync(projectDir, platform, vcsClient);
+
+    const { env } = await evaluateConfigWithEnvVarsAsync({
+      buildProfile: buildProfile.profile,
+      buildProfileName: buildProfile.profileName,
+      graphqlClient,
+      getProjectConfig: getDynamicPrivateProjectConfigAsync,
+      opts: { env: buildProfile.profile.env },
+    });
 
     const fingerprint = await createFingerprintAsync(projectDir, {
       env,
@@ -84,7 +112,7 @@ export default class BuildDev extends EasCommand {
         fingerprintHash: fingerprint.hash,
         status: BuildStatus.Finished,
         simulator: platform === Platform.IOS ? true : undefined,
-        distribution: DistributionType.Internal,
+        distribution: platform === Platform.ANDROID ? DistributionType.Internal : undefined,
         developmentClient: true,
       },
       offset: 0,
@@ -109,18 +137,6 @@ export default class BuildDev extends EasCommand {
     }
 
     Log.log('🚀 No successful build with matching fingerprint found. Starting a new build...');
-    const androidBuildProfile: BuildProfile<Platform.ANDROID> = {
-      credentialsSource: CredentialsSource.LOCAL,
-      distribution: 'internal',
-      withoutCredentials: true,
-      developmentClient: true,
-    };
-    const iosBuildProfile: BuildProfile<Platform.IOS> = {
-      credentialsSource: CredentialsSource.LOCAL,
-      distribution: 'internal',
-      simulator: true,
-      developmentClient: true,
-    };
 
     await runBuildAndSubmitAsync({
       graphqlClient,
@@ -128,7 +144,8 @@ export default class BuildDev extends EasCommand {
       vcsClient,
       projectDir,
       flags: {
-        requestedPlatform: flags.platform,
+        requestedPlatform:
+          platform === Platform.ANDROID ? RequestedPlatform.Android : RequestedPlatform.Ios,
         nonInteractive: false,
         freezeCredentials: false,
         wait: true,
@@ -137,24 +154,136 @@ export default class BuildDev extends EasCommand {
         autoSubmit: false,
         localBuildOptions: {},
         repack: false,
+        profile: flags.profile ?? DEFAULT_EAS_BUILD_RUN_PROFILE_NAME,
       },
       actor,
       getDynamicPrivateProjectConfigAsync,
-      buildProfilesOverride: [
-        platform === Platform.ANDROID
-          ? {
-              platform: Platform.ANDROID,
-              profile: androidBuildProfile,
-              profileName: '__internal-dev-client__',
-            }
-          : {
-              platform: Platform.IOS,
-              profile: iosBuildProfile,
-              profileName: '__internal-dev-client__',
-            },
-      ],
       downloadSimBuildAutoConfirm: true,
       envOverride: env,
     });
+  }
+
+  private async selectPlatformAsync(platform?: Platform): Promise<Platform> {
+    if (platform) {
+      return platform;
+    }
+    const { resolvedPlatform } = await promptAsync({
+      type: 'select',
+      message: 'Select platform',
+      name: 'resolvedPlatform',
+      choices: [
+        { title: 'Android', value: Platform.ANDROID },
+        { title: 'iOS', value: Platform.IOS },
+      ],
+    });
+    return resolvedPlatform;
+  }
+
+  private async validateBuildRunProfileAsync({
+    platform,
+    buildProfile,
+    buildProfileName,
+  }: {
+    platform: Platform;
+    buildProfile: BuildProfile;
+    buildProfileName: string;
+  }): Promise<void> {
+    if (buildProfile.developmentClient !== true) {
+      Errors.error(
+        `Profile "${buildProfileName}" must specify "developmentClient: true" to create a dev client build. Select a different profile or update the profile in eas.json.`,
+        { exit: 1 }
+      );
+    }
+    if (buildProfile.distribution !== 'internal') {
+      Errors.error(
+        `Profile "${buildProfileName}" must specify "distribution: internal" in order to work with eas build:dev command. Select a different profile or update the profile in eas.json.`,
+        { exit: 1 }
+      );
+    }
+
+    if (platform === Platform.IOS) {
+      const iosProfile = buildProfile as BuildProfile<Platform.IOS>;
+      if (iosProfile.simulator !== true && iosProfile.withoutCredentials !== true) {
+        Errors.error(
+          `Profile "${buildProfileName}" must specify "ios.simulator: true" or "withoutCredentials: true" to create an iOS simulator build. Select a different profile or update the profile in eas.json.`,
+          { exit: 1 }
+        );
+      }
+    } else {
+      const androidProfile = buildProfile as BuildProfile<Platform.ANDROID>;
+      if (
+        androidProfile.distribution !== 'internal' &&
+        androidProfile.withoutCredentials !== true
+      ) {
+        Errors.error(
+          `Profile "${buildProfileName}" must specify "distribution: internal" or "withoutCredentials: true" to create an Android emulator build. Select a different profile or update the profile in eas.json.`,
+          { exit: 1 }
+        );
+      }
+    }
+  }
+
+  private async ensureValidBuildRunProfileExistsAsync({
+    projectDir,
+    platform,
+    selectedBuildProfileName,
+  }: {
+    projectDir: string;
+    platform: Platform;
+    selectedBuildProfileName?: string;
+  }): Promise<ProfileData<'build'>> {
+    if (
+      !!selectedBuildProfileName ||
+      (await doesBuildProfileExistAsync({
+        projectDir,
+        profileName: DEFAULT_EAS_BUILD_RUN_PROFILE_NAME,
+      }))
+    ) {
+      const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
+      const [buildProfile] = await getProfilesAsync({
+        type: 'build',
+        easJsonAccessor,
+        platforms: [platform],
+        profileName: selectedBuildProfileName ?? DEFAULT_EAS_BUILD_RUN_PROFILE_NAME,
+        projectDir,
+      });
+      await this.validateBuildRunProfileAsync({
+        buildProfileName: selectedBuildProfileName ?? DEFAULT_EAS_BUILD_RUN_PROFILE_NAME,
+        platform,
+        buildProfile: buildProfile.profile,
+      });
+    } else {
+      const createBuildProfile = await confirmAsync({
+        message: `We want to go ahead and generate "${DEFAULT_EAS_BUILD_RUN_PROFILE_NAME}" build profile for you, that matches eas build:dev criteria. Do you want to proceed?`,
+      });
+      if (!createBuildProfile) {
+        Errors.error(
+          'Come back later or specify different build compliant with eas build:dev requirements by using "--profile" flag.',
+          { exit: 1 }
+        );
+      }
+      await createBuildProfileAsync({
+        projectDir,
+        profileName: DEFAULT_EAS_BUILD_RUN_PROFILE_NAME,
+        profileContents: {
+          developmentClient: true,
+          distribution: 'internal',
+          ios: {
+            simulator: true,
+          },
+          environment: 'development',
+        },
+      });
+    }
+
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
+    const [buildProfile] = await getProfilesAsync({
+      type: 'build',
+      easJsonAccessor,
+      platforms: [platform],
+      profileName: selectedBuildProfileName ?? DEFAULT_EAS_BUILD_RUN_PROFILE_NAME,
+      projectDir,
+    });
+    return buildProfile;
   }
 }

--- a/packages/eas-cli/src/commands/build/dev.ts
+++ b/packages/eas-cli/src/commands/build/dev.ts
@@ -83,6 +83,7 @@ export default class BuildDev extends EasCommand {
         status: BuildStatus.Finished,
         simulator: platform === Platform.IOS ? true : undefined,
         distribution: DistributionType.Internal,
+        developmentClient: true,
       },
       offset: 0,
       limit: 1,

--- a/packages/eas-cli/src/commands/build/dev.ts
+++ b/packages/eas-cli/src/commands/build/dev.ts
@@ -22,6 +22,7 @@ import { runAsync } from '../../run/run';
 import { downloadAndMaybeExtractAppAsync } from '../../utils/download';
 import { createFingerprintAsync } from '../../utils/fingerprintCli';
 import { ProfileData, getProfilesAsync } from '../../utils/profiles';
+import { Client } from '../../vcs/vcs';
 
 const DEFAULT_EAS_BUILD_RUN_PROFILE_NAME = 'development-simulator';
 
@@ -84,6 +85,7 @@ export default class BuildDev extends EasCommand {
       projectDir,
       platform,
       selectedBuildProfileName: flags.profile,
+      vcsClient,
     });
 
     const workflow = await resolveWorkflowAsync(projectDir, platform, vcsClient);
@@ -229,10 +231,12 @@ export default class BuildDev extends EasCommand {
     projectDir,
     platform,
     selectedBuildProfileName,
+    vcsClient,
   }: {
     projectDir: string;
     platform: Platform;
     selectedBuildProfileName?: string;
+    vcsClient: Client;
   }): Promise<ProfileData<'build'>> {
     if (
       !!selectedBuildProfileName ||
@@ -275,6 +279,8 @@ export default class BuildDev extends EasCommand {
           },
           environment: 'development',
         },
+        nonInteractive: false,
+        vcsClient,
       });
     }
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -158,15 +158,15 @@ export default class Build extends EasCommand {
 
     const flagsWithPlatform = await this.ensurePlatformSelectedAsync(flags);
 
-    await runBuildAndSubmitAsync(
+    await runBuildAndSubmitAsync({
       graphqlClient,
       analytics,
       vcsClient,
       projectDir,
-      flagsWithPlatform,
+      flags: flagsWithPlatform,
       actor,
-      getDynamicPrivateProjectConfigAsync
-    );
+      getDynamicPrivateProjectConfigAsync,
+    });
   }
 
   private sanitizeFlags(

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -99,12 +99,12 @@ export default class BuildInspect extends EasCommand {
       await this.copyToOutputDirAsync(tmpWorkingdir, outputDirectory);
     } else {
       try {
-        await runBuildAndSubmitAsync(
+        await runBuildAndSubmitAsync({
           graphqlClient,
           analytics,
           vcsClient,
           projectDir,
-          {
+          flags: {
             nonInteractive: false,
             freezeCredentials: false,
             wait: true,
@@ -124,8 +124,8 @@ export default class BuildInspect extends EasCommand {
             repack: false,
           },
           actor,
-          getDynamicPrivateProjectConfigAsync
-        );
+          getDynamicPrivateProjectConfigAsync,
+        });
         if (!flags.verbose) {
           Log.log(chalk.green('Build successful'));
         }

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -70,12 +70,12 @@ export default class BuildInternal extends EasCommand {
 
     await handleDeprecatedEasJsonAsync(projectDir, flags.nonInteractive);
 
-    await runBuildAndSubmitAsync(
+    await runBuildAndSubmitAsync({
       graphqlClient,
       analytics,
       vcsClient,
       projectDir,
-      {
+      flags: {
         requestedPlatform: flags.platform as RequestedPlatform,
         profile: flags.profile,
         nonInteractive: true,
@@ -91,7 +91,7 @@ export default class BuildInternal extends EasCommand {
         repack: false,
       },
       actor,
-      getDynamicPrivateProjectConfigAsync
-    );
+      getDynamicPrivateProjectConfigAsync,
+    });
   }
 }

--- a/packages/eas-cli/src/commands/dev.ts
+++ b/packages/eas-cli/src/commands/dev.ts
@@ -1,0 +1,157 @@
+import { Platform } from '@expo/eas-build-job';
+import { BuildProfile, CredentialsSource } from '@expo/eas-json';
+import { Errors, Flags } from '@oclif/core';
+
+import { runBuildAndSubmitAsync } from '../build/runBuildAndSubmit';
+import EasCommand from '../commandUtils/EasCommand';
+import {
+  BuildStatus,
+  DistributionType,
+  EnvironmentVariableEnvironment,
+} from '../graphql/generated';
+import { BuildQuery } from '../graphql/queries/BuildQuery';
+import { toAppPlatform } from '../graphql/types/AppPlatform';
+import Log from '../log';
+import { RequestedPlatform } from '../platform';
+import { resolveWorkflowAsync } from '../project/workflow';
+import { runAsync } from '../run/run';
+import { downloadAndMaybeExtractAppAsync } from '../utils/download';
+import { createFingerprintAsync } from '../utils/fingerprintCli';
+
+export default class Dev extends EasCommand {
+  static override description =
+    'run dev client simulator/emulator build with matching fingerprint or create a new one';
+
+  static override flags = {
+    platform: Flags.enum<RequestedPlatform.Ios | RequestedPlatform.Android>({
+      char: 'p',
+      options: [RequestedPlatform.Android, RequestedPlatform.Ios],
+      required: true,
+    }),
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+    ...this.ContextOptions.DynamicProjectConfig,
+    ...this.ContextOptions.ProjectDir,
+    ...this.ContextOptions.Vcs,
+    ...this.ContextOptions.Analytics,
+    ...this.ContextOptions.ServerSideEnvironmentVariables,
+    ...this.ContextOptions.ProjectId,
+  };
+
+  protected override async runAsync(): Promise<any> {
+    const { flags } = await this.parse(Dev);
+
+    const {
+      loggedIn: { actor, graphqlClient },
+      getDynamicPrivateProjectConfigAsync,
+      projectDir,
+      analytics,
+      vcsClient,
+      getServerSideEnvironmentVariablesAsync,
+      projectId,
+    } = await this.getContextAsync(Dev, {
+      nonInteractive: false,
+      withServerSideEnvironment: EnvironmentVariableEnvironment.Development,
+    });
+
+    const platform = flags.platform === RequestedPlatform.Android ? Platform.ANDROID : Platform.IOS;
+    if (process.platform !== 'darwin' && platform === Platform.IOS) {
+      Errors.error('iOS builds are only supported on macOS.', { exit: 1 });
+    }
+
+    const env = await getServerSideEnvironmentVariablesAsync();
+    const workflow = await resolveWorkflowAsync(projectDir, platform, vcsClient);
+
+    const fingerprint = await createFingerprintAsync(projectDir, {
+      env,
+      workflow,
+      platforms: [platform],
+    });
+    if (!fingerprint) {
+      Errors.error('Failed to calculate fingerprint', { exit: 1 });
+    }
+    Log.log(`✨ Calculated fingerprint hash: ${fingerprint.hash}`);
+    Log.newLine();
+
+    const builds = await BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
+      appId: projectId,
+      filter: {
+        platform: toAppPlatform(platform),
+        fingerprintHash: fingerprint.hash,
+        status: BuildStatus.Finished,
+        simulator: platform === Platform.IOS ? true : undefined,
+        distribution: DistributionType.Internal,
+      },
+      offset: 0,
+      limit: 1,
+    });
+    if (builds.length !== 0) {
+      const build = builds[0];
+      Log.succeed(
+        `🎯 Found successful build with matching fingerprint on EAS servers: ${build.artifacts?.buildUrl}. Running it...`
+      );
+
+      if (build.artifacts?.applicationArchiveUrl) {
+        const buildPath = await downloadAndMaybeExtractAppAsync(
+          build.artifacts.applicationArchiveUrl,
+          build.platform
+        );
+        await runAsync(buildPath, build.platform);
+        return;
+      } else {
+        Log.warn('Artifacts for this build expired. New build will be started.');
+      }
+    }
+
+    Log.log('🚀 No successful build with matching fingerprint found. Starting a new build...');
+    const androidBuildProfile: BuildProfile<Platform.ANDROID> = {
+      credentialsSource: CredentialsSource.LOCAL,
+      distribution: 'internal',
+      withoutCredentials: true,
+      developmentClient: true,
+    };
+    const iosBuildProfile: BuildProfile<Platform.IOS> = {
+      credentialsSource: CredentialsSource.LOCAL,
+      distribution: 'internal',
+      simulator: true,
+      developmentClient: true,
+    };
+
+    await runBuildAndSubmitAsync(
+      graphqlClient,
+      analytics,
+      vcsClient,
+      projectDir,
+      {
+        requestedPlatform: flags.platform,
+        nonInteractive: false,
+        freezeCredentials: false,
+        wait: true,
+        clearCache: false,
+        json: false,
+        autoSubmit: false,
+        localBuildOptions: {},
+        repack: false,
+      },
+      actor,
+      getDynamicPrivateProjectConfigAsync,
+      [
+        platform === Platform.ANDROID
+          ? {
+              platform: Platform.ANDROID,
+              profile: androidBuildProfile,
+              profileName: '__internal-dev-client__',
+            }
+          : {
+              platform: Platform.IOS,
+              profile: iosBuildProfile,
+              profileName: '__internal-dev-client__',
+            },
+      ],
+      true,
+      env
+    );
+  }
+}

--- a/packages/eas-cli/src/commands/dev.ts
+++ b/packages/eas-cli/src/commands/dev.ts
@@ -90,7 +90,7 @@ export default class Dev extends EasCommand {
     if (builds.length !== 0) {
       const build = builds[0];
       Log.succeed(
-        `🎯 Found successful build with matching fingerprint on EAS servers: ${build.artifacts?.buildUrl}. Running it...`
+        `🎯 Found successful build with matching fingerprint on EAS servers. Running it...`
       );
 
       if (build.artifacts?.applicationArchiveUrl) {

--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -285,12 +285,12 @@ export default class Onboarding extends EasCommand {
     } else {
       Log.log('🚀 Now we are going to trigger your first build');
       Log.log();
-      const { buildIds } = await runBuildAndSubmitAsync(
+      const { buildIds } = await runBuildAndSubmitAsync({
         graphqlClient,
         analytics,
         vcsClient,
-        finalTargetProjectDirectory,
-        {
+        projectDir: finalTargetProjectDirectory,
+        flags: {
           nonInteractive: true,
           requestedPlatform:
             platform === Platform.ANDROID ? RequestedPlatform.Android : RequestedPlatform.Ios,
@@ -307,8 +307,9 @@ export default class Onboarding extends EasCommand {
           repack: true,
         },
         actor,
-        getDynamicProjectConfigFn
-      );
+        // eslint-disable-next-line async-protect/async-suffix
+        getDynamicPrivateProjectConfigAsync: getDynamicProjectConfigFn,
+      });
       const buildId = buildIds[0];
       Log.log();
       Log.log('🚀 You can now go back to the website to continue:');


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C1QLM27T9/p1734729481930599?thread_ts=1734708689.473259&cid=C1QLM27T9

Add `eas dev` command that:
1. calculates fingerprint
2. checks if we have simulator/emulator dev client builds with such a fingerprint hash on our servers
a. if we do -  it downloads and launches them on the emulator/simulator using the same logic we use for eas build:run
b. if not -  such a build is created and launched afterward 

# How

Do exactly what I mentioned above. Use as much code and functions from build logic and eas build:run that already exist to make it easier to maintain.

# Test Plan

Test manually

https://exponent-internal.slack.com/archives/C1QLM27T9/p1736987685783579?thread_ts=1734708689.473259&cid=C1QLM27T9
