### PR TITLE
[eas-cli] [ENG-14633] Start autoIncremented builds at 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Make new autoIncremented builds start at nr 1 by default ([#2828](https://github.com/expo/eas-cli/pull/2828) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
+
 ## [14.5.0](https://github.com/expo/eas-cli/releases/tag/v14.5.0) - 2025-01-22
 
 ### 🎉 New features

--- a/packages/eas-cli/src/build/android/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/android/__tests__/version-test.ts
@@ -311,6 +311,32 @@ describe(resolveRemoteVersionCodeAsync, () => {
     expect(createAppVersionAsyncSpy.mock.calls[0][1].buildVersion).toBe('1');
   });
 
+  it('increments current remote versionCode when remote version set, autoIncrement=true', async () => {
+    const graphQLClientMock = instance(mock<ExpoGraphqlClient>());
+    const vcsClientMock = instance(mock<Client>());
+    vcsClientMock.getRootPathAsync = async () => '/app';
+    jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue({
+      buildVersion: '11',
+      storeVersion: '1.2.3',
+    });
+    const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
+    const exp = initBareWorkflowProject();
+
+    const result = await resolveRemoteVersionCodeAsync(graphQLClientMock, {
+      projectDir: '/app',
+      projectId: 'fakeProjectId',
+      exp,
+      applicationId: 'fakeApplicationId',
+      buildProfile: { autoIncrement: true } as AndroidBuildProfile,
+      vcsClient: vcsClientMock,
+    });
+
+    expect(result).toBe('12');
+    expect(createAppVersionAsyncSpy).toHaveBeenCalled();
+    expect(createAppVersionAsyncSpy.mock.calls[0][1].storeVersion).toBe('3.0.0');
+    expect(createAppVersionAsyncSpy.mock.calls[0][1].buildVersion).toBe('12');
+  });
+
   it('increments versionCode from local files when remote version not set, autoIncrement=true', async () => {
     const graphQLClientMock = instance(mock<ExpoGraphqlClient>());
     const vcsClientMock = instance(mock<Client>());

--- a/packages/eas-cli/src/build/android/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/android/__tests__/version-test.ts
@@ -1,26 +1,27 @@
 import { ExpoConfig } from '@expo/config';
 import { Platform } from '@expo/eas-build-job';
 import { BuildProfile } from '@expo/eas-json';
+import { AndroidBuildProfile } from '@expo/eas-json/build/build/types';
 import assert from 'assert';
 import fs from 'fs-extra';
 import { vol } from 'memfs';
 import os from 'os';
 import path from 'path';
+import { instance, mock } from 'ts-mockito';
 
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { AppVersionMutation } from '../../../graphql/mutations/AppVersionMutation';
+import { AppVersionQuery } from '../../../graphql/queries/AppVersionQuery';
 import { getAppBuildGradleAsync, resolveConfigValue } from '../../../project/android/gradleUtils';
 import { resolveVcsClient } from '../../../vcs';
+import { Client } from '../../../vcs/vcs';
 import {
   BumpStrategy,
   bumpVersionAsync,
   bumpVersionInAppJsonAsync,
-  maybeResolveVersionsAsync, resolveRemoteVersionCodeAsync,
+  maybeResolveVersionsAsync,
+  resolveRemoteVersionCodeAsync,
 } from '../version';
-import {ExpoGraphqlClient} from "../../../commandUtils/context/contextUtils/createGraphqlClient";
-import {AndroidBuildProfile} from "@expo/eas-json/build/build/types";
-import {Client} from "../../../vcs/vcs";
-import {AppVersionQuery} from "../../../graphql/queries/AppVersionQuery";
-import {AppVersionMutation} from "../../../graphql/mutations/AppVersionMutation";
-import {instance, mock} from "ts-mockito";
 
 const fsReal = jest.requireActual('fs').promises as typeof fs;
 jest.mock('fs');
@@ -246,7 +247,7 @@ describe(resolveRemoteVersionCodeAsync, () => {
     vcsClientMock.getRootPathAsync = async () => '/app';
     jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue({
       buildVersion: '11',
-      storeVersion: '1.2.3'
+      storeVersion: '1.2.3',
     });
     const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
     const exp = initBareWorkflowProject();
@@ -258,11 +259,11 @@ describe(resolveRemoteVersionCodeAsync, () => {
       applicationId: 'fakeApplicationId',
       buildProfile: {} as AndroidBuildProfile,
       vcsClient: vcsClientMock,
-    })
+    });
 
     expect(result).toBe('11');
     expect(createAppVersionAsyncSpy).not.toHaveBeenCalled();
-  })
+  });
 
   it('initializes versionCode from local files when remote version not set, autoIncrement=false', async () => {
     const graphQLClientMock = instance(mock<ExpoGraphqlClient>());
@@ -270,7 +271,7 @@ describe(resolveRemoteVersionCodeAsync, () => {
     vcsClientMock.getRootPathAsync = async () => '/app';
     jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue(null);
     const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
-    const exp = initBareWorkflowProject({versionCode: 22, versionName: '2.3.4'});
+    const exp = initBareWorkflowProject({ versionCode: 22, versionName: '2.3.4' });
 
     const result = await resolveRemoteVersionCodeAsync(graphQLClientMock, {
       projectDir: '/app',
@@ -279,13 +280,13 @@ describe(resolveRemoteVersionCodeAsync, () => {
       applicationId: 'fakeApplicationId',
       buildProfile: {} as AndroidBuildProfile,
       vcsClient: vcsClientMock,
-    })
+    });
 
     expect(result).toBe('22');
     expect(createAppVersionAsyncSpy).toHaveBeenCalled();
     expect(createAppVersionAsyncSpy.mock.calls[0][1].storeVersion).toBe('2.3.4');
     expect(createAppVersionAsyncSpy.mock.calls[0][1].buildVersion).toBe('22');
-  })
+  });
 
   it('initializes versionCode starting with 1 when remote version not set and not set in local files, autoIncrement=false', async () => {
     const graphQLClientMock = instance(mock<ExpoGraphqlClient>());
@@ -293,7 +294,7 @@ describe(resolveRemoteVersionCodeAsync, () => {
     vcsClientMock.getRootPathAsync = async () => '/app';
     jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue(null);
     const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
-    const exp = initBareWorkflowProject({versionCode: null, versionName: null});
+    const exp = initBareWorkflowProject({ versionCode: null, versionName: null });
 
     const result = await resolveRemoteVersionCodeAsync(graphQLClientMock, {
       projectDir: '/app',
@@ -302,13 +303,13 @@ describe(resolveRemoteVersionCodeAsync, () => {
       applicationId: 'fakeApplicationId',
       buildProfile: {} as AndroidBuildProfile,
       vcsClient: vcsClientMock,
-    })
+    });
 
     expect(result).toBe('1');
     expect(createAppVersionAsyncSpy).toHaveBeenCalled();
     expect(createAppVersionAsyncSpy.mock.calls[0][1].storeVersion).toBe('1.0.0');
     expect(createAppVersionAsyncSpy.mock.calls[0][1].buildVersion).toBe('1');
-  })
+  });
 
   it('increments versionCode from local files when remote version not set, autoIncrement=true', async () => {
     const graphQLClientMock = instance(mock<ExpoGraphqlClient>());
@@ -316,22 +317,22 @@ describe(resolveRemoteVersionCodeAsync, () => {
     vcsClientMock.getRootPathAsync = async () => '/app';
     jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue(null);
     const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
-    const exp = initBareWorkflowProject({versionCode: 22, versionName: '2.3.4'});
+    const exp = initBareWorkflowProject({ versionCode: 22, versionName: '2.3.4' });
 
     const result = await resolveRemoteVersionCodeAsync(graphQLClientMock, {
       projectDir: '/app',
       projectId: 'fakeProjectId',
       exp,
       applicationId: 'fakeApplicationId',
-      buildProfile: {autoIncrement: true} as AndroidBuildProfile,
+      buildProfile: { autoIncrement: true } as AndroidBuildProfile,
       vcsClient: vcsClientMock,
-    })
+    });
 
     expect(result).toBe('23');
     expect(createAppVersionAsyncSpy).toHaveBeenCalled();
     expect(createAppVersionAsyncSpy.mock.calls[0][1].storeVersion).toBe('2.3.4');
     expect(createAppVersionAsyncSpy.mock.calls[0][1].buildVersion).toBe('23');
-  })
+  });
 
   it('initializes versionCode starting with 1 when remote version not set and not set in local files, autoIncrement=true', async () => {
     const graphQLClientMock = instance(mock<ExpoGraphqlClient>());
@@ -339,23 +340,23 @@ describe(resolveRemoteVersionCodeAsync, () => {
     vcsClientMock.getRootPathAsync = async () => '/app';
     jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue(null);
     const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
-    const exp = initBareWorkflowProject({versionCode: null, versionName: null});
+    const exp = initBareWorkflowProject({ versionCode: null, versionName: null });
 
     const result = await resolveRemoteVersionCodeAsync(graphQLClientMock, {
       projectDir: '/app',
       projectId: 'fakeProjectId',
       exp,
       applicationId: 'fakeApplicationId',
-      buildProfile: {autoIncrement: true} as AndroidBuildProfile,
+      buildProfile: { autoIncrement: true } as AndroidBuildProfile,
       vcsClient: vcsClientMock,
-    })
+    });
 
     expect(result).toBe('1');
     expect(createAppVersionAsyncSpy).toHaveBeenCalled();
     expect(createAppVersionAsyncSpy.mock.calls[0][1].storeVersion).toBe('1.0.0');
     expect(createAppVersionAsyncSpy.mock.calls[0][1].buildVersion).toBe('1');
-  })
-})
+  });
+});
 
 function initBareWorkflowProject({
   versionCode = 123,

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -99,7 +99,7 @@ export async function maybeResolveVersionsAsync(
   exp: ExpoConfig,
   buildProfile: BuildProfile<Platform.ANDROID>,
   vcsClient: Client
-): Promise<{ appVersion?: string; appBuildVersion?: string, isVersionInitialized?: boolean }> {
+): Promise<{ appVersion?: string; appBuildVersion?: string; isVersionInitialized?: boolean }> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
   if (workflow === Workflow.GENERIC) {
     const buildGradle = await getAppBuildGradleAsync(projectDir);
@@ -113,7 +113,11 @@ export async function maybeResolveVersionsAsync(
           resolveConfigValue(buildGradle, 'versionName', parsedGradleCommand?.flavor) ?? '1.0.0',
         appBuildVersion:
           resolveConfigValue(buildGradle, 'versionCode', parsedGradleCommand?.flavor) ?? '1',
-        isVersionInitialized: !resolveConfigValue(buildGradle, 'versionCode', parsedGradleCommand?.flavor),
+        isVersionInitialized: !resolveConfigValue(
+          buildGradle,
+          'versionCode',
+          parsedGradleCommand?.flavor
+        ),
       };
     } catch {
       return {};
@@ -226,7 +230,10 @@ export async function resolveRemoteVersionCodeAsync(
   }
   if (!buildProfile.autoIncrement && remoteVersions?.buildVersion) {
     return currentBuildVersion;
-  } else if ((!buildProfile.autoIncrement && !remoteVersions?.buildVersion) || shouldInitializeVersionCode) {
+  } else if (
+    (!buildProfile.autoIncrement && !remoteVersions?.buildVersion) ||
+    shouldInitializeVersionCode
+  ) {
     const spinner = ora(
       `Initializing versionCode with ${chalk.bold(currentBuildVersion)}.`
     ).start();

--- a/packages/eas-cli/src/build/android/version.ts
+++ b/packages/eas-cli/src/build/android/version.ts
@@ -99,7 +99,7 @@ export async function maybeResolveVersionsAsync(
   exp: ExpoConfig,
   buildProfile: BuildProfile<Platform.ANDROID>,
   vcsClient: Client
-): Promise<{ appVersion?: string; appBuildVersion?: string }> {
+): Promise<{ appVersion?: string; appBuildVersion?: string, isVersionInitialized?: boolean }> {
   const workflow = await resolveWorkflowAsync(projectDir, Platform.ANDROID, vcsClient);
   if (workflow === Workflow.GENERIC) {
     const buildGradle = await getAppBuildGradleAsync(projectDir);
@@ -113,6 +113,7 @@ export async function maybeResolveVersionsAsync(
           resolveConfigValue(buildGradle, 'versionName', parsedGradleCommand?.flavor) ?? '1.0.0',
         appBuildVersion:
           resolveConfigValue(buildGradle, 'versionCode', parsedGradleCommand?.flavor) ?? '1',
+        isVersionInitialized: !resolveConfigValue(buildGradle, 'versionCode', parsedGradleCommand?.flavor),
       };
     } catch {
       return {};
@@ -204,6 +205,7 @@ export async function resolveRemoteVersionCodeAsync(
 
   const localVersions = await maybeResolveVersionsAsync(projectDir, exp, buildProfile, vcsClient);
   let currentBuildVersion: string;
+  let shouldInitializeVersionCode = false;
   if (remoteVersions?.buildVersion) {
     currentBuildVersion = remoteVersions.buildVersion;
   } else {
@@ -214,6 +216,7 @@ export async function resolveRemoteVersionCodeAsync(
         )
       );
       currentBuildVersion = localVersions.appBuildVersion;
+      shouldInitializeVersionCode = localVersions.isVersionInitialized ?? false;
     } else {
       Log.error(
         `Remote versions are not configured and EAS CLI was not able to read the current version from your project. Use "eas build:version:set" to initialize remote versions.`
@@ -223,7 +226,7 @@ export async function resolveRemoteVersionCodeAsync(
   }
   if (!buildProfile.autoIncrement && remoteVersions?.buildVersion) {
     return currentBuildVersion;
-  } else if (!buildProfile.autoIncrement && !remoteVersions?.buildVersion) {
+  } else if ((!buildProfile.autoIncrement && !remoteVersions?.buildVersion) || shouldInitializeVersionCode) {
     const spinner = ora(
       `Initializing versionCode with ${chalk.bold(currentBuildVersion)}.`
     ).start();

--- a/packages/eas-cli/src/build/ios/__tests__/version-test.ts
+++ b/packages/eas-cli/src/build/ios/__tests__/version-test.ts
@@ -1,12 +1,19 @@
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
+import { IosBuildProfile } from '@expo/eas-json/build/build/types';
 import fs from 'fs-extra';
 import { vol } from 'memfs';
 import os from 'os';
+import { instance, mock } from 'ts-mockito';
 import type { XCBuildConfiguration } from 'xcode';
 
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { Target } from '../../../credentials/ios/types';
+import { AppVersionMutation } from '../../../graphql/mutations/AppVersionMutation';
+import { AppVersionQuery } from '../../../graphql/queries/AppVersionQuery';
 import { readPlistAsync } from '../../../utils/plist';
 import { resolveVcsClient } from '../../../vcs';
+import { Client } from '../../../vcs/vcs';
 import {
   BumpStrategy,
   bumpVersionAsync,
@@ -17,13 +24,6 @@ import {
   readShortVersionAsync,
   resolveRemoteBuildNumberAsync,
 } from '../version';
-import { Target } from '../../../credentials/ios/types'
-import {ExpoGraphqlClient} from "../../../commandUtils/context/contextUtils/createGraphqlClient";
-import {IosBuildProfile} from "@expo/eas-json/build/build/types";
-import {Client} from "../../../vcs/vcs";
-import {AppVersionQuery} from "../../../graphql/queries/AppVersionQuery";
-import {AppVersionMutation} from "../../../graphql/mutations/AppVersionMutation";
-import {instance, mock} from "ts-mockito";
 
 jest.mock('fs');
 jest.mock('../../../commandUtils/context/contextUtils/createGraphqlClient');
@@ -391,7 +391,7 @@ describe(resolveRemoteBuildNumberAsync, () => {
     vcsClientMock.getRootPathAsync = async () => '/app';
     jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue({
       buildVersion: '11',
-      storeVersion: '1.2.3'
+      storeVersion: '1.2.3',
     });
     const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
     const exp = initBareWorkflowProject();
@@ -403,11 +403,11 @@ describe(resolveRemoteBuildNumberAsync, () => {
       applicationTarget: {} as Target,
       buildProfile: {} as IosBuildProfile,
       vcsClient: vcsClientMock,
-    })
+    });
 
     expect(result).toBe('11');
     expect(createAppVersionAsyncSpy).not.toHaveBeenCalled();
-  })
+  });
 
   it('initializes buildNumber from local files when remote version not set, autoIncrement=false', async () => {
     const graphQLClientMock = instance(mock<ExpoGraphqlClient>());
@@ -415,7 +415,7 @@ describe(resolveRemoteBuildNumberAsync, () => {
     vcsClientMock.getRootPathAsync = async () => '/app';
     jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue(null);
     const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
-    const exp = initBareWorkflowProject({buildNumber: '22', appVersion: '2.3.4'});
+    const exp = initBareWorkflowProject({ buildNumber: '22', appVersion: '2.3.4' });
 
     const result = await resolveRemoteBuildNumberAsync(graphQLClientMock, {
       projectDir: '/app',
@@ -424,13 +424,13 @@ describe(resolveRemoteBuildNumberAsync, () => {
       applicationTarget: {} as Target,
       buildProfile: {} as IosBuildProfile,
       vcsClient: vcsClientMock,
-    })
+    });
 
     expect(result).toBe('22');
     expect(createAppVersionAsyncSpy).toHaveBeenCalled();
     expect(createAppVersionAsyncSpy.mock.calls[0][1].storeVersion).toBe('2.3.4');
     expect(createAppVersionAsyncSpy.mock.calls[0][1].buildVersion).toBe('22');
-  })
+  });
 
   it('initializes buildNumber starting with 1 when remote version not set and local version is 1, autoIncrement=false', async () => {
     const graphQLClientMock = instance(mock<ExpoGraphqlClient>());
@@ -438,7 +438,7 @@ describe(resolveRemoteBuildNumberAsync, () => {
     vcsClientMock.getRootPathAsync = async () => '/app';
     jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue(null);
     const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
-    const exp = initBareWorkflowProject({buildNumber: '1', appVersion: '1.0.0'});
+    const exp = initBareWorkflowProject({ buildNumber: '1', appVersion: '1.0.0' });
 
     const result = await resolveRemoteBuildNumberAsync(graphQLClientMock, {
       projectDir: '/app',
@@ -447,13 +447,13 @@ describe(resolveRemoteBuildNumberAsync, () => {
       applicationTarget: {} as Target,
       buildProfile: {} as IosBuildProfile,
       vcsClient: vcsClientMock,
-    })
+    });
 
     expect(result).toBe('1');
     expect(createAppVersionAsyncSpy).toHaveBeenCalled();
     expect(createAppVersionAsyncSpy.mock.calls[0][1].storeVersion).toBe('1.0.0');
     expect(createAppVersionAsyncSpy.mock.calls[0][1].buildVersion).toBe('1');
-  })
+  });
 
   it('increments buildNumber from local files when remote version not set, autoIncrement=true', async () => {
     const graphQLClientMock = instance(mock<ExpoGraphqlClient>());
@@ -461,22 +461,22 @@ describe(resolveRemoteBuildNumberAsync, () => {
     vcsClientMock.getRootPathAsync = async () => '/app';
     jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue(null);
     const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
-    const exp = initBareWorkflowProject({buildNumber: '22', appVersion: '2.3.4'});
+    const exp = initBareWorkflowProject({ buildNumber: '22', appVersion: '2.3.4' });
 
     const result = await resolveRemoteBuildNumberAsync(graphQLClientMock, {
       projectDir: '/app',
       projectId: 'fakeProjectId',
       exp,
       applicationTarget: {} as Target,
-      buildProfile: {autoIncrement: true} as IosBuildProfile,
+      buildProfile: { autoIncrement: true } as IosBuildProfile,
       vcsClient: vcsClientMock,
-    })
+    });
 
     expect(result).toBe('23');
     expect(createAppVersionAsyncSpy).toHaveBeenCalled();
     expect(createAppVersionAsyncSpy.mock.calls[0][1].storeVersion).toBe('2.3.4');
     expect(createAppVersionAsyncSpy.mock.calls[0][1].buildVersion).toBe('23');
-  })
+  });
 
   it('initializes buildNumber starting with 1 when remote version not set and local version is 1, autoIncrement=true', async () => {
     const graphQLClientMock = instance(mock<ExpoGraphqlClient>());
@@ -484,23 +484,23 @@ describe(resolveRemoteBuildNumberAsync, () => {
     vcsClientMock.getRootPathAsync = async () => '/app';
     jest.mocked(AppVersionQuery.latestVersionAsync).mockResolvedValue(null);
     const createAppVersionAsyncSpy = jest.spyOn(AppVersionMutation, 'createAppVersionAsync');
-    const exp = initBareWorkflowProject({buildNumber: '1', appVersion: '1.0.0'});
+    const exp = initBareWorkflowProject({ buildNumber: '1', appVersion: '1.0.0' });
 
     const result = await resolveRemoteBuildNumberAsync(graphQLClientMock, {
       projectDir: '/app',
       projectId: 'fakeProjectId',
       exp,
       applicationTarget: {} as Target,
-      buildProfile: {autoIncrement: true} as IosBuildProfile,
+      buildProfile: { autoIncrement: true } as IosBuildProfile,
       vcsClient: vcsClientMock,
-    })
+    });
 
     expect(result).toBe('1');
     expect(createAppVersionAsyncSpy).toHaveBeenCalled();
     expect(createAppVersionAsyncSpy.mock.calls[0][1].storeVersion).toBe('1.0.0');
     expect(createAppVersionAsyncSpy.mock.calls[0][1].buildVersion).toBe('1');
-  })
-})
+  });
+});
 
 function initBareWorkflowProject({
   appVersion = '1.0.0',

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -351,7 +351,10 @@ export async function resolveRemoteBuildNumberAsync(
   }
   if (!buildProfile.autoIncrement && remoteVersions?.buildVersion) {
     return currentBuildVersion;
-  } else if ((!buildProfile.autoIncrement && !remoteVersions?.buildVersion) || shouldInitializeBuildNumber) {
+  } else if (
+    (!buildProfile.autoIncrement && !remoteVersions?.buildVersion) ||
+    shouldInitializeBuildNumber
+  ) {
     const spinner = ora(
       `Initializing buildNumber with ${chalk.bold(currentBuildVersion)}.`
     ).start();

--- a/packages/eas-cli/src/build/ios/version.ts
+++ b/packages/eas-cli/src/build/ios/version.ts
@@ -330,6 +330,7 @@ export async function resolveRemoteBuildNumberAsync(
     vcsClient
   );
   let currentBuildVersion: string;
+  let shouldInitializeBuildNumber = false;
   if (remoteVersions?.buildVersion) {
     currentBuildVersion = remoteVersions.buildVersion;
   } else {
@@ -340,6 +341,7 @@ export async function resolveRemoteBuildNumberAsync(
         )
       );
       currentBuildVersion = localBuildNumber;
+      shouldInitializeBuildNumber = localBuildNumber === '1';
     } else {
       Log.error(
         `Remote versions are not configured and EAS CLI was not able to read the current version from your project. Use "eas build:version:set" to initialize remote versions.`
@@ -349,7 +351,7 @@ export async function resolveRemoteBuildNumberAsync(
   }
   if (!buildProfile.autoIncrement && remoteVersions?.buildVersion) {
     return currentBuildVersion;
-  } else if (!buildProfile.autoIncrement && !remoteVersions?.buildVersion) {
+  } else if ((!buildProfile.autoIncrement && !remoteVersions?.buildVersion) || shouldInitializeBuildNumber) {
     const spinner = ora(
       `Initializing buildNumber with ${chalk.bold(currentBuildVersion)}.`
     ).start();


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-14633/start-autoincrement-counter-at-0-so-first-build-has-buildnumber-==-1

# How

When versionCode/buildNumber is initialised ignore autoIncrement and use the initial version

# Test Plan

Added tests