### PR TITLE
[eas-cli] fix deploy command typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 ### 🧹 Chores
+- Fix logs typos in the `eas deploy` command. ([#2822](https://github.com/expo/eas-cli/pull/2822) by [@kadikraman](https://github.com/kadikraman))
+
 
 ## [14.4.1](https://github.com/expo/eas-cli/releases/tag/v14.4.1) - 2025-01-15
 

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -111,7 +111,7 @@ export default class WorkerDeploy extends EasCommand {
       enableJsonOutput();
     }
 
-    Log.warn('EAS Hosting is still in beta and subject to changes.');
+    Log.warn('EAS Hosting is still in preview and subject to changes.');
 
     const {
       getDynamicPrivateProjectConfigAsync,

--- a/packages/eas-cli/src/commands/worker/deploy.ts
+++ b/packages/eas-cli/src/commands/worker/deploy.ts
@@ -455,7 +455,7 @@ function logExportedProjectInfo(
   // Only show the timestamp for exports older than 1 minute
   if (project.modifiedAt && Date.now() - project.modifiedAt.getTime() > 60_000) {
     modifiedAgo = ` - exported ${formatTimeAgo(project.modifiedAt)}`;
-    Log.warn(`> Project export: ${project.type}${modifiedAgo}}`);
+    Log.warn(`> Project export: ${project.type}${modifiedAgo}`);
   } else {
     Log.log(chalk`{dim > Project export: ${project.type}}`);
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Minor logs tweaks to the `deploy` command.

# How

- hosting is in "preview" (not "beta")
- remove errant curly when logging out when the project was last exported

# Test Plan

Run `eas deploy` and verify the logs are printed out correctly.
