### PR TITLE
[eas-cli] No longer require owner field for SDK >= 53 or canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Popup website in fingerprint:compare. ([#2859](https://github.com/expo/eas-cli/pull/2859) by [@quinlanj](https://github.com/quinlanj))
 - Fix fingerprint:compare URL. ([#2861](https://github.com/expo/eas-cli/pull/2861) by [@quinlanj](https://github.com/quinlanj))
 - Make less gql calls in fingerprint:compare. ([#2860](https://github.com/expo/eas-cli/pull/2860) by [@quinlanj](https://github.com/quinlanj))
+- No longer require owner field for SDK >= 53 or canary. ([#2835](https://github.com/expo/eas-cli/pull/2835) by [@wschurman](https://github.com/wschurman))
 
 ## [15.0.3](https://github.com/expo/eas-cli/releases/tag/v15.0.3) - 2025-02-04
 

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -1,6 +1,7 @@
 import { ExpoConfig, getProjectConfigDescription } from '@expo/config';
 import { Env } from '@expo/eas-build-job';
 import chalk from 'chalk';
+import semver from 'semver';
 
 import { ExpoGraphqlClient, createGraphqlClient } from './createGraphqlClient';
 import { findProjectRootAsync } from './findProjectDirAndVerifyProjectSetupAsync';
@@ -127,29 +128,33 @@ export async function validateOrSetProjectIdAsync({
       );
     }
 
-    const actorUsername = getActorUsername(actor);
-    if (!exp.owner && appForProjectId.ownerAccount.name !== actorUsername) {
-      if (actorUsername) {
-        throw new Error(
-          `Project config: Owner of project identified by "extra.eas.projectId" (${
-            appForProjectId.ownerAccount.name
-          }) does not match the logged in user (${actorUsername}) and the "owner" field is not specified. To ensure all libraries work correctly, "owner": "${
-            appForProjectId.ownerAccount.name
-          }" should be added to the project config, which can be done automatically by re-running "eas init". ${learnMore(
-            'https://expo.fyi/eas-project-id'
-          )}`
-        );
-      } else {
-        // robot caller
-        throw new Error(
-          `Project config: Owner of project identified by "extra.eas.projectId" (${
-            appForProjectId.ownerAccount.name
-          }) must be specified in "owner" field when using a robot access token. To ensure all libraries work correctly, "owner": "${
-            appForProjectId.ownerAccount.name
-          }" should be added to the project config, which can be done automatically by re-running "eas init". ${learnMore(
-            'https://expo.fyi/eas-project-id'
-          )}`
-        );
+    const sdkVersion = exp.sdkVersion;
+    // SDK 53 and above no longer require owner field in app config
+    if (sdkVersion && semver.satisfies(sdkVersion, '< 53.0.0')) {
+      const actorUsername = getActorUsername(actor);
+      if (!exp.owner && appForProjectId.ownerAccount.name !== actorUsername) {
+        if (actorUsername) {
+          throw new Error(
+            `Project config: Owner of project identified by "extra.eas.projectId" (${
+              appForProjectId.ownerAccount.name
+            }) does not match the logged in user (${actorUsername}) and the "owner" field is not specified. To ensure all libraries work correctly, "owner": "${
+              appForProjectId.ownerAccount.name
+            }" should be added to the project config, which can be done automatically by re-running "eas init". ${learnMore(
+              'https://expo.fyi/eas-project-id'
+            )}`
+          );
+        } else {
+          // robot caller
+          throw new Error(
+            `Project config: Owner of project identified by "extra.eas.projectId" (${
+              appForProjectId.ownerAccount.name
+            }) must be specified in "owner" field when using a robot access token. To ensure all libraries work correctly, "owner": "${
+              appForProjectId.ownerAccount.name
+            }" should be added to the project config, which can be done automatically by re-running "eas init". ${learnMore(
+              'https://expo.fyi/eas-project-id'
+            )}`
+          );
+        }
       }
     }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

As of https://github.com/expo/expo/pull/34209, we no longer need to include the owner field in app config since packages in the SDK no longer use it.

This is needed before the second PR in that stack can land (https://github.com/expo/expo/pull/34210) since it uses eas cli.

# How

Update condition and test.

# Test Plan

Run test.