### PR TITLE
[eas-cli] [ENG-14629] Improve AppleID validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 - Ensure that the AASA file is served with content type application/json ([#2829](https://github.com/expo/eas-cli/pull/2829) by [@kadikraman](https://github.com/kadikraman))
+- Ensure that the AppleID provided in prompt or saved to cache does not contain invalid unprintable characters ([#2830](https://github.com/expo/eas-cli/pull/2830) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 
 ### 🧹 Chores
 - Fix logs typos in the `eas deploy` command. ([#2822](https://github.com/expo/eas-cli/pull/2822) by [@kadikraman](https://github.com/kadikraman))

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/resolveCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/resolveCredentials-test.ts
@@ -232,7 +232,6 @@ describe(resolveUserCredentialsAsync, () => {
     expect(result).toMatchObject({
       username: 'newFakeUsername',
     });
-    expect(cacheAsyncSpy).toHaveBeenCalled();
     expect(cacheAsyncSpy).toHaveBeenCalledWith('./.app-store/auth/username.json', {
       username: 'newFakeUsername',
     });

--- a/packages/eas-cli/src/credentials/ios/appstore/resolveCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/resolveCredentials.ts
@@ -208,13 +208,14 @@ async function promptUsernameAsync(): Promise<string> {
   // the default value for quicker authentication.
   const lastAppleId = await getCachedUsernameAsync();
 
-  const { username } = await promptAsync({
+  let { username } = await promptAsync({
     type: 'text',
     name: 'username',
     message: `Apple ID:`,
     validate: (val: string) => val !== '',
     initial: lastAppleId ?? undefined,
   });
+  username = username.replace(/[\x00-\x1F]/gi, '');
 
   if (username && username !== lastAppleId) {
     await cacheUsernameAsync(username);

--- a/packages/eas-cli/src/credentials/ios/appstore/resolveCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/resolveCredentials.ts
@@ -215,6 +215,10 @@ async function promptUsernameAsync(): Promise<string> {
     validate: (val: string) => val !== '',
     initial: lastAppleId ?? undefined,
   });
+  // https://github.com/expo/eas-cli/issues/2254
+  // user got an invalid unprintable character in their username, which was saved to cache and used to prefill the prompt
+  // which made them accept the prefilled value not knowing it contains the character and fail to log in
+  // this replace makes sure no such characters are used or cached
   username = username.replace(/[\x00-\x1F]/gi, '');
 
   if (username && username !== lastAppleId) {


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-14629/improve-apple-id-input-validation

- user was asked to log into their Apple account
- prompt displayed for the username, pre-filled with value from cache
- value from cache contains invalid, unprintable characters (`\u0017`)
- user accepts "correct" username
- fails to log in
- user removes the cache file
- logs in successfully when manually typing "the same" username (but without invalid characters)

# How

The username value from prompt is cleared of any invalid unprintable characters before updating cache and using the value to log into Apple account

# Test Plan

Added tests for `resolveUserCredentialsAsync` function
Tested the behaviour for a username with reported invalid characters