### PR TITLE
[eas-cli] Detect valid JSON files during hosting upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Allow filtering by `--fingerprint_hash` in `eas build:list` command. ([#2818](https://github.com/expo/eas-cli/pull/2818) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
+- Ensure that the AASA file is served with content type application/json ([#2829](https://github.com/expo/eas-cli/pull/2829) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🧹 Chores
 - Fix logs typos in the `eas deploy` command. ([#2822](https://github.com/expo/eas-cli/pull/2822) by [@kadikraman](https://github.com/kadikraman))


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The apple app site association file (needed for Universal linking on iOS) does not have a file extension, as it's simply served from `/.well-known/apple-app-site-association`.

However in order for it to be valid, the file need to return `Content-Type: application/json` header.


# How

When content type cannot be detected form the mime type, try parsing the file to check if it's a valid JSON and set the header accordingly.

# Test Plan

Deploy a website with an `apple-app-site-association` file and verify that the `Content-Type` header is set to `application/json`.
